### PR TITLE
improve: report error on default arguments in extern method

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -716,8 +716,14 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case (Global.Member(_, lsig), Global.Member(_, rsig)) => lsig == rsig
           case _                                                => false
         }
-
+      val defaultArgs = dd.symbol.paramss.flatten.filter(_.hasDefault)
       rhs match {
+        case _ if defaultArgs.nonEmpty =>
+          reporter.error(
+            defaultArgs.head.pos,
+            "extern method cannot have default argument"
+          )
+          None
         case Apply(ref: RefTree, Seq()) if ref.symbol == ExternMethod =>
           externMethodDecl()
 

--- a/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -277,6 +277,46 @@ class NIRCompilerTest extends AnyFlatSpec with Matchers with Inspectors {
       |""".stripMargin))
   }
 
+  it should "report error on default argument in extern method" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+      |import scala.scalanative.unsafe._
+      |@extern
+      |object foo {
+      |  def baz(a:Int = 1): Unit = extern
+      |}
+      |""".stripMargin))
+    }.getMessage should include(
+      "extern method cannot have default argument"
+    )
+  }
+  it should "report error on default argument mixed with general argument in extern method" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+      |import scala.scalanative.unsafe._
+      |@extern
+      |object foo {
+      |  def baz(a: Double, b:Int = 1): Unit = extern
+      |}
+      |""".stripMargin))
+    }.getMessage should include(
+      "extern method cannot have default argument"
+    )
+  }
+  it should "report error on default arguments in extern method" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+      |import scala.scalanative.unsafe._
+      |@extern
+      |object foo {
+      |  def baz(a: Double=1.0, b:Int = 1): Unit = extern
+      |}
+      |""".stripMargin))
+    }.getMessage should include(
+      "extern method cannot have default argument"
+    )
+  }
+
   it should "report error when closing over local statein CFuncPtr" in {
     intercept[CompilationFailedException] {
       NIRCompiler(


### PR DESCRIPTION
close https://github.com/scala-native/scala-native/issues/2498

report error on default arguments in extern method

```scala
import scala.scalanative.unsafe._
@extern
object foo {
  def baz(a:Int = 1): Unit = extern // error: extern method cannot have default argument
}
```

In Scala 3 implementation, it requires a hack --detecting vertual method generated from default argument by comparing its name with NameKinds.DefaultGetterName-- because just checking whether argument with default params flag exists does not gurantee that the method is not virtual method generated from default argument.

Default argument is rendered as `def baz$default$():ReturnType = <default value>` by Scala compiler and this method is regarded as extern method without arguments because `sym.isExtern` is true. Thus, this method difinition calls `genExternMethod` from `genMethod` in NirGenStat.scala.

I'm not sure why just checking "default argument is empty" works in Scala 2 while it doesn't in Scala 3.

As a sidenote, there is a discussion about better default arguments implementation, see https://contributors.scala-lang.org/t/better-default-arguments/6034