### PR TITLE
Refactor providing memory layout and platform information

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -29,8 +29,7 @@ package runtime
 
 import scalanative.unsafe._
 import scalanative.unsigned._
-import scalanative.runtime.Intrinsics._
-
+import scalanative.runtime.Intrinsics.{castIntToRawSizeUnsigned => intToUSize, _}
 
 sealed abstract class Array[T]
     extends java.io.Serializable
@@ -39,7 +38,7 @@ sealed abstract class Array[T]
   /** Number of elements of the array. */
   @inline def length: Int = {
     val rawptr = castObjectToRawPtr(this)
-    val lenptr = elemRawPtr(rawptr, sizeOfPtr)
+    val lenptr = elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.LengthOffset))
     loadInt(lenptr)
   }
 
@@ -164,11 +163,7 @@ final class BooleanArray private () extends Array[Boolean] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 1 * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 1.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 1 * i))
     }
 
   @inline def apply(i: Int): Boolean = loadBoolean(atRaw(i))
@@ -177,10 +172,7 @@ final class BooleanArray private () extends Array[Boolean] {
 
   @inline override def clone(): BooleanArray = {
     val arrcls  = classOf[BooleanArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 1 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 1.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 1 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -196,17 +188,9 @@ object BooleanArray {
     }
 
     val arrcls  = classOf[BooleanArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 1 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 1.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 1 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), 1)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[BooleanArray]
   }
 
@@ -214,10 +198,7 @@ object BooleanArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(1 * length)
-      else castLongToRawSize(1.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(1 * length))
     libc.memcpy(dst, src, size)
     arr
   }
@@ -233,11 +214,7 @@ final class CharArray private () extends Array[Char] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 2 * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 2.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 2 * i))
     }
 
   @inline def apply(i: Int): Char = loadChar(atRaw(i))
@@ -246,10 +223,7 @@ final class CharArray private () extends Array[Char] {
 
   @inline override def clone(): CharArray = {
     val arrcls  = classOf[CharArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 2 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 2.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 2 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -265,17 +239,9 @@ object CharArray {
     }
 
     val arrcls  = classOf[CharArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 2 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 2.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 2 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), 2)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[CharArray]
   }
 
@@ -283,10 +249,7 @@ object CharArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(2 * length)
-      else castLongToRawSize(2.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(2 * length))
     libc.memcpy(dst, src, size)
     arr
   }
@@ -302,11 +265,7 @@ final class ByteArray private () extends Array[Byte] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 1 * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 1.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 1 * i))
     }
 
   @inline def apply(i: Int): Byte = loadByte(atRaw(i))
@@ -315,10 +274,7 @@ final class ByteArray private () extends Array[Byte] {
 
   @inline override def clone(): ByteArray = {
     val arrcls  = classOf[ByteArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 1 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 1.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 1 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -334,17 +290,9 @@ object ByteArray {
     }
 
     val arrcls  = classOf[ByteArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 1 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 1.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 1 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), 1)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[ByteArray]
   }
 
@@ -352,10 +300,7 @@ object ByteArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(1 * length)
-      else castLongToRawSize(1.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(1 * length))
     libc.memcpy(dst, src, size)
     arr
   }
@@ -371,11 +316,7 @@ final class ShortArray private () extends Array[Short] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 2 * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 2.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 2 * i))
     }
 
   @inline def apply(i: Int): Short = loadShort(atRaw(i))
@@ -384,10 +325,7 @@ final class ShortArray private () extends Array[Short] {
 
   @inline override def clone(): ShortArray = {
     val arrcls  = classOf[ShortArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 2 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 2.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 2 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -403,17 +341,9 @@ object ShortArray {
     }
 
     val arrcls  = classOf[ShortArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 2 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 2.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 2 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), 2)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[ShortArray]
   }
 
@@ -421,10 +351,7 @@ object ShortArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(2 * length)
-      else castLongToRawSize(2.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(2 * length))
     libc.memcpy(dst, src, size)
     arr
   }
@@ -440,11 +367,7 @@ final class IntArray private () extends Array[Int] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 4 * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 4.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 4 * i))
     }
 
   @inline def apply(i: Int): Int = loadInt(atRaw(i))
@@ -453,10 +376,7 @@ final class IntArray private () extends Array[Int] {
 
   @inline override def clone(): IntArray = {
     val arrcls  = classOf[IntArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 4 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 4.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 4 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -472,17 +392,9 @@ object IntArray {
     }
 
     val arrcls  = classOf[IntArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 4 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 4.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 4 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), 4)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[IntArray]
   }
 
@@ -490,10 +402,7 @@ object IntArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(4 * length)
-      else castLongToRawSize(4.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(4 * length))
     libc.memcpy(dst, src, size)
     arr
   }
@@ -509,11 +418,7 @@ final class LongArray private () extends Array[Long] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 8 * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 8.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 8 * i))
     }
 
   @inline def apply(i: Int): Long = loadLong(atRaw(i))
@@ -522,10 +427,7 @@ final class LongArray private () extends Array[Long] {
 
   @inline override def clone(): LongArray = {
     val arrcls  = classOf[LongArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 8 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 8.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 8 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -541,17 +443,9 @@ object LongArray {
     }
 
     val arrcls  = classOf[LongArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 8 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 8.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 8 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), 8)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[LongArray]
   }
 
@@ -559,10 +453,7 @@ object LongArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(8 * length)
-      else castLongToRawSize(8.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(8 * length))
     libc.memcpy(dst, src, size)
     arr
   }
@@ -578,11 +469,7 @@ final class FloatArray private () extends Array[Float] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 4 * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 4.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 4 * i))
     }
 
   @inline def apply(i: Int): Float = loadFloat(atRaw(i))
@@ -591,10 +478,7 @@ final class FloatArray private () extends Array[Float] {
 
   @inline override def clone(): FloatArray = {
     val arrcls  = classOf[FloatArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 4 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 4.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 4 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -610,17 +494,9 @@ object FloatArray {
     }
 
     val arrcls  = classOf[FloatArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 4 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 4.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 4 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), 4)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[FloatArray]
   }
 
@@ -628,10 +504,7 @@ object FloatArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(4 * length)
-      else castLongToRawSize(4.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(4 * length))
     libc.memcpy(dst, src, size)
     arr
   }
@@ -647,11 +520,7 @@ final class DoubleArray private () extends Array[Double] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 8 * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 8.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 8 * i))
     }
 
   @inline def apply(i: Int): Double = loadDouble(atRaw(i))
@@ -660,10 +529,7 @@ final class DoubleArray private () extends Array[Double] {
 
   @inline override def clone(): DoubleArray = {
     val arrcls  = classOf[DoubleArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 8 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 8.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 8 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -679,17 +545,9 @@ object DoubleArray {
     }
 
     val arrcls  = classOf[DoubleArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + 8 * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + 8.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 8 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), 8)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[DoubleArray]
   }
 
@@ -697,10 +555,7 @@ object DoubleArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(8 * length)
-      else castLongToRawSize(8.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(8 * length))
     libc.memcpy(dst, src, size)
     arr
   }
@@ -716,11 +571,7 @@ final class ObjectArray private () extends Array[Object] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + castRawSizeToInt(sizeOfPtr) * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + castRawSizeToInt(sizeOfPtr).toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + castRawSizeToInt(sizeOfPtr) * i))
     }
 
   @inline def apply(i: Int): Object = loadObject(atRaw(i))
@@ -729,10 +580,7 @@ final class ObjectArray private () extends Array[Object] {
 
   @inline override def clone(): ObjectArray = {
     val arrcls  = classOf[ObjectArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + castRawSizeToInt(sizeOfPtr) * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + castRawSizeToInt(sizeOfPtr).toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + castRawSizeToInt(sizeOfPtr) * length))
     val arr     = GC.alloc(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -748,17 +596,9 @@ object ObjectArray {
     }
 
     val arrcls  = classOf[ObjectArray]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + castRawSizeToInt(sizeOfPtr) * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + castRawSizeToInt(sizeOfPtr).toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + castRawSizeToInt(sizeOfPtr) * length))
     val arr     = GC.alloc(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, sizeOfPtr), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) + 4)
-      else castLongToRawSize(castRawSizeToLong(sizeOfPtr) + 4L)
-    ), castRawSizeToInt(sizeOfPtr))
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[ObjectArray]
   }
 
@@ -766,10 +606,7 @@ object ObjectArray {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(sizeOfPtr) * length)
-      else castLongToRawSize(castRawSizeToInt(sizeOfPtr).toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(castRawSizeToInt(sizeOfPtr) * length))
     libc.memcpy(dst, src, size)
     arr
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -191,6 +191,7 @@ object BooleanArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 1 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), 1)
     castRawPtrToObject(arr).asInstanceOf[BooleanArray]
   }
 
@@ -242,6 +243,7 @@ object CharArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 2 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), 2)
     castRawPtrToObject(arr).asInstanceOf[CharArray]
   }
 
@@ -293,6 +295,7 @@ object ByteArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 1 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), 1)
     castRawPtrToObject(arr).asInstanceOf[ByteArray]
   }
 
@@ -344,6 +347,7 @@ object ShortArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 2 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), 2)
     castRawPtrToObject(arr).asInstanceOf[ShortArray]
   }
 
@@ -395,6 +399,7 @@ object IntArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 4 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), 4)
     castRawPtrToObject(arr).asInstanceOf[IntArray]
   }
 
@@ -446,6 +451,7 @@ object LongArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 8 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), 8)
     castRawPtrToObject(arr).asInstanceOf[LongArray]
   }
 
@@ -497,6 +503,7 @@ object FloatArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 4 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), 4)
     castRawPtrToObject(arr).asInstanceOf[FloatArray]
   }
 
@@ -548,6 +555,7 @@ object DoubleArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + 8 * length))
     val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), 8)
     castRawPtrToObject(arr).asInstanceOf[DoubleArray]
   }
 
@@ -599,6 +607,7 @@ object ObjectArray {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + castRawSizeToInt(sizeOfPtr) * length))
     val arr     = GC.alloc(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), castRawSizeToInt(sizeOfPtr))
     castRawPtrToObject(arr).asInstanceOf[ObjectArray]
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -29,9 +29,7 @@ package runtime
 
 import scalanative.unsafe._
 import scalanative.unsigned._
-import scalanative.runtime.Intrinsics._
-
-% sizePtr = 'sizeOfPtr'
+import scalanative.runtime.Intrinsics.{castIntToRawSizeUnsigned => intToUSize, _}
 
 sealed abstract class Array[T]
     extends java.io.Serializable
@@ -40,7 +38,7 @@ sealed abstract class Array[T]
   /** Number of elements of the array. */
   @inline def length: Int = {
     val rawptr = castObjectToRawPtr(this)
-    val lenptr = elemRawPtr(rawptr, ${sizePtr})
+    val lenptr = elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.LengthOffset))
     loadInt(lenptr)
   }
 
@@ -181,11 +179,7 @@ final class ${T}Array private () extends Array[${T}] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(
-        rawptr,
-        if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + ${sizeT} * i)
-        else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + ${sizeT}.toLong * i.toLong)
-      )
+      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + ${sizeT} * i))
     }
 
   @inline def apply(i: Int): ${T} = load${T}(atRaw(i))
@@ -194,10 +188,7 @@ final class ${T}Array private () extends Array[${T}] {
 
   @inline override def clone(): ${T}Array = {
     val arrcls  = classOf[${T}Array]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + ${sizeT} * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + ${sizeT}.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + ${sizeT} * length))
     val arr     = ${alloc}(arrcls, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
@@ -213,17 +204,9 @@ object ${T}Array {
     }
 
     val arrcls  = classOf[${T}Array]
-    val arrsize = new USize(
-      if (is32BitPlatform) castIntToRawSize((castRawSizeToInt(sizeOfPtr) + 8) + ${sizeT} * length)
-      else castLongToRawSize((castRawSizeToLong(sizeOfPtr) + 8L) + ${sizeT}.toLong * length.toLong)
-    )
+    val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + ${sizeT} * length))
     val arr     = ${alloc}(arrcls, arrsize)
-    storeInt(elemRawPtr(arr, ${sizePtr}), length)
-    storeInt(elemRawPtr(
-      arr,
-      if (is32BitPlatform) castIntToRawSize(castRawSizeToInt(${sizePtr}) + 4)
-      else castLongToRawSize(castRawSizeToLong(${sizePtr}) + 4L)
-    ), ${sizeT})
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
     castRawPtrToObject(arr).asInstanceOf[${T}Array]
   }
 
@@ -231,10 +214,7 @@ object ${T}Array {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
     val src  = data
-    val size = new USize(
-      if (is32BitPlatform) castIntToRawSize(${sizeT} * length)
-      else castLongToRawSize(${sizeT}.toLong * length.toLong)
-    )
+    val size = new USize(intToUSize(${sizeT} * length))
     libc.memcpy(dst, src, size)
     arr
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -207,6 +207,7 @@ object ${T}Array {
     val arrsize = new USize(intToUSize(MemoryLayout.Array.ValuesOffset + ${sizeT} * length))
     val arr     = ${alloc}(arrcls, arrsize)
     storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.LengthOffset)), length)
+    storeInt(elemRawPtr(arr, intToUSize(MemoryLayout.Array.StrideOffset)), ${sizeT})
     castRawPtrToObject(arr).asInstanceOf[${T}Array]
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/MemoryLayout.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/MemoryLayout.scala
@@ -21,9 +21,15 @@ object MemoryLayout {
     @alwaysinline def IdOffset = ClassOffset + PtrSize
     @alwaysinline def TraitIdOffset = IdOffset + IntSize
     @alwaysinline def NameOffset = TraitIdOffset + IntSize
-    @alwaysinline def SizeOffset = NameOffset + PtrSize
-    @alwaysinline def IdRangeEndOffset = SizeOffset + IntSize
-    @alwaysinline def ReferenceMapOffset = IdRangeEndOffset + IntSize
+
+    @alwaysinline def size = NameOffset + PtrSize
+  }
+
+  private[scalanative] object ClassRtti {
+    @alwaysinline def RttiOffset = 0
+    @alwaysinline def SizeOffset = RttiOffset + Rtti.size
+    // Remaining fields has optional or contain intrinsic data,
+    // they should never be accessed in the runtime
   }
 
   private[scalanative] object Object {
@@ -34,8 +40,8 @@ object MemoryLayout {
   private[scalanative] object Array {
     @alwaysinline def RttiOffset = 0
     @alwaysinline def LengthOffset = RttiOffset + PtrSize
-    @alwaysinline def PaddingOffset = LengthOffset + IntSize
-    @alwaysinline def ValuesOffset = PaddingOffset + IntSize
+    @alwaysinline def StrideOffset = LengthOffset + IntSize
+    @alwaysinline def ValuesOffset = StrideOffset + IntSize
   }
 
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/MemoryLayout.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/MemoryLayout.scala
@@ -1,0 +1,41 @@
+package scala.scalanative.runtime
+
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.runtime.Intrinsics.castRawSizeToInt
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
+
+object MemoryLayout {
+
+  /*  Even though it might seem non-idiomatic to use `def` instead of `final val`
+   *  for the constants it actual can be faster at runtime. Vals would require
+   *  a fieldload operation and loading the module instance. Def would be
+   *  evaluated and inlined in the optimizer - it would result with replacing
+   *  method call with a constant value.
+   */
+
+  @alwaysinline private def PtrSize = castRawSizeToInt(sizeOfPtr)
+  @alwaysinline private def IntSize = 4
+
+  private[scalanative] object Rtti {
+    @alwaysinline def ClassOffset = 0
+    @alwaysinline def IdOffset = ClassOffset + PtrSize
+    @alwaysinline def TraitIdOffset = IdOffset + IntSize
+    @alwaysinline def NameOffset = TraitIdOffset + IntSize
+    @alwaysinline def SizeOffset = NameOffset + PtrSize
+    @alwaysinline def IdRangeEndOffset = SizeOffset + IntSize
+    @alwaysinline def ReferenceMapOffset = IdRangeEndOffset + IntSize
+  }
+
+  private[scalanative] object Object {
+    @alwaysinline def RttiOffset = 0
+    @alwaysinline def FieldsOffset = RttiOffset + PtrSize
+  }
+
+  private[scalanative] object Array {
+    @alwaysinline def RttiOffset = 0
+    @alwaysinline def LengthOffset = RttiOffset + PtrSize
+    @alwaysinline def PaddingOffset = LengthOffset + IntSize
+    @alwaysinline def ValuesOffset = PaddingOffset + IntSize
+  }
+
+}

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -75,12 +75,11 @@ package object runtime {
 
   /** Called by the generated code in case of incorrect class cast. */
   @noinline def throwClassCast(from: RawPtr, to: RawPtr): Nothing = {
-    // 64-bit systems align pointer to 8 bytes
     val fromName = loadObject(
-      elemRawPtr(from, castIntToRawSize(if (is32BitPlatform) 12 else 16))
+      elemRawPtr(from, castIntToRawSizeUnsigned(MemoryLayout.Rtti.NameOffset))
     )
     val toName = loadObject(
-      elemRawPtr(to, castIntToRawSize(if (is32BitPlatform) 12 else 16))
+      elemRawPtr(to, castIntToRawSizeUnsigned(MemoryLayout.Rtti.NameOffset))
     )
     throw new java.lang.ClassCastException(
       s"$fromName cannot be cast to $toName"

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -692,7 +692,7 @@ private[codegen] abstract class AbstractCodeGen(
               }
               str(", !")
               str(deref)
-              str(" !i")
+              str(" !{i")
               str(platform.sizeOfPtrBits)
               str(" ")
               str(size)

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -61,12 +61,12 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
     val layout = Type.StructValue(
       Type.Ptr :: // RTTI
         Type.Int :: // length
-        Type.Int :: // padding
+        Type.Int :: // stride (used only by GC)
         Nil
     )
 
     final val RttiIdx = 0
     final val LengthIdx = RttiIdx + 1
-    final val PaddingIdx = LengthIdx + 1
+    final val StrideIdx = LengthIdx + 1
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -35,7 +35,7 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
         dynMapType.toList
 
     val layout = genLayout(vtable = Type.ArrayValue(Type.Ptr, 0))
-   
+
     def genLayout(vtable: Type): Type.StructValue = Type.StructValue(
       baseLayout ::: vtable :: Nil
     )

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -1,0 +1,72 @@
+package scala.scalanative.codegen
+
+import scala.scalanative.nir._
+
+class CommonMemoryLayouts(implicit meta: Metadata) {
+  sealed trait Layout {
+    val layout: Type.StructValue
+    lazy val fields: Int = layout.tys.size
+  }
+
+  object Rtti extends Layout {
+    val layout = Type.StructValue(
+      Type.Ptr :: // ClassRtti
+        Type.Int :: // ClassId
+        Type.Int :: // Traitid
+        Type.Ptr :: // ClassName
+        Nil
+    )
+    final val RttiIdx = 0
+    final val ClassIdIdx = RttiIdx + 1
+    final val TraitIdIdx = ClassIdIdx + 1
+    final val ClassNameIdx = TraitIdIdx + 1
+  }
+
+  // RTTI specific for classess, see class RuntimeTypeInformation
+  object ClassRtti extends Layout {
+    val usesDynMap = meta.linked.dynsigs.nonEmpty
+    private val dynMapType = if (usesDynMap) Some(DynamicHashMap.ty) else None
+    // Common layout not including variable-sized virtual table
+    private val baseLayout =
+      Rtti.layout ::
+        Type.Int :: // class size
+        Type.Int :: // id range
+        FieldLayout.referenceOffsetsTy :: // reference offsets
+        dynMapType.toList
+
+    val layout = genLayout(vtable = Type.ArrayValue(Type.Ptr, 0))
+   
+    def genLayout(vtable: Type): Type.StructValue = Type.StructValue(
+      baseLayout ::: vtable :: Nil
+    )
+
+    final val RttiIdx = 0
+    final val SizeIdx = RttiIdx + 1
+    final val IdRangeIdx = SizeIdx + 1
+    final val ReferenceOffsetsIdx = IdRangeIdx + 1
+    final val DynmapIdx =
+      if (usesDynMap) ReferenceOffsetsIdx + 1 else -1
+    final val VtableIdx =
+      (if (usesDynMap) DynmapIdx else ReferenceOffsetsIdx) + 1
+  }
+
+  object ObjectHeader extends Layout {
+    val layout = Type.StructValue(
+      Type.Ptr :: // RTTI
+        Nil
+    )
+  }
+
+  object ArrayHeader extends Layout {
+    val layout = Type.StructValue(
+      Type.Ptr :: // RTTI
+        Type.Int :: // length
+        Type.Int :: // padding
+        Nil
+    )
+
+    final val RttiIdx = 0
+    final val LengthIdx = RttiIdx + 1
+    final val PaddingIdx = LengthIdx + 1
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
@@ -4,6 +4,10 @@ package codegen
 import scalanative.nir._
 import scalanative.linker.{Class, Method}
 
+object DynamicHashMap {
+  final val ty: Type = Type.Ptr
+}
+
 class DynamicHashMap(cls: Class, proxies: Seq[Defn])(implicit meta: Metadata) {
   val methods: Seq[Global.Member] = {
     val own = proxies.collect {
@@ -15,8 +19,5 @@ class DynamicHashMap(cls: Class, proxies: Seq[Defn])(implicit meta: Metadata) {
       .fold(Seq.empty[Global.Member])(meta.dynmap(_).methods)
       .filterNot(m => sigs.contains(m.sig)) ++ own
   }
-  val ty: Type =
-    Type.Ptr
-  val value: Val =
-    DynmethodPerfectHashMap(methods, meta.linked.dynsigs)
+  val value: Val = DynmethodPerfectHashMap(methods, meta.linked.dynsigs)
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
@@ -4,7 +4,7 @@ package codegen
 import scalanative.nir._
 import scalanative.linker.{Class, Method}
 
-class DynamicHashMap(meta: Metadata, cls: Class, proxies: Seq[Defn]) {
+class DynamicHashMap(cls: Class, proxies: Seq[Defn])(implicit meta: Metadata) {
   val methods: Seq[Global.Member] = {
     val own = proxies.collect {
       case p if p.name.top == cls.name =>

--- a/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
@@ -10,6 +10,7 @@ object FieldLayout {
 
 class FieldLayout(cls: Class)(implicit meta: Metadata) {
   import meta.layouts.ObjectHeader
+  import meta.platform
 
   def index(fld: Field) = entries.indexOf(fld) + ObjectHeader.fields
   val entries: Seq[Field] = {
@@ -22,10 +23,9 @@ class FieldLayout(cls: Class)(implicit meta: Metadata) {
     val data = entries.map(_.ty)
     Type.StructValue(ObjectHeader.layout +: data)
   }
-  val layout = MemoryLayout(struct.tys, meta.config.is32BitPlatform)
+  val layout = MemoryLayout(struct.tys)
   val size = layout.size
-  val referenceOffsetsValue =
-    Val.StructValue(
-      Seq(Val.Const(Val.ArrayValue(Type.Long, layout.offsetArray)))
-    )
+  val referenceOffsetsValue = Val.StructValue(
+    Seq(Val.Const(Val.ArrayValue(Type.Long, layout.offsetArray)))
+  )
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
@@ -4,7 +4,7 @@ package codegen
 import scalanative.nir._
 import scalanative.linker.{Class, Field}
 
-class FieldLayout(meta: Metadata, cls: Class) {
+class FieldLayout(cls: Class)(implicit meta: Metadata) {
   def index(fld: Field) =
     entries.indexOf(fld) + 1
   val entries: Seq[Field] = {

--- a/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
@@ -4,9 +4,14 @@ package codegen
 import scalanative.nir._
 import scalanative.linker.{Class, Field}
 
+object FieldLayout {
+  val referenceOffsetsTy = Type.StructValue(Seq(Type.Ptr))
+}
+
 class FieldLayout(cls: Class)(implicit meta: Metadata) {
-  def index(fld: Field) =
-    entries.indexOf(fld) + 1
+  import meta.layouts.ObjectHeader
+
+  def index(fld: Field) = entries.indexOf(fld) + ObjectHeader.fields
   val entries: Seq[Field] = {
     val base = cls.parent.fold {
       Seq.empty[Field]
@@ -15,13 +20,10 @@ class FieldLayout(cls: Class)(implicit meta: Metadata) {
   }
   val struct: Type.StructValue = {
     val data = entries.map(_.ty)
-    val body = Type.Ptr +: data
-    Type.StructValue(body)
+    Type.StructValue(ObjectHeader.layout +: data)
   }
   val layout = MemoryLayout(struct.tys, meta.config.is32BitPlatform)
   val size = layout.size
-  val referenceOffsetsTy =
-    Type.StructValue(Seq(Type.Ptr))
   val referenceOffsetsValue =
     Val.StructValue(
       Seq(Val.Const(Val.ArrayValue(Type.Long, layout.offsetArray)))

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -276,7 +276,7 @@ object Generate {
             val instanceDefn = Defn.Const(
               Attrs.None,
               instanceName,
-              Type.StructValue(Seq(Type.Ptr)),
+              meta.layouts.ObjectHeader.layout,
               instanceVal
             )
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -668,9 +668,10 @@ object Lower {
       )
 
       def shouldSwitchThreadState(name: Global) =
-        platform.isMultithreadingEnabled && linked.infos.get(name).exists { info =>
-          val attrs = info.attrs
-          attrs.isExtern && attrs.isBlocking
+        platform.isMultithreadingEnabled && linked.infos.get(name).exists {
+          info =>
+            val attrs = info.attrs
+            attrs.isExtern && attrs.isBlocking
         }
 
       ptr match {

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1342,7 +1342,7 @@ object Lower {
         Val.StructValue(
           rtti(CharArrayCls).const ::
             charsLength ::
-            zero :: // padding to get next field aligned properly
+            zero :: // stride is used only by GC, global instances use it as padding
             Val.ArrayValue(Type.Char, chars.toSeq.map(Val.Char(_))) :: Nil
         )
       )

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -18,7 +18,6 @@ object Lower {
     import meta.layouts.{Rtti, ClassRtti, ArrayHeader}
 
     implicit val linked: Result = meta.linked
-    val is32BitPlatform = meta.config.is32BitPlatform
 
     val Object = linked.infos(Rt.Object.name).asInstanceOf[Class]
 
@@ -607,7 +606,7 @@ object Lower {
         case Immix => true
         case _     => false
       }
-      private val multithreadingEnabled = meta.config.multithreadingSupport
+      private val multithreadingEnabled = meta.platform.isMultithreadingEnabled
       private val usesSafepoints = multithreadingEnabled && supportedGC
 
       def apply(defn: Defn.Define): Boolean = {
@@ -669,7 +668,7 @@ object Lower {
       )
 
       def shouldSwitchThreadState(name: Global) =
-        config.multithreadingSupport && linked.infos.get(name).exists { info =>
+        platform.isMultithreadingEnabled && linked.infos.get(name).exists { info =>
           val attrs = info.attrs
           attrs.isExtern && attrs.isBlocking
         }
@@ -952,7 +951,7 @@ object Lower {
     ): Unit = {
       val Op.Sizeof(ty) = op
 
-      val memorySize = MemoryLayout.sizeOf(ty, meta.config.is32BitPlatform)
+      val memorySize = MemoryLayout.sizeOf(ty)
       buf.let(n, Op.Copy(Val.Size(memorySize)), unwind)
     }
 
@@ -1128,7 +1127,7 @@ object Lower {
           case Type.Int  => Val.Int(java.lang.Integer.MIN_VALUE)
           case Type.Long => Val.Long(java.lang.Long.MIN_VALUE)
           case Type.Size =>
-            if (is32BitPlatform) Val.Size(java.lang.Integer.MIN_VALUE)
+            if (platform.is32Bit) Val.Size(java.lang.Integer.MIN_VALUE)
             else Val.Size(java.lang.Long.MIN_VALUE)
           case _ => util.unreachable
         }

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -5,12 +5,10 @@ import scala.collection.mutable
 import scalanative.nir.Type.RefKind
 import scalanative.nir.{Type, Val}
 import scalanative.util.unsupported
-import scalanative.codegen.MemoryLayout.PositionedType
 
 final case class MemoryLayout(
     size: Long,
-    tys: Seq[MemoryLayout.PositionedType],
-    is32BitPlatform: Boolean
+    tys: Seq[MemoryLayout.PositionedType]
 ) {
   def offsetArray(implicit meta: Metadata): Seq[Val] = {
     val ptrOffsets =
@@ -32,32 +30,31 @@ object MemoryLayout {
 
   final case class PositionedType(ty: Type, offset: Long)
 
-  def sizeOf(ty: Type, is32BitPlatform: Boolean): Long = ty match {
+  def sizeOf(ty: Type)(implicit platform: PlatformInfo): Long = ty match {
     case primitive: Type.PrimitiveKind =>
       math.max(primitive.width / BITS_IN_BYTE, 1)
     case Type.ArrayValue(ty, n) =>
-      sizeOf(ty, is32BitPlatform) * n
+      sizeOf(ty) * n
     case Type.StructValue(tys) =>
-      MemoryLayout(tys, is32BitPlatform).size
+      MemoryLayout(tys).size
     case Type.Size | Type.Nothing | Type.Ptr | _: Type.RefKind =>
-      if (is32BitPlatform) 4 else 8
+      platform.sizeOfPtr
     case _ =>
       unsupported(s"sizeof $ty")
   }
 
-  def alignmentOf(ty: Type, is32BitPlatform: Boolean): Long = ty match {
-    case Type.Long | Type.Double =>
-      if (is32BitPlatform) 4 else 8
+  def alignmentOf(ty: Type)(implicit platform: PlatformInfo): Long = ty match {
+    case Type.Long | Type.Double => platform.sizeOfPtr
     case primitive: Type.PrimitiveKind =>
       math.max(primitive.width / BITS_IN_BYTE, 1)
     case Type.ArrayValue(ty, n) =>
-      alignmentOf(ty, is32BitPlatform)
+      alignmentOf(ty)
     case Type.StructValue(Seq()) =>
       1
     case Type.StructValue(tys) =>
-      tys.map(alignmentOf(_, is32BitPlatform)).max
+      tys.map(alignmentOf(_)).max
     case Type.Size | Type.Nothing | Type.Ptr | _: Type.RefKind =>
-      if (is32BitPlatform) 4 else 8
+      platform.sizeOfPtr
     case _ =>
       unsupported(s"alignment $ty")
   }
@@ -70,21 +67,21 @@ object MemoryLayout {
     offset + padding
   }
 
-  def apply(tys: Seq[Type], is32BitPlatform: Boolean): MemoryLayout = {
+  def apply(tys: Seq[Type])(implicit platform: PlatformInfo): MemoryLayout = {
     val pos = mutable.UnrolledBuffer.empty[PositionedType]
     var offset = 0L
 
     tys.foreach { ty =>
-      offset = align(offset, alignmentOf(ty, is32BitPlatform))
+      offset = align(offset, alignmentOf(ty))
       pos += PositionedType(ty, offset)
-      offset += sizeOf(ty, is32BitPlatform)
+      offset += sizeOf(ty)
     }
 
     val alignment = {
       if (tys.isEmpty) 1
-      else tys.map(alignmentOf(_, is32BitPlatform)).max
+      else tys.map(alignmentOf(_)).max
     }
 
-    MemoryLayout(align(offset, alignment), pos.toSeq, is32BitPlatform)
+    MemoryLayout(align(offset, alignment), pos.toSeq)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -12,13 +12,14 @@ final case class MemoryLayout(
     tys: Seq[MemoryLayout.PositionedType],
     is32BitPlatform: Boolean
 ) {
-  lazy val offsetArray: Seq[Val] = {
+  def offsetArray(implicit meta: Metadata): Seq[Val] = {
     val ptrOffsets =
       tys.collect {
-        // offset in words without rtti
+        // offset in words without object header
         case MemoryLayout.PositionedType(_: RefKind, offset) =>
-          // refMapStruct is int64_t*
-          Val.Long(offset / MemoryLayout.BYTES_IN_LONG - 1)
+          Val.Long(
+            offset / MemoryLayout.BYTES_IN_LONG - meta.layouts.ObjectHeader.fields
+          )
       }
 
     ptrOffsets :+ Val.Long(-1)

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -9,7 +9,7 @@ class Metadata(
     val linked: linker.Result,
     val config: build.NativeConfig,
     proxies: Seq[Defn]
-) {
+)(implicit val platform: PlatformInfo) {
   implicit private def self: Metadata = this
 
   val layouts = new CommonMemoryLayouts()

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -10,6 +10,8 @@ class Metadata(
     val config: build.NativeConfig,
     proxies: Seq[Defn]
 ) {
+  implicit private def self: Metadata = this
+
   val rtti = mutable.Map.empty[linker.Info, RuntimeTypeInformation]
   val vtable = mutable.Map.empty[linker.Class, VirtualTable]
   val layout = mutable.Map.empty[linker.Class, FieldLayout]
@@ -70,18 +72,18 @@ class Metadata(
 
   def initClassMetadata(): Unit = {
     classes.foreach { node =>
-      vtable(node) = new VirtualTable(this, node)
-      layout(node) = new FieldLayout(this, node)
+      vtable(node) = new VirtualTable(node)
+      layout(node) = new FieldLayout(node)
       if (linked.dynsigs.nonEmpty) {
-        dynmap(node) = new DynamicHashMap(this, node, proxies)
+        dynmap(node) = new DynamicHashMap(node, proxies)
       }
-      rtti(node) = new RuntimeTypeInformation(this, node)
+      rtti(node) = new RuntimeTypeInformation(node)
     }
   }
 
   def initTraitMetadata(): Unit = {
     traits.foreach { node =>
-      rtti(node) = new RuntimeTypeInformation(this, node)
+      rtti(node) = new RuntimeTypeInformation(node)
     }
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/PlatformInfo.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PlatformInfo.scala
@@ -1,0 +1,21 @@
+package scala.scalanative.codegen
+
+import scala.scalanative.build.Config
+
+private[scalanative] case class PlatformInfo(
+    targetTriple: Option[String],
+    targetsWindows: Boolean,
+    is32Bit: Boolean,
+    isMultithreadingEnabled: Boolean
+) {
+  val sizeOfPtr = if (is32Bit) 4 else 8
+  val sizeOfPtrBits = sizeOfPtr * 8
+}
+object PlatformInfo {
+  def apply(config: Config): PlatformInfo = PlatformInfo(
+    targetTriple = config.compilerConfig.targetTriple,
+    targetsWindows = config.targetsWindows,
+    is32Bit = config.compilerConfig.is32BitPlatform,
+    isMultithreadingEnabled = config.compilerConfig.multithreadingSupport
+  )
+}

--- a/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
@@ -5,7 +5,7 @@ import scalanative.util.unreachable
 import scalanative.nir._
 import scalanative.linker.{ScopeInfo, Class, Trait}
 
-class RuntimeTypeInformation(meta: Metadata, info: ScopeInfo) {
+class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
   val name: Global = info.name.member(Sig.Generated("type"))
   val const: Val.Global = Val.Global(name, Type.Ptr)
   val struct: Type.StructValue = info match {

--- a/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 import scalanative.nir._
 import scalanative.nir.Rt._
 
-class VirtualTable(meta: Metadata, cls: linker.Class) {
+class VirtualTable(cls: linker.Class)(implicit meta: Metadata) {
   private val slots: mutable.UnrolledBuffer[Sig] =
     cls.parent.fold {
       mutable.UnrolledBuffer.empty[Sig]

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -479,13 +479,13 @@ trait Combine { self: Interflow =>
         Val.False
       case (Ule, lhs, v) if v.isUnsignedMaxValue =>
         Val.True
-      case (Sgt, lhs, v) if v.isSignedMaxValue(is32BitPlatform) =>
+      case (Sgt, lhs, v) if v.isSignedMaxValue(platform.is32Bit) =>
         Val.False
-      case (Sge, lhs, v) if v.isSignedMinValue(is32BitPlatform) =>
+      case (Sge, lhs, v) if v.isSignedMinValue(platform.is32Bit) =>
         Val.True
-      case (Slt, lhs, v) if v.isSignedMinValue(is32BitPlatform) =>
+      case (Slt, lhs, v) if v.isSignedMinValue(platform.is32Bit) =>
         Val.False
-      case (Sle, lhs, v) if v.isSignedMaxValue(is32BitPlatform) =>
+      case (Sle, lhs, v) if v.isSignedMaxValue(platform.is32Bit) =>
         Val.True
 
       // ((x xor y) == 0) ==> (x == y)

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -2,9 +2,10 @@ package scala.scalanative
 package interflow
 
 import scala.collection.mutable
-import scalanative.nir._
-import scalanative.linker._
-import scalanative.util.ScopedVar
+import scala.scalanative.codegen.PlatformInfo
+import scala.scalanative.nir._
+import scala.scalanative.linker._
+import scala.scalanative.util.ScopedVar
 import java.util.function.Supplier
 
 class Interflow(val config: build.Config)(implicit
@@ -18,6 +19,8 @@ class Interflow(val config: build.Config)(implicit
     with PolyInline
     with Intrinsics
     with Log {
+  implicit val platform: PlatformInfo = PlatformInfo(config)
+
   private val originals = {
     val out = mutable.Map.empty[Global, Defn]
     linked.defns.foreach { defn => out(defn.name) = defn }
@@ -148,7 +151,6 @@ class Interflow(val config: build.Config)(implicit
   }
 
   protected def mode: build.Mode = config.compilerConfig.mode
-  protected def is32BitPlatform: Boolean = config.compilerConfig.is32BitPlatform
 }
 
 object Interflow {

--- a/tools/src/main/scala/scala/scalanative/interflow/Whitelist.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Whitelist.scala
@@ -9,6 +9,10 @@ object Whitelist {
   val constantModules = {
     val out = collection.mutable.Set.empty[Global]
     out += Global.Top("scala.scalanative.runtime.BoxedUnit$")
+    out += Global.Top("scala.scalanative.runtime.MemoryLayout$")
+    out += Global.Top("scala.scalanative.runtime.MemoryLayout$Array$")
+    out += Global.Top("scala.scalanative.runtime.MemoryLayout$Object$")
+    out += Global.Top("scala.scalanative.runtime.MemoryLayout$Rtti$")
     out += Global.Top("scala.scalanative.unsafe.Tag$")
     out += Global.Top("scala.scalanative.unsafe.Tag$Unit$")
     out += Global.Top("scala.scalanative.unsafe.Tag$Boolean$")


### PR DESCRIPTION
* Information about memory layout for `ObjectHeader`, `ArrayHeader`, `Rtti`, `ClassRtti` is now centralized to a single file and calculated based on the `Metadata` 
* Magic values in tools are replaced with constants defined in layouts for mentioned types
* Defined `scala.scalanative.runtime.MemoryLayout` as a counterpart to the toolchain memory layout structure. The magic values used in code are replaced with pseudo-constants (functions that are always inlined, they shall be fully evaluated to constant by the optimizer)
* Added `codegen.PlatformInfo` containing platform specific information. It it used in `Interflow` and `CodeGen` to provide required metadata. It is implicitly used by `MemoryLayout` instead of explicit information about usage of 32bit architecture.