### PR TITLE
Another pass at reconciling clib & posixlib

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/complex.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/complex.scala
@@ -21,8 +21,9 @@ import scalanative.unsafe._
  *  https://en.wikipedia.org/wiki/Long_double
  *  http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/complex.h.html
  */
-@extern
-object complex {
+@extern object complex extends complex
+
+@extern trait complex {
   import Nat._2
   type CFloatComplex = CStruct2[CFloat, CFloat]
   type CDoubleComplex = CStruct2[CDouble, CDouble]

--- a/clib/src/main/scala/scala/scalanative/libc/ctype.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/ctype.scala
@@ -3,8 +3,9 @@ package libc
 
 import scalanative.unsafe._
 
-@extern
-object ctype {
+@extern object ctype extends ctype
+
+@extern trait ctype {
   def isascii(c: CInt): CInt = extern
   def isalnum(c: CInt): CInt = extern
   def isalpha(c: CInt): CInt = extern

--- a/clib/src/main/scala/scala/scalanative/libc/fenv.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/fenv.scala
@@ -3,8 +3,9 @@ package scala.scalanative
 package libc
 import scala.scalanative.unsafe._
 
-@extern
-object fenv {
+@extern object fenv extends fenv
+
+@extern trait fenv {
   type fexcept_t = CStruct0
   type fenv_t = CStruct0
 

--- a/clib/src/main/scala/scala/scalanative/libc/float.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/float.scala
@@ -4,8 +4,10 @@ package libc
 import scalanative.unsafe._
 
 /** Bindings for float.h */
-@extern
-object float {
+
+@extern object float extends float
+
+@extern trait float {
 
   // Macros
 

--- a/clib/src/main/scala/scala/scalanative/libc/tgmath.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/tgmath.scala
@@ -4,7 +4,9 @@ import scalanative.unsafe._
 
 /** tgmath.h binding ISO/IEC 9899:1999(C99)
  */
-object tgmath {
+object tgmath extends tgmath
+
+trait tgmath {
   // real
 
   import scala.scalanative.libc.math

--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -84,7 +84,6 @@ C Header          Scala Native Module
 `tgmath.h`_       scala.scalanative.posix.tgmath_
 `time.h`_         scala.scalanative.posix.time_
 `trace.h`_        N/A
-`ulimit.h`_       N/A
 `unistd.h`_       scala.scalanative.posix.unistd_
 `utime.h`_        scala.scalanative.posix.utime_
 `utmpx.h`_        N/A

--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -61,7 +61,6 @@ C Header          Scala Native Module
 `stdlib.h`_       scala.scalanative.posix.stdlib_
 `string.h`_       scala.scalanative.posix.string_
 `strings.h`_      scala.scalanative.posix.strings_
-`stropts.h`_      N/A
 `sys/ipc.h`_      N/A
 `sys/mman.h`_     scala.scalanative.posix.sys.mman_
 `sys/msg.h`_      N/A
@@ -146,7 +145,6 @@ C Header          Scala Native Module
 .. _stdlib.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdlib.h.html
 .. _string.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/string.h.html
 .. _strings.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/strings.h.html
-.. _stropts.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stropts.h.html
 .. _sys/ipc.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_ipc.h.html
 .. _sys/mman.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_mman.h.html
 .. _sys/msg.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_msg.h.html

--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -12,15 +12,15 @@ C Header          Scala Native Module
 `aio.h`_          N/A - *indicates binding not available*
 `arpa/inet.h`_    scala.scalanative.posix.arpa.inet_ [#inet_ntoa]_
 `assert.h`_       N/A
-`complex.h`_      scala.scalanative.libc.complex_
+`complex.h`_      scala.scalanative.posix.complex_
 `cpio.h`_         scala.scalanative.posix.cpio_
-`ctype.h`_        scala.scalanative.libc.ctype_
+`ctype.h`_        scala.scalanative.posix.ctype_
 `dirent.h`_       scala.scalanative.posix.dirent_
 `dlfcn.h`_        N/A
 `errno.h`_        scala.scalanative.posix.errno_
 `fcntl.h`_        scala.scalanative.posix.fcntl_
-`fenv.h`_         N/A
-`float.h`_        scala.scalanative.libc.float_
+`fenv.h`_         scala.scalanative.posix.fenv_
+`float.h`_        scala.scalanative.posix.float_
 `fmtmsg.h`_       N/A
 `fnmatch.h`_      N/A
 `ftw.h`_          N/A
@@ -82,7 +82,7 @@ C Header          Scala Native Module
 `syslog.h`_       scala.scalanative.posix.syslog_
 `tar.h`_          N/A
 `termios.h`_      scala.scalanative.posix.termios_
-`tgmath.h`_       N/A
+`tgmath.h`_       scala.scalanative.posix.tgmath_
 `time.h`_         scala.scalanative.posix.time_
 `trace.h`_        N/A
 `ulimit.h`_       N/A
@@ -157,6 +157,7 @@ C Header          Scala Native Module
 .. _sys/socket.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
 .. _sys/stat.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html
 .. _sys/statvfs.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_statvfs.h.html
+.. _sys/tgmath.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_tgmath.h.html
 .. _sys/time.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_time.h.html
 .. _sys/times.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_times.h.html
 .. _sys/types.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html
@@ -179,13 +180,14 @@ C Header          Scala Native Module
 .. _wordexp.h: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/wordexp.h.html
 
 .. _scala.scalanative.posix.arpa.inet: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
-.. _scala.scalanative.libc.complex: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/complex.scala
-.. _scala.scalanative.libc.ctype: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/ctype.scala
+.. _scala.scalanative.posix.complex: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/complex.scala
+.. _scala.scalanative.posix.ctype: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/ctype.scala
 .. _scala.scalanative.posix.cpio: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/cpio.scala
 .. _scala.scalanative.posix.dirent: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
 .. _scala.scalanative.posix.errno: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
 .. _scala.scalanative.posix.fcntl: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
-.. _scala.scalanative.libc.float: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/float.scala
+.. _scala.scalanative.posix.fenv: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/fenv.scala
+.. _scala.scalanative.posix.float: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/float.scala
 .. _scala.scalanative.posix.getopt: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
 .. _scala.scalanative.posix.grp: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
 .. _scala.scalanative.posix.inttypes: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/inttypes.scala
@@ -221,6 +223,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.sys.utsname: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/utsname.scala
 .. _scala.scalanative.posix.syslog: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/syslog.scala
 .. _scala.scalanative.posix.termios: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/termios.scala
+.. _scala.scalanative.posix.tgmath: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/tgmath.scala
 .. _scala.scalanative.posix.time: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/time.scala
 .. _scala.scalanative.posix.unistd: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
 .. _scala.scalanative.posix.utime: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/utime.scala

--- a/posixlib/src/main/scala/scala/scalanative/posix/complex.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/complex.scala
@@ -1,0 +1,10 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+@extern object complex extends complex
+
+@extern trait complex extends libc.complex {
+  // no extensions yet
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/ctype.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/ctype.scala
@@ -1,0 +1,10 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+@extern object ctype extends ctype
+
+@extern trait ctype extends libc.ctype {
+  // no extensions yet
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/fenv.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fenv.scala
@@ -1,0 +1,10 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+@extern object fenv extends fenv
+
+@extern trait fenv extends libc.fenv {
+  // no extensions yet
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/float.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/float.scala
@@ -1,0 +1,10 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+@extern object float extends float
+
+@extern trait float extends libc.float {
+  // no extensions yet
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/tgmath.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/tgmath.scala
@@ -1,0 +1,10 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+object tgmath extends tgmath
+
+trait tgmath extends libc.tgmath {
+  // no extensions yet
+}


### PR DESCRIPTION
This PR builds on the recent work of Ekrich & Wojciech using the recent `extern trait` work to  create
files in posixlib based on a clib implementation.

I compared the list of POSIX .h files in `posixlib.rst`  with a list of files implemented in clib. Where
a file existed in clib but not posixlib, I edited the clib file to allow using the `extern trait` idiom in
a new posixlib file.  

Of course, the posixlib documentation was updated.

