### PR TITLE
Fix issue with using opaque types in `CFuncPtr`

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -107,6 +107,8 @@ trait NirGenType(using Context) {
       case ClassInfo(_, sym, _, _, _) => fromSymbol(sym)
       case t @ TypeRef(tpe, _) =>
         SimpleType(t.symbol, tpe.argTypes.map(fromType))
+      case AppliedType(tycon, args) => 
+        SimpleType(tycon.typeSymbol, args.map(fromType))
       case t @ TermRef(_, _) => fromType(t.info.resultType)
       case t => throw new RuntimeException(s"unknown fromType($t)")
     }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -107,7 +107,7 @@ trait NirGenType(using Context) {
       case ClassInfo(_, sym, _, _, _) => fromSymbol(sym)
       case t @ TypeRef(tpe, _) =>
         SimpleType(t.symbol, tpe.argTypes.map(fromType))
-      case AppliedType(tycon, args) => 
+      case AppliedType(tycon, args) =>
         SimpleType(tycon.typeSymbol, args.map(fromType))
       case t @ TermRef(_, _) => fromType(t.info.resultType)
       case t => throw new RuntimeException(s"unknown fromType($t)")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -124,7 +124,9 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
         def resolveGiven = Option.when(s.is(Given)) {
           atPhase(Phases.postTyperPhase) {
             val givenTpe = s.denot.info.argInfos.head
-            fromType(givenTpe)
+            // make sure to dealias the type here,
+            // information about underlying opaque type would not be available after erasue
+            fromType(givenTpe.widenDealias)
           }
         }
 

--- a/unit-tests/native/src/test/scala-3/scala/scala/scalnative/IssuesTestScala3.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalnative/IssuesTestScala3.scala
@@ -16,6 +16,13 @@ class IssuesTestScala3 {
     // Check if compiles
     CFuncPtr1.fromScalaFunction[MyEnum, MyEnum] { a => a }
   }
+
+  @Test def issue3063(): Unit = {
+    import scala.scalanative.issue3063.types.*
+    val ctx: Ptr[mu_Context] = stackalloc()
+    // Check links
+    (!ctx).text_width = CFuncPtr2.fromScalaFunction { (_, _) => 0 }
+  }
 }
 
 object issue2485:
@@ -24,3 +31,16 @@ object issue2485:
     object MyEnum:
       given Tag[MyEnum] = Tag.materializeIntTag
 end issue2485
+
+object issue3063:
+  object types:
+    opaque type mu_Font = Ptr[Byte]
+    object mu_Font:
+      given Tag[mu_Font] = Tag.Ptr(Tag.Byte)
+
+    opaque type mu_Context = Ptr[Byte]
+    object mu_Context:
+      given Tag[mu_Context] = Tag.Ptr(Tag.Byte)
+      extension (struct: mu_Context)
+        def text_width: CFuncPtr2[mu_Font, CString, CInt] = ???
+        def text_width_=(value: CFuncPtr2[mu_Font, CString, CInt]): Unit = ()


### PR DESCRIPTION
Fixes #3063 

Typically Scala Native compiler handles opaque types quite well without any explicit support, since we're executing our code in late phases (similarly to `genBCode`). However, when looking back in the past phases into the postTyper the opaque types needs to be correctly handled. In our case we do it by widening and dealing the type before converting it to `SimpleType` by passing it to the `fromType` method