### PR TITLE
docs: deprecate posix.getopt as it isn't posix 2018

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -186,7 +186,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.fenv: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/fenv.scala
 .. _scala.scalanative.posix.float: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/float.scala
 .. _scala.scalanative.posix.fnmatch: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/fnmatch.scala
-.. _scala.scalanative.posix.getopt: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
+.. _scala.scalanative.posix.getopt: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala [#getopt_no_longer_posix_2018]_
 .. _scala.scalanative.posix.glob: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/glob.scala
 .. _scala.scalanative.posix.grp: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
 .. _scala.scalanative.posix.inttypes: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/inttypes.scala
@@ -241,7 +241,8 @@ C Header          Scala Native Module
                 specification because Scala Native supports only
                 passing structures by reference.  See code for details
 		and usage.
-
+.. [#getopt_no_longer_posix_2018] getopt.scala, introduced in PR `Fix #202: Support assignment to extern variables #1348 <https://github.com/scala-native/scala-native/pull/1348/>`_ 
+                                  is no longer part of POSIX 2018 and will be moved to unistd.scala in the future.
 .. [#monetary_varargs] See file for limit on number of variable arguments.
 
 Continue to :ref:`communitylib`.

--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -242,7 +242,7 @@ C Header          Scala Native Module
                 passing structures by reference.  See code for details
 		and usage.
 .. [#getopt_no_longer_posix_2018] getopt.scala, introduced in PR `Fix #202: Support assignment to extern variables #1348 <https://github.com/scala-native/scala-native/pull/1348/>`_ 
-                                  is no longer part of POSIX 2018 and will be moved to unistd.scala in the future.
+                                  is no longer part of POSIX 2018 and will be unified to unistd.scala in the future.
 .. [#monetary_varargs] See file for limit on number of variable arguments.
 
 Continue to :ref:`communitylib`.

--- a/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
@@ -3,6 +3,9 @@ package posix
 
 import scalanative.unsafe._
 
+@deprecated(
+  "getopt is no longer part of POSIX 2018 and will be moved to unistd"
+)
 @extern
 object getopt {
   var optarg: CString = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
@@ -4,7 +4,7 @@ package posix
 import scalanative.unsafe._
 
 @deprecated(
-  "getopt is no longer part of POSIX 2018 and will be moved to unistd"
+  "getopt is no longer part of POSIX 2018 and will be removed. Use unistd instead"
 )
 @extern
 object getopt {


### PR DESCRIPTION
`getopt` is no longer part of POSIX 2018 and should be moved to unistd.scala.

references #3052