### PR TITLE
Relativize paths in NIR using `mapSourceURI` setting in compiler plugin

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -202,7 +202,17 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
             nscSource.file.path, // Scheme specific part
             null // Fragment
           )
-        case file => file.toURI
+        case file =>
+          val srcURI = file.toURI
+          def matches(pat: java.net.URI) = pat.relativize(srcURI) != srcURI
+
+          scalaNativeOpts.sourceURIMaps
+            .collectFirst {
+              case ScalaNativeOptions.URIMap(from, to) if matches(from) =>
+                val relURI = from.relativize(srcURI)
+                to.fold(relURI)(_.resolve(relURI))
+            }
+            .getOrElse(srcURI)
       }
     }
   }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
@@ -1,11 +1,14 @@
 package scala.scalanative.nscplugin
 
+import java.net.URI
+
 /** This trait allows to query all options to the ScalaNative Plugin
  *
  *  Also see the help text in ScalaNativePlugin for information about particular
  *  options.
  */
 trait ScalaNativeOptions {
+  import ScalaNativeOptions._
 
   /** Should static forwarders be emitted for non-top-level objects.
    *
@@ -14,4 +17,13 @@ trait ScalaNativeOptions {
    *  of JDK classes.
    */
   def genStaticForwardersForNonTopLevelObjects: Boolean
+
+  /** Which source locations in source maps should be relativized (or where
+   *  should they be mapped to)?
+   */
+  def sourceURIMaps: List[URIMap]
+}
+
+object ScalaNativeOptions {
+  case class URIMap(from: URI, to: Option[URI])
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -3,6 +3,8 @@ package nscplugin
 
 import scala.tools.nsc._
 import scala.tools.nsc.plugins._
+import java.net.URI
+import java.net.URISyntaxException
 
 class ScalaNativePlugin(val global: Global) extends Plugin {
   val name = "scalanative"
@@ -22,7 +24,11 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
   object nirAddons extends NirGlobalAddonsEarlyInit[global.type](global)
 
   object scalaNativeOpts extends ScalaNativeOptions {
+    import ScalaNativeOptions.URIMap
+
     var genStaticForwardersForNonTopLevelObjects: Boolean = false
+    lazy val sourceURIMaps: List[URIMap] = _sourceURIMaps.reverse
+    var _sourceURIMaps: List[URIMap] = Nil
   }
 
   object prepNativeInterop extends PrepNativeInterop[global.type](global) {
@@ -43,9 +49,25 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
 
   override def init(options: List[String], error: String => Unit): Boolean = {
     import scalaNativeOpts._
+    import ScalaNativeOptions.URIMap
     options.foreach {
       case "genStaticForwardersForNonTopLevelObjects" =>
         genStaticForwardersForNonTopLevelObjects = true
+      case opt if opt.startsWith("mapSourceURI:") =>
+        val uris = opt.stripPrefix("mapSourceURI:").split("->")
+        if (uris.length != 1 && uris.length != 2) {
+          error("mapSourceURI needs one or two URIs as argument.")
+        } else {
+          try {
+            val from = new URI(uris.head)
+            val to = uris.lift(1).map(str => new URI(str))
+            _sourceURIMaps ::= URIMap(from, to)
+          } catch {
+            case e: URISyntaxException =>
+              error(s"${e.getInput} is not a valid URI")
+          }
+        }
+
       case option =>
         error("Option not understood: " + option)
     }
@@ -54,6 +76,11 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
   }
 
   override val optionsHelp: Option[String] = Some(s"""
+      |  -P:$name:mapSourceURI:FROM_URI[->TO_URI]
+      |     Change the location the source URIs in the emitted IR point to
+      |     - strips away the prefix FROM_URI (if it matches)
+      |     - optionally prefixes the TO_URI, where stripping has been performed
+      |     - any number of occurrences are allowed. Processing is done on a first match basis.
       |  -P:$name:genStaticForwardersForNonTopLevelObjects
       |     Generate static forwarders for non-top-level objects.
       |     This option should be used by codebases that implement JDK classes.

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
@@ -6,6 +6,8 @@ import plugins._
 import core._
 import Contexts._
 
+import java.net.URI
+
 class GenNIR(settings: GenNIR.Settings) extends PluginPhase {
   val phaseName = GenNIR.name
 
@@ -19,5 +21,19 @@ class GenNIR(settings: GenNIR.Settings) extends PluginPhase {
 
 object GenNIR {
   val name = "scalanative-genNIR"
-  case class Settings(genStaticForwardersForNonTopLevelObjects: Boolean = false)
+  case class Settings(
+      /** Should static forwarders be emitted for non-top-level objects.
+       *
+       *  Scala/JVM does not do that and, we do not do it by default either, but
+       *  this option can be used to opt in. This is necessary for
+       *  implementations of JDK classes.
+       */
+      genStaticForwardersForNonTopLevelObjects: Boolean = false,
+      /** Which source locations in source maps should be relativized (or where
+       *  should they be mapped to)?
+       */
+      sourceURIMaps: List[URIMap] = Nil
+  )
+  case class URIMap(from: URI, to: Option[URI])
+
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -28,7 +28,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
 
   protected val defnNir = NirDefinitions.get
   protected val nirPrimitives = new NirPrimitives()
-  protected val positionsConversions = new NirPositions()
+  protected val positionsConversions = new NirPositions(settings.sourceURIMaps)
 
   protected val curClassSym = new util.ScopedVar[ClassSymbol]
   protected val curClassFresh = new util.ScopedVar[nir.Fresh]

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -34,8 +34,8 @@ class ScalaNativePlugin extends StandardPlugin:
           val uris = mapping.split("->")
           if uris.length != 1 && uris.length != 2
           then
-            report.incompleteInputError(
-              "mapSourceUri needs one or two URIs as argument."
+            report.error(
+              s"mapSourceUri needs one or two URIs as argument, got '$mapping'"
             )
             config
           else {
@@ -46,7 +46,7 @@ class ScalaNativePlugin extends StandardPlugin:
               config.copy(sourceURIMaps = sourceMaps)
             catch
               case e: URISyntaxException =>
-                report.incompleteInputError(s"${e.getInput} is not a valid URI")
+                report.error(s"${e.getInput} is not a valid URI")
                 config
           }
         case (config, _) => config

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -1,16 +1,54 @@
 package scala.scalanative.nscplugin
 
 import dotty.tools.dotc.plugins._
+import dotty.tools.dotc.report
+import dotty.tools.dotc.core.Contexts.NoContext
+import java.net.URI
+import java.net.URISyntaxException
+import dotty.tools.dotc.core.Contexts.Context
 
 class ScalaNativePlugin extends StandardPlugin:
   val name: String = "scalanative"
   val description: String = "Scala Native compiler plugin"
 
-  def init(options: List[String]): List[PluginPhase] = {
+  override val optionsHelp: Option[String] =
+    Some(s"""
+      |  -P:$name:mapSourceURI:FROM_URI[->TO_URI]
+      |     Change the location the source URIs in the emitted IR point to
+      |     - strips away the prefix FROM_URI (if it matches)
+      |     - optionally prefixes the TO_URI, where stripping has been performed
+      |     - any number of occurrences are allowed. Processing is done on a first match basis.
+      |  -P:$name:genStaticForwardersForNonTopLevelObjects
+      |     Generate static forwarders for non-top-level objects.
+      |     This option should be used by codebases that implement JDK classes.
+      |     When used together with -Xno-forwarders, this option has no effect.
+      """.stripMargin)
+
+  override def init(options: List[String]): List[PluginPhase] = {
     val genNirSettings = options
       .foldLeft(GenNIR.Settings()) {
         case (config, "genStaticForwardersForNonTopLevelObjects") =>
           config.copy(genStaticForwardersForNonTopLevelObjects = true)
+        case (config, s"mapSourceURI:${mapping}") =>
+          given Context = NoContext
+          val uris = mapping.split("->")
+          if uris.length != 1 && uris.length != 2
+          then
+            report.incompleteInputError(
+              "mapSourceUri needs one or two URIs as argument."
+            )
+            config
+          else {
+            try
+              val from = new URI(uris.head)
+              val to = uris.lift(1).map(str => new URI(str))
+              val sourceMaps = config.sourceURIMaps :+ GenNIR.URIMap(from, to)
+              config.copy(sourceURIMaps = sourceMaps)
+            catch
+              case e: URISyntaxException =>
+                report.incompleteInputError(s"${e.getInput} is not a valid URI")
+                config
+          }
         case (config, _) => config
       }
     List(PrepNativeInterop(), GenNIR(genNirSettings))

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -20,6 +20,16 @@ object MyScalaNativePlugin extends AutoPlugin {
       _.withCheck(true)
         .withCheckFatalWarnings(true)
         .withDump(true)
+    },
+    scalacOptions ++= {
+      // Link source maps to GitHub sources
+      val revision =
+        if (nativeVersion.endsWith("-SNAPSHOT")) "main"
+        else s"v$nativeVersion"
+      Settings.scalaNativeMapSourceURIOption(
+        (LocalProject("scala-native") / baseDirectory).value,
+        s"https://raw.githubusercontent.com/scala-native/scala-native/$revision/"
+      )
     }
   )
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -594,6 +594,23 @@ object Settings {
         baseDirectory.value.getParentFile / "target" / "scalaSources" / sourcesVersion(
           scalaVersion.value
         ),
+      /* Link source maps to the GitHub sources of the original scalalib
+       * This must come *before* the option added by MyScalaJSPlugin
+       * because mapSourceURI works on a first-match basis.
+       */
+      scalacOptions := {
+        val prev = scalacOptions.value
+        val scalaVersion = Keys.scalaVersion.value
+        val option = scalaNativeMapSourceURIOption(
+          baseDir = (fetchScalaSource / artifactPath).value,
+          targetURI =
+            if (scalaVersion.startsWith("3."))
+              s"https://raw.githubusercontent.com/lampepfl/dotty/${scalaVersion}/library/src/"
+            else
+              s"https://raw.githubusercontent.com/scala/scala/v${scalaVersion}/src/library/"
+        )
+        option ++ prev
+      },
       // Scala.js original comment modified to clarify issue is Scala.js.
       /* Work around for https://github.com/scala-js/scala-js/issues/2649
        * We would like to always use `update`, but
@@ -825,6 +842,23 @@ object Settings {
 
   def scalaNativeCompilerOptions(options: String*): Seq[String] = {
     options.map(opt => s"-P:scalanative:$opt")
+  }
+
+  def scalaNativeMapSourceURIOption(
+      baseDir: File,
+      targetURI: String
+  ): Seq[String] = {
+    /* Ensure that there is a trailing '/', otherwise we can get no '/'
+     * before the first compilation (because the directory does not exist yet)
+     * but a '/' after the first compilation, causing a full recompilation on
+     * the *second* run after 'clean' (but not third and following).
+     */
+    val baseDirURI0 = baseDir.toURI.toString
+    val baseDirURI =
+      if (baseDirURI0.endsWith("/")) baseDirURI0
+      else baseDirURI0 + "/"
+
+    scalaNativeCompilerOptions(s"mapSourceURI:$baseDirURI->$targetURI")
   }
 
   def scalaVersionsDependendent[T](scalaVersion: String)(default: T)(


### PR DESCRIPTION
This PR ports Scala.js compiler plugin setting `mapSourceURI`. It allows relativized paths in NIR positions. It would be used for cleaner linking errors and in the future for source code metadata