### PR TITLE
doc: usage of stackalloc in build env

### DIFF
--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -348,7 +348,7 @@ runtime system, one has to be extra careful when working with unmanaged memory.
    ``256`` is converted into ``USize`` by `Implicit conversions <https://docs.scala-lang.org/tour/implicit-conversions.html>`_.
    In general, most of Scala Native users need not to care about this conversion.
    However, if you are contributor to Scala Native, you may find ``stackalloc`` need explicit 
-   conversion(e.g. ``10.toUSize``) in Scala Native internal. This is because implicit conversion
+   conversion(e.g. ``256.toUSize``) in Scala Native internal. This is because implicit conversion
    is not automatically imported in Scala Native build environment.
 
 3. **Manual heap allocation.**

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -344,6 +344,13 @@ runtime system, one has to be extra careful when working with unmanaged memory.
    this memory beyond the lifetime of the method. Dereferencing stack allocated
    memory after the method's execution has completed is undefined behavior.
 
+   Note that ``stackalloc[type](N)`` takes ``Usize`` as an argument. In the example above,
+   ``256`` is converted into ``USize`` by `Implicit conversions <https://docs.scala-lang.org/tour/implicit-conversions.html>`_.
+   In general, most of Scala Native users need not to care about this conversion.
+   However, if you are contributor to Scala Native, you may find ``stackalloc`` need explicit 
+   conversion(e.g. ``10.toUSize``) in Scala Native internal. This is because implicit conversion
+   is not automatically imported in Scala Native build environment.
+
 3. **Manual heap allocation.**
 
    Scala Native's library contains a bindings for a subset of the standard


### PR DESCRIPTION
`stackalloc` doesn't need explicit conversion to `USize` in user environment while it requires explicit conversion in Scala Native build env.

~~will close 2728 and 2786~~

For example, the following snippet compiles by `scala-cli main.scala --native`

```
import scala.scalanative.unsafe.stackalloc

@main def run() =
  val _ = stackalloc[Byte](10)
```

However, you need explicit conversion in Scala Native build environment.

Example from scala.scalanative.unsafe.StackallocTest compiles.

```
val ptr: Ptr[Int] = stackalloc[Int](4.toUInt) // UInt is converted to
USize
```

On the other hand, the following doesn't compile.

```
val ptr: Ptr[Int] = stackalloc[Int](4)
```

```
Type Mismatch Error: /path/to/scala-native/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala:20:40
[error] 20 |    val ptr: Ptr[Int] = stackalloc[Int](4)
[error]    |                                        ^
[error]    |                                Found:    (4 : Int)
[error]    |                                Required: scala.scalanative.unsafe.CSize
```

ref #2728 and #2786