### PR TITLE
Define null guards for methods using `this`

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -38,29 +38,9 @@ final class Sig(val mangle: String) {
 
   final def isVirtual = !(isCtor || isClinit || isExtern)
   final def isPrivate: Boolean = privateIn.isDefined
-  final def isStatic: Boolean = {
-    def isPublicStatic = mangle.last == 'o'
-    def isPrivateStatic = {
-      val sigEnd = mangle.lastIndexOf('E')
-      val scopeIdx = sigEnd + 1
-      def hasScope = mangle.length() > scopeIdx
-      sigEnd > 0 && hasScope && mangle(sigEnd + 1) == 'p'
-    }
-    isPublicStatic || isPrivateStatic
-  }
-  final lazy val privateIn: Option[Global.Top] = {
-    val sigEnd = mangle.lastIndexOf('E')
-    val scopeIdx = sigEnd + 1
-    def hasScope = mangle.length() > scopeIdx
-    def isPrivate = {
-      val scopeIdent = mangle(scopeIdx)
-      scopeIdent == 'p' || scopeIdent == 'P'
-    }
-    if (sigEnd > 0 && hasScope && isPrivate) {
-      val global = Unmangle.unmangleGlobal(mangle.substring(sigEnd + 2))
-      Some(global.top)
-    } else None
-  }
+  final def isStatic: Boolean = unmangled.sigScope.isStatic
+  final lazy val privateIn: Option[Global.Top] =
+    unmangled.sigScope.privateIn.map(_.top)
 }
 object Sig {
   sealed abstract class Scope(

--- a/nir/src/main/scala/scala/scalanative/nir/Traverse.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Traverse.scala
@@ -1,0 +1,182 @@
+package scala.scalanative.nir
+
+trait Traverse {
+  def onDefns(defns: Iterable[Defn]): Unit = defns.foreach(onDefn)
+
+  def onDefn(defn: Defn): Unit = {
+    defn match {
+      case Defn.Var(_, _, ty, value) =>
+        onType(ty)
+        onVal(value)
+      case Defn.Const(_, _, ty, value) =>
+        onType(ty)
+        onVal(value)
+      case Defn.Declare(_, _, ty) =>
+        onType(ty)
+      case Defn.Define(_, _, ty, insts) =>
+        onInsts(insts)
+      case Defn.Trait(_, _, _)     => ()
+      case Defn.Class(_, _, _, _)  => ()
+      case Defn.Module(_, _, _, _) => ()
+    }
+  }
+
+  def onInsts(insts: Iterable[Inst]): Unit =
+    insts.foreach(onInst)
+
+  def onInst(inst: Inst): Unit = {
+    inst match {
+      case Inst.Label(n, params) =>
+        params.foreach { param =>
+          onType(param.ty)
+        }
+      case Inst.Let(n, op, unwind) =>
+        onOp(op)
+        onNext(unwind)
+      case Inst.Ret(v)     => onVal(v)
+      case Inst.Jump(next) => onNext(next)
+      case Inst.If(v, thenp, elsep) =>
+        onVal(v)
+        onNext(thenp)
+        onNext(elsep)
+      case Inst.Switch(v, default, cases) =>
+        onVal(v)
+        onNext(default)
+        cases.foreach(onNext)
+      case Inst.Throw(v, unwind) =>
+        onVal(v)
+        onNext(unwind)
+      case Inst.Unreachable(unwind) =>
+        onNext(unwind)
+      case _: Inst.LinktimeCf =>
+        ()
+    }
+  }
+
+  def onOp(op: Op): Unit = op match {
+    case Op.Call(ty, ptrv, argvs) =>
+      onType(ty)
+      onVal(ptrv)
+      argvs.foreach(onVal)
+    case Op.Load(ty, ptrv, sync) =>
+      onType(ty)
+      onVal(ptrv)
+    case Op.Store(ty, ptrv, v, sync) =>
+      onType(ty)
+      onVal(ptrv)
+      onVal(v)
+    case Op.Elem(ty, ptrv, indexvs) =>
+      onType(ty)
+      onVal(ptrv)
+      indexvs.foreach(onVal)
+    case Op.Extract(aggrv, indexvs) =>
+      onVal(aggrv)
+    case Op.Insert(aggrv, v, indexvs) =>
+      onVal(aggrv)
+      onVal(v)
+    case Op.Stackalloc(ty, v) =>
+      onType(ty)
+      onVal(v)
+    case Op.Bin(bin, ty, lv, rv) =>
+      onType(ty)
+      onVal(lv)
+      onVal(rv)
+    case Op.Comp(comp, ty, lv, rv) =>
+      onType(ty)
+      onVal(lv)
+      onVal(rv)
+    case Op.Conv(conv, ty, v) =>
+      onType(ty)
+      onVal(v)
+
+    case Op.Classalloc(n) => ()
+    case Op.Fieldload(ty, v, n) =>
+      onType(ty)
+      onVal(v)
+    case Op.Fieldstore(ty, v1, n, v2) =>
+      onType(ty)
+      onVal(v1)
+      onVal(v2)
+    case Op.Field(v, n) =>
+      onVal(v)
+    case Op.Method(v, n) =>
+      onVal(v)
+    case Op.Dynmethod(obj, signature) =>
+      onVal(obj)
+    case Op.Module(n) => ()
+    case Op.As(ty, v) =>
+      onType(ty)
+      onVal(v)
+    case Op.Is(ty, v) =>
+      onType(ty)
+      onVal(v)
+    case Op.Copy(v) =>
+      onVal(v)
+    case Op.Sizeof(ty) =>
+      onType(ty)
+    case Op.Box(code, obj) =>
+      onVal(obj)
+    case Op.Unbox(code, obj) =>
+      onVal(obj)
+    case Op.Var(ty) =>
+      onType(ty)
+    case Op.Varload(elem) =>
+      onVal(elem)
+    case Op.Varstore(elem, value) =>
+      onVal(elem)
+      onVal(value)
+    case Op.Arrayalloc(ty, init) =>
+      onType(ty)
+      onVal(init)
+    case Op.Arrayload(ty, arr, idx) =>
+      onType(ty)
+      onVal(arr)
+      onVal(idx)
+    case Op.Arraystore(ty, arr, idx, value) =>
+      onType(ty)
+      onVal(arr)
+      onVal(idx)
+      onVal(value)
+    case Op.Arraylength(arr) =>
+      onVal(arr)
+    case Op.Fence(_) =>
+      ()
+  }
+
+  def onVal(value: Val): Unit = value match {
+    case Val.Zero(ty)            => onType(ty)
+    case Val.StructValue(values) => values.foreach(onVal)
+    case Val.ArrayValue(ty, values) =>
+      onType(ty)
+      values.foreach(onVal)
+    case Val.Local(n, ty)  => onType(ty)
+    case Val.Global(n, ty) => onType(ty)
+    case Val.Const(v)      => onVal(v)
+    case _                 => ()
+  }
+
+  def onType(ty: Type): Unit = ty match {
+    case Type.ArrayValue(ty, n) =>
+      onType(ty)
+    case Type.Function(args, ty) =>
+      args.foreach(onType)
+      onType(ty)
+    case Type.StructValue(tys) =>
+      tys.foreach(onType)
+    case Type.Var(ty) =>
+      onType(ty)
+    case Type.Array(ty, nullable) =>
+      onType(ty)
+    case _ =>
+      ()
+  }
+
+  def onNext(next: Next): Unit = next match {
+    case Next.None => ()
+    case Next.Case(v, n) =>
+      onVal(v)
+      onNext(n)
+    case Next.Unwind(n, next) => onNext(next)
+    case Next.Label(n, args)  => args.foreach(onVal)
+  }
+}

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -76,6 +76,17 @@ class Scala3IssuesTest:
     assertEquals("42", q.baz(21))
   }
 
+  @Test def issue3014(): Unit = {
+    import scala.issues.issue3014._
+    def useUnit(unit: TimeUnit): Long = {
+      // Was throwing `MatchError` when calling `toNanos`
+      unit.toNanos(1L)
+    }
+
+    assertEquals(1L, useUnit(TimeUnit.Nanos))
+    assertThrows(classOf[NullPointerException], () => useUnit(null))
+  }
+
 end Scala3IssuesTest
 
 private object issue2484 {
@@ -96,5 +107,17 @@ private object issue2484 {
 
   trait Functor[F[_]] {
     def map[A, B](fa: F[A])(f: A => B): F[B]
+  }
+}
+
+private object issue3014 {
+  enum TimeUnit {
+    case Millis
+    case Nanos
+
+    def toNanos(value: Long): Long = this match {
+      case Millis => value * 1000000
+      case Nanos  => value
+    }
   }
 }


### PR DESCRIPTION
In multiple functions `this` value is replaced with simple `null`, eg. stor statics. However, there are cases in which we can produce code using `this` without checking if it's not null. It can lead to unexpected behaviour, e.g. matching on `this` could result in `MatchException` instead of expected `NullPointerException`

Fixes #3014

* Added utility for traversal of `nir` structures
* Added null guards for methods using `this` in function body. No check would be emmited for function which does not take or use `this` value to not produce additional overhead
* Fixed resolving of static and private function in Sig. Parsing of the name, was replaced with more stable unmangling of the whole symbol.