### PR TITLE
Fix #3065: FreeBSD once again compiles

### DIFF
--- a/javalib/src/main/resources/scala-native/net/if_dl.c
+++ b/javalib/src/main/resources/scala-native/net/if_dl.c
@@ -3,7 +3,14 @@
 #elif defined(__linux__)
 // Does not exist on Linux, so no check
 #else // macOS, FreeBSD, etc.
-#include <net/if_dl.h>
+
+#if defined(__FreeBSD__)
+// Make u_* types required/used by FreeBSD net/if_dl.h available
+#undef __BSD_VISIBLE
+#define __BSD_VISIBLE 1
+#include <sys/types.h> // size_t
+#endif
+
 #include <net/if_dl.h>
 #include <stddef.h>
 

--- a/nativelib/src/main/resources/scala-native/time_nano.c
+++ b/nativelib/src/main/resources/scala-native/time_nano.c
@@ -40,11 +40,17 @@ long long scalanative_nano_time() {
         }
     }
 #else
+#if defined(__FreeBSD__)
+    int clock = CLOCK_MONOTONIC_PRECISE; // OS has no CLOCK_MONOTONIC_RAW
+#else  // Linux, macOS
+    int clock = CLOCK_MONOTONIC_RAW;
+#endif // !FreeBSD
+
     // return value of 0 is success
     struct timespec ts;
-    if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts) == 0) {
+    if (clock_gettime(clock, &ts) == 0) {
         nano_time = (ts.tv_sec * NANOS_PER_SEC) + ts.tv_nsec;
     }
-#endif
+#endif // !_WIN32
     return nano_time;
 }

--- a/posixlib/src/main/resources/scala-native/sys/times.c
+++ b/posixlib/src/main/resources/scala-native/sys/times.c
@@ -9,7 +9,24 @@
 #include <stddef.h>
 #include <sys/times.h>
 
+// 2023-01-03 FIXME -- need to fuss with timesOps in times.scala
+// 2023-01-03 FIXME -- need to explain here the useful lie.
+
+#if !defined(__FreeBSD__)
+// C long will mirror machine architecture: 64 bits or 32 bit.
 typedef long scalanative_clock_t;
+#else // __FreeBSD
+// See comments in corresponding times.scala.
+/* There is a bit of "person behind the curtain" "sufficiently advance
+ * technology" magic happening here.
+ *
+ * Using the names in timesOps below is recommended on both 32 & 64 bit
+ * architectures. On FreeBSD 64 bit machines using timeOps names rather than
+ * the _N idiom is required in order to extract correct & proper 32 bit values.
+ */
+#import <sys/types.h>
+typedef __int32_t scalanative_clock_t;
+#endif // __FreeBSD__
 
 struct scalanative_tms {
     scalanative_clock_t tms_utime;  //  User CPU time

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -7,14 +7,32 @@
 #include <unistd.h>
 #include "types.h" // scalanative_* types, not <sys/types.h>
 
-// https://man7.org/linux/man-pages/man7/environ.7.html
-// Historically and by standard, environ must be declared in the
-// user program. However, as a (nonstandard) programmer
-// convenience, environ is declared in the header file <unistd.h> if
-// the _GNU_SOURCE feature test macro is defined
-#if !defined(_GNU_SOURCE)
-extern char **environ;
-#endif
+#if defined(__FreeBSD__)
+
+/* Apply a Pareto cost/benefit analysis here.
+ *
+ * Some relevant constants are not defined on FreeBSD.
+ * This implementation is one of at least 3 design possibilities. One can:
+ *   1) cause a runtime or semantic error by returning "known wrong" values
+ *      as done here. This causes only the parts of applications which
+ *      actually use the constants to, hopefully, fail.
+ *
+ *   2) cause a link time error.
+ *
+ *   3) cause a compile time error.
+ *
+ * The last ensure that no wrong constants slip out to a user but they also
+ * prevent an application developer from getting the parts of an application
+ * which do not actually use the constants from running.
+ */
+#define _XOPEN_VERSION 0
+#define _PC_2_SYMLINKS 0
+#define _SC_SS_REPL_MAX 0
+#define _SC_TRACE_EVENT_NAME_MAX 0
+#define _SC_TRACE_NAME_MAX 0
+#define _SC_TRACE_SYS_MAX 0
+#define _SC_TRACE_USER_EVENT_MAX 0
+#endif // __FreeBSD__
 
 long scalanative__posix_version() { return _POSIX_VERSION; }
 

--- a/posixlib/src/main/resources/scala-native/wordexp.c
+++ b/posixlib/src/main/resources/scala-native/wordexp.c
@@ -8,6 +8,13 @@ struct scalanative_wordexp_t {
     size_t we_wordc; //  Count of words matched by 'words'.
     char **we_wordv; // Pointer to list of expanded words.
     size_t we_offs;  // Slots to reserve at the beginning of we_wordv.
+
+    /* Permitted but not requited by POSIX 2018.
+     * Used here to allow direct overlay calling on FreeBSD in addition
+     * to Linux & macOS.
+     */
+    char *we_strings;  // storage for wordv strings
+    size_t *we_nbytes; // size of we_strings
 };
 
 #if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/times.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/times.scala
@@ -4,6 +4,8 @@ package sys
 
 import scalanative.unsafe._
 
+import scalanative.meta.LinktimeInfo.{is32BitPlatform, isFreeBSD}
+
 /** POSIX sys/times.h for Scala
  *
  *  The Open Group Base Specifications
@@ -12,6 +14,21 @@ import scalanative.unsafe._
 
 @extern
 object times {
+
+  /* The 'tms' structure below is defined in a way which allows fast
+   * direct call-thru to the C Runtime Library, without any "glue" code.
+   *
+   * Scala Native uses a CLong clock_t. This will be 64 bits on 64 bit
+   * architectures and 32 bits on 32 bit architectures.
+   *
+   * This works well with Linux & macOS.  FreeBSD uses a fixed 32 bit clock_t
+   * on both 64 and 32 bit architectures.
+   *
+   * Using the names in timesOps below is recommended on any architecture.
+   * On FreeBSD 64 bit machines using timeOps names rather than the _N idiom
+   * is required in order to extract correct & proper 32 bit values.
+   */
+
   type clock_t = types.clock_t
 
   type tms = CStruct4[
@@ -29,16 +46,56 @@ object times {
 object timesOps {
   import times._
 
-  implicit class tmsOps(val ptr: Ptr[tms]) extends AnyVal {
-    def tms_utime(): clock_t = ptr._1
-    def tms_stime(): clock_t = ptr._2
-    def tms_cutime(): clock_t = ptr._3
-    def tms_cstime(): clock_t = ptr._4
+  private def freeBsd64GetLowBits(bits: clock_t): clock_t =
+    (bits.toLong & 0x00000000ffffffffL).toSize
 
-    // The fields are query-only in use. Provide setters for completeness.
-    def tms_utime_=(c: clock_t): Unit = ptr._1 = c
-    def tms_stime_=(c: clock_t): Unit = ptr._2 = c
-    def tms_cutime_=(c: clock_t): Unit = ptr._3 = c
-    def tms_cstime_=(c: clock_t): Unit = ptr._4 = c
+  private def freeBsd64GetHighBits(bits: clock_t): clock_t =
+    (bits.toLong & 0xffffffff00000000L).toSize
+
+  private def freeBsd64SetLowBits(ptr: Ptr[clock_t], value: clock_t): Unit =
+    !ptr = ((!ptr & 0xffffffff00000000L) | value.toInt).toSize
+
+  private def freeBsd64SetHighBits(ptr: Ptr[clock_t], value: clock_t): Unit =
+    !ptr = ((value << 32) | (!ptr & 0x00000000ffffffffL)).toSize
+
+  implicit class tmsOps(val ptr: Ptr[tms]) extends AnyVal {
+    def tms_utime: clock_t = if (!isFreeBSD) ptr._1
+    else if (is32BitPlatform) ptr._1
+    else freeBsd64GetLowBits(ptr._1)
+
+    def tms_stime: clock_t = if (!isFreeBSD) ptr._2
+    else if (is32BitPlatform) ptr._2
+    else freeBsd64GetHighBits(ptr._1)
+
+    def tms_cutime: clock_t = if (!isFreeBSD) ptr._3
+    else if (is32BitPlatform) ptr._3
+    else freeBsd64GetLowBits(ptr._2)
+
+    def tms_cstime: clock_t = if (!isFreeBSD) ptr._4
+    else if (is32BitPlatform) ptr._4
+    else freeBsd64GetHighBits(ptr._2)
+
+    /* The fields are query-only in use.
+     * Provide setters for completeness and testing.
+     */
+    def tms_utime_=(c: clock_t): Unit =
+      if (!isFreeBSD) ptr._1 = c
+      else if (is32BitPlatform) ptr._1 = c
+      else freeBsd64SetLowBits(ptr.at1, c)
+
+    def tms_stime_=(c: clock_t): Unit =
+      if (!isFreeBSD) ptr._2 = c
+      else if (is32BitPlatform) ptr._2 = c
+      else freeBsd64SetHighBits(ptr.at1, c)
+
+    def tms_cutime_=(c: clock_t): Unit =
+      if (!isFreeBSD) ptr._3 = c
+      else if (is32BitPlatform) ptr._3 = c
+      else freeBsd64SetLowBits(ptr.at2, c)
+
+    def tms_cstime_=(c: clock_t): Unit =
+      if (!isFreeBSD) ptr._4 = c
+      else if (is32BitPlatform) ptr._4 = c
+      else freeBsd64SetHighBits(ptr.at2, c)
   }
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/wordexp.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/wordexp.scala
@@ -15,10 +15,17 @@ import scalanative.posix.sys.types.size_t
 @extern
 object wordexp {
 
-  type wordexp_t = CStruct3[
+  type wordexp_t = CStruct5[
     size_t, //  we_wordc  Count of words matched by 'words'.
     Ptr[CString], // we_wordv  Pointer to list of expanded words.
     size_t, // we_offs   Slots to reserve at the beginning of we_wordv.
+
+    /* Permitted but not required by POSIX 2018.
+     * Used here to allow direct overlay calling on FreeBSD in addition
+     * to Linux & macOS.
+     */
+    Ptr[CString], // we_strings, storage for wordv strings
+    size_t // we_nbytes, size of we_strings
   ]
 
   /// Symbolic constants
@@ -76,9 +83,15 @@ object wordexpOps {
     def we_wordc: size_t = ptr._1
     def we_wordv: Ptr[CString] = ptr._2
     def we_offs: size_t = ptr._3
+    // FreeBSD POSIX extensions
+    def we_strings: Ptr[CString] = ptr._4
+    def we_nbytes: size_t = ptr._5
 
     def we_wordc_=(v: size_t): Unit = ptr._1 = v
     def we_wordv_=(v: Ptr[CString]): Unit = ptr._2 = v
     def we_offs_=(v: size_t): Unit = ptr._3 = v
+    // FreeBSD POSIX extensions
+    def we_strings_=(v: Ptr[CString]): Unit = ptr._4
+    def we_nbytes_=(v: size_t): Unit = ptr._5 = v
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/TimesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/TimesTest.scala
@@ -1,0 +1,171 @@
+package org.scalanative.testsuite.posixlib
+package sys
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalanative.meta.LinktimeInfo.{
+  is32BitPlatform,
+  isFreeBSD,
+  isWindows
+}
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+import scala.scalanative.posix.stdlib
+
+import scala.scalanative.posix.sys.times._
+import scala.scalanative.posix.sys.timesOps._
+
+class TimesTest {
+
+  @Test def timesSucceeds(): Unit = {
+    assumeTrue(
+      "times.scala is not implemented on Windows",
+      !isWindows
+    )
+    if (!isWindows) {
+      val timesBuf = stackalloc[tms]()
+
+      // Modify the buffer so we can tell that OS changed values. Expect Zero.
+      timesBuf.tms_cutime = -1
+      timesBuf.tms_cstime = -1
+
+      val status = times(timesBuf)
+
+      assertNotEquals("times() failed: $strerror(errno):", -1, status)
+
+      // A _very_rough_ check for sensible values follows.
+
+      assertNotEquals("tms_utime should be non-zero:", 0L, timesBuf.tms_utime)
+      assertTrue(
+        s"tms_utime ${timesBuf.tms_utime} should be positive:",
+        timesBuf.tms_utime > 0L
+      )
+
+      /* If this test is the first or only test being run, the system
+       * time can be zero.
+       */
+      if (timesBuf.tms_stime != 0L)
+        assertTrue(
+          s"tms_stime ${timesBuf.tms_stime} should be positive:",
+          timesBuf.tms_stime > 0L
+        )
+
+      assertNotEquals("tms_cutime should be zero:", 0L, timesBuf.tms_cutime)
+
+      assertNotEquals("tms_cstime should be zero:", 0L, timesBuf.tms_cstime)
+    }
+  }
+
+  @Test def naturalTimesOpsShouldGetAndSetFields(): Unit = {
+    assumeTrue(
+      "times.scala is not implemented on Windows",
+      !isWindows
+    )
+
+    if (!isWindows && !isFreeBSD) {
+      /* Test the 'natural' cases where there is no FreeBSD64 overlay
+       * of tms fields. Here each of those fields is a Scala Size, 64
+       * or 32 bits as appropriate to the architecture.
+       */
+
+      val timesBuf = stackalloc[tms]()
+
+      val expectedUTime = 123L.toSize
+
+      timesBuf.tms_utime = expectedUTime
+      assertEquals("Unexpected tms_utime:", expectedUTime, timesBuf.tms_utime)
+
+      val expectedSTime = 456L.toSize
+
+      timesBuf.tms_stime = expectedSTime
+      assertEquals("Unexpected tms_stime:", expectedSTime, timesBuf.tms_stime)
+
+      val expectedCUTime = 333L.toSize
+      timesBuf.tms_cutime = expectedCUTime
+      assertEquals(
+        "Unexpected tms_cutime:",
+        expectedCUTime,
+        timesBuf.tms_cutime
+      )
+
+      val expectedCSTime = 789L.toSize
+      timesBuf.tms_cstime = expectedCSTime
+      assertEquals(
+        "Unexpected tms_cstime:",
+        expectedCSTime,
+        (timesBuf.tms_cstime)
+      )
+    }
+  }
+
+  @Test def freeBSD64TimesOpsShouldGetAndSetFields(): Unit = {
+    if (isFreeBSD && !is32BitPlatform) {
+      val timesBuf = stackalloc[tms]()
+
+      val expectedUTime = 222L.toSize
+
+      timesBuf.tms_utime = expectedUTime
+
+      // Was the tmsOps 'set' done correctly?
+      assertEquals(
+        "Unexpected timesBuf._1 low bits:",
+        expectedUTime,
+        timesBuf._1
+      )
+
+      // Does the tmsOp 'get' retrieve correctly?
+      assertEquals("Unexpected tms_utime:", expectedUTime, timesBuf.tms_utime)
+
+      val expectedSTime = 666L.toSize
+
+      timesBuf.tms_stime = expectedSTime
+
+      assertEquals(
+        "Unexpected timesBuf._1 high bits:",
+        expectedSTime,
+        (timesBuf._1 >>> 32)
+      )
+
+      assertEquals(
+        "Unexpected tms_stime:",
+        expectedSTime,
+        (timesBuf.tms_stime >>> 32)
+      )
+
+      val expectedCUTime = 333L.toSize
+      timesBuf.tms_cutime = expectedCUTime
+
+      assertEquals(
+        "Unexpected timesBuf._2 low bits:",
+        expectedCUTime,
+        timesBuf._2
+      )
+
+      assertEquals(
+        "Unexpected tms_cutime:",
+        expectedCUTime,
+        timesBuf.tms_cutime
+      )
+
+      val expectedCSTime = 667L.toSize
+
+      timesBuf.tms_cstime = expectedCSTime
+
+      assertEquals(
+        "Unexpected timesBuf._2 high bits:",
+        expectedCSTime,
+        (timesBuf._2 >>> 32)
+      )
+
+      assertEquals(
+        "Unexpected tms_cstime:",
+        expectedCSTime,
+        (timesBuf.tms_cstime >>> 32)
+      )
+    }
+  }
+}


### PR DESCRIPTION
Fix #3065 

Scala Native 0.5.0 once again compiles on FreeBSD (13.1).