### PR TITLE
posixlib socket.c now compiles on FreeBSD arm64

### DIFF
--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -8,6 +8,9 @@
 #pragma comment(lib, "Ws2_32.lib")
 typedef SSIZE_T ssize_t;
 #else
+#if defined(__FreeBSD__)
+#import <sys/types.h> // u_long & friends. Required by Amazon FreeBSD64 arm64
+#endif                // __FreeBSD__
 #include <netinet/in.h>
 #include <sys/socket.h>
 #if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)


### PR DESCRIPTION
Prior to this PR, posixlib socket.c compiled on the FreeBSD X86_64 hardware architecture but not on arm64.

As of this PR, it compiles on both architectures.