### PR TITLE
Support Scala 3.2.2

### DIFF
--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11]
-        scala: [3.2.1]
+        scala: [3.2.2]
         java: [11, 17]
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [3.2.1]
+        scala: [3.2.2]
         java: [11, 17]
     steps:
       # Disable autocrlf setting, otherwise scalalib patches might not be possible to apply

--- a/.github/workflows/run-tests-linux-multiarch.yml
+++ b/.github/workflows/run-tests-linux-multiarch.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [linux-arm64, linux-x86]
-        scala: [2.13.10, 3.2.1]
+        scala: [2.13.10, 3.2.2]
         build-mode: [debug, release-fast]
         lto: [none, thin]
         gc: [boehm, immix, commix]

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [3.2.1, 2.13.10, 2.12.17]
+        scala: [3.2.2, 2.13.10, 2.12.17]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/linux-setup-env
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [3.2.1, 2.13.10]
+        scala: [3.2.2, 2.13.10]
         build-mode: [debug, release-fast]
         gc: [boehm, immix, commix]
         # Create holes in grid to lower number of tests.
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [3.2.1, 2.13.10]
+        scala: [3.2.2, 2.13.10]
         build-mode: [debug]
         include:
           - scala: 2.13.10
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [3.2.1, 2.13.10]
+        scala: [3.2.2, 2.13.10]
         lto: [thin]
         optimize: [true]
         include:
@@ -140,7 +140,7 @@ jobs:
           - scala: 2.13.10
             lto: full
             optimize: true
-          - scala: 3.2.1
+          - scala: 3.2.2
             lto: full
             optimize: false
 

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [3.2.1, 2.13.10, 2.12.17]
+        scala: [3.2.2, 2.13.10, 2.12.17]
         gc: [immix]
         include:
           - scala: 2.13.10

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        scala: [3.2.1, 2.13.10]
+        scala: [3.2.2, 2.13.10]
         gc: [boehm, immix, commix]
         include:
           - scala: 2.12.17
@@ -96,12 +96,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [3.2.1, 2.13.10]
+        scala: [3.2.2, 2.13.10]
         build-mode: [release-fast]
         lto: [thin]
         optimize: [true]
         include:
-          - scala: 3.2.1
+          - scala: 3.2.2
             lto: full
             optimize: true
           - scala: 2.13.10

--- a/javalib/src/main/scala/java/util/concurrent/CountDownLatch.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CountDownLatch.scala
@@ -1,0 +1,13 @@
+package java.util.concurrent
+
+// No-op stub defined to allow usage of lazy vals with -Ylightweight-lazy-vals
+class CountDownLatch(count: Int) {
+
+  def await(): Unit = ()
+
+  def await(timeout: Long, unit: TimeUnit): Boolean = true
+
+  def countDown(): Unit = ()
+
+  def getCount(): Long = 0L
+}

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
@@ -26,6 +26,16 @@ private object LazyVals {
   }
 
   @`inline`
+  def objCAS(objPtr: RawPtr, exp: Object, n: Object): Boolean = {
+    // Todo: with multithreading use atomic cas
+    if (Intrinsics.loadObject(objPtr) ne exp) false
+    else {
+      Intrinsics.storeObject(objPtr, n)
+      true
+    }
+  }
+
+  @`inline`
   def setFlag(bitmap: RawPtr, v: Int, ord: Int): Unit = {
     val cur = get(bitmap)
     // TODO: with multithreading add waiting for notifications

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -458,6 +458,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           labels.contains(n.name)
         case inst @ Inst.If(_, n1, n2) =>
           labels.contains(n1.name) && labels.contains(n2.name)
+        case inst @ Inst.LinktimeIf(_, n1, n2) =>
+          labels.contains(n1.name) && labels.contains(n2.name)
         case inst @ Inst.Switch(_, n, ns) =>
           labels.contains(n.name) && ns.forall(n => labels.contains(n.name))
         case inst @ Inst.Throw(_, n) =>

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -860,6 +860,8 @@ trait NirGenExpr(using Context) {
           labels.contains(n.name)
         case inst @ Inst.If(_, n1, n2) =>
           labels.contains(n1.name) && labels.contains(n2.name)
+        case inst @ Inst.LinktimeIf(_, n, n2) =>
+          labels.contains(n.name) && labels.contains(n2.name)
         case inst @ Inst.Switch(_, n, ns) =>
           labels.contains(n.name) && ns.forall(n => labels.contains(n.name))
         case inst @ Inst.Throw(_, n) =>

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -6,7 +6,7 @@ object ScalaVersions {
   val crossScala213 = (4 to 10).map(v => s"2.13.$v")
   val crossScala3 = List(
     (0 to 3).map(v => s"3.1.$v"),
-    (0 to 1).map(v => s"3.2.$v")
+    (0 to 2).map(v => s"3.2.$v")
   ).flatten
 
   // Version of Scala 3 standard library sources used for publishing

--- a/scalalib/overrides-3.2.1/scala/runtime/LazyVals.scala.patch
+++ b/scalalib/overrides-3.2.1/scala/runtime/LazyVals.scala.patch
@@ -1,11 +1,11 @@
---- 3.2.2/scala/runtime/LazyVals.scala
+--- 3.2.1/scala/runtime/LazyVals.scala
 +++ overrides-3/scala/runtime/LazyVals.scala
-@@ -4,42 +4,13 @@
+@@ -1,42 +1,12 @@
+ package scala.runtime
  
- import scala.annotation.*
- 
+-import scala.annotation.*
 +import scala.scalanative.runtime.*
-+
+ 
  /**
   * Helper methods used in thread-safe lazy vals.
   */
@@ -29,7 +29,6 @@
 -    val processors = java.lang.Runtime.getRuntime.nn.availableProcessors()
 -    8 * processors * processors
 -  }
--
 -  private[this] val monitors: Array[Object] =
 -    Array.tabulate(base)(_ => new Object)
 -
@@ -45,7 +44,7 @@
  
    /* ------------- Start of public API ------------- */
  
-@@ -71,96 +42,49 @@
+@@ -44,79 +14,38 @@
  
    def STATE(cur: Long, ord: Int): Long = {
      val r = (cur >> (ord * BITS_PER_LAZY_VAL)) & LAZY_VAL_MASK
@@ -60,14 +59,6 @@
 -    val mask = ~(LAZY_VAL_MASK << ord * BITS_PER_LAZY_VAL)
 -    val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
 -    unsafe.compareAndSwapLong(t, offset, e, n)
-+    unexpectedUsage()
-   }
- 
-   @experimental
-   def objCAS(t: Object, offset: Long, exp: Object, n: Object): Boolean = {
--    if (debug)
--      println(s"objCAS($t, $exp, $n)")
--    unsafe.compareAndSwapObject(t, offset, exp, n)
 +    unexpectedUsage()
    }
  
@@ -119,22 +110,11 @@
 +    unexpectedUsage()
    }
  
-   // kept for backward compatibility
    def getOffset(clz: Class[_], name: String): Long = {
 -    @nowarn
 -    val r = unsafe.objectFieldOffset(clz.getDeclaredField(name))
 -    if (debug)
 -      println(s"getOffset($clz, $name) = $r")
--    r
-+    unexpectedUsage()
-   }
- 
-   @experimental
-   def getStaticFieldOffset(field: java.lang.reflect.Field): Long = {
--    @nowarn
--    val r = unsafe.staticFieldOffset(field)
--    if (debug)
--      println(s"getStaticFieldOffset(${field.getDeclaringClass}, ${field.getName}) = $r")
 -    r
 +    unexpectedUsage()
    }

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -580,6 +580,16 @@ class IssuesTest {
     free(null)
   }
 
+  @Test def `can initialize lazy vals using linktime if`() = {
+    object Foo {
+      val fooLiteral = "foo"
+      lazy val fooLazy =
+        if (scala.scalanative.meta.LinktimeInfo.isWindows) fooLiteral
+        else fooLiteral
+    }
+    assertEquals(Foo.fooLiteral, Foo.fooLazy)
+  }
+
 }
 
 package issue1090 {


### PR DESCRIPTION
* Added Scala 3.2.2 to the build crossScalaVersions
* Scala 3.2.2 is now used in the CI (upgrade from 3.2.1)
* Added support for new lazy vals implementation - standard in 3.3.x, enabled in 3.2.2 via `-Ylightweight-lazy-vals` compiler flag
* Fixed issue with multiple execution of finally block when using linktime-if condition