### PR TITLE
Rework optimization from #1549

### DIFF
--- a/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
@@ -11,7 +11,7 @@ import scala.scalanative.runtime.GC
  */
 private[java] object WeakReferenceRegistry {
   private var weakRefList: immutable.List[WeakReference[_]] =
-    immutable.List()
+    immutable.List.empty
 
   private val postGCHandlerMap
       : mutable.HashMap[WeakReference[_], Function0[Unit]] =

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/utils/JUnitTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/utils/JUnitTest.scala
@@ -29,7 +29,7 @@ abstract class JUnitTest {
   }
 
   private val frameworkArgss: List[List[Char]] = List(
-    List(),
+    List.empty,
     List('a'),
     List('v'),
     List('n'),

--- a/nativelib/src/main/scala/java/lang/resource/EmbeddedResourceInputStream.scala
+++ b/nativelib/src/main/scala/java/lang/resource/EmbeddedResourceInputStream.scala
@@ -43,7 +43,7 @@ private[lang] class EmbeddedResourceInputStream(resourceId: Int)
 
   private def invalidateMark(): Unit = {
     markPosition = 0
-    markSeq = Seq()
+    markSeq = Seq.empty
     markReadLimit = 0
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -40,7 +40,7 @@ final case class Attrs(
     isDyn: Boolean = false,
     isStub: Boolean = false,
     isAbstract: Boolean = false,
-    links: Seq[Attr.Link] = Seq()
+    links: Seq[Attr.Link] = Seq.empty
 ) {
   def toSeq: Seq[Attr] = {
     val out = Seq.newBuilder[Attr]

--- a/nir/src/main/scala/scala/scalanative/nir/Next.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Next.scala
@@ -20,7 +20,7 @@ object Next {
   final case class Label(name: Local, args: Seq[Val]) extends Next
 
   def apply(name: Local): Label =
-    Label(name, Seq())
+    Label(name, Seq.empty)
   def Case(value: Val, name: Local): Case =
     Case(value, Next(name))
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -92,7 +92,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     val end = getInt
     var seq: List[Attr] = Nil
     while (i <= end) {
-      getAttr match {
+      getAttr() match {
         case attr: Inline          => inline = attr
         case attr: Attr.Specialize => sp = attr
         case attr: Attr.Opt        => opt = attr

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -305,6 +305,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
 
   private def getTypes(): Seq[Type] = getSeq(getType())
   private def getType(): Type = getInt match {
+    case T.RefType         => Type.Ref(getGlobal(), getBool(), getBool())
     case T.VarargType      => Type.Vararg
     case T.PtrType         => Type.Ptr
     case T.BoolType        => Type.Bool
@@ -325,12 +326,12 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     case T.VarType     => Type.Var(getType())
     case T.UnitType    => Type.Unit
     case T.ArrayType   => Type.Array(getType(), getBool())
-    case T.RefType     => Type.Ref(getGlobal(), getBool(), getBool())
     case T.SizeType    => Type.Size
   }
 
   private def getVals(): Seq[Val] = getSeq(getVal())
   private def getVal(): Val = getInt match {
+    case T.LocalVal       => Val.Local(getLocal(), getType())
     case T.TrueVal        => Val.True
     case T.FalseVal       => Val.False
     case T.NullVal        => Val.Null
@@ -345,7 +346,6 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     case T.StructValueVal => Val.StructValue(getVals())
     case T.ArrayValueVal  => Val.ArrayValue(getType(), getVals())
     case T.CharsVal       => Val.Chars(getBytes().toIndexedSeq)
-    case T.LocalVal       => Val.Local(getLocal(), getType())
     case T.GlobalVal      => Val.Global(getGlobal(), getType())
 
     case T.UnitVal  => Val.Unit

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -223,7 +223,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       // Extract switch cases and assign unique names to them.
       val caseps: Seq[Case] = allcaseps.flatMap {
         case CaseDef(Ident(nme.WILDCARD), _, _) =>
-          Seq()
+          Seq.empty
         case cd @ CaseDef(pat, guard, body) =>
           assert(guard.isEmpty, "CaseDef guard was not empty")
           val vals: Seq[Val] = pat match {
@@ -633,7 +633,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       } else if (sym.isStaticMember) {
         genStaticMember(qualp, sym)
       } else if (sym.isMethod) {
-        genApplyMethod(sym, statically = false, qualp, Seq())
+        genApplyMethod(sym, statically = false, qualp, Seq.empty)
       } else if (owner.isStruct) {
         val index = owner.info.decls.filter(_.isField).toList.indexOf(sym)
         val qual = genExpr(qualp)
@@ -655,7 +655,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         pos: nir.Position
     ): Val = {
       if (sym == BoxedUnit_UNIT) Val.Unit
-      else genApplyStaticMethod(sym, receiver, Seq())
+      else genApplyStaticMethod(sym, receiver, Seq.empty)
     }
 
     def genAssign(tree: Assign): Val = {
@@ -772,7 +772,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val captureFormals = captureTypes.map { ty => Val.Local(fresh(), ty) }
         buf.label(fresh(), self +: captureFormals)
         val superTy = nir.Type.Function(Seq(Rt.Object), Type.Unit)
-        val superName = Rt.Object.name.member(Sig.Ctor(Seq()))
+        val superName = Rt.Object.name.member(Sig.Ctor(Seq.empty))
         val superCtor = Val.Global(superName, Type.Ptr)
         buf.call(superTy, superCtor, Seq(self), Next.None)
         captureNames.zip(captureFormals).foreach {
@@ -1217,7 +1217,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       condp match {
         // if(bool) (...)
-        case Apply(LinktimeProperty(name, position), List()) =>
+        case Apply(LinktimeProperty(name, position), Nil) =>
           Some {
             SimpleCondition(
               propertyName = name,
@@ -1229,10 +1229,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         // if(!bool) (...)
         case Apply(
               Select(
-                Apply(LinktimeProperty(name, position), List()),
+                Apply(LinktimeProperty(name, position), Nil),
                 nme.UNARY_!
               ),
-              List()
+              Nil
             ) =>
           Some {
             SimpleCondition(
@@ -1665,7 +1665,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             value
           } else {
             val meth = Object_toString
-            genApplyMethod(meth, statically = false, value, Seq())
+            genApplyMethod(meth, statically = false, value, Seq.empty)
           }
         }
         genIf(Rt.String, cond, thenp, elsep)
@@ -1699,7 +1699,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val thenp = ValTree(Val.Int(0))
       val elsep = ContTree { () =>
         val meth = NObjectHashCodeMethod
-        genApplyMethod(meth, statically = false, arg, Seq())
+        genApplyMethod(meth, statically = false, arg, Seq.empty)
       }
       genIf(Type.Int, cond, thenp, elsep)
     }
@@ -2088,14 +2088,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         RuntimeMonitorEnterMethod,
         statically = true,
         monitor,
-        Seq()
+        Seq.empty
       )
       val ret = bodyGen(this)
       val exit = genApplyMethod(
         RuntimeMonitorExitMethod,
         statically = true,
         monitor,
-        Seq()
+        Seq.empty
       )
 
       ret

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -161,7 +161,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           Attr.Stub
       }
       val abstractAttr =
-        if (sym.isAbstract) Seq(Attr.Abstract) else Seq()
+        if (sym.isAbstract) Seq(Attr.Abstract) else Seq.empty
 
       Attrs.fromSeq(annotationAttrs ++ abstractAttr)
     }
@@ -275,7 +275,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           // call to super constructor
           exprBuf.call(
             Type.Function(Seq(Type.Ref(superClass)), Type.Unit),
-            Val.Global(superClass.member(Sig.Ctor(Seq())), Type.Ptr),
+            Val.Global(superClass.member(Sig.Ctor(Seq.empty)), Type.Ptr),
             Seq(thisArg),
             unwind(curFresh)
           )
@@ -286,7 +286,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
         reflInstBuffer += Defn.Define(
           Attrs(),
-          reflInstBuffer.name.member(Sig.Ctor(Seq())),
+          reflInstBuffer.name.member(Sig.Ctor(Seq.empty)),
           nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name)), Type.Unit),
           body
         )
@@ -364,11 +364,11 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         )
 
         // Allocate and return an instance of the generated class.
-        allocAndConstruct(exprBuf, reflInstBuffer.name, Seq(), Seq())
+        allocAndConstruct(exprBuf, reflInstBuffer.name, Seq.empty, Seq.empty)
       }
 
       withFreshExprBuffer { exprBuf =>
-        exprBuf.label(curFresh(), Seq())
+        exprBuf.label(curFresh(), Seq.empty)
 
         val fqcnArg = Val.String(fqSymId)
         val runtimeClassArg = Val.ClassOf(fqSymName)
@@ -504,7 +504,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
           // Allocate an instance of the generated class.
           val instantiator =
-            allocAndConstruct(exprBuf, reflInstBuffer.name, Seq(), Seq())
+            allocAndConstruct(exprBuf, reflInstBuffer.name, Seq.empty, Seq.empty)
 
           // Create the current constructor's info. We need:
           // - an array with the runtime classes of the ctor parameters.
@@ -554,7 +554,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         Seq.empty
       else
         withFreshExprBuffer { exprBuf =>
-          exprBuf.label(curFresh(), Seq())
+          exprBuf.label(curFresh(), Seq.empty)
 
           val fqcnArg = Val.String(fqSymId)
           val runtimeClassArg = Val.ClassOf(fqSymName)
@@ -689,7 +689,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       Defn.Define(
         Attrs(inlineHint = Attr.AlwaysInline),
         methodName,
-        Type.Function(Seq(), retty),
+        Type.Function(Seq.empty, retty),
         buf.toSeq
       )
     }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -60,7 +60,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
           abort("ClassInfoType to ArrayClass!")
         case ClassInfoType(_, _, sym) => SimpleType(sym, Seq.empty)
         case t: AnnotatedType         => fromType(t.underlying)
-        case tpe: ErasedValueType     => SimpleType(tpe.valueClazz, Seq())
+        case tpe: ErasedValueType     => SimpleType(tpe.valueClazz, Seq.empty)
       }
 
     implicit def fromSymbol(sym: Symbol): SimpleType =

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -106,7 +106,7 @@ trait GenReflectiveInstantisation(using Context) {
 
     withFreshExprBuffer { buf ?=>
 
-      buf.label(curFresh(), Seq())
+      buf.label(curFresh(), Seq.empty)
       val loadModuleFunArg = genModuleLoader(fqSymName)
       buf.genApplyModuleMethod(
         defnNir.ReflectModule,
@@ -143,7 +143,7 @@ trait GenReflectiveInstantisation(using Context) {
     if (ctors.isEmpty) Nil
     else
       withFreshExprBuffer { buf ?=>
-        buf.label(curFresh(), Seq())
+        buf.label(curFresh(), Seq.empty)
         val instantiateClassFunArg = genClassConstructorsInfo(fqSymName, ctors)
         buf.genApplyModuleMethod(
           defnNir.ReflectModule,
@@ -171,7 +171,7 @@ trait GenReflectiveInstantisation(using Context) {
         // call to super constructor
         buf.call(
           Type.Function(Seq(Type.Ref(superClass)), Type.Unit),
-          Val.Global(superClass.member(Sig.Ctor(Seq())), Type.Ptr),
+          Val.Global(superClass.member(Sig.Ctor(Seq.empty)), Type.Ptr),
           Seq(thisArg),
           unwind(curFresh)
         )
@@ -181,7 +181,7 @@ trait GenReflectiveInstantisation(using Context) {
 
       reflInstBuffer += Defn.Define(
         Attrs(),
-        reflInstBuffer.name.member(Sig.Ctor(Seq())),
+        reflInstBuffer.name.member(Sig.Ctor(Seq.empty)),
         nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name)), Type.Unit),
         body
       )
@@ -249,7 +249,7 @@ trait GenReflectiveInstantisation(using Context) {
     )
 
     // Allocate and return an instance of the generated class.
-    allocAndConstruct(reflInstBuffer.name, Seq(), Seq())(using pos, buf)
+    allocAndConstruct(reflInstBuffer.name, Seq.empty, Seq.empty)(using pos, buf)
   }
 
   // Create a new Tuple2 and initialise it with the provided values.
@@ -353,7 +353,7 @@ trait GenReflectiveInstantisation(using Context) {
       )
 
       // Allocate an instance of the generated class.
-      val instantiator = allocAndConstruct(reflInstBuffer.name, Seq(), Seq())
+      val instantiator = allocAndConstruct(reflInstBuffer.name, Seq.empty, Seq.empty)
 
       // Create the current constructor's info. We need:
       // - an array with the runtime classes of the ctor parameters.

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -277,7 +277,7 @@ trait NirGenExpr(using Context) {
           val buf = new nir.Buffer()(fresh)
 
           val superTy = nir.Type.Function(Seq(Rt.Object), Type.Unit)
-          val superName = Rt.Object.name.member(Sig.Ctor(Seq()))
+          val superName = Rt.Object.name.member(Sig.Ctor(Seq.empty))
           val superCtor = Val.Global(superName, Type.Ptr)
 
           val self = Val.Local(fresh(), Type.Ref(anonClassName))
@@ -540,7 +540,7 @@ trait NirGenExpr(using Context) {
       // Extract switch cases and assign unique names to them.
       val caseps: Seq[Case] = allcaseps.flatMap {
         case CaseDef(Ident(nme.WILDCARD), _, _) =>
-          Seq()
+          Seq.empty
         case cd @ CaseDef(pat, guard, body) =>
           assert(guard.isEmpty, "CaseDef guard was not empty")
           val vals: Seq[Val] = pat match {
@@ -712,7 +712,7 @@ trait NirGenExpr(using Context) {
       else if (sym.isStaticInNIR && !sym.isExtern)
         genStaticMember(sym, qualp.symbol)
       else if (sym.is(Method))
-        genApplyMethod(sym, statically = false, qualp, Seq())
+        genApplyMethod(sym, statically = false, qualp, Seq.empty)
       else if (owner.isStruct) {
         val index = owner.info.decls.filter(_.isField).toList.indexOf(sym)
         val qual = genExpr(qualp)
@@ -974,7 +974,7 @@ trait NirGenExpr(using Context) {
 
       locally {
         given nir.Position = wd.span.endPos
-        buf.label(exitLabel, Seq())
+        buf.label(exitLabel, Seq.empty)
         if (cond == EmptyTree) Val.Zero(genType(defn.NothingClass))
         else Val.Unit
       }
@@ -1519,7 +1519,7 @@ trait NirGenExpr(using Context) {
       val thenp = ValTree(Val.Int(0))
       val elsep = ContTree { () =>
         val meth = defnNir.NObject_hashCode
-        genApplyMethod(meth, statically = false, arg, Seq())
+        genApplyMethod(meth, statically = false, arg, Seq.empty)
       }
       genIf(Type.Int, cond, thenp, elsep)
     }
@@ -1534,7 +1534,7 @@ trait NirGenExpr(using Context) {
           if (sym == defn.StringClass) value
           else {
             val meth = defn.Any_toString
-            genApplyMethod(meth, statically = false, value, Seq())
+            genApplyMethod(meth, statically = false, value, Seq.empty)
           }
         }
         genIf(Rt.String, cond, thenp, elsep)
@@ -1574,7 +1574,7 @@ trait NirGenExpr(using Context) {
 
       if (sym == defn.BoxedUnit_UNIT) Val.Unit
       else if (sym == defn.BoxedUnit_TYPE) Val.Unit
-      else genApplyStaticMethod(sym, receiver, Seq())
+      else genApplyStaticMethod(sym, receiver, Seq.empty)
     }
 
     private def genSynchronized(receiverp: Tree, bodyp: Tree)(using
@@ -1596,14 +1596,14 @@ trait NirGenExpr(using Context) {
         defnNir.RuntimeMonitor_enter,
         statically = true,
         monitor,
-        Seq()
+        Seq.empty
       )
       val ret = bodyGen(this)
       val exit = genApplyMethod(
         defnNir.RuntimeMonitor_exit,
         statically = true,
         monitor,
-        Seq()
+        Seq.empty
       )
 
       ret
@@ -1990,7 +1990,7 @@ trait NirGenExpr(using Context) {
 
       condp match {
         // if(bool) (...)
-        case Apply(LinktimeProperty(name, position), List()) =>
+        case Apply(LinktimeProperty(name, position),Nil) =>
           Some {
             SimpleCondition(
               propertyName = name,
@@ -2002,10 +2002,10 @@ trait NirGenExpr(using Context) {
         // if(!bool) (...)
         case Apply(
               Select(
-                Apply(LinktimeProperty(name, position), List()),
+                Apply(LinktimeProperty(name, position), Nil),
                 nme.UNARY_!
               ),
-              List()
+              Nil
             ) =>
           Some {
             SimpleCondition(
@@ -2039,7 +2039,7 @@ trait NirGenExpr(using Context) {
                 ),
                 nme.UNARY_!
               ),
-              List()
+              Nil
             ) =>
           Some {
             val argValue = genLiteralValue(arg)
@@ -2422,7 +2422,7 @@ trait NirGenExpr(using Context) {
         defnNir.ReflectSelectable_selectedValue,
         statically = false,
         genExpr(receiver),
-        Seq()
+        Seq.empty
       )
 
       // Extract the method name as a String

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -406,7 +406,7 @@ trait NirGenStat(using Context) {
     Defn.Define(
       Attrs(inlineHint = Attr.AlwaysInline),
       methodName,
-      Type.Function(Seq(), retty),
+      Type.Function(Seq.empty, retty),
       buf.toSeq
     )
   }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -43,16 +43,16 @@ object BinaryIncompatibilities {
     exclude[Problem]("scala.scalanative.build.Config*Impl*")
   )
 
-  final val NativeLib = Seq()
+  final val NativeLib = Seq.empty
   final val CLib: Filters = Nil
-  final val PosixLib: Filters = Seq()
+  final val PosixLib: Filters = Seq.empty
   final val WindowsLib: Filters = Nil
 
   final val AuxLib, JavaLib, ScalaLib, Scala3Lib: Filters = Nil
   final val TestRunner: Filters = Nil
   final val TestInterface: Filters = Nil
   final val TestInterfaceSbtDefs: Filters = Nil
-  final val JUnitRuntime: Filters = Seq()
+  final val JUnitRuntime: Filters = Seq.empty
 
   val moduleFilters = Map(
     "util" -> Util,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -636,7 +636,7 @@ object Build {
         testFrameworks ++= {
           if (shouldPartest.value)
             Seq(new TestFramework("scala.tools.partest.scalanative.Framework"))
-          else Seq()
+          else Seq.empty
         }
       )
       .zippedSettings(
@@ -646,7 +646,7 @@ object Build {
           Def.settings(
             Test / definedTests ++= Def
               .taskDyn[Seq[sbt.TestDefinition]] {
-                if (!shouldPartest.value) Def.task(Seq())
+                if (!shouldPartest.value) Def.task(Seq.empty)
                 else
                   Def.task {
                     val _ = (scalaPartest / fetchScalaSource).value

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativePartestOptions.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativePartestOptions.scala
@@ -141,7 +141,7 @@ object ScalaNativePartestOptions {
           optimize = optimize,
           buildMode = mode,
           shouldPrecompileLibraries = precompileLibs,
-          precompiledLibrariesPaths = Seq(),
+          precompiledLibrariesPaths = Seq.empty,
           gc = gc,
           lto = lto
         )

--- a/testing-compiler/src/main/scala-2/scalanative/NIRCompiler.scala
+++ b/testing-compiler/src/main/scala-2/scalanative/NIRCompiler.scala
@@ -40,7 +40,7 @@ class NIRCompiler(outputDir: Path) extends api.NIRCompiler {
   /** List of the files contained in `base` that sastisfy `filter`
    */
   private def getFiles(base: File, filter: File => Boolean): Seq[File] =
-    (if (filter(base)) Seq(base) else Seq()) ++
+    (if (filter(base)) Seq(base) else Seq.empty) ++
       (Option(base.listFiles()) getOrElse Array.empty flatMap (getFiles(
         _,
         filter

--- a/tools/src/main/scala/scala/scalanative/build/GC.scala
+++ b/tools/src/main/scala/scala/scalanative/build/GC.scala
@@ -27,14 +27,14 @@ sealed abstract class GC private (
   override def toString: String = name
 }
 object GC {
-  private[scalanative] case object None extends GC("none", Seq(), Seq("shared"))
-  private[scalanative] case object Boehm extends GC("boehm", Seq("gc"), Seq())
+  private[scalanative] case object None extends GC("none", Seq.empty, Seq("shared"))
+  private[scalanative] case object Boehm extends GC("boehm", Seq("gc"), Seq.empty)
   private[scalanative] case object Immix
-      extends GC("immix", Seq(), Seq("shared", "immix_commix"))
+      extends GC("immix", Seq.empty, Seq("shared", "immix_commix"))
   private[scalanative] case object Commix
-      extends GC("commix", Seq(), Seq("shared", "immix_commix"))
+      extends GC("commix", Seq.empty, Seq("shared", "immix_commix"))
   private[scalanative] case object Experimental
-      extends GC("experimental", Seq(), Seq())
+      extends GC("experimental", Seq.empty, Seq.empty)
 
   /** Non-freeing garbage collector. */
   def none: GC = None

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -59,7 +59,7 @@ private[scalanative] object LLVM {
 
     val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
     val stdflag = {
-      if (isLl) Seq()
+      if (isLl) Seq.empty
       else if (isCpp) {
         // C++14 or newer standard is needed to compile code using Windows API
         // shipped with Windows 10 / Server 2016+ (we do not plan supporting older versions)

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -132,7 +132,7 @@ private[codegen] abstract class AbstractCodeGen(
     case Defn.Const(attrs, name, ty, rhs) =>
       genGlobalDefn(attrs, name, isConst = true, ty, rhs)
     case Defn.Declare(attrs, name, sig) =>
-      genFunctionDefn(attrs, name, sig, Seq(), Fresh())
+      genFunctionDefn(attrs, name, sig, Seq.empty, Fresh())
     case Defn.Define(attrs, name, sig, insts) =>
       genFunctionDefn(attrs, name, sig, insts, Fresh(insts))
     case defn =>

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -159,9 +159,9 @@ object Generate {
         case Defn.Define(_, name: Global.Member, _, _) if name.sig.isClinit =>
           Inst.Let(
             Op.Call(
-              Type.Function(Seq(), Type.Unit),
+              Type.Function(Seq.empty, Type.Unit),
               Val.Global(name, Type.Ref(name)),
-              Seq()
+              Seq.empty
             ),
             unwind()
           )
@@ -182,7 +182,7 @@ object Generate {
         ),
         Inst.Let(Op.Store(Type.Ptr, StackBottomVar, stackBottom), unwind),
         // Init GC
-        Inst.Let(Op.Call(InitSig, Init, Seq()), unwind)
+        Inst.Let(Op.Call(InitSig, Init, Seq.empty), unwind)
       )
     }
 
@@ -283,16 +283,16 @@ object Generate {
             buf += instanceDefn
           } else {
             val initSig = Type.Function(Seq(clsTy), Type.Unit)
-            val init = Val.Global(name.member(Sig.Ctor(Seq())), Type.Ptr)
+            val init = Val.Global(name.member(Sig.Ctor(Seq.empty)), Type.Ptr)
 
             val loadName = name.member(Sig.Generated("load"))
-            val loadSig = Type.Function(Seq(), clsTy)
+            val loadSig = Type.Function(Seq.empty, clsTy)
             val loadDefn = Defn.Define(
               Attrs(inlineHint = Attr.NoInline),
               loadName,
               loadSig,
               Seq(
-                Inst.Label(entry, Seq()),
+                Inst.Label(entry, Seq.empty),
                 Inst.Let(
                   slot.name,
                   Op.Elem(
@@ -309,9 +309,9 @@ object Generate {
                   Next.None
                 ),
                 Inst.If(cond, Next(existing), Next(initialize)),
-                Inst.Label(existing, Seq()),
+                Inst.Label(existing, Seq.empty),
                 Inst.Ret(self),
-                Inst.Label(initialize, Seq()),
+                Inst.Label(initialize, Seq.empty),
                 Inst.Let(alloc.name, Op.Classalloc(name), Next.None),
                 Inst.Let(Op.Store(clsTy, slot, alloc), Next.None),
                 Inst.Let(Op.Call(initSig, init, Seq(alloc)), Next.None),
@@ -477,7 +477,7 @@ object Generate {
       Val.Global(RuntimeLoopName, Type.Ptr)
 
     val LibraryInitName = extern("ScalaNativeInit")
-    val LibraryInitSig = Type.Function(Seq(), Type.Int)
+    val LibraryInitSig = Type.Function(Seq.empty, Type.Int)
 
     val MainName = extern("main")
     val MainSig = Type.Function(Seq(Type.Int, Type.Ptr), Type.Int)
@@ -492,7 +492,7 @@ object Generate {
     val PrintStackTrace =
       Val.Global(PrintStackTraceName, Type.Ptr)
 
-    val InitSig = Type.Function(Seq(), Type.Unit)
+    val InitSig = Type.Function(Seq.empty, Type.Unit)
     val Init = Val.Global(extern("scalanative_init"), Type.Ptr)
     val InitDecl = Defn.Declare(Attrs.None, Init.name, InitSig)
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1048,10 +1048,10 @@ object Lower {
           buf.let(n, Op.Copy(Val.Global(instance, Type.Ptr)), unwind)
 
         case _ =>
-          val loadSig = Type.Function(Seq(), Type.Ref(name))
+          val loadSig = Type.Function(Seq.empty, Type.Ref(name))
           val load = Val.Global(name.member(Sig.Generated("load")), Type.Ptr)
 
-          buf.let(n, Op.Call(loadSig, load, Seq()), unwind)
+          buf.let(n, Op.Call(loadSig, load, Seq.empty), unwind)
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
@@ -27,7 +27,7 @@ object PerfectHashMap {
           .map(i =>
             bucketMap.get(i) match {
               case Some(set) => set.toSeq
-              case None      => Seq()
+              case None      => Seq.empty
             }
           )
           .toList
@@ -61,7 +61,7 @@ object PerfectHashMap {
 
                 if (values.getOrElse(slot, None).isDefined ||
                     slots.contains(slot)) {
-                  findSlots(d + 1, 0, List())
+                  findSlots(d + 1, 0, Nil)
                 } else {
                   findSlots(d, item + 1, slot :: slots)
                 }
@@ -71,9 +71,9 @@ object PerfectHashMap {
             }
           }
 
-          findSlots(1, 0, List()) match {
+          findSlots(1, 0, Nil) match {
             case Some((d, slots)) =>
-              val newValues = bucket.foldLeft(Map[Int, Option[V]]()) {
+              val newValues = bucket.foldLeft(Map.empty[Int, Option[V]]) {
                 case (acc, key) =>
                   val value = entries(key)
                   val valueIndex = mod(hashFunc(key, d), hashMapSize)
@@ -90,7 +90,7 @@ object PerfectHashMap {
         case _ => Some((keys, values))
       }
 
-      placeBuckets(buckets, Map(), Map()) match {
+      placeBuckets(buckets, Map.empty, Map.empty) match {
         case Some((keys, values)) =>
           val valueKeySet = values.keySet
           val freeList = (0 until hashMapSize).filterNot(valueKeySet)
@@ -168,11 +168,11 @@ object DynmethodPerfectHashMap {
   def apply(dynmethods: Seq[Global.Member], allSignatures: Seq[Sig]): Val = {
 
     val signaturesWithIndex =
-      allSignatures.zipWithIndex.foldLeft(Map[Sig, Int]()) {
+      allSignatures.zipWithIndex.foldLeft(Map.empty[Sig, Int]) {
         case (acc, (signature, index)) => acc + (signature -> index)
       }
 
-    val entries = dynmethods.foldLeft(Map[Int, (Int, Val)]()) {
+    val entries = dynmethods.foldLeft(Map.empty[Int, (Int, Val)]) {
       case (acc, m) =>
         val index = signaturesWithIndex(m.sig)
         acc + (index -> (index, Val.Global(m, Type.Ptr)))

--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -67,7 +67,7 @@ private[scalanative] object ResourceEmbedder {
             }
         }
       } else {
-        Seq()
+        Seq.empty
       }
 
     def filterEqualPathNames(

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -110,7 +110,7 @@ class TraitDispatchTable(meta: Metadata) {
     val maxSize = sizes.max
     val totalSize = sizes.sum
 
-    val free = Array.fill[List[Int]](maxSize + 1)(List())
+    val free = Array.fill[List[Int]](maxSize + 1)(List.empty)
     val offsets = mutable.Map.empty[Int, Int]
     val compressed = new Array[Val](totalSize)
     var current = 0

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -249,7 +249,7 @@ class Reach(
         if (!cls.attrs.isAbstract) {
           reachAllocation(cls)
           if (cls.isModule) {
-            val init = cls.name.member(Sig.Ctor(Seq()))
+            val init = cls.name.member(Sig.Ctor(Seq.empty))
             if (loaded(cls.name).contains(init)) {
               reachGlobal(init)
             }
@@ -832,7 +832,7 @@ class Reach(
       reachDynamicMethodTargets(dynsig)
     case Op.Module(n) =>
       classInfo(n).foreach(reachAllocation)
-      val init = n.member(Sig.Ctor(Seq()))
+      val init = n.member(Sig.Ctor(Seq.empty))
       loaded.get(n).fold(addMissing(n, pos)) { defn =>
         if (defn.contains(init)) {
           reachGlobal(init)

--- a/tools/src/test/scala/scala/scalanative/nir/SigManglingSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/SigManglingSuite.scala
@@ -13,7 +13,7 @@ class SigManglingSuite extends AnyFunSuite {
   )
 
   val methodArgs = Seq(
-    Seq(),
+    Seq.empty,
     Seq(Type.Unit),
     Seq(Type.Int, Type.Unit)
   )
@@ -42,7 +42,7 @@ class SigManglingSuite extends AnyFunSuite {
         Sig.Extern("malloc"),
         Sig.Generated("layout"),
         Sig.Generated("type"),
-        Sig.Duplicate(Sig.Method("bar", Seq()), Seq()),
+        Sig.Duplicate(Sig.Method("bar", Seq.empty), Seq.empty),
         Sig.Duplicate(Sig.Method("bar", Seq(Type.Unit)), Seq(Type.Unit))
       )
   }.foreach { sig =>

--- a/unit-tests/native/src/test/scala/java/util/ArrayListTest.scala
+++ b/unit-tests/native/src/test/scala/java/util/ArrayListTest.scala
@@ -381,7 +381,7 @@ class ArrayListTest {
 
   @Test def removeRangeFromToEntireListAllElements(): Unit = {
     val aList = new ArrayList[Int](Seq(50, 72, 650, 12, 7, 28, 3).toJavaList)
-    val expected = new ArrayList[Int](Seq().toJavaList)
+    val expected = new ArrayList[Int](Seq.empty.toJavaList)
 
     aList.removeRange(0, aList.size)
 


### PR DESCRIPTION
This PR reworks parts of #1549
- Seq construction: use List cons + reverse instead of range + map + toSeq
- pattern match order: put frequent ones first

and replaces empty collection's `apply()` with `empty`.

