### PR TITLE
Fix the 0.4.9 version release date in its changelog

### DIFF
--- a/docs/changelog/0.4.9.md
+++ b/docs/changelog/0.4.9.md
@@ -1,11 +1,11 @@
 
 # 0.4.9 (2022-11-23)
 
-We're happy to announce the release of Scala Native 0.4.9. 
+We're happy to announce the release of Scala Native 0.4.9.
 
 It's a patch release fixing linkage errors when building Scala 2.13 libraries using Scala 3 dependenices.
 
-It does also reverse version policy changes leading to problems in sbt-crossproject. Improved version policy would be restored in Scala Native 0.5.x. 
+It does also reverse version policy changes leading to problems in sbt-crossproject. Improved version policy would be restored in Scala Native 0.5.x.
 
 Scala Native 0.4.9 introduces a new feature - an experimental support for incremental compilation.
 
@@ -67,7 +67,6 @@ nativeConfig ~= {
 }
 ```
 
-
 ## Contributors
 
 Big thanks to everybody who contributed to this release or reported an issue!
@@ -82,7 +81,7 @@ $ git shortlog -sn --no-merges v0.4.8..v0.4.9
 
 ## Merged PRs
 
-## [v0.4.9](https://github.com/scala-native/scala-native/tree/v0.4.9) (2022-12-23)
+## [v0.4.9](https://github.com/scala-native/scala-native/tree/v0.4.9) (2022-11-23)
 
 [Full Changelog](https://github.com/scala-native/scala-native/compare/v0.4.8...v0.4.9)
 


### PR DESCRIPTION
I raised this issue #3013, and there was a fix #3029. However, that fix is incomplete: the release date in this changelog title was fixed, but the release date inside this changelog has not been fixed.

By the way, the website https://scala-native.org/en/stable/changelog/0.4.9.html has not been updated after the fix #3029.