### PR TITLE
Fix #2973: Implement some requested j.io.InputStream Java 9 &11 methods

### DIFF
--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -1,5 +1,7 @@
 package java.io
 
+import java.{util => ju}
+
 abstract class InputStream extends Closeable {
   def read(): Int
 
@@ -32,6 +34,81 @@ abstract class InputStream extends Closeable {
     }
   }
 
+  // Allow obvious implementation of readAllBytes() to work on both Java 9 & 11
+  def readNBytesImpl(len: Int): Array[Byte] = {
+    if (len < 0)
+      throw new IllegalArgumentException("len < 0")
+
+    def readBytes(len: Int): ByteArrayOutputStream = {
+      val limit = Math.min(len, 1024)
+
+      val storage = new ByteArrayOutputStream(limit) // can grow itself
+      val buffer = new Array[Byte](limit)
+
+      var remaining = len
+
+      while (remaining > 0) {
+        val nRead = read(buffer, 0, limit)
+
+        if (nRead == -1) remaining = 0 // EOF
+        else {
+          storage.write(buffer, 0, nRead)
+          remaining -= nRead
+        }
+      }
+
+      storage
+    }
+
+    /* To stay within the documented 2 * len memory bound for this method,
+     * ensure that the temporary intermediate read buffer is out of scope
+     * and released before calling toByteArray().
+     */
+
+    readBytes(len).toByteArray()
+  }
+
+  /** Java 9
+   */
+  def readAllBytes(): Array[Byte] = readNBytesImpl(Integer.MAX_VALUE)
+
+  /** Java 9
+   */
+  def readNBytes(buffer: Array[Byte], off: Int, len: Int): Int = {
+    ju.Objects.requireNonNull(buffer)
+
+    if ((off < 0) || (len < 0) || (len > buffer.length - off)) {
+      val range = s"Range [${off}, ${off} + ${len})"
+      throw new IndexOutOfBoundsException(
+        s"${range} out of bounds for length ${buffer.length}"
+      )
+    }
+
+    if (len == 0) 0
+    else {
+      var totalBytesRead = 0
+      var remaining = len
+      var offset = off
+
+      while (remaining > 0) {
+        val nRead = read(buffer, offset, remaining)
+
+        if (nRead == -1) remaining = 0 // EOF
+        else {
+          totalBytesRead += nRead
+          remaining -= nRead
+          offset += nRead
+        }
+      }
+
+      totalBytesRead
+    }
+  }
+
+  /** Java 11
+   */
+  def readNBytes(len: Int): Array[Byte] = readNBytesImpl(len)
+
   def skip(n: Long): Long = {
     var skipped = 0
     while (skipped < n && read() != -1) skipped += 1
@@ -48,4 +125,25 @@ abstract class InputStream extends Closeable {
     throw new IOException("Reset not supported")
 
   def markSupported(): Boolean = false
+
+  /** Java 9
+   */
+  def transferTo(out: OutputStream): Long = {
+    val limit = 1024
+    val buffer = new Array[Byte](limit)
+
+    var nTransferred = 0L
+    var done = false
+
+    while (!done) {
+      val nRead = readNBytes(buffer, 0, limit)
+      if (nRead == 0) done = true // EOF
+      else {
+        out.write(buffer, 0, nRead)
+        nTransferred += nRead
+      }
+    }
+
+    nTransferred
+  }
 }

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK11.scala
@@ -1,0 +1,38 @@
+package javalib.io
+
+import java.io._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class InputStreamTestOnJDK11 {
+
+  @Test def readNBytesLenNegativeLength(): Unit = {
+    val inputBytes =
+      List(255, 254, 253, 252)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+
+    assertThrows(
+      classOf[IllegalArgumentException],
+      streamIn.readNBytes(-3)
+    )
+  }
+
+  @Test def readNBytesLen(): Unit = {
+    val inputBytes =
+      List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+    val len = 5
+    val result = streamIn.readNBytes(len)
+
+    assertEquals("result length", len, result.length)
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK9.scala
@@ -1,0 +1,102 @@
+package javalib.io
+
+import java.io._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class InputStreamTestOnJDK9 {
+
+  @Test def readAllBytes(): Unit = {
+
+    val inputBytes =
+      List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+    val result = streamIn.readAllBytes()
+
+    assertEquals("result length", inputBytes.length, result.length)
+  }
+
+  @Test def readNBytesBufferOffLenExceptions(): Unit = {
+    val inputBytes =
+      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+    val receiver = new Array[Byte](10)
+    val nRead = streamIn.readNBytes(receiver, 0, receiver.length)
+
+    assertThrows(
+      classOf[NullPointerException],
+      streamIn.readNBytes(null, 0, receiver.length)
+    )
+
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      streamIn.readNBytes(receiver, -2, receiver.length)
+    )
+
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      streamIn.readNBytes(receiver, 0, -3)
+    )
+
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      streamIn.readNBytes(receiver, 0, Integer.MAX_VALUE)
+    )
+  }
+
+  @Test def readNBytesBufferOffLen(): Unit = {
+    val inputBytes =
+      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+    val receiver = new Array[Byte](10)
+    val nRead = streamIn.readNBytes(receiver, 0, receiver.length)
+
+    assertEquals("nRead", receiver.length, nRead)
+
+    val expected = 9
+    assertEquals("expected content", expected, receiver(expected))
+  }
+
+  @Test def transferToNullOutStream(): Unit = {
+    val inputBytes =
+      List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+    val streamOut = null.asInstanceOf[ByteArrayOutputStream]
+
+    assertThrows(
+      classOf[NullPointerException],
+      streamIn.transferTo(streamOut)
+    )
+  }
+
+  @Test def transferTo(): Unit = {
+    val inputBytes =
+      List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+    val streamOut = new ByteArrayOutputStream()
+
+    val nTransferred = streamIn.transferTo(streamOut).toInt
+
+    assertEquals("nBytes transferred", inputBytes.length, nTransferred)
+    assertEquals("streamOut size", nTransferred, streamOut.size())
+
+    val outputBytes = streamOut.toByteArray()
+    for (j <- 0 until inputBytes.length)
+      assertEquals(s"in(${j}) != out(${j})", inputBytes(j), outputBytes(j))
+  }
+
+}


### PR DESCRIPTION
Fix #2973 

Implement some methods on `java.io.InputStream`: three for Java 9 and one for Java 11.