### PR TITLE
Support new Scala3 lazy vals enabled by -Ylightweight-lazy-vals flag

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/CountDownLatch.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CountDownLatch.scala
@@ -1,0 +1,13 @@
+package java.util.concurrent
+
+// No-op stub defined to allow usage of lazy vals with -Ylightweight-lazy-vals
+class CountDownLatch(count: Int) {
+
+  def await(): Unit = ()
+
+  def await(timeout: Long, unit: TimeUnit): Boolean = true
+
+  def countDown(): Unit = ()
+
+  def getCount(): Long = 0L
+}

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
@@ -26,6 +26,16 @@ private object LazyVals {
   }
 
   @`inline`
+  def objCAS(objPtr: RawPtr, exp: Object, n: Object): Boolean = {
+    // Todo: with multithreading use atomic cas
+    if (Intrinsics.loadObject(objPtr) ne exp) false
+    else {
+      Intrinsics.storeObject(objPtr, n)
+      true
+    }
+  }
+
+  @`inline`
   def setFlag(bitmap: RawPtr, v: Int, ord: Int): Unit = {
     val cur = get(bitmap)
     // TODO: with multithreading add waiting for notifications

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -458,6 +458,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           labels.contains(n.name)
         case inst @ Inst.If(_, n1, n2) =>
           labels.contains(n1.name) && labels.contains(n2.name)
+        case inst @ Inst.LinktimeIf(_, n1, n2) =>
+          labels.contains(n1.name) && labels.contains(n2.name)
         case inst @ Inst.Switch(_, n, ns) =>
           labels.contains(n.name) && ns.forall(n => labels.contains(n.name))
         case inst @ Inst.Throw(_, n) =>

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -10,6 +10,7 @@ import core.Contexts._
 import core.Names._
 import core.Symbols._
 import core.StdNames._
+import core.Constants.{Constant, ClazzTag}
 import scala.annotation.{threadUnsafe => tu}
 
 // This helper class is responsible for rewriting calls to scala.runtime.LazyVals with
@@ -55,6 +56,14 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
             // Scala 3.2.x
             case Apply(
                   Select(_, GetOffsetStatic),
+                  List(
+                    Apply(Select(_, GetDeclaredField), List(fieldname: Literal))
+                  )
+                ) =>
+              fieldname
+            // Scala 3.2.x + -Ylightweight-lazy-vals
+            case Apply(
+                  Select(_, GetStaticFieldOffset),
                   List(
                     Apply(Select(_, GetDeclaredField), List(fieldname: Literal))
                   )
@@ -117,6 +126,17 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
         fun = ref(defn.NativeLazyVals_setFlag),
         args = List(classFieldPtr(target, fieldRef), value, ord)
       )
+    else if sym == defn.LazyVals_objCAS then
+      val List(targetTree, fieldRef, expected, value) = args
+      val target = targetTree match {
+        case Literal(c: Constant) if c.tag == ClazzTag =>
+          ref(c.typeValue.classSymbol.companionModule)
+        case _ => targetTree
+      }
+      cpy.Apply(tree)(
+        fun = ref(defn.NativeLazyVals_objCAS),
+        args = List(classFieldPtr(target, fieldRef), expected, value)
+      )
     else if sym == defn.LazyVals_CAS then
       val List(target, fieldRef, expected, value, ord) = args
       cpy.Apply(tree)(
@@ -135,6 +155,7 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
     val LazyVals = typeName("LazyVals")
     val GetOffset = termName("getOffset")
     val GetOffsetStatic = termName("getOffsetStatic")
+    val GetStaticFieldOffset = termName("getStaticFieldOffset")
     val GetDeclaredField = termName("getDeclaredField")
   }
 
@@ -150,6 +171,8 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
     @tu lazy val NativeLazyVals_setFlag =
       NativeLazyValsModule.requiredMethod("setFlag")
     @tu lazy val NativeLazyVals_CAS = NativeLazyValsModule.requiredMethod("CAS")
+    @tu lazy val NativeLazyVals_objCAS =
+      NativeLazyValsModule.requiredMethod("objCAS")
     @tu lazy val NativeLazyVals_wait4Notification =
       NativeLazyValsModule.requiredMethod("wait4Notification")
 
@@ -157,6 +180,7 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
     @tu lazy val LazyVals_get = LazyValsModule.requiredMethod("get")
     @tu lazy val LazyVals_setFlag = LazyValsModule.requiredMethod("setFlag")
     @tu lazy val LazyVals_CAS = LazyValsModule.requiredMethod("CAS")
+    @tu lazy val LazyVals_objCAS = LazyValsModule.requiredMethod("objCAS")
     @tu lazy val LazyVals_wait4Notification =
       LazyValsModule.requiredMethod("wait4Notification")
   }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -126,7 +126,7 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
         fun = ref(defn.NativeLazyVals_setFlag),
         args = List(classFieldPtr(target, fieldRef), value, ord)
       )
-    else if sym == defn.LazyVals_objCAS then
+    else if defn.LazyVals_objCAS.contains(sym) then
       val List(targetTree, fieldRef, expected, value) = args
       val target = targetTree match {
         case Literal(c: Constant) if c.tag == ClazzTag =>
@@ -180,9 +180,13 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
     @tu lazy val LazyVals_get = LazyValsModule.requiredMethod("get")
     @tu lazy val LazyVals_setFlag = LazyValsModule.requiredMethod("setFlag")
     @tu lazy val LazyVals_CAS = LazyValsModule.requiredMethod("CAS")
-    @tu lazy val LazyVals_objCAS = LazyValsModule.requiredMethod("objCAS")
     @tu lazy val LazyVals_wait4Notification =
       LazyValsModule.requiredMethod("wait4Notification")
+    // Since 3.2.2 as experimental
+    @tu lazy val LazyVals_objCAS: Option[TermSymbol] =
+      Option(LazyValsModule.info.member(termName("objCAS")).symbol)
+        .filter(_ != NoSymbol)
+        .map(_.asTerm)
   }
 
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -860,6 +860,8 @@ trait NirGenExpr(using Context) {
           labels.contains(n.name)
         case inst @ Inst.If(_, n1, n2) =>
           labels.contains(n1.name) && labels.contains(n2.name)
+        case inst @ Inst.LinktimeIf(_, n, n2) =>
+          labels.contains(n.name) && labels.contains(n2.name)
         case inst @ Inst.Switch(_, n, ns) =>
           labels.contains(n.name) && ns.forall(n => labels.contains(n.name))
         case inst @ Inst.Throw(_, n) =>

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -22,7 +22,10 @@ final case class MultiScalaProject private (
   lazy val v2_13: Project = project("2.13")
   lazy val v3: Project = project("3")
   lazy val v3Next: Project = project(MultiScalaProject.scala3Next)
-    .settings(Settings.experimentalScalaSources)
+    .settings(
+      Settings.experimentalScalaSources,
+      scalacOptions += "-Ylightweight-lazy-vals"
+    )
 
   override def componentProjects: Seq[Project] =
     Seq( /*v2_11,*/ v2_12, v2_13, v3, v3Next)

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -20,7 +20,7 @@ object ScalaVersions {
   val scala212: String = crossScala212.last
   val scala213: String = crossScala213.last
   val scala3: String = "3.1.3"
-  lazy val scala3Experimental = "3.3.0-RC1-bin-20221119-786ad3f-NIGHTLY"
+  lazy val scala3Experimental = "3.3.0-RC1-bin-20221213-5929a50-NIGHTLY"
 
   val sbt10Version: String = "1.1.6" // minimum version
   val sbt10ScalaVersion: String = scala212

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -8,7 +8,7 @@ object ScalaVersions {
   val crossScala3 = List(
     Seq(scala3Experimental),
     (0 to 3).map(v => s"3.1.$v"),
-    (0 to 1).map(v => s"3.2.$v"),
+    (0 to 1).map(v => s"3.2.$v")
   ).flatten
 
   // Version of Scala 3 standard library sources used for publishing

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -580,6 +580,16 @@ class IssuesTest {
     free(null)
   }
 
+  @Test def `can initialize lazy vals using linktime if`() = {
+    object Foo {
+      val fooLiteral = "foo"
+      lazy val fooLazy =
+        if (scala.scalanative.meta.LinktimeInfo.isWindows) fooLiteral
+        else fooLiteral
+    }
+    assertEquals(Foo.fooLiteral, Foo.fooLazy)
+  }
+
 }
 
 package issue1090 {


### PR DESCRIPTION
This PR adds support for lightweight lazy vals and it's targeting dotty-experimental branch. 
This change can be backported to the main branch upon release of Scala 3.2.2 (main branch uses only stable releases, -Ylightweight-lazy-vals is available since 3.2.2-RC1). 
The new lazy vals showed the incorrectness in code generation of try-finally blocks which are using linktime if conditions - finally block could have been visited more then once.  

* Scala-next projects are now always using `-Ylightweight-lazy-vals` flag 
* Fix issue with multiple executions of finally block
* Provide a stub implementation for `java.util.concurrent.CountDownLatch`  
* Upgrade experimental dotty version to latest nightly