### PR TITLE
Implement posixlib langinfo.h & nl_types.h on Unix

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -30,7 +30,7 @@ C Header          Scala Native Module
 `iconv.h`_        N/A
 `inttypes.h`_     scala.scalanative.posix.inttypes_
 `iso646.h`_       N/A
-`langinfo.h`_     N/A
+`langinfo.h`_     scala.scalanative.posix.langinfo_
 `libgen.h`_       scala.scalanative.posix.libgen_
 `limits.h`_       scala.scalanative.posix.limits_
 `locale.h`_       scala.scalanative.posix.locale_
@@ -42,7 +42,7 @@ C Header          Scala Native Module
 `netdb.h`_        scala.scalanative.posix.netdb_
 `netinet/in.h`_   scala.scalanative.posix.netinet.in_
 `netinet/tcp.h`_  scala.scalanative.posix.netinet.tcp_
-`nl_types.h`_     N/A
+`nl_types.h`_     scala.scalanative.posix.nl_types_
 `poll.h`_         scala.scalanative.posix.poll_
 `pthread.h`_      scala.scalanative.posix.pthread_
 `pwd.h`_          scala.scalanative.posix.pwd_
@@ -190,6 +190,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.glob: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/glob.scala
 .. _scala.scalanative.posix.grp: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
 .. _scala.scalanative.posix.inttypes: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/inttypes.scala
+.. _scala.scalanative.posix.langinfo: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/langinfo.scala
 .. _scala.scalanative.posix.limits: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/limits.scala
 .. _scala.scalanative.posix.libgen: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/libgen.scala
 .. _scala.scalanative.posix.locale: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
@@ -199,6 +200,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.netdb: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
 .. _scala.scalanative.posix.netinet.in: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
 .. _scala.scalanative.posix.netinet.tcp: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/netinet/tcp.scala
+.. _scala.scalanative.posix.nl_types: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
 .. _scala.scalanative.posix.poll: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/poll.scala
 .. _scala.scalanative.posix.pthread: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
 .. _scala.scalanative.posix.pwd: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala

--- a/posixlib/src/main/resources/scala-native/langinfo.c
+++ b/posixlib/src/main/resources/scala-native/langinfo.c
@@ -1,0 +1,120 @@
+#if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
+    (defined(__APPLE__) && defined(__MACH__))
+
+#include <langinfo.h>
+
+#endif // Unix or Mac OS
+
+#if defined(_WIN32) // bogus values to keep compiler happy
+
+#endif // _WIN32
+
+int scalanative_codeset() { return CODESET; };
+
+int scalanative_d_t_fmt() { return D_T_FMT; };
+
+int scalanative_d_fmt() { return D_FMT; };
+
+int scalanative_t_fmt() { return T_FMT; };
+
+int scalanative_t_fmt_ampm() { return T_FMT_AMPM; };
+
+int scalanative_am_str() { return AM_STR; };
+
+int scalanative_pm_str() { return PM_STR; };
+
+int scalanative_day_1() { return DAY_1; };
+
+int scalanative_day_2() { return DAY_2; };
+
+int scalanative_day_3() { return DAY_3; };
+
+int scalanative_day_4() { return DAY_4; };
+
+int scalanative_day_5() { return DAY_5; };
+
+int scalanative_day_6() { return DAY_6; };
+
+int scalanative_day_7() { return DAY_7; };
+
+int scalanative_abday_1() { return ABDAY_1; };
+
+int scalanative_abday_2() { return ABDAY_2; };
+
+int scalanative_abday_3() { return ABDAY_3; };
+
+int scalanative_abday_4() { return ABDAY_4; };
+
+int scalanative_abday_5() { return ABDAY_5; };
+
+int scalanative_abday_6() { return ABDAY_6; };
+
+int scalanative_abday_7() { return ABDAY_7; };
+
+int scalanative_mon_1() { return MON_1; };
+
+int scalanative_mon_2() { return MON_2; };
+
+int scalanative_mon_3() { return MON_3; };
+
+int scalanative_mon_4() { return MON_4; };
+
+int scalanative_mon_5() { return MON_5; };
+
+int scalanative_mon_6() { return MON_6; };
+
+int scalanative_mon_7() { return MON_7; };
+
+int scalanative_mon_8() { return MON_8; };
+
+int scalanative_mon_9() { return MON_9; };
+
+int scalanative_mon_10() { return MON_10; };
+
+int scalanative_mon_11() { return MON_11; };
+
+int scalanative_mon_12() { return MON_12; };
+
+int scalanative_abmon_1() { return ABMON_1; };
+
+int scalanative_abmon_2() { return ABMON_2; };
+
+int scalanative_abmon_3() { return ABMON_3; };
+
+int scalanative_abmon_4() { return ABMON_4; };
+
+int scalanative_abmon_5() { return ABMON_5; };
+
+int scalanative_abmon_6() { return ABMON_6; };
+
+int scalanative_abmon_7() { return ABMON_7; };
+
+int scalanative_abmon_8() { return ABMON_8; };
+
+int scalanative_abmon_9() { return ABMON_9; };
+
+int scalanative_abmon_10() { return ABMON_10; };
+
+int scalanative_abmon_11() { return ABMON_11; };
+
+int scalanative_abmon_12() { return ABMON_12; };
+
+int scalanative_era() { return ERA; };
+
+int scalanative_era_d_fmt() { return ERA_D_FMT; };
+
+int scalanative_era_d_t_fmt() { return ERA_D_T_FMT; };
+
+int scalanative_era_t_fmt() { return ERA_T_FMT; };
+
+int scalanative_alt_digits() { return ALT_DIGITS; };
+
+int scalanative_radixchar() { return RADIXCHAR; };
+
+int scalanative_thousep() { return THOUSEP; };
+
+int scalanative_yesexpr() { return YESEXPR; };
+
+int scalanative_noexpr() { return NOEXPR; };
+
+int scalanative_crncystr() { return CRNCYSTR; };

--- a/posixlib/src/main/resources/scala-native/langinfo.c
+++ b/posixlib/src/main/resources/scala-native/langinfo.c
@@ -6,7 +6,61 @@
 #endif // Unix or Mac OS
 
 #if defined(_WIN32) // bogus values to keep compiler happy
-
+#define CODESET -1
+#define D_T_FMT -1
+#define D_FMT -1
+#define T_FMT -1
+#define T_FMT_AMPM -1
+#define AM_STR -1
+#define PM_STR -1
+#define DAY_1 -1
+#define DAY_2 -1
+#define DAY_3 -1
+#define DAY_4 -1
+#define DAY_5 -1
+#define DAY_6 -1
+#define DAY_7 -1
+#define ABDAY_1 -1
+#define ABDAY_2 -1
+#define ABDAY_3 -1
+#define ABDAY_4 -1
+#define ABDAY_5 -1
+#define ABDAY_6 -1
+#define ABDAY_7 -1
+#define MON_1 -1
+#define MON_2 -1
+#define MON_3 -1
+#define MON_4 -1
+#define MON_5 -1
+#define MON_6 -1
+#define MON_7 -1
+#define MON_8 -1
+#define MON_9 -1
+#define MON_10 -1
+#define MON_11 -1
+#define MON_12 -1
+#define ABMON_1 -1
+#define ABMON_2 -1
+#define ABMON_3 -1
+#define ABMON_4 -1
+#define ABMON_5 -1
+#define ABMON_6 -1
+#define ABMON_7 -1
+#define ABMON_8 -1
+#define ABMON_9 -1
+#define ABMON_10 -1
+#define ABMON_11 -1
+#define ABMON_12 -1
+#define ERA -1
+#define ERA_D_FMT -1
+#define ERA_D_T_FMT -1
+#define ERA_T_FMT -1
+#define ALT_DIGITS -1
+#define RADIXCHAR -1
+#define THOUSEP -1
+#define YESEXPR -1
+#define NOEXPR -1
+#define CRNCYSTR -1
 #endif // _WIN32
 
 int scalanative_codeset() { return CODESET; };

--- a/posixlib/src/main/resources/scala-native/nl_types.c
+++ b/posixlib/src/main/resources/scala-native/nl_types.c
@@ -1,0 +1,14 @@
+#if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
+    (defined(__APPLE__) && defined(__MACH__))
+
+#include <nl_types.h>
+
+#endif // Unix or Mac OS
+
+#if defined(_WIN32) // bogus values to keep linker happy
+#define NL_SETD -1
+#define NL_CAT_LOCALE -1
+#endif // _WIN32
+
+int scalanative_nl_setd() { return NL_SETD; };
+int scalanative_nl_cat_locale() { return NL_CAT_LOCALE; };

--- a/posixlib/src/main/scala/scala/scalanative/posix/langinfo.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/langinfo.scala
@@ -1,0 +1,190 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+/** POSIX langinfo.h for Scala
+ *
+ *  The Open Group Base Specifications
+ *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
+ */
+
+@extern object langinfo {
+
+  type locale_t = locale.locale_t
+
+  type nl_item = nl_types.nl_item
+
+// Symbolic constants
+
+  @name("scalanative_codeset")
+  def CODESET: CInt = extern
+
+  @name("scalanative_d_t_fmt")
+  def D_T_FMT: CInt = extern
+
+  @name("scalanative_d_fmt")
+  def D_FMT: CInt = extern
+
+  @name("scalanative_t_fmt")
+  def T_FMT: CInt = extern
+
+  @name("scalanative_t_fmt_ampm")
+  def T_FMT_AMPM: CInt = extern
+
+  @name("scalanative_am_str")
+  def AM_STR: CInt = extern
+
+  @name("scalanative_pm_str")
+  def PM_STR: CInt = extern
+
+  @name("scalanative_day_1")
+  def DAY_1: CInt = extern
+
+  @name("scalanative_day_2")
+  def DAY_2: CInt = extern
+
+  @name("scalanative_day_3")
+  def DAY_3: CInt = extern
+
+  @name("scalanative_day_4")
+  def DAY_4: CInt = extern
+
+  @name("scalanative_day_5")
+  def DAY_5: CInt = extern
+
+  @name("scalanative_day_6")
+  def DAY_6: CInt = extern
+
+  @name("scalanative_day_7")
+  def DAY_7: CInt = extern
+
+  @name("scalanative_abday_1")
+  def ABDAY_1: CInt = extern
+
+  @name("scalanative_abday_2")
+  def ABDAY_2: CInt = extern
+
+  @name("scalanative_abday_3")
+  def ABDAY_3: CInt = extern
+
+  @name("scalanative_abday_4")
+  def ABDAY_4: CInt = extern
+
+  @name("scalanative_abday_5")
+  def ABDAY_5: CInt = extern
+
+  @name("scalanative_abday_6")
+  def ABDAY_6: CInt = extern
+
+  @name("scalanative_abday_7")
+  def ABDAY_7: CInt = extern
+
+  @name("scalanative_mon_1")
+  def MON_1: CInt = extern
+
+  @name("scalanative_mon_2")
+  def MON_2: CInt = extern
+
+  @name("scalanative_mon_3")
+  def MON_3: CInt = extern
+
+  @name("scalanative_mon_4")
+  def MON_4: CInt = extern
+
+  @name("scalanative_mon_5")
+  def MON_5: CInt = extern
+
+  @name("scalanative_mon_6")
+  def MON_6: CInt = extern
+
+  @name("scalanative_mon_7")
+  def MON_7: CInt = extern
+
+  @name("scalanative_mon_8")
+  def MON_8: CInt = extern
+
+  @name("scalanative_mon_9")
+  def MON_9: CInt = extern
+
+  @name("scalanative_mon_10")
+  def MON_10: CInt = extern
+
+  @name("scalanative_mon_11")
+  def MON_11: CInt = extern
+
+  @name("scalanative_mon_12")
+  def MON_12: CInt = extern
+
+  @name("scalanative_abmon_1")
+  def ABMON_1: CInt = extern
+
+  @name("scalanative_abmon_2")
+  def ABMON_2: CInt = extern
+
+  @name("scalanative_abmon_3")
+  def ABMON_3: CInt = extern
+
+  @name("scalanative_abmon_4")
+  def ABMON_4: CInt = extern
+
+  @name("scalanative_abmon_5")
+  def ABMON_5: CInt = extern
+
+  @name("scalanative_abmon_6")
+  def ABMON_6: CInt = extern
+
+  @name("scalanative_abmon_7")
+  def ABMON_7: CInt = extern
+
+  @name("scalanative_abmon_8")
+  def ABMON_8: CInt = extern
+
+  @name("scalanative_abmon_9")
+  def ABMON_9: CInt = extern
+
+  @name("scalanative_abmon_10")
+  def ABMON_10: CInt = extern
+
+  @name("scalanative_abmon_11")
+  def ABMON_11: CInt = extern
+
+  @name("scalanative_abmon_12")
+  def ABMON_12: CInt = extern
+
+  @name("scalanative_era")
+  def ERA: CInt = extern
+
+  @name("scalanative_era_d_fmt")
+  def ERA_D_FMT: CInt = extern
+
+  @name("scalanative_era_d_t_fmt")
+  def ERA_D_T_FMT: CInt = extern
+
+  @name("scalanative_era_t_fmt")
+  def ERA_T_FMT: CInt = extern
+
+  @name("scalanative_alt_digits")
+  def ALT_DIGITS: CInt = extern
+
+  @name("scalanative_radixchar")
+  def RADIXCHAR: CInt = extern
+
+  @name("scalanative_thousep")
+  def THOUSEP: CInt = extern
+
+  @name("scalanative_yesexpr")
+  def YESEXPR: CInt = extern
+
+  @name("scalanative_noexpr")
+  def NOEXPR: CInt = extern
+
+  @name("scalanative_crncystr")
+  def CRNCYSTR: CInt = extern
+
+// Methods
+
+  def nl_langinfo(item: nl_item): CString = extern
+
+  def nl_langinfo_l(item: nl_item, locale: locale_t): CString = extern
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
@@ -1,0 +1,38 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+/** POSIX nl_types.h for Scala
+ *
+ *  The Open Group Base Specifications
+ *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
+ */
+
+@extern object nl_types {
+
+  type nl_catd = Ptr[Byte] // Scala Native idiom for void *.
+
+  type nl_item = CInt
+
+// Symbolic constants
+
+  @name("scalanative_nl_setd")
+  def NL_SETD: CInt = extern
+
+  @name("scalanative_nl_cat_locale")
+  def NL_CAT_LOCALE: CInt = extern
+
+// Methods
+
+  def catclose(catalog: nl_catd): CInt = extern
+
+  def catgets(
+      catalog: nl_catd,
+      setNumber: CInt,
+      messageNumber: CInt,
+      message: CString
+  ): CString = extern
+
+  def catopen(name: CString, flag: CInt): nl_catd = extern
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/LanginfoTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/LanginfoTest.scala
@@ -1,0 +1,175 @@
+package scala.scalanative.posixlib
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{BeforeClass, AfterClass}
+
+import scala.scalanative.meta.LinktimeInfo.{isLinux, isMac, isWindows}
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+import scala.scalanative.posix.langinfo._
+import scala.scalanative.posix.locale.{setlocale, LC_ALL}
+import scala.scalanative.posix.stdlib
+import scala.scalanative.posix.string
+
+object LanginfoTest {
+  private var savedLocale: Option[CString] = None
+
+  @BeforeClass
+  def beforeClass(): Unit = {
+    if (!isWindows) {
+      val entryLocale = setlocale(LC_ALL, null)
+      assertNotNull(
+        "setlocale() could not determine locale at start of test.",
+        entryLocale
+      )
+
+      // Save before setlocale() calls overwrite static buffer returned.
+      savedLocale = Some(string.strdup(entryLocale)) // note: no CString
+
+      /* Require a known locale in order to simplify CI testing.
+       * "soft fail" is the locale is not available, such as in the wild.
+       */
+
+      val requiredLocale = if (isLinux) c"en_US.utf8" else c"en_US.UTF-8"
+
+      if (setlocale(LC_ALL, requiredLocale) == null)
+        savedLocale = None // Oops, no change! Nothing to restore. Fail later.
+    }
+  }
+
+  @AfterClass
+  def afterClass(): Unit = {
+    if (!isWindows) {
+      savedLocale.map { sl =>
+        // Restore Locale as recorded on entry.
+        val restoredLocale = setlocale(LC_ALL, sl)
+
+        stdlib.free(sl)
+
+        if (restoredLocale == null)
+          fail("setlocale() was unable to restore the locale.")
+      }
+    }
+  }
+}
+
+/* Can't tell the players without a program or this legend.
+ * The testing matrix is complex because locales and their configurations are
+ * highly variable.
+ *
+ * Testing is done on Linux & macOS when the required en_US.utf8 (Linux) or
+ * en_US.UTF-8 locale is available.
+ *
+ * - No testing at all is done on Windows (because not implemented).
+ * - The testing on CI multiarch machines "soft fails" because the
+ *   required locale is not available.
+ * - No os specific testing is done on FreeBSD, for want of a suitable
+ *   validation environment.
+ */
+
+class LanginfoTest {
+
+  case class LanginfoItem(name: String, code: nl_item, expected: String)
+
+  def verify(item: LanginfoItem): Unit = {
+    assertEquals(
+      s"${item.name}",
+      item.expected,
+      fromCString(nl_langinfo(item.code))
+    )
+  }
+
+  @Test def langinfo_Using_en_US_UTF8(): Unit = {
+    assumeTrue(
+      "langinfo.scala is not implemented on Windows",
+      !isWindows
+    )
+
+    /* Warn here instead of doing a hard fail.
+     *   Multi-arch CI tests do not have an en_US locale.
+     *   This may also be true of non-CI systems in the wild.
+     */
+    assumeTrue(
+      "setlocale() failed to set an en_US.[utf8|UTF-8] test locale",
+      LanginfoTest.savedLocale.isDefined
+    )
+
+    if (!isWindows) {
+      val osSharedItems = Array(
+        LanginfoItem("CODESET", CODESET, "UTF-8"),
+        LanginfoItem("D_FMT", D_FMT, "%m/%d/%Y"),
+        LanginfoItem("T_FMT_AMPM", T_FMT_AMPM, "%I:%M:%S %p"),
+        LanginfoItem("AM_STR", AM_STR, "AM"),
+        LanginfoItem("PM_STR", PM_STR, "PM"),
+        LanginfoItem("DAY_1", DAY_1, "Sunday"),
+        LanginfoItem("DAY_2", DAY_2, "Monday"),
+        LanginfoItem("DAY_3", DAY_3, "Tuesday"),
+        LanginfoItem("DAY_4", DAY_4, "Wednesday"),
+        LanginfoItem("DAY_5", DAY_5, "Thursday"),
+        LanginfoItem("DAY_6", DAY_6, "Friday"),
+        LanginfoItem("DAY_7", DAY_7, "Saturday"),
+        LanginfoItem("ABDAY_1", ABDAY_1, "Sun"),
+        LanginfoItem("ABDAY_2", ABDAY_2, "Mon"),
+        LanginfoItem("ABDAY_3", ABDAY_3, "Tue"),
+        LanginfoItem("ABDAY_4", ABDAY_4, "Wed"),
+        LanginfoItem("ABDAY_5", ABDAY_5, "Thu"),
+        LanginfoItem("ABDAY_6", ABDAY_6, "Fri"),
+        LanginfoItem("ABDAY_7", ABDAY_7, "Sat"),
+        LanginfoItem("MON_1", MON_1, "January"),
+        LanginfoItem("MON_2", MON_2, "February"),
+        LanginfoItem("MON_3", MON_3, "March"),
+        LanginfoItem("MON_4", MON_4, "April"),
+        LanginfoItem("MON_5", MON_5, "May"),
+        LanginfoItem("MON_6", MON_6, "June"),
+        LanginfoItem("MON_7", MON_7, "July"),
+        LanginfoItem("MON_8", MON_8, "August"),
+        LanginfoItem("MON_9", MON_9, "September"),
+        LanginfoItem("MON_10", MON_10, "October"),
+        LanginfoItem("MON_11", MON_11, "November"),
+        LanginfoItem("MON_12", MON_12, "December"),
+        LanginfoItem("ABMON_1", ABMON_1, "Jan"),
+        LanginfoItem("ABMON_2", ABMON_2, "Feb"),
+        LanginfoItem("ABMON_3", ABMON_3, "Mar"),
+        LanginfoItem("ABMON_4", ABMON_4, "Apr"),
+        LanginfoItem("ABMON_5", ABMON_5, "May"),
+        LanginfoItem("ABMON_6", ABMON_6, "Jun"),
+        LanginfoItem("ABMON_7", ABMON_7, "Jul"),
+        LanginfoItem("ABMON_8", ABMON_8, "Aug"),
+        LanginfoItem("ABMON_9", ABMON_9, "Sep"),
+        LanginfoItem("ABMON_10", ABMON_10, "Oct"),
+        LanginfoItem("ABMON_11", ABMON_11, "Nov"),
+        LanginfoItem("ABMON_12", ABMON_12, "Dec"),
+        LanginfoItem("ERA", ERA, ""),
+        LanginfoItem("ERA_D_FMT", ERA_D_FMT, ""),
+        LanginfoItem("ERA_D_T_FMT", ERA_D_T_FMT, ""),
+        LanginfoItem("ERA_T_FMT", ERA_T_FMT, ""),
+        LanginfoItem("ALT_DIGITS", ALT_DIGITS, ""),
+        LanginfoItem("RADIXCHAR", RADIXCHAR, "."),
+        LanginfoItem("THOUSEP", THOUSEP, ","), // linux
+        LanginfoItem("CRNCYSTR", CRNCYSTR, "-$")
+      )
+
+      osSharedItems.foreach(verify(_))
+
+      if (isLinux) {
+        Array(
+          LanginfoItem("D_T_FMT", D_T_FMT, "%a %d %b %Y %r %Z"),
+          LanginfoItem("T_FMT", T_FMT, "%r"),
+          LanginfoItem("YESEXPR", YESEXPR, "^[+1yY]"),
+          LanginfoItem("NOEXPR", NOEXPR, "^[-0nN]")
+        ).foreach(verify(_))
+      } else if (isMac) {
+        Array(
+          LanginfoItem("D_T_FMT", D_T_FMT, "%a %b %e %X %Y"),
+          LanginfoItem("T_FMT", T_FMT, "%H:%M:%S"),
+          LanginfoItem("YESEXPR", YESEXPR, "^[yYsS].*"),
+          LanginfoItem("NOEXPR", NOEXPR, "^[nN].*")
+        ).foreach(verify(_))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement posixlib langinfo.scala & nl_types.scala on Unix.

Update posixlib.rst with new methods .

A note on testing:  

1) A reasonable implementation of a LanginfoTest.scala depends upon methods
    introduced in PR #3034, 
    which is awaiting merge.  (Wojciech: I went to add LanginfoTest.scala and realized
    the I had previously gotten the blocking PR wrong, sorry & thank you
    for the one merged.) 

    I have a Test file which works in my Linux & macOS environments. I can
    submit  when `setlocale()` and friends are available. I need to see
    what surprises & pleasures CI brings, especially multiarch.

2) An automated test for nl_types is not feasible because it would rely
    upon configuration data (presence & location of GNU message files).  There are
    a number of ways for users in the wild to change the configuration in ways
   that would break the test. 