### PR TITLE
feat: javalib/Path of

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Path.scala
+++ b/javalib/src/main/scala/java/nio/file/Path.scala
@@ -36,11 +36,9 @@ trait Path extends Comparable[Path] with Iterable[Path] with Watchable {
   def toUri(): URI
 }
 
-// https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Paths.html
-// It is recommended to obtain a Path via the Path.of methods instead of via the get methods
-// defined in this class(=java.nio.file.Paths) as this class may be deprecated in a future release.
 object Path {
   private lazy val fs = FileSystems.getDefault()
+  // Introduced in Java 11
   def of(path: String, paths: Array[String]): Path = fs.getPath(path, paths)
   def of(uri: URI): Path = if (uri.getScheme() == null) {
     throw new IllegalArgumentException("Missing scheme")

--- a/javalib/src/main/scala/java/nio/file/Path.scala
+++ b/javalib/src/main/scala/java/nio/file/Path.scala
@@ -35,3 +35,20 @@ trait Path extends Comparable[Path] with Iterable[Path] with Watchable {
   def toString(): String
   def toUri(): URI
 }
+
+// https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Paths.html
+// It is recommended to obtain a Path via the Path.of methods instead of via the get methods
+// defined in this class(=java.nio.file.Paths) as this class may be deprecated in a future release.
+object Path {
+  private lazy val fs = FileSystems.getDefault()
+  def of(path: String, paths: Array[String]): Path = fs.getPath(path, paths)
+  def of(uri: URI): Path = if (uri.getScheme() == null) {
+    throw new IllegalArgumentException("Missing scheme")
+  } else if (uri.getScheme().toLowerCase == "file") {
+    fs.getPath(uri.getPath(), Array.empty)
+  } else {
+    throw new FileSystemNotFoundException(
+      s"Provider ${uri.getScheme()} is not installed."
+    )
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/PathTest.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/PathTest.scala
@@ -1,0 +1,88 @@
+package javalib.nio.file
+
+import java.nio.file._
+import java.io.File
+import java.net.URI
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.isWindows
+
+class PathTest {
+
+  @Test def pathOfRelativePathReturnsPathRelativeToCwd(): Unit = {
+    val pathString = if (isWindows) raw"foo\bar" else "foo/bar"
+    val path = Path.of(pathString)
+    val file = new File(pathString)
+    assertEquals(pathString, path.toString)
+    assertTrue(path.toAbsolutePath.toString != path.toString)
+    assertTrue(path.toAbsolutePath.toString.endsWith(path.toString))
+
+    assertTrue(file.getAbsolutePath != path.toString)
+    assertEquals(path.toAbsolutePath.toString, file.getAbsolutePath)
+  }
+
+  @Test def pathOfAbsolutePathReturnsAnAbsolutePath(): Unit = {
+    val pathString = if (isWindows) raw"C:\foo\bar" else "/foo/bar"
+
+    val path = Path.of(pathString)
+    val file = new File(pathString)
+    assertEquals(pathString, path.toString)
+    assertEquals(path.toString, path.toAbsolutePath.toString)
+
+    assertEquals(path.toString, file.getAbsolutePath)
+    assertEquals(path.toAbsolutePath.toString, file.getAbsolutePath)
+  }
+
+  @Test def pathOfUriThrowsExceptionWhenSchemeIsMissing(): Unit = {
+    assertThrows(
+      classOf[IllegalArgumentException],
+      Path.of(new URI(null, null, null, 0, "foo", null, null))
+    )
+  }
+
+  @Test def pathOfUriThrowsExceptionWhenSchemeIsNotFile(): Unit = {
+    assertThrows(
+      classOf[FileSystemNotFoundException],
+      Path.of(new URI("http", null, "google.com", 0, "/", null, null))
+    )
+  }
+
+  @Test def pathOfUriReturnsPathIfSchemeIsFile(): Unit = {
+    val pathString1 = if (isWindows) "/C:/foo/bar" else "/foo/bar"
+    val expected1 = if (isWindows) raw"C:\foo\bar" else pathString1
+    val pathString2 = if (isWindows) "/C:/hello/world" else "/hello/world"
+    val expected2 = if (isWindows) raw"C:\hello\world" else pathString2
+
+    val path =
+      Path.of(new URI("file", null, null, 0, pathString1, null, null))
+    assertEquals(expected1, path.toString)
+
+    val path2 =
+      Path.of(new URI("fIlE", null, null, 0, pathString2, null, null))
+    assertEquals(expected2, path2.toString)
+  }
+
+  @Test def driveRelativePathToStringShownAsAbsolute() = {
+    val absolutePath = "/absolute/file"
+    val expected = if (isWindows) "\\absolute\\file" else "/absolute/file"
+
+    val path = Path.of(absolutePath)
+
+    assertEquals(expected, path.toString)
+  }
+
+  // issue #2433
+  @Test def spaceAllowedInPath() = {
+    val withSpaces = "space dir/space file"
+    val expected = if (isWindows) raw"space dir\space file" else withSpaces
+
+    val path = Path.of("space dir/space file")
+    assertEquals(expected, path.toString)
+  }
+  @Test def joiningEmptyIsEmpty() = {
+    assertEquals(Path.of(""), Path.of("", ""))
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/PathTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/PathTestOnJDK11.scala
@@ -1,3 +1,4 @@
+package org.scalanative.testsuite
 package javalib.nio.file
 
 import java.nio.file._
@@ -10,7 +11,7 @@ import org.junit.Assert._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform.isWindows
 
-class PathTest {
+class PathTestOnJDK11 {
 
   @Test def pathOfRelativePathReturnsPathRelativeToCwd(): Unit = {
     val pathString = if (isWindows) raw"foo\bar" else "foo/bar"
@@ -82,6 +83,7 @@ class PathTest {
     val path = Path.of("space dir/space file")
     assertEquals(expected, path.toString)
   }
+
   @Test def joiningEmptyIsEmpty() = {
     assertEquals(Path.of(""), Path.of("", ""))
   }


### PR DESCRIPTION
close #3070

The document linked in the issue says `Paths.get` will be deprecated in the future. Though Scala Native is supposed to be compatible with Java 8, I think providing recommended API will save future user toil(replacing `Paths.get` with `Path.of`).

nb:
Just out of curiosity, I wonder why defining `Path.of(p:String,ps:String*)` gets linker error while `Path.of(p:String,ps:Array[String])` not. Probably because of difference between Java and Scala varargs?