### PR TITLE
Make initialization of `System.properties` a lazy operation

### DIFF
--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -91,16 +91,19 @@ object System {
   var err: PrintStream =
     new PrintStream(new FileOutputStream(FileDescriptor.err))
 
-  private val systemProperties = loadProperties()
-  Platform.setOSProps { (key: CString, value: CString) =>
-    val _ = systemProperties.setProperty(fromCString(key), fromCString(value))
-  }
-
   def lineSeparator(): String = {
     if (Platform.isWindows()) "\r\n"
     else "\n"
   }
 
+  private lazy val systemProperties0 = loadProperties()
+  private lazy val systemProperties = {
+    Platform.setOSProps { (key: CString, value: CString) =>
+      systemProperties0.setProperty(fromCString(key), fromCString(value))
+      ()
+    }
+    systemProperties0
+  }
   def getProperties(): Properties = systemProperties
 
   def clearProperty(key: String): String =


### PR DESCRIPTION
Currently, System.properties are being initialized in the body of `System` constructor, even though typically they are not used. 
These changes delay this operation. 
Early initialization of System properties also caused multiple issues in initialization of cyclic dependencies  - mostly due to trasnsitive dependencies on other methods defined in `java.lang.System`