### PR TITLE
Allow to use inherited `org.junit.{Aftter,Before}Class` methods

### DIFF
--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -110,6 +110,34 @@ object Assert {
   def assertNotEquals(unexpected: Float, actual: Float, delta: Float): Unit =
     assertNotEquals(null, unexpected, actual, delta)
 
+  // This deprecation should not be removed, it mapping the deprecation in the JUnit library to match bevaiour on the JVM
+  @deprecated(
+    "Use assertEquals(double expected, double actual, double " +
+      "epsilon) instead",
+    ""
+  )
+  @noinline
+  def assertEquals(expected: Double, actual: Double): Unit = {
+    fail(
+      "Use assertEquals(expected, actual, delta) to compare " +
+        "floating-point numbers"
+    )
+  }
+
+  // This deprecation should not be removed, it mapping the deprecation in the JUnit library to match bevaiour on the JVM
+  @deprecated(
+    "Use assertEquals(String message, double expected, double " +
+      "actual, double epsilon) instead",
+    ""
+  )
+  @noinline
+  def assertEquals(message: String, expected: Double, actual: Double): Unit = {
+    fail(
+      "Use assertEquals(expected, actual, delta) to compare " +
+        "floating-point numbers"
+    )
+  }
+
   @noinline
   def assertEquals(expected: Long, actual: Long): Unit =
     assertEquals(null, expected, actual)

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_.txt
@@ -1,0 +1,6 @@
+ld[34mTest run started[0m
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_a.txt
@@ -1,0 +1,6 @@
+ld[34mTest run started[0m
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_n.txt
@@ -1,0 +1,6 @@
+ldTest run started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_na.txt
@@ -1,0 +1,6 @@
+ldTest run started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nv.txt
@@ -1,0 +1,6 @@
+liTest run started
+liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nva.txt
@@ -1,0 +1,6 @@
+liTest run started
+liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvc.txt
@@ -1,0 +1,6 @@
+liTest run started
+liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvca.txt
@@ -1,0 +1,6 @@
+liTest run started
+liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_v.txt
@@ -1,0 +1,6 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_va.txt
@@ -1,0 +1,6 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vc.txt
@@ -1,0 +1,6 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vs.txt
@@ -1,0 +1,6 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vsn.txt
@@ -1,0 +1,6 @@
+liTest run started
+liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
+ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/AsyncTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/AsyncTest.scala
@@ -11,18 +11,18 @@ import scala.scalanative.junit.utils._
 
 class AsyncTest {
   @Test
-  def success(): AsyncResult = await {
+  def success(): Unit = await {
     Future(1 + 1).filter(_ == 2)
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def expectedException(): AsyncResult = await {
+  def expectedException(): Unit = await {
     // Do not throw synchronously.
     Future.failed(new IllegalArgumentException)
   }
 
   @Test
-  def asyncFailure(): AsyncResult = await {
+  def asyncFailure(): Unit = await {
     // Do not throw synchronously.
     Future.failed(new IllegalArgumentException)
   }

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/BeforeAndAfterClassTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/BeforeAndAfterClassTest.scala
@@ -1,0 +1,58 @@
+package scala.scalanative.junit
+
+import org.junit._
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalanative.junit.utils.JUnitTest
+
+object TraitParent {
+  @BeforeClass def beforeTrait(): Unit =
+    assumeFalse("before should be ignored in trait", true)
+  @AfterClass def afterTrait(): Unit =
+    assumeFalse("after should be ignored in trait", true)
+}
+
+trait TraitParent {
+  @Test def test(): Unit = ()
+}
+
+object ClassParent {
+  var wasReached = false
+  @BeforeClass def beforeParentClass(): Unit = {
+    assertFalse("beforeParent class should not be yet reached", wasReached)
+    wasReached = true
+  }
+  @AfterClass def afterParentClass(): Unit = {
+    assertFalse("afterParent should be reset in child", wasReached)
+  }
+}
+abstract class ClassParent extends TraitParent()
+
+object BeforeAndAfterClassTest {
+  var wasChildReached = false
+  @BeforeClass def beforeClass(): Unit = {
+    assertTrue("beforeClass parent should be reached", ClassParent.wasReached)
+    assertFalse("beforeClass child should not be reached", wasChildReached)
+    wasChildReached = true
+  }
+  @AfterClass def afterClass(): Unit = {
+    assertTrue("afterClass parent should be reached", ClassParent.wasReached)
+    assertTrue("afterClass child should be reached", wasChildReached)
+
+    // Clean the static state for the next run
+    ClassParent.wasReached = false // checked in ClassParent::afterParentClass
+    wasChildReached = false
+  }
+}
+
+/* Expected order of execution:
+ * - Before parent
+ * - Before class
+ * - Test
+ * - After class
+ * - After parent
+ */
+class BeforeAndAfterClassTest extends ClassParent()
+
+class BeforeAndAfterClassTestAssertions extends JUnitTest

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/utils/JUnitTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/utils/JUnitTest.scala
@@ -79,7 +79,7 @@ abstract class JUnitTest {
       Array(
         new TaskDef(
           suiteUnderTestName,
-          framework.fingerprints.head,
+          framework.fingerprints().head,
           true,
           Array.empty
         )
@@ -188,7 +188,8 @@ abstract class JUnitTest {
     case Done(_) => None
   }
 
-  private val colorRE = """\u001B\[\d\d?m""".r
+  // Scala 3 bug https://github.com/lampepfl/dotty/issues/16592
+  private val colorRE = "\u001B\\[\\d\\d?m".r
   private val timeRE = """\d+(\.\d+)?(E\-\d+)?( sec|s)\b""".r
 
   def replaceTime(out: Output): Output = out match {
@@ -203,7 +204,7 @@ abstract class JUnitTest {
   class JUnitTestRecorder extends Logger with EventHandler {
     private val buf = List.newBuilder[Output]
 
-    val ansiCodesSupported: Boolean = true
+    def ansiCodesSupported(): Boolean = true
 
     def info(msg: String): Unit = buf += Log('i', msg)
 
@@ -244,7 +245,8 @@ object JUnitTest {
     def deserialize(line: String): Output = line.toList match {
       case 'l' :: level :: msg => Log(level, msg.mkString(""))
       case 'e' :: s :: testName =>
-        Event(Status.values()(s - '0'), testName.mkString(""))
+        val status = Status.values
+        Event(status(s - '0'), testName.mkString(""))
       case 'd' :: msg => Done(msg.mkString(""))
       case _ => throw new RuntimeException("unexpected token in deserialize")
     }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -802,7 +802,9 @@ object Settings {
     Compile / publishArtifact := false,
     Test / parallelExecution := false,
     Test / unmanagedSourceDirectories +=
-      baseDirectory.value.getParentFile / "shared/src/test/scala",
+      baseDirectory.value
+        .getParentFile()
+        .getParentFile() / "shared/src/test/scala",
     Test / testOptions ++= Seq(
       Tests.Argument(TestFrameworks.JUnit, "-a", "-s", "-v"),
       Tests.Filter(_.endsWith("Assertions"))

--- a/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala.patch
+++ b/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala.patch
@@ -1,20 +1,29 @@
---- 2.12.15/scala/concurrent/ExecutionContext.scala
+--- 2.12.17/scala/concurrent/ExecutionContext.scala
 +++ overrides-2.12/scala/concurrent/ExecutionContext.scala
-@@ -138,7 +138,7 @@
-    *
-    * @return the global `ExecutionContext`
-    */
--  def global: ExecutionContextExecutor = Implicits.global.asInstanceOf[ExecutionContextExecutor]
-+  def global: ExecutionContextExecutor = scala.scalanative.runtime.ExecutionContext.global
+@@ -15,6 +15,7 @@
  
-   object Implicits {
-     /**
-@@ -149,7 +149,7 @@
+ import java.util.concurrent.{ ExecutorService, Executor }
+ import scala.annotation.implicitNotFound
++import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
+ 
+ /**
+  * An `ExecutionContext` can execute program logic asynchronously,
+@@ -149,7 +150,11 @@
       * the thread pool uses a target number of worker threads equal to the number of
       * [[https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors-- available processors]].
       */
 -    implicit lazy val global: ExecutionContext = impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+    implicit lazy val global: ExecutionContext = ExecutionContext.global
++    implicit lazy val global: ExecutionContext = {
++      if(isMultithreadingEnabled)
++        impl.ExecutionContextImpl.fromExecutor(null: Executor)
++      else scala.scalanative.runtime.ExecutionContext.singleThreaded
++    }
    }
  
    /** Creates an `ExecutionContext` from the given `ExecutorService`.
+@@ -198,5 +203,3 @@
+    */
+   def defaultReporter: Throwable => Unit = _.printStackTrace()
+ }
+-
+-

--- a/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala.patch
+++ b/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala.patch
@@ -1,29 +1,20 @@
---- 2.12.17/scala/concurrent/ExecutionContext.scala
+--- 2.12.15/scala/concurrent/ExecutionContext.scala
 +++ overrides-2.12/scala/concurrent/ExecutionContext.scala
-@@ -15,6 +15,7 @@
+@@ -138,7 +138,7 @@
+    *
+    * @return the global `ExecutionContext`
+    */
+-  def global: ExecutionContextExecutor = Implicits.global.asInstanceOf[ExecutionContextExecutor]
++  def global: ExecutionContextExecutor = scala.scalanative.runtime.ExecutionContext.global
  
- import java.util.concurrent.{ ExecutorService, Executor }
- import scala.annotation.implicitNotFound
-+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
- 
- /**
-  * An `ExecutionContext` can execute program logic asynchronously,
-@@ -149,7 +150,11 @@
+   object Implicits {
+     /**
+@@ -149,7 +149,7 @@
       * the thread pool uses a target number of worker threads equal to the number of
       * [[https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors-- available processors]].
       */
 -    implicit lazy val global: ExecutionContext = impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+    implicit lazy val global: ExecutionContext = {
-+      if(isMultithreadingEnabled)
-+        impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+      else scala.scalanative.runtime.ExecutionContext.singleThreaded
-+    }
++    implicit lazy val global: ExecutionContext = ExecutionContext.global
    }
  
    /** Creates an `ExecutionContext` from the given `ExecutorService`.
-@@ -198,5 +203,3 @@
-    */
-   def defaultReporter: Throwable => Unit = _.printStackTrace()
- }
--
--

--- a/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala.patch
+++ b/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala.patch
@@ -1,31 +1,54 @@
---- 2.13.6/scala/concurrent/ExecutionContext.scala
+--- 2.13.10/scala/concurrent/ExecutionContext.scala
 +++ overrides-2.13/scala/concurrent/ExecutionContext.scala
-@@ -197,7 +197,7 @@
+@@ -15,6 +15,7 @@
+ 
+ import java.util.concurrent.{ ExecutorService, Executor }
+ import scala.annotation.implicitNotFound
++import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
+ 
+ /**
+  * An `ExecutionContext` can execute program logic asynchronously,
+@@ -197,7 +198,12 @@
     *
     * @return the global [[ExecutionContext]]
     */
 -  final lazy val global: ExecutionContextExecutor = impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+  final lazy val global: ExecutionContextExecutor = scala.scalanative.runtime.ExecutionContext.global
++  final lazy val global: ExecutionContextExecutor = {
++    if(isMultithreadingEnabled)
++      impl.ExecutionContextImpl.fromExecutor(null: Executor)
++    else
++      scala.scalanative.runtime.ExecutionContext.singleThreaded
++  }
  
    /**
     * WARNING: Only ever execute logic which will quickly return control to the caller.
-@@ -227,18 +227,8 @@
+@@ -227,16 +233,21 @@
    /**
     * See [[ExecutionContext.global]].
     */
 -  private[scala] lazy val opportunistic: ExecutionContextExecutor = new ExecutionContextExecutor with BatchingExecutor {
 -    final override def submitForExecution(runnable: Runnable): Unit = global.execute(runnable)
-+  private[scala] lazy val opportunistic: ExecutionContextExecutor = ExecutionContext.global
++  private[scala] lazy val opportunistic: ExecutionContextExecutor = {
++    if(!isMultithreadingEnabled) ExecutionContext.global
++    else {
++      new ExecutionContextExecutor with BatchingExecutor {
++        final override def submitForExecution(runnable: Runnable): Unit = global.execute(runnable)
  
 -    final override def execute(runnable: Runnable): Unit =
 -      if ((!runnable.isInstanceOf[impl.Promise.Transformation[_,_]] || runnable.asInstanceOf[impl.Promise.Transformation[_,_]].benefitsFromBatching) && runnable.isInstanceOf[Batchable])
 -        submitAsyncBatched(runnable)
 -      else
 -        submitForExecution(runnable)
--
++        final override def execute(runnable: Runnable): Unit =
++          if ((!runnable.isInstanceOf[impl.Promise.Transformation[_, _]] || runnable.asInstanceOf[impl.Promise.Transformation[_, _]].benefitsFromBatching) && runnable.isInstanceOf[Batchable])
++            submitAsyncBatched(runnable)
++          else
++            submitForExecution(runnable)
+ 
 -    override final def reportFailure(t: Throwable): Unit = global.reportFailure(t)
--  }
--
++        override final def reportFailure(t: Throwable): Unit = global.reportFailure(t)
++      }
++    }
+   }
+ 
    object Implicits {
-     /**
-      * An accessor that can be used to import the global `ExecutionContext` into the implicit scope,

--- a/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala.patch
+++ b/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala.patch
@@ -1,54 +1,31 @@
---- 2.13.10/scala/concurrent/ExecutionContext.scala
+--- 2.13.6/scala/concurrent/ExecutionContext.scala
 +++ overrides-2.13/scala/concurrent/ExecutionContext.scala
-@@ -15,6 +15,7 @@
- 
- import java.util.concurrent.{ ExecutorService, Executor }
- import scala.annotation.implicitNotFound
-+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
- 
- /**
-  * An `ExecutionContext` can execute program logic asynchronously,
-@@ -197,7 +198,12 @@
+@@ -197,7 +197,7 @@
     *
     * @return the global [[ExecutionContext]]
     */
 -  final lazy val global: ExecutionContextExecutor = impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+  final lazy val global: ExecutionContextExecutor = {
-+    if(isMultithreadingEnabled)
-+      impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+    else
-+      scala.scalanative.runtime.ExecutionContext.singleThreaded
-+  }
++  final lazy val global: ExecutionContextExecutor = scala.scalanative.runtime.ExecutionContext.global
  
    /**
     * WARNING: Only ever execute logic which will quickly return control to the caller.
-@@ -227,16 +233,21 @@
+@@ -227,18 +227,8 @@
    /**
     * See [[ExecutionContext.global]].
     */
 -  private[scala] lazy val opportunistic: ExecutionContextExecutor = new ExecutionContextExecutor with BatchingExecutor {
 -    final override def submitForExecution(runnable: Runnable): Unit = global.execute(runnable)
-+  private[scala] lazy val opportunistic: ExecutionContextExecutor = {
-+    if(!isMultithreadingEnabled) ExecutionContext.global
-+    else {
-+      new ExecutionContextExecutor with BatchingExecutor {
-+        final override def submitForExecution(runnable: Runnable): Unit = global.execute(runnable)
++  private[scala] lazy val opportunistic: ExecutionContextExecutor = ExecutionContext.global
  
 -    final override def execute(runnable: Runnable): Unit =
 -      if ((!runnable.isInstanceOf[impl.Promise.Transformation[_,_]] || runnable.asInstanceOf[impl.Promise.Transformation[_,_]].benefitsFromBatching) && runnable.isInstanceOf[Batchable])
 -        submitAsyncBatched(runnable)
 -      else
 -        submitForExecution(runnable)
-+        final override def execute(runnable: Runnable): Unit =
-+          if ((!runnable.isInstanceOf[impl.Promise.Transformation[_, _]] || runnable.asInstanceOf[impl.Promise.Transformation[_, _]].benefitsFromBatching) && runnable.isInstanceOf[Batchable])
-+            submitAsyncBatched(runnable)
-+          else
-+            submitForExecution(runnable)
- 
+-
 -    override final def reportFailure(t: Throwable): Unit = global.reportFailure(t)
-+        override final def reportFailure(t: Throwable): Unit = global.reportFailure(t)
-+      }
-+    }
-   }
- 
+-  }
+-
    object Implicits {
+     /**
+      * An accessor that can be used to import the global `ExecutionContext` into the implicit scope,


### PR DESCRIPTION
This PR fixes the behavior of AfterClass and BeforeClass annotations. On JVM it's possible to use inherited static methods annotated with this method, but in ScalaNativ we would call only direct parent (excluding transitive ancestors) or only methods defined in the current class companion (behaviour ported from Scala.js). The current implementation follows the same order of execution as JVM. It also excluded annotated methods defined for companion of a trait for compliance with behavior on the JVM.  

Also, since migration build to `MultiScalaVersions` `junitTestOutputsXY` tests were not executed - due to misconfiguration they included no sources. This PR fixes the build and fixes currently not detected cross-build problems.

Restoring the actual outputs tests discovered issue with the recently removed deprecated method in 6b92eb57ce43cffa55bc555a6eb05ba11e4f5d80 - methods defined in the Assert class should have been not removed, as they provide implementation of Java Junit runtime library