### PR TITLE
Add `NativeTags.Link` to limit concurrency of `nativeLink`

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -14,6 +14,22 @@ object ScalaNativePlugin extends AutoPlugin {
 
     val nativeVersion = nir.Versions.current
 
+    /** Declares `Tag`s which may be used to limit the concurrency of build
+     *  tasks.
+     *
+     *  For example, the following snippet can be used to limit the number of
+     *  linking tasks which are able to run at once:
+     *
+     *  {{{
+     *  Global / concurrentRestrictions += Tags.limit(NativeTags.Link, 2)
+     *  }}}
+     */
+    object NativeTags {
+
+      /** This tag is applied to the [[nativeLink]] task. */
+      val Link = Tags.Tag("native-link")
+    }
+
     val nativeConfig =
       taskKey[build.NativeConfig](
         "User configuration for the native build, NativeConfig"


### PR DESCRIPTION
Closes https://github.com/scala-native/scala-native/issues/2853.

Adds a new `NativeTags.Link` tag to the sbt plugin that can be used to limit the number of `nativeLink` tasks running concurrently. This is useful for large, multi-module projects that have limited resources available in CI.

Example use:
```scala
Global / concurrentRestrictions += Tags.limit(NativeTags.Link, 2)
```

Further reading:
https://www.scala-sbt.org/1.x/docs/Parallel-Execution.html

---

Scala.js implements a similar functionality for limiting the concurrency of `fastLinkJS` and `fullLinkJS`.
https://github.com/scala-js/scala-js/blob/f673258b9960a723e335a549d682a879e7467b84/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala#L36-L50

