### PR TITLE
javalib UnixProcess now uses kevent on FreeBSD64

### DIFF
--- a/javalib/src/main/scala/java/lang/process/BsdOsSpecific.scala
+++ b/javalib/src/main/scala/java/lang/process/BsdOsSpecific.scala
@@ -6,9 +6,10 @@ import scala.scalanative.posix.time.timespec
 object BsdOsSpecific {
   // Beware: FreeBSD and other BSD layouts have not been tested.
 
-  /* This file is indented for use by UnixProcessGen2 on 64 bit macOS only.
-   * IT IS INCOMPLETE AND ENTIRELY UNTESTED ON FREEBSD AND OTHER BSD
-   * DERIVATIVES.
+  /* This file is intended for use by UnixProcessGen2 on 64 bit macOS
+   * and FreeBSD only.
+   * IT IS BOTH INCOMPLETE on any OS AND ENTIRELY UNTESTED ON OTHER
+   * BSD DERIVATIVES.
    *
    * It contains the minimal declarations, plus a few extras, needed by
    * UnixProcessGen2. It is fit for service for that purpose only.
@@ -27,7 +28,7 @@ object BsdOsSpecific {
    *   https://wiki.netbsd.org/tutorials/kqueue_tutorial/
    */
 
-  // Beware: FreeBSD and other BSD layouts have not been tested.
+  // Beware: BSD layouts other than macOS & FreeBSD have not been tested.
 
 // format: off
 

--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -17,8 +17,8 @@ object UnixProcess {
       false
     } else if (LinktimeInfo.isLinux) {
       LinuxOsSpecific.hasPidfdOpen()
-    } else if (LinktimeInfo.isMac) {
-      // Other FreeBSD & other BSDs should work but have not been exercised.
+    } else if ((LinktimeInfo.isMac) || (LinktimeInfo.isFreeBSD)) {
+      // Other BSDs should work but have not been exercised.
       true
     } else {
       false


### PR DESCRIPTION
FreeBSD 64 bit systems now uses kevent system call, not process_monitor, to wait for child processes to exit. 

Modify prior macOS-only code  to use kevent rather than kevent64 so that macOS and FreeBSD
can use common code.