### PR TITLE
Delay discovery for Build, take 2

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -38,49 +38,6 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeLink =
       taskKey[File]("Generates native binary without running it.")
 
-    // 10 raw settings for minimal sbt projects
-
-    val nativeClang =
-      settingKey[File]("Location of the clang compiler.")
-
-    val nativeClangPP =
-      settingKey[File]("Location of the clang++ compiler.")
-
-    val nativeCompileOptions =
-      settingKey[Seq[String]](
-        "Additional options are passed to clang during compilation."
-      )
-
-    val nativeLinkingOptions =
-      settingKey[Seq[String]](
-        "Additional options that are passed to clang during linking."
-      )
-
-    val nativeLinkStubs =
-      settingKey[Boolean]("Whether to link `@stub` methods, or ignore them.")
-
-    val nativeMode =
-      settingKey[String](
-        "Compilation mode, either \"debug\", \"release-size\", \"release-fast\", or \"release-full\"."
-      )
-
-    val nativeGC =
-      settingKey[String](
-        "GC choice, either \"none\", \"boehm\", \"immix\" or \"commix\"."
-      )
-
-    val nativeLTO =
-      settingKey[String](
-        "LTO variant used for release mode, either \"none\", \"thin\", or \"full\" (legacy)."
-      )
-
-    val nativeCheck =
-      settingKey[Boolean]("Shall native toolchain check NIR during linking?")
-
-    val nativeDump =
-      settingKey[Boolean](
-        "Shall native toolchain dump intermediate NIR to disk during linking?"
-      )
   }
 
   override def globalSettings: Seq[Setting[_]] =

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -31,7 +31,7 @@ object ScalaNativePlugin extends AutoPlugin {
     }
 
     val nativeConfig =
-      taskKey[build.NativeConfig](
+      settingKey[build.NativeConfig](
         "User configuration for the native build, NativeConfig"
       )
 
@@ -41,23 +41,23 @@ object ScalaNativePlugin extends AutoPlugin {
     // raw settings minimal sbt projects
 
     val nativeClang =
-      taskKey[File]("Location of the clang compiler.")
+      settingKey[File]("Location of the clang compiler.")
 
     val nativeClangPP =
-      taskKey[File]("Location of the clang++ compiler.")
+      settingKey[File]("Location of the clang++ compiler.")
 
     val nativeCompileOptions =
-      taskKey[Seq[String]](
+      settingKey[Seq[String]](
         "Additional options are passed to clang during compilation."
       )
 
     val nativeLinkingOptions =
-      taskKey[Seq[String]](
+      settingKey[Seq[String]](
         "Additional options that are passed to clang during linking."
       )
 
     val nativeLinkStubs =
-      taskKey[Boolean]("Whether to link `@stub` methods, or ignore them.")
+      settingKey[Boolean]("Whether to link `@stub` methods, or ignore them.")
 
     val nativeMode =
       taskKey[String](
@@ -65,20 +65,20 @@ object ScalaNativePlugin extends AutoPlugin {
       )
 
     val nativeGC =
-      taskKey[String](
+      settingKey[String](
         "GC choice, either \"none\", \"boehm\", \"immix\" or \"commix\"."
       )
 
     val nativeLTO =
-      taskKey[String](
+      settingKey[String](
         "LTO variant used for release mode, either \"none\", \"thin\", or \"full\" (legacy)."
       )
 
     val nativeCheck =
-      taskKey[Boolean]("Shall native toolchain check NIR during linking?")
+      settingKey[Boolean]("Shall native toolchain check NIR during linking?")
 
     val nativeDump =
-      taskKey[Boolean](
+      settingKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?"
       )
   }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -35,6 +35,11 @@ object ScalaNativePlugin extends AutoPlugin {
         "User configuration for the native build, NativeConfig"
       )
 
+    val nativeLink =
+      taskKey[File]("Generates native binary without running it.")
+
+    // raw settings minimal sbt projects
+
     val nativeClang =
       taskKey[File]("Location of the clang compiler.")
 
@@ -53,9 +58,6 @@ object ScalaNativePlugin extends AutoPlugin {
 
     val nativeLinkStubs =
       taskKey[Boolean]("Whether to link `@stub` methods, or ignore them.")
-
-    val nativeLink =
-      taskKey[File]("Generates native binary without running it.")
 
     val nativeMode =
       taskKey[String](

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -38,7 +38,7 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeLink =
       taskKey[File]("Generates native binary without running it.")
 
-    // raw settings minimal sbt projects
+    // 10 raw settings for minimal sbt projects
 
     val nativeClang =
       settingKey[File]("Location of the clang compiler.")
@@ -60,7 +60,7 @@ object ScalaNativePlugin extends AutoPlugin {
       settingKey[Boolean]("Whether to link `@stub` methods, or ignore them.")
 
     val nativeMode =
-      taskKey[String](
+      settingKey[String](
         "Compilation mode, either \"debug\", \"release-size\", \"release-fast\", or \"release-full\"."
       )
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -81,28 +81,18 @@ object ScalaNativePluginInternal {
    *  later the settings will be preserved.
    */
   lazy val scalaNativeBaseSettings: Seq[Setting[_]] = {
-    val nativeConfig = build.NativeConfig.empty
     Seq(
       crossVersion := ScalaNativeCrossVersion.binary,
-      platformDepsCrossVersion := ScalaNativeCrossVersion.binary,
-      nativeClang := nativeConfig.clang.toFile,
-      nativeClangPP := nativeConfig.clangPP.toFile,
-      nativeCompileOptions := nativeConfig.compileOptions,
-      nativeLinkingOptions := nativeConfig.linkingOptions,
-      nativeMode := nativeConfig.mode.name,
-      nativeGC := nativeConfig.gc.name,
-      nativeLTO := nativeConfig.lto.name,
-      nativeLinkStubs := nativeConfig.linkStubs,
-      nativeCheck := nativeConfig.check,
-      nativeDump := nativeConfig.dump
+      platformDepsCrossVersion := ScalaNativeCrossVersion.binary
     )
   }
 
   /** Called in overridden method in plugin
    *
-   *  A nativeConfig object is created to satisfy sbt scope: Global /
-   *  nativeConfig and allow the settings to be set. Discovery is delayed until
-   *  after build is called.
+   *  A nativeConfig object is created to satisfy sbt scope: `Global /
+   *  nativeConfig` otherwise we get errors in configSettings because
+   *  nativeConfig does not exist. Discovery is delayed until after build is
+   *  called.
    */
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = {
     Seq(
@@ -128,24 +118,13 @@ object ScalaNativePluginInternal {
     )
   }
 
-  /** Uses overrides defined in the 10 raw setting keys. They are either set raw
-   *  or default from baseSettings. Discovered commands need to be handled when
-   *  build is called so that the code calling the tools has complete control of
-   *  the settings.
+  /** Config settings are called for each project, for each version, and for
+   *  test and app configurations. The total 3 version or 6 times per project.
    */
   def scalaNativeConfigSettings(testConfig: Boolean): Seq[Setting[_]] = Seq(
     nativeConfig := {
+      // do we need a new one for each config?
       val config = nativeConfig.value
-        .withClang(nativeClang.value.toPath)
-        .withClangPP(nativeClangPP.value.toPath)
-        .withCompileOptions(nativeCompileOptions.value)
-        .withLinkingOptions(nativeLinkingOptions.value)
-        .withGC(build.GC(nativeGC.value))
-        .withMode(build.Mode(nativeMode.value))
-        .withLTO(build.LTO(nativeLTO.value))
-        .withLinkStubs(nativeLinkStubs.value)
-        .withCheck(nativeCheck.value)
-        .withDump(nativeDump.value)
       config
     },
     nativeLink := Def

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -159,7 +159,7 @@ object ScalaNativePluginInternal {
         .withLinkStubs(nativeLinkStubs.value)
         .withCheck(nativeCheck.value)
         .withDump(nativeDump.value)
-      println(s"$config ${NativeConfig.cnt}")
+      println(s"config ${NativeConfig.cnt}")
       config
     },
     nativeLink := Def

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -100,7 +100,10 @@ object ScalaNativePluginInternal {
     )
   }
 
-  // called in overridden method in plugin
+  /** Called in overridden method in plugin
+   *
+   *  nativeConfig created to satisfy sbt scope: Global / nativeConfig
+   */
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = {
     println("scalaNativeGlobalSettings new empty nativeConfig set")
     Seq(
@@ -156,7 +159,7 @@ object ScalaNativePluginInternal {
         .withLinkStubs(nativeLinkStubs.value)
         .withCheck(nativeCheck.value)
         .withDump(nativeDump.value)
-      // println(s"$config")
+      println(s"$config ${NativeConfig.cnt}")
       config
     },
     nativeLink := Def
@@ -165,6 +168,7 @@ object ScalaNativePluginInternal {
         val classpath = fullClasspath.value.map(_.data.toPath)
         val logger = streams.value.log.toLogger
 
+        println(s"$nativeLink ${NativeConfig.cnt}")
         val config =
           build.Config.empty
             .withLogger(logger)

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -143,7 +143,7 @@ object ScalaNativePluginInternal {
   def scalaNativeConfigSettings(testConfig: Boolean): Seq[Setting[_]] = Seq(
     nativeConfig := {
       println(
-        s"scalaNativeConfigSettings($testConfig) set existing nativeConfig with raw settings: ${projectID.value}"
+        s"${projectID.value} scalaNativeConfigSettings($testConfig) "
       )
       val config = nativeConfig.value
         .withClang(nativeClang.value.toPath)

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -67,7 +67,7 @@ object ScalaNativePluginInternal {
    */
   lazy val scalaNativeBaseSettings: Seq[Setting[_]] = {
     println("scalaNativeBaseSettings")
-    println("Before set from nativeConfig")
+    println("set raw setting from empty nativeConfig")
     val nativeConfig = build.NativeConfig.empty
     Seq(
       crossVersion := ScalaNativeCrossVersion.binary,
@@ -88,12 +88,13 @@ object ScalaNativePluginInternal {
   // called in overridden method in plugin
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = {
     println("scalaNativeGlobalSettings")
+    println("empty nativeConfig set")
     Seq(
       nativeConfig := build.NativeConfig.empty
-        .withClang(interceptBuildException(Discover.clang()))
-        .withClangPP(interceptBuildException(Discover.clangpp()))
-        .withCompileOptions(Discover.compileOptions())
-        .withLinkingOptions(Discover.linkingOptions())
+        // .withClang(interceptBuildException(Discover.clang()))
+        // .withClangPP(interceptBuildException(Discover.clangpp()))
+        // .withCompileOptions(Discover.compileOptions())
+        // .withLinkingOptions(Discover.linkingOptions())
         .withLTO(Discover.LTO())
         .withGC(Discover.GC())
         .withMode(Discover.mode())
@@ -128,29 +129,21 @@ object ScalaNativePluginInternal {
   def scalaNativeConfigSettings(testConfig: Boolean): Seq[Setting[_]] = Seq(
     nativeConfig := {
       println(s"scalaNativeConfigSettings($testConfig)")
-      println(s"Before raw settings: ${projectID.value}")
-      println(s"Clang: ${nativeClang.value}")
-      println(s"Clang++: ${nativeClangPP.value}")
-      println(s"Compile Opts: ${nativeCompileOptions.value}")
-      println(s"Linking Opts: ${nativeLinkingOptions.value}")
-      println(s"GC: ${nativeGC.value}")
-      println(s"Mode: ${nativeMode.value}")
-      println(s"LTO: ${nativeLTO.value}")
-      println(s"LinkStubs: ${nativeLinkStubs.value}")
-      println(s"Check: ${nativeCheck.value}")
-      println(s"dump: ${nativeDump.value}")
+      println(
+        s"set existing nativeConfig with raw settings: ${projectID.value}"
+      )
       val config = nativeConfig.value
-        // .withClang(nativeClang.value.toPath)
-        // .withClangPP(nativeClangPP.value.toPath)
-        // .withCompileOptions(nativeCompileOptions.value)
-        // .withLinkingOptions(nativeLinkingOptions.value)
+        .withClang(nativeClang.value.toPath)
+        .withClangPP(nativeClangPP.value.toPath)
+        .withCompileOptions(nativeCompileOptions.value)
+        .withLinkingOptions(nativeLinkingOptions.value)
         .withGC(build.GC(nativeGC.value))
         .withMode(build.Mode(nativeMode.value))
         .withLTO(build.LTO(nativeLTO.value))
         .withLinkStubs(nativeLinkStubs.value)
         .withCheck(nativeCheck.value)
         .withDump(nativeDump.value)
-      println(s"$config")
+      // println(s"$config")
       config
     },
     nativeLink := Def

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -21,6 +21,12 @@ import scala.util.Try
 import scala.scalanative.build.Platform
 import java.nio.file.{Files, Path}
 
+/** ScalaNativePlugin delegates to this object
+ *
+ *  Call order on load: scalaNativeProjectSettings scalaNativeBaseSettings
+ *  scalaNativeCompileSettings scalaNativeTestSettings scalaNativeGlobalSettings
+ *  scalaNativeConfigSettings more than once for each project
+ */
 object ScalaNativePluginInternal {
 
   val nativeWarnOldJVM =
@@ -66,8 +72,9 @@ object ScalaNativePluginInternal {
    *  everything is fine here.
    */
   lazy val scalaNativeBaseSettings: Seq[Setting[_]] = {
-    println("scalaNativeBaseSettings")
-    println("set raw setting from empty nativeConfig")
+    println(
+      "scalaNativeBaseSettings set raw setting from new empty nativeConfig"
+    )
     val nativeConfig = build.NativeConfig.empty
     Seq(
       crossVersion := ScalaNativeCrossVersion.binary,
@@ -87,8 +94,7 @@ object ScalaNativePluginInternal {
 
   // called in overridden method in plugin
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = {
-    println("scalaNativeGlobalSettings")
-    println("empty nativeConfig set")
+    println("scalaNativeGlobalSettings new empty nativeConfig set")
     Seq(
       nativeConfig := build.NativeConfig.empty
         // .withClang(interceptBuildException(Discover.clang()))
@@ -128,9 +134,8 @@ object ScalaNativePluginInternal {
    */
   def scalaNativeConfigSettings(testConfig: Boolean): Seq[Setting[_]] = Seq(
     nativeConfig := {
-      println(s"scalaNativeConfigSettings($testConfig)")
       println(
-        s"set existing nativeConfig with raw settings: ${projectID.value}"
+        s"scalaNativeConfigSettings($testConfig) set existing nativeConfig with raw settings: ${projectID.value}"
       )
       val config = nativeConfig.value
         .withClang(nativeClang.value.toPath)

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -121,7 +121,9 @@ object ScalaNativePluginInternal {
   }
 
   /** Uses overrides defined in the 10 raw setting keys. They are either set raw
-   *  or default from baseSettings.
+   *  or default from baseSettings. Discovered commands need to be handled when
+   *  build is called so that the code calling the tools has complete control of
+   *  the settings.
    */
   def scalaNativeConfigSettings(testConfig: Boolean): Seq[Setting[_]] = Seq(
     nativeConfig := {

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -107,15 +107,15 @@ object ScalaNativePluginInternal {
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = {
     println("scalaNativeGlobalSettings new empty nativeConfig set")
     Seq(
-      nativeConfig := build.NativeConfig.empty
+      nativeConfig := build.NativeConfig.empty,
         // .withClang(interceptBuildException(Discover.clang()))
         // .withClangPP(interceptBuildException(Discover.clangpp()))
         // .withCompileOptions(Discover.compileOptions())
         // .withLinkingOptions(Discover.linkingOptions())
-        .withLTO(Discover.LTO())
-        .withGC(Discover.GC())
-        .withMode(Discover.mode())
-        .withOptimize(Discover.optimize()),
+        // .withLTO(Discover.LTO())
+        // .withGC(Discover.GC())
+        // .withMode(Discover.mode())
+        // .withOptimize(Discover.optimize()),
       // discovery will be delayed until after build is called
       nativeWarnOldJVM := {
         val logger = streams.value.log

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -23,6 +23,10 @@ import java.nio.file.{Files, Path}
 
 /** ScalaNativePlugin delegates to this object
  *
+ *  Note: All logic should be in the Config, NativeConfig, or the build itself.
+ *  Logic should not be in this plugin to avoid logic duplication in downstream
+ *  build tools.
+ *
  *  Call order on load: scalaNativeProjectSettings scalaNativeBaseSettings
  *  scalaNativeCompileSettings scalaNativeTestSettings scalaNativeGlobalSettings
  *  scalaNativeConfigSettings more than once for each project
@@ -167,18 +171,18 @@ object ScalaNativePluginInternal {
         }
         val logger = streams.value.log.toLogger
 
-        val baseConfig =
+        val config =
           build.Config.empty
             .withLogger(logger)
             .withClassPath(classpath)
             .withBasedir(crossTarget.value.toPath())
             .withDefaultBasename(moduleName.value)
-            // .withMainClass(selectMainClass.value.get) // for now
+            .withMainClass(selectMainClass.value)
             .withTestConfig(testConfig)
             .withCompilerConfig(nativeConfig.value)
 
         // set main class in config if an application
-        val config = mainClass.foldLeft(baseConfig)(_.withMainClass(_))
+        // val config = mainClass.foldLeft(baseConfig)(_.withMainClass(_))
 
         interceptBuildException {
           // returns config.artifactPath

--- a/scala-partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/scala-partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -70,7 +70,7 @@ class MainGenericRunner {
 
           commandClasspath ++ nativeClasspath
         }
-        .withMainClass(command.thingToRun)
+        .withMainClass(Some(command.thingToRun))
         .withBasedir(dir)
 
       Scope { implicit s => Build.build(config) }

--- a/scripted-tests/run/java-io-file-2/build.sbt
+++ b/scripted-tests/run/java-io-file-2/build.sbt
@@ -14,7 +14,9 @@ scalaVersion := {
   else scalaVersion
 }
 
-nativeLinkStubs := true // DateFormatSymbols
+Compile / nativeConfig ~= {
+  _.withLinkStubs(true) // DateFormatSymbols
+}
 
 lazy val setupTests = taskKey[Unit]("")
 

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -13,14 +13,16 @@ scalaVersion := {
   else scalaVersion
 }
 
-Compile / nativeLinkingOptions += s"-L${target.value.getAbsoluteFile}"
-
 Compile / compile := {
   val log = streams.value.log
   val cwd = target.value
-  val compileOptions = nativeCompileOptions.value
+  val nc = nativeConfig.value
+  nc.withLinkingOptions(
+    nc.linkingOptions ++ Seq(s"-L${cwd.getAbsoluteFile}")
+  )
+  val compileOptions = nc.compileOptions
   val cpaths = (baseDirectory.value.getAbsoluteFile * "*.c").get
-  val clangPath = nativeClang.value.toPath.toAbsolutePath.toString
+  val clangPath = nc.clang.toAbsolutePath.toString
 
   cwd.mkdirs()
 

--- a/scripted-tests/run/link-stubs/build.sbt
+++ b/scripted-tests/run/link-stubs/build.sbt
@@ -9,3 +9,7 @@ scalaVersion := {
     )
   else scalaVersion
 }
+
+Compile / nativeConfig ~= {
+  _.withLinkStubs(true)
+}

--- a/scripted-tests/run/link-stubs/test
+++ b/scripted-tests/run/link-stubs/test
@@ -1,3 +1,1 @@
--> nativeLink
-> set nativeLinkStubs := true
 > nativeLink

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -27,9 +27,9 @@ object Build {
    *    config with discovery if needed and validation
    */
   private def checkCache(config: Config): Config = {
-    // should be unique but defaultBasename might be better
-    // need to validate not empty or null
-    val name = config.basename
+    // Requires that defaultBasename or basename is set
+    // and unique across sub-projects in the same project
+    val name = config.artifactName
     // always use a fresh logger
     cache.get(name) match {
       case Some(value) =>

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -3,9 +3,6 @@ package build
 
 import java.nio.file.{Files, Path, Paths}
 import scala.scalanative.util.Scope
-import scala.scalanative.build.core.Filter
-import scala.scalanative.build.core.NativeLib
-import scala.scalanative.build.core.ScalaNative
 import scala.util.Try
 
 /** Utility methods for building code using Scala Native. */

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -70,15 +70,10 @@ object Build {
    */
   def build(config: Config)(implicit scope: Scope): Path =
     config.logger.time("Total") {
-      val cconfig = checkCache(config);
+      val fconfig = checkCache(config);
       // create workdir if needed
-      if (Files.notExists(cconfig.workdir)) {
-        Files.createDirectories(cconfig.workdir)
-      }
-      // validate classpath - use fconfig below
-      val fconfig = {
-        val fclasspath = NativeLib.filterClasspath(cconfig.classPath)
-        cconfig.withClassPath(fclasspath)
+      if (Files.notExists(fconfig.workdir)) {
+        Files.createDirectories(fconfig.workdir)
       }
 
       // find and link

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -72,13 +72,13 @@ object Build {
     config.logger.time("Total") {
       val cconfig = checkCache(config);
       // create workdir if needed
-      if (Files.notExists(config.workdir)) {
-        Files.createDirectories(config.workdir)
+      if (Files.notExists(cconfig.workdir)) {
+        Files.createDirectories(cconfig.workdir)
       }
       // validate classpath - use fconfig below
       val fconfig = {
-        val fclasspath = NativeLib.filterClasspath(config.classPath)
-        config.withClassPath(fclasspath)
+        val fclasspath = NativeLib.filterClasspath(cconfig.classPath)
+        cconfig.withClassPath(fclasspath)
       }
 
       // find and link
@@ -91,8 +91,8 @@ object Build {
 
       // optimize and generate ll
       val generated = {
-        val optimized = ScalaNative.optimize(config, linked)
-        ScalaNative.codegen(config, optimized)
+        val optimized = ScalaNative.optimize(fconfig, linked)
+        ScalaNative.codegen(fconfig, optimized)
       }
 
       val objectPaths = fconfig.logger.time("Compiling to native code") {

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -69,59 +69,57 @@ object Build {
    *    `outpath`, the path to the resulting native binary.
    */
   def build(config: Config)(implicit scope: Scope): Path = {
+    // use config only for logger and to check cache
     config.logger.time("Total") {
       val cconfig = checkCache(config)
-      buildImpl(cconfig)
-    }
-  }
+      // called each time for clean or directory removal
+      checkWorkdirExists(cconfig)
 
-  private def buildImpl(config: Config)(implicit scope: Scope): Path = {
-    // called each time for clean or directory removal
-    checkWorkdirExists(config)
 
-    // find and link
-    val linked = {
-      val entries = ScalaNative.entries(config)
-      val linked = ScalaNative.link(config, entries)
-      ScalaNative.logLinked(config, linked)
-      linked
-    }
-
-    // optimize and generate ll
-    val generated = {
-      val optimized = ScalaNative.optimize(config, linked)
-      ScalaNative.codegen(config, optimized)
-    }
-
-    val objectPaths = config.logger.time("Compiling to native code") {
-      // compile generated LLVM IR
-      val llObjectPaths = LLVM.compile(config, generated)
-
-      /* Used to pass alternative paths of compiled native (lib) sources,
-       * eg: reused native sources used in partests.
-       */
-      val libObjectPaths = scala.util.Properties
-        .propOrNone("scalanative.build.paths.libobj") match {
-        case None =>
-          /* Finds all the libraries on the classpath that contain native
-           * code and then compiles them.
-           */
-          findAndCompileNativeLibs(config, linked)
-        case Some(libObjectPaths) =>
-          libObjectPaths
-            .split(java.io.File.pathSeparatorChar)
-            .toSeq
-            .map(Paths.get(_))
+      // find and link
+      val linked = {
+        val entries = ScalaNative.entries(cconfig)
+        val linked = ScalaNative.link(cconfig, entries)
+        ScalaNative.logLinked(cconfig, linked)
+        linked
       }
 
-      libObjectPaths ++ llObjectPaths
-    }
+      // optimize and generate ll
+      val generated = {
+        val optimized = ScalaNative.optimize(cconfig, linked)
+        ScalaNative.codegen(cconfig, optimized)
+      }
 
-    // finally link
-    config.logger.time(
-      s"Linking native code (${config.gc.name} gc, ${config.LTO.name} lto)"
-    ) {
-      LLVM.link(config, linked, objectPaths)
+      val objectPaths = config.logger.time("Compiling to native code") {
+        // compile generated LLVM IR
+        val llObjectPaths = LLVM.compile(cconfig, generated)
+
+        /* Used to pass alternative paths of compiled native (lib) sources,
+         * eg: reused native sources used in partests.
+         */
+        val libObjectPaths = scala.util.Properties
+          .propOrNone("scalanative.build.paths.libobj") match {
+          case None =>
+            /* Finds all the libraries on the classpath that contain native
+             * code and then compiles them.
+             */
+            findAndCompileNativeLibs(cconfig, linked)
+          case Some(libObjectPaths) =>
+            libObjectPaths
+              .split(java.io.File.pathSeparatorChar)
+              .toSeq
+              .map(Paths.get(_))
+        }
+
+        libObjectPaths ++ llObjectPaths
+      }
+
+      // finally link
+      config.logger.time(
+        s"Linking native code (${cconfig.gc.name} gc, ${cconfig.LTO.name} lto)"
+      ) {
+        LLVM.link(cconfig, linked, objectPaths)
+      }
     }
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -75,7 +75,10 @@ object Build {
     }
   }
 
-  def buildImpl(config: Config)(implicit scope: Scope): Path = {
+  private def buildImpl(config: Config)(implicit scope: Scope): Path = {
+    // called each time for clean or directory removal
+    checkWorkdirExists(config)
+
     // find and link
     val linked = {
       val entries = ScalaNative.entries(config)
@@ -131,7 +134,7 @@ object Build {
    *  @return
    *    a sequence of the object file paths
    */
-  def findAndCompileNativeLibs(
+  private def findAndCompileNativeLibs(
       config: Config,
       linkerResult: linker.Result
   ): Seq[Path] = {
@@ -140,5 +143,13 @@ object Build {
       .flatMap(nativeLib =>
         NativeLib.compileNativeLibrary(config, linkerResult, nativeLib)
       )
+  }
+
+  private def checkWorkdirExists(config: Config): Unit = {
+    // create workdir if needed
+    val workdir = config.workdir
+    if (Files.notExists(workdir)) {
+      Files.createDirectories(workdir)
+    }
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -70,11 +70,7 @@ object Build {
    */
   def build(config: Config)(implicit scope: Scope): Path =
     config.logger.time("Total") {
-      val fconfig = checkCache(config);
-      // create workdir if needed
-      if (Files.notExists(fconfig.workdir)) {
-        Files.createDirectories(fconfig.workdir)
-      }
+      val fconfig = checkCache(config)
 
       // find and link
       val linked = {

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -9,6 +9,7 @@ import scala.util.Try
 /** Utility methods for building code using Scala Native. */
 object Build {
 
+  // holds project basename and the related Config
   private val cache = mutable.HashMap.empty[String, Config]
 
   /** Reuse config from cache or cache the config after running any needed
@@ -149,7 +150,7 @@ object Build {
    *  @return
    *    a sequence of the object file paths
    */
-  private def findAndCompileNativeLibs(
+  def findAndCompileNativeLibs(
       config: Config,
       linkerResult: linker.Result
   ): Seq[Path] = {

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -27,14 +27,14 @@ object Build {
    *    config with discovery if needed and validation
    */
   private def checkCache(config: Config): Config = {
+    // should be unique but defaultBasename might be better
+    // need to validate not empty or null
     val name = config.basename
-    println(s"Check cache: $name")
     // always use a fresh logger
     cache.get(name) match {
       case Some(value) =>
         value.withLogger(config.logger)
       case None =>
-        println("No config in cache")
         val vconfig = Validator.validate(Discover.discover(config))
         cache.put(name, vconfig)
         vconfig

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -15,26 +15,26 @@ sealed trait Config {
   def testConfig: Boolean
 
   /** Directory to emit intermediate compilation results. Calculated based on
-   *  [[basedir]] / native or native-test if a test project. The build creates
+   *  [[#basedir]] / native or native-test if a test project. The build creates
    *  directories if they do not exist.
    */
   def workdir: Path
 
   /** Base name for executable or library, typically the project name from the
-   *  build tool [[defaultBasename]] or can be overridden by the user with
+   *  build tool [[#withDefaultBasename]] or can be overridden by the user with
    *  [[NativeConfig#basename]].
    */
   def basename: String
 
   /** This is the name of the executable or library. Calculated based on a
-   *  prefix for libraries `lib` for UNIX like OSes, [[basename]], `-test` if
-   *  [[withTestConfig]] is `true`, and the executable or library suffix
-   *  depending on platform and library type.
+   *  prefix for libraries `lib` for UNIX like OSes, [[NativeConfig#basename]],
+   *  `-test` if [[#withTestConfig]] is `true`, and the executable or library
+   *  suffix depending on platform and library type.
    */
   def artifactName: String
 
   /** Path to the output file, executable or library. Calculated based on
-   *  [[basedir]] `/` [[artifactName]].
+   *  [[#basedir]] `/` [[#artifactName]].
    */
   def artifactPath: Path
 
@@ -60,11 +60,10 @@ sealed trait Config {
 
   /** Create new config with a fully qualified (with package) main class name as
    *  an [[Option]]. Only applicable if [[NativeConfig#buildTarget]] is a
-   *  [[BuildTarget#Application]].
+   *  [[BuildTarget#application]].
    *
    *  @param value
-   *    fully qualified main class name as an [[Option]], default
-   *    [[Option#none]]
+   *    fully qualified main class name as an [[Option]], default [[None]]
    *  @return
    *    this config object
    */

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -26,9 +26,15 @@ sealed trait Config {
    */
   def basename: String
 
+  /** This is the name of the executable or library. Calculated based on a
+   *  prefix for libraries `lib` for UNIX like OSes, [[basename]], `-test` if
+   *  [[withTestConfig]] is `true`, and the executable or library suffix
+   *  depending on platform and library type.
+   */
+  def artifactName: String
+
   /** Path to the output file, executable or library. Calculated based on
-   *  [[basedir]] / [[basename]] or [[NativeConfig#basename]] and -test, if a
-   *  test project.
+   *  [[basedir]] `/` [[artifactName]].
    */
   def artifactPath: Path
 
@@ -179,7 +185,7 @@ object Config {
       case _                 => defaultBasename
     }
 
-    override lazy val artifactPath: Path = {
+    override lazy val artifactName: String = {
       val ext = compilerConfig.buildTarget match {
         case BuildTarget.Application =>
           if (targetsWindows) ".exe" else ""
@@ -195,7 +201,11 @@ object Config {
         case BuildTarget.Application => ""
         case _: BuildTarget.Library  => if (targetsWindows) "" else "lib"
       }
-      basedir.resolve(s"$namePrefix${basename}$nameSuffix$ext")
+      s"$namePrefix${basename}$nameSuffix$ext"
+    }
+
+    override lazy val artifactPath: Path = {
+      basedir.resolve(artifactName)
     }
 
     override def toString: String = {

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -21,7 +21,7 @@ sealed trait Config {
   def workdir: Path
 
   /** Base name for executable or library, typically the project name from the
-   *  build tool [[defaultBaseName]] or can be overridden by the user with
+   *  build tool [[defaultBasename]] or can be overridden by the user with
    *  [[NativeConfig#basename]].
    */
   def basename: String
@@ -57,7 +57,8 @@ sealed trait Config {
    *  [[BuildTarget#Application]].
    *
    *  @param value
-   *    fully qualified main class name as a [[Option]], default [[Option#none]]
+   *    fully qualified main class name as an [[Option]], default
+   *    [[Option#none]]
    *  @return
    *    this config object
    */

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -52,8 +52,16 @@ sealed trait Config {
   /** Create a new config with test (true) or normal config (false). */
   def withTestConfig(value: Boolean): Config
 
-  /** Create new config with given mainClass point. */
-  def withMainClass(value: String): Config
+  /** Create new config with a fully qualified (with package) main class name as
+   *  an [[Option]]. Only applicable if [[NativeConfig#buildTarget]] is a
+   *  [[BuildTarget#Application]].
+   *
+   *  @param value
+   *    fully qualified main class name as a [[Option]], default [[Option#none]]
+   *  @return
+   *    this config object
+   */
+  def withMainClass(value: Option[String]): Config
 
   /** Create a new config with given nir paths. */
   def withClassPath(value: Seq[Path]): Config
@@ -138,8 +146,8 @@ object Config {
     def withNativelib(value: Path): Config =
       copy(nativelib = value)
 
-    def withMainClass(value: String): Config =
-      copy(mainClass = Option(value).filter(_.nonEmpty))
+    def withMainClass(value: Option[String]): Config =
+      copy(mainClass = value)
 
     def withClassPath(value: Seq[Path]): Config =
       copy(classPath = value)

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -96,8 +96,8 @@ object Discover {
    *  environment variables that can be used to control the build. This only
    *  calls discovery if the value is default.
    *
-   *  Discovery is only run the first time on the [[#compilerConfig]] which is
-   *  the the [[NativeConfig]] object.
+   *  Discovery is only run the first time on the [[Config#compilerConfig]]
+   *  which is the the [[NativeConfig]] object.
    *
    *  @param config
    *    the config used for discovery

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -5,7 +5,7 @@ import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scala.util.Try
 import scala.sys.process._
-import scalanative.build.core.IO.RichPath
+import scalanative.build.IO.RichPath
 
 /** Utilities for discovery of command-line tools and settings required to build
  *  Scala Native applications.

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -105,7 +105,6 @@ object Discover {
    *    the final config modified by the discovery process
    */
   def discover(config: Config): Config = {
-    println("In discover")
     val empty = build.NativeConfig.empty
     var nconfig = config.compilerConfig
     if (nconfig.clang == empty.clang)

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -92,7 +92,9 @@ object Discover {
   }
 
   /** Discover features where the default is not sufficient to execute a build
-   *  that will succeed.
+   *  that will succeed. This also calls discovery for setting that have
+   *  environment variables that can be used to control the build. This only
+   *  calls discovery if the value is default.
    *
    *  Discovery is only run the first time on the [[#compilerConfig]] which is
    *  the the [[NativeConfig]] object.
@@ -114,6 +116,14 @@ object Discover {
       nconfig = nconfig.withCompileOptions(Discover.compileOptions())
     if (nconfig.linkingOptions == empty.linkingOptions)
       nconfig = nconfig.withLinkingOptions(Discover.linkingOptions())
+    if (nconfig.lto == empty.lto)
+      nconfig = nconfig.withLTO(Discover.LTO())
+    if (nconfig.gc == empty.gc)
+      nconfig = nconfig.withGC(Discover.GC())
+    if (nconfig.mode == empty.mode)
+      nconfig = nconfig.withMode(Discover.mode())
+    if (nconfig.optimize == empty.optimize)
+      nconfig = nconfig.withOptimize(Discover.optimize())
     config.withCompilerConfig(nconfig)
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -93,7 +93,17 @@ object Discover {
 
   def discover(config: Config): Config = {
     println("In discover")
-    config
+    val empty = build.NativeConfig.empty
+    var nconfig = config.compilerConfig
+    if (nconfig.clang == empty.clang)
+      nconfig = nconfig.withClang(Discover.clang())
+    if (nconfig.clangPP == empty.clangPP)
+      nconfig = nconfig.withClangPP(Discover.clangpp())
+    if (nconfig.compileOptions == empty.compileOptions)
+      nconfig = nconfig.withCompileOptions(Discover.compileOptions())
+    if (nconfig.linkingOptions == empty.linkingOptions)
+      nconfig = nconfig.withLinkingOptions(Discover.linkingOptions())
+    config.withCompilerConfig(nconfig)
   }
 
   private def clangVersionMajorFullTarget(

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -91,6 +91,11 @@ object Discover {
     libs
   }
 
+  def discover(config: Config): Config = {
+    println("In discover")
+    config
+  }
+
   private def clangVersionMajorFullTarget(
       clang: String
   ): (Int, String, String) = {

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -91,6 +91,17 @@ object Discover {
     libs
   }
 
+  /** Discover features where the default is not sufficient to execute a build
+   *  that will succeed.
+   *
+   *  Discovery is only run the first time on the [[#compilerConfig]] which is
+   *  the the [[NativeConfig]] object.
+   *
+   *  @param config
+   *    the config used for discovery
+   *  @return
+   *    the final config modified by the discovery process
+   */
   def discover(config: Config): Config = {
     println("In discover")
     val empty = build.NativeConfig.empty

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -1,11 +1,10 @@
 package scala.scalanative
 package build
-package core
 
 import java.nio.file.{Files, Path, Paths}
 
-import scalanative.build.core.IO.RichPath
-import scalanative.build.core.NativeLib._
+import scalanative.build.IO.RichPath
+import scalanative.build.NativeLib._
 import scalanative.build.LLVM._
 
 private[scalanative] object Filter {

--- a/tools/src/main/scala/scala/scalanative/build/IO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/IO.scala
@@ -1,6 +1,5 @@
 package scala.scalanative
 package build
-package core
 
 import java.io.IOException
 import java.nio.file.{

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -4,7 +4,7 @@ package build
 import java.io.{File, PrintWriter}
 import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 import scala.sys.process._
-import scalanative.build.core.IO.RichPath
+import scalanative.build.IO.RichPath
 import scalanative.compat.CompatParColls.Converters._
 import scalanative.nir.Attr.Link
 import scala.scalanative.build.BuildTarget._

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -167,10 +167,12 @@ sealed trait NativeConfig {
 
 object NativeConfig {
   type LinktimeProperites = Map[String, Any]
+  var cnt = 1
 
   /** Default empty config object where all of the fields are left blank. */
   def empty: NativeConfig = {
-    println("NativeConfig.empty")
+    println(s"NativeConfig.empty $cnt")
+    cnt += 1
     Impl(
       clang = Paths.get(""),
       clangPP = Paths.get(""),

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -167,12 +167,9 @@ sealed trait NativeConfig {
 
 object NativeConfig {
   type LinktimeProperites = Map[String, Any]
-  var cnt = 1
 
   /** Default empty config object where all of the fields are left blank. */
   def empty: NativeConfig = {
-    println(s"NativeConfig.empty $cnt")
-    cnt += 1
     Impl(
       clang = Paths.get(""),
       clangPP = Paths.get(""),

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -169,7 +169,8 @@ object NativeConfig {
   type LinktimeProperites = Map[String, Any]
 
   /** Default empty config object where all of the fields are left blank. */
-  def empty: NativeConfig =
+  def empty: NativeConfig = {
+    println("NativeConfig.empty")
     Impl(
       clang = Paths.get(""),
       clangPP = Paths.get(""),
@@ -192,6 +193,7 @@ object NativeConfig {
       basename = "",
       optimizerConfig = OptimizerConfig.empty
     )
+  }
 
   private final case class Impl(
       clang: Path,

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -1,13 +1,10 @@
 package scala.scalanative
 package build
-package core
 
 import java.io.File
 import java.nio.file.{Files, Path}
 import java.util.Arrays
 import java.util.regex._
-
-import scalanative.build.LLVM
 
 /** Original jar or dir path and generated dir path for native code */
 private[scalanative] case class NativeLib(src: Path, dest: Path)

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -1,6 +1,5 @@
 package scala.scalanative
 package build
-package core
 
 import java.nio.file.{Path, Files}
 import scala.collection.mutable

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -4,8 +4,10 @@ import java.nio.file.Files
 
 object Validator {
   def validate(config: Config): Config = {
-    validateMainClass(config) // side effecting
-    // returns Config
+    // side effecting
+    validateMainClass(config)
+    validateBasename(config)
+    // returns new Config
     validateClasspath(config)
   }
 
@@ -22,6 +24,14 @@ object Validator {
       case _: BuildTarget.Library => ()
     }
   }
+
+  // throws if no defaultBasename or basename is set
+  private def validateBasename(config: Config): Unit =
+    if (config.basename.trim.isEmpty) { // trim for non default error
+      throw new BuildException(
+        "Config defaultBasename or NativeConfig basename must be set."
+      )
+    }
 
   // filter so classpath only has jars or directories
   private def validateClasspath(config: Config): Config = {

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -4,8 +4,8 @@ import java.nio.file.Files
 
 object Validator {
   def validate(config: Config): Config = {
-    println("In validate")
-    validateMainClass(config)
+    validateMainClass(config) // side effecting
+    // returns Config
     validateClasspath(config)
   }
 
@@ -15,7 +15,9 @@ object Validator {
     nativeConfig.buildTarget match {
       case BuildTarget.Application =>
         if (config.mainClass.isEmpty) {
-          throw new BuildException("No main class detected.")
+          throw new BuildException(
+            "No main class detected with Application selected."
+          )
         }
       case _: BuildTarget.Library => ()
     }

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -3,11 +3,11 @@ package scala.scalanative.build
 object Validator {
   def validate(config: Config): Config = {
     println("In validate")
-    validateMain(config)
-    config
+    validateMainClass(config) // can throw
+    validateClasspath(config)
   }
 
-  private def validateMain(config: Config): Unit = {
+  private def validateMainClass(config: Config): Unit = {
     val nativeConfig = config.compilerConfig
     nativeConfig.buildTarget match {
       case BuildTarget.Application =>
@@ -16,5 +16,10 @@ object Validator {
         }
       case _: BuildTarget.Library => ()
     }
+  }
+
+  private def validateClasspath(config: Config): Config = {
+    val fclasspath = NativeLib.filterClasspath(config.classPath)
+    config.withClassPath(fclasspath)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -1,0 +1,8 @@
+package scala.scalanative.build
+
+object Validator {
+  def validate(config: Config): Config = {
+    println("In validate")
+    config
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -6,7 +6,6 @@ object Validator {
   def validate(config: Config): Config = {
     println("In validate")
     validateMainClass(config)
-    validateWorkdirExists(config)
     validateClasspath(config)
   }
 
@@ -19,14 +18,6 @@ object Validator {
           throw new BuildException("No main class detected.")
         }
       case _: BuildTarget.Library => ()
-    }
-  }
-
-  // validate that workdir exists - can throw exception
-  private def validateWorkdirExists(config: Config): Unit = {
-    // create workdir if needed
-    if (Files.notExists(config.workdir)) {
-      Files.createDirectories(config.workdir)
     }
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -3,6 +3,18 @@ package scala.scalanative.build
 object Validator {
   def validate(config: Config): Config = {
     println("In validate")
+    validateMain(config)
     config
+  }
+
+  private def validateMain(config: Config): Unit = {
+    val nativeConfig = config.compilerConfig
+    nativeConfig.buildTarget match {
+      case BuildTarget.Application =>
+        if (config.mainClass.isEmpty) {
+          throw new BuildException("No main class detected.")
+        }
+      case _: BuildTarget.Library => ()
+    }
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -1,12 +1,16 @@
 package scala.scalanative.build
 
+import java.nio.file.Files
+
 object Validator {
   def validate(config: Config): Config = {
     println("In validate")
-    validateMainClass(config) // can throw
+    validateMainClass(config)
+    validateWorkdirExists(config)
     validateClasspath(config)
   }
 
+  // throws if Application with no mainClass
   private def validateMainClass(config: Config): Unit = {
     val nativeConfig = config.compilerConfig
     nativeConfig.buildTarget match {
@@ -18,6 +22,15 @@ object Validator {
     }
   }
 
+  // validate that workdir exists - can throw exception
+  private def validateWorkdirExists(config: Config): Unit = {
+    // create workdir if needed
+    if (Files.notExists(config.workdir)) {
+      Files.createDirectories(config.workdir)
+    }
+  }
+
+  // filter so classpath only has jars or directories
   private def validateClasspath(config: Config): Config = {
     val fclasspath = NativeLib.filterClasspath(config.classPath)
     config.withClassPath(fclasspath)

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -5,7 +5,7 @@ import java.io.File
 import java.nio.file.{Path, Paths, Files}
 import scala.collection.mutable
 import scala.scalanative.build.Config
-import scala.scalanative.build.core.ScalaNative.{dumpDefns, encodedMainClass}
+import scala.scalanative.build.ScalaNative.{dumpDefns, encodedMainClass}
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir._
 import scala.scalanative.util.{Scope, partitionBy, procs}

--- a/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
+++ b/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
@@ -7,7 +7,8 @@ import java.nio.file.{Files, Path, Paths}
 import scala.scalanative.build.{Config, NativeConfig, _}
 import scala.scalanative.util.Scope
 
-// The test is used for incremental compilation
+// The test is used for incremental compilation.
+// Each test should have a different defaultBasename
 
 class IncCompilationTest extends codegen.CodeGenSpec with Matchers {
   "The test framework" should "generate the llvm IR of object A" in {
@@ -41,7 +42,7 @@ class IncCompilationTest extends codegen.CodeGenSpec with Matchers {
         .withMaxInlineSize(1)
       val nativeConfig = defaultNativeConfig
         .withOptimizerConfig(optimizerConfig)
-      val config = makeConfig(outDir, entry, nativeConfig)
+      val config = makeConfig(outDir, "out", entry, nativeConfig)
       Build.build(config)
     }
   }
@@ -82,7 +83,7 @@ class IncCompilationTest extends codegen.CodeGenSpec with Matchers {
       val sourcesDir = NIRCompiler.writeSources(sources)
       val files = compiler.compile(sourcesDir)
       makeChanged(outDir, changedTop)
-      val config = makeConfig(outDir, entry, defaultNativeConfig)
+      val config = makeConfig(outDir, "out1", entry, defaultNativeConfig)
 
       Build.build(config)
     }
@@ -108,6 +109,7 @@ class IncCompilationTest extends codegen.CodeGenSpec with Matchers {
 
   private def makeConfig(
       outDir: Path,
+      defaultBasename: String,
       entry: String,
       setupNativeConfig: NativeConfig
   )(implicit in: Scope): Config = {
@@ -116,6 +118,7 @@ class IncCompilationTest extends codegen.CodeGenSpec with Matchers {
       .withBasedir(outDir)
       .withClassPath(classpath.toSeq)
       .withMainClass(Some(entry))
+      .withDefaultBasename(defaultBasename)
       .withCompilerConfig(setupNativeConfig)
   }
 
@@ -128,6 +131,5 @@ class IncCompilationTest extends codegen.CodeGenSpec with Matchers {
     .withGC(Discover.GC())
     .withMode(Discover.mode())
     .withOptimize(Discover.optimize())
-    .withBasename("out")
 
 }

--- a/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
+++ b/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
@@ -91,9 +91,7 @@ class IncCompilationTest extends codegen.CodeGenSpec with Matchers {
   private def makeChanged(outDir: Path, changedTop: Set[String])(implicit
       in: Scope
   ): Unit = {
-    val pw = new PrintWriter(
-      new File(outDir.toFile, "changed")
-    )
+    val pw = new PrintWriter(new File(outDir.toFile, "changed"))
     changedTop.foreach(changedTop => pw.write(changedTop + "\n"))
     pw.close()
   }

--- a/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
+++ b/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
@@ -117,7 +117,7 @@ class IncCompilationTest extends codegen.CodeGenSpec with Matchers {
     Config.empty
       .withBasedir(outDir)
       .withClassPath(classpath.toSeq)
-      .withMainClass(entry)
+      .withMainClass(Some(entry))
       .withCompilerConfig(setupNativeConfig)
   }
 

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -4,7 +4,7 @@ import scala.language.implicitConversions
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scalanative.build.{Config, NativeConfig}
-import scalanative.build.core.ScalaNative
+import scalanative.build.ScalaNative
 import scalanative.util.Scope
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -60,7 +60,7 @@ abstract class LinkerSpec extends AnyFlatSpec {
     Config.empty
       .withBasedir(outDir)
       .withClassPath(classpath.toSeq)
-      .withMainClass(entry)
+      .withMainClass(Some(entry))
       .withCompilerConfig(setupNativeConfig.andThen(withDefaults))
   }
 

--- a/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 
 import scala.scalanative.build.{Config, NativeConfig, Mode}
-import scala.scalanative.build.core.ScalaNative
+import scala.scalanative.build.ScalaNative
 
 /** Base class to test the optimizer */
 abstract class OptimizerSpec extends LinkerSpec {

--- a/tools/src/test/scala/scala/scalanative/codegen/CodeGenSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/codegen/CodeGenSpec.scala
@@ -4,7 +4,7 @@ package codegen
 import java.nio.file.{Path, Paths}
 import scalanative.io.VirtualDirectory
 import scalanative.build.Config
-import scalanative.build.core.ScalaNative
+import scalanative.build.ScalaNative
 import scalanative.util.Scope
 
 /** Base class to test code generation */

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -7,7 +7,7 @@ import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scalanative.util.Scope
 import scalanative.nir.{Sig, Global}
-import scalanative.build.core.ScalaNative
+import scalanative.build.ScalaNative
 
 trait ReachabilitySuite extends AnyFunSuite {
 
@@ -111,6 +111,6 @@ trait ReachabilitySuite extends AnyFunSuite {
       .withCompilerConfig {
         _.withTargetTriple("x86_64-unknown-unknown")
       }
-      .withMainClass(mainClass)
+      .withMainClass(Some(mainClass))
   }
 }


### PR DESCRIPTION
The previous attempt to do what was suggested did not well. See https://github.com/scala-native/scala-native/pull/2380

This is a new attempt.

- gets rid of the build logic out of the plugin
- solves a whole bunch of complaints about settings on the build.
- uses delayed discovery and validation but hopefully in a nicer way
- caches the build ~ 200ms the first time to 0ms on subsequent builds

At least one test is failing for me so we will see how it does in CI. Probably many more.