### PR TITLE
Cleanup of `Size` handling in tools and runtime

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.meta
 
 import scala.scalanative.unsafe._
-import scala.scalanative.runtime.RawSize
 
 /** Constants resolved at link-time from NativeConfig, can be conditionally
  *  discard some parts of NIR instructions when linking
@@ -27,9 +26,6 @@ object LinktimeInfo {
 
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.is32BitPlatform")
   def is32BitPlatform: Boolean = resolved
-
-  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.sizeOfPtr")
-  def sizeOfPtr: RawSize = resolved
 
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.asanEnabled")
   def asanEnabled: Boolean = resolved

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -30,7 +30,6 @@ package runtime
 import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.runtime.Intrinsics._
-import scala.scalanative.meta.LinktimeInfo.{is32BitPlatform, sizeOfPtr}
 
 
 sealed abstract class Array[T]

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -30,7 +30,6 @@ package runtime
 import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.runtime.Intrinsics._
-import scala.scalanative.meta.LinktimeInfo.{is32BitPlatform, sizeOfPtr}
 
 % sizePtr = 'sizeOfPtr'
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -60,6 +60,9 @@ package object runtime {
   @alwaysinline def toRawSize(size: USize): RawSize =
     Boxes.unboxToUSize(size)
 
+  @alwaysinline def sizeOfPtr =
+    castIntToRawSize(if (is32BitPlatform) 4 else 8)
+
   /** Run the runtime's event loop. The method is called from the generated
    *  C-style after the application's main method terminates.
    */

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
@@ -25,13 +25,9 @@ sealed abstract class Tag[T] {
   @noinline def store(ptr: unsafe.Ptr[T], value: T): Unit = throwUndefined()
 }
 
-// Separate object to avoid dependency cycles
-private[unsafe] object TagUtil {
-  val ptrSize = new USize(scala.scalanative.meta.LinktimeInfo.sizeOfPtr)
-}
-
 object Tag {
-  import TagUtil._
+  @alwaysinline def ptrSize = new USize(scala.scalanative.runtime.sizeOfPtr)
+
   final case class Ptr[T](of: Tag[T])
       extends Tag[unsafe.Ptr[T]] {
     @alwaysinline def size: CSize = ptrSize

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
@@ -25,13 +25,9 @@ sealed abstract class Tag[T] {
   @noinline def store(ptr: unsafe.Ptr[T], value: T): Unit = throwUndefined()
 }
 
-// Separate object to avoid dependency cycles
-private[unsafe] object TagUtil {
-  val ptrSize = new USize(scala.scalanative.meta.LinktimeInfo.sizeOfPtr)
-}
-
 object Tag {
-  import TagUtil._
+  @alwaysinline def ptrSize = new USize(scala.scalanative.runtime.sizeOfPtr)
+
   final case class Ptr[T](of: Tag[T])
       extends Tag[unsafe.Ptr[T]] {
     @alwaysinline def size: CSize = ptrSize

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -751,23 +751,16 @@ trait Eval { self: Interflow =>
     def bailOut =
       throw BailOut(s"can't eval conv op: $conv[${ty.show}] ${value.show}")
     conv match {
-      case _ if ty == value.ty =>
-        value
-
+      case _ if ty == value.ty => value
       case Conv.SSizeCast | Conv.ZSizeCast =>
-        val fromSize = value.ty match {
+        def size(ty: Type) = ty match {
           case Type.Size =>
             if (is32BitPlatform) 32 else 64
           case Type.FixedSizeI(s, _) => s
           case o                     => bailOut
         }
-
-        val toSize = ty match {
-          case Type.Size =>
-            if (is32BitPlatform) 32 else 64
-          case Type.FixedSizeI(s, _) => s
-          case o                     => bailOut
-        }
+        val fromSize = size(value.ty)
+        val toSize = size(ty)
 
         if (fromSize == toSize) eval(Conv.Bitcast, ty, value)
         else if (fromSize > toSize) eval(Conv.Trunc, ty, value)
@@ -803,6 +796,8 @@ trait Eval { self: Interflow =>
             Val.Long(v.toChar.toLong)
           case (Val.Int(v), Type.Long) =>
             Val.Long(java.lang.Integer.toUnsignedLong(v))
+          case (Val.Int(v), Type.Size) if !is32BitPlatform =>
+            Val.Size(java.lang.Integer.toUnsignedLong(v))
           case (Val.Size(v), Type.Long) if is32BitPlatform =>
             Val.Long(java.lang.Integer.toUnsignedLong(v.toInt))
           case _ =>
@@ -817,6 +812,7 @@ trait Eval { self: Interflow =>
           case (Val.Short(v), Type.Int)  => Val.Int(v.toInt)
           case (Val.Short(v), Type.Long) => Val.Long(v.toLong)
           case (Val.Int(v), Type.Long)   => Val.Long(v.toLong)
+          case (Val.Int(v), Type.Size) if !is32BitPlatform => Val.Size(v.toLong)
           case (Val.Size(v), Type.Long) if is32BitPlatform =>
             Val.Long(v.toInt.toLong)
           case _ => bailOut
@@ -866,11 +862,13 @@ trait Eval { self: Interflow =>
       case Conv.Ptrtoint =>
         (value, ty) match {
           case (Val.Null, Type.Long) => Val.Long(0L)
+          case (Val.Null, Type.Int)  => Val.Int(0)
           case _                     => bailOut
         }
       case Conv.Inttoptr =>
         (value, ty) match {
           case (Val.Long(0L), Type.Ptr) => Val.Null
+          case (Val.Int(0L), Type.Ptr)  => Val.Null
           case _                        => bailOut
         }
       case Conv.Bitcast =>

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -23,8 +23,6 @@ trait LinktimeValueResolver { self: Reach =>
         conf.gc == GC.Commix
       },
       s"$linktimeInfo.is32BitPlatform" -> conf.is32BitPlatform,
-      s"$linktimeInfo.sizeOfPtr" -> (if (conf.is32BitPlatform) Val.Size(4)
-                                     else Val.Size(8)),
       s"$linktimeInfo.asanEnabled" -> conf.asan
     )
     NativeConfig.checkLinktimeProperties(predefined)
@@ -169,7 +167,6 @@ private[linker] object LinktimeValueResolver {
         case v: Float   => ComparableVal(v, Val.Float(v))
         case v: Double  => ComparableVal(v, Val.Double(v))
         case v: String  => ComparableVal(v, Val.String(v))
-        case v: Val     => fromNir(v)
         case other =>
           throw new LinkingException(
             s"Unsupported value for link-time resolving: $other"
@@ -187,7 +184,6 @@ private[linker] object LinktimeValueResolver {
         case Val.Short(value)  => ComparableVal(value, v)
         case Val.Int(value)    => ComparableVal(value, v)
         case Val.Long(value)   => ComparableVal(value, v)
-        case Val.Size(value)   => ComparableVal(value, v)
         case Val.Float(value)  => ComparableVal(value, v)
         case Val.Double(value) => ComparableVal(value, v)
         case Val.Null          => ComparableVal(null, v)

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -62,8 +62,7 @@ class LinktimeConditionsSpec extends OptimizerSpec with Matchers {
       s"$linktimeInfo.isMac",
       s"$linktimeInfo.isWindows",
       s"$linktimeInfo.isMultithreadingEnabled",
-      s"$linktimeInfo.isWeakReferenceSupported",
-      s"$linktimeInfo.sizeOfPtr"
+      s"$linktimeInfo.isWeakReferenceSupported"
     )
   }
 


### PR DESCRIPTION
* Move `sizeOfPtr` from `meta.LinktimeInfo` to `runtime` package. There is no runtime regression since it is always inlined and effectively emitted as a constant. 
* Remove handling of NIR values from `LinktimeValuesResolver`
* Remove code duplicates from `interflow.Eval` 
* Fix unhandled and potentially failing conversions in `interflow.Eval`