### PR TITLE
Fix #2900: Implement posixlib un.scala

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -76,7 +76,7 @@ C Header          Scala Native Module
 `sys/times.h`_    N/A
 `sys/types.h`_    scala.scalanative.posix.sys.types_
 `sys/uio.h`_      scala.scalanative.posix.sys.uio_
-`sys/un.h`_       N/A
+`sys/un.h`_       scala.scalanative.posix.sys.un_
 `sys/utsname.h`_  scala.scalanative.posix.sys.utsname_
 `sys/wait.h`_     N/A
 `syslog.h`_       scala.scalanative.posix.syslog_
@@ -218,6 +218,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.sys.time: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
 .. _scala.scalanative.posix.sys.types: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/types.scala
 .. _scala.scalanative.posix.sys.uio: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
+.. _scala.scalanative.posix.sys.un: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
 .. _scala.scalanative.posix.sys.utsname: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/utsname.scala
 .. _scala.scalanative.posix.syslog: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/syslog.scala
 .. _scala.scalanative.posix.termios: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/termios.scala

--- a/posixlib/src/main/resources/scala-native/sys/un.c
+++ b/posixlib/src/main/resources/scala-native/sys/un.c
@@ -1,0 +1,35 @@
+#ifdef _WIN32
+// Recent Windows has <afunix.h>, which uses 108 for sun_path.
+// No code here to assure that.
+#else
+#include <sys/socket.h>
+#if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
+#ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
+#warning "Size and order of C structures are not checked when -std < c11."
+#endif
+#else // POSIX
+#include <stddef.h>
+#include <sys/un.h>
+
+typedef unsigned short scalanative_sa_family_t;
+
+// 108 for sun_path is the Linux value is >= macOS value of 104. Checked below.
+struct scalanative_sockaddr_un {
+    scalanative_sa_family_t sun_family;
+    char sun_path[108];
+};
+
+// Also verifies that Scala Native sun_family field has the traditional size.
+_Static_assert(offsetof(struct scalanative_sockaddr_un, sun_path) == 2,
+               "Unexpected size: scalanative_sockaddr_un sun_family");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_un, sun_path) ==
+                   offsetof(struct sockaddr_un, sun_path),
+               "offset mismatch: sockaddr_un sun_path");
+
+_Static_assert(sizeof(struct sockaddr_un) <=
+                   sizeof(struct scalanative_sockaddr_un),
+               "size mismatch: sockaddr_un sun_path");
+
+#endif // POSIX
+#endif // ! _WIN32

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
@@ -5,8 +5,6 @@ package sys
 import scalanative.unsafe._
 import scalanative.unsigned._
 
-import scalanative.posix.sys.socket
-
 import scalanative.runtime.Platform
 
 /** POSIX sys/un.h for Scala

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
@@ -1,0 +1,69 @@
+package scala.scalanative
+package posix
+package sys
+
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+import scalanative.posix.sys.socket
+
+import scalanative.runtime.Platform
+
+/** POSIX sys/un.h for Scala
+ */
+
+@extern
+object un {
+  type _108 = Nat.Digit3[Nat._1, Nat._0, Nat._8]
+
+  type sa_family_t = socket.sa_family_t
+
+  /* _Static_assert guard code in the un.c assures the SN sockaddr_un is
+   * >= the  corresponding Unix operating system version.
+   * 108 for sun_path is the Linux & Windows value. It is >= macOS 104 bytes.
+   */
+
+  type sockaddr_un = CStruct2[
+    sa_family_t, // sun_family, sun_len is synthesized if needed
+    CArray[CChar, _108] // sun_path
+  ]
+}
+
+/** Allow using C names to access socket_un structure fields.
+ */
+object unOps {
+  import un._
+  import posix.inttypes.uint8_t
+
+  val useSinXLen = !Platform.isLinux() &&
+    (Platform.isMac() || Platform.isFreeBSD())
+
+  implicit class sockaddr_unOps(val ptr: Ptr[sockaddr_un]) extends AnyVal {
+    def sun_len: uint8_t = if (!useSinXLen) {
+      sizeof[sockaddr_un].toUByte // length is synthesized
+    } else {
+      ptr._1.toUByte
+    }
+
+    def sun_family: sa_family_t = if (!useSinXLen) {
+      ptr._1
+    } else {
+      (ptr._1 >>> 8).toUByte
+    }
+
+    def sun_path: CArray[CChar, _108] = ptr._2
+
+    def sun_len_=(v: uint8_t): Unit = if (useSinXLen) {
+      ptr._1 = ((ptr._1 & 0xff00.toUShort) + v).toUShort
+    } // else silently do nothing
+
+    def sun_family_=(v: sa_family_t): Unit =
+      if (!useSinXLen) {
+        ptr._1 = v
+      } else {
+        ptr._1 = ((v << 8) + ptr.sun_len).toUShort
+      }
+
+    def sun_path_=(v: CArray[CChar, _108]): Unit = ptr._2 = v
+  }
+}


### PR DESCRIPTION
Fix #2900 Fix #2899

Implement POSIX un.h.  That file provides the `sockaddr_un` structure used with AF_UNIX
sockets. This PR defines that structure in a way which should work across Linux, macOS, &
recent enough Windows.

This PR is based upon work by Arman Bilge in `fs2-io_uring` and used by kind contribution
& license. Thank you Arman.    As always, any bugs are my original work.