### PR TITLE
Fix #3608: Remove deprecation warnings in ExternTest

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
@@ -4,7 +4,8 @@ package posix
 import scalanative.unsafe._
 
 @deprecated(
-  "getopt is no longer part of POSIX 2018 and will be removed. Use unistd instead"
+  "getopt is no longer part of POSIX 2018 and will be removed. Use unistd instead.",
+  "0.5.0"
 )
 @extern
 object getopt {

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -59,7 +59,7 @@ class ExternTest {
   }
 
   def externVariableReadAndAssignUnix(): Unit = {
-    import scala.scalanative.posix.getopt
+    import scala.scalanative.posix.unistd
 
     val args = Seq("skipped", "skipped", "skipped", "-b", "-f", "farg")
 
@@ -72,14 +72,14 @@ class ExternTest {
       }
 
       // Skip first 3 arguments
-      getopt.optind = 3
+      unistd.optind = 3
 
-      val bOpt = getopt.getopt(args.length, argv, c"bf:")
+      val bOpt = unistd.getopt(args.length, argv, c"bf:")
       assertTrue(bOpt == 'b')
 
-      val fOpt = getopt.getopt(args.length, argv, c"bf:")
+      val fOpt = unistd.getopt(args.length, argv, c"bf:")
       assertTrue(fOpt == 'f')
-      val fArg = fromCString(getopt.optarg)
+      val fArg = fromCString(unistd.optarg)
       assertTrue(fArg == "farg")
     }
   }


### PR DESCRIPTION
Fix #2608.  unit-test ExternTest.scala now runs without deprecation warnings.

Also touched up the recently added getopt deprecation message to make it 
easier to remove in the future (by saying when it was added).