### PR TITLE
Implement j.net.NetworkInterface & InterfaceAddress classes

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -192,9 +192,10 @@ Here is the list of currently available classes:
 * ``java.net.Inet4Address``
 * ``java.net.Inet6Address``
 * ``java.net.InetAddress``
-* ``java.net.InetAddressBase``
 * ``java.net.InetSocketAddress``
+* ``java.net.InterfaceAddress``
 * ``java.net.MalformedURLException``
+* ``java.net.NetworkInterface``
 * ``java.net.NoRouteToHostException``
 * ``java.net.PortUnreachableException``
 * ``java.net.ServerSocket``

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -1,7 +1,7 @@
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
-int getifaddrs(void *);
-void freeifaddrs(void *);
+int getifaddrs(void *) { return -1; };
+void freeifaddrs(void *){};
 #else
 #include <ifaddrs.h>
 #include <stddef.h>

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -1,7 +1,7 @@
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
-int getifaddrs(void *) { return -1; };
-void freeifaddrs(void *){};
+int getifaddrs(void *dummy) { return -1; };
+void freeifaddrs(void *dummy){};
 #else
 #include <ifaddrs.h>
 #include <stddef.h>

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -1,0 +1,84 @@
+#ifdef _WIN32
+// NO Windows support
+#else
+#include <ifaddrs.h>
+#include <stddef.h>
+
+#if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
+#ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
+#warning "Size and order of C structures are not checked when -std < c11."
+#endif
+#else
+/* Check that the fields defined by Scala Native match "closely enough" those
+ * defined by the operating system.
+ */
+
+/* Reference: man getifaddrs
+ *	      #include <ifaddrs.h>
+ */
+
+/* type ifaddrs = CStruct7[
+ *   Ptr[Byte], // Ptr[ifaddrs] ifa_next: Next item in list
+ *   CString, // ifa_name: Name of interface
+ *   CUnsignedInt, // ifa_flags: Flags from SIOCGIFFLAGS
+ *   Ptr[sockaddr], // ifa_addr: Address of interface
+ *   Ptr[sockaddr], // ifa_netmask: Netmask of interface
+ *   Ptr[sockaddr], // union:
+ *   // ifu_broadaddr: Broadcast address of interface
+ *   // ifu_dstaddr: Point-to-point destination address
+ *   Ptr[Byte] // ifa_data: Address-specific data
+ * ]
+ */
+
+struct scalanative_ifaddrs {
+    struct ifaddrs *ifa_next;     /* Next item in list */
+    char *ifa_name;               /* Name of interface */
+    unsigned int ifa_flags;       /* Flags from SIOCGIFFLAGS */
+    struct sockaddr *ifa_addr;    /* Address of interface */
+    struct sockaddr *ifa_netmask; /* Netmask of interface */
+#ifndef __linux__
+    struct sockaddr *ifa_dstaddr; // macOS/BSD #define's ifa_broadcast to this.
+#else
+    union {
+        struct sockaddr *ifu_broadaddr;
+        /* Broadcast address of interface */
+        struct sockaddr *ifu_dstaddr;
+        /* Point-to-point destination address */
+    } ifa_ifu;
+#endif
+    void *ifa_data;               /* Address-specific data */
+};
+
+_Static_assert(sizeof(struct scalanative_ifaddrs) <= sizeof(struct ifaddrs),
+               "unexpected size for ifaddrs");
+
+_Static_assert(offsetof(struct scalanative_ifaddrs, ifa_next) ==
+                   offsetof(struct ifaddrs, ifa_next),
+               "Unexpected offset: ifaddrs ifa_next");
+
+_Static_assert(offsetof(struct scalanative_ifaddrs, ifa_name) ==
+                   offsetof(struct ifaddrs, ifa_name),
+               "Unexpected offset: ifaddrs ifa_name");
+
+_Static_assert(offsetof(struct scalanative_ifaddrs, ifa_flags) ==
+                   offsetof(struct ifaddrs, ifa_flags),
+               "Unexpected offset: ifaddrs ifa_flags");
+
+_Static_assert(offsetof(struct scalanative_ifaddrs, ifa_addr) ==
+                   offsetof(struct ifaddrs, ifa_addr),
+               "Unexpected offset: ifaddrs ifa_addr");
+
+_Static_assert(offsetof(struct scalanative_ifaddrs, ifa_netmask) ==
+                   offsetof(struct ifaddrs, ifa_netmask),
+               "Unexpected offset: ifaddrs ifa_netmask");
+
+_Static_assert(offsetof(struct scalanative_ifaddrs, ifa_broadaddr) ==
+                   offsetof(struct ifaddrs, ifa_broadaddr),
+               "Unexpected offset: ifaddrs ifa_broadaddr");
+
+_Static_assert(offsetof(struct scalanative_ifaddrs, ifa_data) ==
+                   offsetof(struct ifaddrs, ifa_data),
+               "Unexpected offset: ifaddrs ifa_data");
+
+#endif
+#endif // not _WIN32

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -1,5 +1,7 @@
-#ifdef _WIN32
-// NO Windows support
+#if defined(_WIN32)
+// No Windows support. These are dummies for linking.
+int getifaddrs(void *);
+void freeifaddrs(void *);
 #else
 #include <ifaddrs.h>
 #include <stddef.h>

--- a/javalib/src/main/resources/scala-native/net/if_dl.c
+++ b/javalib/src/main/resources/scala-native/net/if_dl.c
@@ -1,0 +1,82 @@
+#ifdef _WIN32
+// NO Windows support
+#elif defined(__linux__)
+// Does not exist on Linux, so no check
+#else // macOS, FreeBSD, etc.
+#include <net/if_dl.h>
+#include <net/if_dl.h>
+#include <stddef.h>
+
+#if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
+#ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
+#warning "Size and order of C structures are not checked when -std < c11."
+#endif
+#else
+/* Check that the fields defined by Scala Native match "closely enough" those
+ * defined by the operating system.
+ */
+
+/* Reference: macOs: man sockaddr_dl
+ *	#include <net/if_dl.h>
+ */
+
+/* type sockaddr_dl = CStruct7[
+ *   CShort, // sdl_family;	// address family
+ *   CShort, // sdl_index
+ *   Byte, // sdl_type
+ *   Byte, // sdl_nlen
+ *   Byte, // sdl_alen
+ *   Byte, // sdl_slen
+ *   CArray[CChar, _46] // sdl_data, max(macOs == 12, FreeBsd == 46)
+ * ]
+ */
+
+struct scalanative_sockaddr_dl {
+    unsigned char sdl_len;    //  Total length of sockaddr
+    unsigned char sdl_family; // address family
+    unsigned short sdl_index; // if != 0, system interface index
+    unsigned char sdl_type;   // interface type
+    unsigned char sdl_nlen;   // interface name length
+    unsigned char sdl_alen;   // link level address length
+    unsigned char sdl_slen;   // link layer selector length
+    char sdl_data[46];        // contains both if name and ll address
+                              // sdl_data, max(macOs == 12, FreeBsd == 46)
+};
+
+/* SN >= os because macOS declares sdl_data to have size 12 but uses
+ * it as a longer variable length buffer.
+ * SN uses the FreeBSD 46 to make it easier to avoid array index errors.
+ */
+_Static_assert(sizeof(struct scalanative_sockaddr_dl) >=
+                   sizeof(struct sockaddr_dl),
+               "unexpected size for sockaddr_dl");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_dl, sdl_family) ==
+                   offsetof(struct sockaddr_dl, sdl_family),
+               "Unexpected offset: ifaddrs sdl_family");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_dl, sdl_index) ==
+                   offsetof(struct sockaddr_dl, sdl_index),
+               "Unexpected offset: ifaddrs sdl_index");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_dl, sdl_type) ==
+                   offsetof(struct sockaddr_dl, sdl_type),
+               "Unexpected offset: ifaddrs sdl_type");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_dl, sdl_nlen) ==
+                   offsetof(struct sockaddr_dl, sdl_nlen),
+               "Unexpected offset: ifaddrs sdl_nlen");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_dl, sdl_alen) ==
+                   offsetof(struct sockaddr_dl, sdl_alen),
+               "Unexpected offset: ifaddrs sdl_alen");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_dl, sdl_slen) ==
+                   offsetof(struct sockaddr_dl, sdl_slen),
+               "Unexpected offset: ifaddrs sdl_slen");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_dl, sdl_data) ==
+                   offsetof(struct sockaddr_dl, sdl_data),
+               "Unexpected offset: ifaddrs sdl_data");
+#endif
+#endif // not _WIN32

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -4,8 +4,8 @@ int scalanative_iff_loopback() { return 0; }
 int scalanative_iff_multicast() { return 0; }
 int scalanative_iff_pointopoint() { return 0; }
 int scalanative_iff_up() { return 0; }
-void *if_nameindex(void) { return (void *) 0; }
-void if_freenameindex(void * dummy) {};
+void *if_nameindex(void) { return (void *)0; }
+void if_freenameindex(void *dummy){};
 #else
 #include <sys/ioctl.h>
 #include <net/if.h>

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -3,9 +3,9 @@
 int scalanative_iff_loopback() { return 0; }
 int scalanative_iff_multicast() { return 0; }
 int scalanative_iff_pointopoint() { return 0; }
-int scalanative_iff_up() { return 9; }
-void *if_nameindex(void) { return NULL; }
-void if_freenameindex(void *){};
+int scalanative_iff_up() { return 0; }
+void *if_nameindex(void) { return (void *) 0; }
+void if_freenameindex(void * dummy) {};
 #else
 #include <sys/ioctl.h>
 #include <net/if.h>

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -1,0 +1,47 @@
+#if !defined(_WIN32)
+#include <sys/ioctl.h>
+#include <net/if.h>
+
+// Possibility for macOS, which lacks SIOCGIFHWADDR
+// https://stackoverflow.com/questions/10593736/
+//    mac-address-from-interface-on-os-x-c
+
+// Ref: "man 7 netdevice"
+
+// Symbolic constants
+
+int scalanative_ifnamesiz() { return IFNAMSIZ; }
+
+/* Broadcast address valid.  */
+int scalanative_iff_broadcast() { return IFF_BROADCAST; }
+
+/* Is a loopback net.  */
+int scalanative_iff_loopback() { return IFF_LOOPBACK; }
+
+/* Supports multicast.  */
+int scalanative_iff_multicast() { return IFF_MULTICAST; }
+
+/* Interface is point-to-point link.  */
+int scalanative_iff_pointopoint() { return IFF_POINTOPOINT; }
+
+/* Resources allocated.  */
+int scalanative_iff_running() { return IFF_RUNNING; }
+
+/* get flags */
+int scalanative_siocgifflags() { return SIOCGIFFLAGS; }
+
+// FIXME macOS appears to not have this ioctl. Hard to find replacement.
+
+#ifndef SIOCGIFHWADDR
+#define SIOCGIFHWADDR 0 // cause failure
+#endif
+/* Get hardware address */
+int scalanative_siocgifhwaddr() { return SIOCGIFHWADDR; }
+
+/* get MTU size */
+int scalanative_siocgifmtu() { return SIOCGIFMTU; }
+
+/* Interface is up.  */
+int scalanative_iff_up() { return IFF_UP; }
+
+#endif // !_WIN32

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -1,4 +1,12 @@
-#if !defined(_WIN32)
+#if defined(_WIN32)
+// No Windows support. These are dummies for linking.
+int scalanative_iff_loopback() { return IFF_LOOPBACK; }
+int scalanative_iff_multicast() { return 0; }
+int scalanative_iff_pointopoint() { return 0; }
+int scalanative_iff_up() { return 9; }
+void *if_nameindex(void);
+void if_freenameindex(void *);
+#else
 #include <sys/ioctl.h>
 #include <net/if.h>
 

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -4,8 +4,8 @@ int scalanative_iff_loopback() { return 0; }
 int scalanative_iff_multicast() { return 0; }
 int scalanative_iff_pointopoint() { return 0; }
 int scalanative_iff_up() { return 9; }
-void *if_nameindex(void);
-void if_freenameindex(void *);
+void *if_nameindex(void) { return NULL; }
+void if_freenameindex(void *){};
 #else
 #include <sys/ioctl.h>
 #include <net/if.h>

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
-int scalanative_iff_loopback() { return IFF_LOOPBACK; }
+int scalanative_iff_loopback() { return 0; }
 int scalanative_iff_multicast() { return 0; }
 int scalanative_iff_pointopoint() { return 0; }
 int scalanative_iff_up() { return 9; }

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -12,11 +12,8 @@ import scala.scalanative.unsigned._
 import scala.annotation.tailrec
 
 import java.io.IOException
+import java.net.SocketHelpers.sockaddrToByteArray
 import java.{util => ju}
-
-import scala.scalanative.annotation.alwaysinline
-
-import scala.scalanative.libc.string.memcpy
 
 import scala.scalanative.posix.arpa.inet._
 import scala.scalanative.posix.errno.errno
@@ -24,7 +21,7 @@ import scala.scalanative.posix.netinet.in._
 import scala.scalanative.posix.netinet.inOps._
 import scala.scalanative.posix.netdb._
 import scala.scalanative.posix.netdbOps._
-import scala.scalanative.posix.string.strerror
+import scala.scalanative.posix.string.{memcpy, strerror}
 import scala.scalanative.posix.sys.socket._
 import scala.scalanative.posix.time.{time_t, time, difftime}
 import scala.scalanative.posix.unistd
@@ -87,13 +84,12 @@ class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
   }
 
   def getHostAddress(): String = {
+    val bytes = ipAddress.at(0)
     if (ipAddress.length == 4) {
-      formatIn4Addr(arrayByteToPtrByte(ipAddress))
+      formatIn4Addr(bytes)
     } else if (ipAddress.length == 16) {
-      if (isIPv4MappedAddress(arrayByteToPtrByte(ipAddress))) {
-        formatIn4Addr(
-          arrayByteToPtrByte(extractIP4Bytes(arrayByteToPtrByte(ipAddress)))
-        )
+      if (isIPv4MappedAddress(bytes)) {
+        formatIn4Addr(extractIP4Bytes(bytes).at(0))
       } else {
         Inet6Address.formatInet6Address(this.asInstanceOf[Inet6Address])
       }
@@ -259,41 +255,11 @@ object InetAddress {
     }
   }
 
-  /* This is for littleEndian machines. It may need to detect BigEndian
-   * machines and do something different, at worst a byte-by-byte copy.
-   */
   private def addrinfoToByteArray(
       addrinfoP: Ptr[addrinfo]
   ): Array[Byte] = {
-
-    if (addrinfoP.ai_family == AF_INET6) {
-      val bufSize = 16
-      val buf = new Array[Byte](bufSize)
-
-      val addr = addrinfoP.ai_addr.asInstanceOf[Ptr[sockaddr_in6]]
-      val addrBytes = addr.sin6_addr.at1.asInstanceOf[Ptr[Byte]]
-
-      memcpy(arrayByteToPtrByte(buf), addrBytes, bufSize.toUInt)
-
-      buf
-    } else if (addrinfoP.ai_family == AF_INET) {
-      val buf = new Array[Byte](4)
-
-      val v4addr = addrinfoP.ai_addr.asInstanceOf[Ptr[sockaddr_in]]
-      val sinAddr = v4addr.sin_addr
-
-      val dst = arrayByteToPtrByte(buf).asInstanceOf[Ptr[in_addr]]
-      !dst = sinAddr // Structure copy
-
-      buf
-    } else {
-      // caller should have detected & thrown before getting this far.
-      Array.empty[Byte]
-    }
+    sockaddrToByteArray(addrinfoP.ai_addr)
   }
-
-  @alwaysinline private def arrayByteToPtrByte(ab: Array[Byte]): Ptr[Byte] =
-    ab.asInstanceOf[scala.scalanative.runtime.ByteArray].at(0)
 
   private def extractIP4Bytes(pb: Ptr[Byte]): Array[Byte] = {
     val buf = new Array[Byte](4)
@@ -317,7 +283,9 @@ object InetAddress {
     )
 
     if (result == null)
-      throw new IOException(s"inet_ntop IPv4 failed, errno: ${errno}")
+      throw new IOException(
+        s"inet_ntop IPv4 failed,${fromCString(strerror(errno))}"
+      )
 
     fromCString(dst)
   }
@@ -487,8 +455,7 @@ object InetAddress {
     val MAXDNAME = 1025.toUInt /* maximum presentation domain name */
 
     def tailorSockaddr(ipBA: Array[Byte], addr: Ptr[sockaddr]): Unit = {
-      val from =
-        ipBA.asInstanceOf[scala.scalanative.runtime.Array[Byte]].at(0)
+      val from = ipBA.at(0)
 
       // By contract the 'sockaddr' argument passed in is cleared/all_zeros.
       if (ipBA.length == 16) {

--- a/javalib/src/main/scala/java/net/InterfaceAddress.scala
+++ b/javalib/src/main/scala/java/net/InterfaceAddress.scala
@@ -1,0 +1,43 @@
+package java.net
+
+class InterfaceAddress private[net] (
+    inetAddr: InetAddress,
+    broadcastAddr: Option[Array[Byte]],
+    prefixLength: Short
+) {
+
+  override def equals(that: Any): Boolean = that match {
+    case that: InterfaceAddress => this.hashCode() == that.hashCode()
+    case _                      => false
+  }
+
+  def getAddress(): InetAddress = inetAddr
+
+  lazy val bcAddress = {
+    if (broadcastAddr.isEmpty) null
+    else InetAddress.getByAddress(broadcastAddr.get)
+  }
+
+  def getBroadcast(): InetAddress = bcAddress
+
+  def getNetworkPrefixLength(): Short = prefixLength
+
+  /** This hashCode is not intended or guaranteed to match Java.
+   */
+  override def hashCode(): Int =
+    inetAddr.hashCode() + broadcastAddr.hashCode() + prefixLength
+
+  override def toString(): String = {
+    val iaPart = inetAddr.getHostAddress()
+
+    val broadcastPart =
+      if (broadcastAddr.isEmpty) "null"
+      else {
+        // Not the most runtime efficient algorithm, but easy to implement.
+        InetAddress.getByAddress(broadcastAddr.get).toString()
+      }
+
+    s"/${iaPart}/${prefixLength} [${broadcastPart}]"
+  }
+
+}

--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -1,0 +1,982 @@
+package java.net
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+import scala.annotation.tailrec
+
+import java.net.SocketHelpers.sockaddrToByteArray
+
+import java.{util => ju}
+import ju.Objects
+import ju.stream.Stream
+
+import scala.scalanative.posix.errno.{errno, ENXIO}
+import scala.scalanative.posix.net.`if`._
+import scala.scalanative.posix.net.ifOps._
+import scala.scalanative.posix.netinet.in._
+import scala.scalanative.posix.netinet.inOps._
+import scala.scalanative.posix.sys.ioctl.ioctl
+import scala.scalanative.posix.sys.socket._
+import scala.scalanative.posix.sys.socketOps._
+import scala.scalanative.posix.string._
+import scala.scalanative.posix.unistd
+
+import scala.scalanative.meta.LinktimeInfo
+import scala.scalanative.runtime.Platform
+
+import macOsIf._
+import macOsIfDl._
+
+/* Design Notes:
+ *   1) This code is Unix only. On Windows, "empty" values are returned.
+ *      A Windows implementation is left as an exercise for the reader.
+ *
+ *   2) The Unix implementation often splits into a Linux path and a
+ *      macOS/BSD path.  The former uses ioctl() calls and lets the
+ *      operating system search for the named interface.  Such a kernel
+ *      search should be marginally faster and less error prone than
+ *      the user land search of getifaddrs() results done on the
+ *      macOS/BSD path.
+ *
+ *   3) Virtual and/or sub-interface methods rely on the convention that such
+ *      interfaces have a colon (:) in the name. Improvements are welcome.
+ *
+ *   4) For future reference:
+ *      GetAdaptersAddresses() function exist on Windows Vista and later.
+ *      Function returns a linked list of detailed adapter information
+ *      (much more than just addresses).
+ *      C examples are provided in the documentation on MSDN.
+ */
+
+class NetworkInterface private (ifName: String) {
+
+  override def equals(that: Any): Boolean = that match {
+    case that: NetworkInterface => this.hashCode() == that.hashCode()
+    case _                      => false
+  }
+
+  def getDisplayName(): String = getName()
+
+  def getHardwareAddress(): Array[Byte] = {
+    if (Platform.isWindows()) new Array[Byte](0) // No Windows support
+    else {
+      NetworkInterface.unixImplGetHardwareAddress(ifName)
+    }
+  }
+
+  def getIndex(): Int = {
+    if (Platform.isWindows()) 0 // No Windows support
+    else {
+      NetworkInterface.unixImplGetIndex(ifName)
+    }
+  }
+
+  def getInetAddresses(): ju.Enumeration[InetAddress] = {
+    if (Platform.isWindows()) { // No Windows support
+      ju.Collections.enumeration[InetAddress](new ju.ArrayList[InetAddress])
+    } else {
+      NetworkInterface.unixImplGetInetAddresses(ifName)
+    }
+  }
+
+  def getInterfaceAddresses(): ju.List[InterfaceAddress] = {
+    if (Platform.isWindows()) { // No Windows support
+      ju.Collections.emptyList[InterfaceAddress]()
+    } else {
+      NetworkInterface.unixImplGetInterfaceAddresses(ifName)
+    }
+  }
+
+  def getMTU(): Int = {
+    if (Platform.isWindows()) 0 // No Windows support
+    else {
+      NetworkInterface.unixImplGetIfMTU(ifName)
+    }
+  }
+
+  def getName(): String = ifName
+
+  def getParent(): NetworkInterface = {
+    if (Platform.isWindows()) null // No Windows support
+    else if (!this.isVirtual()) null
+    else {
+      val parentName = ifName.split(":")(0)
+      NetworkInterface.getByName(parentName)
+    }
+  }
+
+  def getSubInterfaces(): ju.Enumeration[NetworkInterface] = {
+    val ifList = new ju.ArrayList[NetworkInterface]()
+
+    // No Windows support, so empty Enumeration will be returned.
+    if (!Platform.isWindows()) {
+      val allIfs = NetworkInterface.getNetworkInterfaces()
+      val matchMe = s"${ifName}:"
+      while (allIfs.hasMoreElements()) {
+        val elem = allIfs.nextElement()
+        val elemName = elem.getName()
+        if (elemName.startsWith(matchMe))
+          ifList.add(elem)
+      }
+    }
+    ju.Collections.enumeration[NetworkInterface](ifList)
+  }
+
+  def inetAddresses(): Stream[InetAddress] = {
+    if (Platform.isWindows()) Stream.empty[InetAddress]() // No Windows support
+    else {
+      NetworkInterface.unixImplInetAddresses(ifName)
+    }
+  }
+
+  def isLoopback(): Boolean = {
+    if (Platform.isWindows()) false // No Windows support
+    else {
+      val ifFlags = NetworkInterface.unixImplGetIfFlags(ifName)
+      (ifFlags & unixIf.IFF_LOOPBACK) == unixIf.IFF_LOOPBACK
+    }
+  }
+
+  def isPointToPoint(): Boolean = {
+    if (Platform.isWindows()) false // No Windows support
+    else {
+      val ifFlags = NetworkInterface.unixImplGetIfFlags(ifName)
+      (ifFlags & unixIf.IFF_POINTOPOINT) == unixIf.IFF_POINTOPOINT
+    }
+  }
+
+  def isUp(): Boolean = {
+    if (Platform.isWindows()) false // No Windows support
+    else {
+      val ifFlags = NetworkInterface.unixImplGetIfFlags(ifName)
+      (ifFlags & unixIf.IFF_UP) == unixIf.IFF_UP
+    }
+  }
+
+  // relies upon convention that Virtual or sub-interfaces have colon in name.
+  def isVirtual(): Boolean = ifName.indexOf(':') >= 0 // a best guess
+
+  override def hashCode(): Int = ifName.hashCode()
+
+  def subInterfaces(): Stream[NetworkInterface] = {
+    val allIfs = NetworkInterface.networkInterfaces()
+    val matchMe = s"${ifName}:"
+    allIfs.filter(_.getName().startsWith(matchMe))
+  }
+
+  def supportsMulticast(): Boolean = {
+    if (Platform.isWindows()) false // No Windows support
+    else {
+      val ifFlags = NetworkInterface.unixImplGetIfFlags(ifName)
+      (ifFlags & unixIf.IFF_MULTICAST) == unixIf.IFF_MULTICAST
+    }
+  }
+
+  override def toString(): String = s"name:${ifName} (${ifName})"
+
+}
+
+object NetworkInterface {
+  import unixIfaddrs._
+  import unixIfaddrsOps._
+
+  def getByIndex(index: Int): NetworkInterface = {
+    if (index < 0)
+      throw new IllegalArgumentException("Interface index can't be negative")
+
+    if (Platform.isWindows()) {
+      null
+    } else {
+      unixGetByIndex(index)
+    }
+  }
+
+  def getByInetAddress(addr: InetAddress): NetworkInterface = {
+    Objects.requireNonNull(addr)
+    if (Platform.isWindows()) {
+      null
+    } else {
+      unixGetByInetAddress(addr)
+    }
+  }
+
+  def getByName(name: String): NetworkInterface = {
+    Objects.requireNonNull(name)
+    if (Platform.isWindows()) {
+      null
+    } else {
+      unixGetByName(name)
+    }
+  }
+
+  def getNetworkInterfaces(): ju.Enumeration[NetworkInterface] = {
+    if (Platform.isWindows()) {
+      null
+    } else {
+      unixGetNetworkInterfaces()
+    }
+  }
+
+  /** networkInterfaces() method is Java 9. It is provided because Streams are
+   *  less clumsy than Enumerations.
+   */
+  def networkInterfaces(): Stream[NetworkInterface] = {
+    if (Platform.isWindows()) {
+      null
+    } else {
+      unixNetworkInterfaces()
+    }
+  }
+
+  private def createInetAddress(
+      ifa: Ptr[ifaddrs],
+      ifName: String
+  ): Option[InetAddress] = {
+    val sa = ifa.ifa_addr
+    val af = sa.sa_family.toInt
+
+    if (!((af == AF_INET) || (af == AF_INET6))) None
+    else {
+      val bytes = sockaddrToByteArray(sa)
+      if (af == AF_INET) {
+        Some(InetAddress.getByAddress(bytes))
+      } else {
+        val scopeId = sa.asInstanceOf[Ptr[sockaddr_in6]].sin6_scope_id.toInt
+        Some(Inet6Address(bytes, "", scopeId, ifName))
+      }
+    }
+  }
+
+  private def createInterfaceAddress(
+      ifa: Ptr[ifaddrs],
+      interfaceName: String
+  ): Option[InterfaceAddress] = {
+
+    def decodePrefixLength(sa: Ptr[sockaddr]): Short = {
+      val result =
+        if (sa.sa_family.toInt == AF_INET) {
+          val sin4 = sa.asInstanceOf[Ptr[sockaddr_in]]
+          val mask = sin4.sin_addr.s_addr.toInt
+          Integer.bitCount(mask)
+        } else if (sa.sa_family.toInt == AF_INET6) {
+          val sin6 = sa.asInstanceOf[Ptr[sockaddr_in6]]
+          val longs =
+            sin6.sin6_addr.at1.asInstanceOf[Ptr[scala.Long]]
+          java.lang.Long.bitCount(longs(0)) + java.lang.Long.bitCount(longs(1))
+        } else {
+          0 // Blivet! Unknown address family, assume zero length prefix.
+        }
+      result.toShort
+    }
+
+    val sa = ifa.ifa_addr
+    val af = sa.sa_family.toInt
+    if (!((af == AF_INET) || (af == AF_INET6))) {
+      None // Silently skip AF_PACKET (17) and such.
+    } else {
+      val bytes = sockaddrToByteArray(sa)
+      val inetAddress = if (af == AF_INET) {
+        InetAddress.getByAddress(bytes)
+      } else {
+        val scopeId = sa.asInstanceOf[Ptr[sockaddr_in6]].sin6_scope_id
+        Inet6Address(bytes, "", scopeId.toInt, interfaceName)
+      }
+
+      val broadcastAddress: Option[Array[Byte]] =
+        if (sa.sa_family.toInt == AF_INET6) None
+        else if ((ifa.ifa_flags & unixIf.IFF_LOOPBACK.toUInt) != 0.toUInt) None
+        else Some(sockaddrToByteArray(ifa.ifa_broadaddr))
+
+      val prefixLen = decodePrefixLength(ifa.ifa_netmask)
+
+      val ifAddress =
+        new InterfaceAddress(inetAddress, broadcastAddress, prefixLen)
+
+      Some(ifAddress)
+    }
+  }
+
+  private def createNetworkInterface(ifa: Ptr[ifaddrs]): NetworkInterface = {
+    val ifName = fromCString(ifa.ifa_name)
+    new NetworkInterface(ifName)
+  }
+
+  private def unixGetByIndex(index: Int): NetworkInterface = {
+    val buf = stackalloc[Byte](IF_NAMESIZE.toUInt)
+
+    val ret = if_indextoname(index.toUInt, buf)
+
+    if (ret != null) unixGetByName(fromCString(ret))
+    else if (errno == ENXIO) null // no interface has that index
+    else
+      throw new SocketException(fromCString(strerror(errno)))
+  }
+
+  private def unixGetByInetAddress(addr: InetAddress): NetworkInterface = {
+
+    def found(addr: Array[Byte], addrLen: Int, sa: Ptr[sockaddr]): Boolean = {
+      val sa_family = sa.sa_family.toInt
+      if (sa_family == AF_INET6) {
+        if (addrLen != 16) false
+        else {
+          val sa6 = sa.asInstanceOf[Ptr[sockaddr_in6]]
+          val sin6Addr = sa6.sin6_addr.at1.asInstanceOf[Ptr[Byte]]
+          memcmp(addr.at(0), sin6Addr, addrLen.toUInt) == 0
+        }
+      } else if (sa_family == AF_INET) {
+        val sa4 = sa.asInstanceOf[Ptr[sockaddr_in]]
+        val sin4Addr = sa4.sin_addr.at1.asInstanceOf[Ptr[Byte]]
+        memcmp(addr.at(0), sin4Addr, addrLen.toUInt) == 0
+      } else false
+    }
+
+    @tailrec
+    def findIfInetAddress(
+        ipAddress: Array[Byte],
+        addrLen: Int,
+        ifa: Ptr[ifaddrs]
+    ): NetworkInterface = {
+      if (ifa == null) null
+      else if (found(ipAddress, addrLen, ifa.ifa_addr))
+        createNetworkInterface(ifa)
+      else
+        findIfInetAddress(
+          ipAddress,
+          addrLen,
+          ifa.ifa_next.asInstanceOf[Ptr[ifaddrs]]
+        )
+    }
+
+    val addrBytes = addr.getAddress()
+    val len = addrBytes.length // check this once, not N times
+
+    if (!((len == 4) || (len == 16)))
+      throw new SocketException(
+        s"unixGetByInetAddress: wrong Array[Byte] length: ${len}"
+      )
+    else {
+      val ifap = stackalloc[Ptr[ifaddrs]]()
+
+      val gifStatus = getifaddrs(ifap)
+      if (gifStatus == -1)
+        throw new SocketException(
+          s"getifaddrs failed: ${fromCString(strerror(errno))}"
+        )
+
+      val result =
+        try {
+          findIfInetAddress(addrBytes, len, !ifap)
+        } finally {
+          freeifaddrs(!ifap)
+        }
+
+      result
+    }
+  }
+
+  private def unixGetByName(name: String): NetworkInterface = Zone {
+    implicit z =>
+      @tailrec
+      def findIfName(
+          cName: CString,
+          ifa: Ptr[ifaddrs]
+      ): NetworkInterface = {
+        if (ifa == null) null
+        else if (strcmp(ifa.ifa_name, cName) == 0)
+          createNetworkInterface(ifa)
+        else findIfName(cName, ifa.ifa_next.asInstanceOf[Ptr[ifaddrs]])
+      }
+
+      val cName = toCString(name)
+      val ifap = stackalloc[Ptr[ifaddrs]]()
+
+      val gifStatus = getifaddrs(ifap)
+      if (gifStatus == -1)
+        throw new SocketException(
+          s"getifaddrs failed: ${fromCString(strerror(errno))}"
+        )
+
+      val result =
+        try {
+          findIfName(cName, !ifap)
+        } finally {
+          freeifaddrs(!ifap)
+        }
+
+      result
+  }
+
+  private def unixAccumulateNetworkInterfaces(
+      accumulator: (NetworkInterface) => Unit
+  ): Unit = {
+
+    @tailrec
+    def accumulateNetIfs(
+        ni: Ptr[if_nameindex],
+        addOne: (NetworkInterface) => Unit
+    ): Unit = {
+      if ((ni.if_index.toInt != 0) || (ni.if_name != null)) {
+        val ifName =
+          if (ni.if_name == null) ""
+          else fromCString(ni.if_name)
+
+        addOne(new NetworkInterface(ifName))
+
+        accumulateNetIfs(
+          ni + 1, // + 1 should skip entire structure
+          accumulator
+        )
+      }
+    }
+
+    val nameIndex = if_nameindex()
+
+    if (nameIndex == null)
+      throw new SocketException(
+        s"if_nameindex() failed: ${fromCString(strerror(errno))}"
+      )
+
+    try {
+      accumulateNetIfs(nameIndex, accumulator)
+    } finally {
+      if_freenameindex(nameIndex)
+    }
+  }
+
+  private def unixGetNetworkInterfaces(): ju.Enumeration[NetworkInterface] = {
+    val ifList = new ju.ArrayList[NetworkInterface]()
+    unixAccumulateNetworkInterfaces((netIf: NetworkInterface) => {
+      ifList.add(netIf); ()
+    })
+    ju.Collections.enumeration[NetworkInterface](ifList)
+  }
+
+  private def unixNetworkInterfaces(): Stream[NetworkInterface] = {
+    val builder = Stream.builder[NetworkInterface]()
+    unixAccumulateNetworkInterfaces((netIf: NetworkInterface) => {
+      builder.add(netIf); ()
+    })
+    builder.build()
+  }
+
+  /* Implement OS specific class & helper methods
+   */
+
+  private def linuxImplGetIoctlFd(): Int = {
+    val fd = socket(AF_INET, SOCK_DGRAM, 0)
+
+    if (fd == -1) {
+      val msg = fromCString(strerror(errno))
+      throw new SocketException(s"socket(AF_INET, SOCK_DGRAM) failed: ${msg}\n")
+    }
+
+    fd
+  }
+
+  private def macOsImplExecCallback(
+      ifName: String,
+      callback: Ptr[ifaddrs] => Tuple2[Int, Array[Byte]]
+  ): Tuple2[Int, Array[Byte]] = {
+    @tailrec
+    def findAfLinkIfName(
+        ifNameC: CString,
+        ifa: Ptr[ifaddrs]
+    ): Ptr[ifaddrs] = {
+      if (ifa == null) null
+      else if ((strcmp(ifNameC, ifa.ifa_name) == 0)
+          && (ifa.ifa_addr.sa_family.toInt == 18 /* AF_LINK */ ))
+        ifa
+      else
+        findAfLinkIfName(ifNameC, ifa.ifa_next)
+    }
+
+    val ifap = stackalloc[Ptr[ifaddrs]]()
+
+    val gifStatus = getifaddrs(ifap)
+    if (gifStatus == -1)
+      throw new SocketException(
+        s"getifaddrs failed: ${fromCString(strerror(errno))}"
+      )
+
+    try
+      Zone { implicit z =>
+        val foundIfa = findAfLinkIfName(toCString(ifName), !ifap)
+        callback(foundIfa)
+      }
+    finally {
+      freeifaddrs(!ifap)
+    }
+  }
+
+  private def unixImplGetIndex(ifName: String): Int = Zone { implicit z =>
+    // toInt truncation OK, since index will never be larger than MAX_INT
+    if_nametoindex(toCString(ifName)).toInt
+    // Return 0 on error. Do not give errno error message.
+  }
+
+  private def unixImplGetHardwareAddress(ifName: String): Array[Byte] = {
+    if (LinktimeInfo.isLinux)
+      linuxImplGetHardwareAddress(ifName)
+    else
+      macOsImplGetHardwareAddress(ifName)
+  }
+
+  private def macOsImplGetHardwareAddress(ifName: String): Array[Byte] = {
+    def decodeSocketDl(sockaddrDl: Ptr[macOsIfDl.sockaddr_dl]): Array[Byte] = {
+
+      val nBytes = if (sockaddrDl == null) 0 else sockaddrDl.sdl_alen.toInt
+      val bytes = new Array[Byte](nBytes)
+
+      if (nBytes > 0) { // skip name
+        val src = sockaddrDl.sdl_data.at(sockaddrDl.sdl_nlen.toInt)
+        val dst = bytes.at(0)
+        memcpy(dst, src, nBytes.toUInt)
+      }
+      bytes
+    }
+
+    def cb(ifa: Ptr[ifaddrs]): Tuple2[Int, Array[Byte]] = {
+      val arr =
+        if (ifa == null) new Array[Byte](0)
+        else
+          decodeSocketDl(ifa.ifa_addr.asInstanceOf[Ptr[sockaddr_dl]])
+
+      (0, arr)
+    }
+
+    macOsImplExecCallback(ifName, cb)._2
+  }
+
+  private def linuxImplGetHardwareAddress(ifName: String): Array[Byte] = Zone {
+    implicit z =>
+      // acknowledge:
+      //   https://www.geekpage.jp/en/programming/linux-network/get-macaddr.php
+
+      val request = stackalloc[unixIf.ifreq_hwaddress]()
+
+      strncpy(
+        request.at1.asInstanceOf[CString],
+        toCString(ifName),
+        (unixIf.IFNAMSIZ - 1).toUSize
+      )
+
+      val saP = request.at2.asInstanceOf[Ptr[sockaddr]]
+      saP.sa_family = AF_INET.toUShort
+
+      val fd = linuxImplGetIoctlFd()
+
+      try {
+        val status =
+          ioctl(fd, unixIf.SIOCGIFHWADDR, request.asInstanceOf[Ptr[Byte]]);
+        if (status != 0) {
+          val msg = fromCString(strerror(errno))
+          throw new SocketException(s"ioctl SIOCGIFHWADDR failed: ${msg}\n")
+        }
+      } finally {
+        unistd.close(fd)
+      }
+
+      val hwAddress = new Array[Byte](6)
+      val hwAddrBytes = request.at2.sa_data
+
+      for (j <- 0 until 6)
+        hwAddress(j) = hwAddrBytes(j)
+
+      hwAddress
+  }
+
+  private def unixImplGetIfMTU(ifName: String): Int = {
+    if (LinktimeInfo.isLinux)
+      linuxImplGetIfMTU(ifName)
+    else
+      macOsImplGetIfMTU(ifName)
+  }
+
+  private def macOsImplGetIfMTU(ifName: String): Int = {
+    def cb(ifa: Ptr[ifaddrs]): Tuple2[Int, Array[Byte]] = {
+      val result =
+        if (ifa == null) 0
+        else
+          ifa.ifa_data.asInstanceOf[Ptr[macOsIf.if_data]].ifi_mtu.toInt
+
+      (result, null)
+    }
+
+    macOsImplExecCallback(ifName, cb)._1
+  }
+
+  private def linuxImplGetIfMTU(ifName: String): Int = Zone { implicit z =>
+    val request = stackalloc[unixIf.ifreq_mtu]()
+
+    strncpy(
+      request.at1.asInstanceOf[CString],
+      toCString(ifName),
+      (unixIf.IFNAMSIZ - 1).toUSize
+    )
+
+    val saP = request.at2.asInstanceOf[Ptr[sockaddr]]
+    saP.sa_family = AF_INET.toUShort
+
+    val fd = linuxImplGetIoctlFd()
+
+    try {
+      val status =
+        ioctl(fd, unixIf.SIOCGIFMTU, request.asInstanceOf[Ptr[Byte]]);
+      if (status != 0)
+        throw new SocketException(
+          s"ioctl SIOCGIFMTU failed: ${fromCString(strerror(errno))}"
+        )
+
+    } finally {
+      unistd.close(fd)
+    }
+
+    request._2 // ifr_mtu
+  }
+
+  private def unixImplGetIfFlags(ifName: String): Short = {
+    if (LinktimeInfo.isLinux)
+      linuxImplGetIfFlags(ifName)
+    else
+      macOsImplGetIfFlags(ifName)
+  }
+
+  private def macOsImplGetIfFlags(ifName: String): Short = {
+    def cb(ifa: Ptr[ifaddrs]): Tuple2[Int, Array[Byte]] = {
+      val result =
+        if (ifa == null) 0
+        else ifa.ifa_flags.toInt
+
+      (result, null)
+    }
+
+    macOsImplExecCallback(ifName, cb)._1.toShort
+  }
+
+  private def linuxImplGetIfFlags(ifName: String): Short = Zone { implicit z =>
+    val request = stackalloc[unixIf.ifreq_flags]()
+
+    strncpy(
+      request.at1.asInstanceOf[CString],
+      toCString(ifName),
+      (unixIf.IFNAMSIZ - 1).toUSize
+    )
+
+    val saP = request.at2.asInstanceOf[Ptr[sockaddr]]
+    saP.sa_family = AF_INET.toUShort
+
+    val fd = linuxImplGetIoctlFd()
+
+    try {
+      val status =
+        ioctl(fd, unixIf.SIOCGIFFLAGS, request.asInstanceOf[Ptr[Byte]]);
+
+      if (status != 0) {
+        val msg = fromCString(strerror(errno))
+        throw new SocketException(s"ioctl SIOCGIFFLAGS failed: ${msg}\n")
+      }
+    } finally {
+      unistd.close(fd)
+    }
+
+    request._2 // ifr_flags
+  }
+
+  private def unixAccumulateInetAddresses(
+      ifNameJ: String,
+      accumulator: (InetAddress) => Unit
+  ): Unit = Zone { implicit z =>
+    @tailrec
+    def accumulateInetAddresses(
+        ifNameC: CString,
+        addOne: (InetAddress) => Unit,
+        ifa: Ptr[ifaddrs]
+    ): Unit = {
+      if (ifa != null) {
+        if (strcmp(ifNameC, ifa.ifa_name) == 0) {
+          createInetAddress(ifa, ifNameJ).map(ia => addOne(ia))
+        }
+        accumulateInetAddresses(
+          ifNameC,
+          addOne,
+          ifa.ifa_next.asInstanceOf[Ptr[ifaddrs]]
+        )
+      }
+    }
+
+    val ifap = stackalloc[Ptr[ifaddrs]]()
+
+    val gifStatus = getifaddrs(ifap)
+
+    if (gifStatus == -1)
+      throw new SocketException(
+        s"getifaddrs failed: ${fromCString(strerror(errno))}"
+      )
+
+    try {
+      accumulateInetAddresses(toCString(ifNameJ), accumulator, !ifap)
+    } finally {
+      freeifaddrs(!ifap)
+    }
+  }
+
+  private def unixAccumulateInterfaceAddresses(
+      ifName: String,
+      accumulator: (InterfaceAddress) => Unit
+  ): Unit = Zone { implicit z =>
+    @tailrec
+    def accumulateInterfaceAddresses(
+        ifNameJ: String,
+        ifNameC: CString,
+        addOne: (InterfaceAddress) => Unit,
+        ifa: Ptr[ifaddrs]
+    ): Unit = {
+      if (ifa != null) {
+        if (strcmp(ifNameC, ifa.ifa_name) == 0) {
+          createInterfaceAddress(ifa, ifNameJ).map(ia => addOne(ia))
+        }
+        accumulateInterfaceAddresses(
+          ifNameJ,
+          ifNameC,
+          addOne,
+          ifa.ifa_next.asInstanceOf[Ptr[ifaddrs]]
+        )
+      }
+    }
+
+    val ifap = stackalloc[Ptr[ifaddrs]]()
+
+    val gifStatus = getifaddrs(ifap)
+
+    if (gifStatus == -1)
+      throw new SocketException(
+        s"getifaddrs failed: ${fromCString(strerror(errno))}"
+      )
+
+    try {
+      accumulateInterfaceAddresses(
+        ifName,
+        toCString(ifName),
+        accumulator,
+        !ifap
+      )
+    } finally {
+      freeifaddrs(!ifap)
+    }
+  }
+
+  private def unixImplGetInterfaceAddresses(
+      ifName: String
+  ): ju.List[InterfaceAddress] = {
+    val ifaList = new ju.ArrayList[InterfaceAddress]()
+    unixAccumulateInterfaceAddresses(
+      ifName,
+      (ifa: InterfaceAddress) => { ifaList.add(ifa); () }
+    )
+    ifaList
+  }
+
+  private def unixImplGetInetAddresses(
+      ifName: String
+  ): ju.Enumeration[InetAddress] = {
+    val ifList = new ju.ArrayList[InetAddress]()
+    unixAccumulateInetAddresses(
+      ifName,
+      (ia: InetAddress) => { ifList.add(ia); () }
+    )
+    ju.Collections.enumeration[InetAddress](ifList)
+  }
+
+  private def unixImplInetAddresses(ifName: String): Stream[InetAddress] = {
+    val builder = Stream.builder[InetAddress]()
+    unixAccumulateInetAddresses(
+      ifName,
+      (ia: InetAddress) => { builder.add(ia); () }
+    )
+    builder.build()
+  }
+
+}
+
+@extern
+private object unixIfaddrs {
+  /* Reference: man getifaddrs
+   *            #include <ifaddrs.h>
+   */
+
+  // format: off
+  type ifaddrs = CStruct7[
+    Ptr[Byte], /* Ptr[ifaddrs] */ // ifa_next: Next item in list
+    CString, // ifa_name: Name of interface
+    CUnsignedInt, // ifa_flags: Flags from SIOCGIFFLAGS
+    Ptr[sockaddr], // ifa_addr: Address of interface
+    Ptr[sockaddr], // ifa_netmask: Netmask of interface
+    // ifu_broadaddr: Broadcast address of interface
+    // ifu_dstaddr: Point-to-point destination address
+    Ptr[sockaddr], // union: ifu_broadaddr, ifu_dstaddr
+    Ptr[Byte] // ifa_data: Address-specific data
+  ]
+  // format: on
+
+  def getifaddrs(ifap: Ptr[Ptr[ifaddrs]]): CInt = extern
+
+  def freeifaddrs(ifa: Ptr[ifaddrs]): Unit = extern
+}
+
+private object unixIfaddrsOps {
+  import unixIfaddrs._
+
+  implicit class unixIfaddrOps(val ptr: Ptr[ifaddrs]) extends AnyVal {
+    def ifa_next: Ptr[ifaddrs] = ptr._1.asInstanceOf[Ptr[ifaddrs]]
+    def ifa_name: CString = ptr._2
+    def ifa_flags: CUnsignedInt = ptr._3
+    def ifa_addr: Ptr[sockaddr] = ptr._4
+    def ifa_netmask: Ptr[sockaddr] = ptr._5
+    def ifa_broadaddr: Ptr[sockaddr] = ptr._6
+    def ifa_dstaddr: Ptr[sockaddr] = ptr._6
+    def ifa_data: Ptr[Byte] = ptr._7
+
+    // ifa fields are read-only in use, so no Ops here to set them.
+  }
+}
+
+@extern
+private object unixIf {
+  /* Reference: man 7 netdevice
+   *            #include <net/if.h>
+   */
+
+  // Three SN-only types used to facilitate retrieving specific types of data.
+  type ifreq_hwaddress = CStruct2[
+    CArray[CChar, Nat.Digit2[Nat._1, Nat._6]],
+    sockaddr
+  ]
+
+  type ifreq_mtu = CStruct2[
+    CArray[CChar, Nat.Digit2[Nat._1, Nat._6]],
+    CInt
+  ]
+
+  type ifreq_flags = CStruct2[
+    CArray[CChar, Nat.Digit2[Nat._1, Nat._6]],
+    CShort
+  ]
+
+  @name("scalanative_ifnamesiz")
+  def IFNAMSIZ: CInt = extern
+
+  @name("scalanative_iff_broadcast")
+  def IFF_BROADCAST: CInt = extern
+
+  @name("scalanative_iff_loopback")
+  def IFF_LOOPBACK: CInt = extern
+
+  @name("scalanative_iff_multicast")
+  def IFF_MULTICAST: CInt = extern
+
+  @name("scalanative_iff_pointopoint")
+  def IFF_POINTOPOINT: CInt = extern
+
+  @name("scalanative_iff_running")
+  def IFF_RUNNING: CInt = extern
+
+  @name("scalanative_siocgifflags")
+  def SIOCGIFFLAGS: CInt = extern
+
+  @name("scalanative_siocgifhwaddr")
+  def SIOCGIFHWADDR: CInt = extern
+
+  @name("scalanative_siocgifmtu")
+  def SIOCGIFMTU: CInt = extern
+
+  @name("scalanative_iff_up")
+  def IFF_UP: CInt = extern
+}
+
+private object macOsIf {
+
+  /*  Scala if_data & corresponding ifDataOps definitions are not complete.
+   *  Only items used in NetworkInterface are declared.
+   */
+
+  /* Reference: macOS
+   *  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+   *      /net/if_var.h
+   *
+   * struct if_data {
+   *   // generic interface information
+   *   u_char          ifi_type;       // ethernet, tokenring, etc
+   *   u_char          ifi_typelen;    // Length of frame type id
+   *   u_char          ifi_physical;   // e.g., AUI, Thinnet, 10base-T, etc
+   *   u_char          ifi_addrlen;    // media address length
+   *   u_char          ifi_hdrlen;     // media header length
+   *   u_char          ifi_recvquota;  // polling quota for receive intrs
+   *   u_char          ifi_xmitquota;  // polling quota for xmit intrs
+   *   u_char          ifi_unused1;    // for future use
+   *   u_int32_t       ifi_mtu;        // maximum transmission unit
+   */
+
+  // Incomplete
+  type if_data = CStruct2[
+    CLongLong, // Placeholder, consolidate & skip fields of no interest.
+    CUnsignedInt // ifi_mtu
+  ]
+
+  // Incomplete, corresponding to incomplete if_data just above.
+  implicit class ifDataOps(val ptr: Ptr[if_data]) extends AnyVal {
+    def ifi_mtu: CUnsignedInt = ptr._2
+  }
+  // ifi fields read-only fields in use, so no Ops here to set them.
+}
+
+private object macOsIfDl {
+  /*  Scala sockaddr_dl & corresponding sockaddrDlOps definitions are not
+   *  complete. They are only what NetworkInterface uses.
+   */
+
+  /* Reference: FreeBSD man sockaddr_dl
+   *    #include <net/if_dl.h>
+   *
+   * For sdl_data field, use the larger of macOS defined 12 and
+   * FreeBSD defined 46.
+   *
+   * struct sockaddr_dl
+   *  The sockaddr_dl structure is used to describe a layer 2 link-level
+   *  address. The structure has the following members:
+   *
+   *      ushort_t sdl_family;     // address family
+   *      ushort_t sdl_index;      // if != 0, system interface index
+   *      uchar_t  sdl_type;       // interface type
+   *      uchar_t  sdl_nlen;       // interface name length
+   *      uchar_t  sdl_alen;       // link level address length
+   *      uchar_t  sdl_slen;       // link layer selector length
+   *      char     sdl_data[46];   // contains both if name and ll address
+   */
+
+  // sdl_data, max(macOs == 12, FreeBsd == 46)
+  type _46 = Nat.Digit2[Nat._4, Nat._6]
+  type sdl_data_t = CArray[CChar, _46]
+
+  type sockaddr_dl = CStruct8[
+    Byte, // sdl_len;    //  Total length of sockaddr
+    Byte, // sdl_family; // address family
+    CShort, // sdl_index
+    Byte, // sdl_type
+    Byte, // sdl_nlen
+    Byte, // sdl_alen
+    Byte, // sdl_slen
+    sdl_data_t
+  ]
+
+  implicit class sockaddrDlOps(val ptr: Ptr[sockaddr_dl]) extends AnyVal {
+    def sdl_len: UByte = ptr._1.toUByte
+    def sdl_family: UByte = ptr._2.toUByte
+    def sdl_index: UShort = ptr._3.toUShort
+    def sdl_type: UByte = ptr._4.toUByte
+    def sdl_nlen: UByte = ptr._5.toUByte
+    def sdl_alen: UByte = ptr._6.toUByte
+    def sdl_slen: UByte = ptr._7.toUByte
+    def sdl_data: sdl_data_t = ptr._8
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/net/NetworkInterfaceTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/net/NetworkInterfaceTestOnJDK9.scala
@@ -1,0 +1,44 @@
+package javalib.net
+
+import java.net._
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalanative.testsuite.utils.Platform
+
+/* Design Notes:
+ *    1)  See Design Notes in NetworkInterfaceTest.scala
+ */
+
+class NetworkInterfaceTestOnJDK9 {
+
+  val localhostIf =
+    if (Platform.isLinux) "lo"
+    else "lo0"
+
+// Test instance method(s)
+
+  @Test def instanceInetAddresses(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf)
+
+    // SN Stream implements neither Stream.count() nor Stream.reduce()
+    val iaStream = lbIf.inetAddresses()
+
+    var count = 0
+
+    val itr = iaStream.iterator()
+
+    while (itr.hasNext()) {
+      itr.next()
+      count += 1
+    }
+
+    assertTrue("count > 0", count > 0)
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/javalib/net/InterfaceAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InterfaceAddressTest.scala
@@ -9,7 +9,7 @@ import org.junit.Assume._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform
 
-import scala.scalanative.meta.LinktimeInfo
+import scalanative.meta.LinktimeInfo
 
 /* Design Notes:
  *    1) As the underlying implementation is Unix only, so are these Tests.

--- a/unit-tests/shared/src/test/scala/javalib/net/InterfaceAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InterfaceAddressTest.scala
@@ -1,0 +1,156 @@
+package javalib.net
+
+import java.net._
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform
+
+import scala.scalanative.meta.LinktimeInfo
+
+/* Design Notes:
+ *    1) As the underlying implementation is Unix only, so are these Tests.
+ *
+ *    2) Network interface configuration is can and does vary greatly from
+ *       system to system. These tests are written to succeed with the
+ *       configuration used by the Scala Native Continuous Integration systems.
+ *
+ *       They may fail if used outside of that environment and require
+ *       editing to reflect that local configuration.
+ */
+
+class InterfaceAddressTest {
+
+  /* The tests in this class depend upon a competent NetworkInterface class.
+   * They also assume, perhaps unwisely, that the loopback address has index 1.
+   */
+
+  val localhostIf =
+    if (LinktimeInfo.isLinux) "lo"
+    else "lo0"
+
+  val osIPv6PrefixLength =
+    if (LinktimeInfo.isMac) 64
+    else 128
+
+  val osIPv6LoopbackSuffix =
+    s":0:0:0:0:0:0:1%${localhostIf}"
+
+  val osIPv6LoopbackAddress =
+    if (LinktimeInfo.isMac) s"fe80${osIPv6LoopbackSuffix}"
+    else s"0${osIPv6LoopbackSuffix}"
+
+  /* Test equals() but there is no good, simple way to test corresponding
+   * hashCode(). The contents of the components used in the hash vary by
+   * operating system.
+   *
+   * equals() calls hashCode() showing that the latter at least executes.
+   */
+  @Test def testEquals(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val netIf = NetworkInterface.getByIndex(1) // loopback
+    assertNotNull(netIf)
+
+    val ifAddresses = netIf.getInterfaceAddresses()
+    assertTrue("No InterfaceAddress found", ifAddresses.size > 0)
+
+    assumeTrue("not enough ifAddresses for test", ifAddresses.size >= 2)
+
+    val ifa1 = ifAddresses.get(0)
+    val ifa2 = ifAddresses.get(1)
+
+    assertEquals("InterfaceAddress equal", ifa1, ifa1)
+    assertNotEquals("InterfaceAddress not equal", ifa1, ifa2)
+  }
+
+  @Test def testGetAddress(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val netIf = NetworkInterface.getByIndex(1) // loopback
+    assertNotNull(netIf)
+
+    val ifAddresses = netIf.getInterfaceAddresses()
+    assertTrue("No InterfaceAddress found", ifAddresses.size > 0)
+
+    ifAddresses.forEach { addr =>
+      val hostAddr = addr.getAddress().getHostAddress()
+
+      // macOS can have two forms of IPv6 loopback address.
+      val expected =
+        if (!hostAddr.contains(":")) {
+          "127.0.0.1"
+        } else if (hostAddr.startsWith("0")) {
+          s"0:0:0:0:0:0:0:1%${localhostIf}"
+        } else if (hostAddr.startsWith("f")) {
+          s"${osIPv6LoopbackAddress}"
+        } else "" // fail in a way that will print out ifAddrString
+
+      assertEquals("Unexpected result", expected, hostAddr)
+    }
+  }
+
+  /*  @Test def testGetBroadcast(): Unit = {}
+   *  Not implemented - system dependent.
+   *  Loopback addresses have not broadcast address to get.
+   *  Non-loopback primary interface varies and can not be determined.
+   */
+
+  @Test def testGetNetworkPrefixLength(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val netIf = NetworkInterface.getByIndex(1) // loopback
+    assertNotNull(netIf)
+
+    val ifAddresses = netIf.getInterfaceAddresses()
+    assertTrue("No InterfaceAddress found", ifAddresses.size > 0)
+
+    ifAddresses.forEach { addr =>
+      val ia = addr.getAddress().getAddress()
+      val len = ia.length
+
+      val expected =
+        if (len == 4) 8.toShort // IPv4
+        else if (len != 16) -1.toShort // fail but print prefixLen
+        else if (ia(0) == 0) 128.toShort // Linux & macOS ::1 form
+        else osIPv6PrefixLength.toShort // macOs ff80::1 form
+
+      val prefixLen = addr.getNetworkPrefixLength()
+      assertEquals("unexpected prefix length", expected, prefixLen)
+    }
+  }
+
+  @Test def testLoopbackToString(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    /* The toString should have the form:
+     *     InetAddress / prefix length [ broadcast address ]
+     */
+
+    val netIf = NetworkInterface.getByIndex(1) // loopback
+    assertNotNull(netIf)
+
+    val ifAddresses = netIf.getInterfaceAddresses()
+    assertTrue("No InterfaceAddress found", ifAddresses.size > 0)
+
+    ifAddresses.forEach { addr =>
+      val ifAddrString = addr.toString
+
+      // macOS can have two forms of IPv6 loopback address.
+      val expected =
+        if (!ifAddrString.contains(":")) {
+          "/127.0.0.1/8 [null]"
+        } else if (ifAddrString.startsWith("/0")) {
+          s"/0:0:0:0:0:0:0:1%${localhostIf}/128 [null]"
+        } else if (ifAddrString.startsWith("/f")) {
+          s"/${osIPv6LoopbackAddress}/${osIPv6PrefixLength} [null]"
+        } else "" // fail in a way that will print out ifAddrString
+
+      assertEquals("InterfaceAddress", expected, ifAddrString)
+    }
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/javalib/net/InterfaceAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InterfaceAddressTest.scala
@@ -9,8 +9,6 @@ import org.junit.Assume._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform
 
-import scalanative.meta.LinktimeInfo
-
 /* Design Notes:
  *    1) As the underlying implementation is Unix only, so are these Tests.
  *
@@ -29,18 +27,18 @@ class InterfaceAddressTest {
    */
 
   val localhostIf =
-    if (LinktimeInfo.isLinux) "lo"
+    if (Platform.isLinux) "lo"
     else "lo0"
 
   val osIPv6PrefixLength =
-    if (LinktimeInfo.isMac) 64
+    if (Platform.isMacOs) 64
     else 128
 
   val osIPv6LoopbackSuffix =
     s":0:0:0:0:0:0:1%${localhostIf}"
 
   val osIPv6LoopbackAddress =
-    if (LinktimeInfo.isMac) s"fe80${osIPv6LoopbackSuffix}"
+    if (Platform.isMacOs) s"fe80${osIPv6LoopbackSuffix}"
     else s"0${osIPv6LoopbackSuffix}"
 
   /* Test equals() but there is no good, simple way to test corresponding

--- a/unit-tests/shared/src/test/scala/javalib/net/NetworkInterfaceTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/NetworkInterfaceTest.scala
@@ -9,7 +9,7 @@ import org.junit.Assume._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform
 
-import scala.scalanative.meta.LinktimeInfo
+import scalanative.meta.LinktimeInfo
 
 /* Design Notes:
  *    1) As the underlying implementation is Unix only, so are these Tests.

--- a/unit-tests/shared/src/test/scala/javalib/net/NetworkInterfaceTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/NetworkInterfaceTest.scala
@@ -1,0 +1,283 @@
+package javalib.net
+
+import java.net._
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform
+
+import scala.scalanative.meta.LinktimeInfo
+
+/* Design Notes:
+ *    1) As the underlying implementation is Unix only, so are these Tests.
+ *
+ *    2) Network interface configuration is can and does vary greatly from
+ *       system to system. These tests are written to succeed with the
+ *       configuration used by the Scala Native Continuous Integration systems.
+ *
+ *       They may fail if used outside of that environment and require
+ *       editing to reflect that local configuration.
+ */
+
+class NetworkInterfaceTest {
+
+  val localhostIf =
+    if (LinktimeInfo.isLinux) "lo"
+    else "lo0"
+
+// Test static (object) methods
+
+  @Test def getByIndexMinusTwo(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+    assertThrows(
+      "getByIndex(-2)",
+      classOf[IllegalArgumentException],
+      NetworkInterface.getByIndex(-2)
+    )
+  }
+
+  @Test def getByIndexZero(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+    assertNull(NetworkInterface.getByIndex(0))
+  }
+
+  @Test def getByIndexOne(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+    val netIf = NetworkInterface.getByIndex(1) // loopback
+
+    assertNotNull("a1", netIf)
+
+    val sought = localhostIf
+    val ifName = netIf.getName()
+    assertEquals("a2", sought, ifName)
+  }
+
+  @Test def getByIndexMaxValue(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+    val netIf = NetworkInterface.getByIndex(Integer.MAX_VALUE)
+    assertNull("Unlikely interface found for MAX_VALUE index", netIf)
+  }
+
+  @Test def getByInetAddressNull(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+    assertThrows(
+      "getByInetAddress(null)",
+      classOf[NullPointerException],
+      NetworkInterface.getByInetAddress(null)
+    )
+  }
+
+  @Test def getByInetAddressLoopbackIPv4(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+    val lba4 = InetAddress.getByName("127.0.0.1")
+
+    val netIf = NetworkInterface.getByInetAddress(lba4)
+
+    assertNotNull("a1", netIf)
+
+    val sought = localhostIf
+    val ifName = netIf.getName()
+    assertEquals("a1", sought, ifName)
+  }
+
+  @Test def getByInetAddressLoopbackIPv6(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+    val lba6 = InetAddress.getByName("::1")
+
+    val netIf = NetworkInterface.getByInetAddress(lba6)
+
+    // Do not fail on null. IPv6 might not be enabled on the system.
+    if (netIf != null) {
+      val sought = localhostIf
+      val ifName = netIf.getName()
+      assertEquals("a1", sought, ifName)
+    }
+  }
+
+  @Test def getByNameNull(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+    assertThrows(
+      "getByName(null)",
+      classOf[NullPointerException],
+      NetworkInterface.getByName(null)
+    )
+  }
+
+  @Test def getByName(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val sought = localhostIf
+    val netIf = NetworkInterface.getByName(sought)
+    assertNotNull(netIf)
+
+    val ifName = netIf.getName()
+
+    assertEquals("a1", sought, ifName)
+  }
+
+  @Test def testToString(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val netIf = NetworkInterface.getByIndex(1) // loopback
+    assertNotNull(netIf)
+
+    val ifName = netIf.getName()
+
+    // "lo" is Linux, systemd, "lo0" is macOS
+    if ((ifName == "lo") || (ifName == "lo0")) {
+      assertEquals("a1", s"name:${ifName} (${ifName})", netIf.toString)
+    } // else unknown configuration; skip, not fail.
+  }
+
+  @Test def getNetworkInterfaces(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val netIfs = NetworkInterface.getNetworkInterfaces()
+    assertNotNull(netIfs)
+
+    var count = 0
+
+    while (netIfs.hasMoreElements()) {
+      netIfs.nextElement()
+      count += 1
+    }
+
+    // count != 0 1 for loopback, 1 for World and possibly many more (macOS).
+    assertTrue("count >= 2", count >= 2)
+  }
+
+  @Test def networkInterfaces(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val netIfs = NetworkInterface.networkInterfaces()
+    assertNotNull(netIfs)
+
+    var count = 0
+
+    val itr = netIfs.iterator()
+    while (itr.hasNext()) {
+      itr.next
+      count += 1
+    }
+
+    // count != 0 1 for loopback, 1 for World and possibly many more (macOS).
+    assertTrue("count >= 2", count >= 2)
+  }
+
+// Test instance methods
+
+  @Test def instanceGetIndex(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf1 = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf1)
+    assertEquals(1, lbIf1.getIndex())
+  }
+
+  /*  @Test def instanceGetHardwareAddress(): Unit = {
+   *  Not implemented - system dependent.
+   *  Loopback addresses do not have hardware address to get.
+   *  Non-loopback primary interface varies and can not be determined.
+   */
+
+  @Test def instanceGetMTU(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf)
+
+    val mtu = lbIf.getMTU()
+
+    // To get tighter bounds, one would need to know config specific info.
+    assertTrue("mtu > 0", mtu > 0)
+    assertTrue("mtu <= 65536", mtu <= 65536)
+  }
+
+  @Test def instanceIsLoopback(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf)
+    assertEquals("a1", true, lbIf.isLoopback())
+  }
+
+  @Test def instanceIsPoinToPoint(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf)
+    assertEquals("a1", false, lbIf.isPointToPoint())
+  }
+
+  @Test def instanceIsUp(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf)
+    assertEquals("a1", true, lbIf.isUp())
+  }
+
+  @Test def instanceSupportsMulticast(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf)
+
+    val expected =
+      if (LinktimeInfo.isMac) true
+      else false // Linux
+    // else (FreeBSD?)
+
+    assertEquals("a1", expected, lbIf.supportsMulticast())
+  }
+
+  @Test def instanceGetInetAddresses(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf)
+
+    val iaEnumeration = lbIf.getInetAddresses()
+
+    var count = 0
+    while (iaEnumeration.hasMoreElements()) {
+      iaEnumeration.nextElement()
+      count += 1
+    }
+
+    if (Platform.isLinux) {
+      assertEquals("Linux", 2, count)
+    } else if (Platform.isMacOs) {
+      assertEquals("macOS", 3, count)
+    } // else add Platforms as they are verified
+  }
+
+  @Test def instanceInetAddresses(): Unit = {
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+
+    val lbIf = NetworkInterface.getByName(localhostIf)
+    assertNotNull(lbIf)
+
+    // SN Stream implements neither Stream.count() nor Stream.reduce()
+    val iaStream = lbIf.inetAddresses()
+
+    var count = 0
+
+    val itr = iaStream.iterator()
+
+    while (itr.hasNext()) {
+      itr.next()
+      count += 1
+    }
+
+    if (Platform.isLinux) {
+      assertEquals("Linux", 2, count)
+    } else if (Platform.isMacOs) {
+      assertEquals("macOS", 3, count)
+    } // else add Platforms as they are verified
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/javalib/net/NetworkInterfaceTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/NetworkInterfaceTest.scala
@@ -228,11 +228,7 @@ class NetworkInterfaceTest {
       count += 1
     }
 
-    if (Platform.isLinux) {
-      assertEquals("Linux", 2, count)
-    } else if (Platform.isMacOs) {
-      assertEquals("macOS", 3, count)
-    } // else add Platforms as they are verified
+    assertTrue("count > 0", count > 0)
   }
 
 }

--- a/unit-tests/shared/src/test/scala/javalib/net/NetworkInterfaceTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/NetworkInterfaceTest.scala
@@ -9,8 +9,6 @@ import org.junit.Assume._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform
 
-import scalanative.meta.LinktimeInfo
-
 /* Design Notes:
  *    1) As the underlying implementation is Unix only, so are these Tests.
  *
@@ -25,7 +23,7 @@ import scalanative.meta.LinktimeInfo
 class NetworkInterfaceTest {
 
   val localhostIf =
-    if (LinktimeInfo.isLinux) "lo"
+    if (Platform.isLinux) "lo"
     else "lo0"
 
 // Test static (object) methods
@@ -149,24 +147,6 @@ class NetworkInterfaceTest {
     assertTrue("count >= 2", count >= 2)
   }
 
-  @Test def networkInterfaces(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val netIfs = NetworkInterface.networkInterfaces()
-    assertNotNull(netIfs)
-
-    var count = 0
-
-    val itr = netIfs.iterator()
-    while (itr.hasNext()) {
-      itr.next
-      count += 1
-    }
-
-    // count != 0 1 for loopback, 1 for World and possibly many more (macOS).
-    assertTrue("count >= 2", count >= 2)
-  }
-
 // Test instance methods
 
   @Test def instanceGetIndex(): Unit = {
@@ -227,7 +207,7 @@ class NetworkInterfaceTest {
     assertNotNull(lbIf)
 
     val expected =
-      if (LinktimeInfo.isMac) true
+      if (Platform.isMacOs) true
       else false // Linux
     // else (FreeBSD?)
 
@@ -245,31 +225,6 @@ class NetworkInterfaceTest {
     var count = 0
     while (iaEnumeration.hasMoreElements()) {
       iaEnumeration.nextElement()
-      count += 1
-    }
-
-    if (Platform.isLinux) {
-      assertEquals("Linux", 2, count)
-    } else if (Platform.isMacOs) {
-      assertEquals("macOS", 3, count)
-    } // else add Platforms as they are verified
-  }
-
-  @Test def instanceInetAddresses(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val lbIf = NetworkInterface.getByName(localhostIf)
-    assertNotNull(lbIf)
-
-    // SN Stream implements neither Stream.count() nor Stream.reduce()
-    val iaStream = lbIf.inetAddresses()
-
-    var count = 0
-
-    val itr = iaStream.iterator()
-
-    while (itr.hasNext()) {
-      itr.next()
       count += 1
     }
 


### PR DESCRIPTION
The javalib `java.net.NetworkInterface` and `InterfaceAddress` classes allow to enumerate & query the 
network interfaces on a system.

This PR implements these classes on Linux & macOS. A Windows implementation should be possible
but is not part of this PR.