### PR TITLE
Generate scaladoc for javalib in Scala 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Getting Started and full documentation can be found at [https://www.scala-native
 ## Online Scaladoc
 
 [![Scaladoc nativelib](https://javadoc.io/badge2/org.scala-native/nativelib_native0.4_3/javadoc.svg?label=nativelib)](https://javadoc.io/doc/org.scala-native/nativelib_native0.4_3)
+[![Scaladoc javalib](https://javadoc.io/badge2/org.scala-native/javalib_native0.4_3/javadoc.svg?label=javalib)](https://javadoc.io/doc/org.scala-native/javalib_native0.4_3)
 [![Scaladoc clib](https://javadoc.io/badge2/org.scala-native/clib_native0.4_3/javadoc.svg?label=clib)](https://javadoc.io/doc/org.scala-native/clib_native0.4_3)
 [![Scaladoc posixlib](https://javadoc.io/badge2/org.scala-native/posixlib_native0.4_3/javadoc.svg?label=posixlib)](https://javadoc.io/doc/org.scala-native/posixlib_native0.4_3)
 [![Scaladoc windowslib](https://javadoc.io/badge2/org.scala-native/windowslib_native0.4_3/javadoc.svg?label=windowslib)](https://javadoc.io/doc/org.scala-native/windowslib_native0.4_3)

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -182,8 +182,8 @@ class Character(val _value: scala.Char)
 
 object Character {
   final val TYPE = scala.Predef.classOf[scala.scalanative.runtime.PrimitiveChar]
-  final val MIN_VALUE = '\u0000'
-  final val MAX_VALUE = '\uffff'
+  final val MIN_VALUE: Char = '\u0000'
+  final val MAX_VALUE: Char = '\uffff'
   final val SIZE = 16
   final val BYTES = 2
 
@@ -224,12 +224,12 @@ object Character {
   final val MIN_RADIX = 2
   final val MAX_RADIX = 36
 
-  final val MIN_HIGH_SURROGATE = '\uD800'
-  final val MAX_HIGH_SURROGATE = '\uDBFF'
-  final val MIN_LOW_SURROGATE = '\uDC00'
-  final val MAX_LOW_SURROGATE = '\uDFFF'
-  final val MIN_SURROGATE = MIN_HIGH_SURROGATE
-  final val MAX_SURROGATE = MAX_LOW_SURROGATE
+  final val MIN_HIGH_SURROGATE: Char = '\uD800'
+  final val MAX_HIGH_SURROGATE: Char = '\uDBFF'
+  final val MIN_LOW_SURROGATE: Char = '\uDC00'
+  final val MAX_LOW_SURROGATE: Char = '\uDFFF'
+  final val MIN_SURROGATE: Char = MIN_HIGH_SURROGATE
+  final val MAX_SURROGATE: Char = MAX_LOW_SURROGATE
 
   final val MIN_CODE_POINT = 0
   final val MAX_CODE_POINT = 0x10ffff

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -250,7 +250,7 @@ private[lang] class UnixProcessGen2 private (
 
     val fds = stackalloc[struct_pollfd](1.toUInt)
     (fds + 0).fd = pidFd
-    (fds + 0).events = pollEvents.POLLIN | pollEvents.POLLRDNORM
+    (fds + 0).events = (pollEvents.POLLIN | pollEvents.POLLRDNORM).toShort
 
     val tmo = timeout.getOrElse(null)
 

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -17,98 +17,23 @@ import java.util.function.UnaryOperator
 
 import ArrayDeque._
 
-/** Resizable-array implementation of the {@link Deque} interface. Array deques
- *  have no capacity restrictions; they grow as necessary to support usage. They
- *  are not thread-safe; in the absence of external synchronization, they do not
- *  support concurrent access by multiple threads. Null elements are prohibited.
- *  This class is likely to be faster than {@link Stack} when used as a stack,
- *  and faster than {@link LinkedList} when used as a queue.
- *
- *  <p>Most {@code ArrayDeque} operations run in amortized constant time.
- *  Exceptions include {@link #remove(Object) remove}, {@link
- *  #removeFirstOccurrence removeFirstOccurrence}, {@link #removeLastOccurrence
- *  removeLastOccurrence}, {@link #contains contains}, {@link #iterator
- *  iterator.remove()}, and the bulk operations, all of which run in linear
- *  time.
- *
- *  <p>The iterators returned by this class's {@link #iterator() iterator}
- *  method are <em>fail-fast</em>: If the deque is modified at any time after
- *  the iterator is created, in any way except through the iterator's own {@code
- *  remove} method, the iterator will generally throw a {@link
- *  ConcurrentModificationException}. Thus, in the face of concurrent
- *  modification, the iterator fails quickly and cleanly, rather than risking
- *  arbitrary, non-deterministic behavior at an undetermined time in the future.
- *
- *  <p>Note that the fail-fast behavior of an iterator cannot be guaranteed as
- *  it is, generally speaking, impossible to make any hard guarantees in the
- *  presence of unsynchronized concurrent modification. Fail-fast iterators
- *  throw {@code ConcurrentModificationException} on a best-effort basis.
- *  Therefore, it would be wrong to write a program that depended on this
- *  exception for its correctness: <i>the fail-fast behavior of iterators should
- *  be used only to detect bugs.</i>
- *
- *  <p>This class and its iterator implement all of the <em>optional</em>
- *  methods of the {@link Collection} and {@link Iterator} interfaces.
- *
- *  <p>This class is a member of the <a
- *  href="{@docRoot}/java.base/java/util/package-summary.html#CollectionsFramework">
- *  Java Collections Framework</a>.
- *
- *  @author
- *    Josh Bloch and Doug Lea
- *  @param <E>
- *    the type of elements held in this deque
- *  @since 1.6
- */
 object ArrayDeque {
 
-  /** The maximum size of array to allocate. Some VMs reserve some header words
-   *  in an array. Attempts to allocate larger arrays may result in
-   *  OutOfMemoryError: Requested array size exceeds VM limit
-   */
   private val MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8
 
 }
 
 class ArrayDeque[E](
-    /** The array in which the elements of the deque are stored. All array cells
-     *  not holding deque elements are always null. The array always has at
-     *  least one null slot (at tail).
-     */
     var elements: Array[Object]
 ) extends AbstractCollection[E]
     with Deque[E]
     with Cloneable
     with Serializable {
-  /*
-   * VMs excel at optimizing simple array loops where indices are
-   * incrementing or decrementing over a valid slice, e.g.
-   *
-   * for (int i = start; i < end; i++) ... elements[i]
-   *
-   * Because in a circular array, elements are in general stored in
-   * two disjoint such slices, we help the VM by writing unusual
-   * nested loops for all traversals over the elements.  Having only
-   * one hot inner loop body instead of two or three eases human
-   * maintenance and encourages VM loop inlining into the caller.
-   */
 
-  /** The index of the element at the head of the deque (which is the element
-   *  that would be removed by remove() or pop()); or an arbitrary number 0 <=
-   *  head < elements.length equal to tail if the deque is empty.
-   */
   var head: Int = _
 
-  /** The index at which the next element would be added to the tail of the
-   *  deque (via addLast(E), add(E), or push(E)); elements[tail] is always null.
-   */
   var tail: Int = _
 
-  /** Increases the capacity of this deque by at least the given amount.
-   *
-   *  @param needed
-   *    the required minimum extra capacity; must be positive
-   */
   private def grow(needed: Int): Unit = {
     // overflow-conscious code
     val oldCapacity = elements.length
@@ -138,7 +63,6 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
-  /** Capacity calculation for edge conditions, especially overflow. */
   private def newCapacity(needed: Int, jump: Int): Int = {
     val oldCapacity = elements.length
     val minCapacity = oldCapacity + needed
@@ -154,14 +78,6 @@ class ArrayDeque[E](
     else MAX_ARRAY_SIZE
   }
 
-  /** Increases the internal storage of this collection, if necessary, to ensure
-   *  that it can hold at least the given number of elements.
-   *
-   *  @param minCapacity
-   *    the desired minimum capacity
-   *  @since TBD
-   */
-  /* public */
   def ensureCapacity(minCapacity: Int): Unit = {
     val needed = minCapacity + 1 - elements.length
     if (needed > 0)
@@ -169,11 +85,6 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
-  /** Minimizes the internal storage of this collection.
-   *
-   *  @since TBD
-   */
-  /* public */
   def trimToSize(): Unit = {
     val size = this.size()
     if (size + 1 < elements.length) {
@@ -184,19 +95,10 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
-  /** Constructs an empty array deque with an initial capacity sufficient to
-   *  hold 16 elements.
-   */
   def this() = {
     this(new Array[Object](16 + 1))
   }
 
-  /** Constructs an empty array deque with an initial capacity sufficient to
-   *  hold the specified number of elements.
-   *
-   *  @param numElements
-   *    lower bound on initial capacity of the deque
-   */
   def this(numElements: Int) = {
     this(
       new Array[Object](
@@ -208,73 +110,39 @@ class ArrayDeque[E](
     )
   }
 
-  /** Constructs a deque containing the elements of the specified collection, in
-   *  the order they are returned by the collection's iterator. (The first
-   *  element returned by the collection's iterator becomes the first element,
-   *  or <i>front</i> of the deque.)
-   *
-   *  @param c
-   *    the collection whose elements are to be placed into the deque
-   *  @throws NullPointerException
-   *    if the specified collection is null
-   */
   def this(c: Collection[_ <: E]) = {
     this(c.size())
     copyElements(c)
   }
 
-  /** Circularly increments i, mod modulus. Precondition and postcondition: 0 <=
-   *  i < modulus.
-   */
   private def inc(_i: Int, modulus: Int): Int = {
     var i = _i + 1
     if (i >= modulus) i = 0
     return i
   }
 
-  /** Circularly decrements i, mod modulus. Precondition and postcondition: 0 <=
-   *  i < modulus.
-   */
   private def dec(_i: Int, modulus: Int): Int = {
     var i = _i - 1
     if (i < 0) i = modulus - 1
     return i
   }
 
-  /** Circularly adds the given distance to index i, mod modulus. Precondition:
-   *  0 <= i < modulus, 0 <= distance <= modulus.
-   *  @return
-   *    index 0 <= i < modulus
-   */
   private def inc(_i: Int, distance: Int, modulus: Int): Int = {
     var i = _i + distance
     if (i - modulus >= 0) i -= modulus
     return i
   }
 
-  /** Subtracts j from i, mod modulus. Index i must be logically ahead of index
-   *  j. Precondition: 0 <= i < modulus, 0 <= j < modulus.
-   *  @return
-   *    the "circular distance" from j to i; corner case i == j is disambiguated
-   *    to "empty", returning 0.
-   */
   private def sub(_i: Int, j: Int, modulus: Int): Int = {
     var i = _i - j
     if (i < 0) i += modulus
     return i
   }
 
-  /** Returns element at array index i. This is a slight abuse of generics,
-   *  accepted by javac.
-   */
   private def elementAt(es: Array[Object], i: Int): E = {
     return es(i).asInstanceOf[E]
   }
 
-  /** A version of elementAt that checks for null elements. This check doesn't
-   *  catch all possible comodifications, but does catch ones that corrupt
-   *  traversal.
-   */
   private def nonNullElementAt(es: Array[Object], i: Int): E = {
     val e = es(i).asInstanceOf[E]
     if (e == null)
@@ -282,17 +150,6 @@ class ArrayDeque[E](
     return e
   }
 
-  // The main insertion and extraction methods are addFirst,
-  // addLast, pollFirst, pollLast. The other methods are defined in
-  // terms of these.
-
-  /** Inserts the specified element at the front of this deque.
-   *
-   *  @param e
-   *    the element to add
-   *  @throws NullPointerException
-   *    if the specified element is null
-   */
   def addFirst(e: E): Unit = {
     if (e == null)
       throw new NullPointerException()
@@ -304,15 +161,6 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
-  /** Inserts the specified element at the end of this deque.
-   *
-   *  <p>This method is equivalent to {@link #add}.
-   *
-   *  @param e
-   *    the element to add
-   *  @throws NullPointerException
-   *    if the specified element is null
-   */
   def addLast(e: E): Unit = {
     if (e == null)
       throw new NullPointerException()
@@ -324,17 +172,6 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
-  /** Adds all of the elements in the specified collection at the end of this
-   *  deque, as if by calling {@link #addLast} on each one, in the order that
-   *  they are returned by the collection's iterator.
-   *
-   *  @param c
-   *    the elements to be inserted into this deque
-   *  @return
-   *    {@code true} if this deque changed as a result of the call
-   *  @throws NullPointerException
-   *    if the specified collection or any of its elements are null
-   */
   override def addAll(c: Collection[_ <: E]): Boolean = {
     val s = size()
     val needed = s + c.size() + 1 - elements.length
@@ -349,37 +186,16 @@ class ArrayDeque[E](
     c.forEach(addLast(_))
   }
 
-  /** Inserts the specified element at the front of this deque.
-   *
-   *  @param e
-   *    the element to add
-   *  @return
-   *    {@code true} (as specified by {@link Deque#offerFirst})
-   *  @throws NullPointerException
-   *    if the specified element is null
-   */
   def offerFirst(e: E): Boolean = {
     addFirst(e)
     return true
   }
 
-  /** Inserts the specified element at the end of this deque.
-   *
-   *  @param e
-   *    the element to add
-   *  @return
-   *    {@code true} (as specified by {@link Deque#offerLast})
-   *  @throws NullPointerException
-   *    if the specified element is null
-   */
   def offerLast(e: E): Boolean = {
     addLast(e)
     return true
   }
 
-  /** @throws NoSuchElementException
-   *    {@inheritDoc}
-   */
   def removeFirst(): E = {
     val e = pollFirst()
     if (e == null)
@@ -388,9 +204,6 @@ class ArrayDeque[E](
     return e
   }
 
-  /** @throws NoSuchElementException
-   *    {@inheritDoc}
-   */
   def removeLast(): E = {
     val e = pollLast()
     if (e == null)
@@ -423,9 +236,6 @@ class ArrayDeque[E](
     return e
   }
 
-  /** @throws NoSuchElementException
-   *    {@inheritDoc}
-   */
   def getFirst(): E = {
     val e = elementAt(elements, head)
     if (e == null)
@@ -434,9 +244,6 @@ class ArrayDeque[E](
     return e
   }
 
-  /** @throws NoSuchElementException
-   *    {@inheritDoc}
-   */
   def getLast(): E = {
     val es = elements
     val e = elementAt(es, dec(tail, es.length))
@@ -457,18 +264,6 @@ class ArrayDeque[E](
     return elementAt(es, dec(tail, es.length))
   }
 
-  /** Removes the first occurrence of the specified element in this deque (when
-   *  traversing the deque from head to tail). If the deque does not contain the
-   *  element, it is unchanged. More formally, removes the first element {@code
-   *  e} such that {@code o.equals(e)} (if such an element exists). Returns
-   *  {@code true} if this deque contained the specified element (or
-   *  equivalently, if this deque changed as a result of the call).
-   *
-   *  @param o
-   *    element to be removed from this deque, if present
-   *  @return
-   *    {@code true} if the deque contained the specified element
-   */
   def removeFirstOccurrence(o: Any): Boolean = {
     if (o != null) {
       val es = elements
@@ -491,18 +286,6 @@ class ArrayDeque[E](
     return false
   }
 
-  /** Removes the last occurrence of the specified element in this deque (when
-   *  traversing the deque from head to tail). If the deque does not contain the
-   *  element, it is unchanged. More formally, removes the last element {@code
-   *  e} such that {@code o.equals(e)} (if such an element exists). Returns
-   *  {@code true} if this deque contained the specified element (or
-   *  equivalently, if this deque changed as a result of the call).
-   *
-   *  @param o
-   *    element to be removed from this deque, if present
-   *  @return
-   *    {@code true} if the deque contained the specified element
-   */
   def removeLastOccurrence(o: Any): Boolean = {
     if (o != null) {
       val es = elements
@@ -528,136 +311,41 @@ class ArrayDeque[E](
 
   // *** Queue methods ***
 
-  /** Inserts the specified element at the end of this deque.
-   *
-   *  <p>This method is equivalent to {@link #addLast}.
-   *
-   *  @param e
-   *    the element to add
-   *  @return
-   *    {@code true} (as specified by {@link Collection#add})
-   *  @throws NullPointerException
-   *    if the specified element is null
-   */
   override def add(e: E): Boolean = {
     addLast(e)
     return true
   }
 
-  /** Inserts the specified element at the end of this deque.
-   *
-   *  <p>This method is equivalent to {@link #offerLast}.
-   *
-   *  @param e
-   *    the element to add
-   *  @return
-   *    {@code true} (as specified by {@link Queue#offer})
-   *  @throws NullPointerException
-   *    if the specified element is null
-   */
   def offer(e: E): Boolean = {
     return offerLast(e)
   }
 
-  /** Retrieves and removes the head of the queue represented by this deque.
-   *
-   *  This method differs from {@link #poll() poll()} only in that it throws an
-   *  exception if this deque is empty.
-   *
-   *  <p>This method is equivalent to {@link #removeFirst}.
-   *
-   *  @return
-   *    the head of the queue represented by this deque
-   *  @throws NoSuchElementException
-   *    {@inheritDoc}
-   */
   def remove(): E = {
     return removeFirst()
   }
 
-  /** Retrieves and removes the head of the queue represented by this deque (in
-   *  other words, the first element of this deque), or returns {@code null} if
-   *  this deque is empty.
-   *
-   *  <p>This method is equivalent to {@link #pollFirst}.
-   *
-   *  @return
-   *    the head of the queue represented by this deque, or {@code null} if this
-   *    deque is empty
-   */
   def poll(): E = {
     return pollFirst()
   }
 
-  /** Retrieves, but does not remove, the head of the queue represented by this
-   *  deque. This method differs from {@link #peek peek} only in that it throws
-   *  an exception if this deque is empty.
-   *
-   *  <p>This method is equivalent to {@link #getFirst}.
-   *
-   *  @return
-   *    the head of the queue represented by this deque
-   *  @throws NoSuchElementException
-   *    {@inheritDoc}
-   */
   def element(): E = {
     return getFirst()
   }
 
-  /** Retrieves, but does not remove, the head of the queue represented by this
-   *  deque, or returns {@code null} if this deque is empty.
-   *
-   *  <p>This method is equivalent to {@link #peekFirst}.
-   *
-   *  @return
-   *    the head of the queue represented by this deque, or {@code null} if this
-   *    deque is empty
-   */
   def peek(): E = {
     return peekFirst()
   }
 
   // *** Stack methods ***
 
-  /** Pushes an element onto the stack represented by this deque. In other
-   *  words, inserts the element at the front of this deque.
-   *
-   *  <p>This method is equivalent to {@link #addFirst}.
-   *
-   *  @param e
-   *    the element to push
-   *  @throws NullPointerException
-   *    if the specified element is null
-   */
   def push(e: E): Unit = {
     addFirst(e)
   }
 
-  /** Pops an element from the stack represented by this deque. In other words,
-   *  removes and returns the first element of this deque.
-   *
-   *  <p>This method is equivalent to {@link #removeFirst()}.
-   *
-   *  @return
-   *    the element at the front of this deque (which is the top of the stack
-   *    represented by this deque)
-   *  @throws NoSuchElementException
-   *    {@inheritDoc}
-   */
   def pop(): E = {
     return removeFirst()
   }
 
-  /** Removes the element at the specified position in the elements array. This
-   *  can result in forward or backwards motion of array elements. We optimize
-   *  for least element motion.
-   *
-   *  <p>This method is called delete rather than remove to emphasize that its
-   *  semantics differ from those of {@link List#remove(int)}.
-   *
-   *  @return
-   *    true if elements near tail moved backwards
-   */
   private def delete(i: Int): Boolean = {
     // checkInvariants();
     val es = elements
@@ -699,32 +387,14 @@ class ArrayDeque[E](
 
   // *** Collection Methods ***
 
-  /** Returns the number of elements in this deque.
-   *
-   *  @return
-   *    the number of elements in this deque
-   */
   def size(): Int = {
     return sub(tail, head, elements.length)
   }
 
-  /** Returns {@code true} if this deque contains no elements.
-   *
-   *  @return
-   *    {@code true} if this deque contains no elements
-   */
   override def isEmpty(): Boolean = {
     return head == tail;
   }
 
-  /** Returns an iterator over the elements in this deque. The elements will be
-   *  ordered from first (head) to last (tail). This is the same order that
-   *  elements would be dequeued (via successive calls to {@link #remove} or
-   *  popped (via successive calls to {@link #pop}).
-   *
-   *  @return
-   *    an iterator over the elements in this deque
-   */
   def iterator(): Iterator[E] = {
     return new DeqIterator()
   }
@@ -850,29 +520,15 @@ class ArrayDeque[E](
     }
   }
 
-  /** Creates a <em><a href="Spliterator.html#binding">late-binding</a></em> and
-   *  <em>fail-fast</em> {@link Spliterator} over the elements in this deque.
-   *
-   *  <p>The {@code Spliterator} reports {@link Spliterator#SIZED}, {@link
-   *  Spliterator#SUBSIZED}, {@link Spliterator#ORDERED}, and {@link
-   *  Spliterator#NONNULL}. Overriding implementations should document the
-   *  reporting of additional characteristic values.
-   *
-   *  @return
-   *    a {@code Spliterator} over the elements in this deque
-   *  @since 1.8
-   */
   def spliterator(): Spliterator[E] = {
     return new DeqSpliterator()
   }
 
   final class DeqSpliterator extends Spliterator[E] {
 
-    /** Constructs late-binding spliterator over all elements. */
     private var fence: Int = -1 // -1 until first use
     private var cursor: Int = _ // current index, modified on traverse/split
 
-    /** Constructs spliterator over the given range. */
     def this(origin: Int, fence: Int) = {
       this()
       // assert 0 <= origin && origin < elements.length;
@@ -881,7 +537,6 @@ class ArrayDeque[E](
       this.fence = fence
     }
 
-    /** Ensures late-binding initialization; then returns fence. */
     private def getFence(): Int = { // force initialization
       var t = fence
       if (t < 0) {
@@ -951,9 +606,6 @@ class ArrayDeque[E](
     }
   }
 
-  /** @throws NullPointerException
-   *    {@inheritDoc}
-   */
   override def forEach(action: Consumer[_ >: E]): Unit = {
     Objects.requireNonNull(action)
     val es = elements
@@ -975,13 +627,6 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
-  /** Replaces each element of this deque with the result of applying the
-   *  operator to that element, as specified by {@link List#replaceAll}.
-   *
-   *  @param operator
-   *    the operator to apply to each element
-   *  @since TBD
-   */
   def replaceAll(operator: UnaryOperator[E]): Unit = {
     Objects.requireNonNull(operator)
     val es = elements
@@ -1003,31 +648,21 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
-  /** @throws NullPointerException
-   *    {@inheritDoc}
-   */
   override def removeIf(filter: Predicate[_ >: E]): Boolean = {
     Objects.requireNonNull(filter)
     return bulkRemove(filter)
   }
 
-  /** @throws NullPointerException
-   *    {@inheritDoc}
-   */
   override def removeAll(c: Collection[_]): Boolean = {
     Objects.requireNonNull(c)
     return bulkRemove(c.contains(_))
   }
 
-  /** @throws NullPointerException
-   *    {@inheritDoc}
-   */
   override def retainAll(c: Collection[_]): Boolean = {
     Objects.requireNonNull(c)
     return bulkRemove(!c.contains(_))
   }
 
-  /** Implementation of bulk remove methods. */
   def bulkRemove(filter: Predicate[_ >: E]): Boolean = {
     // checkInvariants();
     val es = elements
@@ -1063,14 +698,6 @@ class ArrayDeque[E](
     return (bits(i >> 6) & (1L << i)) == 0
   }
 
-  /** Helper for bulkRemove, in case of at least one deletion. Tolerate
-   *  predicates that reentrantly access the collection for read (but writers
-   *  still get CME), so traverse once to find elements to delete, a second pass
-   *  to physically expunge.
-   *
-   *  @param beg
-   *    valid index of first element to be deleted
-   */
   private def bulkRemoveModified(
       filter: Predicate[_ >: E],
       beg: Int
@@ -1141,15 +768,6 @@ class ArrayDeque[E](
     return true;
   }
 
-  /** Returns {@code true} if this deque contains the specified element. More
-   *  formally, returns {@code true} if and only if this deque contains at least
-   *  one element {@code e} such that {@code o.equals(e)}.
-   *
-   *  @param o
-   *    object to be checked for containment in this deque
-   *  @return
-   *    {@code true} if this deque contains the specified element
-   */
   override def contains(o: Any): Boolean = {
     if (o != null) {
       val es = elements
@@ -1170,27 +788,10 @@ class ArrayDeque[E](
     return false
   }
 
-  /** Removes a single instance of the specified element from this deque. If the
-   *  deque does not contain the element, it is unchanged. More formally,
-   *  removes the first element {@code e} such that {@code o.equals(e)} (if such
-   *  an element exists). Returns {@code true} if this deque contained the
-   *  specified element (or equivalently, if this deque changed as a result of
-   *  the call).
-   *
-   *  <p>This method is equivalent to {@link #removeFirstOccurrence(Object)}.
-   *
-   *  @param o
-   *    element to be removed from this deque, if present
-   *  @return
-   *    {@code true} if this deque contained the specified element
-   */
   override def remove(o: Any): Boolean = {
     return removeFirstOccurrence(o)
   }
 
-  /** Removes all of the elements from this deque. The deque will be empty after
-   *  this call returns.
-   */
   override def clear(): Unit = {
     circularClear(elements, head, tail)
     head = 0
@@ -1198,9 +799,6 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
-  /** Nulls out slots starting at array index i, upto index end. Condition i ==
-   *  end means "empty" - nothing to do.
-   */
   private def circularClear(es: Array[Object], _i: Int, end: Int): Unit = {
     var i = _i
     var to = if (i <= end) end else es.length
@@ -1217,19 +815,6 @@ class ArrayDeque[E](
     }
   }
 
-  /** Returns an array containing all of the elements in this deque in proper
-   *  sequence (from first to last element).
-   *
-   *  <p>The returned array will be "safe" in that no references to it are
-   *  maintained by this deque. (In other words, this method must allocate a new
-   *  array). The caller is thus free to modify the returned array.
-   *
-   *  <p>This method acts as bridge between array-based and collection-based
-   *  APIs.
-   *
-   *  @return
-   *    an array containing all of the elements in this deque
-   */
   override def toArray(): Array[Object] = {
     return toArrayImpl(classOf[Array[Object]])
   }
@@ -1253,42 +838,6 @@ class ArrayDeque[E](
     return a
   }
 
-  /** Returns an array containing all of the elements in this deque in proper
-   *  sequence (from first to last element); the runtime type of the returned
-   *  array is that of the specified array. If the deque fits in the specified
-   *  array, it is returned therein. Otherwise, a new array is allocated with
-   *  the runtime type of the specified array and the size of this deque.
-   *
-   *  <p>If this deque fits in the specified array with room to spare (i.e., the
-   *  array has more elements than this deque), the element in the array
-   *  immediately following the end of the deque is set to {@code null}.
-   *
-   *  <p>Like the {@link #toArray()} method, this method acts as bridge between
-   *  array-based and collection-based APIs. Further, this method allows precise
-   *  control over the runtime type of the output array, and may, under certain
-   *  circumstances, be used to save allocation costs.
-   *
-   *  <p>Suppose {@code x} is a deque known to contain only strings. The
-   *  following code can be used to dump the deque into a newly allocated array
-   *  of {@code String}:
-   *
-   *  <pre> {@code String[] y = x.toArray(new String[0]);}</pre>
-   *
-   *  Note that {@code toArray(new Object[0])} is identical in function to
-   *  {@code toArray()}.
-   *
-   *  @param a
-   *    the array into which the elements of the deque are to be stored, if it
-   *    is big enough; otherwise, a new array of the same runtime type is
-   *    allocated for this purpose
-   *  @return
-   *    an array containing all of the elements in this deque
-   *  @throws ArrayStoreException
-   *    if the runtime type of the specified array is not a supertype of the
-   *    runtime type of every element in this deque
-   *  @throws NullPointerException
-   *    if the specified array is null
-   */
   override def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
     val size = this.size()
     if (size > a.length)
@@ -1314,11 +863,6 @@ class ArrayDeque[E](
 
   // *** Object methods ***
 
-  /** Returns a copy of this deque.
-   *
-   *  @return
-   *    a copy of this deque
-   */
   override def clone(): ArrayDeque[E] = {
     val result = new ArrayDeque[E](Arrays.copyOf(elements, elements.length))
     result.head = this.head
@@ -1326,7 +870,6 @@ class ArrayDeque[E](
     result
   }
 
-  /** debugging */
   private def checkInvariants(): Unit = {
     // Use head and tail fields with empty slot at tail strategy.
     // head == tail disambiguates to "empty".

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -8,7 +8,7 @@
  * https://gee.cs.oswego.edu/dl/concurrency-interest/index.html
  */
 
-package java.util;
+package java.util
 
 import java.io.Serializable
 import java.util.function.Consumer
@@ -19,21 +19,94 @@ import ArrayDeque._
 
 object ArrayDeque {
 
+  /** The maximum size of array to allocate. Some VMs reserve some header words
+   *  in an array. Attempts to allocate larger arrays may result in
+   *  OutOfMemoryError: Requested array size exceeds VM limit
+   */
   private val MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8
 
 }
 
+/** Resizable-array implementation of the {@link Deque} interface. Array deques
+ *  have no capacity restrictions; they grow as necessary to support usage. They
+ *  are not thread-safe; in the absence of external synchronization, they do not
+ *  support concurrent access by multiple threads. Null elements are prohibited.
+ *  This class is likely to be faster than java.util.Stack when used as a stack,
+ *  and faster than {@link LinkedList} when used as a queue.
+ *
+ *  Exceptions include remove, {@link #removeFirstOccurrence
+ *  removeFirstOccurrence}, {@link #removeLastOccurrence removeLastOccurrence},
+ *  {@link #contains contains}, {@link #iterator iterator.remove()}, and the
+ *  bulk operations, all of which run in linear time.
+ *
+ *  <p>The iterators returned by this class's {@link #iterator iterator} method
+ *  are <em>fail-fast</em>: If the deque is modified at any time after the
+ *  iterator is created, in any way except through the iterator's own {@code
+ *  remove} method, the iterator will generally throw a
+ *  ConcurrentModificationException. Thus, in the face of concurrent
+ *  modification, the iterator fails quickly and cleanly, rather than risking
+ *  arbitrary, non-deterministic behavior at an undetermined time in the future.
+ *
+ *  <p>Note that the fail-fast behavior of an iterator cannot be guaranteed as
+ *  it is, generally speaking, impossible to make any hard guarantees in the
+ *  presence of unsynchronized concurrent modification. Fail-fast iterators
+ *  throw ConcurrentModificationException on a best-effort basis. Therefore, it
+ *  would be wrong to write a program that depended on this exception for its
+ *  correctness: <i>the fail-fast behavior of iterators should be used only to
+ *  detect bugs.</i>
+ *
+ *  <p>This class and its iterator implement all of the <em>optional</em>
+ *  methods of the {@link Collection} and {@link Iterator} interfaces.
+ *
+ *  <p>This class is a member of the <a
+ *  href="{@docRoot}/java.base/java/util/package-summary.html#CollectionsFramework">
+ *  Java Collections Framework</a>.
+ *
+ *  @author
+ *    Josh Bloch and Doug Lea
+ *  @param <E>
+ *    the type of elements held in this deque
+ *  @since 1.6
+ */
 class ArrayDeque[E](
+    /** The array in which the elements of the deque are stored. All array cells
+     *  not holding deque elements are always null. The array always has at
+     *  least one null slot (at tail).
+     */
     var elements: Array[Object]
 ) extends AbstractCollection[E]
     with Deque[E]
     with Cloneable
     with Serializable {
+  /*
+   * VMs excel at optimizing simple array loops where indices are
+   * incrementing or decrementing over a valid slice, e.g.
+   *
+   * for (int i = start; i < end; i++) ... elements[i]
+   *
+   * Because in a circular array, elements are in general stored in
+   * two disjoint such slices, we help the VM by writing unusual
+   * nested loops for all traversals over the elements.  Having only
+   * one hot inner loop body instead of two or three eases human
+   * maintenance and encourages VM loop inlining into the caller.
+   */
 
+  /** The index of the element at the head of the deque (which is the element
+   *  that would be removed by remove() or pop()); or an arbitrary number 0 <=
+   *  head < elements.length equal to tail if the deque is empty.
+   */
   var head: Int = _
 
+  /** The index at which the next element would be added to the tail of the
+   *  deque (via addLast(E), add(E), or push(E)); elements[tail] is always null.
+   */
   var tail: Int = _
 
+  /** Increases the capacity of this deque by at least the given amount.
+   *
+   *  @param needed
+   *    the required minimum extra capacity; must be positive
+   */
   private def grow(needed: Int): Unit = {
     // overflow-conscious code
     val oldCapacity = elements.length
@@ -63,6 +136,7 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
+  /** Capacity calculation for edge conditions, especially overflow. */
   private def newCapacity(needed: Int, jump: Int): Int = {
     val oldCapacity = elements.length
     val minCapacity = oldCapacity + needed
@@ -78,6 +152,14 @@ class ArrayDeque[E](
     else MAX_ARRAY_SIZE
   }
 
+  /** Increases the internal storage of this collection, if necessary, to ensure
+   *  that it can hold at least the given number of elements.
+   *
+   *  @param minCapacity
+   *    the desired minimum capacity
+   *  @since TBD
+   */
+  /* public */
   def ensureCapacity(minCapacity: Int): Unit = {
     val needed = minCapacity + 1 - elements.length
     if (needed > 0)
@@ -85,6 +167,11 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
+  /** Minimizes the internal storage of this collection.
+   *
+   *  @since TBD
+   */
+  /* public */
   def trimToSize(): Unit = {
     val size = this.size()
     if (size + 1 < elements.length) {
@@ -95,10 +182,19 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
+  /** Constructs an empty array deque with an initial capacity sufficient to
+   *  hold 16 elements.
+   */
   def this() = {
     this(new Array[Object](16 + 1))
   }
 
+  /** Constructs an empty array deque with an initial capacity sufficient to
+   *  hold the specified number of elements.
+   *
+   *  @param numElements
+   *    lower bound on initial capacity of the deque
+   */
   def this(numElements: Int) = {
     this(
       new Array[Object](
@@ -110,39 +206,73 @@ class ArrayDeque[E](
     )
   }
 
+  /** Constructs a deque containing the elements of the specified collection, in
+   *  the order they are returned by the collection's iterator. (The first
+   *  element returned by the collection's iterator becomes the first element,
+   *  or <i>front</i> of the deque.)
+   *
+   *  @param c
+   *    the collection whose elements are to be placed into the deque
+   *  @throws java.lang.NullPointerException
+   *    if the specified collection is null
+   */
   def this(c: Collection[_ <: E]) = {
     this(c.size())
     copyElements(c)
   }
 
+  /** Circularly increments i, mod modulus. Precondition and postcondition: 0 <=
+   *  i < modulus.
+   */
   private def inc(_i: Int, modulus: Int): Int = {
     var i = _i + 1
     if (i >= modulus) i = 0
     return i
   }
 
+  /** Circularly decrements i, mod modulus. Precondition and postcondition: 0 <=
+   *  i < modulus.
+   */
   private def dec(_i: Int, modulus: Int): Int = {
     var i = _i - 1
     if (i < 0) i = modulus - 1
     return i
   }
 
+  /** Circularly adds the given distance to index i, mod modulus. Precondition:
+   *  0 <= i < modulus, 0 <= distance <= modulus.
+   *  @return
+   *    index 0 <= i < modulus
+   */
   private def inc(_i: Int, distance: Int, modulus: Int): Int = {
     var i = _i + distance
     if (i - modulus >= 0) i -= modulus
     return i
   }
 
+  /** Subtracts j from i, mod modulus. Index i must be logically ahead of index
+   *  j. Precondition: 0 <= i < modulus, 0 <= j < modulus.
+   *  @return
+   *    the "circular distance" from j to i; corner case i == j is disambiguated
+   *    to "empty", returning 0.
+   */
   private def sub(_i: Int, j: Int, modulus: Int): Int = {
     var i = _i - j
     if (i < 0) i += modulus
     return i
   }
 
+  /** Returns element at array index i. This is a slight abuse of generics,
+   *  accepted by javac.
+   */
   private def elementAt(es: Array[Object], i: Int): E = {
     return es(i).asInstanceOf[E]
   }
 
+  /** A version of elementAt that checks for null elements. This check doesn't
+   *  catch all possible comodifications, but does catch ones that corrupt
+   *  traversal.
+   */
   private def nonNullElementAt(es: Array[Object], i: Int): E = {
     val e = es(i).asInstanceOf[E]
     if (e == null)
@@ -150,6 +280,17 @@ class ArrayDeque[E](
     return e
   }
 
+  // The main insertion and extraction methods are addFirst,
+  // addLast, pollFirst, pollLast. The other methods are defined in
+  // terms of these.
+
+  /** Inserts the specified element at the front of this deque.
+   *
+   *  @param e
+   *    the element to add
+   *  @throws java.lang.NullPointerException
+   *    if the specified element is null
+   */
   def addFirst(e: E): Unit = {
     if (e == null)
       throw new NullPointerException()
@@ -161,6 +302,15 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
+  /** Inserts the specified element at the end of this deque.
+   *
+   *  <p>This method is equivalent to {@link #add}.
+   *
+   *  @param e
+   *    the element to add
+   *  @throws java.lang.NullPointerException
+   *    if the specified element is null
+   */
   def addLast(e: E): Unit = {
     if (e == null)
       throw new NullPointerException()
@@ -172,6 +322,17 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
+  /** Adds all of the elements in the specified collection at the end of this
+   *  deque, as if by calling {@link #addLast} on each one, in the order that
+   *  they are returned by the collection's iterator.
+   *
+   *  @param c
+   *    the elements to be inserted into this deque
+   *  @return
+   *    {@code true} if this deque changed as a result of the call
+   *  @throws java.lang.NullPointerException
+   *    if the specified collection or any of its elements are null
+   */
   override def addAll(c: Collection[_ <: E]): Boolean = {
     val s = size()
     val needed = s + c.size() + 1 - elements.length
@@ -186,16 +347,35 @@ class ArrayDeque[E](
     c.forEach(addLast(_))
   }
 
+  /** Inserts the specified element at the front of this deque.
+   *
+   *  @param e
+   *    the element to add
+   *  @return
+   *    {@code true} (as specified by {@link Deque#offerFirst})
+   *  @throws java.lang.NullPointerException
+   *    if the specified element is null
+   */
   def offerFirst(e: E): Boolean = {
     addFirst(e)
     return true
   }
 
+  /** Inserts the specified element at the end of this deque.
+   *
+   *  @param e
+   *    the element to add
+   *  @return
+   *    {@code true} (as specified by {@link Deque#offerLast})
+   *  @throws java.lang.NullPointerException
+   *    if the specified element is null
+   */
   def offerLast(e: E): Boolean = {
     addLast(e)
     return true
   }
 
+  /** @throws NoSuchElementException */
   def removeFirst(): E = {
     val e = pollFirst()
     if (e == null)
@@ -204,6 +384,7 @@ class ArrayDeque[E](
     return e
   }
 
+  /** @throws NoSuchElementException */
   def removeLast(): E = {
     val e = pollLast()
     if (e == null)
@@ -236,6 +417,7 @@ class ArrayDeque[E](
     return e
   }
 
+  /** @throws NoSuchElementException */
   def getFirst(): E = {
     val e = elementAt(elements, head)
     if (e == null)
@@ -244,6 +426,7 @@ class ArrayDeque[E](
     return e
   }
 
+  /** @throws NoSuchElementException */
   def getLast(): E = {
     val es = elements
     val e = elementAt(es, dec(tail, es.length))
@@ -264,6 +447,18 @@ class ArrayDeque[E](
     return elementAt(es, dec(tail, es.length))
   }
 
+  /** Removes the first occurrence of the specified element in this deque (when
+   *  traversing the deque from head to tail). If the deque does not contain the
+   *  element, it is unchanged. More formally, removes the first element {@code
+   *  e} such that {@code o.equals(e)} (if such an element exists). Returns
+   *  {@code true} if this deque contained the specified element (or
+   *  equivalently, if this deque changed as a result of the call).
+   *
+   *  @param o
+   *    element to be removed from this deque, if present
+   *  @return
+   *    {@code true} if the deque contained the specified element
+   */
   def removeFirstOccurrence(o: Any): Boolean = {
     if (o != null) {
       val es = elements
@@ -286,6 +481,20 @@ class ArrayDeque[E](
     return false
   }
 
+  /** Removes the last occurrence of the specified element in this deque (when
+   *  traversing the deque from head to tail). If the deque does not contain the
+   *  element, it is unchanged.
+   *
+   *  More formally, removes the last element such that {@code o.equals(e)} (if
+   *  such an element exists). Returns {@code true} if this deque contained the
+   *  specified element (or equivalently, if this deque changed as a result of
+   *  the call).
+   *
+   *  @param o
+   *    element to be removed from this deque, if present
+   *  @return
+   *    {@code true} if the deque contained the specified element
+   */
   def removeLastOccurrence(o: Any): Boolean = {
     if (o != null) {
       val es = elements
@@ -311,41 +520,133 @@ class ArrayDeque[E](
 
   // *** Queue methods ***
 
+  /** Inserts the specified element at the end of this deque.
+   *
+   *  <p>This method is equivalent to {@link #addLast}.
+   *
+   *  @param e
+   *    the element to add
+   *  @return
+   *    {@code true} (as specified by {@link Collection#add})
+   *  @throws java.lang.NullPointerException
+   *    if the specified element is null
+   */
   override def add(e: E): Boolean = {
     addLast(e)
     return true
   }
 
+  /** Inserts the specified element at the end of this deque.
+   *
+   *  <p>This method is equivalent to {@link #offerLast}.
+   *
+   *  @param e
+   *    the element to add
+   *  @return
+   *    {@code true} (as specified by {@link Queue#offer})
+   *  @throws java.lang.NullPointerException
+   *    if the specified element is null
+   */
   def offer(e: E): Boolean = {
     return offerLast(e)
   }
 
+  /** Retrieves and removes the head of the queue represented by this deque.
+   *
+   *  This method differs from {@link #poll poll()} only in that it throws an
+   *  exception if this deque is empty.
+   *
+   *  <p>This method is equivalent to {@link #removeFirst}.
+   *
+   *  @return
+   *    the head of the queue represented by this deque
+   *  @throws NoSuchElementException
+   */
   def remove(): E = {
     return removeFirst()
   }
 
+  /** Retrieves and removes the head of the queue represented by this deque (in
+   *  other words, the first element of this deque), or returns {@code null} if
+   *  this deque is empty.
+   *
+   *  <p>This method is equivalent to {@link #pollFirst}.
+   *
+   *  @return
+   *    the head of the queue represented by this deque, or {@code null} if this
+   *    deque is empty
+   */
   def poll(): E = {
     return pollFirst()
   }
 
+  /** Retrieves, but does not remove, the head of the queue represented by this
+   *  deque. This method differs from {@link #peek peek} only in that it throws
+   *  an exception if this deque is empty.
+   *
+   *  <p>This method is equivalent to {@link #getFirst}.
+   *
+   *  @return
+   *    the head of the queue represented by this deque
+   *  @throws NoSuchElementException
+   */
   def element(): E = {
     return getFirst()
   }
 
+  /** Retrieves, but does not remove, the head of the queue represented by this
+   *  deque, or returns {@code null} if this deque is empty.
+   *
+   *  <p>This method is equivalent to {@link #peekFirst}.
+   *
+   *  @return
+   *    the head of the queue represented by this deque, or {@code null} if this
+   *    deque is empty
+   */
   def peek(): E = {
     return peekFirst()
   }
 
   // *** Stack methods ***
 
+  /** Pushes an element onto the stack represented by this deque. In other
+   *  words, inserts the element at the front of this deque.
+   *
+   *  <p>This method is equivalent to {@link #addFirst}.
+   *
+   *  @param e
+   *    the element to push
+   *  @throws java.lang.NullPointerException
+   *    if the specified element is null
+   */
   def push(e: E): Unit = {
     addFirst(e)
   }
 
+  /** Pops an element from the stack represented by this deque. In other words,
+   *  removes and returns the first element of this deque.
+   *
+   *  <p>This method is equivalent to {@link #removeFirst}.
+   *
+   *  @return
+   *    the element at the front of this deque (which is the top of the stack
+   *    represented by this deque)
+   *  @throws NoSuchElementException
+   */
   def pop(): E = {
     return removeFirst()
   }
 
+  /** Removes the element at the specified position in the elements array. This
+   *  can result in forward or backwards motion of array elements. We optimize
+   *  for least element motion.
+   *
+   *  <p>This method is called delete rather than remove to emphasize that its
+   *  semantics differ from those of {@link List#remove(int)}.
+   *
+   *  @return
+   *    true if elements near tail moved backwards
+   */
   private def delete(i: Int): Boolean = {
     // checkInvariants();
     val es = elements
@@ -387,14 +688,32 @@ class ArrayDeque[E](
 
   // *** Collection Methods ***
 
+  /** Returns the number of elements in this deque.
+   *
+   *  @return
+   *    the number of elements in this deque
+   */
   def size(): Int = {
     return sub(tail, head, elements.length)
   }
 
+  /** Returns {@code true} if this deque contains no elements.
+   *
+   *  @return
+   *    {@code true} if this deque contains no elements
+   */
   override def isEmpty(): Boolean = {
     return head == tail;
   }
 
+  /** Returns an iterator over the elements in this deque. The elements will be
+   *  ordered from first (head) to last (tail). This is the same order that
+   *  elements would be dequeued (via successive calls to remove or popped (via
+   *  successive calls to {@link #pop}).
+   *
+   *  @return
+   *    an iterator over the elements in this deque
+   */
   def iterator(): Iterator[E] = {
     return new DeqIterator()
   }
@@ -520,15 +839,29 @@ class ArrayDeque[E](
     }
   }
 
+  /** Creates a <em><a href="Spliterator.html#binding">late-binding</a></em> and
+   *  <em>fail-fast</em> {@link Spliterator} over the elements in this deque.
+   *
+   *  <p>The {@code Spliterator} reports [[Spliterator.SIZED]],
+   *  [[Spliterator.SUBSIZED]], [[Spliterator.ORDERED]], and
+   *  [[Spliterator.NONNULL]]. Overriding implementations should document the
+   *  reporting of additional characteristic values.
+   *
+   *  @return
+   *    a {@code Spliterator} over the elements in this deque
+   *  @since 1.8
+   */
   def spliterator(): Spliterator[E] = {
     return new DeqSpliterator()
   }
 
   final class DeqSpliterator extends Spliterator[E] {
 
+    /** Constructs late-binding spliterator over all elements. */
     private var fence: Int = -1 // -1 until first use
     private var cursor: Int = _ // current index, modified on traverse/split
 
+    /** Constructs spliterator over the given range. */
     def this(origin: Int, fence: Int) = {
       this()
       // assert 0 <= origin && origin < elements.length;
@@ -537,6 +870,7 @@ class ArrayDeque[E](
       this.fence = fence
     }
 
+    /** Ensures late-binding initialization; then returns fence. */
     private def getFence(): Int = { // force initialization
       var t = fence
       if (t < 0) {
@@ -606,6 +940,7 @@ class ArrayDeque[E](
     }
   }
 
+  /** @throws java.lang.NullPointerException */
   override def forEach(action: Consumer[_ >: E]): Unit = {
     Objects.requireNonNull(action)
     val es = elements
@@ -627,6 +962,13 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
+  /** Replaces each element of this deque with the result of applying the
+   *  operator to that element, as specified by {@link List#replaceAll}.
+   *
+   *  @param operator
+   *    the operator to apply to each element
+   *  @since TBD
+   */
   def replaceAll(operator: UnaryOperator[E]): Unit = {
     Objects.requireNonNull(operator)
     val es = elements
@@ -648,21 +990,25 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
+  /** @throws java.lang.NullPointerException */
   override def removeIf(filter: Predicate[_ >: E]): Boolean = {
     Objects.requireNonNull(filter)
     return bulkRemove(filter)
   }
 
+  /** @throws java.lang.NullPointerException */
   override def removeAll(c: Collection[_]): Boolean = {
     Objects.requireNonNull(c)
     return bulkRemove(c.contains(_))
   }
 
+  /** @throws java.lang.NullPointerException */
   override def retainAll(c: Collection[_]): Boolean = {
     Objects.requireNonNull(c)
     return bulkRemove(!c.contains(_))
   }
 
+  /** Implementation of bulk remove methods. */
   def bulkRemove(filter: Predicate[_ >: E]): Boolean = {
     // checkInvariants();
     val es = elements
@@ -698,6 +1044,14 @@ class ArrayDeque[E](
     return (bits(i >> 6) & (1L << i)) == 0
   }
 
+  /** Helper for bulkRemove, in case of at least one deletion. Tolerate
+   *  predicates that reentrantly access the collection for read (but writers
+   *  still get CME), so traverse once to find elements to delete, a second pass
+   *  to physically expunge.
+   *
+   *  @param beg
+   *    valid index of first element to be deleted
+   */
   private def bulkRemoveModified(
       filter: Predicate[_ >: E],
       beg: Int
@@ -768,6 +1122,15 @@ class ArrayDeque[E](
     return true;
   }
 
+  /** Returns {@code true} if this deque contains the specified element. More
+   *  formally, returns {@code true} if and only if this deque contains at least
+   *  one element {@code e} such that {@code o.equals(e)}.
+   *
+   *  @param o
+   *    object to be checked for containment in this deque
+   *  @return
+   *    {@code true} if this deque contains the specified element
+   */
   override def contains(o: Any): Boolean = {
     if (o != null) {
       val es = elements
@@ -788,10 +1151,27 @@ class ArrayDeque[E](
     return false
   }
 
+  /** Removes a single instance of the specified element from this deque. If the
+   *  deque does not contain the element, it is unchanged. More formally,
+   *  removes the first element {@code e} such that {@code o.equals(e)} (if such
+   *  an element exists). Returns {@code true} if this deque contained the
+   *  specified element (or equivalently, if this deque changed as a result of
+   *  the call).
+   *
+   *  <p>This method is equivalent to [[removeFirstOccurrence]].
+   *
+   *  @param o
+   *    element to be removed from this deque, if present
+   *  @return
+   *    {@code true} if this deque contained the specified element
+   */
   override def remove(o: Any): Boolean = {
     return removeFirstOccurrence(o)
   }
 
+  /** Removes all of the elements from this deque. The deque will be empty after
+   *  this call returns.
+   */
   override def clear(): Unit = {
     circularClear(elements, head, tail)
     head = 0
@@ -799,6 +1179,9 @@ class ArrayDeque[E](
     // checkInvariants();
   }
 
+  /** Nulls out slots starting at array index i, upto index end. Condition i ==
+   *  end means "empty" - nothing to do.
+   */
   private def circularClear(es: Array[Object], _i: Int, end: Int): Unit = {
     var i = _i
     var to = if (i <= end) end else es.length
@@ -815,6 +1198,19 @@ class ArrayDeque[E](
     }
   }
 
+  /** Returns an array containing all of the elements in this deque in proper
+   *  sequence (from first to last element).
+   *
+   *  <p>The returned array will be "safe" in that no references to it are
+   *  maintained by this deque. (In other words, this method must allocate a new
+   *  array). The caller is thus free to modify the returned array.
+   *
+   *  <p>This method acts as bridge between array-based and collection-based
+   *  APIs.
+   *
+   *  @return
+   *    an array containing all of the elements in this deque
+   */
   override def toArray(): Array[Object] = {
     return toArrayImpl(classOf[Array[Object]])
   }
@@ -838,6 +1234,42 @@ class ArrayDeque[E](
     return a
   }
 
+  /** Returns an array containing all of the elements in this deque in proper
+   *  sequence (from first to last element); the runtime type of the returned
+   *  array is that of the specified array. If the deque fits in the specified
+   *  array, it is returned therein. Otherwise, a new array is allocated with
+   *  the runtime type of the specified array and the size of this deque.
+   *
+   *  <p>If this deque fits in the specified array with room to spare (i.e., the
+   *  array has more elements than this deque), the element in the array
+   *  immediately following the end of the deque is set to {@code null}.
+   *
+   *  <p>Like the [[toArray()*]] method, this method acts as bridge between
+   *  array-based and collection-based APIs. Further, this method allows precise
+   *  control over the runtime type of the output array, and may, under certain
+   *  circumstances, be used to save allocation costs.
+   *
+   *  <p>Suppose {@code x} is a deque known to contain only strings. The
+   *  following code can be used to dump the deque into a newly allocated array
+   *  of {@code String}:
+   *
+   *  <pre> {@code String[] y = x.toArray(new String[0]);}</pre>
+   *
+   *  Note that {@code toArray(new Object[0])} is identical in function to
+   *  {@code toArray()}.
+   *
+   *  @param a
+   *    the array into which the elements of the deque are to be stored, if it
+   *    is big enough; otherwise, a new array of the same runtime type is
+   *    allocated for this purpose
+   *  @return
+   *    an array containing all of the elements in this deque
+   *  @throws java.lang.ArrayStoreException
+   *    if the runtime type of the specified array is not a supertype of the
+   *    runtime type of every element in this deque
+   *  @throws java.lang.NullPointerException
+   *    if the specified array is null
+   */
   override def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
     val size = this.size()
     if (size > a.length)
@@ -863,6 +1295,11 @@ class ArrayDeque[E](
 
   // *** Object methods ***
 
+  /** Returns a copy of this deque.
+   *
+   *  @return
+   *    a copy of this deque
+   */
   override def clone(): ArrayDeque[E] = {
     val result = new ArrayDeque[E](Arrays.copyOf(elements, elements.length))
     result.head = this.head
@@ -870,6 +1307,7 @@ class ArrayDeque[E](
     result
   }
 
+  /** debugging */
   private def checkInvariants(): Unit = {
     // Use head and tail fields with empty slot at tail strategy.
     // head == tail disambiguates to "empty".

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -286,7 +286,13 @@ object Build {
 // Language standard libraries ------------------------------------------------
   lazy val javalib = MultiScalaProject("javalib")
     .enablePlugins(MyScalaNativePlugin)
-    .settings(mavenPublishSettings, commonJavalibSettings, docsSettings)
+    .settings(mavenPublishSettings, commonJavalibSettings)
+    .mapBinaryVersions {
+      // Scaladoc in Scala 3 fails to generate documentation in javalib
+      // https://github.com/lampepfl/dotty/issues/16709
+      case "3" => _.settings(disabledDocsSettings)
+      case _   => _.settings(docsSettings)
+    }
     .dependsOn(posixlib, windowslib, clib)
     .withNativeCompilerPlugin
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -286,7 +286,7 @@ object Build {
 // Language standard libraries ------------------------------------------------
   lazy val javalib = MultiScalaProject("javalib")
     .enablePlugins(MyScalaNativePlugin)
-    .settings(mavenPublishSettings, commonJavalibSettings)
+    .settings(mavenPublishSettings, commonJavalibSettings, docsSettings)
     .dependsOn(posixlib, windowslib, clib)
     .withNativeCompilerPlugin
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -293,13 +293,13 @@ object Build {
   lazy val javalibExtDummies =
     MultiScalaProject("javalibExtDummies", file("javalib-ext-dummies"))
       .enablePlugins(MyScalaNativePlugin)
-      .settings(noPublishSettings, commonJavalibSettings)
+      .settings(noPublishSettings, commonJavalibSettings, disabledDocsSettings)
       .dependsOn(nativelib)
       .withNativeCompilerPlugin
 
   lazy val auxlib = MultiScalaProject("auxlib")
     .enablePlugins(MyScalaNativePlugin)
-    .settings(mavenPublishSettings, commonJavalibSettings)
+    .settings(mavenPublishSettings, commonJavalibSettings, disabledDocsSettings)
     .dependsOn(nativelib)
     .withNativeCompilerPlugin
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -517,7 +517,7 @@ object Settings {
   )
 
   lazy val commonJavalibSettings = Def.settings(
-    disabledDocsSettings,
+    ensureSAMSupportSetting,
     // This is required to have incremental compilation to work in javalib.
     // We put our classes on scalac's `javabootclasspath` so that it uses them
     // when compiling rather than the definitions from the JDK.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -517,7 +517,6 @@ object Settings {
   )
 
   lazy val commonJavalibSettings = Def.settings(
-    ensureSAMSupportSetting,
     // This is required to have incremental compilation to work in javalib.
     // We put our classes on scalac's `javabootclasspath` so that it uses them
     // when compiling rather than the definitions from the JDK.


### PR DESCRIPTION
Interestingly I get the following error using `javalib2_12/doc` but not `javalib2_12/compile`.
```Scala
[error] /Users/eric/workspace/scala-native/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala:253:42: type mismatch;
[error]  found   : Int
[error]  required: scala.scalanative.posix.poll.pollEvent_t
[error]     (which expands to)  Short
[error]     (fds + 0).events = pollEvents.POLLIN | pollEvents.POLLRDNORM
```
The LHS is a `CShort` or `Short` which can be fixed by adding `( ... ).toShort` but the error does not occur using 2.13. Instead we get the following which may be the unicode issue?
```scala
[info] Main Scala API documentation to /Users/eric/workspace/scala-native/javalib/.2.13/target/scala-2.13/api...
[error] stack trace is suppressed; run last javalib2_13 / Compile / doc for the full output
[error] (javalib2_13 / Compile / doc) java.nio.charset.MalformedInputException: Input length = 1
```
Scaladoc 3 generation has the tasty issue but that could be because Scala 3.1.3 is broken?