### PR TITLE
CI - Improve stability of Windows setup actions by using choco install with retries

### DIFF
--- a/.github/actions/windows-setup-env/action.yml
+++ b/.github/actions/windows-setup-env/action.yml
@@ -60,9 +60,10 @@ runs:
         key: ${{ runner.os }}-${{ inputs.scala-version }}-deps
 
     # Install LLVM in case if cache is missing
+    # Choco-Install is GH Actions wrappers around choco, which does retries
     - name: Install LLVM
       shell: pwsh
-      run: choco install llvm --version=11.0.0 --allow-downgrade
+      run: Choco-Install -PackageName llvm -ArgumentList "--version=11.0.0", "--allow-downgrade"
 
     - name: Add LLVM on Path
       shell: pwsh


### PR DESCRIPTION
Replace direct usage of choco with Github Actions helper, which does provide retries functionality https://github.com/actions/runner-images/pull/721