### PR TITLE
chore: use var instead of def for extern variables

### DIFF
--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -12,8 +12,8 @@
 // user program. However, as a (nonstandard) programmer
 // convenience, environ is declared in the header file <unistd.h> if
 // the _GNU_SOURCE feature test macro is defined
-#if #defined(_GNU_SOURCE)
-    extern char **environ;
+#if !defined(_GNU_SOURCE)
+extern char **environ;
 #endif
 
 long scalanative__posix_version() { return _POSIX_VERSION; }

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -7,7 +7,14 @@
 #include <unistd.h>
 #include "types.h" // scalanative_* types, not <sys/types.h>
 
-extern char **environ;
+// https://man7.org/linux/man-pages/man7/environ.7.html
+// Historically and by standard, environ must be declared in the
+// user program. However, as a (nonstandard) programmer
+// convenience, environ is declared in the header file <unistd.h> if
+// the _GNU_SOURCE feature test macro is defined
+#if #defined(_GNU_SOURCE)
+    extern char **environ;
+#endif
 
 long scalanative__posix_version() { return _POSIX_VERSION; }
 

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -11,16 +11,6 @@ extern char **environ;
 extern char *optarg;
 extern int opterr, optind, optopt;
 
-char **scalanative_environ() { return environ; }
-
-char *scalanative_optarg() { return optarg; }
-
-int scalanative_opterr() { return opterr; }
-
-int scalanative_optind() { return optind; }
-
-int scalanative_optopt() { return optopt; }
-
 long scalanative__posix_version() { return _POSIX_VERSION; }
 
 int scalanative__xopen_version() { return _XOPEN_VERSION; }

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -8,8 +8,6 @@
 #include "types.h" // scalanative_* types, not <sys/types.h>
 
 extern char **environ;
-extern char *optarg;
-extern int opterr, optind, optopt;
 
 long scalanative__posix_version() { return _POSIX_VERSION; }
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -33,22 +33,17 @@ object unistd {
   @name("scalanative__xopen_version")
   def _XOPEN_VERSION: CInt = extern
 
-  @name("scalanative_environ")
-  def environ: Ptr[CString] = extern
+  var environ: Ptr[CString] = extern
 
   // optarg, opterr, optopt, and optopt are used by getopt().
 
-  @name("scalanative_optarg")
-  def optarg: CString = extern
+  var optarg: CString = extern
 
-  @name("scalanative_opterr")
-  def opterr: CInt = extern
+  var opterr: CInt = extern
 
-  @name("scalanative_optind")
-  def optind: CInt = extern
+  var optind: CInt = extern
 
-  @name("scalanative_optopt")
-  def optopt: CInt = extern
+  var optopt: CInt = extern
 
 // Methods/functions
   def access(pathname: CString, mode: CInt): CInt = extern


### PR DESCRIPTION
As far as I know,  extern var can bind c variable.
Besides, variables are not read only, thus I think `var` is preferable to method.
1. setting `optind` to 1 allows users to traverse argv again
2. setting `opterr` to 0 disables error log output