### PR TITLE
Introduce concept of `blocking extern` functions for better interop of GC with foreign code

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stdio.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdio.scala
@@ -34,7 +34,7 @@ import scalanative.unsafe._
    *  @return
    *    0 on success, EOF otherwise
    */
-  def fclose(stream: Ptr[FILE]): CInt = extern
+  @blocking def fclose(stream: Ptr[FILE]): CInt = extern
 
   /** For output streams (and for update streams on which the last operation was
    *  output), writes any unwritten data from the stream's buffer to the
@@ -151,13 +151,12 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/fread]]
    */
-  def fread(
+  @blocking def fread(
       buffer: Ptr[Byte],
       size: CSize,
       count: CSize,
       stream: Ptr[FILE]
-  ): CSize =
-    extern
+  ): CSize = extern
 
   /** Writes count of objects from the given array buffer to the output stream
    *  stream. The objects are written as if by reinterpreting each object as an
@@ -189,13 +188,12 @@ import scalanative.unsafe._
    *    [[https://en.cppreference.com/w/c/io/fwrite]]
    */
 
-  def fwrite(
+  @blocking def fwrite(
       buffer: Ptr[Byte],
       size: CSize,
       count: CSize,
       stream: Ptr[FILE]
-  ): CSize =
-    extern
+  ): CSize = extern
 
   // Unformatted input/output
   /** Reads the next character from the given input stream.
@@ -211,7 +209,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/fgetc]]
    */
-  def fgetc(stream: Ptr[FILE]): CInt = extern
+  @blocking def fgetc(stream: Ptr[FILE]): CInt = extern
 
   /** Same as fgetc, except that if getc is implemented as a macro, it may
    *  evaluate stream more than once, so the corresponding argument should never
@@ -228,7 +226,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/fgetc]]
    */
-  def getc(stream: Ptr[FILE]): CInt = extern
+  @blocking def getc(stream: Ptr[FILE]): CInt = extern
 
   /** Reads at most count - 1 characters from the given file stream and stores
    *  them in the character array pointed to by str. Parsing stops if a newline
@@ -254,7 +252,8 @@ import scalanative.unsafe._
    *    indicator (see ferror()) on stream. The contents of the array pointed to
    *    by str are indeterminate (it may not even be null-terminated).
    */
-  def fgets(str: CString, count: CInt, stream: Ptr[FILE]): CString = extern
+  @blocking def fgets(str: CString, count: CInt, stream: Ptr[FILE]): CString =
+    extern
 
   /** Writes a character ch to the given output stream stream. putc() may be
    *  implemented as a macro and evaluate stream more than once, so the
@@ -274,7 +273,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/fputc]]
    */
-  def fputc(ch: CInt, stream: Ptr[FILE]): CInt = extern
+  @blocking def fputc(ch: CInt, stream: Ptr[FILE]): CInt = extern
 
   /** Writes a character ch to the given output stream stream. putc() may be
    *  implemented as a macro and evaluate stream more than once, so the
@@ -294,7 +293,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/fputc]]
    */
-  def putc(ch: CInt, stream: Ptr[FILE]): CInt = extern
+  @blocking def putc(ch: CInt, stream: Ptr[FILE]): CInt = extern
 
   /** Writes every character from the null-terminated string str to the output
    *  stream stream, as if by repeatedly executing fputc.
@@ -311,7 +310,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/fputs]]
    */
-  def fputs(str: CString, stream: Ptr[FILE]): CInt = extern
+  @blocking def fputs(str: CString, stream: Ptr[FILE]): CInt = extern
 
   /** Reads the next character from stdin.
    *
@@ -321,7 +320,7 @@ import scalanative.unsafe._
    *    indicator (see feof()) on stdin. If the failure has been caused by some
    *    other error, sets the error indicator (see ferror()) on stdin.
    */
-  def getchar(): CInt = extern
+  @blocking def getchar(): CInt = extern
 
   /** Reads stdin into given character string until a newline character is found
    *  or end-of-file occurs.
@@ -336,7 +335,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/cpp/io/c/gets]]
    */
-  def gets(str: CString): CString = extern
+  @blocking def gets(str: CString): CString = extern
 
   /** Writes a character ch to stdout. Internally, the character is converted to
    *  unsigned char just before being written.
@@ -353,7 +352,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/ferror]] for error indicators.
    */
-  def putchar(ch: CInt): CInt = extern
+  @blocking def putchar(ch: CInt): CInt = extern
 
   /** Writes every character from the null-terminated string str and one
    *  additional newline character '\n' to the output stream stdout, as if by
@@ -373,7 +372,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/ferror]] for error indicators.
    */
-  def puts(str: CString): CInt = extern
+  @blocking def puts(str: CString): CInt = extern
 
   /** If ch does not equal EOF, pushes the character ch (reinterpreted as
    *  unsigned char) into the input buffer associated with the stream stream in
@@ -412,7 +411,7 @@ import scalanative.unsafe._
    *    ch on success. Otherwise returns EOF and the given stream remains
    *    unchanged.
    */
-  def ungetc(ch: CInt, stream: Ptr[FILE]): CInt = extern
+  @blocking def ungetc(ch: CInt, stream: Ptr[FILE]): CInt = extern
 
   // Formatted input/output
 
@@ -433,7 +432,7 @@ import scalanative.unsafe._
    *    the proper indicator is set (feof or ferror). And, if either happens
    *    before any data could be successfully read, EOF is returned.
    */
-  def vscanf(format: CString, valist: CVarArgList): CInt = extern
+  @blocking def vscanf(format: CString, valist: CVarArgList): CInt = extern
 
   /** Read formatted data from stream into variable argument list Reads data
    *  from the stream and stores them according to parameter format into the
@@ -456,7 +455,11 @@ import scalanative.unsafe._
    *  @see
    *    [[https://www.cplusplus.com/reference/cstdio/vfscanf/]]
    */
-  def vfscanf(stream: Ptr[FILE], format: CString, valist: CVarArgList): CInt =
+  @blocking def vfscanf(
+      stream: Ptr[FILE],
+      format: CString,
+      valist: CVarArgList
+  ): CInt =
     extern
 
   /** Reads the data from stdin
@@ -473,7 +476,11 @@ import scalanative.unsafe._
    *    Number of receiving arguments successfully assigned, or EOF if read
    *    failure occurs before the first receiving argument was assigned
    */
-  def vsscanf(buffer: CString, format: CString, valist: CVarArgList): CInt =
+  @blocking def vsscanf(
+      buffer: CString,
+      format: CString,
+      valist: CVarArgList
+  ): CInt =
     extern
 
   /** Writes the results to stdout.
@@ -489,7 +496,7 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/vfprintf]]
    */
-  def vprintf(format: CString, valist: CVarArgList): CInt = extern
+  @blocking def vprintf(format: CString, valist: CVarArgList): CInt = extern
 
   /** Writes the results to a file stream stream.
    *  @param stream
@@ -506,7 +513,11 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/vfprintf]]
    */
-  def vfprintf(stream: Ptr[FILE], format: CString, valist: CVarArgList): CInt =
+  @blocking def vfprintf(
+      stream: Ptr[FILE],
+      format: CString,
+      valist: CVarArgList
+  ): CInt =
     extern
 
   /** Writes the results to a character string buffer.
@@ -524,7 +535,11 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/vfprintf]]
    */
-  def vsprintf(buffer: CString, format: CString, valist: CVarArgList): CInt =
+  @blocking def vsprintf(
+      buffer: CString,
+      format: CString,
+      valist: CVarArgList
+  ): CInt =
     extern
 
   /** The number of characters written if successful or negative value if an
@@ -549,13 +564,12 @@ import scalanative.unsafe._
    *  @see
    *    [[https://en.cppreference.com/w/c/io/vfprintf]]
    */
-  def vsnprintf(
+  @blocking def vsnprintf(
       buffer: CString,
       bufsz: CInt,
       format: CString,
       valist: CVarArgList
-  ): CInt =
-    extern
+  ): CInt = extern
 
   // File positioning
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -112,6 +112,11 @@ package object unsafe extends unsafe.UnsafePackageCompat {
    */
   final class extern extends scala.annotation.StaticAnnotation
 
+  /** An annotation that is used to mark methods that contain externally-defined
+   *  and potentially blocking methods
+   */
+  final class blocking extends scala.annotation.StaticAnnotation
+
   /** Used as right hand side of external method and field declarations. */
   def extern: Nothing = intrinsic
 

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -87,12 +87,12 @@ object Attrs {
       case Extern(blocking) =>
         isExtern = true
         isBlocking = blocking
-      case Dyn              => isDyn = true
-      case Stub             => isStub = true
-      case link: Attr.Link  => links += link
-      case Abstract         => isAbstract = true
-      case Volatile         => isVolatile = true
-      case Final            => isFinal = true
+      case Dyn             => isDyn = true
+      case Stub            => isStub = true
+      case link: Attr.Link => links += link
+      case Abstract        => isAbstract = true
+      case Volatile        => isVolatile = true
+      case Final           => isFinal = true
     }
 
     new Attrs(

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -27,7 +27,7 @@ object Attr {
 
   case object Dyn extends Attr
   case object Stub extends Attr
-  case object Extern extends Attr
+  case class Extern(blocking: Boolean) extends Attr
   final case class Link(name: String) extends Attr
   case object Abstract extends Attr
 }
@@ -37,6 +37,7 @@ final case class Attrs(
     specialize: Specialize = MaySpecialize,
     opt: Opt = UnOpt,
     isExtern: Boolean = false,
+    isBlocking: Boolean = false,
     isDyn: Boolean = false,
     isStub: Boolean = false,
     isAbstract: Boolean = false,
@@ -48,7 +49,7 @@ final case class Attrs(
     if (inlineHint != MayInline) out += inlineHint
     if (specialize != MaySpecialize) out += specialize
     if (opt != UnOpt) out += opt
-    if (isExtern) out += Extern
+    if (isExtern) out += Extern(isBlocking)
     if (isDyn) out += Dyn
     if (isStub) out += Stub
     if (isAbstract) out += Abstract
@@ -68,13 +69,16 @@ object Attrs {
     var isDyn = false
     var isStub = false
     var isAbstract = false
+    var isBlocking = false
     val links = Seq.newBuilder[Attr.Link]
 
     attrs.foreach {
       case attr: Inline     => inline = attr
       case attr: Specialize => specialize = attr
       case attr: Opt        => opt = attr
-      case Extern           => isExtern = true
+      case Extern(blocking) =>
+        isExtern = true
+        isBlocking = blocking
       case Dyn              => isDyn = true
       case Stub             => isStub = true
       case link: Attr.Link  => links += link
@@ -86,6 +90,7 @@ object Attrs {
       specialize = specialize,
       opt = opt,
       isExtern = isExtern,
+      isBlocking = isBlocking,
       isDyn = isDyn,
       isStub = isStub,
       isAbstract = isAbstract,

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -79,10 +79,10 @@ object Attrs {
       case Extern(blocking) =>
         isExtern = true
         isBlocking = blocking
-      case Dyn              => isDyn = true
-      case Stub             => isStub = true
-      case link: Attr.Link  => links += link
-      case Abstract         => isAbstract = true
+      case Dyn             => isDyn = true
+      case Stub            => isStub = true
+      case link: Attr.Link => links += link
+      case Abstract        => isAbstract = true
     }
 
     new Attrs(

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -93,8 +93,9 @@ object Show {
         str("dyn")
       case Attr.Stub =>
         str("stub")
-      case Attr.Extern =>
+      case Attr.Extern(isBlocking) =>
         str("extern")
+        if (isBlocking) str(" blocking")
       case Attr.Link(name) =>
         str("link(\"")
         str(escapeQuotes(name))

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -76,7 +76,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
 
     case T.DynAttr      => Attr.Dyn
     case T.StubAttr     => Attr.Stub
-    case T.ExternAttr   => Attr.Extern
+    case T.ExternAttr   => Attr.Extern(getBool())
     case T.LinkAttr     => Attr.Link(getUTF8String())
     case T.AbstractAttr => Attr.Abstract
   }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -104,9 +104,11 @@ final class BinarySerializer {
     case Attr.DidOpt       => putInt(T.DidOptAttr)
     case Attr.BailOpt(msg) => putInt(T.BailOptAttr); putUTF8String(msg)
 
-    case Attr.Dyn      => putInt(T.DynAttr)
-    case Attr.Stub     => putInt(T.StubAttr)
-    case Attr.Extern   => putInt(T.ExternAttr)
+    case Attr.Dyn  => putInt(T.DynAttr)
+    case Attr.Stub => putInt(T.StubAttr)
+    case Attr.Extern(isBlocking) =>
+      putInt(T.ExternAttr)
+      putBool(isBlocking)
     case Attr.Link(s)  => putInt(T.LinkAttr); putUTF8String(s)
     case Attr.Abstract => putInt(T.AbstractAttr)
   }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -30,6 +30,9 @@ trait NirDefinitions {
     lazy val ExternClass = getRequiredClass(
       "scala.scalanative.unsafe.package$extern"
     )
+    lazy val BlockingClass = getRequiredClass(
+      "scala.scalanative.unsafe.package$blocking"
+    )
     lazy val ExportedClass = getRequiredClass(
       "scala.scalanative.unsafe.exported"
     )

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -26,6 +26,9 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
       (isScalaModule || sym.isTraitOrInterface) &&
         sym.annotations.exists(_.symbol == ExternClass)
 
+    def isBlocking: Boolean =
+      sym.annotations.exists(_.symbol == BlockingClass)
+
     def isStruct: Boolean =
       sym.annotations.exists(_.symbol == StructClass)
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -33,6 +33,7 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val NameType = requiredClassRef("scala.scalanative.unsafe.name")
   @tu lazy val LinkType = requiredClassRef("scala.scalanative.unsafe.link")
   @tu lazy val ExternType = requiredClassRef("scala.scalanative.unsafe.extern")
+  @tu lazy val BlockingType = requiredClassRef("scala.scalanative.unsafe.blocking")
   @tu lazy val StructType = requiredClassRef("scala.scalanative.runtime.struct")
   @tu lazy val ResolvedAtLinktimeType = requiredClassRef("scala.scalanative.unsafe.resolvedAtLinktime")
   @tu lazy val ExportedType = requiredClassRef("scala.scalanative.unsafe.exported")
@@ -41,6 +42,7 @@ final class NirDefinitions()(using ctx: Context) {
   def NameClass(using Context) = NameType.symbol.asClass
   def LinkClass(using Context) = LinkType.symbol.asClass
   def ExternClass(using Context) = ExternType.symbol.asClass
+  def BlockingClass(using Context) = BlockingType.symbol.asClass
   def StructClass(using Context) = StructType.symbol.asClass
   def ResolvedAtLinktimeClass(using Context) = ResolvedAtLinktimeType.symbol.asClass
   def ExportedClass(using Context) = ExportedType.symbol.asClass

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -248,7 +248,7 @@ trait NirGenStat(using Context) {
         case defnNir.NoSpecializeType => Attr.NoSpecialize
         case defnNir.StubType         => Attr.Stub
       }
-    val externAttrs = Option.when(sym.owner.isExternType) {
+    val externAttrs = Option.when(sym.isExtern) {
       Attr.Extern(sym.isBlocking || sym.owner.isBlocking)
     }
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -54,6 +54,9 @@ trait NirGenType(using Context) {
       (isScalaModule || sym.isTraitOrInterface) &&
         sym.hasAnnotation(defnNir.ExternClass)
 
+    def isBlocking: Boolean =
+      sym.exists && sym.hasAnnotation(defnNir.BlockingClass)
+
     def isStruct: Boolean =
       sym.hasAnnotation(defnNir.StructClass)
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/poll.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/poll.scala
@@ -18,6 +18,7 @@ object poll {
     pollEvent_t // returned events
   ]
 
+  @blocking
   def poll(fds: Ptr[struct_pollfd], nfds: nfds_t, timeout: CInt): CInt = extern
 
   // TL;DR

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -109,12 +109,14 @@ object pthread {
 
   def pthread_cond_signal(cond: Ptr[pthread_cond_t]): CInt = extern
 
+  @blocking
   def pthread_cond_timedwait(
       cond: Ptr[pthread_cond_t],
       mutex: Ptr[pthread_mutex_t],
       timespec: Ptr[timespec]
   ): CInt = extern
 
+  @blocking
   def pthread_cond_wait(
       cond: Ptr[pthread_cond_t],
       mutex: Ptr[pthread_mutex_t]
@@ -168,6 +170,7 @@ object pthread {
 
   def pthread_getspecific(key: pthread_key_t): Ptr[Byte] = extern
 
+  @blocking
   def pthread_join(thread: pthread_t, value_ptr: Ptr[Ptr[Byte]]): CInt = extern
 
   def pthread_key_create(
@@ -191,6 +194,7 @@ object pthread {
       attr: Ptr[pthread_mutexattr_t]
   ): CInt = extern
 
+  @blocking
   def pthread_mutex_lock(mutex: Ptr[pthread_mutex_t]): CInt = extern
 
   def pthread_mutex_setprioceiling(
@@ -259,6 +263,7 @@ object pthread {
       attr: Ptr[pthread_rwlockattr_t]
   ): CInt = extern
 
+  @blocking
   def pthread_rwlock_rdlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
 
   def pthread_rwlock_tryrdlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
@@ -267,6 +272,7 @@ object pthread {
 
   def pthread_rwlock_unlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
 
+  @blocking
   def pthread_rwlock_wrlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
 
   def pthread_rwlockattr_destroy(attr: Ptr[pthread_rwlockattr_t]): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
@@ -20,6 +20,7 @@ object sched {
 
   def sched_getscheduler(pid: pid_t): CInt = extern
 
+  @blocking
   def sched_yield(): CInt = extern
 
   def sched_get_priority_max(algorithm: CInt): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
@@ -353,6 +353,7 @@ import scala.scalanative.unsafe._
   def sigignore(sig: CInt): CInt = extern
   def siginterrupt(sig: CInt, flag: CInt): CInt = extern
   def sigismember(set: Ptr[sigset_t], signo: CInt): CInt = extern
+  @blocking
   def sigpause(sig: CInt): CInt = extern
   def sigpending(set: Ptr[sigset_t]): CInt = extern
   def sigprocmask(how: CInt, set: Ptr[sigset_t], oset: Ptr[sigset_t]): CInt =
@@ -361,13 +362,17 @@ import scala.scalanative.unsafe._
   def sigrelse(sig: CInt): CInt = extern
   def sigset(sig: CInt, disp: CFuncPtr1[CInt, Unit]): CFuncPtr1[CInt, Unit] =
     extern
+  @blocking
   def sigsuspend(sigmask: Ptr[sigset_t]): CInt = extern
+  @blocking
   def sigtimedwait(
       set: Ptr[sigset_t],
       info: Ptr[siginfo_t],
       timeout: Ptr[timespec]
   ): CInt = extern
+  @blocking
   def sigwait(set: Ptr[sigset_t], sig: Ptr[CInt]): CInt = extern
+  @blocking
   def sigwaitinfo(set: Ptr[sigset_t], info: Ptr[siginfo_t]): CInt = extern
 }
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/ioctl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/ioctl.scala
@@ -6,6 +6,7 @@ import scalanative.unsafe._
 object ioctl {
 
   @name("scalanative_ioctl")
+  @blocking
   def ioctl(fd: CInt, request: CLongInt, argp: Ptr[Byte]): CInt = extern
 
   @name("scalanative_fionread")

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
@@ -19,6 +19,7 @@ object mman {
 
   def munmap(addr: Ptr[_], length: size_t): CInt = extern
 
+  @blocking
   def msync(addr: Ptr[_], length: size_t, flags: CInt): CInt = extern
 
   @name("scalanative_prot_exec")

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -274,6 +274,7 @@ object socket {
    *   to ENOTSUP.
    */
 
+  @blocking
   def accept(
       socket: CInt,
       address: Ptr[sockaddr],
@@ -283,6 +284,7 @@ object socket {
   def bind(socket: CInt, address: Ptr[sockaddr], address_len: socklen_t): CInt =
     extern
 
+  @blocking
   def connect(
       socket: CInt,
       address: Ptr[sockaddr],
@@ -311,6 +313,7 @@ object socket {
 
   def listen(socket: CInt, backlog: CInt): CInt = extern
 
+  @blocking
   def recv(
       socket: CInt,
       buffer: Ptr[Byte],
@@ -318,6 +321,7 @@ object socket {
       flags: CInt
   ): CSSize = extern
 
+  @blocking
   def recvfrom(
       socket: CInt,
       buffer: Ptr[Byte],
@@ -329,12 +333,14 @@ object socket {
 
   // See comments above msghdr declaration at top of file, re: fixup & sizeof
   @name("scalanative_recvmsg")
+  @blocking
   def recvmsg(
       socket: CInt,
       buffer: Ptr[msghdr],
       flags: CInt
   ): CSSize = extern
 
+  @blocking
   def send(
       socket: CInt,
       buffer: Ptr[Byte],
@@ -344,12 +350,14 @@ object socket {
 
   // See comments above msghdr declaration at top of file, re: fixup & sizeof
   @name("scalanative_sendmsg")
+  @blocking
   def sendmsg(
       socket: CInt,
       buffer: Ptr[msghdr],
       flags: CInt
   ): CSSize = extern
 
+  @blocking
   def sendto(
       socket: CInt,
       buffer: Ptr[Byte],

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
@@ -11,9 +11,10 @@ object uio {
     CSize // iov_len
   ]
 
-  def readv(d: CInt, buf: Ptr[iovec], iovcnt: CInt): CSSize = extern
+  @blocking def readv(d: CInt, buf: Ptr[iovec], iovcnt: CInt): CSSize = extern
 
-  def writev(fildes: CInt, iov: Ptr[iovec], iovcnt: CInt): CSSize = extern
+  @blocking def writev(fildes: CInt, iov: Ptr[iovec], iovcnt: CInt): CSSize =
+    extern
 }
 
 object uioOps {

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
@@ -102,8 +102,10 @@ object wait {
 
   /** See declaration & usage note in class description.
    */
+  @blocking
   def wait(status: Ptr[CInt]): pid_t = extern
 
+  @blocking
   def waitid(
       idtype: idtype_t,
       id: id_t,
@@ -111,6 +113,7 @@ object wait {
       options: CInt
   ): CInt = extern
 
+  @blocking
   def waitpid(pid: pid_t, status: Ptr[CInt], options: CInt): pid_t = extern
 
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -73,6 +73,7 @@ import scala.scalanative.posix.signal.sigevent
 
   // No clock_nanosleep on macOS. time.c provides a stub always returning -1.
   @name("scalanative_clock_nanosleep")
+  @blocking
   def clock_nanosleep(
       clockid: clockid_t,
       flags: CInt,
@@ -94,8 +95,11 @@ import scala.scalanative.posix.signal.sigevent
 
   def mktime(time: Ptr[tm]): time_t = extern
 
-  def nanosleep(requested: Ptr[timespec], remaining: Ptr[timespec]): CInt =
-    extern
+  @blocking
+  def nanosleep(
+      requested: Ptr[timespec],
+      remaining: Ptr[timespec]
+  ): CInt = extern
 
   @name("scalanative_strftime")
   def strftime(

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -88,12 +88,15 @@ object unistd {
   ): CInt = extern
 
   // POSIX SIO
+  @blocking
   def fdatasync(filedes: CInt): CInt = extern
 
   def fexecve(fd: CInt, argv: Ptr[CString], envp: Ptr[CString]): CInt = extern
   def fork(): pid_t = extern
   def fpathconf(fd: CInt, name: CInt): CLong = extern
+  @blocking
   def fsync(fildes: CInt): CInt = extern
+  @blocking
   def ftruncate(fildes: CInt, length: off_t): CInt = extern
 
   def getcwd(buf: CString, size: CSize): CString = extern
@@ -129,7 +132,7 @@ object unistd {
   ): CInt = extern
 
   // XSI
-  def lockf(fd: CInt, cmd: CInt, len: off_t): CInt = extern
+  @blocking def lockf(fd: CInt, cmd: CInt, len: off_t): CInt = extern
 
   def lseek(fildes: CInt, offset: off_t, whence: CInt): off_t = extern
 
@@ -137,13 +140,17 @@ object unistd {
   def nice(inc: CInt): CInt = extern
 
   def pathconf(path: CString, name: CInt): CLong = extern
+  @blocking
   def pause(): CInt = extern
   def pipe(fildes: Ptr[CInt]): CInt = extern
+  @blocking
   def pread(fd: CInt, buf: Ptr[Byte], count: size_t, offset: off_t): ssize_t =
     extern
+  @blocking
   def pwrite(fd: CInt, buf: Ptr[Byte], count: size_t, offset: off_t): ssize_t =
     extern
 
+  @blocking
   def read(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
   def readlink(path: CString, buf: CString, bufsize: CSize): CInt = extern
   def readlinkat(
@@ -167,6 +174,7 @@ object unistd {
 
   def setsid(): pid_t = extern
   def setuid(uid: uid_t): CInt = extern
+  @blocking
   def sleep(seconds: CUnsignedInt): CUnsignedInt = extern
 
 // XSI
@@ -176,6 +184,7 @@ object unistd {
   def symlinkat(path1: CString, fd: CInt, path2: CString): CInt = extern
 
 // XSI
+  @blocking
   def sync(): Unit = extern
 
   def sysconf(name: CInt): CLong = extern
@@ -200,7 +209,7 @@ object unistd {
     "Removed in POSIX.1-2008. Use POSIX time.h nanosleep().",
     since = "posixlib 0.4.5"
   )
-  def usleep(usecs: CUnsignedInt): CInt = extern
+  @blocking def usleep(usecs: CUnsignedInt): CInt = extern
 
   @deprecated(
     "Removed in POSIX.1-2008. Consider posix_spawn().",
@@ -208,7 +217,7 @@ object unistd {
   )
   def vfork(): CInt = extern
 
-  def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
+  @blocking def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
 
 // Symbolic constants
 

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -20,8 +20,12 @@ object MyScalaNativePlugin extends AutoPlugin {
       _.withCheck(true)
         .withCheckFatalWarnings(true)
         .withDump(true)
+        .withGC(scalanative.build.GC.boehm)
+        .withMode(scalanative.build.Mode.releaseFast)
+        .withLTO(scalanative.build.LTO.thin)
         .withMultithreadingSupport(
-          sys.props.contains("scala.scalanative.multithreading.enable")
+          true
+          // sys.props.contains("scala.scalanative.multithreading.enable")
         )
     },
     scalacOptions ++= {

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -20,12 +20,8 @@ object MyScalaNativePlugin extends AutoPlugin {
       _.withCheck(true)
         .withCheckFatalWarnings(true)
         .withDump(true)
-        .withGC(scalanative.build.GC.boehm)
-        .withMode(scalanative.build.Mode.releaseFast)
-        .withLTO(scalanative.build.LTO.thin)
         .withMultithreadingSupport(
-          true
-          // sys.props.contains("scala.scalanative.multithreading.enable")
+          sys.props.contains("scala.scalanative.multithreading.enable")
         )
     },
     scalacOptions ++= {

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -574,9 +574,9 @@ object Lower {
       )
 
       def shouldSwitchThreadState(name: Global) =
-        config.multithreadingSupport && linked.infos.get(name).exists { info =>
+        linked.infos.get(name).exists { info =>
           val attrs = info.attrs
-          attrs.isExtern
+          attrs.isExtern && attrs.isBlocking
         }
 
       ptr match {

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -574,7 +574,7 @@ object Lower {
       )
 
       def shouldSwitchThreadState(name: Global) =
-        linked.infos.get(name).exists { info =>
+        config.multithreadingSupport && linked.infos.get(name).exists { info =>
           val attrs = info.attrs
           attrs.isExtern && attrs.isBlocking
         }

--- a/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
@@ -139,9 +139,9 @@ class IssuesSpec extends LinkerSpec with Matchers {
       |
       |object Test {
       |  def main(args: Array[String]): Unit = {
-      |     val _ = lib.sync()
-      |     val _ = lib.async()
-      |     val _ = syncLib.foo()
+      |     val a = lib.sync()
+      |     val b = lib.async()
+      |     val c = syncLib.foo()
       |  }
       |}""".stripMargin) { result =>
       val Lib = Global.Top("lib$")

--- a/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
@@ -118,10 +118,48 @@ class IssuesSpec extends LinkerSpec with Matchers {
       val decls = result.defns
         .collect {
           case defn @ Defn.Declare(attrs, LibField, tpe) =>
-            println(s"got $defn")
             assert(attrs.isExtern)
         }
       if (decls.isEmpty) fail("Not found extern declaration")
+    }
+  }
+
+  it should "blocking extern methods should have correct attributes" in {
+    testLinked(s"""
+      |import scala.scalanative.unsafe._
+      |
+      |@extern object lib {
+      |  @blocking def sync(): CInt = extern
+      |  def async(): CInt = extern
+      |}
+      |
+      |@extern @blocking object syncLib{
+      |  def foo(): CInt = extern
+      |}
+      |
+      |object Test {
+      |  def main(args: Array[String]): Unit = {
+      |     val _ = lib.sync()
+      |     val _ = lib.async()
+      |     val _ = syncLib.foo()
+      |  }
+      |}""".stripMargin) { result =>
+      val Lib = Global.Top("lib$")
+      val SyncLib = Global.Top("syncLib$")
+      val LibSync = Lib.member(Sig.Extern("sync"))
+      val LibAsync = Lib.member(Sig.Extern("async"))
+      val SyncLibFoo = SyncLib.member(Sig.Extern("foo"))
+
+      val found = result.defns
+        .collect {
+          case Defn.Declare(attrs, LibSync, _) =>
+            assert(attrs.isExtern && attrs.isBlocking)
+          case Defn.Declare(attrs, LibAsync, _) =>
+            assert(attrs.isExtern && !attrs.isBlocking)
+          case Defn.Declare(attrs, SyncLibFoo, _) =>
+            assert(attrs.isExtern && attrs.isBlocking)
+        }
+      found.size shouldEqual 3
     }
   }
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
@@ -93,6 +93,7 @@ object FileApi {
       findFileData: Ptr[Win32FindDataW]
   ): Boolean = extern
   def FindClose(searchHandle: Handle): Boolean = extern
+  @blocking
   def FlushFileBuffers(handle: Handle): Boolean = extern
   def GetFileAttributesA(filename: CString): DWord = extern
   def GetFileAttributesW(filename: CWString): DWord = extern
@@ -157,6 +158,7 @@ object FileApi {
       bufferLength: DWord
   ): Boolean = extern
 
+  @blocking
   def ReadFile(
       fileHandle: Handle,
       buffer: Ptr[Byte],
@@ -185,7 +187,7 @@ object FileApi {
       lastWriteTime: Ptr[FileTime]
   ): Boolean = extern
 
-  def WriteFile(
+  @blocking def WriteFile(
       fileHandle: Handle,
       buffer: Ptr[Byte],
       bytesToRead: DWord,
@@ -201,7 +203,7 @@ object FileApi {
       nNumberOfBytesToLockHigh: DWord
   ): Boolean = extern
 
-  def LockFileEx(
+  @blocking def LockFileEx(
       hfile: Handle,
       dwFlags: DWord,
       dwReserved: DWord,

--- a/windowslib/src/main/scala/scala/scalanative/windows/HandleApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/HandleApi.scala
@@ -10,6 +10,7 @@ import scala.scalanative.windows.HandleApi.Handle
 object HandleApi {
   type Handle = Ptr[Byte]
 
+  @blocking
   def CloseHandle(handle: Handle): Boolean = extern
 
   def DuplicateHandle(

--- a/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
@@ -16,6 +16,7 @@ object MemoryApi {
 
   def UnmapViewOfFile(lpBaseAddress: Ptr[Byte]): Boolean = extern
 
+  @blocking
   def FlushViewOfFile(
       lpBaseAddress: Ptr[Byte],
       dwNumberOfBytesToFlush: DWord

--- a/windowslib/src/main/scala/scala/scalanative/windows/ProcessThreadsApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ProcessThreadsApi.scala
@@ -47,6 +47,7 @@ object ProcessThreadsApi {
 
   def ExitProcess(exitCode: UInt): Unit = extern
   def ExitThread(exitCode: DWord): Unit = extern
+  @blocking
   def FlushProcessWriteBuffers(): Unit = extern
   def GetCurrentProcess(): Handle = extern
   def GetCurrentProcessToken(): Handle = extern
@@ -71,8 +72,8 @@ object ProcessThreadsApi {
   ): Boolean = extern
 
   def ResumeThread(thread: Handle): DWord = extern
-  def SwitchToThread(): Boolean = extern
-  def SuspendThread(thread: Handle): DWord = extern
+  @blocking def SwitchToThread(): Boolean = extern
+  @blocking def SuspendThread(thread: Handle): DWord = extern
 
   def SetThreadPriority(thread: Handle, priority: Int): Boolean = extern
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/SynchApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SynchApi.scala
@@ -65,11 +65,12 @@ object SynchApi {
 
   def TryEnterCriticalSection(criticalSection: CriticalSection): Boolean =
     extern
+  @blocking
   def EnterCriticalSection(criticalSection: CriticalSection): Unit = extern
   def LeaveCriticalSection(criticalSection: CriticalSection): Unit = extern
 
-  def Sleep(milliseconds: DWord): Unit = extern
-  def SleepConditionVariableCS(
+  @blocking def Sleep(milliseconds: DWord): Unit = extern
+  @blocking def SleepConditionVariableCS(
       conditionVariable: ConditionVariable,
       criticalSection: CriticalSection,
       milliseconds: DWord
@@ -77,7 +78,7 @@ object SynchApi {
   def WakeAllConditionVariable(conditionVariable: ConditionVariable): Unit =
     extern
   def WakeConditionVariable(conditionVariable: ConditionVariable): Unit = extern
-  def WaitForSingleObject(
+  @blocking def WaitForSingleObject(
       ref: Handle,
       miliseconds: DWord
   ): DWord = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
@@ -29,6 +29,7 @@ object WinSocketApi {
       flags: DWord
   ): Socket = extern
 
+  @blocking
   def WSAPoll(
       fds: Ptr[WSAPollFd],
       nfds: CUnsignedLongInt,
@@ -42,6 +43,7 @@ object WinSocketApi {
   def ioctlSocket(socket: Socket, cmd: CInt, argp: Ptr[CInt]): CInt = extern
 
   @name("closesocket")
+  @blocking
   def closeSocket(socket: Socket): CInt = extern
 
   @name("scalanative_winsock_fionbio")


### PR DESCRIPTION
Introduce the concept of blocking extern functions. 
Extern functions marked as blocking have special handling in the GC - upon transiting from managed to unmanaged execution (Scala to Native library) information about the current stack top and content of registers is saved to allow for GC. 
It is used to skip waiting for potentially blocking threads in the StopTheWorld event, in case the given thread is executing a blocking syscall, eg. waiting for socket connect or reading from a file. 
This change allows us to shorten the time spent when synchronizing the threads in case of StopTheWorld event, and does not require us to interrupt threads in order to force they're execution to reach safepoint. 

* Added `scala.scalanative.unsafe.blocking` annotation
* Add `isBlocking` attribute to NIR as field of `Attr.Extern`
* Handle `@blocking` annotation in the compiler plugin
* Mark potentially blocking functions in libc, posixlib and windowslib