### PR TITLE
Port all missing `java.util.function` types

### DIFF
--- a/javalib/src/main/scala/java/util/function/BiConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/BiConsumer.scala
@@ -1,17 +1,11 @@
-// Ported from Scala.js commit: f86ed6 c2f5a43 dated: 2020-09-06
-
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 trait BiConsumer[T, U] {
-  self =>
-
   def accept(t: T, u: U): Unit
 
-  def andThen(after: BiConsumer[T, U]): BiConsumer[T, U] =
-    new BiConsumer[T, U]() {
-      override def accept(t: T, u: U): Unit = {
-        self.accept(t, u)
-        after.accept(t, u)
-      }
-    }
+  def andThen(after: BiConsumer[T, U]): BiConsumer[T, U] = { (t: T, u: U) =>
+    accept(t, u)
+    after.accept(t, u)
+  }
 }

--- a/javalib/src/main/scala/java/util/function/BiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/BiFunction.scala
@@ -1,13 +1,11 @@
-// Ported from Scala.js commit:  d3a9711 dated: 2020-09-06
-
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
-trait BiFunction[T, U, R] { self =>
+trait BiFunction[T, U, R] {
   def apply(t: T, u: U): R
 
   def andThen[V](after: Function[_ >: R, _ <: V]): BiFunction[T, U, V] = {
-    new BiFunction[T, U, V] {
-      def apply(t: T, u: U): V = after.apply(self.apply(t, u))
-    }
+    (t: T, u: U) =>
+      after.apply(this.apply(t, u))
   }
 }

--- a/javalib/src/main/scala/java/util/function/BiPredicate.scala
+++ b/javalib/src/main/scala/java/util/function/BiPredicate.scala
@@ -1,25 +1,18 @@
-// Ported from Scala.js commit: 0c27b64 dated: 2020-09-06
-
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
-trait BiPredicate[T, U] { self =>
+trait BiPredicate[T, U] {
   def test(t: T, u: U): Boolean
 
-  def and(other: BiPredicate[_ >: T, _ >: U]): BiPredicate[T, U] =
-    new BiPredicate[T, U] {
-      override def test(t: T, u: U): Boolean =
-        self.test(t, u) && other.test(t, u)
-    }
+  def and(other: BiPredicate[_ >: T, _ >: U]): BiPredicate[T, U] = {
+    (t: T, u: U) =>
+      test(t, u) && other.test(t, u)
+  }
 
-  def negate(): BiPredicate[T, U] =
-    new BiPredicate[T, U] {
-      override def test(t: T, u: U): Boolean =
-        !self.test(t, u)
-    }
+  def negate(): BiPredicate[T, U] = (t: T, u: U) => !test(t, u)
 
-  def or(other: BiPredicate[_ >: T, _ >: U]): BiPredicate[T, U] =
-    new BiPredicate[T, U] {
-      override def test(t: T, u: U): Boolean =
-        self.test(t, u) || other.test(t, u)
-    }
+  def or(other: BiPredicate[_ >: T, _ >: U]): BiPredicate[T, U] = {
+    (t: T, u: U) =>
+      test(t, u) || other.test(t, u)
+  }
 }

--- a/javalib/src/main/scala/java/util/function/BinaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/BinaryOperator.scala
@@ -1,24 +1,20 @@
+// Ported from Scala.js, commit SHA: 1ef4c4e0f dated: 2020-09-06
 package java.util.function
 
-import java.util.{Comparator, Objects}
+import java.util.Comparator
 
-trait BinaryOperator[T] extends BiFunction[T, T, T] { self => }
+trait BinaryOperator[T] extends BiFunction[T, T, T]
 
 object BinaryOperator {
-
   def minBy[T](comparator: Comparator[_ >: T]): BinaryOperator[T] = {
-    Objects.requireNonNull(comparator)
-    new BinaryOperator[T] {
-      override def apply(a: T, b: T): T =
-        if (comparator.compare(a, b) <= 0) a else b
-    }
+    (a: T, b: T) =>
+      if (comparator.compare(a, b) <= 0) a
+      else b
   }
 
   def maxBy[T](comparator: Comparator[_ >: T]): BinaryOperator[T] = {
-    Objects.requireNonNull(comparator)
-    new BinaryOperator[T] {
-      override def apply(a: T, b: T): T =
-        if (comparator.compare(a, b) >= 0) a else b
-    }
+    (a: T, b: T) =>
+      if (comparator.compare(a, b) >= 0) a
+      else b
   }
 }

--- a/javalib/src/main/scala/java/util/function/BooleanSupplier.scala
+++ b/javalib/src/main/scala/java/util/function/BooleanSupplier.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+// Ported from Scala.js, commit SHA: db63dabed dated: 2020-10-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/BooleanSupplier.scala
+++ b/javalib/src/main/scala/java/util/function/BooleanSupplier.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+package java.util.function
+
+@FunctionalInterface
+trait BooleanSupplier {
+  def getAsBoolean(): Boolean
+}

--- a/javalib/src/main/scala/java/util/function/Consumer.scala
+++ b/javalib/src/main/scala/java/util/function/Consumer.scala
@@ -1,12 +1,16 @@
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
+@FunctionalInterface
 trait Consumer[T] { self =>
   def accept(t: T): Unit
 
-  def andThen(after: Consumer[T]): Consumer[T] = new Consumer[T]() {
-    def accept(t: T): Unit = {
-      self.accept(t)
-      after.accept(t)
+  def andThen(after: Consumer[_ >: T]): Consumer[T] = {
+    new Consumer[T] {
+      def accept(t: T): Unit = {
+        self.accept(t)
+        after.accept(t)
+      }
     }
   }
 }

--- a/javalib/src/main/scala/java/util/function/DoubleBinaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleBinaryOperator.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait DoubleBinaryOperator {
+  def applyAsDouble(left: Double, right: Double): Double
+}

--- a/javalib/src/main/scala/java/util/function/DoubleBinaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleBinaryOperator.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/DoubleConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleConsumer.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/DoubleConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleConsumer.scala
@@ -1,0 +1,12 @@
+// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait DoubleConsumer {
+  def accept(value: Double): Unit
+
+  def andThen(after: DoubleConsumer): DoubleConsumer = { (value: Double) =>
+    this.accept(value)
+    after.accept(value)
+  }
+}

--- a/javalib/src/main/scala/java/util/function/DoubleFunction.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait DoubleFunction[R] {
+  def apply(value: Double): R
+}

--- a/javalib/src/main/scala/java/util/function/DoubleFunction.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/DoublePredicate.scala
+++ b/javalib/src/main/scala/java/util/function/DoublePredicate.scala
@@ -1,0 +1,28 @@
+// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait DoublePredicate { self =>
+  def test(t: Double): Boolean
+
+  def and(other: DoublePredicate): DoublePredicate = {
+    new DoublePredicate {
+      def test(value: Double): Boolean =
+        self.test(value) && other.test(value) // the order and short-circuit are by-spec
+    }
+  }
+
+  def negate(): DoublePredicate = {
+    new DoublePredicate {
+      def test(value: Double): Boolean =
+        !self.test(value)
+    }
+  }
+
+  def or(other: DoublePredicate): DoublePredicate = {
+    new DoublePredicate {
+      def test(value: Double): Boolean =
+        self.test(value) || other.test(value) // the order and short-circuit are by-spec
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/function/DoublePredicate.scala
+++ b/javalib/src/main/scala/java/util/function/DoublePredicate.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface
@@ -8,7 +8,8 @@ trait DoublePredicate { self =>
   def and(other: DoublePredicate): DoublePredicate = {
     new DoublePredicate {
       def test(value: Double): Boolean =
-        self.test(value) && other.test(value) // the order and short-circuit are by-spec
+        // the order and short-circuit are by-spec
+        self.test(value) && other.test(value)
     }
   }
 
@@ -22,7 +23,8 @@ trait DoublePredicate { self =>
   def or(other: DoublePredicate): DoublePredicate = {
     new DoublePredicate {
       def test(value: Double): Boolean =
-        self.test(value) || other.test(value) // the order and short-circuit are by-spec
+        // the order and short-circuit are by-spec
+        self.test(value) || other.test(value)
     }
   }
 }

--- a/javalib/src/main/scala/java/util/function/DoubleSupplier.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleSupplier.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+// Ported from Scala.js, commit SHA: db63dabed dated: 2020-10-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/DoubleSupplier.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleSupplier.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+package java.util.function
+
+@FunctionalInterface
+trait DoubleSupplier {
+  def getAsDouble(): Double
+}

--- a/javalib/src/main/scala/java/util/function/DoubleToIntFunction.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleToIntFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait DoubleToIntFunction {
+  def applyAsInt(value: Double): Int
+}

--- a/javalib/src/main/scala/java/util/function/DoubleToIntFunction.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleToIntFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/DoubleToLongFunction.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleToLongFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait DoubleToLongFunction {
+  def applyAsLong(value: Double): Long
+}

--- a/javalib/src/main/scala/java/util/function/DoubleToLongFunction.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleToLongFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/DoubleUnaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleUnaryOperator.scala
@@ -1,0 +1,19 @@
+// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait DoubleUnaryOperator {
+  def applyAsDouble(operand: Double): Double
+
+  def andThen(after: DoubleUnaryOperator): DoubleUnaryOperator = { (d: Double) =>
+    after.applyAsDouble(applyAsDouble(d))
+  }
+
+  def compose(before: DoubleUnaryOperator): DoubleUnaryOperator = { (d: Double) =>
+    applyAsDouble(before.applyAsDouble(d))
+  }
+}
+
+object DoubleUnaryOperator {
+  def identity(): DoubleUnaryOperator = (d: Double) => d
+}

--- a/javalib/src/main/scala/java/util/function/DoubleUnaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/DoubleUnaryOperator.scala
@@ -1,16 +1,18 @@
-// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface
 trait DoubleUnaryOperator {
   def applyAsDouble(operand: Double): Double
 
-  def andThen(after: DoubleUnaryOperator): DoubleUnaryOperator = { (d: Double) =>
-    after.applyAsDouble(applyAsDouble(d))
+  def andThen(after: DoubleUnaryOperator): DoubleUnaryOperator = {
+    (d: Double) =>
+      after.applyAsDouble(applyAsDouble(d))
   }
 
-  def compose(before: DoubleUnaryOperator): DoubleUnaryOperator = { (d: Double) =>
-    applyAsDouble(before.applyAsDouble(d))
+  def compose(before: DoubleUnaryOperator): DoubleUnaryOperator = {
+    (d: Double) =>
+      applyAsDouble(before.applyAsDouble(d))
   }
 }
 

--- a/javalib/src/main/scala/java/util/function/Function.scala
+++ b/javalib/src/main/scala/java/util/function/Function.scala
@@ -1,24 +1,18 @@
-// Ported from Scala.js commit: eb637e3 dated: 2020-09-06
-
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
-trait Function[T, R] { self =>
+trait Function[T, R] {
   def apply(t: T): R
 
-  def andThen[V](after: Function[_ >: R, _ <: V]): Function[T, V] =
-    new Function[T, V] {
-      override def apply(t: T): V = after.apply(self.apply(t))
-    }
+  def andThen[V](after: Function[_ >: R, _ <: V]): Function[T, V] = { (t: T) =>
+    after.apply(apply(t))
+  }
 
-  def compose[V](before: Function[_ >: V, _ <: T]): Function[V, R] =
-    new Function[V, R] {
-      override def apply(v: V): R = self.apply(before.apply(v))
-    }
+  def compose[V](before: Function[_ >: V, _ <: T]): Function[V, R] = { (v: V) =>
+    apply(before.apply(v))
+  }
 }
 
 object Function {
-  def identity[T](): Function[T, T] =
-    new Function[T, T] {
-      override def apply(t: T): T = t
-    }
+  def identity[T](): Function[T, T] = (t: T) => t
 }

--- a/javalib/src/main/scala/java/util/function/IntBinaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/IntBinaryOperator.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait IntBinaryOperator {
+  def applyAsInt(left: Int, right: Int): Int
+}

--- a/javalib/src/main/scala/java/util/function/IntBinaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/IntBinaryOperator.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/IntConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/IntConsumer.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/IntConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/IntConsumer.scala
@@ -1,0 +1,12 @@
+// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait IntConsumer {
+  def accept(value: Int): Unit
+
+  def andThen(after: IntConsumer): IntConsumer = { (value: Int) =>
+    this.accept(value)
+    after.accept(value)
+  }
+}

--- a/javalib/src/main/scala/java/util/function/IntFunction.scala
+++ b/javalib/src/main/scala/java/util/function/IntFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/IntFunction.scala
+++ b/javalib/src/main/scala/java/util/function/IntFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait IntFunction[R] {
+  def apply(value: Int): R
+}

--- a/javalib/src/main/scala/java/util/function/IntPredicate.scala
+++ b/javalib/src/main/scala/java/util/function/IntPredicate.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface
@@ -8,7 +8,8 @@ trait IntPredicate { self =>
   def and(other: IntPredicate): IntPredicate = {
     new IntPredicate {
       def test(value: Int): Boolean =
-        self.test(value) && other.test(value) // the order and short-circuit are by-spec
+        // the order and short-circuit are by-spec
+        self.test(value) && other.test(value)
     }
   }
 
@@ -22,7 +23,8 @@ trait IntPredicate { self =>
   def or(other: IntPredicate): IntPredicate = {
     new IntPredicate {
       def test(value: Int): Boolean =
-        self.test(value) || other.test(value) // the order and short-circuit are by-spec
+        // the order and short-circuit are by-spec
+        self.test(value) || other.test(value)
     }
   }
 }

--- a/javalib/src/main/scala/java/util/function/IntPredicate.scala
+++ b/javalib/src/main/scala/java/util/function/IntPredicate.scala
@@ -1,0 +1,28 @@
+// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait IntPredicate { self =>
+  def test(t: Int): Boolean
+
+  def and(other: IntPredicate): IntPredicate = {
+    new IntPredicate {
+      def test(value: Int): Boolean =
+        self.test(value) && other.test(value) // the order and short-circuit are by-spec
+    }
+  }
+
+  def negate(): IntPredicate = {
+    new IntPredicate {
+      def test(value: Int): Boolean =
+        !self.test(value)
+    }
+  }
+
+  def or(other: IntPredicate): IntPredicate = {
+    new IntPredicate {
+      def test(value: Int): Boolean =
+        self.test(value) || other.test(value) // the order and short-circuit are by-spec
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/function/IntSupplier.scala
+++ b/javalib/src/main/scala/java/util/function/IntSupplier.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+package java.util.function
+
+@FunctionalInterface
+trait IntSupplier {
+  def getAsInt(): Int
+}

--- a/javalib/src/main/scala/java/util/function/IntSupplier.scala
+++ b/javalib/src/main/scala/java/util/function/IntSupplier.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+// Ported from Scala.js, commit SHA: db63dabed dated: 2020-10-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/IntToDoubleFunction.scala
+++ b/javalib/src/main/scala/java/util/function/IntToDoubleFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait IntToDoubleFunction {
+  def applyAsDouble(value: Int): Double
+}

--- a/javalib/src/main/scala/java/util/function/IntToDoubleFunction.scala
+++ b/javalib/src/main/scala/java/util/function/IntToDoubleFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/IntToLongFunction.scala
+++ b/javalib/src/main/scala/java/util/function/IntToLongFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait IntToLongFunction {
+  def applyAsLong(value: Int): Long
+}

--- a/javalib/src/main/scala/java/util/function/IntToLongFunction.scala
+++ b/javalib/src/main/scala/java/util/function/IntToLongFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/IntUnaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/IntUnaryOperator.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: d028054 dated: 2022-05-16
-
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/LongBinaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/LongBinaryOperator.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/LongBinaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/LongBinaryOperator.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait LongBinaryOperator {
+  def applyAsLong(left: Long, right: Long): Long
+}

--- a/javalib/src/main/scala/java/util/function/LongConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/LongConsumer.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/LongConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/LongConsumer.scala
@@ -1,0 +1,12 @@
+// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait LongConsumer {
+  def accept(value: Long): Unit
+
+  def andThen(after: LongConsumer): LongConsumer = { (value: Long) =>
+    this.accept(value)
+    after.accept(value)
+  }
+}

--- a/javalib/src/main/scala/java/util/function/LongFunction.scala
+++ b/javalib/src/main/scala/java/util/function/LongFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait LongFunction[R] {
+  def apply(value: Long): R
+}

--- a/javalib/src/main/scala/java/util/function/LongFunction.scala
+++ b/javalib/src/main/scala/java/util/function/LongFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/LongPredicate.scala
+++ b/javalib/src/main/scala/java/util/function/LongPredicate.scala
@@ -1,0 +1,28 @@
+// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait LongPredicate { self =>
+  def test(t: Long): Boolean
+
+  def and(other: LongPredicate): LongPredicate = {
+    new LongPredicate {
+      def test(value: Long): Boolean =
+        self.test(value) && other.test(value) // the order and short-circuit are by-spec
+    }
+  }
+
+  def negate(): LongPredicate = {
+    new LongPredicate {
+      def test(value: Long): Boolean =
+        !self.test(value)
+    }
+  }
+
+  def or(other: LongPredicate): LongPredicate = {
+    new LongPredicate {
+      def test(value: Long): Boolean =
+        self.test(value) || other.test(value) // the order and short-circuit are by-spec
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/function/LongPredicate.scala
+++ b/javalib/src/main/scala/java/util/function/LongPredicate.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface
@@ -8,7 +8,8 @@ trait LongPredicate { self =>
   def and(other: LongPredicate): LongPredicate = {
     new LongPredicate {
       def test(value: Long): Boolean =
-        self.test(value) && other.test(value) // the order and short-circuit are by-spec
+        // the order and short-circuit are by-spec
+        self.test(value) && other.test(value)
     }
   }
 
@@ -22,7 +23,8 @@ trait LongPredicate { self =>
   def or(other: LongPredicate): LongPredicate = {
     new LongPredicate {
       def test(value: Long): Boolean =
-        self.test(value) || other.test(value) // the order and short-circuit are by-spec
+        // the order and short-circuit are by-spec
+        self.test(value) || other.test(value)
     }
   }
 }

--- a/javalib/src/main/scala/java/util/function/LongSupplier.scala
+++ b/javalib/src/main/scala/java/util/function/LongSupplier.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+package java.util.function
+
+@FunctionalInterface
+trait LongSupplier {
+  def getAsLong(): Long
+}

--- a/javalib/src/main/scala/java/util/function/LongSupplier.scala
+++ b/javalib/src/main/scala/java/util/function/LongSupplier.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+// Ported from Scala.js, commit SHA: db63dabed dated: 2020-10-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/LongToDoubleFunction.scala
+++ b/javalib/src/main/scala/java/util/function/LongToDoubleFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait LongToDoubleFunction {
+  def applyAsDouble(value: Long): Double
+}

--- a/javalib/src/main/scala/java/util/function/LongToDoubleFunction.scala
+++ b/javalib/src/main/scala/java/util/function/LongToDoubleFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/LongToIntFunction.scala
+++ b/javalib/src/main/scala/java/util/function/LongToIntFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait LongToIntFunction {
+  def applyAsInt(value: Long): Int
+}

--- a/javalib/src/main/scala/java/util/function/LongToIntFunction.scala
+++ b/javalib/src/main/scala/java/util/function/LongToIntFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/LongUnaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/LongUnaryOperator.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/LongUnaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/LongUnaryOperator.scala
@@ -1,0 +1,19 @@
+// Ported from Scala.js, commit sha:7b4e8a80b dated:2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait LongUnaryOperator {
+  def applyAsLong(operand: Long): Long
+
+  def andThen(after: LongUnaryOperator): LongUnaryOperator = { (l: Long) =>
+    after.applyAsLong(applyAsLong(l))
+  }
+
+  def compose(before: LongUnaryOperator): LongUnaryOperator = { (l: Long) =>
+    applyAsLong(before.applyAsLong(l))
+  }
+}
+
+object LongUnaryOperator {
+  def identity(): LongUnaryOperator = (l: Long) => l
+}

--- a/javalib/src/main/scala/java/util/function/ObjDoubleConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/ObjDoubleConsumer.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait ObjDoubleConsumer[T] {
+  def accept(t: T, value: Double): Unit
+}

--- a/javalib/src/main/scala/java/util/function/ObjDoubleConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/ObjDoubleConsumer.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/ObjIntConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/ObjIntConsumer.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait ObjIntConsumer[T] {
+  def accept(t: T, value: Int): Unit
+}

--- a/javalib/src/main/scala/java/util/function/ObjIntConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/ObjIntConsumer.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/ObjLongConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/ObjLongConsumer.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait ObjLongConsumer[T] {
+  def accept(t: T, value: Long): Unit
+}

--- a/javalib/src/main/scala/java/util/function/ObjLongConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/ObjLongConsumer.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/Predicate.scala
+++ b/javalib/src/main/scala/java/util/function/Predicate.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: 137c11d dated: 2019-07-03
-
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
 import java.{util => ju}

--- a/javalib/src/main/scala/java/util/function/Supplier.scala
+++ b/javalib/src/main/scala/java/util/function/Supplier.scala
@@ -1,3 +1,4 @@
+// Ported from Scala.js, commit SHA: 5df5a4142 dated: 2020-09-06
 package java.util.function
 
 trait Supplier[T] {

--- a/javalib/src/main/scala/java/util/function/ToDoubleBiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToDoubleBiFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait ToDoubleBiFunction[T, U] {
+  def applyAsDouble(t: T, u: U): Double
+}

--- a/javalib/src/main/scala/java/util/function/ToDoubleBiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToDoubleBiFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/ToDoubleFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToDoubleFunction.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit 00e462d dated: 2023-01-22
-
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/ToIntBiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToIntBiFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait ToIntBiFunction[T, U] {
+  def applyAsInt(t: T, u: U): Int
+}

--- a/javalib/src/main/scala/java/util/function/ToIntBiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToIntBiFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/ToIntFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToIntFunction.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit 00e462d dated: 2023-01-22
-
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/ToLongBiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToLongBiFunction.scala
@@ -1,0 +1,7 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package java.util.function
+
+@FunctionalInterface
+trait ToLongBiFunction[T, U] {
+  def applyAsLong(t: T, u: U): Long
+}

--- a/javalib/src/main/scala/java/util/function/ToLongBiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToLongBiFunction.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/ToLongFunction.scala
+++ b/javalib/src/main/scala/java/util/function/ToLongFunction.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit 00e462d dated: 2023-01-22
-
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package java.util.function
 
 @FunctionalInterface

--- a/javalib/src/main/scala/java/util/function/UnaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/UnaryOperator.scala
@@ -1,10 +1,8 @@
+// Ported from Scala.js, commit SHA: 4a394815e dated: 2020-09-06
 package java.util.function
 
-trait UnaryOperator[T] extends Function[T, T] { self => }
+trait UnaryOperator[T] extends Function[T, T]
 
 object UnaryOperator {
-  def identity[T](): UnaryOperator[T] =
-    new UnaryOperator[T] {
-      override def apply(t: T): T = t
-    }
+  def identity[T](): UnaryOperator[T] = (t: T) => t
 }

--- a/scripts/portScalaJsSource.scala
+++ b/scripts/portScalaJsSource.scala
@@ -21,7 +21,7 @@ import scala.util.chaining.scalaUtilChainingOps
   val snPath = scalaNativeAbsPath / relPath
 
   def getShortSha(sjsFile: os.Path): String =
-    val format = "// Ported from Scala.js, commit sha:%h dated:%as"
+    val format = "// Ported from Scala.js, commit SHA: %h dated: %as"
     val out = os
       .proc("git", "log", "-n1", s"--pretty=format:${format}", sjsFile)
       .call(cwd = scalaJSAbsPath, check = true, stdout = os.Pipe)
@@ -52,6 +52,7 @@ import scala.util.chaining.scalaUtilChainingOps
       .read(sjsPath)
       .pipe(stripHeader)
     os.write.append(snPath, sjsSource)
+    os.write.append(snPath, System.lineSeparator())
 
 private def stripHeader(input: String) = {
   val nl = System.lineSeparator()

--- a/scripts/portScalaJsSource.scala
+++ b/scripts/portScalaJsSource.scala
@@ -1,0 +1,77 @@
+#!/usr/bin/env -S scala-cli shebang
+//> using lib "org.virtuslab::toolkit-alpha::0.1.13"
+//> using scala "3.2"
+
+// Combine with bash loop
+// SJSPath="sjs-abs-path/unit-tests/shared/src/test/scala/org/scalanative"
+// SNPath="sn-abs-path  /test-suite/shared/src/test/scala/org/scalajs"
+// for file in $(ls ${SJSPath}/javalib/util/function/* ); do
+//   ./scripts/portScalaJsSource.scala $SNPath $SJSPath $file;
+// done
+
+import scala.util.chaining.scalaUtilChainingOps
+
+@main def portScalaJSSource(
+    scalaNativeAbsPath: os.Path,
+    scalaJSAbsPath: os.Path,
+    fileAbsPath: os.Path
+) =
+  val relPath = fileAbsPath.relativeTo(scalaJSAbsPath)
+  val sjsPath = scalaJSAbsPath / relPath
+  val snPath = scalaNativeAbsPath / relPath
+
+  def getShortSha(sjsFile: os.Path): String =
+    val format = "// Ported from Scala.js, commit sha:%h dated:%as"
+    val out = os
+      .proc("git", "log", "-n1", s"--pretty=format:${format}", sjsFile)
+      .call(cwd = scalaJSAbsPath, check = true, stdout = os.Pipe)
+    out.out.text()
+
+  println(s"""
+  |ScalaNative base dir: $scalaNativeAbsPath
+  |ScalaJS     base dir: $scalaJSAbsPath
+  |Rel path:             ${relPath}       
+  |Porting ${sjsPath} into ${snPath}
+  """.stripMargin)
+
+  assert(
+    os.exists(scalaNativeAbsPath),
+    "Scala Native directory does not exist"
+  )
+  assert(
+    os.exists(scalaNativeAbsPath),
+    "Scala JS directory does not exists"
+  )
+  assert(os.exists(sjsPath), s"ScalaJS file does not exits ${sjsPath}")
+  if os.exists(snPath)
+  then println(s"ScalaNative file alread exists ${snPath}, skipping")
+  else
+    val revisionMessage = getShortSha(sjsPath)
+    os.write(snPath, revisionMessage + "\n", createFolders = true)
+    val sjsSource = os
+      .read(sjsPath)
+      .pipe(stripHeader)
+    os.write.append(snPath, sjsSource)
+
+private def stripHeader(input: String) = {
+  val nl = System.lineSeparator()
+  val commentsCtrl = Seq("/*", "*/", "*", "//")
+  input
+    .split(nl)
+    .dropWhile { line =>
+      val trimmed = line.trim()
+      trimmed.isEmpty || commentsCtrl.exists(trimmed.startsWith(_))
+    }
+    .mkString(nl)
+}
+
+import scala.util.CommandLineParser.FromString
+private given FromString[os.Path] = { str =>
+  val nio = java.nio.file.Paths.get(str)
+  os.Path(nio.toRealPath())
+}
+
+private given FromString[os.RelPath] = { str =>
+  val nio = java.nio.file.Paths.get(str)
+  os.RelPath(nio)
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BiConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BiConsumerTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: c2f5a43 dated: 2020-09-06
-
+// Ported from Scala.js, commit SHA: c473689c9 dated: 2021-05-03
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.BiConsumer
@@ -77,11 +76,13 @@ object BiConsumerTest {
       extends Exception(s"throwing consumer called with ($x, $y)")
 
   private val throwingConsumer: BiConsumer[Int, Int] = makeBiConsumer {
-    (t, u) => throw new ThrowingConsumerException(t, u)
+    (t, u) =>
+      throw new ThrowingConsumerException(t, u)
   }
 
   private val dontCallConsumer: BiConsumer[Int, Int] = makeBiConsumer {
-    (t, u) => throw new AssertionError(s"dontCallConsumer.accept($t, $u)")
+    (t, u) =>
+      throw new AssertionError(s"dontCallConsumer.accept($t, $u)")
   }
 
   def makeBiConsumer[T, U](f: (T, U) => Unit): BiConsumer[T, U] = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BiFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BiFunctionTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: d3a9711 dated: 2020-09-06
-
+// Ported from Scala.js, commit SHA: cbf86bbb8 dated: 2020-10-23
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.{Function, BiFunction}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BiPredicateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BiPredicateTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: 0c27b64 dated: 2020-09-06
-
+// Ported from Scala.js, commit SHA: c473689c9 dated: 2021-05-03
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.BiPredicate
@@ -90,11 +89,13 @@ object BiPredicateTest {
   }
 
   private val throwingPredicate: BiPredicate[Int, Int] = makeBiPredicate {
-    (t, _) => throw new ThrowingPredicateException(t)
+    (t, _) =>
+      throw new ThrowingPredicateException(t)
   }
 
   private val dontCallPredicate: BiPredicate[Int, Int] = makeBiPredicate {
-    (t, u) => throw new AssertionError(s"dontCallPredicate.test($t, $u)")
+    (t, u) =>
+      throw new AssertionError(s"dontCallPredicate.test($t, $u)")
   }
 
   private[this] def makeBiPredicate[T, U](

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BinaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BinaryOperatorTest.scala
@@ -1,23 +1,19 @@
+// Ported from Scala.js, commit SHA: 1ef4c4e0f dated: 2020-09-06
 package org.scalanative.testsuite.javalib.util.function
 
-import java.util.function._
-import java.util.Collections
+import java.util.function.BinaryOperator
 
-import org.junit.Test
 import org.junit.Assert._
+import org.junit.Test
 
 class BinaryOperatorTest {
-  @Test def testMinBy(): Unit = {
-    val binaryOperator = BinaryOperator.minBy[Int](Collections.reverseOrder())
-    val min = binaryOperator.apply(2004, 2018)
-
-    assertTrue(min == 2018)
+  @Test def minBy(): Unit = {
+    val binOp: BinaryOperator[Int] = BinaryOperator.minBy(Ordering[Int])
+    assertEquals(10, binOp.apply(10, 20))
   }
 
-  @Test def testMaxBy(): Unit = {
-    val binaryOperator = BinaryOperator.maxBy[Int](Collections.reverseOrder())
-    val max = binaryOperator.apply(2004, 2018)
-
-    assertTrue(max == 2004)
+  @Test def maxBy(): Unit = {
+    val binOp: BinaryOperator[Int] = BinaryOperator.maxBy(Ordering[Int])
+    assertEquals(20, binOp.apply(10, 20))
   }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BooleanSupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BooleanSupplierTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+// Ported from Scala.js, commit SHA: db63dabed dated: 2020-10-06
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.BooleanSupplier

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BooleanSupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/BooleanSupplierTest.scala
@@ -1,0 +1,24 @@
+// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.BooleanSupplier
+
+import org.junit.Assert._
+import org.junit.Test
+
+class BooleanSupplierTest {
+  import BooleanSupplierTest._
+
+  @Test def getAsBoolean(): Unit = {
+    assertEquals(true, makeSupplier(true).getAsBoolean())
+    assertEquals(false, makeSupplier(false).getAsBoolean())
+  }
+}
+
+object BooleanSupplierTest {
+  def makeSupplier(f: => Boolean): BooleanSupplier = {
+    new BooleanSupplier {
+      def getAsBoolean(): Boolean = f
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ConsumerTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: 7fd9ebb dated: 2020=01-06
-
+// Ported from Scala.js, commit SHA: c473689c9 dated: 2021-05-03
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.Consumer

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleBinaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleBinaryOperatorTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._
@@ -9,7 +9,8 @@ import java.util.function._
 class DoubleBinaryOperatorTest {
   @Test def applyAsDouble(): Unit = {
     val sumOp = new DoubleBinaryOperator {
-      override def applyAsDouble(left: Double, right: Double): Double = left + right
+      override def applyAsDouble(left: Double, right: Double): Double =
+        left + right
     }
     assertEquals(30, sumOp.applyAsDouble(10, 20), 0)
   }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleBinaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleBinaryOperatorTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class DoubleBinaryOperatorTest {
+  @Test def applyAsDouble(): Unit = {
+    val sumOp = new DoubleBinaryOperator {
+      override def applyAsDouble(left: Double, right: Double): Double = left + right
+    }
+    assertEquals(30, sumOp.applyAsDouble(10, 20), 0)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleConsumerTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleConsumerTest.scala
@@ -1,0 +1,41 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class DoubleConsumerTest {
+  @Test def accept(): Unit = {
+    // Side-effects
+    var current: Double = 0
+
+    val add = new DoubleConsumer {
+      override def accept(value: Double): Unit = current += value
+    }
+
+    add.accept(5)
+    assertEquals(5, current, 0)
+    add.accept(15)
+    assertEquals(20, current, 0)
+  }
+
+  @Test def andThen(): Unit = {
+    // Side-effects
+    var buffer = scala.collection.mutable.ListBuffer.empty[Double]
+
+    val add = new DoubleConsumer {
+      override def accept(value: Double): Unit = buffer += value
+    }
+    val add2x = new DoubleConsumer {
+      override def accept(value: Double): Unit = buffer += value * 2
+    }
+    val merged: DoubleConsumer = add.andThen(add2x)
+
+    merged.accept(1d)
+    assertEquals(List(1d, 2d), buffer.toList)
+    merged.accept(4d)
+    assertEquals(List(1d, 2d, 4d, 8d), buffer.toList)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleFunctionTest.scala
@@ -1,0 +1,17 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class DoubleFunctionTest {
+  @Test def testApply(): Unit = {
+    val f = new DoubleFunction[String] {
+      override def apply(value: Double): String = s"${value}d"
+    }
+    assertEquals(f.apply(0.5), "0.5d")
+    assertEquals(f.apply(3.3), "3.3d")
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoublePredicateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoublePredicateTest.scala
@@ -1,0 +1,70 @@
+// Ported from Scala.js, commit sha:c473689c9 dated:2021-05-03
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.DoublePredicate
+
+import org.junit.Assert._
+import org.junit.Test
+
+class DoublePredicateTest {
+  import DoublePredicateTest._
+
+  private val largerThan10 = makePredicate(_ > 10.0d)
+  private val even = makePredicate(_ % 2 == 0.0d)
+
+  private val throwingPredicate =
+    makePredicate(x => throw new ThrowingPredicateException(x))
+
+  private val dontCallPredicate =
+    makePredicate(x => throw new AssertionError(s"dontCallPredicate.test($x)"))
+
+  @Test def and(): Unit = {
+    // Truth table
+    val evenAndLargerThan10 = largerThan10.and(even)
+    assertTrue(evenAndLargerThan10.test(22.0d))
+    assertFalse(evenAndLargerThan10.test(21.0d))
+    assertFalse(evenAndLargerThan10.test(6.0d))
+    assertFalse(evenAndLargerThan10.test(5.0d))
+
+    // Short-circuit
+    assertFalse(largerThan10.and(dontCallPredicate).test(5.0d))
+    assertThrows(
+      classOf[ThrowingPredicateException],
+      () => throwingPredicate.and(dontCallPredicate).test(5.0d)
+    )
+  }
+
+  @Test def negate(): Unit = {
+    // Truth table
+    val notLargerThan10 = largerThan10.negate()
+    assertTrue(notLargerThan10.test(5.0d))
+    assertFalse(notLargerThan10.test(15.0d))
+  }
+
+  @Test def or(): Unit = {
+    // Truth table
+    val evenOrLargerThan10 = largerThan10.or(even)
+    assertTrue(evenOrLargerThan10.test(22.0d))
+    assertTrue(evenOrLargerThan10.test(21.0d))
+    assertTrue(evenOrLargerThan10.test(6.0d))
+    assertFalse(evenOrLargerThan10.test(5.0))
+
+    // Short-circuit
+    assertTrue(largerThan10.or(dontCallPredicate).test(15.0d))
+    assertThrows(
+      classOf[ThrowingPredicateException],
+      () => throwingPredicate.or(dontCallPredicate).test(15.0d)
+    )
+  }
+}
+
+object DoublePredicateTest {
+  final class ThrowingPredicateException(x: Any)
+      extends Exception(s"throwing predicate called with $x")
+
+  def makePredicate(f: Double => Boolean): DoublePredicate = {
+    new DoublePredicate {
+      def test(value: Double): Boolean = f(value)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoublePredicateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoublePredicateTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:c473689c9 dated:2021-05-03
+// Ported from Scala.js, commit SHA: c473689c9 dated: 2021-05-03
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.DoublePredicate

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleSupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleSupplierTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+// Ported from Scala.js, commit SHA: db63dabed dated: 2020-10-06
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.DoubleSupplier

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleSupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleSupplierTest.scala
@@ -1,0 +1,23 @@
+// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.DoubleSupplier
+
+import org.junit.Assert._
+import org.junit.Test
+
+class DoubleSupplierTest {
+  import DoubleSupplierTest._
+
+  @Test def getAsDouble(): Unit = {
+    assertEquals(1.234d, makeSupplier(1.234d).getAsDouble(), 0.0d)
+  }
+}
+
+object DoubleSupplierTest {
+  def makeSupplier(f: => Double): DoubleSupplier = {
+    new DoubleSupplier {
+      def getAsDouble(): Double = f
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleToIntFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleToIntFunctionTest.scala
@@ -1,0 +1,17 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class DoubleToIntFunctionTest {
+  @Test def applyAsInt(): Unit = {
+    val f = new DoubleToIntFunction {
+      override def applyAsInt(value: Double): Int = value.toInt
+    }
+    assertEquals(f.applyAsInt(0.5), 0)
+    assertEquals(f.applyAsInt(3.3), 3)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleToIntFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleToIntFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleToLongFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleToLongFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleToLongFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleToLongFunctionTest.scala
@@ -1,0 +1,17 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class DoubleToLongFunctionTest {
+  @Test def applyAsLong(): Unit = {
+    val f = new DoubleToLongFunction {
+      override def applyAsLong(value: Double): Long = (10 * value).toLong
+    }
+    assertEquals(f.applyAsLong(0.5), 5L)
+    assertEquals(f.applyAsLong(3.3), 33L)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleUnaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleUnaryOperatorTest.scala
@@ -1,0 +1,40 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class DoubleUnaryOperatorTest {
+  private val minus5 = new DoubleUnaryOperator {
+    override def applyAsDouble(operand: Double): Double = operand - 5
+  }
+  private val times2 = new DoubleUnaryOperator {
+    override def applyAsDouble(operand: Double): Double = operand * 2
+  }
+
+  @Test def applyAsDouble(): Unit = {
+    val times4 = new DoubleUnaryOperator {
+      override def applyAsDouble(operand: Double): Double = operand * 4
+    }
+    assertEquals(times4.applyAsDouble(0.5), 2.0, 0)
+    assertEquals(times4.applyAsDouble(3.3), 13.2, 0)
+  }
+
+  @Test def andThen(): Unit = {
+    val f: DoubleUnaryOperator = minus5.andThen(times2)
+    assertEquals(f.applyAsDouble(3), -4, 0)
+  }
+
+  @Test def compose(): Unit = {
+    val f: DoubleUnaryOperator = minus5.compose(times2)
+    assertEquals(f.applyAsDouble(3), 1, 0)
+  }
+
+  @Test def identity(): Unit = {
+    val id: DoubleUnaryOperator = DoubleUnaryOperator.identity()
+    assertEquals(id.applyAsDouble(3), 3, 0)
+    assertEquals(id.applyAsDouble(10), 10, 0)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleUnaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/DoubleUnaryOperatorTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/FunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/FunctionTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: eb637e3 dated: 200-09-06
-
+// Ported from Scala.js, commit SHA: cbf86bbb8 dated: 2020-10-23
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.Function
@@ -14,7 +13,7 @@ class FunctionTest {
     assertEquals(10, identityFunc(10))
   }
 
-  @Test def create_and_apply(): Unit = {
+  @Test def createAndApply(): Unit = {
     assertEquals(2, doubleFunc(1))
   }
 
@@ -28,7 +27,7 @@ class FunctionTest {
     assertEquals(22, incFunc.andThen(doubleFunc)(10))
   }
 
-  @Test def identity_compose_andThen(): Unit = {
+  @Test def identityComposeAndThen(): Unit = {
     // i.e. (self + 1) * 2
     val combined = identityFunc.andThen(doubleFunc).compose(incFunc)
     assertEquals(42, combined(20))

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntBinaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntBinaryOperatorTest.scala
@@ -1,0 +1,17 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class IntBinaryOperatorTest {
+  @Test def applyAsInt(): Unit = {
+    val max = new IntBinaryOperator {
+      override def applyAsInt(left: Int, right: Int): Int = left.max(right)
+    }
+    assertEquals(max.applyAsInt(3, 5), 5)
+    assertEquals(max.applyAsInt(0, -2), 0)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntBinaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntBinaryOperatorTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntConsumerTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntConsumerTest.scala
@@ -1,0 +1,41 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class IntConsumerTest {
+  @Test def accept(): Unit = {
+    // side-effects
+    var current: Int = 0
+
+    val add = new IntConsumer {
+      override def accept(value: Int): Unit = current += value
+    }
+
+    add.accept(3)
+    assertEquals(current, 3)
+    add.accept(-10)
+    assertEquals(current, -7)
+  }
+
+  @Test def andThen(): Unit = {
+    // side-effects
+    var buffer = scala.collection.mutable.ListBuffer.empty[Int]
+
+    val add = new IntConsumer {
+      override def accept(value: Int): Unit = buffer += value
+    }
+    val add10x = new IntConsumer {
+      override def accept(value: Int): Unit = buffer += value * 10
+    }
+    val f: IntConsumer = add.andThen(add10x)
+
+    f.accept(1)
+    assertEquals(List(1, 10), buffer.toList)
+    f.accept(2)
+    assertEquals(List(1, 10, 2, 20), buffer.toList)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntFunctionTest.scala
@@ -1,0 +1,17 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class IntFunctionTest {
+  @Test def testApply(): Unit = {
+    val repeat = new IntFunction[String] {
+      override def apply(value: Int): String = "." * value
+    }
+    assertEquals(repeat.apply(1), ".")
+    assertEquals(repeat.apply(3), "...")
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntPredicateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntPredicateTest.scala
@@ -1,0 +1,70 @@
+// Ported from Scala.js, commit sha:c473689c9 dated:2021-05-03
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.IntPredicate
+
+import org.junit.Assert._
+import org.junit.Test
+
+class IntPredicateTest {
+  import IntPredicateTest._
+
+  private val largerThan10 = makePredicate(_ > 10)
+  private val even = makePredicate(_ % 2 == 0)
+
+  private val throwingPredicate =
+    makePredicate(x => throw new ThrowingPredicateException(x))
+
+  private val dontCallPredicate =
+    makePredicate(x => throw new AssertionError(s"dontCallPredicate.test($x)"))
+
+  @Test def and(): Unit = {
+    // Truth table
+    val evenAndLargerThan10 = largerThan10.and(even)
+    assertTrue(evenAndLargerThan10.test(22))
+    assertFalse(evenAndLargerThan10.test(21))
+    assertFalse(evenAndLargerThan10.test(6))
+    assertFalse(evenAndLargerThan10.test(5))
+
+    // Short-circuit
+    assertFalse(largerThan10.and(dontCallPredicate).test(5))
+    assertThrows(
+      classOf[ThrowingPredicateException],
+      () => throwingPredicate.and(dontCallPredicate).test(5)
+    )
+  }
+
+  @Test def negate(): Unit = {
+    // Truth table
+    val notLargerThan10 = largerThan10.negate()
+    assertTrue(notLargerThan10.test(5))
+    assertFalse(notLargerThan10.test(15))
+  }
+
+  @Test def or(): Unit = {
+    // Truth table
+    val evenOrLargerThan10 = largerThan10.or(even)
+    assertTrue(evenOrLargerThan10.test(22))
+    assertTrue(evenOrLargerThan10.test(21))
+    assertTrue(evenOrLargerThan10.test(6))
+    assertFalse(evenOrLargerThan10.test(5))
+
+    // Short-circuit
+    assertTrue(largerThan10.or(dontCallPredicate).test(15))
+    assertThrows(
+      classOf[ThrowingPredicateException],
+      () => throwingPredicate.or(dontCallPredicate).test(15)
+    )
+  }
+}
+
+object IntPredicateTest {
+  final class ThrowingPredicateException(x: Any)
+      extends Exception(s"throwing predicate called with $x")
+
+  def makePredicate(f: Int => Boolean): IntPredicate = {
+    new IntPredicate {
+      def test(value: Int): Boolean = f(value)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntPredicateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntPredicateTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:c473689c9 dated:2021-05-03
+// Ported from Scala.js, commit SHA: c473689c9 dated: 2021-05-03
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.IntPredicate

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntSupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntSupplierTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+// Ported from Scala.js, commit SHA: db63dabed dated: 2020-10-06
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.IntSupplier

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntSupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntSupplierTest.scala
@@ -1,0 +1,25 @@
+// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.IntSupplier
+
+import org.junit.Assert._
+import org.junit.Test
+
+class IntSupplierTest {
+  import IntSupplierTest._
+
+  @Test def getAsInt(): Unit = {
+    assertEquals(Int.MinValue, makeSupplier(Int.MinValue).getAsInt())
+    assertEquals(1024, makeSupplier(1024).getAsInt())
+    assertEquals(Int.MaxValue, makeSupplier(Int.MaxValue).getAsInt())
+  }
+}
+
+object IntSupplierTest {
+  def makeSupplier(f: => Int): IntSupplier = {
+    new IntSupplier {
+      def getAsInt(): Int = f
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntToDoubleFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntToDoubleFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntToDoubleFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntToDoubleFunctionTest.scala
@@ -1,0 +1,17 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class IntToDoubleFunctionTest {
+  @Test def testApply(): Unit = {
+    val f = new IntToDoubleFunction {
+      override def applyAsDouble(value: Int): Double = value.toDouble / 10d
+    }
+    assertEquals(f.applyAsDouble(3), 0.3, 0.0)
+    assertEquals(f.applyAsDouble(20), 2, 0.0)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntToLongFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntToLongFunctionTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class IntToLongFunctionTest {
+  @Test def testApply(): Unit = {
+    val f = new IntToLongFunction {
+      override def applyAsLong(value: Int): Long = value.toLong * Int.MaxValue
+    }
+    assertEquals(f.applyAsLong(3), 6442450941L)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntToLongFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntToLongFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntUnaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/IntUnaryOperatorTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: d028054 dated: 2022-05-16
-
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongBinaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongBinaryOperatorTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongBinaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongBinaryOperatorTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class LongBinaryOperatorTest {
+  @Test def applyAsLong(): Unit = {
+    val sumOp = new LongBinaryOperator {
+      override def applyAsLong(left: Long, right: Long): Long = left + right
+    }
+    assertEquals(30, sumOp.applyAsLong(10, 20))
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongConsumerTest.scala
@@ -1,0 +1,41 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class LongConsumerTest {
+  @Test def accept(): Unit = {
+    // side-effects
+    var current: Long = 0
+
+    val add = new LongConsumer {
+      override def accept(value: Long): Unit = current += value
+    }
+
+    add.accept(3)
+    assertEquals(current, 3)
+    add.accept(-10)
+    assertEquals(current, -7)
+  }
+
+  @Test def andThen(): Unit = {
+    // side-effects
+    var buffer = scala.collection.mutable.ListBuffer.empty[Long]
+
+    val add = new LongConsumer {
+      override def accept(value: Long): Unit = buffer += value
+    }
+    val add10x = new LongConsumer {
+      override def accept(value: Long): Unit = buffer += value * 10
+    }
+    val f: LongConsumer = add.andThen(add10x)
+
+    f.accept(1)
+    assertEquals(List(1L, 10L), buffer.toList)
+    f.accept(2)
+    assertEquals(List(1L, 10L, 2L, 20L), buffer.toList)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongConsumerTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongFunctionTest.scala
@@ -1,0 +1,17 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class LongFunctionTest {
+  @Test def testApply(): Unit = {
+    val f = new LongFunction[Seq[Long]] {
+      override def apply(value: Long): Seq[Long] = List.fill(value.toInt)(value)
+    }
+    assertEquals(f.apply(1L), Seq(1L))
+    assertEquals(f.apply(3L), Seq(3L, 3L, 3L))
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongPredicateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongPredicateTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:c473689c9 dated:2021-05-03
+// Ported from Scala.js, commit SHA: c473689c9 dated: 2021-05-03
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.LongPredicate

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongPredicateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongPredicateTest.scala
@@ -1,0 +1,70 @@
+// Ported from Scala.js, commit sha:c473689c9 dated:2021-05-03
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.LongPredicate
+
+import org.junit.Assert._
+import org.junit.Test
+
+class LongPredicateTest {
+  import LongPredicateTest._
+
+  private val largerThan10 = makePredicate(_ > 10L)
+  private val even = makePredicate(_ % 2 == 0L)
+
+  private val throwingPredicate =
+    makePredicate(x => throw new ThrowingPredicateException(x))
+
+  private val dontCallPredicate =
+    makePredicate(x => throw new AssertionError(s"dontCallPredicate.test($x)"))
+
+  @Test def and(): Unit = {
+    // Truth table
+    val evenAndLargerThan10 = largerThan10.and(even)
+    assertTrue(evenAndLargerThan10.test(22L))
+    assertFalse(evenAndLargerThan10.test(21L))
+    assertFalse(evenAndLargerThan10.test(6L))
+    assertFalse(evenAndLargerThan10.test(5L))
+
+    // Short-circuit
+    assertFalse(largerThan10.and(dontCallPredicate).test(5L))
+    assertThrows(
+      classOf[ThrowingPredicateException],
+      () => throwingPredicate.and(dontCallPredicate).test(5L)
+    )
+  }
+
+  @Test def negate(): Unit = {
+    // Truth table
+    val notLargerThan10 = largerThan10.negate()
+    assertTrue(notLargerThan10.test(5L))
+    assertFalse(notLargerThan10.test(15L))
+  }
+
+  @Test def or(): Unit = {
+    // Truth table
+    val evenOrLargerThan10 = largerThan10.or(even)
+    assertTrue(evenOrLargerThan10.test(22L))
+    assertTrue(evenOrLargerThan10.test(21L))
+    assertTrue(evenOrLargerThan10.test(6L))
+    assertFalse(evenOrLargerThan10.test(5L))
+
+    // Short-circuit
+    assertTrue(largerThan10.or(dontCallPredicate).test(15L))
+    assertThrows(
+      classOf[ThrowingPredicateException],
+      () => throwingPredicate.or(dontCallPredicate).test(15L)
+    )
+  }
+}
+
+object LongPredicateTest {
+  final class ThrowingPredicateException(x: Any)
+      extends Exception(s"throwing predicate called with $x")
+
+  def makePredicate(f: Long => Boolean): LongPredicate = {
+    new LongPredicate {
+      def test(value: Long): Boolean = f(value)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongSupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongSupplierTest.scala
@@ -1,0 +1,25 @@
+// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.LongSupplier
+
+import org.junit.Assert._
+import org.junit.Test
+
+class LongSupplierTest {
+  import LongSupplierTest._
+
+  @Test def getAsLong(): Unit = {
+    assertEquals(Long.MinValue, makeSupplier(Long.MinValue).getAsLong())
+    assertEquals(1024L, makeSupplier(1024L).getAsLong())
+    assertEquals(Long.MaxValue, makeSupplier(Long.MaxValue).getAsLong())
+  }
+}
+
+object LongSupplierTest {
+  def makeSupplier(f: => Long): LongSupplier = {
+    new LongSupplier {
+      def getAsLong(): Long = f
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongSupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongSupplierTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:db63dabed dated:2020-10-06
+// Ported from Scala.js, commit SHA: db63dabed dated: 2020-10-06
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.LongSupplier

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongToDoubleFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongToDoubleFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongToDoubleFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongToDoubleFunctionTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class LongToDoubleFunctionTest {
+  @Test def testApply(): Unit = {
+    val f = new LongToDoubleFunction {
+      override def applyAsDouble(value: Long): Double = value.toDouble * 0.5
+    }
+    assertEquals(f.applyAsDouble(3), 1.5, 0.0)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongToIntFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongToIntFunctionTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class LongToIntFunctionTest {
+  @Test def testApply(): Unit = {
+    val f = new LongToIntFunction {
+      override def applyAsInt(value: Long): Int = value.toInt / 2
+    }
+    assertEquals(f.applyAsInt(3), 1)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongToIntFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongToIntFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongUnaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongUnaryOperatorTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongUnaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/LongUnaryOperatorTest.scala
@@ -1,0 +1,35 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class LongUnaryOperatorTest {
+  private val f = new LongUnaryOperator {
+    override def applyAsLong(operand: Long): Long = operand * 10
+  }
+  private val g = new LongUnaryOperator {
+    override def applyAsLong(operand: Long): Long = operand - 20
+  }
+
+  @Test def applyAsLong(): Unit = {
+    assertEquals(f.applyAsLong(3), 30)
+  }
+
+  @Test def andThen(): Unit = {
+    val h: LongUnaryOperator = f.andThen(g)
+    assertEquals(h.applyAsLong(5), 30)
+  }
+
+  @Test def compose(): Unit = {
+    val h: LongUnaryOperator = f.compose(g)
+    assertEquals(h.applyAsLong(5), -150)
+  }
+
+  @Test def identity(): Unit = {
+    val f: LongUnaryOperator = LongUnaryOperator.identity()
+    assertEquals(1L, f.applyAsLong(1))
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjDoubleConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjDoubleConsumerTest.scala
@@ -1,0 +1,22 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class ObjDoubleConsumerTest {
+  @Test def accept(): Unit = {
+    // side-effects
+    var current: String = ""
+
+    val op = new ObjDoubleConsumer[String] {
+      override def accept(left: String, right: Double): Unit = current += s"$left $right "
+    }
+
+    op.accept("First", 1.1)
+    op.accept("Second", 2.2)
+    assertEquals(current, "First 1.1 Second 2.2 ")
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjDoubleConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjDoubleConsumerTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._
@@ -12,7 +12,8 @@ class ObjDoubleConsumerTest {
     var current: String = ""
 
     val op = new ObjDoubleConsumer[String] {
-      override def accept(left: String, right: Double): Unit = current += s"$left $right "
+      override def accept(left: String, right: Double): Unit =
+        current += s"$left $right "
     }
 
     op.accept("First", 1.1)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjIntConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjIntConsumerTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._
@@ -12,7 +12,8 @@ class ObjIntConsumerTest {
     var current: String = ""
 
     val op = new ObjIntConsumer[String] {
-      override def accept(left: String, right: Int): Unit = current += left * right
+      override def accept(left: String, right: Int): Unit =
+        current += left * right
     }
 
     op.accept("First", 1)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjIntConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjIntConsumerTest.scala
@@ -1,0 +1,22 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class ObjIntConsumerTest {
+  @Test def accept(): Unit = {
+    // side-effects
+    var current: String = ""
+
+    val op = new ObjIntConsumer[String] {
+      override def accept(left: String, right: Int): Unit = current += left * right
+    }
+
+    op.accept("First", 1)
+    op.accept("Second", 2)
+    assertEquals(current, "FirstSecondSecond")
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjLongConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjLongConsumerTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._
@@ -12,7 +12,8 @@ class ObjLongConsumerTest {
     var current: String = ""
 
     val op = new ObjLongConsumer[String] {
-      override def accept(left: String, right: Long): Unit = current += s"$left $right "
+      override def accept(left: String, right: Long): Unit =
+        current += s"$left $right "
     }
     op.accept("First", 2L)
     op.accept("Second", 3L)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjLongConsumerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ObjLongConsumerTest.scala
@@ -1,0 +1,21 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class ObjLongConsumerTest {
+  @Test def accept(): Unit = {
+    // side-effects
+    var current: String = ""
+
+    val op = new ObjLongConsumer[String] {
+      override def accept(left: String, right: Long): Unit = current += s"$left $right "
+    }
+    op.accept("First", 2L)
+    op.accept("Second", 3L)
+    assertEquals(current, "First 2 Second 3 ")
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/PredicateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/PredicateTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit: 137c11d dated: 2019-07-03
-
+// Ported from Scala.js, commit SHA: c473689c9 dated: 2021-05-03
 package org.scalanative.testsuite.javalib.util.function
 
 import java.util.function.Predicate

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/SupplierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/SupplierTest.scala
@@ -1,17 +1,25 @@
-package org.scalanative.testsuite.javalib.util
-package function
+// Ported from Scala.js, commit SHA: 5df5a4142 dated: 2020-09-06
+package org.scalanative.testsuite.javalib.util.function
 
-import java.util.function._
-import java.util._
+import java.util.function.Supplier
 
-import org.junit.Test
 import org.junit.Assert._
+import org.junit.Test
 
 class SupplierTest {
-  @Test def testGet(): Unit = {
-    val string = new Supplier[String] {
-      override def get(): String = "scala"
+  import SupplierTest._
+
+  @Test def get(): Unit = {
+    val supplier: Supplier[String] = makeSupplier("scala")
+
+    assertEquals("scala", supplier.get())
+  }
+}
+
+object SupplierTest {
+  def makeSupplier[T](f: => T): Supplier[T] = {
+    new Supplier[T] {
+      def get(): T = f
     }
-    assertTrue(string.get() == "scala")
   }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToDoubleBiFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToDoubleBiFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._
@@ -9,7 +9,8 @@ import java.util.function._
 class ToDoubleBiFunctionTest {
   @Test def applyAsDouble(): Unit = {
     val op = new ToDoubleBiFunction[String, String] {
-      override def applyAsDouble(t: String, u: String): Double = s"$t.$u".toDouble
+      override def applyAsDouble(t: String, u: String): Double =
+        s"$t.$u".toDouble
     }
     assertEquals(op.applyAsDouble("123", "456"), 123.456, 0.0)
   }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToDoubleBiFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToDoubleBiFunctionTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class ToDoubleBiFunctionTest {
+  @Test def applyAsDouble(): Unit = {
+    val op = new ToDoubleBiFunction[String, String] {
+      override def applyAsDouble(t: String, u: String): Double = s"$t.$u".toDouble
+    }
+    assertEquals(op.applyAsDouble("123", "456"), 123.456, 0.0)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToDoubleFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToDoubleFunctionTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit 00e462d dated: 2023-01-22
-
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToIntBiFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToIntBiFunctionTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class ToIntBiFunctionTest {
+  @Test def applyAsInt(): Unit = {
+    val op = new ToIntBiFunction[String, String]{
+      override def applyAsInt(t: String, u: String): Int = s"$t$u".toInt
+    }
+    assertEquals(op.applyAsInt("10", "24"), 1024)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToIntBiFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToIntBiFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._
@@ -8,7 +8,7 @@ import java.util.function._
 
 class ToIntBiFunctionTest {
   @Test def applyAsInt(): Unit = {
-    val op = new ToIntBiFunction[String, String]{
+    val op = new ToIntBiFunction[String, String] {
       override def applyAsInt(t: String, u: String): Int = s"$t$u".toInt
     }
     assertEquals(op.applyAsInt("10", "24"), 1024)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToIntFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToIntFunctionTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit 00e462d dated: 2023-01-22
-
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToLongBiFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToLongBiFunctionTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+package org.scalanative.testsuite.javalib.util.function
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.function._
+
+class ToLongBiFunctionTest {
+  @Test def applyAsLong(): Unit = {
+    val op = new ToLongBiFunction[String, String] {
+      override def applyAsLong(t: String, u: String): Long = t.toLong * u.toLong
+    }
+    assertEquals(op.applyAsLong("11111111", "2222222"), 24691355308642L)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToLongBiFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToLongBiFunctionTest.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js, commit sha:cfb4888a6 dated:2021-01-07
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToLongFunctionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/ToLongFunctionTest.scala
@@ -1,5 +1,4 @@
-// Ported from Scala.js commit 00e462d dated: 2023-01-22
-
+// Ported from Scala.js, commit SHA: cfb4888a6 dated: 2021-01-07
 package org.scalanative.testsuite.javalib.util.function
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/UnaryOperatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/function/UnaryOperatorTest.scala
@@ -1,13 +1,30 @@
+// Ported from Scala.js, commit SHA: cbf86bbb8 dated: 2020-10-23
 package org.scalanative.testsuite.javalib.util.function
 
-import java.util.function._
+import java.util.function.UnaryOperator
 
-import org.junit.Test
 import org.junit.Assert._
+import org.junit.Test
 
 class UnaryOperatorTest {
-  @Test def testUnaryOperator(): Unit = {
+  import UnaryOperatorTest._
+
+  @Test def identity(): Unit = {
     val unaryOperatorString: UnaryOperator[String] = UnaryOperator.identity()
-    assertTrue(unaryOperatorString.apply("scala") == "scala")
+    assertEquals("scala", unaryOperatorString.apply("scala"))
+  }
+
+  @Test def createAndApply(): Unit = {
+    val double: UnaryOperator[Int] = makeUnaryOperator(_ * 2)
+    assertEquals(20, double.apply(10))
+    assertEquals(20, double.apply(10))
+  }
+}
+
+object UnaryOperatorTest {
+  private def makeUnaryOperator[T](f: T => T): UnaryOperator[T] = {
+    new UnaryOperator[T] {
+      def apply(t: T): T = f(t)
+    }
   }
 }


### PR DESCRIPTION
Fixes #3092 
* Adds or updates or existing defintions for `java.util.function` and its corresponding tests
* Added helper script to perform porting of the Scala.js sources (automatic header with port information, revision, date and removal of original sjs header)