### PR TITLE
Port sbt console warning from Scala.js

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -158,6 +158,14 @@ object ScalaNativePluginInternal {
       }
       .tag(NativeTags.Link)
       .value,
+    console := console
+      .dependsOn(Def.task {
+        streams.value.log.warn(
+          "Scala REPL doesn't work with Scala Native. You " +
+            "are running a JVM REPL. Native things won't work."
+        )
+      })
+      .value,
     run := {
       val env = (run / envVars).value.toSeq
       val logger = streams.value.log


### PR DESCRIPTION
Taken from https://github.com/scala-js/scala-js/blob/ab60f8260be87000dc60aade640ae84247747fc3/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala#L491-L494

Relates to https://github.com/scala-native/scala-native/issues/3104, but I'm not sure if it actually solves it. Since this PR is only adding a warning to the `console` task, it is not actually re-defining it. So I'm not sure what causes that NPE.