### PR TITLE
0.5.x: use higher resolution file stat fields

### DIFF
--- a/docs/changelog/0.5.0.md
+++ b/docs/changelog/0.5.0.md
@@ -93,6 +93,75 @@ Javadoc and JVM output:
     throw new IllegalArgumentException("URI is not absolute")
   }
 ```
+
+### Replace time_t fields with timespec in POSIX sys/stat.scala
+
+In order to support nanosecond resolution for `java.nio.file.attribute.BasicFileAttributes`, we introduce breaking changes to sys/stat struct.
+
+Previously, `stat` struct was defined as following and you were able to access second resolution file stat fields `st_atime`, `st_mtime` and `st_ctime` by `_7`, `_8` and `_9`.
+
+```scala
+type stat = CStruct13[
+  dev_t, // st_dev
+  dev_t, // st_rdev
+  ino_t, // st_ino
+  uid_t, // st_uid
+  gid_t, // st_gid
+  off_t, // st_size
+  time_t, // st_atime
+  time_t, // st_mtime
+  time_t, // st_ctime
+  blkcnt_t, // st_blocks
+  blksize_t, // st_blksize
+  nlink_t, // st_nlink
+  mode_t // st_mode
+]
+```
+
+Since 0.5.0, `stat` struct uses `timespec` for file stat fields. Therefore, you need to replace `_7`, `_8` and `_9` with `_7._1`, `_8._1` and `_9._1` to access those fields.
+
+```scala
+  type stat = CStruct13[
+    dev_t, // st_dev
+    dev_t, // st_rdev
+    ino_t, // st_ino
+    uid_t, // st_uid
+    gid_t, // st_gid
+    off_t, // st_size
+    timespec, // st_atim or st_atimespec
+    timespec, // st_mtim or st_mtimespec
+    timespec, // st_ctim or st_ctimespec
+    blkcnt_t, // st_blocks
+    blksize_t, // st_blksize
+    nlink_t, // st_nlink
+    mode_t // st_mode
+  ]
+```
+
+There is a helper implicit class `statOps`, which provides human-friendly field accessors like `st_dev` or `st_rdev`. It is recommended to use these fields from `statOps` rather than accessing fields by `_N`.
+
+For example, import `scala.scalanative.posix.timeOps._` and `scala.scalanative.posix.sys.statOps.statOps`, then you can get the last access time of a file by `st_atime` or `st_atim` field.
+
+```scala
+import scala.scalanative.unsafe._
+import scala.scalanative.posix.sys.stat
+import scala.scalanative.posix.timeOps._
+import scala.scalanative.posix.sys.statOps.statOps
+
+Zone { implicit z =>
+  val filepath = c"/path/to/file"
+  val stat = alloc[stat.stat]()
+  stat.stat(filepath, stat)
+  // directly get the last access time in second resolution
+  val atime = stat.st_atime
+  // get the last access time in second resolution from timespec
+  val atimesec = stat.st_atim.tv_sec 
+  // get access time in nanosecond resolution from timespec
+  val atimensec = stat.st_atim.tv_nsec
+}
+
+```
+
 ## Deprecated definitions 
 
 ### Removed in this version

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -473,7 +473,8 @@ class File(_path: String) extends Serializable with Comparable[File] {
           val statbuf = alloc[stat.stat]()
           if (stat.stat(toCString(path), statbuf) == 0) {
             val timebuf = alloc[utime.utimbuf]()
-            timebuf._1 = statbuf._8._1
+            import scala.scalanative.posix.sys.statOps.statOps
+            timebuf._1 = statbuf.st_mtime
             timebuf._2 = time.toSize / 1000
             utime.utime(toCString(path), timebuf) == 0
           } else {

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -415,7 +415,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
       } else {
         val buf = alloc[stat.stat]()
         if (stat.stat(toCString(path), buf) == 0) {
-          buf._8 * 1000L
+          buf._8._1 * 1000L
         } else {
           0L
         }
@@ -473,7 +473,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
           val statbuf = alloc[stat.stat]()
           if (stat.stat(toCString(path), statbuf) == 0) {
             val timebuf = alloc[utime.utimbuf]()
-            timebuf._1 = statbuf._8
+            timebuf._1 = statbuf._8._1
             timebuf._2 = time.toSize / 1000
             utime.utime(toCString(path), timebuf) == 0
           } else {

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -413,9 +413,10 @@ class File(_path: String) extends Serializable with Comparable[File] {
             MinWinBaseApiOps.FileTimeOps.toUnixEpochMillis(!lastModified)
         }
       } else {
+        import scala.scalanative.posix.sys.statOps.statOps
         val buf = alloc[stat.stat]()
         if (stat.stat(toCString(path), buf) == 0) {
-          buf._8._1 * 1000L
+          buf.st_mtime * 1000L
         } else {
           0L
         }

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -30,15 +30,16 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       lastAccessTime: FileTime,
       createTime: FileTime
   ): Unit = Zone { implicit z =>
+    import scala.scalanative.posix.sys.statOps.statOps
     val sb = getStat()
 
     val buf = alloc[utime.utimbuf]()
     buf._1 =
       if (lastAccessTime != null) lastAccessTime.to(TimeUnit.SECONDS).toSize
-      else sb._7._1
+      else sb.st_atime
     buf._2 =
       if (lastModifiedTime != null) lastModifiedTime.to(TimeUnit.SECONDS).toSize
-      else sb._8._1
+      else sb.st_mtime
     // createTime is ignored: No posix-y way to set it.
     if (utime.utime(toCString(path.toString), buf) != 0)
       throwIOException()

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -98,15 +98,16 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
 
       Zone { implicit z =>
         val buf = getStat()
+        import scala.scalanative.posix.sys.statOps.statOps
 
         // Copy only what is referenced below. Save runtime cycles.
-        st_ino = buf._3
-        st_uid = buf._4
-        st_gid = buf._5
-        st_size = buf._6
-        st_atime = buf._7._1
-        st_mtime = buf._8._1
-        st_mode = buf._13
+        st_ino = buf.st_ino
+        st_uid = buf.st_uid
+        st_gid = buf.st_gid
+        st_size = buf.st_size
+        st_atime = buf.st_atime
+        st_mtime = buf.st_mtime
+        st_mode = buf.st_mode
       }
 
       override def fileKey() = st_ino.asInstanceOf[Object]

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -35,10 +35,10 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
     val buf = alloc[utime.utimbuf]()
     buf._1 =
       if (lastAccessTime != null) lastAccessTime.to(TimeUnit.SECONDS).toSize
-      else sb._7
+      else sb._7._1
     buf._2 =
       if (lastModifiedTime != null) lastModifiedTime.to(TimeUnit.SECONDS).toSize
-      else sb._8
+      else sb._8._1
     // createTime is ignored: No posix-y way to set it.
     if (utime.utime(toCString(path.toString), buf) != 0)
       throwIOException()
@@ -104,8 +104,8 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
         st_uid = buf._4
         st_gid = buf._5
         st_size = buf._6
-        st_atime = buf._7
-        st_mtime = buf._8
+        st_atime = buf._7._1
+        st_mtime = buf._8._1
         st_mode = buf._13
       }
 

--- a/posixlib/src/main/resources/scala-native/sys/stat.c
+++ b/posixlib/src/main/resources/scala-native/sys/stat.c
@@ -21,9 +21,9 @@ struct scalanative_stat {
                                       length in bytes. For a typed memory object,
                                       the length in bytes. For other file types,
                                       the use of this field is unspecified. */
-    scalanative_time_t _st_atime; /** Time of last access. */
-    scalanative_time_t _st_mtime; /** Time of last data modification. */
-    scalanative_time_t _st_ctime; /** Time of last status change. */
+    scalanative_timespec st_atim; /** Time of last access. */
+    scalanative_timespec st_mtim; /** Time of last data modification. */
+    scalanative_timespec st_ctim; /** Time of last status change. */
     scalanative_blkcnt_t st_blocks;   /** Number of blocks allocated for this
                                           object. */
     scalanative_blksize_t st_blksize; /** A file system-specific preferred I/O
@@ -42,9 +42,18 @@ void scalanative_stat_init(struct stat *stat,
     my_stat->st_uid = stat->st_uid;
     my_stat->st_gid = stat->st_gid;
     my_stat->st_size = stat->st_size;
-    my_stat->_st_atime = stat->st_atime;
-    my_stat->_st_mtime = stat->st_mtime;
-    my_stat->_st_ctime = stat->st_ctime;
+// see https://linux.die.net/man/2/stat
+#if defined(_BSD_SOURCE) || defined(_SVID_SOURCE) ||                           \
+    defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L ||                  \
+    defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
+    my_stat->st_atim = stat->st_atim;
+    my_stat->st_mtim = stat->st_mtim;
+    my_stat->st_ctim = stat->st_ctim;
+#else
+    my_stat->st_atim = stat->st_atimespec;
+    my_stat->st_mtim = stat->st_mtimespec;
+    my_stat->st_ctim = stat->st_ctimespec;
+#endif
     my_stat->st_blksize = stat->st_blksize;
     my_stat->st_blocks = stat->st_blocks;
     my_stat->st_nlink = stat->st_nlink;

--- a/posixlib/src/main/resources/scala-native/sys/stat.c
+++ b/posixlib/src/main/resources/scala-native/sys/stat.c
@@ -49,7 +49,7 @@ void scalanative_stat_init(struct stat *stat,
     my_stat->st_atim = stat->st_atim;
     my_stat->st_mtim = stat->st_mtim;
     my_stat->st_ctim = stat->st_ctim;
-#else
+#else // APPLE
     my_stat->st_atim = stat->st_atimespec;
     my_stat->st_mtim = stat->st_mtimespec;
     my_stat->st_ctim = stat->st_ctimespec;

--- a/posixlib/src/main/resources/scala-native/types.h
+++ b/posixlib/src/main/resources/scala-native/types.h
@@ -10,6 +10,7 @@ typedef unsigned int scalanative_uid_t;
 typedef unsigned int scalanative_gid_t;
 typedef long long scalanative_off_t;
 typedef long int scalanative_time_t;
+typedef struct timespec scalanative_timespec;
 typedef long long scalanative_blkcnt_t;
 typedef long scalanative_blksize_t;
 typedef unsigned long scalanative_nlink_t;

--- a/posixlib/src/main/resources/scala-native/types.h
+++ b/posixlib/src/main/resources/scala-native/types.h
@@ -10,7 +10,6 @@ typedef unsigned int scalanative_uid_t;
 typedef unsigned int scalanative_gid_t;
 typedef long long scalanative_off_t;
 typedef long int scalanative_time_t;
-typedef struct timespec scalanative_timespec;
 typedef long long scalanative_blkcnt_t;
 typedef long scalanative_blksize_t;
 typedef unsigned long scalanative_nlink_t;

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -132,3 +132,40 @@ object stat {
   def S_IXOTH: mode_t = extern
 
 }
+
+object statOps {
+  implicit class statOps(val c: Ptr[stat.stat]) extends AnyVal {
+    def st_dev: stat.dev_t = c._1
+    def st_dev_=(dev_t: stat.dev_t): Unit = c._1 = dev_t
+    def st_rdev: stat.dev_t = c._2
+    def st_rdev_=(dev_t: stat.dev_t): Unit = c._2 = dev_t
+    def st_ino: stat.ino_t = c._3
+    def st_ino_=(ino_t: stat.ino_t): Unit = c._3 = ino_t
+    def st_uid: uid_t = c._4
+    def st_uid_=(uid: uid_t): Unit = c._4 = uid
+    def st_gid: gid_t = c._5
+    def st_gid_=(gid: gid_t): Unit = c._5 = gid
+    def st_size: stat.off_t = c._6
+    def st_size_=(size: stat.off_t): Unit = c._6 = size
+    def st_atim: timespec = c._7
+    def st_atim_=(t: timespec): Unit = c._7 = t
+    def st_atime: time_t = c._7._1
+    def st_atime_=(t: time_t): Unit = c._7._1 = t
+    def st_mtim: timespec = c._8
+    def st_mtim_=(t: timespec): Unit = c._8 = t
+    def st_mtime_=(t: time_t): Unit = c._8._1 = t
+    def st_mtime: time_t = c._8._1
+    def st_ctim: timespec = c._9
+    def st_ctim_=(t: timespec): Unit = c._9 = t
+    def st_ctime: time_t = c._9._1
+    def st_ctime_=(t: time_t): Unit = c._9._1 = t
+    def st_blocks: stat.blkcnt_t = c._10
+    def st_blocks_=(blc: stat.blkcnt_t): Unit = c._10 = blc
+    def st_blksize: blksize_t = c._11
+    def st_blksize_=(blcsize: blksize_t): Unit = c._11 = blcsize
+    def st_nlink: nlink_t = c._12
+    def st_nlink_=(nlink: nlink_t): Unit = c._12 = nlink
+    def st_mode: mode_t = c._13
+    def st_mode_=(mode: mode_t): Unit = c._13 = mode
+  }
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -167,5 +167,13 @@ object statOps {
     def st_nlink_=(nlink: nlink_t): Unit = c._12 = nlink
     def st_mode: mode_t = c._13
     def st_mode_=(mode: mode_t): Unit = c._13 = mode
+
+    // helpers for Non POSIX(most likely Apple) st_* equivalents
+    def st_atimespec: timespec = c._7
+    def st_atimespec_=(t: timespec): Unit = c._7 = t
+    def st_mtimespec: timespec = c._8
+    def st_mtimespec_=(t: timespec): Unit = c._8 = t
+    def st_ctimespec: timespec = c._9
+    def st_ctimespec_=(t: timespec): Unit = c._9 = t
   }
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -51,9 +51,9 @@ object stat {
     uid_t, // st_uid
     gid_t, // st_gid
     off_t, // st_size
-    time_t, // st_atime
-    time_t, // st_mtime
-    time_t, // st_ctime
+    timespec, // st_atim or st_atimespec
+    timespec, // st_mtim or st_mtimespec
+    timespec, // st_ctim or st_ctimespec
     blkcnt_t, // st_blocks
     blksize_t, // st_blksize
     nlink_t, // st_nlink

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -60,12 +60,48 @@ object stat {
     mode_t // st_mode
   ]
 
+  /** stat gets file metadata from path
+   *  @param path
+   *    path to file/directory
+   *  @param buf
+   *    pointer to buffer into which stat struct is written.
+   *  @return
+   *    Return `0` on success. Otherwise return `-1` with `errno` being set.
+   *    `errno` can be the followings:
+   *    - EACCES(permission denied)
+   *    - EBADF(invalid filedes)
+   *    - EFAULT(wrong address)
+   *    - ELOOP(too many symbolic links)
+   *    - ENAMETOOLONG(too long name)
+   *    - ENOENT(path component not found or path is empty string)
+   *    - ENOMEM(kernel out of memory)
+   *    - ENOTDIR(path component is not a directory)
+   *  @example
+   *    {{{
+   *    import scala.scalanative.unsafe._
+   *    import scala.scalanative.posix.sys.stat
+   *    Zone { implicit z =>
+   *      val s = alloc[stat.stat]()
+   *      val code = stat.stat(filename,s)
+   *      if (code == 0) {
+   *        ???
+   *      }
+   *    }
+   *    }}}
+   */
   @name("scalanative_stat")
   def stat(path: CString, buf: Ptr[stat]): CInt = extern
 
+  /** similar to [[stat]], but different in that `fstat` uses fd instead of path
+   *  string.
+   */
   @name("scalanative_fstat")
   def fstat(fildes: CInt, buf: Ptr[stat]): CInt = extern
 
+  /** similar to [[stat]], but different in that `lstat` gets stat of the link
+   *  itself instead of that of file the link refers to when path points to
+   *  link.
+   */
   @name("scalanative_lstat")
   def lstat(path: CString, buf: Ptr[stat]): CInt = extern
 
@@ -171,9 +207,15 @@ object statOps {
     // helpers for Non POSIX(most likely Apple) st_* equivalents
     def st_atimespec: timespec = c._7
     def st_atimespec_=(t: timespec): Unit = c._7 = t
+    def st_atimensec: time_t = c._7._1
+    def st_atimensec_=(t: time_t): Unit = c._7._1 = t
     def st_mtimespec: timespec = c._8
     def st_mtimespec_=(t: timespec): Unit = c._8 = t
+    def st_mtimensec: time_t = c._8._1
+    def st_mtimensec_=(t: time_t): Unit = c._8._1 = t
     def st_ctimespec: timespec = c._9
     def st_ctimespec_=(t: timespec): Unit = c._9 = t
+    def st_ctimensec: time_t = c._9._1
+    def st_ctimensec_=(t: time_t): Unit = c._9._1 = t
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/StatTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/StatTest.scala
@@ -1,0 +1,193 @@
+package scala.scalanative.posix.sys
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{Before, After}
+import scala.scalanative.posix.limits
+import scala.scalanative.meta.LinktimeInfo.{isLinux, isWindows}
+
+import scala.scalanative.libc.stdio
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+import scala.scalanative.posix.unistd
+import scala.scalanative.posix.fcntl
+import scala.scalanative.posix.errno
+
+class StatTest {
+
+  @Test def fileStatTest(): Unit = if (!isWindows) {
+    Zone { implicit z =>
+      import scala.scalanative.posix.sys.statOps.statOps
+      val partSize = limits.PATH_MAX.toUInt
+      val buf: CString = alloc[Byte](partSize)
+      val tmpname = stdio.tmpnam(buf)
+      val fd = fcntl.open(tmpname, fcntl.O_CREAT)
+      val statFromPath = alloc[stat.stat]()
+      val code = stat.stat(tmpname, statFromPath)
+      assertEquals(
+        s"failed to get stat from $tmpname, errno = ${errno.errno}",
+        0,
+        code
+      )
+      val statFromFd = alloc[stat.stat]()
+      val code0 = stat.fstat(fd, statFromFd)
+      assertEquals(
+        s"failed to get stat from fd $fd of $tmpname, errno = ${errno.errno}",
+        0,
+        code0
+      )
+      assertEquals(
+        "st_dev from path and from fd must be the same",
+        statFromPath.st_dev,
+        statFromFd.st_dev
+      )
+      assertEquals(
+        "st_rdev from path and from fd must be the same",
+        statFromPath.st_rdev,
+        statFromFd.st_rdev
+      )
+      assertEquals(
+        "st_rdev must be 0 for regular file",
+        0.toUSize,
+        statFromPath.st_rdev
+      )
+      assertEquals(
+        "st_ino from path and from fd must be the same",
+        statFromPath.st_ino,
+        statFromFd.st_ino
+      )
+      assertEquals(
+        "st_uid from path and from fd must be the same",
+        statFromPath.st_uid,
+        statFromFd.st_uid
+      )
+      assertEquals(
+        "st_gid from path and from fd must be the same",
+        statFromPath.st_gid,
+        statFromFd.st_gid
+      )
+      assertEquals("tmpfile must be empty", 0, statFromPath.st_size)
+      assertEquals("tmpfile must be empty", 0, statFromFd.st_size)
+      assertEquals("tmpfile must not have blksize", 0, statFromPath.st_blocks)
+      assertEquals("tmpfile must not have blksize", 0, statFromFd.st_blocks)
+      assertEquals(
+        "st_atime from path and from fd must be the same",
+        statFromPath.st_atime,
+        statFromFd.st_atime
+      )
+      assertEquals(
+        "st_mtime from path and from fd must be the same",
+        statFromPath.st_mtime,
+        statFromFd.st_mtime
+      )
+      assertEquals(
+        "st_ctime from path and from fd must be the same",
+        statFromPath.st_ctime,
+        statFromFd.st_ctime
+      )
+      assertEquals(
+        "st_mode from path and from fd must be the same",
+        statFromPath.st_mode,
+        statFromFd.st_mode
+      )
+      assertEquals(
+        "second part of st_atim from path and from fd must be the same",
+        statFromPath.st_atim._1,
+        statFromFd.st_atim._1
+      )
+      assertEquals(
+        "nanosecond part of st_atim from path and from fd must be the same",
+        statFromPath.st_atim._2,
+        statFromFd.st_atim._2
+      )
+      assertEquals(
+        "second part of st_mtim from path and from fd must be the same",
+        statFromPath.st_mtim._1,
+        statFromFd.st_mtim._1
+      )
+      assertEquals(
+        "nanosecond part of st_mtim from path and from fd must be the same",
+        statFromPath.st_mtim._2,
+        statFromFd.st_mtim._2
+      )
+      assertEquals(
+        "second part of st_ctim from path and from fd must be the same",
+        statFromPath.st_ctim._1,
+        statFromFd.st_ctim._1
+      )
+      assertEquals(
+        "nanosecond part of st_ctim from path and from fd must be the same",
+        statFromPath.st_ctim._2,
+        statFromFd.st_ctim._2
+      )
+      assertEquals(
+        "st_nlink from path and from fd must be the same",
+        statFromPath.st_nlink,
+        statFromFd.st_nlink
+      )
+      assert(
+        statFromPath.st_nlink.toInt >= 1,
+        "regular file must have at least 1 nlink"
+      )
+      assertEquals(
+        "tmpfile must be regular file",
+        1,
+        stat.S_ISREG(statFromPath.st_mode)
+      )
+      assertEquals(
+        "tmpfile must not be dir",
+        0,
+        stat.S_ISDIR(statFromPath.st_mode)
+      )
+      assertEquals(
+        "tmpfile must not be chr",
+        0,
+        stat.S_ISCHR(statFromPath.st_mode)
+      )
+      assertEquals(
+        "tmpfile must not be blk",
+        0,
+        stat.S_ISBLK(statFromPath.st_mode)
+      )
+      assertEquals(
+        "tmpfile must not be fifo",
+        0,
+        stat.S_ISFIFO(statFromPath.st_mode)
+      )
+      assertEquals(
+        "tmpfile must not be lnk",
+        0,
+        stat.S_ISLNK(statFromPath.st_mode)
+      )
+      assertEquals(
+        "tmpfile must not be sock",
+        0,
+        stat.S_ISSOCK(statFromPath.st_mode)
+      )
+
+      val dirnamebuf: CString = alloc[Byte](partSize)
+      val tmpdirname = stdio.tmpnam(dirnamebuf)
+      val dirFd = stat.mkdir(tmpdirname, Integer.parseInt("0777", 8).toUInt)
+      val dirStatFromPath = alloc[stat.stat]()
+      val dircode = stat.stat(tmpdirname, dirStatFromPath)
+      assertEquals(0, dircode)
+      assertEquals(
+        0,
+        stat.S_ISREG(dirStatFromPath.st_mode)
+      )
+      assertEquals(
+        1,
+        stat.S_ISDIR(dirStatFromPath.st_mode)
+      )
+      assertEquals(
+        "st_rdev must be 0 for dir",
+        0.toUSize,
+        dirStatFromPath.st_rdev
+      )
+      assert(
+        dirStatFromPath.st_nlink.toInt >= 2
+      )
+    }
+  }
+}


### PR DESCRIPTION
rel https://github.com/scala-native/scala-native/issues/1610
prepare for reworking #1635: nanosecond resolution in javalib FileTime and posixlib sys/stat

__This commit introduces breaking changes in public api__

This commit changes stat struct fields so that it can use high resolution file stat, which is available since linux kernel 2.5.48 and later.
For more detail,see linux man page https://linux.die.net/man/2/stat