### PR TITLE
Build: Update sbt to 1.8.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.0
+sbt.version = 1.8.2


### PR DESCRIPTION
Update the version of sbt which the sbt runner uses to build Scala Native to sbt 1.8.2.

No attempt is made to update the versions of the sbt runner itself.