### PR TITLE
Partial fix #2765: Remove deprecated  dead C code

### DIFF
--- a/nativelib/src/main/resources/scala-native/platform/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform/platform.c
@@ -85,24 +85,6 @@ int scalanative_platform_is_windows() {
 #endif
 }
 
-char *scalanative_windows_get_user_lang() {
-#ifdef _WIN32
-    char *dest = malloc(9);
-    GetLocaleInfoA(LOCALE_USER_DEFAULT, LOCALE_SISO639LANGNAME, dest, 9);
-    return dest;
-#endif
-    return "";
-}
-
-char *scalanative_windows_get_user_country() {
-#ifdef _WIN32
-    char *dest = malloc(9);
-    GetLocaleInfoA(LOCALE_USER_DEFAULT, LOCALE_SISO3166CTRYNAME, dest, 9);
-    return dest;
-#endif
-    return "";
-}
-
 // See http://stackoverflow.com/a/4181991
 int scalanative_little_endian() {
     int n = 1;


### PR DESCRIPTION

Two deprecated `mumble_get_windows` Scala methods were removed in now merged PR #3024.
This PR removes the now dead corresponding C code.  