### PR TITLE
Fix #2291, #2764: Document long standing fact that unsafe.stackalloc[T] zeros returned memory

### DIFF
--- a/docs/changelog/0.5.0.md
+++ b/docs/changelog/0.5.0.md
@@ -162,7 +162,9 @@ lazy val myproj = project
 We added ...
 
 ## Bugfixes
-* xxx
+
+* Document the long standing fact that ``unsafe.stackalloc[T]``
+  zeros the allocated memory.
 
 ## Contributors
 

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -338,7 +338,7 @@ runtime system, one has to be extra careful when working with unmanaged memory.
 
    This code will allocate 256 bytes that are going to be available until
    the enclosing method returns. Number of elements to be allocated is optional
-   and defaults to 1 otherwise. Memory is not zeroed out by default.
+   and defaults to 1 otherwise. Memory **is zeroed out** by default.
 
    When using stack allocated memory one has to be careful not to capture
    this memory beyond the lifetime of the method. Dereferencing stack allocated


### PR DESCRIPTION
Fix #2291, Fix #2764

For 18+ months, `stackalloc[t]` has been documented in the code as _zeroing_ returned memory. The
corresponding `memset()` gives credence that the documentation is correct.

The PR brings the user documentation into correspondence with the actual behavior.

This may allow some developer who believed the now superseded documentation
to remove code to zero memory immediately after a `stackalloc[T]`  and gain a few
CPU cycles of performance.