### PR TITLE
Support JavaMemoryModel behaviour for shared variables

### DIFF
--- a/auxlib/src/main/scala/scala/runtime/RefTypes.scala
+++ b/auxlib/src/main/scala/scala/runtime/RefTypes.scala
@@ -12,7 +12,7 @@ object BooleanRef {
 }
 
 @inline
-class VolatileBooleanRef(var elem: Boolean) extends Serializable {
+class VolatileBooleanRef(@volatile var elem: Boolean) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileBooleanRef {
@@ -31,7 +31,7 @@ object CharRef {
 }
 
 @inline
-class VolatileCharRef(var elem: Char) extends Serializable {
+class VolatileCharRef(@volatile var elem: Char) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileCharRef {
@@ -49,7 +49,7 @@ object ByteRef {
 }
 
 @inline
-class VolatileByteRef(var elem: Byte) extends Serializable {
+class VolatileByteRef(@volatile var elem: Byte) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileByteRef {
@@ -67,7 +67,7 @@ object ShortRef {
 }
 
 @inline
-class VolatileShortRef(var elem: Short) extends Serializable {
+class VolatileShortRef(@volatile var elem: Short) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileShortRef {
@@ -85,7 +85,7 @@ object IntRef {
 }
 
 @inline
-class VolatileIntRef(var elem: Int) extends Serializable {
+class VolatileIntRef(@volatile var elem: Int) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileIntRef {
@@ -103,7 +103,7 @@ object LongRef {
 }
 
 @inline
-class VolatileLongRef(var elem: Long) extends Serializable {
+class VolatileLongRef(@volatile var elem: Long) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileLongRef {
@@ -121,7 +121,7 @@ object FloatRef {
 }
 
 @inline
-class VolatileFloatRef(var elem: Float) extends Serializable {
+class VolatileFloatRef(@volatile var elem: Float) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileFloatRef {
@@ -139,7 +139,7 @@ object DoubleRef {
 }
 
 @inline
-class VolatileDoubleRef(var elem: Double) extends Serializable {
+class VolatileDoubleRef(@volatile var elem: Double) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileDoubleRef {
@@ -158,7 +158,7 @@ object ObjectRef {
 }
 
 @inline
-class VolatileObjectRef[A](var elem: A) extends Serializable {
+class VolatileObjectRef[A](@volatile var elem: A) extends Serializable {
   override def toString() = String.valueOf(elem)
 }
 object VolatileObjectRef {

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -30,6 +30,8 @@ object Attr {
   case object Extern extends Attr
   final case class Link(name: String) extends Attr
   case object Abstract extends Attr
+  case object Volatile extends Attr
+  case object Final extends Attr
 }
 
 final case class Attrs(
@@ -40,6 +42,8 @@ final case class Attrs(
     isDyn: Boolean = false,
     isStub: Boolean = false,
     isAbstract: Boolean = false,
+    isVolatile: Boolean = false,
+    isFinal: Boolean = false,
     links: Seq[Attr.Link] = Seq.empty
 ) {
   def toSeq: Seq[Attr] = {
@@ -52,6 +56,8 @@ final case class Attrs(
     if (isDyn) out += Dyn
     if (isStub) out += Stub
     if (isAbstract) out += Abstract
+    if (isVolatile) out += Volatile
+    if (isFinal) out += Final
     out ++= links
 
     out.result()
@@ -68,6 +74,8 @@ object Attrs {
     var isDyn = false
     var isStub = false
     var isAbstract = false
+    var isVolatile = false
+    var isFinal = false
     val links = Seq.newBuilder[Attr.Link]
 
     attrs.foreach {
@@ -79,6 +87,8 @@ object Attrs {
       case Stub             => isStub = true
       case link: Attr.Link  => links += link
       case Abstract         => isAbstract = true
+      case Volatile         => isVolatile = true
+      case Final            => isFinal = true
     }
 
     new Attrs(
@@ -89,6 +99,8 @@ object Attrs {
       isDyn = isDyn,
       isStub = isStub,
       isAbstract = isAbstract,
+      isVolatile = isVolatile,
+      isFinal = isFinal,
       links = links.result()
     )
   }

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -55,8 +55,13 @@ class Buffer(implicit fresh: Fresh) {
       pos: Position
   ): Val =
     let(Op.Call(ty, ptr, args), unwind)
-  def load(ty: Type, ptr: Val, unwind: Next, syncAttrs: Option[SyncAttrs] = None)(
-      implicit pos: Position
+  def load(
+      ty: Type,
+      ptr: Val,
+      unwind: Next,
+      syncAttrs: Option[SyncAttrs] = None
+  )(implicit
+      pos: Position
   ): Val =
     let(Op.Load(ty, ptr, syncAttrs), unwind)
   def store(

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -55,12 +55,20 @@ class Buffer(implicit fresh: Fresh) {
       pos: Position
   ): Val =
     let(Op.Call(ty, ptr, args), unwind)
-  def load(ty: Type, ptr: Val, unwind: Next)(implicit pos: Position): Val =
-    let(Op.Load(ty, ptr), unwind)
-  def store(ty: Type, ptr: Val, value: Val, unwind: Next)(implicit
+  def load(ty: Type, ptr: Val, unwind: Next, syncAttrs: Option[SyncAttrs] = None)(
+      implicit pos: Position
+  ): Val =
+    let(Op.Load(ty, ptr, syncAttrs), unwind)
+  def store(
+      ty: Type,
+      ptr: Val,
+      value: Val,
+      unwind: Next,
+      syncAttrs: Option[SyncAttrs] = None
+  )(implicit
       pos: Position
   ): Val =
-    let(Op.Store(ty, ptr, value), unwind)
+    let(Op.Store(ty, ptr, value, syncAttrs), unwind)
   def elem(ty: Type, ptr: Val, indexes: Seq[Val], unwind: Next)(implicit
       pos: Position
   ): Val =

--- a/nir/src/main/scala/scala/scalanative/nir/MemoryOrder.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/MemoryOrder.scala
@@ -1,0 +1,23 @@
+package scala.scalanative
+package nir
+
+import scala.annotation.switch
+
+case class SyncAttrs(
+    memoryOrder: MemoryOrder,
+    isVolatile: Boolean = true,
+    scope: Option[Global] = None
+)
+
+sealed abstract class MemoryOrder(private[nir] val tag: Int) {
+  final def show: String = nir.Show(this)
+}
+
+object MemoryOrder {
+  case object Unordered extends MemoryOrder(0)
+  case object Monotonic extends MemoryOrder(1)
+  case object Acquire extends MemoryOrder(2)
+  case object Release extends MemoryOrder(3)
+  case object AcqRel extends MemoryOrder(4)
+  case object SeqCst extends MemoryOrder(5)
+}

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -11,8 +11,8 @@ sealed abstract class Op {
   final def resty: Type = this match {
     case Op.Call(Type.Function(_, ret), _, _) => ret
     case Op.Call(_, _, _)                     => unreachable
-    case Op.Load(ty, _)                       => ty
-    case Op.Store(_, _, _)                    => Type.Unit
+    case Op.Load(ty, _, _)                    => ty
+    case Op.Store(_, _, _, _)                 => Type.Unit
     case Op.Elem(_, _, _)                     => Type.Ptr
     case Op.Extract(aggr, indexes) => aggr.ty.elemty(indexes.map(Val.Int(_)))
     case Op.Insert(aggr, _, _)     => aggr.ty
@@ -20,6 +20,7 @@ sealed abstract class Op {
     case Op.Bin(_, ty, _, _)       => ty
     case Op.Comp(_, _, _, _)       => Type.Bool
     case Op.Conv(_, ty, _)         => ty
+    case Op.Fence(_)               => Type.Unit
 
     case Op.Classalloc(n)       => Type.Ref(n, exact = true, nullable = false)
     case Op.Fieldload(ty, _, _) => ty
@@ -115,8 +116,14 @@ sealed abstract class Op {
 object Op {
   // low-level
   final case class Call(ty: Type, ptr: Val, args: Seq[Val]) extends Op
-  final case class Load(ty: Type, ptr: Val) extends Op
-  final case class Store(ty: Type, ptr: Val, value: Val) extends Op
+  final case class Load(ty: Type, ptr: Val, syncAttrs: Option[SyncAttrs] = None)
+      extends Op
+  final case class Store(
+      ty: Type,
+      ptr: Val,
+      value: Val,
+      syncAttrs: Option[SyncAttrs] = None
+  ) extends Op
   final case class Elem(ty: Type, ptr: Val, indexes: Seq[Val]) extends Op
   final case class Extract(aggr: Val, indexes: Seq[Int]) extends Op
   final case class Insert(aggr: Val, value: Val, indexes: Seq[Int]) extends Op
@@ -124,6 +131,7 @@ object Op {
   final case class Bin(bin: nir.Bin, ty: Type, l: Val, r: Val) extends Op
   final case class Comp(comp: nir.Comp, ty: Type, l: Val, r: Val) extends Op
   final case class Conv(conv: nir.Conv, ty: Type, value: Val) extends Op
+  final case class Fence(syncAttrs: SyncAttrs) extends Op
 
   // high-level
   final case class Classalloc(name: Global) extends Op

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -101,6 +101,10 @@ object Show {
         str("\")")
       case Attr.Abstract =>
         str("abstract")
+      case Attr.Volatile =>
+        str("volatile")
+      case Attr.Final =>
+        str("final")
     }
 
     def next_(next: Next): Unit = next match {

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -58,10 +58,10 @@ trait Transform {
   def onOp(op: Op): Op = op match {
     case Op.Call(ty, ptrv, argvs) =>
       Op.Call(onType(ty), onVal(ptrv), argvs.map(onVal))
-    case Op.Load(ty, ptrv) =>
-      Op.Load(onType(ty), onVal(ptrv))
-    case Op.Store(ty, ptrv, v) =>
-      Op.Store(onType(ty), onVal(ptrv), onVal(v))
+    case Op.Load(ty, ptrv, syncAttrs) =>
+      Op.Load(onType(ty), onVal(ptrv), syncAttrs)
+    case Op.Store(ty, ptrv, v, syncAttrs) =>
+      Op.Store(onType(ty), onVal(ptrv), onVal(v), syncAttrs)
     case Op.Elem(ty, ptrv, indexvs) =>
       Op.Elem(onType(ty), onVal(ptrv), indexvs.map(onVal))
     case Op.Extract(aggrv, indexvs) =>
@@ -76,6 +76,7 @@ trait Transform {
       Op.Comp(comp, onType(ty), onVal(lv), onVal(rv))
     case Op.Conv(conv, ty, v) =>
       Op.Conv(conv, onType(ty), onVal(v))
+    case Op.Fence(_) => op
 
     case Op.Classalloc(n) =>
       Op.Classalloc(n)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -79,6 +79,8 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     case T.ExternAttr   => Attr.Extern
     case T.LinkAttr     => Attr.Link(getUTF8String())
     case T.AbstractAttr => Attr.Abstract
+    case T.VolatileAttr => Attr.Volatile
+    case T.FinalAttr    => Attr.Final
   }
 
   private def getBin(): Bin = getInt match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -319,16 +319,18 @@ final class BinarySerializer {
       putVal(v)
       putVals(args)
 
-    case Op.Load(ty, ptr) =>
+    case Op.Load(ty, ptr, syncAttrs) =>
       putInt(T.LoadOp)
       putType(ty)
       putVal(ptr)
+      putOpt(syncAttrs)(putSyncAttrs(_))
 
-    case Op.Store(ty, value, ptr) =>
+    case Op.Store(ty, value, ptr, syncAttrs) =>
       putInt(T.StoreOp)
       putType(ty)
       putVal(value)
       putVal(ptr)
+      putOpt(syncAttrs)(putSyncAttrs(_))
 
     case Op.Elem(ty, v, indexes) =>
       putInt(T.ElemOp)
@@ -371,6 +373,10 @@ final class BinarySerializer {
       putConv(conv)
       putType(ty)
       putVal(v)
+
+    case Op.Fence(syncAttrs) =>
+      putInt(T.FenceOp)
+      putSyncAttrs(syncAttrs)
 
     case Op.Classalloc(n) =>
       putInt(T.ClassallocOp)
@@ -543,6 +549,24 @@ final class BinarySerializer {
     case Val.Virtual(v)   => putInt(T.VirtualVal); putLong(v)
     case Val.ClassOf(cls) => putInt(T.ClassOfVal); putGlobal(cls)
     case Val.Size(v)      => putInt(T.SizeVal); putLong(v)
+  }
+
+  def putSyncAttrs(value: SyncAttrs) = {
+    putMemoryOrder(value.memoryOrder)
+    putBool(value.isVolatile)
+    putGlobalOpt(value.scope)
+  }
+
+  def putMemoryOrder(value: MemoryOrder): Unit = {
+    val tag = value match {
+      case MemoryOrder.Unordered => T.Unordered
+      case MemoryOrder.Monotonic => T.MonotonicOrder
+      case MemoryOrder.Acquire   => T.AcquireOrder
+      case MemoryOrder.Release   => T.ReleaseOrder
+      case MemoryOrder.AcqRel    => T.AcqRelOrder
+      case MemoryOrder.SeqCst    => T.SeqCstOrder
+    }
+    putInt(tag)
   }
 
   private def putLinktimeCondition(cond: LinktimeCondition): Unit = cond match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -109,6 +109,8 @@ final class BinarySerializer {
     case Attr.Extern   => putInt(T.ExternAttr)
     case Attr.Link(s)  => putInt(T.LinkAttr); putUTF8String(s)
     case Attr.Abstract => putInt(T.AbstractAttr)
+    case Attr.Volatile => putInt(T.VolatileAttr)
+    case Attr.Final    => putInt(T.FinalAttr)
   }
 
   private def putBin(bin: Bin) = bin match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -183,6 +183,7 @@ object Tags {
   final val ArraystoreOp = 1 + ArrayloadOp
   final val ArraylengthOp = 1 + ArraystoreOp
   final val FieldOp = 1 + ArraylengthOp
+  final val FenceOp = 1 + FieldOp
 
   // Types
 
@@ -238,4 +239,16 @@ object Tags {
 
   final val LinktimeConditionVal = 1 + ClassOfVal
   final val SizeVal = 1 + LinktimeConditionVal
+
+  // Synchronization info
+
+  final val SyncAttrs = Val + 32
+
+  final val MemoryOrder = 1 + SyncAttrs
+  final val Unordered = 1 + MemoryOrder
+  final val MonotonicOrder = 1 + Unordered
+  final val AcquireOrder = 1 + MonotonicOrder
+  final val ReleaseOrder = 1 + AcquireOrder
+  final val AcqRelOrder = 1 + ReleaseOrder
+  final val SeqCstOrder = 1 + AcqRelOrder
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -27,6 +27,8 @@ object Tags {
   final val DynAttr = 1 + LinkAttr
   final val StubAttr = 1 + DynAttr
   final val AbstractAttr = 1 + StubAttr
+  final val VolatileAttr = 1 + AbstractAttr
+  final val FinalAttr = 1 + VolatileAttr
 
   // Binary ops
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -201,8 +201,14 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val ty = genType(f.tpe)
         val name = genFieldName(f)
         val pos: nir.Position = f.pos
+        // Thats what JVM backend does
+        // https://github.com/scala/scala/blob/fe724bcbbfdc4846e5520b9708628d994ae76798/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala#L760-L764
+        val fieldAttrs = attrs.copy(
+          isVolatile = f.isVolatile,
+          isFinal = !f.isMutable
+        )
 
-        buf += Defn.Var(attrs, name, ty, Val.Zero(ty))(pos)
+        buf += Defn.Var(fieldAttrs, name, ty, Val.Zero(ty))(pos)
       }
     }
 
@@ -707,9 +713,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     ): Option[nir.Defn] = {
       val rhs = dd.rhs
       def externMethodDecl() = {
-        val externAttrs = Attrs(isExtern = true)
         val externSig = genExternMethodSig(curMethodSym)
-        val externDefn = Defn.Declare(externAttrs, name, externSig)(rhs.pos)
+        val externDefn = Defn.Declare(attrs, name, externSig)(rhs.pos)
+
         Some(externDefn)
       }
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -44,6 +44,8 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
           CFuncPtrNClass.contains(parent.typeSymbol)
         }
       }
+
+    def isVolatile: Boolean = isField && sym.hasAnnotation(VolatileAttr)
   }
 
   object SimpleType {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -136,7 +136,13 @@ trait NirGenStat(using Context) {
       if (isExtern && !mutable) {
         report.error("`extern` cannot be used in val definition")
       }
-      val attrs = nir.Attrs(isExtern = f.isExtern)
+      // That what JVM backend does
+      // https://github.com/lampepfl/dotty/blob/786ad3ff248cca39e2da80c3a15b27b38eec2ff6/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala#L340-L347
+      val attrs = nir.Attrs(
+        isExtern = isExtern,
+        isVolatile = f.isVolatile,
+        isFinal = !f.is(Mutable)
+      )
       val ty = genType(f.info.resultType)
       val fieldName @ Global.Member(owner, sig) = genFieldName(f): @unchecked
       generatedDefns += Defn.Var(attrs, fieldName, ty, Val.Zero(ty))
@@ -420,9 +426,8 @@ trait NirGenStat(using Context) {
     val rhs: Tree = dd.rhs
     given nir.Position = rhs.span
     def externMethodDecl() = {
-      val externAttrs = Attrs(isExtern = true)
       val externSig = genExternMethodSig(curMethodSym)
-      val externDefn = Defn.Declare(externAttrs, name, externSig)
+      val externDefn = Defn.Declare(attrs, name, externSig)
       Some(externDefn)
     }
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -253,7 +253,7 @@ trait NirGenStat(using Context) {
         case defnNir.NoSpecializeType => Attr.NoSpecialize
         case defnNir.StubType         => Attr.Stub
       }
-    val externAttrs = if (sym.owner.isExternType) Seq(Attr.Extern) else Nil
+    val externAttrs = if (sym.isExtern) Seq(Attr.Extern) else Nil
 
     Attrs.fromSeq(inlineAttrs ++ annotatedAttrs ++ externAttrs)
   }

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -143,9 +143,9 @@ final class Check(implicit linked: linker.Result) {
         case _ =>
           error("call type must be a function type")
       }
-    case Op.Load(ty, ptr) =>
+    case Op.Load(ty, ptr, _) =>
       expect(Type.Ptr, ptr)
-    case Op.Store(ty, ptr, value) =>
+    case Op.Store(ty, ptr, value, _) =>
       expect(Type.Ptr, ptr)
       expect(ty, value)
     case Op.Elem(ty, ptr, indexes) =>
@@ -173,6 +173,7 @@ final class Check(implicit linked: linker.Result) {
       checkCompOp(comp, ty, l, r)
     case Op.Conv(conv, ty, value) =>
       checkConvOp(conv, ty, value)
+    case Op.Fence(_) => ok
     case Op.Classalloc(name) =>
       linked.infos
         .get(name)

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -802,18 +802,6 @@ private[codegen] abstract class AbstractCodeGen(
   )(implicit fresh: Fresh, sb: ShowBuilder): Unit = {
     import sb._
     call match {
-      case Op.Call(_, Lower.GCSafepoint, _) =>
-        // Temporal hack until volatile store is implemented
-        // Safepoint load needs to be volatile, otherwise it would be optimized out
-        touch(Lower.GCSafepoint.name)
-        val safepoint, pollResult = fresh().id
-        val Sig.Extern(name) = Lower.GCSafepointName.sig.unmangled: @unchecked
-
-        newline()
-        str(s"%_$safepoint = load i8*, i8** @$name, align 8")
-        newline()
-        str(s"%_$pollResult = load volatile i8, i8* %_$safepoint, align 1")
-
       case Op.Call(ty, Val.Global(pointee, _), args) if lookup(pointee) == ty =>
         val Type.Function(argtys, _) = ty: @unchecked
         touch(pointee)

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -654,7 +654,7 @@ private[codegen] abstract class AbstractCodeGen(
         }
         genCall(genBind, callDef, unwind)
 
-      case Op.Load(ty, ptr) =>
+      case Op.Load(ty, ptr, syncAttrs) =>
         val pointee = fresh()
 
         newline()
@@ -689,7 +689,7 @@ private[codegen] abstract class AbstractCodeGen(
             ()
         }
 
-      case Op.Store(ty, ptr, value) =>
+      case Op.Store(ty, ptr, value, syncAttrs) =>
         val pointee = fresh()
 
         newline()

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -20,6 +20,8 @@ private[codegen] abstract class AbstractCodeGen(
 
   private val targetTriple: Option[String] = config.compilerConfig.targetTriple
   private val is32BitPlatform: Boolean = config.compilerConfig.is32BitPlatform
+  private val isMultithreadingEnabled =
+    config.compilerConfig.multithreadingSupport
 
   private var currentBlockName: Local = _
   private var currentBlockSplit: Int = _
@@ -656,6 +658,9 @@ private[codegen] abstract class AbstractCodeGen(
 
       case Op.Load(ty, ptr, syncAttrs) =>
         val pointee = fresh()
+        val isAtomic = isMultithreadingEnabled && syncAttrs.isDefined
+        val isVolatile =
+          isMultithreadingEnabled && syncAttrs.exists(_.isVolatile)
 
         newline()
         str("%")
@@ -669,28 +674,40 @@ private[codegen] abstract class AbstractCodeGen(
         newline()
         genBind()
         str("load ")
+        if (isAtomic) str("atomic ")
+        if (isVolatile) str("volatile ")
         genType(ty)
         str(", ")
         genType(ty)
         str("* %")
         genLocal(pointee)
-        ty match {
-          case refty: Type.RefKind =>
-            val (nonnull, deref, size) = toDereferenceable(refty)
-            if (nonnull) {
-              str(", !nonnull !{}")
-            }
-            str(", !")
-            str(deref)
-            str(" !{i64 ")
-            str(size)
-            str("}")
-          case _ =>
-            ()
+        if (isAtomic) {
+          str(" ")
+          syncAttrs.foreach(genSyncAttrs)
+          str(", align ")
+          str(MemoryLayout.alignmentOf(ty, is32BitPlatform))
+        } else {
+          ty match {
+            case refty: Type.RefKind =>
+              val (nonnull, deref, size) = toDereferenceable(refty)
+              if (nonnull) {
+                str(", !nonnull !{}")
+              }
+              str(", !")
+              str(deref)
+              if (is32BitPlatform) str(" !{i32 ") else str(" !{i64 ")
+              str(size)
+              str("}")
+            case _ =>
+              ()
+          }
         }
 
       case Op.Store(ty, ptr, value, syncAttrs) =>
         val pointee = fresh()
+        val isAtomic = isMultithreadingEnabled && syncAttrs.isDefined
+        val isVolatile =
+          isMultithreadingEnabled && syncAttrs.exists(_.isVolatile)
 
         newline()
         str("%")
@@ -704,11 +721,19 @@ private[codegen] abstract class AbstractCodeGen(
         newline()
         genBind()
         str("store ")
+        if (isAtomic) str("atomic ")
+        if (isVolatile) str("volatile ")
         genVal(value)
         str(", ")
         genType(ty)
         str("* %")
         genLocal(pointee)
+        if (isAtomic) syncAttrs.foreach {
+          str(" ")
+          genSyncAttrs(_)
+        }
+        str(", align ")
+        str(MemoryLayout.alignmentOf(ty, is32BitPlatform))
 
       case Op.Elem(ty, ptr, indexes) =>
         val pointee = fresh()
@@ -949,9 +974,33 @@ private[codegen] abstract class AbstractCodeGen(
         genVal(v)
         str(" to ")
         genType(ty)
+      case Op.Fence(syncAttrs) =>
+        str("fence ")
+        genSyncAttrs(syncAttrs)
+
       case op =>
         unsupported(op)
     }
+  }
+
+  private def genSyncAttrs(
+      attrs: SyncAttrs
+  )(implicit sb: ShowBuilder): Unit = {
+    import sb._
+    val SyncAttrs(memoryOrder, _, scope) = attrs
+    scope.foreach { scope =>
+      str("syncscope(")
+      genGlobal(scope)
+      str(") ")
+    }
+    str(memoryOrder match {
+      case MemoryOrder.Unordered => "unordered"
+      case MemoryOrder.Monotonic => "monotonic"
+      case MemoryOrder.Acquire   => "acquire"
+      case MemoryOrder.Release   => "release"
+      case MemoryOrder.AcqRel    => "acq_rel"
+      case MemoryOrder.SeqCst    => "seq_cst"
+    })
   }
 
   private[codegen] def genNext(next: Next)(implicit sb: ShowBuilder): Unit = {

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -492,7 +492,7 @@ object Lower {
     def genStoreOp(buf: Buffer, n: Local, op: Op.Store)(implicit
         pos: Position
     ) = {
-      val Op.Store(ty, ptr, value) = op
+      val Op.Store(ty, ptr, value, syncAttrs) = op
       buf.let(n, Op.Store(ty, genVal(buf, ptr), genVal(buf, value)), unwind)
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -626,10 +626,13 @@ object Lower {
           if (genUnwind && unwindHandler.isInitialized) unwind
           else Next.None
         }
-        // TODO: volatile, replace dummy method call transformed to loads in AbstractCodeGen
-        buf.call(Type.Function(Nil, Type.Unit), GCSafepoint, Nil, handler)
-        // val safepointAddr = buf.load(Type.Ptr, GCSafepoint, handler)
-        // volatile buf.load(Type.Ptr, safepointAddr, handler)
+        val syncAttrs = SyncAttrs(
+          memoryOrder = MemoryOrder.Unordered,
+          isVolatile = true,
+          scope = None
+        )
+        val safepointAddr = buf.load(Type.Ptr, GCSafepoint, handler)
+        buf.load(Type.Ptr, safepointAddr, handler, Some(syncAttrs))
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -2,21 +2,9 @@ package scala.scalanative
 package codegen
 
 import scala.collection.mutable
-import scala.scalanative.build.BuildException
 import scalanative.util.{ScopedVar, unsupported}
 import scalanative.nir._
-import scalanative.linker.{
-  Class,
-  ClassRef,
-  FieldRef,
-  LinkingException,
-  MethodRef,
-  Result,
-  ScopeInfo,
-  ScopeRef,
-  Trait,
-  TraitRef
-}
+import scalanative.linker._
 import scalanative.interflow.UseDef.eliminateDeadCode
 
 object Lower {
@@ -404,7 +392,11 @@ object Lower {
         case Op.Varload(Val.Local(slot, Type.Var(ty))) =>
           buf.let(n, Op.Load(ty, Val.Local(slot, Type.Ptr)), unwind)
         case Op.Varstore(Val.Local(slot, Type.Var(ty)), value) =>
-          buf.let(n, Op.Store(ty, Val.Local(slot, Type.Ptr), value), unwind)
+          buf.let(
+            n,
+            Op.Store(ty, Val.Local(slot, Type.Ptr), genVal(buf, value)),
+            unwind
+          )
         case op: Op.Arrayalloc =>
           genArrayallocOp(buf, n, op)
         case op: Op.Arrayload =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -161,10 +161,17 @@ trait Eval { self: Interflow =>
           case _ =>
             nonIntrinsic
         }
-      case Op.Load(ty, ptr) =>
-        emit(Op.Load(ty, materialize(eval(ptr))))
-      case Op.Store(ty, ptr, value) =>
-        emit(Op.Store(ty, materialize(eval(ptr)), materialize(eval(value))))
+      case op @ Op.Load(ty, ptr, syncAttrs) =>
+        emit(
+          op.copy(ptr = materialize(eval(ptr)))
+        )
+      case op @ Op.Store(ty, ptr, value, syncAttrs) =>
+        emit(
+          op.copy(
+            ptr = materialize(eval(ptr)),
+            value = materialize(eval(value))
+          )
+        )
       case Op.Elem(ty, ptr, indexes) =>
         delay(Op.Elem(ty, eval(ptr), indexes.map(eval)))
       case Op.Extract(aggr, indexes) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
@@ -49,9 +49,9 @@ trait NoOpt { self: Interflow =>
     case Op.Call(_, ptrv, argvs) =>
       noOptVal(ptrv)
       argvs.foreach(noOptVal)
-    case Op.Load(_, ptrv) =>
+    case Op.Load(_, ptrv, _) =>
       noOptVal(ptrv)
-    case Op.Store(_, ptrv, v) =>
+    case Op.Store(_, ptrv, v, _) =>
       noOptVal(ptrv)
       noOptVal(v)
     case Op.Elem(_, ptrv, indexvs) =>
@@ -72,6 +72,7 @@ trait NoOpt { self: Interflow =>
       noOptVal(rv)
     case Op.Conv(conv, _, v) =>
       noOptVal(v)
+    case Op.Fence(_) => ()
 
     case Op.Classalloc(n) =>
       noOptGlobal(n)

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -180,16 +180,17 @@ final class State(block: Local) {
     }
 
     def reachOp(op: Op): Unit = op match {
-      case Op.Call(_, v, vs)     => reachVal(v); vs.foreach(reachVal)
-      case Op.Load(_, v)         => reachVal(v)
-      case Op.Store(_, v1, v2)   => reachVal(v1); reachVal(v2)
-      case Op.Elem(_, v, vs)     => reachVal(v); vs.foreach(reachVal)
-      case Op.Extract(v, _)      => reachVal(v)
-      case Op.Insert(v1, v2, _)  => reachVal(v1); reachVal(v2)
-      case Op.Stackalloc(_, v)   => reachVal(v)
-      case Op.Bin(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
-      case Op.Comp(_, _, v1, v2) => reachVal(v1); reachVal(v2)
-      case Op.Conv(_, _, v)      => reachVal(v)
+      case Op.Call(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case Op.Load(_, v, _)       => reachVal(v)
+      case Op.Store(_, v1, v2, _) => reachVal(v1); reachVal(v2)
+      case Op.Elem(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case Op.Extract(v, _)       => reachVal(v)
+      case Op.Insert(v1, v2, _)   => reachVal(v1); reachVal(v2)
+      case Op.Stackalloc(_, v)    => reachVal(v)
+      case Op.Bin(_, _, v1, v2)   => reachVal(v1); reachVal(v2)
+      case Op.Comp(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
+      case Op.Conv(_, _, v)       => reachVal(v)
+      case Op.Fence(_)            => ()
 
       case _: Op.Classalloc            => ()
       case Op.Fieldload(_, v, _)       => reachVal(v)
@@ -343,16 +344,17 @@ final class State(block: Local) {
     }
 
     def reachOp(op: Op): Unit = op match {
-      case Op.Call(_, v, vs)     => reachVal(v); vs.foreach(reachVal)
-      case Op.Load(_, v)         => reachVal(v)
-      case Op.Store(_, v1, v2)   => reachVal(v1); reachVal(v2)
-      case Op.Elem(_, v, vs)     => reachVal(v); vs.foreach(reachVal)
-      case Op.Extract(v, _)      => reachVal(v)
-      case Op.Insert(v1, v2, _)  => reachVal(v1); reachVal(v2)
-      case Op.Stackalloc(_, v)   => reachVal(v)
-      case Op.Bin(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
-      case Op.Comp(_, _, v1, v2) => reachVal(v1); reachVal(v2)
-      case Op.Conv(_, _, v)      => reachVal(v)
+      case Op.Call(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case Op.Load(_, v, _)       => reachVal(v)
+      case Op.Store(_, v1, v2, _) => reachVal(v1); reachVal(v2)
+      case Op.Elem(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case Op.Extract(v, _)       => reachVal(v)
+      case Op.Insert(v1, v2, _)   => reachVal(v1); reachVal(v2)
+      case Op.Stackalloc(_, v)    => reachVal(v)
+      case Op.Bin(_, _, v1, v2)   => reachVal(v1); reachVal(v2)
+      case Op.Comp(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
+      case Op.Conv(_, _, v)       => reachVal(v)
+      case Op.Fence(_)            => ()
 
       case _: Op.Classalloc            => ()
       case Op.Fieldload(_, v, _)       => reachVal(v)
@@ -387,10 +389,10 @@ final class State(block: Local) {
     def escapedOp(op: Op): Op = op match {
       case Op.Call(ty, v, vs) =>
         Op.Call(ty, escapedVal(v), vs.map(escapedVal))
-      case Op.Load(ty, v) =>
-        Op.Load(ty, escapedVal(v))
-      case Op.Store(ty, v1, v2) =>
-        Op.Store(ty, escapedVal(v1), escapedVal(v2))
+      case op @ Op.Load(_, v, _) =>
+        op.copy(ptr = escapedVal(v))
+      case op @ Op.Store(_, v1, v2, _) =>
+        op.copy(ptr = escapedVal(v1), value = escapedVal(v2))
       case Op.Elem(ty, v, vs) =>
         Op.Elem(ty, escapedVal(v), vs.map(escapedVal))
       case Op.Extract(v, idxs) =>
@@ -405,6 +407,7 @@ final class State(block: Local) {
         Op.Comp(comp, ty, escapedVal(v1), escapedVal(v2))
       case Op.Conv(conv, ty, v) =>
         Op.Conv(conv, ty, escapedVal(v))
+      case Op.Fence(_) => op
 
       case op: Op.Classalloc =>
         op

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -779,13 +779,15 @@ class Reach(
       reachType(ty)
       reachVal(ptrv)
       argvs.foreach(reachVal)
-    case Op.Load(ty, ptrv) =>
+    case Op.Load(ty, ptrv, syncAttrs) =>
       reachType(ty)
       reachVal(ptrv)
-    case Op.Store(ty, ptrv, v) =>
+      syncAttrs.foreach(reachSyncAttrs(_))
+    case Op.Store(ty, ptrv, v, syncAttrs) =>
       reachType(ty)
       reachVal(ptrv)
       reachVal(v)
+      syncAttrs.foreach(reachSyncAttrs(_))
     case Op.Elem(ty, ptrv, indexvs) =>
       reachType(ty)
       reachVal(ptrv)
@@ -809,6 +811,8 @@ class Reach(
     case Op.Conv(conv, ty, v) =>
       reachType(ty)
       reachVal(v)
+    case Op.Fence(attrs) =>
+      reachSyncAttrs(attrs)
 
     case Op.Classalloc(n) =>
       classInfo(n).foreach(reachAllocation)
@@ -874,6 +878,10 @@ class Reach(
       reachVal(value)
     case Op.Arraylength(arr) =>
       reachVal(arr)
+  }
+
+  def reachSyncAttrs(attrs: SyncAttrs): Unit = {
+    attrs.scope.foreach(reachGlobal(_))
   }
 
   def reachNext(next: Next): Unit = next match {


### PR DESCRIPTION
This change implements a subset of behaviors known from the Java Memory Model in the scope of shared variables (class fields). 

Final class fields (`val x = ???`) and volatile fields `@volatile var x = ???` are now trying to follow the JMM. Stores/Load from these fields are always atomic and use Acquire/Relese memory order accordingly. Writes to final fields also use additional memory fence. 

Other shared variables (non-final and non-volatile) are also using atomic load/store, but with LLVM Unordered memory order - which guarantees atomic write/load, but does not enforce any synchronization. 

* Add new `nir.Attrs` for `Final` and `Volatile` fields
* Handle new attrs in compiler plugin, allow for atomic load/write of `@volatile ptr: Ptr[_]`
* Add Synchronization Attributes to NIR Op.Load / Op.Store
* Add Op.Fence and basic MemoryOrder types
* Use Field attrs in lowering to provide JMM behaviour of shared variables
* Adapt CodeGen to produce correct values for new NIR instruction
* In lowering convert final/volatile boolean load/store which are unsupported on LLVM to use byte type instead
* Remove GC safepoints dummy method in Lower/AbstractCodeGen, use volatile load instead in Lower
* Add missing @volatile annotations to VolatileXXRefs classes (used by the compiler when to pass local volatile field to clousure )