### PR TITLE
Port `java.util.concurrent.Atomic` types from JSR-166

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
@@ -1,34 +1,337 @@
+/*
+ * Based on JSR-166 originally written by Doug Lea with assistance
+ * from members of JCP JSR-166 Expert Group and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
 package java.util.concurrent.atomic
 
-class AtomicBoolean(private[this] var value: Boolean) extends Serializable {
-  def this() = this(false)
+import scala.annotation.tailrec
+import scala.language.implicitConversions
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.unsafe._
+import scala.scalanative.libc.atomic.memory_order._
+import scala.scalanative.libc.atomic.CAtomicByte
+import scala.scalanative.runtime.{fromRawPtr, MemoryLayout}
+import scala.scalanative.runtime.Intrinsics
 
+@SerialVersionUID(4654671469794556979L)
+class AtomicBoolean private (private var value: Byte) extends Serializable {
+
+  // Pointer to field containing underlying Byte.
+  @alwaysinline
+  private[concurrent] def valueRef: CAtomicByte = new CAtomicByte(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "value"))
+  )
+
+  def this() = {
+    this(0.toByte)
+  }
+
+  def this(initialValue: Boolean) = {
+    this(if (initialValue) 1.toByte else 0.toByte)
+  }
+
+  private implicit def byteToBoolean(v: Byte): Boolean = v != 0
+  private implicit def booleanToByte(v: scala.Boolean): Byte = if (v) 1 else 0
+
+  /** Returns the current value, with memory effects of volatile read
+   *
+   *  @return
+   *    the current value
+   */
   final def get(): Boolean = value
 
-  final def compareAndSet(expect: Boolean, update: Boolean): Boolean = {
-    if (expect != value) false
-    else {
-      value = update
+  /** Atomically sets the value to {@code newValue} if the current value {@code
+   *  \== expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful. False return indicates that the actual value
+   *    was not equal to the expected value.
+   */
+  final def compareAndSet(
+      expectedValue: Boolean,
+      newValue: Boolean
+  ): Boolean = {
+    valueRef.compareExchangeStrong(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSetPlain}.
+   *
+   *  @deprecated
+   *    This method has plain memory effects but the method name implies
+   *    volatile memory effects (see methods such as {@link #compareAndExchange}
+   *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
+   *    memory effects it is recommended that the method {@link
+   *    #weakCompareAndSetPlain} be used instead.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @see
+   *    #weakCompareAndSetPlain
+   */
+  @deprecated("", "9")
+  def weakCompareAndSet(expectedValue: Boolean, newValue: Boolean): Boolean =
+    valueRef.compareExchangeWeak(expectedValue, newValue)
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSetPlain}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  def weakCompareAndSetPlain(
+      expectedValue: Boolean,
+      newValue: Boolean
+  ): Boolean = {
+    if (byteToBoolean(value) == expectedValue) {
+      value = newValue
       true
-    }
+    } else false
   }
 
-  // For some reason, this method is not final
-  def weakCompareAndSet(expect: Boolean, update: Boolean): Boolean =
-    compareAndSet(expect, update)
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle#setVolatile}.
+   *
+   *  @param newValue
+   *    the new value
+   */
+  final def set(newValue: Boolean): Unit = {
+    valueRef.store(newValue)
+  }
 
-  final def set(newValue: Boolean): Unit =
-    value = newValue
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle#setRelease}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 1.6
+   */
+  final def lazySet(newValue: Boolean): Unit = {
+    valueRef.store(newValue, memory_order_release)
+  }
 
-  final def lazySet(newValue: Boolean): Unit =
-    set(newValue)
-
+  /** Atomically sets the value to {@code newValue} and returns the old value,
+   *  with memory effects as specified by {@link VarHandle#getAndSet}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the previous value
+   */
   final def getAndSet(newValue: Boolean): Boolean = {
-    val old = value
-    value = newValue
-    old
+    valueRef.exchange(newValue)
   }
 
-  override def toString(): String =
-    value.toString()
+  /** Returns the String representation of the current value.
+   *  @return
+   *    the String representation of the current value
+   */
+  override def toString(): String = java.lang.Boolean.toString(get())
+
+  /** Returns the current value, with memory semantics of reading as if the
+   *  variable was declared non-{@code volatile}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getPlain(): Boolean = value
+
+  /** Sets the value to {@code newValue}, with memory semantics of setting as if
+   *  the variable was declared non-{@code volatile} and non-{@code final}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setPlain(newValue: Boolean): Unit = {
+    value = newValue
+  }
+
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle#getOpaque}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getOpaque: Boolean = {
+    valueRef.load(memory_order_relaxed)
+  }
+
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle#setOpaque}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setOpaque(newValue: Boolean): Unit = {
+    valueRef.store(newValue, memory_order_relaxed)
+  }
+
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle#getAcquire}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getAcquire: Boolean = {
+    valueRef.load(memory_order_acquire)
+  }
+
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle#setRelease}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setRelease(newValue: Boolean): Unit = {
+    valueRef.store(newValue, memory_order_release)
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#compareAndExchange}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchange(
+      expectedValue: Boolean,
+      newValue: Boolean
+  ): Boolean = {
+    val expected = stackalloc[Byte]()
+    !expected = expectedValue.toByte
+    valueRef.compareExchangeStrong(expected, newValue)
+    !expected
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link
+   *  VarHandle#compareAndExchangeAcquire}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeAcquire(
+      expectedValue: Boolean,
+      newValue: Boolean
+  ): Boolean = {
+    val expected = stackalloc[Byte]()
+    !expected = expectedValue.toByte
+    valueRef.compareExchangeStrong(expected, newValue, memory_order_acquire)
+    !expected
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link
+   *  VarHandle#compareAndExchangeRelease}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeRelease(
+      expectedValue: Boolean,
+      newValue: Boolean
+  ): Boolean = {
+    val expected = stackalloc[Byte]()
+    !expected = expectedValue.toByte
+    valueRef.compareExchangeStrong(expected, newValue, memory_order_release)
+    !expected
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSet}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetVolatile(
+      expectedValue: Boolean,
+      newValue: Boolean
+  ): Boolean =
+    valueRef.compareExchangeWeak(expectedValue, newValue)
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSetAcquire}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetAcquire(
+      expectedValue: Boolean,
+      newValue: Boolean
+  ): Boolean =
+    valueRef.compareExchangeWeak(expectedValue, newValue, memory_order_acquire)
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSetRelease}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetRelease(
+      expectedValue: Boolean,
+      newValue: Boolean
+  ): Boolean =
+    valueRef.compareExchangeWeak(expectedValue, newValue, memory_order_release)
 }

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
@@ -43,8 +43,8 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
   final def get(): Boolean = value
 
   /** Atomically sets the value to {@code newValue} if the current value {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndSet`.
    *
    *  @param expectedValue
    *    the expected value
@@ -62,15 +62,15 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSetPlain}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetPlain`.
    *
    *  @deprecated
    *    This method has plain memory effects but the method name implies
    *    volatile memory effects (see methods such as {@link #compareAndExchange}
    *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
-   *    memory effects it is recommended that the method {@link
-   *    #weakCompareAndSetPlain} be used instead.
+   *    memory effects it is recommended that the method
+   *    [[#weakCompareAndSetPlain]] be used instead.
    *
    *  @param expectedValue
    *    the expected value
@@ -86,8 +86,8 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
     valueRef.compareExchangeWeak(expectedValue, newValue)
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSetPlain}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetPlain`.
    *
    *  @param expectedValue
    *    the expected value
@@ -108,7 +108,7 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
   }
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle#setVolatile}.
+   *  `VarHandle#setVolatile`.
    *
    *  @param newValue
    *    the new value
@@ -118,7 +118,7 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
   }
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle#setRelease}.
+   *  `VarHandle#setRelease`.
    *
    *  @param newValue
    *    the new value
@@ -129,7 +129,7 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
   }
 
   /** Atomically sets the value to {@code newValue} and returns the old value,
-   *  with memory effects as specified by {@link VarHandle#getAndSet}.
+   *  with memory effects as specified by `VarHandle#getAndSet`.
    *
    *  @param newValue
    *    the new value
@@ -166,8 +166,8 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
     value = newValue
   }
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle#getOpaque}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getOpaque`.
    *
    *  @return
    *    the value
@@ -178,7 +178,7 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
   }
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle#setOpaque}.
+   *  `VarHandle#setOpaque`.
    *
    *  @param newValue
    *    the new value
@@ -188,8 +188,8 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
     valueRef.store(newValue, memory_order_relaxed)
   }
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle#getAcquire}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getAcquire`.
    *
    *  @return
    *    the value
@@ -200,7 +200,7 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
   }
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle#setRelease}.
+   *  `VarHandle#setRelease`.
    *
    *  @param newValue
    *    the new value
@@ -212,7 +212,7 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#compareAndExchange}.
+   *  memory effects as specified by `VarHandle#compareAndExchange`.
    *
    *  @param expectedValue
    *    the expected value
@@ -235,8 +235,7 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeAcquire}.
+   *  memory effects as specified by `VarHandle#compareAndExchangeAcquire`.
    *
    *  @param expectedValue
    *    the expected value
@@ -259,8 +258,7 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeRelease}.
+   *  memory effects as specified by `VarHandle#compareAndExchangeRelease`.
    *
    *  @param expectedValue
    *    the expected value
@@ -282,8 +280,8 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSet}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSet`.
    *
    *  @param expectedValue
    *    the expected value
@@ -300,8 +298,8 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
     valueRef.compareExchangeWeak(expectedValue, newValue)
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSetAcquire}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetAcquire`.
    *
    *  @param expectedValue
    *    the expected value
@@ -318,8 +316,8 @@ class AtomicBoolean private (private var value: Byte) extends Serializable {
     valueRef.compareExchangeWeak(expectedValue, newValue, memory_order_acquire)
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSetRelease}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetRelease`.
    *
    *  @param expectedValue
    *    the expected value

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
@@ -1,65 +1,552 @@
+/*
+ * Based on JSR-166 originally written by Doug Lea with assistance
+ * from members of JCP JSR-166 Expert Group and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
 package java.util.concurrent.atomic
 
+import java.io.Serializable
+import scala.annotation.tailrec
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.unsafe._
+import scala.scalanative.libc.atomic.CAtomicInt
+import scala.scalanative.libc.atomic.memory_order._
+import scala.scalanative.runtime.{fromRawPtr}
+import java.util.function.IntBinaryOperator
+import java.util.function.IntUnaryOperator
+import scala.scalanative.runtime.Intrinsics
+
+@SerialVersionUID(6214790243416807050L)
 class AtomicInteger(private[this] var value: Int)
     extends Number
     with Serializable {
 
-  def this() = this(0)
+  def this() = {
+    this(0)
+  }
 
-  final def get(): Int = value
+  // Pointer to field containing underlying Integer.
+  @alwaysinline
+  private[concurrent] def valueRef: CAtomicInt = new CAtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "value"))
+  )
 
-  final def set(newValue: Int): Unit =
-    value = newValue
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle# getVolatile}.
+   *
+   *  @return
+   *    the current value
+   */
+  final def get(): Int = valueRef.load()
 
-  final def lazySet(newValue: Int): Unit =
-    set(newValue)
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle# setVolatile}.
+   *
+   *  @param newValue
+   *    the new value
+   */
+  final def set(newValue: Int): Unit = valueRef.store(newValue)
 
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle# setRelease}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 1.6
+   */
+  final def lazySet(newValue: Int): Unit = {
+    valueRef.store(newValue, memory_order_release)
+  }
+
+  /** Atomically sets the value to {@code newValue} and returns the old value,
+   *  with memory effects as specified by {@link VarHandle# getAndSet}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the previous value
+   */
   final def getAndSet(newValue: Int): Int = {
-    val old = value
-    value = newValue
-    old
+    valueRef.exchange(newValue)
   }
 
-  final def compareAndSet(expect: Int, update: Int): Boolean = {
-    if (expect != value) false
-    else {
-      value = update
+  /** Atomically sets the value to {@code newValue} if the current value {@code
+   *  \== expectedValue}, with memory effects as specified by {@link VarHandle#
+   *  compareAndSet}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful. False return indicates that the actual value
+   *    was not equal to the expected value.
+   */
+  final def compareAndSet(expectedValue: Int, newValue: Int): Boolean = {
+    valueRef.compareExchangeStrong(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSetPlain}.
+   *
+   *  @deprecated
+   *    This method has plain memory effects but the method name implies
+   *    volatile memory effects (see methods such as {@link #compareAndExchange}
+   *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
+   *    memory effects it is recommended that the method {@link
+   *    #weakCompareAndSetPlain} be used instead.
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @see
+   *    #weakCompareAndSetPlain
+   */
+  @deprecated("", "9")
+  final def weakCompareAndSet(expectedValue: Int, newValue: Int): Boolean = {
+    valueRef.compareExchangeWeak(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSetPlain}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetPlain(
+      expectedValue: Int,
+      newValue: Int
+  ): Boolean = {
+    if (value == expectedValue) {
+      value = newValue
       true
+    } else false
+  }
+
+  /** Atomically increments the current value, with memory effects as specified
+   *  by {@link VarHandle# getAndAdd}.
+   *
+   *  <p>Equivalent to {@code getAndAdd(1)}.
+   *
+   *  @return
+   *    the previous value
+   */
+  final def getAndIncrement(): Int = getAndAdd(1)
+
+  /** Atomically decrements the current value, with memory effects as specified
+   *  by {@link VarHandle# getAndAdd}.
+   *
+   *  <p>Equivalent to {@code getAndAdd(-1)}.
+   *
+   *  @return
+   *    the previous value
+   */
+  final def getAndDecrement(): Int = getAndAdd(-1)
+
+  /** Atomically adds the given value to the current value, with memory effects
+   *  as specified by {@link VarHandle# getAndAdd}.
+   *
+   *  @param delta
+   *    the value to add
+   *  @return
+   *    the previous value
+   */
+  final def getAndAdd(delta: Int): Int = {
+    valueRef.fetchAdd(delta)
+  }
+
+  /** Atomically increments the current value, with memory effects as specified
+   *  by {@link VarHandle# getAndAdd}.
+   *
+   *  <p>Equivalent to {@code addAndGet(1)}.
+   *
+   *  @return
+   *    the updated value
+   */
+  final def incrementAndGet(): Int = addAndGet(1)
+
+  /** Atomically decrements the current value, with memory effects as specified
+   *  by {@link VarHandle# getAndAdd}.
+   *
+   *  <p>Equivalent to {@code addAndGet(-1)}.
+   *
+   *  @return
+   *    the updated value
+   */
+  final def decrementAndGet(): Int = addAndGet(-1)
+
+  /** Atomically adds the given value to the current value, with memory effects
+   *  as specified by {@link VarHandle# getAndAdd}.
+   *
+   *  @param delta
+   *    the value to add
+   *  @return
+   *    the updated value
+   */
+  final def addAndGet(delta: Int): Int = valueRef.fetchAdd(delta) + delta
+
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function, returning the previous value. The function should be
+   *  side-effect-free, since it may be re-applied when attempted updates fail
+   *  due to contention among threads.
+   *
+   *  @param updateFunction
+   *    a side-effect-free function
+   *  @return
+   *    the previous value
+   *  @since 1.8
+   */
+  final def getAndUpdate(updateFunction: IntUnaryOperator): Int = {
+    @tailrec
+    def loop(prev: Int, next: Int, haveNext: Boolean): Int = {
+      val newNext =
+        if (!haveNext) updateFunction.applyAsInt(prev)
+        else next
+
+      if (weakCompareAndSetVolatile(prev, newNext)) prev
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
     }
+    loop(get(), 0, false)
   }
 
-  final def weakCompareAndSet(expect: Int, update: Int): Boolean =
-    compareAndSet(expect, update)
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function, returning the updated value. The function should be
+   *  side-effect-free, since it may be re-applied when attempted updates fail
+   *  due to contention among threads.
+   *
+   *  @param updateFunction
+   *    a side-effect-free function
+   *  @return
+   *    the updated value
+   *  @since 1.8
+   */
+  final def updateAndGet(updateFunction: IntUnaryOperator): Int = {
+    @tailrec
+    def loop(prev: Int, next: Int, haveNext: Boolean): Int = {
+      val newNext =
+        if (!haveNext) updateFunction.applyAsInt(prev)
+        else next
 
-  final def getAndIncrement(): Int =
-    getAndAdd(1)
-
-  final def getAndDecrement(): Int =
-    getAndAdd(-1)
-
-  @inline final def getAndAdd(delta: Int): Int = {
-    val old = value
-    value = old + delta
-    old
+      if (weakCompareAndSetVolatile(prev, newNext)) newNext
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
+    }
+    loop(get(), 0, false)
   }
 
-  final def incrementAndGet(): Int =
-    addAndGet(1)
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function to the current and given values, returning the previous
+   *  value. The function should be side-effect-free, since it may be re-applied
+   *  when attempted updates fail due to contention among threads. The function
+   *  is applied with the current value as its first argument, and the given
+   *  update as the second argument.
+   *
+   *  @param x
+   *    the update value
+   *  @param accumulatorFunction
+   *    a side-effect-free function of two arguments
+   *  @return
+   *    the previous value
+   *  @since 1.8
+   */
+  final def getAndAccumulate(
+      x: Int,
+      accumulatorFunction: IntBinaryOperator
+  ): Int = {
+    @tailrec
+    def loop(prev: Int, next: Int, haveNext: Boolean): Int = {
+      val newNext =
+        if (!haveNext) accumulatorFunction.applyAsInt(prev, x)
+        else next
 
-  final def decrementAndGet(): Int =
-    addAndGet(-1)
+      if (weakCompareAndSetVolatile(prev, newNext)) prev
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
+    }
+    loop(get(), 0, false)
+  }
 
-  @inline final def addAndGet(delta: Int): Int = {
-    val newValue = value + delta
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function to the current and given values, returning the updated
+   *  value. The function should be side-effect-free, since it may be re-applied
+   *  when attempted updates fail due to contention among threads. The function
+   *  is applied with the current value as its first argument, and the given
+   *  update as the second argument.
+   *
+   *  @param x
+   *    the update value
+   *  @param accumulatorFunction
+   *    a side-effect-free function of two arguments
+   *  @return
+   *    the updated value
+   *  @since 1.8
+   */
+  final def accumulateAndGet(
+      x: Int,
+      accumulatorFunction: IntBinaryOperator
+  ): Int = {
+    @tailrec
+    def loop(prev: Int, next: Int, haveNext: Boolean): Int = {
+      val newNext =
+        if (!haveNext) accumulatorFunction.applyAsInt(prev, x)
+        else next
+
+      if (weakCompareAndSetVolatile(prev, newNext)) newNext
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
+    }
+    loop(get(), 0, false)
+  }
+
+  /** Returns the String representation of the current value.
+   *
+   *  @return
+   *    the String representation of the current value
+   */
+  override def toString(): String = get().toString()
+
+  /** Returns the current value of this {@code AtomicInteger} as an {@code int},
+   *  with memory effects as specified by {@link VarHandle# getVolatile}.
+   *
+   *  Equivalent to {@link #get ( )}.
+   */
+  override def intValue(): Int = get()
+
+  /** Returns the current value of this {@code AtomicInteger} as a {@code long}
+   *  after a widening primitive conversion, with memory effects as specified by
+   *  {@link VarHandle# getVolatile}.
+   *
+   *  @jls
+   *    5.1.2 Widening Primitive Conversion
+   */
+  override def longValue(): Long = get().toLong
+
+  /** Returns the current value of this {@code AtomicInteger} as a {@code float}
+   *  after a widening primitive conversion, with memory effects as specified by
+   *  {@link VarHandle# getVolatile}.
+   *
+   *  @jls
+   *    5.1.2 Widening Primitive Conversion
+   */
+  override def floatValue(): Float = get().toFloat
+
+  /** Returns the current value of this {@code AtomicInteger} as a {@code
+   *  double} after a widening primitive conversion, with memory effects as
+   *  specified by {@link VarHandle# getVolatile}.
+   *
+   *  @jls
+   *    5.1.2 Widening Primitive Conversion
+   */
+  override def doubleValue(): Double = get().toDouble
+
+  /** Returns the current value, with memory semantics of reading as if the
+   *  variable was declared non-{@code volatile}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getPlain(): Int = value
+
+  /** Sets the value to {@code newValue}, with memory semantics of setting as if
+   *  the variable was declared non-{@code volatile} and non-{@code final}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setPlain(newValue: Int): Unit = {
     value = newValue
-    newValue
   }
 
-  override def toString(): String =
-    value.toString()
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle# getOpaque}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getOpaque(): Int = valueRef.load(memory_order_relaxed)
 
-  def intValue(): Int = value
-  def longValue(): Long = value.toLong
-  def floatValue(): Float = value.toFloat
-  def doubleValue(): Double = value.toDouble
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle# setOpaque}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setOpaque(newValue: Int): Unit =
+    valueRef.store(newValue, memory_order_relaxed)
+
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle# getAcquire}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getAcquire(): Int = valueRef.load(memory_order_acquire)
+
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle# setRelease}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setRelease(newValue: Int): Unit =
+    valueRef.store(newValue, memory_order_release)
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle# compareAndExchange}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchange(expectedValue: Int, newValue: Int): Int = {
+    val expected = stackalloc[Int]()
+    !expected = expectedValue
+    valueRef
+      .compareExchangeStrong(expected, newValue)
+    !expected
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#
+   *  compareAndExchangeAcquire}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeAcquire(
+      expectedValue: Int,
+      newValue: Int
+  ): Int = {
+    val expected = stackalloc[Int]()
+    !expected = expectedValue
+    valueRef
+      .compareExchangeStrong(expected, newValue, memory_order_acquire)
+    !expected
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#
+   *  compareAndExchangeRelease}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeRelease(
+      expectedValue: Int,
+      newValue: Int
+  ): Int = {
+    val expected = stackalloc[Int]()
+    !expected = expectedValue
+    valueRef
+      .compareExchangeStrong(expected, newValue, memory_order_release)
+    !expected
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSet}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetVolatile(
+      expectedValue: Int,
+      newValue: Int
+  ): Boolean = {
+    valueRef.compareExchangeWeak(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSetAcquire}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetAcquire(
+      expectedValue: Int,
+      newValue: Int
+  ): Boolean = {
+    valueRef
+      .compareExchangeWeak(expectedValue, newValue, memory_order_acquire)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSetRelease}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetRelease(
+      expectedValue: Int,
+      newValue: Int
+  ): Boolean = {
+    valueRef
+      .compareExchangeWeak(expectedValue, newValue, memory_order_release)
+  }
 }

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
@@ -32,8 +32,8 @@ class AtomicInteger(private[this] var value: Int)
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "value"))
   )
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle# getVolatile}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getVolatile`.
    *
    *  @return
    *    the current value
@@ -41,7 +41,7 @@ class AtomicInteger(private[this] var value: Int)
   final def get(): Int = valueRef.load()
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle# setVolatile}.
+   *  `VarHandle#setVolatile`.
    *
    *  @param newValue
    *    the new value
@@ -49,7 +49,7 @@ class AtomicInteger(private[this] var value: Int)
   final def set(newValue: Int): Unit = valueRef.store(newValue)
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle# setRelease}.
+   *  `VarHandle#setRelease`.
    *
    *  @param newValue
    *    the new value
@@ -60,7 +60,7 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Atomically sets the value to {@code newValue} and returns the old value,
-   *  with memory effects as specified by {@link VarHandle# getAndSet}.
+   *  with memory effects as specified by `VarHandle#getAndSet`.
    *
    *  @param newValue
    *    the new value
@@ -72,8 +72,8 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Atomically sets the value to {@code newValue} if the current value {@code
-   *  \== expectedValue}, with memory effects as specified by {@link VarHandle#
-   *  compareAndSet}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndSet`.
    *
    *  @param expectedValue
    *    the expected value
@@ -88,15 +88,15 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSetPlain}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetPlain`.
    *
    *  @deprecated
    *    This method has plain memory effects but the method name implies
    *    volatile memory effects (see methods such as {@link #compareAndExchange}
    *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
-   *    memory effects it is recommended that the method {@link
-   *    #weakCompareAndSetPlain} be used instead.
+   *    memory effects it is recommended that the method
+   *    [[#weakCompareAndSetPlain]] be used instead.
    *  @param expectedValue
    *    the expected value
    *  @param newValue
@@ -112,8 +112,8 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSetPlain}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetPlain`.
    *
    *  @param expectedValue
    *    the expected value
@@ -134,7 +134,7 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Atomically increments the current value, with memory effects as specified
-   *  by {@link VarHandle# getAndAdd}.
+   *  by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code getAndAdd(1)}.
    *
@@ -144,7 +144,7 @@ class AtomicInteger(private[this] var value: Int)
   final def getAndIncrement(): Int = getAndAdd(1)
 
   /** Atomically decrements the current value, with memory effects as specified
-   *  by {@link VarHandle# getAndAdd}.
+   *  by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code getAndAdd(-1)}.
    *
@@ -154,7 +154,7 @@ class AtomicInteger(private[this] var value: Int)
   final def getAndDecrement(): Int = getAndAdd(-1)
 
   /** Atomically adds the given value to the current value, with memory effects
-   *  as specified by {@link VarHandle# getAndAdd}.
+   *  as specified by `VarHandle#getAndAdd`.
    *
    *  @param delta
    *    the value to add
@@ -166,7 +166,7 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Atomically increments the current value, with memory effects as specified
-   *  by {@link VarHandle# getAndAdd}.
+   *  by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code addAndGet(1)}.
    *
@@ -176,7 +176,7 @@ class AtomicInteger(private[this] var value: Int)
   final def incrementAndGet(): Int = addAndGet(1)
 
   /** Atomically decrements the current value, with memory effects as specified
-   *  by {@link VarHandle# getAndAdd}.
+   *  by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code addAndGet(-1)}.
    *
@@ -186,7 +186,7 @@ class AtomicInteger(private[this] var value: Int)
   final def decrementAndGet(): Int = addAndGet(-1)
 
   /** Atomically adds the given value to the current value, with memory effects
-   *  as specified by {@link VarHandle# getAndAdd}.
+   *  as specified by `VarHandle#getAndAdd`.
    *
    *  @param delta
    *    the value to add
@@ -195,8 +195,8 @@ class AtomicInteger(private[this] var value: Int)
    */
   final def addAndGet(delta: Int): Int = valueRef.fetchAdd(delta) + delta
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function, returning the previous value. The function should be
    *  side-effect-free, since it may be re-applied when attempted updates fail
    *  due to contention among threads.
@@ -223,8 +223,8 @@ class AtomicInteger(private[this] var value: Int)
     loop(get(), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function, returning the updated value. The function should be
    *  side-effect-free, since it may be re-applied when attempted updates fail
    *  due to contention among threads.
@@ -251,8 +251,8 @@ class AtomicInteger(private[this] var value: Int)
     loop(get(), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function to the current and given values, returning the previous
    *  value. The function should be side-effect-free, since it may be re-applied
    *  when attempted updates fail due to contention among threads. The function
@@ -286,8 +286,8 @@ class AtomicInteger(private[this] var value: Int)
     loop(get(), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function to the current and given values, returning the updated
    *  value. The function should be side-effect-free, since it may be re-applied
    *  when attempted updates fail due to contention among threads. The function
@@ -329,7 +329,7 @@ class AtomicInteger(private[this] var value: Int)
   override def toString(): String = get().toString()
 
   /** Returns the current value of this {@code AtomicInteger} as an {@code int},
-   *  with memory effects as specified by {@link VarHandle# getVolatile}.
+   *  with memory effects as specified by `VarHandle#getVolatile`.
    *
    *  Equivalent to {@link #get ( )}.
    */
@@ -337,28 +337,19 @@ class AtomicInteger(private[this] var value: Int)
 
   /** Returns the current value of this {@code AtomicInteger} as a {@code long}
    *  after a widening primitive conversion, with memory effects as specified by
-   *  {@link VarHandle# getVolatile}.
-   *
-   *  @jls
-   *    5.1.2 Widening Primitive Conversion
+   *  `VarHandle#getVolatile`.
    */
   override def longValue(): Long = get().toLong
 
   /** Returns the current value of this {@code AtomicInteger} as a {@code float}
    *  after a widening primitive conversion, with memory effects as specified by
-   *  {@link VarHandle# getVolatile}.
-   *
-   *  @jls
-   *    5.1.2 Widening Primitive Conversion
+   *  `VarHandle#getVolatile`.
    */
   override def floatValue(): Float = get().toFloat
 
   /** Returns the current value of this {@code AtomicInteger} as a {@code
    *  double} after a widening primitive conversion, with memory effects as
-   *  specified by {@link VarHandle# getVolatile}.
-   *
-   *  @jls
-   *    5.1.2 Widening Primitive Conversion
+   *  specified by `VarHandle#getVolatile`.
    */
   override def doubleValue(): Double = get().toDouble
 
@@ -382,8 +373,8 @@ class AtomicInteger(private[this] var value: Int)
     value = newValue
   }
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle# getOpaque}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getOpaque`.
    *
    *  @return
    *    the value
@@ -392,7 +383,7 @@ class AtomicInteger(private[this] var value: Int)
   final def getOpaque(): Int = valueRef.load(memory_order_relaxed)
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle# setOpaque}.
+   *  `VarHandle#setOpaque`.
    *
    *  @param newValue
    *    the new value
@@ -401,8 +392,8 @@ class AtomicInteger(private[this] var value: Int)
   final def setOpaque(newValue: Int): Unit =
     valueRef.store(newValue, memory_order_relaxed)
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle# getAcquire}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getAcquire`.
    *
    *  @return
    *    the value
@@ -411,7 +402,7 @@ class AtomicInteger(private[this] var value: Int)
   final def getAcquire(): Int = valueRef.load(memory_order_acquire)
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle# setRelease}.
+   *  `VarHandle#setRelease`.
    *
    *  @param newValue
    *    the new value
@@ -422,7 +413,7 @@ class AtomicInteger(private[this] var value: Int)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle# compareAndExchange}.
+   *  memory effects as specified by `VarHandle#compareAndExchange`.
    *
    *  @param expectedValue
    *    the expected value
@@ -443,8 +434,7 @@ class AtomicInteger(private[this] var value: Int)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#
-   *  compareAndExchangeAcquire}.
+   *  memory effects as specified by `VarHandle#compareAndExchangeAcquire`.
    *
    *  @param expectedValue
    *    the expected value
@@ -468,8 +458,7 @@ class AtomicInteger(private[this] var value: Int)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#
-   *  compareAndExchangeRelease}.
+   *  memory effects as specified by `VarHandle#compareAndExchangeRelease`.
    *
    *  @param expectedValue
    *    the expected value
@@ -492,8 +481,8 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSet}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSet`.
    *
    *  @param expectedValue
    *    the expected value
@@ -511,8 +500,8 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSetAcquire}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetAcquire`.
    *
    *  @param expectedValue
    *    the expected value
@@ -531,8 +520,8 @@ class AtomicInteger(private[this] var value: Int)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSetRelease}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetRelease`.
    *
    *  @param expectedValue
    *    the expected value

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerArray.scala
@@ -43,7 +43,7 @@ class AtomicIntegerArray extends Serializable {
    *
    *  @param array
    *    the array to copy elements from
-   *  @throws NullPointerException
+   *  @throws java.lang.NullPointerException
    *    if array is null
    */
   def this(array: Array[Int]) = {
@@ -59,7 +59,7 @@ class AtomicIntegerArray extends Serializable {
   final def length(): Int = array.length
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getVolatile}.
+   *  effects as specified by `VarHandle#getVolatile`.
    *
    *  @param i
    *    the index
@@ -71,7 +71,7 @@ class AtomicIntegerArray extends Serializable {
   }
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setVolatile}.
+   *  effects as specified by `VarHandle#setVolatile`.
    *
    *  @param i
    *    the index
@@ -83,7 +83,7 @@ class AtomicIntegerArray extends Serializable {
   }
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setRelease}.
+   *  effects as specified by `VarHandle#setRelease`.
    *
    *  @param i
    *    the index
@@ -96,8 +96,8 @@ class AtomicIntegerArray extends Serializable {
   }
 
   /** Atomically sets the element at index {@code i} to {@code newValue} and
-   *  returns the old value, with memory effects as specified by {@link
-   *  VarHandle#getAndSet}.
+   *  returns the old value, with memory effects as specified by
+   *  `VarHandle#getAndSet`.
    *
    *  @param i
    *    the index
@@ -112,7 +112,7 @@ class AtomicIntegerArray extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value {@code == expectedValue}, with memory effects as
-   *  specified by {@link VarHandle#compareAndSet}.
+   *  specified by `VarHandle#compareAndSet`.
    *
    *  @param i
    *    the index
@@ -129,14 +129,14 @@ class AtomicIntegerArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetPlain}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetPlain`.
    *
    *  @deprecated
    *    This method has plain memory effects but the method name implies
    *    volatile memory effects (see methods such as {@link #compareAndExchange}
    *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
-   *    memory effects it is recommended that the method {@link
-   *    #weakCompareAndSetPlain} be used instead.
+   *    memory effects it is recommended that the method
+   *    [[#weakCompareAndSetPlain]] be used instead.
    *
    *  @param i
    *    the index
@@ -159,7 +159,7 @@ class AtomicIntegerArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetPlain}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetPlain`.
    *
    *  @param i
    *    the index
@@ -184,7 +184,7 @@ class AtomicIntegerArray extends Serializable {
   }
 
   /** Atomically increments the value of the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code getAndAdd(i, 1)}.
    *
@@ -198,7 +198,7 @@ class AtomicIntegerArray extends Serializable {
   }
 
   /** Atomically decrements the value of the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code getAndAdd(i, -1)}.
    *
@@ -211,7 +211,7 @@ class AtomicIntegerArray extends Serializable {
     nativeArray.at(i).fetchAdd(-1)
 
   /** Atomically adds the given value to the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  @param i
    *    the index
@@ -224,7 +224,7 @@ class AtomicIntegerArray extends Serializable {
     nativeArray.at(i).fetchAdd(delta)
 
   /** Atomically increments the value of the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code addAndGet(i, 1)}.
    *
@@ -237,7 +237,7 @@ class AtomicIntegerArray extends Serializable {
     nativeArray.at(i).fetchAdd(1) + 1
 
   /** Atomically decrements the value of the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code addAndGet(i, -1)}.
    *
@@ -250,7 +250,7 @@ class AtomicIntegerArray extends Serializable {
     nativeArray.at(i).fetchAdd(-1) - 1
 
   /** Atomically adds the given value to the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  @param i
    *    the index
@@ -262,8 +262,8 @@ class AtomicIntegerArray extends Serializable {
   final def addAndGet(i: Int, delta: Int): Int =
     nativeArray.at(i).fetchAdd(delta) + delta
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function, returning the previous value. The function
    *  should be side-effect-free, since it may be re-applied when attempted
    *  updates fail due to contention among threads.
@@ -292,8 +292,8 @@ class AtomicIntegerArray extends Serializable {
     loop(get(i), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function, returning the updated value. The function
    *  should be side-effect-free, since it may be re-applied when attempted
    *  updates fail due to contention among threads.
@@ -322,8 +322,8 @@ class AtomicIntegerArray extends Serializable {
     loop(get(i), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function to the current and given values, returning
    *  the previous value. The function should be side-effect-free, since it may
    *  be re-applied when attempted updates fail due to contention among threads.
@@ -361,8 +361,8 @@ class AtomicIntegerArray extends Serializable {
     loop(get(i), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function to the current and given values, returning
    *  the updated value. The function should be side-effect-free, since it may
    *  be re-applied when attempted updates fail due to contention among threads.
@@ -435,7 +435,7 @@ class AtomicIntegerArray extends Serializable {
   }
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getOpaque}.
+   *  effects as specified by `VarHandle#getOpaque`.
    *
    *  @param i
    *    the index
@@ -447,7 +447,7 @@ class AtomicIntegerArray extends Serializable {
     nativeArray.at(i).load(memory_order_relaxed)
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setOpaque}.
+   *  effects as specified by `VarHandle#setOpaque`.
    *
    *  @param i
    *    the index
@@ -460,7 +460,7 @@ class AtomicIntegerArray extends Serializable {
   }
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getAcquire}.
+   *  effects as specified by `VarHandle#getAcquire`.
    *
    *  @param i
    *    the index
@@ -473,7 +473,7 @@ class AtomicIntegerArray extends Serializable {
   }
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setRelease}.
+   *  effects as specified by `VarHandle#setRelease`.
    *
    *  @param i
    *    the index
@@ -487,8 +487,8 @@ class AtomicIntegerArray extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchange}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchange`.
    *
    *  @param i
    *    the index
@@ -516,8 +516,8 @@ class AtomicIntegerArray extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeAcquire}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchangeAcquire`.
    *
    *  @param i
    *    the index
@@ -545,8 +545,8 @@ class AtomicIntegerArray extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeRelease}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchangeRelease`.
    *
    *  @param i
    *    the index
@@ -574,7 +574,7 @@ class AtomicIntegerArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSet}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSet`.
    *
    *  @param i
    *    the index
@@ -597,7 +597,7 @@ class AtomicIntegerArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetAcquire}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetAcquire`.
    *
    *  @param i
    *    the index
@@ -620,7 +620,7 @@ class AtomicIntegerArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetRelease}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetRelease`.
    *
    *  @param i
    *    the index

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
@@ -30,8 +30,8 @@ class AtomicLong(private[this] var value: Long)
     this(0)
   }
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle# getVolatile}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getVolatile`.
    *
    *  @return
    *    the current value
@@ -39,7 +39,7 @@ class AtomicLong(private[this] var value: Long)
   final def get(): Long = valueRef.load()
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle# setVolatile}.
+   *  `VarHandle#setVolatile`.
    *
    *  @param newValue
    *    the new value
@@ -47,7 +47,7 @@ class AtomicLong(private[this] var value: Long)
   final def set(newValue: Long): Unit = valueRef.store(newValue)
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle# setRelease}.
+   *  `VarHandle#setRelease`.
    *
    *  @param newValue
    *    the new value
@@ -58,7 +58,7 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Atomically sets the value to {@code newValue} and returns the old value,
-   *  with memory effects as specified by {@link VarHandle# getAndSet}.
+   *  with memory effects as specified by `VarHandle#getAndSet`.
    *
    *  @param newValue
    *    the new value
@@ -70,8 +70,8 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Atomically sets the value to {@code newValue} if the current value {@code
-   *  \== expectedValue}, with memory effects as specified by {@link VarHandle#
-   *  compareAndSet}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndSet`.
    *
    *  @param expectedValue
    *    the expected value
@@ -86,15 +86,15 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSetPlain}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetPlain`.
    *
    *  @deprecated
    *    This method has plain memory effects but the method name implies
    *    volatile memory effects (see methods such as {@link #compareAndExchange}
    *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
-   *    memory effects it is recommended that the method {@link
-   *    #weakCompareAndSetPlain} be used instead.
+   *    memory effects it is recommended that the method
+   *    [[#weakCompareAndSetPlain]] be used instead.
    *  @param expectedValue
    *    the expected value
    *  @param newValue
@@ -110,8 +110,8 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSetPlain}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetPlain`.
    *
    *  @param expectedValue
    *    the expected value
@@ -132,7 +132,7 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Atomically increments the current value, with memory effects as specified
-   *  by {@link VarHandle# getAndAdd}.
+   *  by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code getAndAdd(1)}.
    *
@@ -142,7 +142,7 @@ class AtomicLong(private[this] var value: Long)
   final def getAndIncrement(): Long = getAndAdd(1)
 
   /** Atomically decrements the current value, with memory effects as specified
-   *  by {@link VarHandle# getAndAdd}.
+   *  by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code getAndAdd(-1)}.
    *
@@ -152,7 +152,7 @@ class AtomicLong(private[this] var value: Long)
   final def getAndDecrement(): Long = getAndAdd(-1)
 
   /** Atomically adds the given value to the current value, with memory effects
-   *  as specified by {@link VarHandle# getAndAdd}.
+   *  as specified by `VarHandle#getAndAdd`.
    *
    *  @param delta
    *    the value to add
@@ -164,7 +164,7 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Atomically increments the current value, with memory effects as specified
-   *  by {@link VarHandle# getAndAdd}.
+   *  by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code addAndGet(1)}.
    *
@@ -174,7 +174,7 @@ class AtomicLong(private[this] var value: Long)
   final def incrementAndGet(): Long = addAndGet(1)
 
   /** Atomically decrements the current value, with memory effects as specified
-   *  by {@link VarHandle# getAndAdd}.
+   *  by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code addAndGet(-1)}.
    *
@@ -184,7 +184,7 @@ class AtomicLong(private[this] var value: Long)
   final def decrementAndGet(): Long = addAndGet(-1)
 
   /** Atomically adds the given value to the current value, with memory effects
-   *  as specified by {@link VarHandle# getAndAdd}.
+   *  as specified by `VarHandle#getAndAdd`.
    *
    *  @param delta
    *    the value to add
@@ -193,8 +193,8 @@ class AtomicLong(private[this] var value: Long)
    */
   final def addAndGet(delta: Long): Long = valueRef.fetchAdd(delta) + delta
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function, returning the previous value. The function should be
    *  side-effect-free, since it may be re-applied when attempted updates fail
    *  due to contention among threads.
@@ -221,8 +221,8 @@ class AtomicLong(private[this] var value: Long)
     loop(get(), 0L, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function, returning the updated value. The function should be
    *  side-effect-free, since it may be re-applied when attempted updates fail
    *  due to contention among threads.
@@ -249,8 +249,8 @@ class AtomicLong(private[this] var value: Long)
     loop(get(), 0L, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function to the current and given values, returning the previous
    *  value. The function should be side-effect-free, since it may be re-applied
    *  when attempted updates fail due to contention among threads. The function
@@ -284,8 +284,8 @@ class AtomicLong(private[this] var value: Long)
     loop(get(), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function to the current and given values, returning the updated
    *  value. The function should be side-effect-free, since it may be re-applied
    *  when attempted updates fail due to contention among threads. The function
@@ -327,7 +327,7 @@ class AtomicLong(private[this] var value: Long)
   override def toString(): String = get().toString()
 
   /** Returns the current value of this {@code AtomicInteger} as an {@code int},
-   *  with memory effects as specified by {@link VarHandle# getVolatile}.
+   *  with memory effects as specified by `VarHandle#getVolatile`.
    *
    *  Equivalent to {@link #get ( )}.
    */
@@ -335,28 +335,19 @@ class AtomicLong(private[this] var value: Long)
 
   /** Returns the current value of this {@code AtomicInteger} as a {@code long}
    *  after a widening primitive conversion, with memory effects as specified by
-   *  {@link VarHandle# getVolatile}.
-   *
-   *  @jls
-   *    5.1.2 Widening Primitive Conversion
+   *  `VarHandle#getVolatile`.
    */
   override def longValue(): Long = get().toLong
 
   /** Returns the current value of this {@code AtomicInteger} as a {@code float}
    *  after a widening primitive conversion, with memory effects as specified by
-   *  {@link VarHandle# getVolatile}.
-   *
-   *  @jls
-   *    5.1.2 Widening Primitive Conversion
+   *  `VarHandle#getVolatile`.
    */
   override def floatValue(): Float = get().toFloat
 
   /** Returns the current value of this {@code AtomicInteger} as a {@code
    *  double} after a widening primitive conversion, with memory effects as
-   *  specified by {@link VarHandle# getVolatile}.
-   *
-   *  @jls
-   *    5.1.2 Widening Primitive Conversion
+   *  specified by `VarHandle#getVolatile`.
    */
   override def doubleValue(): Double = get().toDouble
 
@@ -380,8 +371,8 @@ class AtomicLong(private[this] var value: Long)
     value = newValue
   }
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle# getOpaque}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getOpaque`.
    *
    *  @return
    *    the value
@@ -390,7 +381,7 @@ class AtomicLong(private[this] var value: Long)
   final def getOpaque(): Long = valueRef.load(memory_order_relaxed)
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle# setOpaque}.
+   *  `VarHandle#setOpaque`.
    *
    *  @param newValue
    *    the new value
@@ -399,8 +390,8 @@ class AtomicLong(private[this] var value: Long)
   final def setOpaque(newValue: Long): Unit =
     valueRef.store(newValue, memory_order_relaxed)
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle# getAcquire}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getAcquire`.
    *
    *  @return
    *    the value
@@ -409,7 +400,7 @@ class AtomicLong(private[this] var value: Long)
   final def getAcquire: Long = valueRef.load(memory_order_acquire)
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle# setRelease}.
+   *  `VarHandle#setRelease`.
    *
    *  @param newValue
    *    the new value
@@ -420,7 +411,7 @@ class AtomicLong(private[this] var value: Long)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle# compareAndExchange}.
+   *  memory effects as specified by `VarHandle#compareAndExchange`.
    *
    *  @param expectedValue
    *    the expected value
@@ -440,8 +431,7 @@ class AtomicLong(private[this] var value: Long)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#
-   *  compareAndExchangeAcquire}.
+   *  memory effects as specified by `VarHandle#compareAndExchangeAcquire`.
    *
    *  @param expectedValue
    *    the expected value
@@ -464,8 +454,7 @@ class AtomicLong(private[this] var value: Long)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#
-   *  compareAndExchangeRelease}.
+   *  memory effects as specified by `VarHandle#compareAndExchangeRelease`.
    *
    *  @param expectedValue
    *    the expected value
@@ -487,8 +476,8 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSet}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSet`.
    *
    *  @param expectedValue
    *    the expected value
@@ -506,8 +495,8 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSetAcquire}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetAcquire`.
    *
    *  @param expectedValue
    *    the expected value
@@ -526,8 +515,8 @@ class AtomicLong(private[this] var value: Long)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle# weakCompareAndSetRelease}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetRelease`.
    *
    *  @param expectedValue
    *    the expected value

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
@@ -1,64 +1,547 @@
+/*
+ * Based on JSR-166 originally written by Doug Lea with assistance
+ * from members of JCP JSR-166 Expert Group and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
 package java.util.concurrent.atomic
 
+import java.io.Serializable
+import scala.annotation.tailrec
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.unsafe._
+import scala.scalanative.libc.atomic.CAtomicLongLong
+import scala.scalanative.libc.atomic.memory_order._
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
+import java.util.function.{LongBinaryOperator, LongUnaryOperator}
+
+@SerialVersionUID(1927816293512124184L)
 class AtomicLong(private[this] var value: Long)
     extends Number
     with Serializable {
-  def this() = this(0L)
 
-  final def get(): Long = value
+  // Pointer to field containing underlying Long.
+  @alwaysinline
+  private[concurrent] def valueRef = new CAtomicLongLong(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "value"))
+  )
 
-  final def set(newValue: Long): Unit =
-    value = newValue
+  def this() = {
+    this(0)
+  }
 
-  final def lazySet(newValue: Long): Unit =
-    set(newValue)
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle# getVolatile}.
+   *
+   *  @return
+   *    the current value
+   */
+  final def get(): Long = valueRef.load()
 
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle# setVolatile}.
+   *
+   *  @param newValue
+   *    the new value
+   */
+  final def set(newValue: Long): Unit = valueRef.store(newValue)
+
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle# setRelease}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 1.6
+   */
+  final def lazySet(newValue: Long): Unit = {
+    valueRef.store(newValue, memory_order_release)
+  }
+
+  /** Atomically sets the value to {@code newValue} and returns the old value,
+   *  with memory effects as specified by {@link VarHandle# getAndSet}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the previous value
+   */
   final def getAndSet(newValue: Long): Long = {
-    val old = value
-    value = newValue
-    old
+    valueRef.exchange(newValue)
   }
 
-  final def compareAndSet(expect: Long, update: Long): Boolean = {
-    if (expect != value) false
-    else {
-      value = update
+  /** Atomically sets the value to {@code newValue} if the current value {@code
+   *  \== expectedValue}, with memory effects as specified by {@link VarHandle#
+   *  compareAndSet}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful. False return indicates that the actual value
+   *    was not equal to the expected value.
+   */
+  final def compareAndSet(expectedValue: Long, newValue: Long): Boolean = {
+    valueRef.compareExchangeStrong(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSetPlain}.
+   *
+   *  @deprecated
+   *    This method has plain memory effects but the method name implies
+   *    volatile memory effects (see methods such as {@link #compareAndExchange}
+   *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
+   *    memory effects it is recommended that the method {@link
+   *    #weakCompareAndSetPlain} be used instead.
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @see
+   *    #weakCompareAndSetPlain
+   */
+  @deprecated("", "9")
+  final def weakCompareAndSet(expectedValue: Long, newValue: Long): Boolean = {
+    valueRef.compareExchangeWeak(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSetPlain}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetPlain(
+      expectedValue: Long,
+      newValue: Long
+  ): Boolean = {
+    if (value == expectedValue) {
+      value = newValue
       true
+    } else false
+  }
+
+  /** Atomically increments the current value, with memory effects as specified
+   *  by {@link VarHandle# getAndAdd}.
+   *
+   *  <p>Equivalent to {@code getAndAdd(1)}.
+   *
+   *  @return
+   *    the previous value
+   */
+  final def getAndIncrement(): Long = getAndAdd(1)
+
+  /** Atomically decrements the current value, with memory effects as specified
+   *  by {@link VarHandle# getAndAdd}.
+   *
+   *  <p>Equivalent to {@code getAndAdd(-1)}.
+   *
+   *  @return
+   *    the previous value
+   */
+  final def getAndDecrement(): Long = getAndAdd(-1)
+
+  /** Atomically adds the given value to the current value, with memory effects
+   *  as specified by {@link VarHandle# getAndAdd}.
+   *
+   *  @param delta
+   *    the value to add
+   *  @return
+   *    the previous value
+   */
+  final def getAndAdd(delta: Long): Long = {
+    valueRef.fetchAdd(delta)
+  }
+
+  /** Atomically increments the current value, with memory effects as specified
+   *  by {@link VarHandle# getAndAdd}.
+   *
+   *  <p>Equivalent to {@code addAndGet(1)}.
+   *
+   *  @return
+   *    the updated value
+   */
+  final def incrementAndGet(): Long = addAndGet(1)
+
+  /** Atomically decrements the current value, with memory effects as specified
+   *  by {@link VarHandle# getAndAdd}.
+   *
+   *  <p>Equivalent to {@code addAndGet(-1)}.
+   *
+   *  @return
+   *    the updated value
+   */
+  final def decrementAndGet(): Long = addAndGet(-1)
+
+  /** Atomically adds the given value to the current value, with memory effects
+   *  as specified by {@link VarHandle# getAndAdd}.
+   *
+   *  @param delta
+   *    the value to add
+   *  @return
+   *    the updated value
+   */
+  final def addAndGet(delta: Long): Long = valueRef.fetchAdd(delta) + delta
+
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function, returning the previous value. The function should be
+   *  side-effect-free, since it may be re-applied when attempted updates fail
+   *  due to contention among threads.
+   *
+   *  @param updateFunction
+   *    a side-effect-free function
+   *  @return
+   *    the previous value
+   *  @since 1.8
+   */
+  final def getAndUpdate(updateFunction: LongUnaryOperator): Long = {
+    @tailrec
+    def loop(prev: Long, next: Long, haveNext: Boolean): Long = {
+      val newNext =
+        if (!haveNext) updateFunction.applyAsLong(prev)
+        else next
+
+      if (weakCompareAndSetVolatile(prev, newNext)) prev
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, haveNext = prev == newPrev)
+      }
     }
+    loop(get(), 0L, false)
   }
 
-  final def weakCompareAndSet(expect: Long, update: Long): Boolean =
-    compareAndSet(expect, update)
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function, returning the updated value. The function should be
+   *  side-effect-free, since it may be re-applied when attempted updates fail
+   *  due to contention among threads.
+   *
+   *  @param updateFunction
+   *    a side-effect-free function
+   *  @return
+   *    the updated value
+   *  @since 1.8
+   */
+  final def updateAndGet(updateFunction: LongUnaryOperator): Long = {
+    @tailrec
+    def loop(prev: Long, next: Long, haveNext: Boolean): Long = {
+      val newNext =
+        if (!haveNext) updateFunction.applyAsLong(prev)
+        else next
 
-  final def getAndIncrement(): Long =
-    getAndAdd(1L)
-
-  final def getAndDecrement(): Long =
-    getAndAdd(-1L)
-
-  @inline final def getAndAdd(delta: Long): Long = {
-    val old = value
-    value = old + delta
-    old
+      if (weakCompareAndSetVolatile(prev, newNext)) newNext
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
+    }
+    loop(get(), 0L, false)
   }
 
-  final def incrementAndGet(): Long =
-    addAndGet(1L)
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function to the current and given values, returning the previous
+   *  value. The function should be side-effect-free, since it may be re-applied
+   *  when attempted updates fail due to contention among threads. The function
+   *  is applied with the current value as its first argument, and the given
+   *  update as the second argument.
+   *
+   *  @param x
+   *    the update value
+   *  @param accumulatorFunction
+   *    a side-effect-free function of two arguments
+   *  @return
+   *    the previous value
+   *  @since 1.8
+   */
+  final def getAndAccumulate(
+      x: Long,
+      accumulatorFunction: LongBinaryOperator
+  ): Long = {
+    @tailrec
+    def loop(prev: Long, next: Long, haveNext: Boolean): Long = {
+      val newNext =
+        if (!haveNext) accumulatorFunction.applyAsLong(prev, x)
+        else next
 
-  final def decrementAndGet(): Long =
-    addAndGet(-1L)
+      if (weakCompareAndSetVolatile(prev, newNext)) prev
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
+    }
+    loop(get(), 0, false)
+  }
 
-  @inline final def addAndGet(delta: Long): Long = {
-    val newValue = value + delta
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function to the current and given values, returning the updated
+   *  value. The function should be side-effect-free, since it may be re-applied
+   *  when attempted updates fail due to contention among threads. The function
+   *  is applied with the current value as its first argument, and the given
+   *  update as the second argument.
+   *
+   *  @param x
+   *    the update value
+   *  @param accumulatorFunction
+   *    a side-effect-free function of two arguments
+   *  @return
+   *    the updated value
+   *  @since 1.8
+   */
+  final def accumulateAndGet(
+      x: Long,
+      accumulatorFunction: LongBinaryOperator
+  ): Long = {
+    @tailrec
+    def loop(prev: Long, next: Long, haveNext: Boolean): Long = {
+      val newNext =
+        if (!haveNext) accumulatorFunction.applyAsLong(prev, x)
+        else next
+
+      if (weakCompareAndSetVolatile(prev, newNext)) newNext
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
+    }
+    loop(get(), 0, false)
+  }
+
+  /** Returns the String representation of the current value.
+   *
+   *  @return
+   *    the String representation of the current value
+   */
+  override def toString(): String = get().toString()
+
+  /** Returns the current value of this {@code AtomicInteger} as an {@code int},
+   *  with memory effects as specified by {@link VarHandle# getVolatile}.
+   *
+   *  Equivalent to {@link #get ( )}.
+   */
+  override def intValue(): Int = get().toInt
+
+  /** Returns the current value of this {@code AtomicInteger} as a {@code long}
+   *  after a widening primitive conversion, with memory effects as specified by
+   *  {@link VarHandle# getVolatile}.
+   *
+   *  @jls
+   *    5.1.2 Widening Primitive Conversion
+   */
+  override def longValue(): Long = get().toLong
+
+  /** Returns the current value of this {@code AtomicInteger} as a {@code float}
+   *  after a widening primitive conversion, with memory effects as specified by
+   *  {@link VarHandle# getVolatile}.
+   *
+   *  @jls
+   *    5.1.2 Widening Primitive Conversion
+   */
+  override def floatValue(): Float = get().toFloat
+
+  /** Returns the current value of this {@code AtomicInteger} as a {@code
+   *  double} after a widening primitive conversion, with memory effects as
+   *  specified by {@link VarHandle# getVolatile}.
+   *
+   *  @jls
+   *    5.1.2 Widening Primitive Conversion
+   */
+  override def doubleValue(): Double = get().toDouble
+
+  /** Returns the current value, with memory semantics of reading as if the
+   *  variable was declared non-{@code volatile}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getPlain(): Long = value
+
+  /** Sets the value to {@code newValue}, with memory semantics of setting as if
+   *  the variable was declared non-{@code volatile} and non-{@code final}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setPlain(newValue: Long): Unit = {
     value = newValue
-    newValue
   }
 
-  override def toString(): String =
-    value.toString()
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle# getOpaque}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getOpaque(): Long = valueRef.load(memory_order_relaxed)
 
-  def intValue(): Int = value.toInt
-  def longValue(): Long = value
-  def floatValue(): Float = value.toFloat
-  def doubleValue(): Double = value.toDouble
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle# setOpaque}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setOpaque(newValue: Long): Unit =
+    valueRef.store(newValue, memory_order_relaxed)
+
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle# getAcquire}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getAcquire: Long = valueRef.load(memory_order_acquire)
+
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle# setRelease}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setRelease(newValue: Long): Unit =
+    valueRef.store(newValue, memory_order_release)
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle# compareAndExchange}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchange(expectedValue: Long, newValue: Long): Long = {
+    val expected = stackalloc[Long]()
+    !expected = expectedValue
+    valueRef.compareExchangeStrong(expected, newValue)
+    !expected
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#
+   *  compareAndExchangeAcquire}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeAcquire(
+      expectedValue: Long,
+      newValue: Long
+  ): Long = {
+    val expected = stackalloc[Long]()
+    !expected = expectedValue
+    valueRef.compareExchangeStrong(expected, newValue, memory_order_acquire)
+    !expected
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#
+   *  compareAndExchangeRelease}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeRelease(
+      expectedValue: Long,
+      newValue: Long
+  ): Long = {
+    val expected = stackalloc[Long]()
+    !expected = expectedValue
+    valueRef.compareExchangeStrong(expected, newValue, memory_order_release)
+    !expected
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSet}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetVolatile(
+      expectedValue: Long,
+      newValue: Long
+  ): Boolean = {
+    valueRef.compareExchangeWeak(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSetAcquire}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetAcquire(
+      expectedValue: Long,
+      newValue: Long
+  ): Boolean = {
+    valueRef
+      .compareExchangeWeak(expectedValue, newValue, memory_order_acquire)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle# weakCompareAndSetRelease}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetRelease(
+      expectedValue: Long,
+      newValue: Long
+  ): Boolean = {
+    valueRef
+      .compareExchangeWeak(expectedValue, newValue, memory_order_release)
+  }
 }

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
@@ -45,7 +45,7 @@ class AtomicLongArray extends Serializable {
    *
    *  @param array
    *    the array to copy elements from
-   *  @throws NullPointerException
+   *  @throws java.lang.NullPointerException
    *    if array is null
    */
   def this(array: Array[Long]) = {
@@ -61,7 +61,7 @@ class AtomicLongArray extends Serializable {
   final def length(): Int = array.length
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getVolatile}.
+   *  effects as specified by `VarHandle#getVolatile`.
    *
    *  @param i
    *    the index
@@ -73,7 +73,7 @@ class AtomicLongArray extends Serializable {
   }
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setVolatile}.
+   *  effects as specified by `VarHandle#setVolatile`.
    *
    *  @param i
    *    the index
@@ -85,7 +85,7 @@ class AtomicLongArray extends Serializable {
   }
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setRelease}.
+   *  effects as specified by `VarHandle#setRelease`.
    *
    *  @param i
    *    the index
@@ -98,8 +98,8 @@ class AtomicLongArray extends Serializable {
   }
 
   /** Atomically sets the element at index {@code i} to {@code newValue} and
-   *  returns the old value, with memory effects as specified by {@link
-   *  VarHandle#getAndSet}.
+   *  returns the old value, with memory effects as specified by
+   *  `VarHandle#getAndSet`.
    *
    *  @param i
    *    the index
@@ -114,7 +114,7 @@ class AtomicLongArray extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value {@code == expectedValue}, with memory effects as
-   *  specified by {@link VarHandle#compareAndSet}.
+   *  specified by `VarHandle#compareAndSet`.
    *
    *  @param i
    *    the index
@@ -135,14 +135,14 @@ class AtomicLongArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetPlain}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetPlain`.
    *
    *  @deprecated
    *    This method has plain memory effects but the method name implies
    *    volatile memory effects (see methods such as {@link #compareAndExchange}
    *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
-   *    memory effects it is recommended that the method {@link
-   *    #weakCompareAndSetPlain} be used instead.
+   *    memory effects it is recommended that the method
+   *    [[#weakCompareAndSetPlain]] be used instead.
    *
    *  @param i
    *    the index
@@ -165,7 +165,7 @@ class AtomicLongArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetPlain}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetPlain`.
    *
    *  @param i
    *    the index
@@ -190,7 +190,7 @@ class AtomicLongArray extends Serializable {
   }
 
   /** Atomically increments the value of the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code getAndAdd(i, 1)}.
    *
@@ -204,7 +204,7 @@ class AtomicLongArray extends Serializable {
   }
 
   /** Atomically decrements the value of the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code getAndAdd(i, -1)}.
    *
@@ -217,7 +217,7 @@ class AtomicLongArray extends Serializable {
     nativeArray.at(i).fetchAdd(-1)
 
   /** Atomically adds the given value to the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  @param i
    *    the index
@@ -230,7 +230,7 @@ class AtomicLongArray extends Serializable {
     nativeArray.at(i).fetchAdd(delta)
 
   /** Atomically increments the value of the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code addAndGet(i, 1)}.
    *
@@ -243,7 +243,7 @@ class AtomicLongArray extends Serializable {
     nativeArray.at(i).fetchAdd(1) + 1
 
   /** Atomically decrements the value of the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  <p>Equivalent to {@code addAndGet(i, -1)}.
    *
@@ -256,7 +256,7 @@ class AtomicLongArray extends Serializable {
     nativeArray.at(i).fetchAdd(-1) - 1
 
   /** Atomically adds the given value to the element at index {@code i}, with
-   *  memory effects as specified by {@link VarHandle#getAndAdd}.
+   *  memory effects as specified by `VarHandle#getAndAdd`.
    *
    *  @param i
    *    the index
@@ -268,8 +268,8 @@ class AtomicLongArray extends Serializable {
   final def addAndGet(i: Int, delta: Long): Long =
     nativeArray.at(i).fetchAdd(delta) + delta
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function, returning the previous value. The function
    *  should be side-effect-free, since it may be re-applied when attempted
    *  updates fail due to contention among threads.
@@ -298,8 +298,8 @@ class AtomicLongArray extends Serializable {
     loop(get(i), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function, returning the updated value. The function
    *  should be side-effect-free, since it may be re-applied when attempted
    *  updates fail due to contention among threads.
@@ -328,8 +328,8 @@ class AtomicLongArray extends Serializable {
     loop(get(i), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function to the current and given values, returning
    *  the previous value. The function should be side-effect-free, since it may
    *  be re-applied when attempted updates fail due to contention among threads.
@@ -367,8 +367,8 @@ class AtomicLongArray extends Serializable {
     loop(get(i), 0, false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function to the current and given values, returning
    *  the updated value. The function should be side-effect-free, since it may
    *  be re-applied when attempted updates fail due to contention among threads.
@@ -441,7 +441,7 @@ class AtomicLongArray extends Serializable {
   }
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getOpaque}.
+   *  effects as specified by `VarHandle#getOpaque`.
    *
    *  @param i
    *    the index
@@ -453,7 +453,7 @@ class AtomicLongArray extends Serializable {
     nativeArray.at(i).load(memory_order_relaxed)
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setOpaque}.
+   *  effects as specified by `VarHandle#setOpaque`.
    *
    *  @param i
    *    the index
@@ -466,7 +466,7 @@ class AtomicLongArray extends Serializable {
   }
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getAcquire}.
+   *  effects as specified by `VarHandle#getAcquire`.
    *
    *  @param i
    *    the index
@@ -479,7 +479,7 @@ class AtomicLongArray extends Serializable {
   }
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setRelease}.
+   *  effects as specified by `VarHandle#setRelease`.
    *
    *  @param i
    *    the index
@@ -493,8 +493,8 @@ class AtomicLongArray extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchange}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchange`.
    *
    *  @param i
    *    the index
@@ -522,8 +522,8 @@ class AtomicLongArray extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeAcquire}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchangeAcquire`.
    *
    *  @param i
    *    the index
@@ -551,8 +551,8 @@ class AtomicLongArray extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeRelease}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchangeRelease`.
    *
    *  @param i
    *    the index
@@ -580,7 +580,7 @@ class AtomicLongArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSet}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSet`.
    *
    *  @param i
    *    the index
@@ -603,7 +603,7 @@ class AtomicLongArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetAcquire}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetAcquire`.
    *
    *  @param i
    *    the index
@@ -626,7 +626,7 @@ class AtomicLongArray extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetRelease}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetRelease`.
    *
    *  @param i
    *    the index

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicMarkableReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicMarkableReference.scala
@@ -1,0 +1,169 @@
+/*
+ * Based on JSR-166 originally written by Doug Lea with assistance
+ * from members of JCP JSR-166 Expert Group and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent.atomic
+
+import scala.annotation.tailrec
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.unsafe._
+import scala.scalanative.libc.atomic.CAtomicRef
+import scala.scalanative.libc.atomic.memory_order._
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
+import scala.scalanative.runtime.Intrinsics
+
+object AtomicMarkableReference {
+  private[concurrent] case class MarkableReference[T <: AnyRef](
+      reference: T,
+      mark: Boolean
+  )
+}
+
+import AtomicMarkableReference._
+class AtomicMarkableReference[V <: AnyRef](
+    private[this] var value: MarkableReference[V]
+) {
+
+  def this(initialRef: V, initialMark: Boolean) = {
+    this(MarkableReference(initialRef, initialMark))
+  }
+
+  // Pointer to field containing underlying MarkableReference.
+  @alwaysinline
+  private[concurrent] def valueRef: CAtomicRef[MarkableReference[V]] = {
+    new CAtomicRef(
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "value"))
+    )
+  }
+
+  /** Returns the current value of the reference.
+   *
+   *  @return
+   *    the current value of the reference
+   */
+  def getReference(): V = valueRef.load().reference
+
+  /** Returns the current value of the mark.
+   *
+   *  @return
+   *    the current value of the mark
+   */
+  def isMarked(): Boolean = valueRef.load().mark
+
+  /** Returns the current values of both the reference and the mark. Typical
+   *  usage is {@code boolean[1] holder; ref = v.get(holder); }.
+   *
+   *  @param markHolder
+   *    an array of size of at least one. On return, {@code markHolder[0]} will
+   *    hold the value of the mark.
+   *  @return
+   *    the current value of the reference
+   */
+  def get(markHolder: Array[Boolean]): V = {
+    val current = valueRef.load()
+    markHolder(0) = current.mark
+    current.reference
+  }
+
+  /** Atomically sets the value of both the reference and mark to the given
+   *  update values if the current reference is {@code ==} to the expected
+   *  reference and the current mark is equal to the expected mark. This
+   *  operation may fail spuriously and does not provide ordering guarantees, so
+   *  is only rarely an appropriate alternative to {@code compareAndSet}.
+   *
+   *  @param expectedReference
+   *    the expected value of the reference
+   *  @param newReference
+   *    the new value for the reference
+   *  @param expectedMark
+   *    the expected value of the mark
+   *  @param newMark
+   *    the new value for the mark
+   *  @return
+   *    {@code true} if successful
+   */
+  def weakCompareAndSet(
+      expectedReference: V,
+      newReference: V,
+      expectedMark: Boolean,
+      newMark: Boolean
+  ): Boolean =
+    compareAndSet(expectedReference, newReference, expectedMark, newMark)
+
+  /** Atomically sets the value of both the reference and mark to the given
+   *  update values if the current reference is {@code ==} to the expected
+   *  reference and the current mark is equal to the expected mark.
+   *
+   *  @param expectedReference
+   *    the expected value of the reference
+   *  @param newReference
+   *    the new value for the reference
+   *  @param expectedMark
+   *    the expected value of the mark
+   *  @param newMark
+   *    the new value for the mark
+   *  @return
+   *    {@code true} if successful
+   */
+  def compareAndSet(
+      expectedReference: V,
+      newReference: V,
+      expectedMark: Boolean,
+      newMark: Boolean
+  ): Boolean = {
+    val current = valueRef.load()
+
+    (expectedReference eq current.reference) &&
+      expectedMark == current.mark && {
+        ((newReference eq current.reference) && newMark == current.mark) ||
+        valueRef
+          .compareExchangeStrong(
+            current,
+            MarkableReference(newReference, newMark)
+          )
+      }
+  }
+
+  /** Unconditionally sets the value of both the reference and mark.
+   *
+   *  @param newReference
+   *    the new value for the reference
+   *  @param newMark
+   *    the new value for the mark
+   */
+  def set(newReference: V, newMark: Boolean): Unit = {
+    val current = valueRef.load()
+    if ((newReference ne current.reference) || newMark != current.mark) {
+      valueRef.store(MarkableReference(newReference, newMark))
+    }
+  }
+
+  /** Atomically sets the value of the mark to the given update value if the
+   *  current reference is {@code ==} to the expected reference. Any given
+   *  invocation of this operation may fail (return {@code false}) spuriously,
+   *  but repeated invocation when the current value holds the expected value
+   *  and no other thread is also attempting to set the value will eventually
+   *  succeed.
+   *
+   *  @param expectedReference
+   *    the expected value of the reference
+   *  @param newMark
+   *    the new value for the mark
+   *  @return
+   *    {@code true} if successful
+   */
+  def attemptMark(expectedReference: V, newMark: Boolean): Boolean = {
+    val current = valueRef.load()
+    (expectedReference eq current.reference) && {
+      newMark == current.mark ||
+      valueRef
+        .compareExchangeStrong(
+          current,
+          MarkableReference(expectedReference, newMark)
+        )
+    }
+  }
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
@@ -1,51 +1,456 @@
+/*
+ * Based on JSR-166 originally written by Doug Lea with assistance
+ * from members of JCP JSR-166 Expert Group and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
 package java.util.concurrent.atomic
 
-// Warning: The current implementation of this entire package relies on
-//          Scala Native being single threaded.
+import scala.annotation.tailrec
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.unsafe._
+import scala.scalanative.libc.atomic.CAtomicRef
+import scala.scalanative.libc.atomic.memory_order._
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
+import java.util.function.{BinaryOperator, UnaryOperator}
 
-import java.util.function.UnaryOperator
-
-class AtomicReference[T <: AnyRef](private[this] var value: T)
+@SerialVersionUID(-1848883965231344442L)
+class AtomicReference[V <: AnyRef](@volatile private var value: V)
     extends Serializable {
+  def this() = {
+    this(null.asInstanceOf[V])
+  }
 
-  def this() = this(null.asInstanceOf[T])
+  assert(valueRef.load() == value, "Value reference does not match field")
 
-  final def get(): T = value
+  // Pointer to field containing underlying V.
+  @alwaysinline
+  private[concurrent] def valueRef: CAtomicRef[V] =
+    new CAtomicRef[V](
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "value"))
+    )
 
-  final def set(newValue: T): Unit =
-    value = newValue
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle#getVolatile}.
+   *
+   *  @return
+   *    the current value
+   */
+  final def get(): V = value
 
-  final def lazySet(newValue: T): Unit =
-    set(newValue)
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle#setVolatile}.
+   *
+   *  @param newValue
+   *    the new value
+   */
+  final def set(newValue: V): Unit = value = newValue
 
-  final def compareAndSet(expect: T, update: T): Boolean = {
-    if (expect ne value) false
-    else {
-      value = update
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle#setRelease}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 1.6
+   */
+  final def lazySet(newValue: V): Unit = {
+    valueRef.store(newValue, memory_order_release)
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value {@code
+   *  \== expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful. False return indicates that the actual value
+   *    was not equal to the expected value.
+   */
+  final def compareAndSet(expectedValue: V, newValue: V): Boolean =
+    valueRef.compareExchangeStrong(expectedValue, newValue)
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSetPlain}.
+   *
+   *  @deprecated
+   *    This method has plain memory effects but the method name implies
+   *    volatile memory effects (see methods such as {@link #compareAndExchange}
+   *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
+   *    memory effects it is recommended that the method {@link
+   *    #weakCompareAndSetPlain} be used instead.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @see
+   *    #weakCompareAndSetPlain
+   */
+  @deprecated("", "9")
+  final def weakCompareAndSet(expectedValue: V, newValue: V): Boolean = {
+    weakCompareAndSetPlain(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSetPlain}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetPlain(expectedValue: V, newValue: V): Boolean = {
+    if (value eq expectedValue) {
+      value = newValue
       true
+    } else false
+  }
+
+  /** Atomically sets the value to {@code newValue} and returns the old value,
+   *  with memory effects as specified by {@link VarHandle#getAndSet}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the previous value
+   */
+  final def getAndSet(newValue: V): V = {
+    valueRef.exchange(newValue)
+  }
+
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function, returning the previous value. The function should be
+   *  side-effect-free, since it may be re-applied when attempted updates fail
+   *  due to contention among threads.
+   *
+   *  @param updateFunction
+   *    a side-effect-free function
+   *  @return
+   *    the previous value
+   *  @since 1.8
+   */
+  final def getAndUpdate(updateFunction: UnaryOperator[V]): V = {
+    @tailrec
+    def loop(prev: V, next: V, haveNext: Boolean): V = {
+      val newNext =
+        if (!haveNext) updateFunction.apply(prev)
+        else next
+      if (weakCompareAndSetVolatile(prev, newNext)) prev
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
     }
+    loop(get(), null.asInstanceOf[V], false)
   }
 
-  final def weakCompareAndSet(expect: T, update: T): Boolean =
-    compareAndSet(expect, update)
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function, returning the updated value. The function should be
+   *  side-effect-free, since it may be re-applied when attempted updates fail
+   *  due to contention among threads.
+   *
+   *  @param updateFunction
+   *    a side-effect-free function
+   *  @return
+   *    the updated value
+   *  @since 1.8
+   */
+  final def updateAndGet(updateFunction: UnaryOperator[V]): V = {
+    @tailrec
+    def loop(prev: V, next: V, haveNext: Boolean): V = {
+      val newNext =
+        if (!haveNext) updateFunction.apply(prev)
+        else next
+      if (weakCompareAndSetVolatile(prev, newNext)) newNext
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
+    }
+    loop(get(), null.asInstanceOf[V], false)
+  }
 
-  final def getAndSet(newValue: T): T = {
-    val old = value
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function to the current and given values, returning the previous
+   *  value. The function should be side-effect-free, since it may be re-applied
+   *  when attempted updates fail due to contention among threads. The function
+   *  is applied with the current value as its first argument, and the given
+   *  update as the second argument.
+   *
+   *  @param x
+   *    the update value
+   *  @param accumulatorFunction
+   *    a side-effect-free function of two arguments
+   *  @return
+   *    the previous value
+   *  @since 1.8
+   */
+  final def getAndAccumulate(
+      x: V,
+      accumulatorFunction: BinaryOperator[V]
+  ): V = {
+    @tailrec
+    def loop(prev: V, next: V, hasNext: Boolean): V = {
+      val newNext = if (hasNext) next else accumulatorFunction.apply(prev, x)
+      if (weakCompareAndSetVolatile(prev, newNext)) prev
+      else {
+        val newPrev = get()
+        loop(newPrev, newNext, prev == newPrev)
+      }
+    }
+    loop(get(), null.asInstanceOf[V], false)
+  }
+
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the current value with the results of applying
+   *  the given function to the current and given values, returning the updated
+   *  value. The function should be side-effect-free, since it may be re-applied
+   *  when attempted updates fail due to contention among threads. The function
+   *  is applied with the current value as its first argument, and the given
+   *  update as the second argument.
+   *
+   *  @param x
+   *    the update value
+   *  @param accumulatorFunction
+   *    a side-effect-free function of two arguments
+   *  @return
+   *    the updated value
+   *  @since 1.8
+   */
+  final def accumulateAndGet(
+      x: V,
+      accumulatorFunction: BinaryOperator[V]
+  ): V = {
+    @tailrec
+    def loop(prev: V, next: Option[V]): V = {
+      val newNext = next.getOrElse(accumulatorFunction.apply(prev, x))
+      if (weakCompareAndSetVolatile(prev, newNext)) newNext
+      else {
+        val newPrev = get()
+        loop(newPrev, if (newPrev eq prev) Some(newNext) else None)
+      }
+    }
+    loop(get(), None)
+  }
+
+  /** Returns the String representation of the current value.
+   *  @return
+   *    the String representation of the current value
+   */
+  override def toString(): String = String.valueOf(get())
+
+  /** Returns the current value, with memory semantics of reading as if the
+   *  variable was declared non-{@code volatile}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getPlain(): V = value
+
+  /** Sets the value to {@code newValue}, with memory semantics of setting as if
+   *  the variable was declared non-{@code volatile} and non-{@code final}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setPlain(newValue: V): Unit = {
     value = newValue
-    old
   }
 
-  final def getAndUpdate(updateFunction: UnaryOperator[T]): T = {
-    val old = value
-    value = updateFunction(old)
-    old
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle#getOpaque}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getOpaque(): V = valueRef.load(memory_order_relaxed)
+
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle#setOpaque}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setOpaque(newValue: V): Unit =
+    valueRef.store(newValue, memory_order_relaxed)
+
+  /** Returns the current value, with memory effects as specified by {@link
+   *  VarHandle#getAcquire}.
+   *
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getAcquire: V = {
+    valueRef.load(memory_order_acquire)
   }
 
-  final def updateAndGet(updateFunction: UnaryOperator[T]): T = {
-    value = updateFunction(value)
-    value
+  /** Sets the value to {@code newValue}, with memory effects as specified by
+   *  {@link VarHandle#setRelease}.
+   *
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setRelease(newValue: V): Unit = {
+    valueRef.store(newValue, memory_order_release)
   }
 
-  override def toString(): String =
-    String.valueOf(value)
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#compareAndExchange}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchange(expectedValue: V, newValue: V): V = {
+    val expected = stackalloc[AnyRef]()
+    !expected = expectedValue
+    valueRef
+      .compareExchangeStrong(
+        expected.asInstanceOf[Ptr[V]],
+        newValue
+      )
+    (!expected).asInstanceOf[V]
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link
+   *  VarHandle#compareAndExchangeAcquire}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeAcquire(expectedValue: V, newValue: V): V = {
+    val expected = stackalloc[AnyRef]()
+    !expected = expectedValue
+    valueRef
+      .compareExchangeStrong(
+        expected.asInstanceOf[Ptr[V]],
+        newValue,
+        memory_order_acquire
+      )
+    (!expected).asInstanceOf[V]
+  }
+
+  /** Atomically sets the value to {@code newValue} if the current value,
+   *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
+   *  memory effects as specified by {@link
+   *  VarHandle#compareAndExchangeRelease}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeRelease(expectedValue: V, newValue: V): V = {
+    val expected = stackalloc[AnyRef]()
+    !expected = expectedValue
+    valueRef
+      .compareExchangeStrong(
+        expected.asInstanceOf[Ptr[V]],
+        newValue,
+        memory_order_release
+      )
+    (!expected).asInstanceOf[V]
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSet}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetVolatile(
+      expectedValue: V,
+      newValue: V
+  ): Boolean = {
+    valueRef.compareExchangeWeak(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSetAcquire}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetAcquire(expectedValue: V, newValue: V): Boolean = {
+    val expected = stackalloc[AnyRef]()
+    !expected = expectedValue
+    valueRef
+      .compareExchangeWeak(
+        expected.asInstanceOf[Ptr[V]],
+        newValue,
+        memory_order_acquire
+      )
+  }
+
+  /** Possibly atomically sets the value to {@code newValue} if the current
+   *  value {@code == expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#weakCompareAndSetRelease}.
+   *
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetRelease(expectedValue: V, newValue: V): Boolean = {
+    val expected = stackalloc[AnyRef]()
+    !expected = expectedValue
+    valueRef
+      .compareExchangeWeak(
+        expected.asInstanceOf[Ptr[V]],
+        newValue,
+        memory_order_release
+      )
+  }
 }

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
@@ -30,8 +30,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "value"))
     )
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle#getVolatile}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getVolatile`.
    *
    *  @return
    *    the current value
@@ -39,7 +39,7 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   final def get(): V = value
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle#setVolatile}.
+   *  `VarHandle#setVolatile`.
    *
    *  @param newValue
    *    the new value
@@ -47,7 +47,7 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   final def set(newValue: V): Unit = value = newValue
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle#setRelease}.
+   *  `VarHandle#setRelease`.
    *
    *  @param newValue
    *    the new value
@@ -58,8 +58,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   }
 
   /** Atomically sets the value to {@code newValue} if the current value {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndSet`.
    *
    *  @param expectedValue
    *    the expected value
@@ -73,15 +73,15 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
     valueRef.compareExchangeStrong(expectedValue, newValue)
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSetPlain}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetPlain`.
    *
    *  @deprecated
    *    This method has plain memory effects but the method name implies
    *    volatile memory effects (see methods such as {@link #compareAndExchange}
    *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
-   *    memory effects it is recommended that the method {@link
-   *    #weakCompareAndSetPlain} be used instead.
+   *    memory effects it is recommended that the method
+   *    [[#weakCompareAndSetPlain]] be used instead.
    *
    *  @param expectedValue
    *    the expected value
@@ -98,8 +98,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSetPlain}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetPlain`.
    *
    *  @param expectedValue
    *    the expected value
@@ -117,7 +117,7 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   }
 
   /** Atomically sets the value to {@code newValue} and returns the old value,
-   *  with memory effects as specified by {@link VarHandle#getAndSet}.
+   *  with memory effects as specified by `VarHandle#getAndSet`.
    *
    *  @param newValue
    *    the new value
@@ -128,8 +128,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
     valueRef.exchange(newValue)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function, returning the previous value. The function should be
    *  side-effect-free, since it may be re-applied when attempted updates fail
    *  due to contention among threads.
@@ -155,8 +155,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
     loop(get(), null.asInstanceOf[V], false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function, returning the updated value. The function should be
    *  side-effect-free, since it may be re-applied when attempted updates fail
    *  due to contention among threads.
@@ -182,8 +182,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
     loop(get(), null.asInstanceOf[V], false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function to the current and given values, returning the previous
    *  value. The function should be side-effect-free, since it may be re-applied
    *  when attempted updates fail due to contention among threads. The function
@@ -214,8 +214,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
     loop(get(), null.asInstanceOf[V], false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the current value with the results of applying
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the current value with the results of applying
    *  the given function to the current and given values, returning the updated
    *  value. The function should be side-effect-free, since it may be re-applied
    *  when attempted updates fail due to contention among threads. The function
@@ -272,8 +272,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
     value = newValue
   }
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle#getOpaque}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getOpaque`.
    *
    *  @return
    *    the value
@@ -282,7 +282,7 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   final def getOpaque(): V = valueRef.load(memory_order_relaxed)
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle#setOpaque}.
+   *  `VarHandle#setOpaque`.
    *
    *  @param newValue
    *    the new value
@@ -291,8 +291,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   final def setOpaque(newValue: V): Unit =
     valueRef.store(newValue, memory_order_relaxed)
 
-  /** Returns the current value, with memory effects as specified by {@link
-   *  VarHandle#getAcquire}.
+  /** Returns the current value, with memory effects as specified by
+   *  `VarHandle#getAcquire`.
    *
    *  @return
    *    the value
@@ -303,7 +303,7 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   }
 
   /** Sets the value to {@code newValue}, with memory effects as specified by
-   *  {@link VarHandle#setRelease}.
+   *  `VarHandle#setRelease`.
    *
    *  @param newValue
    *    the new value
@@ -315,7 +315,7 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#compareAndExchange}.
+   *  memory effects as specified by `VarHandle#compareAndExchange`.
    *
    *  @param expectedValue
    *    the expected value
@@ -339,8 +339,7 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeAcquire}.
+   *  memory effects as specified by `VarHandle#compareAndExchangeAcquire`.
    *
    *  @param expectedValue
    *    the expected value
@@ -365,8 +364,7 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
 
   /** Atomically sets the value to {@code newValue} if the current value,
    *  referred to as the <em>witness value</em>, {@code == expectedValue}, with
-   *  memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeRelease}.
+   *  memory effects as specified by `VarHandle#compareAndExchangeRelease`.
    *
    *  @param expectedValue
    *    the expected value
@@ -390,8 +388,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSet}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSet`.
    *
    *  @param expectedValue
    *    the expected value
@@ -409,8 +407,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSetAcquire}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetAcquire`.
    *
    *  @param expectedValue
    *    the expected value
@@ -432,8 +430,8 @@ class AtomicReference[V <: AnyRef](@volatile private var value: V)
   }
 
   /** Possibly atomically sets the value to {@code newValue} if the current
-   *  value {@code == expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#weakCompareAndSetRelease}.
+   *  value {@code == expectedValue}, with memory effects as specified by
+   *  `VarHandle#weakCompareAndSetRelease`.
    *
    *  @param expectedValue
    *    the expected value

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
@@ -1,43 +1,572 @@
+/*
+ * Based on JSR-166 originally written by Doug Lea with assistance
+ * from members of JCP JSR-166 Expert Group and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
 package java.util.concurrent.atomic
 
-class AtomicReferenceArray[E <: AnyRef](_length: Int) extends Serializable {
+import scala.annotation.tailrec
+import scala.language.implicitConversions
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.unsafe._
+import scala.scalanative.libc.atomic.CAtomicRef
+import scala.scalanative.libc.atomic.memory_order._
+import scala.scalanative.runtime.ObjectArray
+import java.util.Arrays
+import java.util.function.{BinaryOperator, UnaryOperator}
 
+class AtomicReferenceArray[E <: AnyRef] extends Serializable {
+
+  final private var array: Array[E] = null
+
+  @alwaysinline
+  private[concurrent] def nativeArray: ObjectArray =
+    array.asInstanceOf[ObjectArray]
+
+  @alwaysinline
+  private implicit def ptrRefToAtomicRef(ptr: Ptr[Object]): CAtomicRef[E] =
+    new CAtomicRef[E](ptr.asInstanceOf[Ptr[E]])
+
+  /** Creates a new AtomicReferenceArray of the given length, with all elements
+   *  initially null.
+   *
+   *  @param length
+   *    the length of the array
+   */
+  def this(length: Int) = {
+    this()
+    this.array = new Array[AnyRef](length).asInstanceOf[Array[E]]
+  }
+
+  /** Creates a new AtomicReferenceArray with the same length as, and all
+   *  elements copied from, the given array.
+   *
+   *  @param array
+   *    the array to copy elements from
+   *  @throws NullPointerException
+   *    if array is null
+   */
   def this(array: Array[E]) = {
-    this(array.size)
-    System.arraycopy(array, 0, inner, 0, _length)
+    this()
+    this.array = Arrays.copyOf[E](array, array.length)
   }
 
-  private val inner: Array[AnyRef] = new Array[AnyRef](_length)
+  /** Returns the length of the array.
+   *
+   *  @return
+   *    the length of the array
+   */
+  final def length(): Int = array.length
 
-  final def length(): Int =
-    inner.length
+  /** Returns the current value of the element at index {@code i}, with memory
+   *  effects as specified by {@link VarHandle#getVolatile}.
+   *
+   *  @param i
+   *    the index
+   *  @return
+   *    the current value
+   */
+  final def get(i: Int): E = nativeArray.at(i).load()
 
-  final def get(i: Int): E =
-    inner(i).asInstanceOf[E]
-
-  final def set(i: Int, newValue: E): Unit =
-    inner(i) = newValue
-
-  final def lazySet(i: Int, newValue: E): Unit =
-    set(i, newValue)
-
-  final def getAndSet(i: Int, newValue: E): E = {
-    val ret = get(i)
-    set(i, newValue)
-    ret
+  /** Sets the element at index {@code i} to {@code newValue}, with memory
+   *  effects as specified by {@link VarHandle#setVolatile}.
+   *
+   *  @param i
+   *    the index
+   *  @param newValue
+   *    the new value
+   */
+  final def set(i: Int, newValue: E): Unit = {
+    nativeArray.at(i).store(newValue)
   }
 
-  final def compareAndSet(i: Int, expect: E, update: E): Boolean = {
-    if (get(i) ne expect) false
-    else {
-      set(i, update)
+  /** Sets the element at index {@code i} to {@code newValue}, with memory
+   *  effects as specified by {@link VarHandle#setRelease}.
+   *
+   *  @param i
+   *    the index
+   *  @param newValue
+   *    the new value
+   *  @since 1.6
+   */
+  final def lazySet(i: Int, newValue: E): Unit = {
+    nativeArray.at(i).store(newValue, memory_order_release)
+  }
+
+  /** Atomically sets the element at index {@code i} to {@code newValue} and
+   *  returns the old value, with memory effects as specified by {@link
+   *  VarHandle#getAndSet}.
+   *
+   *  @param i
+   *    the index
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the previous value
+   */
+  final def getAndSet(i: Int, newValue: E): E =
+    nativeArray.at(i).exchange(newValue)
+
+  /** Atomically sets the element at index {@code i} to {@code newValue} if the
+   *  element's current value {@code == expectedValue}, with memory effects as
+   *  specified by {@link VarHandle#compareAndSet}.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful. False return indicates that the actual value
+   *    was not equal to the expected value.
+   */
+  final def compareAndSet(i: Int, expectedValue: E, newValue: E): Boolean =
+    nativeArray.at(i).compareExchangeStrong(expectedValue, newValue)
+
+  /** Possibly atomically sets the element at index {@code i} to {@code
+   *  newValue} if the element's current value {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#weakCompareAndSetPlain}.
+   *
+   *  @deprecated
+   *    This method has plain memory effects but the method name implies
+   *    volatile memory effects (see methods such as {@link #compareAndExchange}
+   *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
+   *    memory effects it is recommended that the method {@link
+   *    #weakCompareAndSetPlain} be used instead.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @see
+   *    #weakCompareAndSetPlain
+   */
+  @deprecated("", "9")
+  final def weakCompareAndSet(i: Int, expectedValue: E, newValue: E): Boolean =
+    weakCompareAndSetPlain(i, expectedValue, newValue)
+
+  /** Possibly atomically sets the element at index {@code i} to {@code
+   *  newValue} if the element's current value {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#weakCompareAndSetPlain}.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetPlain(
+      i: Int,
+      expectedValue: E,
+      newValue: E
+  ): Boolean =
+    if (array(i) eq expectedValue) {
+      array(i) = newValue
       true
+    } else false
+
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+   *  of applying the given function, returning the previous value. The function
+   *  should be side-effect-free, since it may be re-applied when attempted
+   *  updates fail due to contention among threads.
+   *
+   *  @param i
+   *    the index
+   *  @param updateFunction
+   *    a side-effect-free function
+   *  @return
+   *    the previous value
+   *  @since 1.8
+   */
+  final def getAndUpdate(i: Int, updateFunction: UnaryOperator[E]): E = {
+    @tailrec
+    def loop(prev: E, next: E, haveNext: Boolean): E = {
+      val newNext =
+        if (!haveNext) updateFunction.apply(prev)
+        else next
+
+      if (weakCompareAndSetVolatile(i, prev, newNext)) prev
+      else {
+        val newPrev = get(i)
+        loop(newPrev, newNext, prev eq newPrev)
+      }
     }
+    loop(get(i), null.asInstanceOf[E], false)
   }
 
-  final def weakCompareAndSet(i: Int, expect: E, update: E): Boolean =
-    compareAndSet(i, expect, update)
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+   *  of applying the given function, returning the updated value. The function
+   *  should be side-effect-free, since it may be re-applied when attempted
+   *  updates fail due to contention among threads.
+   *
+   *  @param i
+   *    the index
+   *  @param updateFunction
+   *    a side-effect-free function
+   *  @return
+   *    the updated value
+   *  @since 1.8
+   */
+  final def updateAndGet(i: Int, updateFunction: UnaryOperator[E]): E = {
+    @tailrec
+    def loop(prev: E, next: E, haveNext: Boolean): E = {
+      val newNext =
+        if (!haveNext) updateFunction.apply(prev)
+        else next
 
-  override def toString(): String =
-    inner.mkString("[", ", ", "]")
+      if (weakCompareAndSetVolatile(i, prev, newNext)) newNext
+      else {
+        val newPrev = get(i)
+        loop(newPrev, newNext, prev eq newPrev)
+      }
+    }
+    loop(get(i), null.asInstanceOf[E], false)
+  }
+
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+   *  of applying the given function to the current and given values, returning
+   *  the previous value. The function should be side-effect-free, since it may
+   *  be re-applied when attempted updates fail due to contention among threads.
+   *  The function is applied with the current value of the element at index
+   *  {@code i} as its first argument, and the given update as the second
+   *  argument.
+   *
+   *  @param i
+   *    the index
+   *  @param x
+   *    the update value
+   *  @param accumulatorFunction
+   *    a side-effect-free function of two arguments
+   *  @return
+   *    the previous value
+   *  @since 1.8
+   */
+  final def getAndAccumulate(
+      i: Int,
+      x: E,
+      accumulatorFunction: BinaryOperator[E]
+  ): E = {
+    @tailrec
+    def loop(prev: E, next: E, haveNext: Boolean): E = {
+      val newNext =
+        if (!haveNext) accumulatorFunction.apply(prev, x)
+        else next
+
+      if (weakCompareAndSetVolatile(i, prev, newNext)) prev
+      else {
+        val newPrev = get(i)
+        loop(newPrev, newNext, prev eq newPrev)
+      }
+    }
+    loop(get(i), null.asInstanceOf[E], false)
+  }
+
+  /** Atomically updates (with memory effects as specified by {@link
+   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+   *  of applying the given function to the current and given values, returning
+   *  tnewNexthe updated value. The function should be side-effect-free, since
+   *  it may be re-applied when attempted updates fail due to contention among
+   *  threads. The function is applied with the current value of the element at
+   *  index {@code i} as its first argument, and the given update as the second
+   *  argument.
+   *
+   *  @param i
+   *    the index
+   *  @param x
+   *    the update value
+   *  @param accumulatorFunction
+   *    a side-effect-free function of two arguments
+   *  @return
+   *    the updated value
+   *  @since 1.8
+   */
+  final def accumulateAndGet(
+      i: Int,
+      x: E,
+      accumulatorFunction: BinaryOperator[E]
+  ): E = {
+    @tailrec
+    def loop(prev: E, next: E, haveNext: Boolean): E = {
+      val newNext =
+        if (!haveNext) accumulatorFunction.apply(prev, x)
+        else next
+
+      if (weakCompareAndSetVolatile(i, prev, newNext)) newNext
+      else {
+        val newPrev = get(i)
+        loop(newPrev, newNext, prev eq newPrev)
+      }
+    }
+    loop(get(i), null.asInstanceOf[E], false)
+  }
+
+  /** Returns the String representation of the current values of array.
+   *  @return
+   *    the String representation of the current values of array
+   */
+  override def toString(): String = {
+    array.indices.map(get(_)).mkString("[", ", ", "]")
+  }
+
+  /** Returns the current value of the element at index {@code i}, with memory
+   *  semantics of reading as if the variable was declared non-{@code volatile}.
+   *
+   *  @param i
+   *    the index
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getPlain(i: Int): E = {
+    array(i)
+  }
+
+  /** Sets the element at index {@code i} to {@code newValue}, with memory
+   *  semantics of setting as if the variable was declared non-{@code volatile}
+   *  and non-{@code final}.
+   *
+   *  @param i
+   *    the index
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setPlain(i: Int, newValue: E): Unit = {
+    array(i) = newValue
+  }
+
+  /** Returns the current value of the element at index {@code i}, with memory
+   *  effects as specified by {@link VarHandle#getOpaque}.
+   *
+   *  @param i
+   *    the index
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getOpaque(i: Int): E = nativeArray.at(i).load(memory_order_relaxed)
+
+  /** Sets the element at index {@code i} to {@code newValue}, with memory
+   *  effects as specified by {@link VarHandle#setOpaque}.
+   *
+   *  @param i
+   *    the index
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setOpaque(i: Int, newValue: E): Unit =
+    nativeArray.at(i).store(newValue, memory_order_relaxed)
+
+  /** Returns the current value of the element at index {@code i}, with memory
+   *  effects as specified by {@link VarHandle#getAcquire}.
+   *
+   *  @param i
+   *    the index
+   *  @return
+   *    the value
+   *  @since 9
+   */
+  final def getAcquire(i: Int): E = nativeArray.at(i).load(memory_order_acquire)
+
+  /** Sets the element at index {@code i} to {@code newValue}, with memory
+   *  effects as specified by {@link VarHandle#setRelease}.
+   *
+   *  @param i
+   *    the index
+   *  @param newValue
+   *    the new value
+   *  @since 9
+   */
+  final def setRelease(i: Int, newValue: E): Unit = {
+    nativeArray.at(i).store(newValue, memory_order_release)
+  }
+
+  /** Atomically sets the element at index {@code i} to {@code newValue} if the
+   *  element's current value, referred to as the <em>witness value</em>, {@code
+   *  \== expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#compareAndExchange}.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchange(i: Int, expectedValue: E, newValue: E): E = {
+    val expected = stackalloc[AnyRef]()
+    !expected = expectedValue
+    nativeArray
+      .at(i)
+      .compareExchangeStrong(expected.asInstanceOf[Ptr[E]], newValue)
+    (!expected).asInstanceOf[E]
+  }
+
+  /** Atomically sets the element at index {@code i} to {@code newValue} if the
+   *  element's current value, referred to as the <em>witness value</em>, {@code
+   *  \== expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#compareAndExchangeAcquire}.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeAcquire(
+      i: Int,
+      expectedValue: E,
+      newValue: E
+  ): E = {
+    val expected = stackalloc[AnyRef]()
+    !expected = expectedValue
+    nativeArray
+      .at(i)
+      .compareExchangeStrong(
+        expected.asInstanceOf[Ptr[E]],
+        newValue,
+        memory_order_acquire
+      )
+    (!expected).asInstanceOf[E]
+  }
+
+  /** Atomically sets the element at index {@code i} to {@code newValue} if the
+   *  element's current value, referred to as the <em>witness value</em>, {@code
+   *  \== expectedValue}, with memory effects as specified by {@link
+   *  VarHandle#compareAndExchangeRelease}.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    the witness value, which will be the same as the expected value if
+   *    successful
+   *  @since 9
+   */
+  final def compareAndExchangeRelease(
+      i: Int,
+      expectedValue: E,
+      newValue: E
+  ): E = {
+    val expectedAny = stackalloc[AnyRef]()
+    !expectedAny = expectedValue
+    nativeArray
+      .at(i)
+      .compareExchangeStrong(
+        expectedAny.asInstanceOf[Ptr[E]],
+        newValue,
+        memory_order_release
+      )
+    (!expectedAny).asInstanceOf[E]
+  }
+
+  /** Possibly atomically sets the element at index {@code i} to {@code
+   *  newValue} if the element's current value {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#weakCompareAndSet}.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetVolatile(
+      i: Int,
+      expectedValue: E,
+      newValue: E
+  ): Boolean = {
+    nativeArray
+      .at(i)
+      .compareExchangeWeak(expectedValue, newValue)
+  }
+
+  /** Possibly atomically sets the element at index {@code i} to {@code
+   *  newValue} if the element's current value {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#weakCompareAndSetAcquire}.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetAcquire(
+      i: Int,
+      expectedValue: E,
+      newValue: E
+  ): Boolean = {
+    val expected = stackalloc[AnyRef]()
+    !expected = expectedValue
+    nativeArray
+      .at(i)
+      .compareExchangeWeak(
+        expected.asInstanceOf[Ptr[E]],
+        newValue,
+        memory_order_acquire
+      )
+  }
+
+  /** Possibly atomically sets the element at index {@code i} to {@code
+   *  newValue} if the element's current value {@code == expectedValue}, with
+   *  memory effects as specified by {@link VarHandle#weakCompareAndSetRelease}.
+   *
+   *  @param i
+   *    the index
+   *  @param expectedValue
+   *    the expected value
+   *  @param newValue
+   *    the new value
+   *  @return
+   *    {@code true} if successful
+   *  @since 9
+   */
+  final def weakCompareAndSetRelease(
+      i: Int,
+      expectedValue: E,
+      newValue: E
+  ): Boolean = {
+    val expected = stackalloc[Object]()
+    !expected = expectedValue
+    nativeArray
+      .at(i)
+      .compareExchangeWeak(
+        expected.asInstanceOf[Ptr[E]],
+        newValue,
+        memory_order_release
+      )
+  }
 }

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
@@ -44,7 +44,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
    *
    *  @param array
    *    the array to copy elements from
-   *  @throws NullPointerException
+   *  @throws java.lang.NullPointerException
    *    if array is null
    */
   def this(array: Array[E]) = {
@@ -60,7 +60,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
   final def length(): Int = array.length
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getVolatile}.
+   *  effects as specified by `VarHandle#getVolatile`.
    *
    *  @param i
    *    the index
@@ -70,7 +70,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
   final def get(i: Int): E = nativeArray.at(i).load()
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setVolatile}.
+   *  effects as specified by `VarHandle#setVolatile`.
    *
    *  @param i
    *    the index
@@ -82,7 +82,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
   }
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setRelease}.
+   *  effects as specified by `VarHandle#setRelease`.
    *
    *  @param i
    *    the index
@@ -95,8 +95,8 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
   }
 
   /** Atomically sets the element at index {@code i} to {@code newValue} and
-   *  returns the old value, with memory effects as specified by {@link
-   *  VarHandle#getAndSet}.
+   *  returns the old value, with memory effects as specified by
+   *  `VarHandle#getAndSet`.
    *
    *  @param i
    *    the index
@@ -110,7 +110,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value {@code == expectedValue}, with memory effects as
-   *  specified by {@link VarHandle#compareAndSet}.
+   *  specified by `VarHandle#compareAndSet`.
    *
    *  @param i
    *    the index
@@ -127,14 +127,14 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetPlain}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetPlain`.
    *
    *  @deprecated
    *    This method has plain memory effects but the method name implies
    *    volatile memory effects (see methods such as {@link #compareAndExchange}
    *    and {@link #compareAndSet}). To avoid confusion over plain or volatile
-   *    memory effects it is recommended that the method {@link
-   *    #weakCompareAndSetPlain} be used instead.
+   *    memory effects it is recommended that the method
+   *    [[#weakCompareAndSetPlain]] be used instead.
    *
    *  @param i
    *    the index
@@ -153,7 +153,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetPlain}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetPlain`.
    *
    *  @param i
    *    the index
@@ -175,8 +175,8 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
       true
     } else false
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function, returning the previous value. The function
    *  should be side-effect-free, since it may be re-applied when attempted
    *  updates fail due to contention among threads.
@@ -205,8 +205,8 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
     loop(get(i), null.asInstanceOf[E], false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function, returning the updated value. The function
    *  should be side-effect-free, since it may be re-applied when attempted
    *  updates fail due to contention among threads.
@@ -235,8 +235,8 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
     loop(get(i), null.asInstanceOf[E], false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function to the current and given values, returning
    *  the previous value. The function should be side-effect-free, since it may
    *  be re-applied when attempted updates fail due to contention among threads.
@@ -274,8 +274,8 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
     loop(get(i), null.asInstanceOf[E], false)
   }
 
-  /** Atomically updates (with memory effects as specified by {@link
-   *  VarHandle#compareAndSet}) the element at index {@code i} with the results
+  /** Atomically updates (with memory effects as specified by
+   *  `VarHandle#compareAndSet`) the element at index {@code i} with the results
    *  of applying the given function to the current and given values, returning
    *  tnewNexthe updated value. The function should be side-effect-free, since
    *  it may be re-applied when attempted updates fail due to contention among
@@ -349,7 +349,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
   }
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getOpaque}.
+   *  effects as specified by `VarHandle#getOpaque`.
    *
    *  @param i
    *    the index
@@ -360,7 +360,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
   final def getOpaque(i: Int): E = nativeArray.at(i).load(memory_order_relaxed)
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setOpaque}.
+   *  effects as specified by `VarHandle#setOpaque`.
    *
    *  @param i
    *    the index
@@ -372,7 +372,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
     nativeArray.at(i).store(newValue, memory_order_relaxed)
 
   /** Returns the current value of the element at index {@code i}, with memory
-   *  effects as specified by {@link VarHandle#getAcquire}.
+   *  effects as specified by `VarHandle#getAcquire`.
    *
    *  @param i
    *    the index
@@ -383,7 +383,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
   final def getAcquire(i: Int): E = nativeArray.at(i).load(memory_order_acquire)
 
   /** Sets the element at index {@code i} to {@code newValue}, with memory
-   *  effects as specified by {@link VarHandle#setRelease}.
+   *  effects as specified by `VarHandle#setRelease`.
    *
    *  @param i
    *    the index
@@ -397,8 +397,8 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchange}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchange`.
    *
    *  @param i
    *    the index
@@ -422,8 +422,8 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeAcquire}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchangeAcquire`.
    *
    *  @param i
    *    the index
@@ -455,8 +455,8 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Atomically sets the element at index {@code i} to {@code newValue} if the
    *  element's current value, referred to as the <em>witness value</em>, {@code
-   *  \== expectedValue}, with memory effects as specified by {@link
-   *  VarHandle#compareAndExchangeRelease}.
+   *  \== expectedValue}, with memory effects as specified by
+   *  `VarHandle#compareAndExchangeRelease`.
    *
    *  @param i
    *    the index
@@ -488,7 +488,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSet}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSet`.
    *
    *  @param i
    *    the index
@@ -512,7 +512,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetAcquire}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetAcquire`.
    *
    *  @param i
    *    the index
@@ -542,7 +542,7 @@ class AtomicReferenceArray[E <: AnyRef] extends Serializable {
 
   /** Possibly atomically sets the element at index {@code i} to {@code
    *  newValue} if the element's current value {@code == expectedValue}, with
-   *  memory effects as specified by {@link VarHandle#weakCompareAndSetRelease}.
+   *  memory effects as specified by `VarHandle#weakCompareAndSetRelease`.
    *
    *  @param i
    *    the index

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicStampedReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicStampedReference.scala
@@ -1,0 +1,174 @@
+/*
+ * Based on JSR-166 originally written by Doug Lea with assistance
+ * from members of JCP JSR-166 Expert Group and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent.atomic
+
+import scala.annotation.tailrec
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.unsafe._
+import scala.scalanative.libc.atomic.CAtomicRef
+import scala.scalanative.libc.atomic.memory_order._
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
+
+object AtomicStampedReference {
+  private[concurrent] case class StampedReference[V <: AnyRef](
+      ref: V,
+      stamp: Int
+  )
+}
+
+import AtomicStampedReference._
+
+class AtomicStampedReference[V <: AnyRef] private (
+    private[this] var value: StampedReference[V]
+) {
+
+  def this(initialRef: V, initialStamp: Int) = {
+    this(StampedReference(initialRef, initialStamp))
+  }
+
+  // Pointer to field containing underlying StampedReference.
+  @alwaysinline
+  private[concurrent] def valueRef: CAtomicRef[StampedReference[V]] =
+    new CAtomicRef(
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "value"))
+    )
+
+  /** Returns the current value of the reference.
+   *
+   *  @return
+   *    the current value of the reference
+   */
+  def getReference(): V = valueRef.load().ref
+
+  /** Returns the current value of the stamp.
+   *
+   *  @return
+   *    the current value of the stamp
+   */
+  def getStamp(): Int = valueRef.load().stamp
+
+  /** Returns the current values of both the reference and the stamp. Typical
+   *  usage is {@code int[1] holder; ref = v.get(holder); }.
+   *
+   *  @param stampHolder
+   *    an array of size of at least one. On return, {@code stampHolder[0]} will
+   *    hold the value of the stamp.
+   *  @return
+   *    the current value of the reference
+   */
+  def get(stampHolder: Array[Int]): V = {
+    val current = valueRef.load()
+    stampHolder(0) = current.stamp
+    current.ref
+  }
+
+  /** Atomically sets the value of both the reference and stamp to the given
+   *  update values if the current reference is {@code ==} to the expected
+   *  reference and the current stamp is equal to the expected stamp. This
+   *  operation may fail spuriously and does not provide ordering guarantees, so
+   *  is only rarely an appropriate alternative to {@code compareAndSet}.
+   *
+   *  @param expectedReference
+   *    the expected value of the reference
+   *  @param newReference
+   *    the new value for the reference
+   *  @param expectedStamp
+   *    the expected value of the stamp
+   *  @param newStamp
+   *    the new value for the stamp
+   *  @return
+   *    {@code true} if successful
+   */
+  def weakCompareAndSet(
+      expectedReference: V,
+      newReference: V,
+      expectedStamp: Int,
+      newStamp: Int
+  ): Boolean =
+    compareAndSet(expectedReference, newReference, expectedStamp, newStamp)
+
+  /** Atomically sets the value of both the reference and stamp to the given
+   *  update values if the current reference is {@code ==} to the expected
+   *  reference and the current stamp is equal to the expected stamp.
+   *
+   *  @param expectedReference
+   *    the expected value of the reference
+   *  @param newReference
+   *    the new value for the reference
+   *  @param expectedStamp
+   *    the expected value of the stamp
+   *  @param newStamp
+   *    the new value for the stamp
+   *  @return
+   *    {@code true} if successful
+   */
+  def compareAndSet(
+      expectedReference: V,
+      newReference: V,
+      expectedStamp: Int,
+      newStamp: Int
+  ): Boolean = {
+    val current = valueRef.load()
+
+    def matchesExpected: Boolean =
+      (expectedReference eq current.ref) &&
+        (expectedStamp == current.stamp)
+
+    def matchesNew: Boolean =
+      (newReference eq current.ref) && newStamp == current.stamp
+
+    def compareAndSetNew(): Boolean =
+      valueRef
+        .compareExchangeStrong(
+          current,
+          StampedReference(newReference, newStamp)
+        )
+
+    matchesExpected && (matchesNew || compareAndSetNew())
+  }
+
+  /** Unconditionally sets the value of both the reference and stamp.
+   *
+   *  @param newReference
+   *    the new value for the reference
+   *  @param newStamp
+   *    the new value for the stamp
+   */
+  def set(newReference: V, newStamp: Int): Unit = {
+    val current = valueRef.load()
+    if ((newReference ne current.ref) || newStamp != current.stamp) {
+      valueRef.store(StampedReference(newReference, newStamp))
+    }
+  }
+
+  /** Atomically sets the value of the stamp to the given update value if the
+   *  current reference is {@code ==} to the expected reference. Any given
+   *  invocation of this operation may fail (return {@code false}) spuriously,
+   *  but repeated invocation when the current value holds the expected value
+   *  and no other thread is also attempting to set the value will eventually
+   *  succeed.
+   *
+   *  @param expectedReference
+   *    the expected value of the reference
+   *  @param newStamp
+   *    the new value for the stamp
+   *  @return
+   *    {@code true} if successful
+   */
+  def attemptStamp(expectedReference: V, newStamp: Int): Boolean = {
+    val current = valueRef.load()
+
+    (expectedReference eq current.ref) && {
+      newStamp == current.stamp ||
+      valueRef
+        .compareExchangeStrong(
+          current,
+          StampedReference(expectedReference, newStamp)
+        )
+    }
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicBoolean9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicBoolean9Test.scala
@@ -1,0 +1,172 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import org.junit.Test
+import org.junit.Assert._
+
+class AtomicBoolean9Test extends JSR166Test {
+
+  /** getPlain returns the last value set
+   */
+  @Test def testGetPlainSet(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.getPlain)
+    ai.set(false)
+    assertEquals(false, ai.getPlain)
+    ai.set(true)
+    assertEquals(true, ai.getPlain)
+  }
+
+  /** getOpaque returns the last value set
+   */
+  @Test def testGetOpaqueSet(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.getOpaque)
+    ai.set(false)
+    assertEquals(false, ai.getOpaque)
+    ai.set(true)
+    assertEquals(true, ai.getOpaque)
+  }
+
+  /** getAcquire returns the last value set
+   */
+  @Test def testGetAcquireSet(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.getAcquire)
+    ai.set(false)
+    assertEquals(false, ai.getAcquire)
+    ai.set(true)
+    assertEquals(true, ai.getAcquire)
+  }
+
+  /** get returns the last value setPlain
+   */
+  @Test def testGetSetPlain(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.get)
+    ai.setPlain(false)
+    assertEquals(false, ai.get)
+    ai.setPlain(true)
+    assertEquals(true, ai.get)
+  }
+
+  /** get returns the last value setOpaque
+   */
+  @Test def testGetSetOpaque(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.get)
+    ai.setOpaque(false)
+    assertEquals(false, ai.get)
+    ai.setOpaque(true)
+    assertEquals(true, ai.get)
+  }
+
+  /** get returns the last value setRelease
+   */
+  @Test def testGetSetRelease(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.get)
+    ai.setRelease(false)
+    assertEquals(false, ai.get)
+    ai.setRelease(true)
+    assertEquals(true, ai.get)
+  }
+
+  /** compareAndExchange succeeds in changing value if equal to expected else
+   *  fails
+   */
+  @Test def testCompareAndExchange(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.compareAndExchange(true, false))
+    assertEquals(false, ai.compareAndExchange(false, false))
+    assertEquals(false, ai.get)
+    assertEquals(false, ai.compareAndExchange(true, true))
+    assertEquals(false, ai.get)
+    assertEquals(false, ai.compareAndExchange(false, true))
+    assertEquals(true, ai.get)
+  }
+
+  /** compareAndExchangeAcquire succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeAcquire(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.compareAndExchangeAcquire(true, false))
+    assertEquals(false, ai.compareAndExchangeAcquire(false, false))
+    assertEquals(false, ai.get)
+    assertEquals(false, ai.compareAndExchangeAcquire(true, true))
+    assertEquals(false, ai.get)
+    assertEquals(false, ai.compareAndExchangeAcquire(false, true))
+    assertEquals(true, ai.get)
+  }
+
+  /** compareAndExchangeRelease succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeRelease(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertEquals(true, ai.compareAndExchangeRelease(true, false))
+    assertEquals(false, ai.compareAndExchangeRelease(false, false))
+    assertEquals(false, ai.get)
+    assertEquals(false, ai.compareAndExchangeRelease(true, true))
+    assertEquals(false, ai.get)
+    assertEquals(false, ai.compareAndExchangeRelease(false, true))
+    assertEquals(true, ai.get)
+  }
+
+  /** repeated weakCompareAndSetPlain succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetPlain(): Unit = {
+    val ai = new AtomicBoolean(true)
+    while (!ai.weakCompareAndSetPlain(true, false)) ()
+    while (!ai.weakCompareAndSetPlain(false, false)) ()
+    assertFalse(ai.get)
+    while (!ai.weakCompareAndSetPlain(false, true)) ()
+    assertTrue(ai.get)
+  }
+
+  /** repeated weakCompareAndSetVolatile succeeds in changing value when equal
+   *  to expected
+   */
+  @Test def testWeakCompareAndSetVolatile(): Unit = {
+    val ai = new AtomicBoolean(true)
+    while (!ai.weakCompareAndSetVolatile(true, false)) ()
+    while (!ai.weakCompareAndSetVolatile(false, false)) ()
+    assertEquals(false, ai.get)
+    while (!ai.weakCompareAndSetVolatile(false, true)) ()
+    assertEquals(true, ai.get)
+  }
+
+  /** repeated weakCompareAndSetAcquire succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetAcquire(): Unit = {
+    val ai = new AtomicBoolean(true)
+    while (!ai.weakCompareAndSetAcquire(true, false)) ()
+    while (!ai.weakCompareAndSetAcquire(false, false)) ()
+    assertEquals(false, ai.get)
+    while (!ai.weakCompareAndSetAcquire(false, true)) ()
+    assertEquals(true, ai.get)
+  }
+
+  /** repeated weakCompareAndSetRelease succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetRelease(): Unit = {
+    val ai = new AtomicBoolean(true)
+    while (!ai.weakCompareAndSetRelease(true, false)) ()
+    while (!ai.weakCompareAndSetRelease(false, false)) ()
+    assertEquals(false, ai.get)
+    while (!ai.weakCompareAndSetRelease(false, true)) ()
+    assertEquals(true, ai.get)
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicInteger9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicInteger9Test.scala
@@ -1,0 +1,171 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.junit.Test
+import org.junit.Assert._
+
+class AtomicInteger9Test extends JSR166Test {
+
+  /** getPlain returns the last value set
+   */
+  @Test def testGetPlainSet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.getPlain)
+    ai.set(2)
+    assertEquals(2, ai.getPlain)
+    ai.set(-3)
+    assertEquals(-3, ai.getPlain)
+  }
+
+  /** getOpaque returns the last value set
+   */
+  @Test def testGetOpaqueSet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.getOpaque)
+    ai.set(2)
+    assertEquals(2, ai.getOpaque)
+    ai.set(-3)
+    assertEquals(-3, ai.getOpaque)
+  }
+
+  /** getAcquire returns the last value set
+   */
+  @Test def testGetAcquireSet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.getAcquire)
+    ai.set(2)
+    assertEquals(2, ai.getAcquire)
+    ai.set(-3)
+    assertEquals(-3, ai.getAcquire)
+  }
+
+  /** get returns the last value setPlain
+   */
+  @Test def testGetSetPlain(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.get)
+    ai.setPlain(2)
+    assertEquals(2, ai.get)
+    ai.setPlain(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** get returns the last value setOpaque
+   */
+  @Test def testGetSetOpaque(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.get)
+    ai.setOpaque(2)
+    assertEquals(2, ai.get)
+    ai.setOpaque(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** get returns the last value setRelease
+   */
+  @Test def testGetSetRelease(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.get)
+    ai.setRelease(2)
+    assertEquals(2, ai.get)
+    ai.setRelease(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** compareAndExchange succeeds in changing value if equal to expected else
+   *  fails
+   */
+  @Test def testCompareAndExchange(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.compareAndExchange(1, 2))
+    assertEquals(2, ai.compareAndExchange(2, -4))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchange(-5, 7))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchange(-4, 7))
+    assertEquals(7, ai.get)
+  }
+
+  /** compareAndExchangeAcquire succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeAcquire(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.compareAndExchangeAcquire(1, 2))
+    assertEquals(2, ai.compareAndExchangeAcquire(2, -4))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchangeAcquire(-5, 7))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchangeAcquire(-4, 7))
+    assertEquals(7, ai.get)
+  }
+
+  /** compareAndExchangeRelease succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeRelease(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.compareAndExchangeRelease(1, 2))
+    assertEquals(2, ai.compareAndExchangeRelease(2, -4))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchangeRelease(-5, 7))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchangeRelease(-4, 7))
+    assertEquals(7, ai.get)
+  }
+
+  /** repeated weakCompareAndSetPlain succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetPlain(): Unit = {
+    val ai = new AtomicInteger(1)
+    while (!ai.weakCompareAndSetPlain(1, 2)) ()
+    while (!ai.weakCompareAndSetPlain(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSetPlain(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+
+  /** repeated weakCompareAndSetVolatile succeeds in changing value when equal
+   *  to expected
+   */
+  @Test def testWeakCompareAndSetVolatile(): Unit = {
+    val ai = new AtomicInteger(1)
+    while (!ai.weakCompareAndSetVolatile(1, 2)) ()
+    while (!ai.weakCompareAndSetVolatile(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSetVolatile(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+
+  /** repeated weakCompareAndSetAcquire succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetAcquire(): Unit = {
+    val ai = new AtomicInteger(1)
+    while (!ai.weakCompareAndSetAcquire(1, 2)) ()
+    while (!ai.weakCompareAndSetAcquire(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSetAcquire(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+
+  /** repeated weakCompareAndSetRelease succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetRelease(): Unit = {
+    val ai = new AtomicInteger(1)
+    while (!ai.weakCompareAndSetRelease(1, 2)) ()
+    while (!ai.weakCompareAndSetRelease(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSetRelease(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicIntegerArray9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicIntegerArray9Test.scala
@@ -1,0 +1,238 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import JSR166Test._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.util.concurrent.atomic.AtomicIntegerArray
+
+class AtomicIntegerArray9Test extends JSR166Test {
+
+  /** get and set for out of bound indices throw IndexOutOfBoundsException
+   */
+  @Test def testIndexing(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (index <- Array[Int](-1, SIZE)) {
+      val j = index
+      assertThrows(
+        classOf[IndexOutOfBoundsException],
+        () => aa.getPlain(j),
+        () => aa.getOpaque(j),
+        () => aa.getAcquire(j),
+        () => aa.setPlain(j, 1),
+        () => aa.setOpaque(j, 1),
+        () => aa.setRelease(j, 1),
+        () => aa.compareAndExchange(j, 1, 2),
+        () => aa.compareAndExchangeAcquire(j, 1, 2),
+        () => aa.compareAndExchangeRelease(j, 1, 2),
+        () => aa.weakCompareAndSetPlain(j, 1, 2),
+        () => aa.weakCompareAndSetVolatile(j, 1, 2),
+        () => aa.weakCompareAndSetAcquire(j, 1, 2),
+        () => aa.weakCompareAndSetRelease(j, 1, 2)
+      )
+    }
+  }
+
+  /** getPlain returns the last value set
+   */
+  @Test def testGetPlainSet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getPlain(i))
+      aa.set(i, 2)
+      assertEquals(2, aa.getPlain(i))
+      aa.set(i, -3)
+      assertEquals(-3, aa.getPlain(i))
+    }
+  }
+
+  /** getOpaque returns the last value set
+   */
+  @Test def testGetOpaqueSet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getOpaque(i))
+      aa.set(i, 2)
+      assertEquals(2, aa.getOpaque(i))
+      aa.set(i, -3)
+      assertEquals(-3, aa.getOpaque(i))
+    }
+  }
+
+  /** getAcquire returns the last value set
+   */
+  @Test def testGetAcquireSet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAcquire(i))
+      aa.set(i, 2)
+      assertEquals(2, aa.getAcquire(i))
+      aa.set(i, -3)
+      assertEquals(-3, aa.getAcquire(i))
+    }
+  }
+
+  /** get returns the last value setPlain
+   */
+  @Test def testGetSetPlain(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setPlain(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.setPlain(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.setPlain(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value setOpaque
+   */
+  @Test def testGetSetOpaque(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setOpaque(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.setOpaque(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.setOpaque(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value setRelease
+   */
+  @Test def testGetSetRelease(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setRelease(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.setRelease(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.setRelease(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** compareAndExchange succeeds in changing value if equal to expected else
+   *  fails
+   */
+  @Test def testCompareAndExchange(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.compareAndExchange(i, 1, 2))
+      assertEquals(2, aa.compareAndExchange(i, 2, -4))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchange(i, -5, 7))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchange(i, -4, 7))
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** compareAndExchangeAcquire succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeAcquire(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.compareAndExchangeAcquire(i, 1, 2))
+      assertEquals(2, aa.compareAndExchangeAcquire(i, 2, -4))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchangeAcquire(i, -5, 7))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchangeAcquire(i, -4, 7))
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** compareAndExchangeRelease succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeRelease(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.compareAndExchangeRelease(i, 1, 2))
+      assertEquals(2, aa.compareAndExchangeRelease(i, 2, -4))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchangeRelease(i, -5, 7))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchangeRelease(i, -4, 7))
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetPlain succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetPlain(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSetPlain(i, 1, 2)) ()
+      while (!aa.weakCompareAndSetPlain(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSetPlain(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetVolatile succeeds in changing value when equal
+   *  to expected
+   */
+  @Test def testWeakCompareAndSetVolatile(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSetVolatile(i, 1, 2)) ()
+      while (!aa.weakCompareAndSetVolatile(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSetVolatile(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetAcquire succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetAcquire(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSetAcquire(i, 1, 2)) ()
+      while (!aa.weakCompareAndSetAcquire(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSetAcquire(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetRelease succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetRelease(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSetRelease(i, 1, 2)) ()
+      while (!aa.weakCompareAndSetRelease(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSetRelease(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicLong9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicLong9Test.scala
@@ -1,0 +1,173 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicLong
+
+import org.junit.Test
+import org.junit.Assert._
+
+class AtomicLong9Test extends JSR166Test {
+  import JSR166Test._
+
+  /** getPlain returns the last value set
+   */
+  @Test def testGetPlainSet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.getPlain)
+    ai.set(2)
+    assertEquals(2, ai.getPlain)
+    ai.set(-3)
+    assertEquals(-3, ai.getPlain)
+  }
+
+  /** getOpaque returns the last value set
+   */
+  @Test def testGetOpaqueSet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.getOpaque)
+    ai.set(2)
+    assertEquals(2, ai.getOpaque)
+    ai.set(-3)
+    assertEquals(-3, ai.getOpaque)
+  }
+
+  /** getAcquire returns the last value set
+   */
+  @Test def testGetAcquireSet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.getAcquire)
+    ai.set(2)
+    assertEquals(2, ai.getAcquire)
+    ai.set(-3)
+    assertEquals(-3, ai.getAcquire)
+  }
+
+  /** get returns the last value setPlain
+   */
+  @Test def testGetSetPlain(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.get)
+    ai.setPlain(2)
+    assertEquals(2, ai.get)
+    ai.setPlain(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** get returns the last value setOpaque
+   */
+  @Test def testGetSetOpaque(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.get)
+    ai.setOpaque(2)
+    assertEquals(2, ai.get)
+    ai.setOpaque(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** get returns the last value setRelease
+   */
+  @Test def testGetSetRelease(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.get)
+    ai.setRelease(2)
+    assertEquals(2, ai.get)
+    ai.setRelease(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** compareAndExchange succeeds in changing value if equal to expected else
+   *  fails
+   */
+  @Test def testCompareAndExchange(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.compareAndExchange(1, 2))
+    assertEquals(2, ai.compareAndExchange(2, -4))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchange(-5, 7))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchange(-4, 7))
+    assertEquals(7, ai.get)
+  }
+
+  /** compareAndExchangeAcquire succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeAcquire(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.compareAndExchangeAcquire(1, 2))
+    assertEquals(2, ai.compareAndExchangeAcquire(2, -4))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchangeAcquire(-5, 7))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchangeAcquire(-4, 7))
+    assertEquals(7, ai.get)
+  }
+
+  /** compareAndExchangeRelease succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeRelease(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.compareAndExchangeRelease(1, 2))
+    assertEquals(2, ai.compareAndExchangeRelease(2, -4))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchangeRelease(-5, 7))
+    assertEquals(-4, ai.get)
+    assertEquals(-4, ai.compareAndExchangeRelease(-4, 7))
+    assertEquals(7, ai.get)
+  }
+
+  /** repeated weakCompareAndSetPlain succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetPlain(): Unit = {
+    val ai = new AtomicLong(1)
+    while (!ai.weakCompareAndSetPlain(1, 2)) ()
+    while (!ai.weakCompareAndSetPlain(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSetPlain(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+
+  /** repeated weakCompareAndSetVolatile succeeds in changing value when equal
+   *  to expected
+   */
+  @Test def testWeakCompareAndSetVolatile(): Unit = {
+    val ai = new AtomicLong(1)
+    while (!ai.weakCompareAndSetVolatile(1, 2)) ()
+    while (!ai.weakCompareAndSetVolatile(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSetVolatile(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+
+  /** repeated weakCompareAndSetAcquire succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetAcquire(): Unit = {
+    val ai = new AtomicLong(1)
+    while (!ai.weakCompareAndSetAcquire(1, 2)) ()
+    while (!ai.weakCompareAndSetAcquire(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSetAcquire(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+
+  /** repeated weakCompareAndSetRelease succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetRelease(): Unit = {
+    val ai = new AtomicLong(1)
+    while (!ai.weakCompareAndSetRelease(1, 2)) ()
+    while (!ai.weakCompareAndSetRelease(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSetRelease(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicLongArray9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicLongArray9Test.scala
@@ -1,0 +1,238 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicLongArray
+import java.util.Arrays
+
+import org.junit.Test
+import org.junit.Assert._
+
+class AtomicLongArray9Test extends JSR166Test {
+  import JSR166Test._
+
+  /** get and set for out of bound indices throw IndexOutOfBoundsException
+   */
+  @Test def testIndexing(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (index <- Array[Int](-1, SIZE)) {
+      val j = index
+      assertThrows(
+        classOf[IndexOutOfBoundsException],
+        () => aa.getPlain(j),
+        () => aa.getOpaque(j),
+        () => aa.getAcquire(j),
+        () => aa.setPlain(j, 1),
+        () => aa.setOpaque(j, 1),
+        () => aa.setRelease(j, 1),
+        () => aa.compareAndExchange(j, 1, 2),
+        () => aa.compareAndExchangeAcquire(j, 1, 2),
+        () => aa.compareAndExchangeRelease(j, 1, 2),
+        () => aa.weakCompareAndSetPlain(j, 1, 2),
+        () => aa.weakCompareAndSetVolatile(j, 1, 2),
+        () => aa.weakCompareAndSetAcquire(j, 1, 2),
+        () => aa.weakCompareAndSetRelease(j, 1, 2)
+      )
+    }
+  }
+
+  /** getPlain returns the last value set
+   */
+  @Test def testGetPlainSet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getPlain(i))
+      aa.set(i, 2)
+      assertEquals(2, aa.getPlain(i))
+      aa.set(i, -3)
+      assertEquals(-3, aa.getPlain(i))
+    }
+  }
+
+  /** getOpaque returns the last value set
+   */
+  @Test def testGetOpaqueSet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getOpaque(i))
+      aa.set(i, 2)
+      assertEquals(2, aa.getOpaque(i))
+      aa.set(i, -3)
+      assertEquals(-3, aa.getOpaque(i))
+    }
+  }
+
+  /** getAcquire returns the last value set
+   */
+  @Test def testGetAcquireSet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAcquire(i))
+      aa.set(i, 2)
+      assertEquals(2, aa.getAcquire(i))
+      aa.set(i, -3)
+      assertEquals(-3, aa.getAcquire(i))
+    }
+  }
+
+  /** get returns the last value setPlain
+   */
+  @Test def testGetSetPlain(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setPlain(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.setPlain(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.setPlain(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value setOpaque
+   */
+  @Test def testGetSetOpaque(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setOpaque(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.setOpaque(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.setOpaque(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value setRelease
+   */
+  @Test def testGetSetRelease(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setRelease(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.setRelease(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.setRelease(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** compareAndExchange succeeds in changing value if equal to expected else
+   *  fails
+   */
+  @Test def testCompareAndExchange(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.compareAndExchange(i, 1, 2))
+      assertEquals(2, aa.compareAndExchange(i, 2, -4))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchange(i, -5, 7))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchange(i, -4, 7))
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** compareAndExchangeAcquire succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeAcquire(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.compareAndExchangeAcquire(i, 1, 2))
+      assertEquals(2, aa.compareAndExchangeAcquire(i, 2, -4))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchangeAcquire(i, -5, 7))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchangeAcquire(i, -4, 7))
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** compareAndExchangeRelease succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeRelease(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.compareAndExchangeRelease(i, 1, 2))
+      assertEquals(2, aa.compareAndExchangeRelease(i, 2, -4))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchangeRelease(i, -5, 7))
+      assertEquals(-4, aa.get(i))
+      assertEquals(-4, aa.compareAndExchangeRelease(i, -4, 7))
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetPlain succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetPlain(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSetPlain(i, 1, 2)) ()
+      while (!aa.weakCompareAndSetPlain(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSetPlain(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetVolatile succeeds in changing value when equal
+   *  to expected
+   */
+  @Test def testWeakCompareAndSetVolatile(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSetVolatile(i, 1, 2)) ()
+      while (!aa.weakCompareAndSetVolatile(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSetVolatile(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetAcquire succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetAcquire(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSetAcquire(i, 1, 2)) ()
+      while (!aa.weakCompareAndSetAcquire(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSetAcquire(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetRelease succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetRelease(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSetRelease(i, 1, 2)) ()
+      while (!aa.weakCompareAndSetRelease(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSetRelease(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicReference9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicReference9Test.scala
@@ -1,0 +1,173 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicReference
+
+import org.junit.Test
+import org.junit.Assert._
+
+class AtomicReference9Test extends JSR166Test {
+  import JSR166Test._
+
+  /** getPlain returns the last value set
+   */
+  @Test def testGetPlainSet(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.getPlain)
+    ai.set(two)
+    assertEquals(two, ai.getPlain)
+    ai.set(m3)
+    assertEquals(m3, ai.getPlain)
+  }
+
+  /** getOpaque returns the last value set
+   */
+  @Test def testGetOpaqueSet(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.getOpaque)
+    ai.set(two)
+    assertEquals(two, ai.getOpaque)
+    ai.set(m3)
+    assertEquals(m3, ai.getOpaque)
+  }
+
+  /** getAcquire returns the last value set
+   */
+  @Test def testGetAcquireSet(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.getAcquire)
+    ai.set(two)
+    assertEquals(two, ai.getAcquire)
+    ai.set(m3)
+    assertEquals(m3, ai.getAcquire)
+  }
+
+  /** get returns the last value setPlain
+   */
+  @Test def testGetSetPlain(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.get)
+    ai.setPlain(two)
+    assertEquals(two, ai.get)
+    ai.setPlain(m3)
+    assertEquals(m3, ai.get)
+  }
+
+  /** get returns the last value setOpaque
+   */
+  @Test def testGetSetOpaque(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.get)
+    ai.setOpaque(two)
+    assertEquals(two, ai.get)
+    ai.setOpaque(m3)
+    assertEquals(m3, ai.get)
+  }
+
+  /** get returns the last value setRelease
+   */
+  @Test def testGetSetRelease(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.get)
+    ai.setRelease(two)
+    assertEquals(two, ai.get)
+    ai.setRelease(m3)
+    assertEquals(m3, ai.get)
+  }
+
+  /** compareAndExchange succeeds in changing value if equal to expected else
+   *  fails
+   */
+  @Test def testCompareAndExchange(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.compareAndExchange(one, two))
+    assertEquals(two, ai.compareAndExchange(two, m4))
+    assertEquals(m4, ai.get)
+    assertEquals(m4, ai.compareAndExchange(m5, seven))
+    assertEquals(m4, ai.get)
+    assertEquals(m4, ai.compareAndExchange(m4, seven))
+    assertEquals(seven, ai.get)
+  }
+
+  /** compareAndExchangeAcquire succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeAcquire(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.compareAndExchangeAcquire(one, two))
+    assertEquals(two, ai.compareAndExchangeAcquire(two, m4))
+    assertEquals(m4, ai.get)
+    assertEquals(m4, ai.compareAndExchangeAcquire(m5, seven))
+    assertEquals(m4, ai.get)
+    assertEquals(m4, ai.compareAndExchangeAcquire(m4, seven))
+    assertEquals(seven, ai.get)
+  }
+
+  /** compareAndExchangeRelease succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeRelease(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    assertEquals(one, ai.compareAndExchangeRelease(one, two))
+    assertEquals(two, ai.compareAndExchangeRelease(two, m4))
+    assertEquals(m4, ai.get)
+    assertEquals(m4, ai.compareAndExchangeRelease(m5, seven))
+    assertEquals(m4, ai.get)
+    assertEquals(m4, ai.compareAndExchangeRelease(m4, seven))
+    assertEquals(seven, ai.get)
+  }
+
+  /** repeated weakCompareAndSetPlain succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetPlain(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    while (!ai.weakCompareAndSetPlain(one, two)) ()
+    while (!ai.weakCompareAndSetPlain(two, m4)) ()
+    assertEquals(m4, ai.get)
+    while (!ai.weakCompareAndSetPlain(m4, seven)) ()
+    assertEquals(seven, ai.get)
+  }
+
+  /** repeated weakCompareAndSetVolatile succeeds in changing value when equal
+   *  to expected
+   */
+  @Test def testWeakCompareAndSetVolatile(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    while (!ai.weakCompareAndSetVolatile(one, two)) ()
+    while (!ai.weakCompareAndSetVolatile(two, m4)) ()
+    assertEquals(m4, ai.get)
+    while (!ai.weakCompareAndSetVolatile(m4, seven)) ()
+    assertEquals(seven, ai.get)
+  }
+
+  /** repeated weakCompareAndSetAcquire succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetAcquire(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    while (!ai.weakCompareAndSetAcquire(one, two)) ()
+    while (!ai.weakCompareAndSetAcquire(two, m4)) ()
+    assertEquals(m4, ai.get)
+    while (!ai.weakCompareAndSetAcquire(m4, seven)) ()
+    assertEquals(seven, ai.get)
+  }
+
+  /** repeated weakCompareAndSetRelease succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetRelease(): Unit = {
+    val ai = new AtomicReference[Integer](one)
+    while (!ai.weakCompareAndSetRelease(one, two)) ()
+    while (!ai.weakCompareAndSetRelease(two, m4)) ()
+    assertEquals(m4, ai.get)
+    while (!ai.weakCompareAndSetRelease(m4, seven)) ()
+    assertEquals(seven, ai.get)
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicReferenceArray9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicReferenceArray9Test.scala
@@ -1,0 +1,251 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicReferenceArray
+
+import org.junit.Test
+import org.junit.Assert._
+
+class AtomicReferenceArray9Test extends JSR166Test {
+  import JSR166Test._
+
+  /** get and set for out of bound indices throw IndexOutOfBoundsException
+   */
+  @Test def testIndexing(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (index <- Array[Int](-1, SIZE)) {
+      val j = index
+      assertThrows(
+        classOf[IndexOutOfBoundsException],
+        () => aa.getPlain(j),
+        () => aa.getOpaque(j),
+        () => aa.getAcquire(j),
+        () => aa.setPlain(j, null),
+        () => aa.setOpaque(j, null),
+        () => aa.setRelease(j, null),
+        () => aa.compareAndExchange(j, null, null),
+        () => aa.compareAndExchangeAcquire(j, null, null),
+        () => aa.compareAndExchangeRelease(j, null, null),
+        () => aa.weakCompareAndSetPlain(j, null, null),
+        () => aa.weakCompareAndSetVolatile(j, null, null),
+        () => aa.weakCompareAndSetAcquire(j, null, null),
+        () => aa.weakCompareAndSetRelease(j, null, null)
+      )
+    }
+  }
+
+  /** getPlain returns the last value set
+   */
+  @Test def testGetPlainSet(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertEquals(one, aa.getPlain(i))
+      aa.set(i, two)
+      assertEquals(two, aa.getPlain(i))
+      aa.set(i, m3)
+      assertEquals(m3, aa.getPlain(i))
+    }
+  }
+
+  /** getOpaque returns the last value set
+   */
+  @Test def testGetOpaqueSet(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertEquals(one, aa.getOpaque(i))
+      aa.set(i, two)
+      assertEquals(two, aa.getOpaque(i))
+      aa.set(i, m3)
+      assertEquals(m3, aa.getOpaque(i))
+    }
+  }
+
+  /** getAcquire returns the last value set
+   */
+  @Test def testGetAcquireSet(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertEquals(one, aa.getAcquire(i))
+      aa.set(i, two)
+      assertEquals(two, aa.getAcquire(i))
+      aa.set(i, m3)
+      assertEquals(m3, aa.getAcquire(i))
+    }
+  }
+
+  /** get returns the last value setPlain
+   */
+  @Test def testGetSetPlain(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setPlain(i, one)
+      assertEquals(one, aa.get(i))
+      aa.setPlain(i, two)
+      assertEquals(two, aa.get(i))
+      aa.setPlain(i, m3)
+      assertEquals(m3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value setOpaque
+   */
+  @Test def testGetSetOpaque(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setOpaque(i, one)
+      assertEquals(one, aa.get(i))
+      aa.setOpaque(i, two)
+      assertEquals(two, aa.get(i))
+      aa.setOpaque(i, m3)
+      assertEquals(m3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value setRelease
+   */
+  @Test def testGetSetRelease(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.setRelease(i, one)
+      assertEquals(one, aa.get(i))
+      aa.setRelease(i, two)
+      assertEquals(two, aa.get(i))
+      aa.setRelease(i, m3)
+      assertEquals(m3, aa.get(i))
+    }
+  }
+
+  /** compareAndExchange succeeds in changing value if equal to expected else
+   *  fails
+   */
+  @Test def testCompareAndExchange(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertEquals(one, aa.compareAndExchange(i, one, two))
+      assertEquals(two, aa.compareAndExchange(i, two, m4))
+      assertEquals(m4, aa.get(i))
+      assertEquals(m4, aa.compareAndExchange(i, m5, seven))
+      assertEquals(m4, aa.get(i))
+      assertEquals(m4, aa.compareAndExchange(i, m4, seven))
+      assertEquals(seven, aa.get(i))
+    }
+  }
+
+  /** compareAndExchangeAcquire succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeAcquire(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertEquals(one, aa.compareAndExchangeAcquire(i, one, two))
+      assertEquals(two, aa.compareAndExchangeAcquire(i, two, m4))
+      assertEquals(m4, aa.get(i))
+      assertEquals(m4, aa.compareAndExchangeAcquire(i, m5, seven))
+      assertEquals(m4, aa.get(i))
+      assertEquals(m4, aa.compareAndExchangeAcquire(i, m4, seven))
+      assertEquals(seven, aa.get(i))
+    }
+  }
+
+  /** compareAndExchangeRelease succeeds in changing value if equal to expected
+   *  else fails
+   */
+  @Test def testCompareAndExchangeRelease(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertEquals(one, aa.compareAndExchangeRelease(i, one, two))
+      assertEquals(two, aa.compareAndExchangeRelease(i, two, m4))
+      assertEquals(m4, aa.get(i))
+      assertEquals(m4, aa.compareAndExchangeRelease(i, m5, seven))
+      assertEquals(m4, aa.get(i))
+      assertEquals(m4, aa.compareAndExchangeRelease(i, m4, seven))
+      assertEquals(seven, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetPlain succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetPlain(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      while (!aa.weakCompareAndSetPlain(i, one, two)) ()
+      while (!aa.weakCompareAndSetPlain(i, two, m4)) ()
+      assertEquals(m4, aa.get(i))
+      while (!aa.weakCompareAndSetPlain(i, m4, seven)) ()
+      assertEquals(seven, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetVolatile succeeds in changing value when equal
+   *  to expected
+   */
+  @Test def testWeakCompareAndSetVolatile(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      while (!aa.weakCompareAndSetVolatile(i, one, two)) ()
+      while (!aa.weakCompareAndSetVolatile(i, two, m4)) ()
+      assertEquals(m4, aa.get(i))
+      while (!aa.weakCompareAndSetVolatile(i, m4, seven)) ()
+      assertEquals(seven, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetAcquire succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetAcquire(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      while (!aa.weakCompareAndSetAcquire(i, one, two)) ()
+      while (!aa.weakCompareAndSetAcquire(i, two, m4)) ()
+      assertEquals(m4, aa.get(i))
+      while (!aa.weakCompareAndSetAcquire(i, m4, seven)) ()
+      assertEquals(seven, aa.get(i))
+    }
+  }
+
+  /** repeated weakCompareAndSetRelease succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSetRelease(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      while (!aa.weakCompareAndSetRelease(i, one, two)) ()
+      while (!aa.weakCompareAndSetRelease(i, two, m4)) ()
+      assertEquals(m4, aa.get(i))
+      while (!aa.weakCompareAndSetRelease(i, m4, seven)) ()
+      assertEquals(seven, aa.get(i))
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/JSR166Test.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/JSR166Test.scala
@@ -1,0 +1,1170 @@
+/*
+ * Written by Doug Lea and Martin Buchholz with assistance from
+ * members of JCP JSR-166 Expert Group and released to the public
+ * domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit._
+import java.io._
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import java.util.regex.Pattern
+
+import org.junit.Assert._
+import org.junit.BeforeClass
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import scala.scalanative.junit.utils.AssumesHelper
+
+/** Base class for JSR166 Junit TCK tests. Defines some constants, utility
+ *  methods and classes, as well as a simple framework for helping to make sure
+ *  that assertions failing in generated threads cause the associated test that
+ *  generated them to itself fail (which JUnit does not otherwise arrange). The
+ *  rules for creating such tests are:
+ */
+abstract class JSR166Test {
+  import JSR166Test._
+
+  /** Returns a random element from given choices.
+   */
+  def chooseRandomly[T](choices: List[T]): T =
+    choices.get(ThreadLocalRandom.current().nextInt(choices.size()))
+
+  /** Returns a random element from given choices.
+   */
+  def chooseRandomly[T](choices: Array[T]): T = {
+    choices(ThreadLocalRandom.current().nextInt(choices.length))
+  }
+
+  /** Returns the shortest timed delay. This can be scaled up for slow machines
+   *  using the jsr166.delay.factor system property, or via jtreg's
+   *  -timeoutFactor: flag. http://openjdk.java.net/jtreg/command-help.html
+   */
+  protected def getShortDelay(): Long = SHORT_DELAY_MS
+
+  /** Returns a new Date instance representing a time at least delayMillis
+   *  milliseconds in the future.
+   */
+  def delayedDate(delayMillis: Long): Date = {
+    // Add 1 because currentTimeMillis is known to round into the past.
+    new Date(System.currentTimeMillis() + delayMillis + 1)
+  }
+
+  /** The first exception encountered if any threadAssertXXX method fails.
+   */
+  private final val threadFailure: AtomicReference[Throwable] =
+    new AtomicReference(null)
+
+  /** Records an exception so that it can be rethrown later in the test harness
+   *  thread, triggering a test case failure. Only the first failure is recorded
+   *  subsequent calls to this method from within the same test have no effect.
+   */
+  def threadRecordFailure(t: Throwable) = {
+    System.err.println(t)
+    if (threadFailure.compareAndSet(null, t)) () // dumpTestThreads()
+  }
+
+  /** Just like fail(reason), but additionally recording (using
+   *  threadRecordFailure) any AssertionError thrown, so that the current
+   *  testcase will fail.
+   */
+  def threadFail(reason: String): Unit = {
+    try fail(reason)
+    catch {
+      case fail: AssertionError =>
+        threadRecordFailure(fail)
+        throw fail
+    }
+  }
+
+  /** Just like assertTrue(b), but additionally recording (using
+   *  threadRecordFailure) any AssertionError thrown, so that the current
+   *  testcase will fail.
+   */
+  def threadAssertTrue(pred: => Boolean): Unit = {
+    try assertTrue(pred)
+    catch {
+      case fail: AssertionError =>
+        threadRecordFailure(fail)
+        throw fail
+    }
+  }
+
+  /** Just like assertFalse(b), but additionally recording (using
+   *  threadRecordFailure) any AssertionError thrown, so that the current
+   *  testcase will fail.
+   */
+  def threadAssertFalse(pred: => Boolean): Unit = {
+    try assertFalse(pred)
+    catch {
+      case fail: AssertionError =>
+        threadRecordFailure(fail)
+        throw fail
+    }
+  }
+
+  /** Just like assertNull(x), but additionally recording (using
+   *  threadRecordFailure) any AssertionError thrown, so that the current
+   *  testcase will fail.
+   */
+  def threadAssertNull(x: Object): Unit =
+    try assertNull(x)
+    catch {
+      case fail: AssertionError =>
+        threadRecordFailure(fail)
+        throw fail
+    }
+
+  /** Just like assertEquals(x, y), but additionally recording (using
+   *  threadRecordFailure) any AssertionError thrown, so that the current
+   *  testcase will fail.
+   */
+  def threadAssertEquals(x: Long, y: Long): Unit =
+    try assertEquals(x, y)
+    catch {
+      case fail: AssertionError =>
+        threadRecordFailure(fail)
+        throw fail
+    }
+
+  /** Just like assertEquals(x, y), but additionally recording (using
+   *  threadRecordFailure) any AssertionError thrown, so that the current
+   *  testcase will fail.
+   */
+  def threadAssertEquals(x: Object, y: Object): Unit =
+    try assertEquals(x, y)
+    catch {
+      case fail: AssertionError =>
+        threadRecordFailure(fail)
+        throw fail
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+
+  /** Fails with message "should throw exception".
+   */
+  def shouldThrow(exceptionName: String = "exception"): Unit = fail(
+    s"Should throw $exceptionName"
+  )
+
+  /** Just like assertSame(x, y), but additionally recording (using
+   *  threadRecordFailure) any AssertionError thrown, so that the current
+   *  testcase will fail.
+   */
+  def threadAssertSame(x: Object, y: Object): Unit =
+    try assertSame(x, y)
+    catch {
+      case fail: AssertionError =>
+        threadRecordFailure(fail)
+        throw fail
+    }
+
+  /** Calls threadFail with message "should throw exception".
+   */
+  def threadShouldThrow(): Unit = threadFail("should throw exception")
+
+  /** Calls threadFail with message "should throw" + exceptionName.
+   */
+  def threadShouldThrow(exceptionName: String): Unit = threadFail(
+    "should throw " + exceptionName
+  )
+
+  /** Records the given exception using {@link #threadRecordFailure}, then
+   *  rethrows the exception, wrapping it in an AssertionError if necessary.
+   */
+  def threadUnexpectedException(t: Throwable): Unit = {
+    threadRecordFailure(t)
+    // t.printStackTrace()
+    t match {
+      case t: RuntimeException => throw t
+      case t: Error            => throw t
+      case t => throw new AssertionError(s"unexpected exception: $t", t)
+    }
+  }
+
+  /** Allows use of try-with-resources with per-test thread pools.
+   */
+  class PoolCleaner(val pool: ExecutorService) extends AutoCloseable {
+    def close(): Unit = joinPool(pool)
+  }
+
+  /** An extension of PoolCleaner that has an action to release the pool.
+   */
+  class PoolCleanerWithReleaser(pool: ExecutorService, releaser: Runnable)
+      extends PoolCleaner(pool) {
+    override def close(): Unit = {
+      try releaser.run()
+      finally super.close()
+    }
+  }
+
+  def usingWrappedPoolCleaner[Executor <: ExecutorService, T](pool: Executor)(
+      wrapper: Executor => PoolCleaner
+  )(fn: Executor => T): T = usingPoolCleaner(pool, wrapper)(fn)
+
+  def usingPoolCleaner[Executor <: ExecutorService, T](
+      pool: Executor,
+      wrapper: Executor => PoolCleaner = cleaner(_: ExecutorService)
+  )(fn: Executor => T): T = {
+    val cleaner = wrapper(pool)
+    try fn(pool)
+    catch {
+      case t: Throwable =>
+        println(t)
+        t.printStackTrace()
+        throw new RuntimeException("Pool cleanup failed", t)
+        fail(s"Pool cleanup failed: $t")
+        null.asInstanceOf[T]
+    } finally cleaner.close()
+  }
+
+  def cleaner(pool: ExecutorService): PoolCleaner = new PoolCleaner(pool)
+  def cleaner(pool: ExecutorService, releaser: Runnable) =
+    new PoolCleanerWithReleaser(pool, releaser)
+  def cleaner(pool: ExecutorService, latch: CountDownLatch) =
+    new PoolCleanerWithReleaser(pool, releaser(latch))
+  def cleaner(pool: ExecutorService, flag: AtomicBoolean) =
+    new PoolCleanerWithReleaser(pool, releaser(flag))
+
+  def releaser(latch: CountDownLatch) = new Runnable() {
+    def run(): Unit = while ({
+      latch.countDown()
+      latch.getCount() > 0
+    }) ()
+  }
+
+  def releaser(flag: AtomicBoolean) = new Runnable() {
+    def run(): Unit = flag.set(true)
+  }
+
+  /** Waits out termination of a thread pool or fails doing so.
+   */
+  def joinPool(pool: ExecutorService): Unit =
+    try {
+      pool.shutdown()
+      if (!pool.awaitTermination(2 * LONG_DELAY_MS, MILLISECONDS)) {
+        try {
+          threadFail(
+            s"ExecutorService $pool did not terminate in a timely manner"
+          )
+        } finally {
+          // last resort, for the benefit of subsequent tests
+          pool.shutdownNow()
+          val res = pool.awaitTermination(MEDIUM_DELAY_MS, MILLISECONDS)
+        }
+      }
+    } catch {
+      case ok: SecurityException =>
+        // Allowed in case test doesn't have privs
+        ()
+      case fail: InterruptedException =>
+        threadFail("Unexpected InterruptedException")
+    }
+
+  /** Like Runnable, but with the freedom to throw anything. junit folks had the
+   *  same idea:
+   *  http://junit.org/junit5/docs/snapshot/api/org/junit/gen5/api/Executable.html
+   */
+  trait Action { def run(): Unit }
+
+  /** Runs all the given actions in parallel, failing if any fail. Useful for
+   *  running multiple variants of tests that are necessarily individually slow
+   *  because they must block.
+   */
+  def testInParallel(actions: Action*): Unit =
+    usingPoolCleaner(Executors.newCachedThreadPool()) { pool =>
+      actions
+        .map { action =>
+          pool.submit(new CheckedRunnable() {
+            def realRun(): Unit = action.run()
+          })
+        }
+        .foreach { future =>
+          try assertNull(future.get(LONG_DELAY_MS, MILLISECONDS))
+          catch {
+            case ex: ExecutionException =>
+              threadUnexpectedException(ex.getCause())
+            case ex: Exception => threadUnexpectedException(ex)
+          }
+        }
+    }
+
+  /** Checks that thread eventually enters the expected blocked thread state.
+   */
+  def assertThreadBlocks(thread: Thread, expected: Thread.State): Unit = {
+    // always sleep at least 1 ms, with high probability avoiding
+    // transitory states
+    var retries = LONG_DELAY_MS * 3 / 4
+    while (retries > 0) {
+      try delay(1)
+      catch {
+        case fail: InterruptedException =>
+          throw new AssertionError("Unexpected InterruptedException", fail)
+      }
+      val s = thread.getState()
+      if (s == expected) return ()
+      else if (s == Thread.State.TERMINATED)
+        fail("Unexpected thread termination")
+      retries -= 1
+    }
+    fail("timed out waiting for thread to enter thread state " + expected)
+  }
+
+  /** Checks that future.get times out, with the default timeout of {@code
+   *  timeoutMillis()}.
+   */
+  def assertFutureTimesOut(future: Future[_]): Unit =
+    assertFutureTimesOut(future, timeoutMillis())
+
+  /** Checks that future.get times out, with the given millisecond timeout.
+   */
+  def assertFutureTimesOut(future: Future[_], timeoutMillis: Long): Unit = {
+    val startTime = System.nanoTime()
+    try {
+      future.get(timeoutMillis, MILLISECONDS)
+      shouldThrow()
+    } catch {
+      case _: TimeoutException => ()
+      case fail: Exception     => threadUnexpectedException(fail)
+    }
+    assertTrue(millisElapsedSince(startTime) >= timeoutMillis)
+    assertFalse(future.isDone())
+  }
+
+  /** Spin-waits up to the specified number of milliseconds for the given thread
+   *  to enter a wait state: BLOCKED, WAITING, or TIMED_WAITING.
+   *  @param waitingForGodot
+   *    if non-null, an additional condition to satisfy
+   */
+  def waitForThreadToEnterWaitState(
+      thread: Thread,
+      timeoutMillis: Long,
+      waitingForGodot: Callable[Boolean]
+  ): Unit = {
+    lazy val startTime = System.nanoTime()
+    import Thread.State._
+    while (true) {
+      thread.getState() match {
+        case BLOCKED | WAITING | TIMED_WAITING =>
+          try {
+            if (waitingForGodot == null || waitingForGodot.call()) return ()
+          } catch { case fail: Throwable => threadUnexpectedException(fail) }
+        case TERMINATED =>
+          fail("Unexpected thread termination")
+        case _ => ()
+      }
+      if (millisElapsedSince(startTime) > timeoutMillis) {
+        assertTrue(thread.isAlive())
+        if (waitingForGodot == null
+            || thread.getState() == Thread.State.RUNNABLE)
+          fail("timed out waiting for thread to enter wait state")
+        else
+          fail(
+            s"timed out waiting for condition, thread state=${thread.getState()}"
+          )
+      }
+      Thread.`yield`()
+    }
+  }
+
+  /** Spin-waits up to the specified number of milliseconds for the given thread
+   *  to enter a wait state: BLOCKED, WAITING, or TIMED_WAITING.
+   */
+  def waitForThreadToEnterWaitState(thread: Thread, timeoutMillis: Long): Unit =
+    waitForThreadToEnterWaitState(thread, timeoutMillis, null)
+
+  /** Spin-waits up to LONG_DELAY_MS milliseconds for the given thread to enter
+   *  a wait state: BLOCKED, WAITING, or TIMED_WAITING.
+   */
+  def waitForThreadToEnterWaitState(thread: Thread): Unit =
+    waitForThreadToEnterWaitState(thread, LONG_DELAY_MS, null)
+
+  /** Spin-waits up to LONG_DELAY_MS milliseconds for the given thread to enter
+   *  a wait state: BLOCKED, WAITING, or TIMED_WAITING, and additionally satisfy
+   *  the given condition.
+   */
+  def waitForThreadToEnterWaitState(
+      thread: Thread,
+      waitingForGodot: Callable[Boolean]
+  ): Unit =
+    waitForThreadToEnterWaitState(thread, LONG_DELAY_MS, waitingForGodot)
+
+  /** Spin-waits up to LONG_DELAY_MS milliseconds for the current thread to be
+   *  interrupted. Clears the interrupt status before returning.
+   */
+  def awaitInterrupted(): Unit = {
+    lazy val startTime = System.nanoTime()
+    while (!Thread.interrupted()) {
+      if (millisElapsedSince(startTime) > LONG_DELAY_MS)
+        fail("timed out waiting for thread interrupt")
+      Thread.`yield`()
+    }
+  }
+
+  /** Checks that timed f.get() returns the expected value, and does not wait
+   *  for the timeout to elapse before returning.
+   */
+  def checkTimedGet[T](
+      f: Future[T],
+      expectedValue: T,
+      timeoutMillis: Long
+  ): Unit = {
+    val startTime = System.nanoTime()
+    val actual =
+      try f.get(timeoutMillis, MILLISECONDS)
+      catch {
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+          null
+      }
+    assertEquals(expectedValue, actual)
+    if (millisElapsedSince(startTime) > timeoutMillis / 2)
+      throw new AssertionError("timed get did not return promptly")
+  }
+  def checkTimedGet[T](f: Future[T], expectedValue: T): Unit =
+    checkTimedGet(f, expectedValue, LONGER_DELAY_MS)
+
+  /** Returns a new started daemon Thread running the given runnable.
+   */
+  def newStartedThread(runnable: Runnable): Thread = {
+    val t = new Thread(runnable)
+    t.setDaemon(true)
+    t.start()
+    t
+  }
+
+  /** Returns a new started daemon Thread running the given action, wrapped in a
+   *  CheckedRunnable.
+   */
+  def newStartedThread(action: Action): Thread = newStartedThread(
+    checkedRunnable(action)
+  )
+
+  /** Waits for the specified time (in milliseconds) for the thread to terminate
+   *  (using {@link Thread#join(long)}), else interrupts the thread (in the hope
+   *  that it may terminate later) and fails.
+   */
+  def awaitTermination(thread: Thread, timeoutMillis: Long = LONG_DELAY_MS) = {
+    try thread.join(timeoutMillis)
+    catch { case fail: InterruptedException => threadUnexpectedException(fail) }
+    if (thread.getState() != Thread.State.TERMINATED) {
+      try
+        threadFail(
+          s"timed out waiting for thread to terminate, thread=$thread, state=${thread.getState()}"
+        )
+      // Interrupt thread __after__ having reported its stack trace
+      finally thread.interrupt()
+    }
+  }
+
+  // Some convenient Runnable classes
+
+  abstract class CheckedRunnable extends Runnable {
+    @throws[Throwable]
+    protected def realRun(): Unit
+
+    final def run(): Unit = {
+      try realRun()
+      catch {
+        case fail: Throwable => threadUnexpectedException(fail)
+      }
+    }
+  }
+
+  def checkedRunnable(action: Action): Runnable = new CheckedRunnable() {
+    def realRun(): Unit = action.run()
+  }
+
+  abstract class ThreadShouldThrow[T](val exceptionClass: Class[T])
+      extends Thread {
+    protected def realRun(): Unit
+    final override def run(): Unit = {
+      try {
+        realRun()
+        threadShouldThrow(exceptionClass.getSimpleName())
+      } catch {
+        case t: Throwable =>
+          if (!exceptionClass.isInstance(t)) threadUnexpectedException(t)
+      }
+    }
+  }
+
+  abstract class CheckedInterruptedRunnable extends Runnable {
+    protected def realRun(): Unit
+
+    final def run(): Unit = {
+      try
+        assertThrows(classOf[InterruptedException], () => realRun)
+      catch {
+        case success: InterruptedException =>
+          threadAssertFalse(Thread.interrupted())
+        case fail: Throwable => threadUnexpectedException(fail)
+      }
+
+    }
+  }
+
+  abstract class CheckedCallable[T] extends Callable[T] {
+    protected def realCall(): T
+    final def call(): T = {
+      try return realCall()
+      catch {
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+          null.asInstanceOf[T]
+      }
+      throw new AssertionError("unreached")
+    }
+  }
+
+  class NoOpRunnable extends Runnable {
+    def run() = ()
+  }
+
+  class NoOpCallable extends Callable[Any] {
+    def call(): Any = java.lang.Boolean.TRUE
+  }
+
+  final val TEST_STRING = "a test string"
+
+  class StringTask(value: String = TEST_STRING) extends Callable[String] {
+    def call() = value
+  }
+
+  def latchAwaitingStringTask(latch: CountDownLatch): Callable[String] =
+    new CheckedCallable[String] {
+      override protected def realCall(): String = {
+        try latch.await()
+        catch {
+          case quittingTime: InterruptedException => ()
+        }
+        TEST_STRING
+      }
+    }
+
+  def countDowner(latch: CountDownLatch): Runnable = new CheckedRunnable() {
+    protected def realRun(): Unit = latch.countDown()
+  }
+
+  object LatchAwaiter {
+    final val NEW = 0
+    final val RUNNING = 1
+    final val DONE = 2
+  }
+  class LatchAwaiter(latch: CountDownLatch) extends CheckedRunnable {
+    import LatchAwaiter._
+    var state = NEW
+    @throws[InterruptedException]
+    def realRun(): Unit = {
+      state = 1
+      await(latch)
+      state = 2
+    }
+  }
+
+  def awaiter(latch: CountDownLatch) = new LatchAwaiter(latch)
+
+  def await(latch: CountDownLatch, timeoutMillis: Long = LONG_DELAY_MS) = {
+    val timedOut =
+      try !latch.await(timeoutMillis, MILLISECONDS)
+      catch {
+        case fail: Throwable => threadUnexpectedException(fail); false
+      }
+    if (timedOut) {
+      fail(
+        s"timed out waiting for CountDownLatch for ${timeoutMillis / 1000} sec"
+      )
+    }
+  }
+
+  def await(semaphore: Semaphore): Unit = {
+    val timedOut =
+      try !semaphore.tryAcquire(LONG_DELAY_MS, MILLISECONDS)
+      catch {
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+          false
+      }
+    if (timedOut)
+      fail(
+        "timed out waiting for Semaphore for "
+          + (LONG_DELAY_MS / 1000) + " sec"
+      )
+  }
+
+  def await(barrier: CyclicBarrier): Unit =
+    try barrier.await(LONG_DELAY_MS, MILLISECONDS)
+    catch {
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+
+    }
+
+  /** Spin-waits up to LONG_DELAY_MS until flag becomes true.
+   */
+  def await(flag: AtomicBoolean): Unit = await(flag, LONG_DELAY_MS)
+
+  /** Spin-waits up to the specified timeout until flag becomes true.
+   */
+  def await(flag: AtomicBoolean, timeoutMillis: Long) = {
+    val startTime = System.nanoTime()
+    while (!flag.get()) {
+      if (millisElapsedSince(startTime) > timeoutMillis)
+        throw new AssertionError("timed out")
+      Thread.`yield`()
+    }
+  }
+
+  class NPETask extends Callable[String] {
+    override def call(): String = throw new NullPointerException()
+  }
+
+  def possiblyInterruptedRunnable(timeoutMillis: Long): Runnable =
+    new CheckedRunnable() {
+      override protected def realRun() =
+        try delay(timeoutMillis)
+        catch { case ok: InterruptedException => () }
+    }
+
+  /** For use as ThreadFactory in constructors
+   */
+  class SimpleThreadFactory extends ThreadFactory {
+    def newThread(r: Runnable): Thread = new Thread(r)
+  }
+
+  trait TrackedRunnable extends Runnable {
+    def isDone: Boolean
+  }
+
+  class TrackedNoOpRunnable extends Runnable {
+    @volatile var done = false
+    def run(): Unit = {
+      done = true
+    }
+  }
+
+  /** Analog of CheckedRunnable for RecursiveAction
+   */
+  abstract class CheckedRecursiveAction extends RecursiveAction {
+    protected def realCompute(): Unit
+
+    override protected final def compute(): Unit =
+      try realCompute()
+      catch { case fail: Throwable => threadUnexpectedException(fail) }
+  }
+
+  /** Analog of CheckedCallable for RecursiveTask
+   */
+  abstract class CheckedRecursiveTask[T] extends RecursiveTask[T] {
+    protected def realCompute(): T
+    override final protected def compute(): T = {
+      try {
+        return realCompute()
+      } catch {
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+      throw new AssertionError("unreached")
+    }
+  }
+
+  /** For use as RejectedExecutionHandler in constructors
+   */
+  class NoOpREHandler extends RejectedExecutionHandler {
+    def rejectedExecution(r: Runnable, executor: ThreadPoolExecutor): Unit = ()
+  }
+
+  /** A CyclicBarrier that uses timed await and fails with AssertionErrors
+   *  instead of throwing checked exceptions.
+   */
+  class CheckedBarrier(parties: Int) extends CyclicBarrier(parties) {
+    override def await(): Int = {
+      try super.await(LONGER_DELAY_MS, MILLISECONDS)
+      catch {
+        case _: TimeoutException => throw new AssertionError("timed out")
+        case fail: Exception =>
+          throw new AssertionError("Unexpected exception: " + fail, fail)
+      }
+    }
+  }
+
+  def checkEmpty(q: BlockingQueue[_]): Unit = {
+    try {
+      assertTrue(q.isEmpty())
+      assertEquals(0, q.size())
+      assertNull(q.peek())
+      assertNull(q.poll())
+      assertNull(q.poll(randomExpiredTimeout(), randomTimeUnit()))
+      assertEquals(q.toString(), "[]")
+      assertTrue(Arrays.equals(q.toArray(), Array.empty[AnyRef]))
+      assertFalse(q.iterator().hasNext())
+      try {
+        q.element()
+        shouldThrow()
+      } catch { case _: NoSuchElementException => () }
+      try {
+        q.iterator().next()
+        shouldThrow()
+      } catch { case _: NoSuchElementException => () }
+      try {
+        q.remove()
+        shouldThrow()
+      } catch { case _: NoSuchElementException => () }
+    } catch {
+      case fail: InterruptedException => threadUnexpectedException(fail)
+    }
+  }
+
+  def assertImmutable(o: Object): Unit = {
+    o match {
+      case c: Collection[Any] @unchecked =>
+        assertThrows(
+          classOf[UnsupportedOperationException],
+          () => c.add(null: Any)
+        )
+      case _ => ()
+    }
+  }
+
+  def assertThrows(
+      expectedExceptionClass: Class[_ <: Throwable],
+      throwingActions: Action*
+  ): Unit = {
+    for (throwingAction <- throwingActions) {
+      try {
+        throwingAction.run()
+        shouldThrow(expectedExceptionClass.getName())
+      } catch {
+        case t: Throwable =>
+          if (!expectedExceptionClass.isInstance(t))
+            throw new AssertionError(
+              "Expected " + expectedExceptionClass.getName() +
+                ", got " + t.getClass().getName(),
+              t
+            )
+      }
+    }
+  }
+
+  def assertIteratorExhausted(it: Iterator[_]): Unit = {
+    try {
+      it.next()
+      shouldThrow()
+    } catch { case _: NoSuchElementException => () }
+    assertFalse(it.hasNext())
+  }
+
+  def callableThrowing[T](ex: Exception): Callable[T] = new Callable[T] {
+    def call(): T = throw ex
+  }
+
+  def runnableThrowing(ex: Exception): Runnable = new Runnable {
+    def run(): Unit = throw ex
+  }
+
+  /** A reusable thread pool to be shared by tests. */
+  final lazy val cachedThreadPool: ExecutorService =
+    new ThreadPoolExecutor(
+      0,
+      Integer.MAX_VALUE,
+      1000L,
+      MILLISECONDS,
+      new SynchronousQueue[Runnable]()
+    )
+
+  def shuffle[T](array: Array[T]) = {
+    Collections.shuffle(Arrays.asList(array), ThreadLocalRandom.current())
+  }
+
+  /** Returns the same String as would be returned by {@link Object#toString},
+   *  whether or not the given object's class overrides toString().
+   *
+   *  @see
+   *    System#identityHashCode
+   */
+  def identityString(x: AnyRef): String = {
+    x.getClass().getName() + "@" +
+      Integer.toHexString(System.identityHashCode(x))
+  }
+
+  // --- Shared assertions for Executor tests ---
+
+  def assertNullTaskSubmissionThrowsNullPointerException(e: Executor): Unit = {
+    val nullRunnable: Runnable = null
+    val nullCallable: Callable[Any] = null
+    try {
+      e.execute(nullRunnable)
+      shouldThrow()
+    } catch { case success: NullPointerException => () }
+
+    if (!e.isInstanceOf[ExecutorService]) return ()
+
+    val es = e.asInstanceOf[ExecutorService]
+    try {
+      es.submit(nullRunnable)
+      shouldThrow()
+    } catch { case _: NullPointerException => () }
+
+    try {
+      es.submit(nullRunnable, java.lang.Boolean.TRUE)
+      shouldThrow()
+    } catch { case sucess: NullPointerException => () }
+    try {
+      es.submit(nullCallable)
+      shouldThrow()
+    } catch { case sucess: NullPointerException => () }
+
+    if (!e.isInstanceOf[ScheduledExecutorService]) return ()
+    val ses = e.asInstanceOf[ScheduledExecutorService]
+    try {
+      ses.schedule(nullRunnable, randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch { case sucess: NullPointerException => () }
+    try {
+      ses.schedule(nullCallable, randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch { case sucess: NullPointerException => () }
+    try {
+      ses.scheduleAtFixedRate(
+        nullRunnable,
+        randomTimeout(),
+        LONG_DELAY_MS,
+        MILLISECONDS
+      )
+      shouldThrow()
+    } catch { case sucess: NullPointerException => () }
+    try {
+      ses.scheduleWithFixedDelay(
+        nullRunnable,
+        randomTimeout(),
+        LONG_DELAY_MS,
+        MILLISECONDS
+      )
+      shouldThrow()
+    } catch { case sucess: NullPointerException => () }
+  }
+
+  def setRejectedExecutionHandler(
+      p: ThreadPoolExecutor,
+      handler: RejectedExecutionHandler
+  ): Unit = {
+    p.setRejectedExecutionHandler(handler)
+    assertSame(handler, p.getRejectedExecutionHandler())
+  }
+
+  def assertTaskSubmissionsAreRejected(p: ThreadPoolExecutor): Unit = {
+    val savedHandler = p.getRejectedExecutionHandler()
+    val savedTaskCount = p.getTaskCount()
+    val savedCompletedTaskCount = p.getCompletedTaskCount()
+    val savedQueueSize = p.getQueue().size()
+    val stock = true // (p.getClass().getClassLoader() == null)
+
+    val r: Runnable = () => {}
+    val c: Callable[Boolean] = () => java.lang.Boolean.TRUE
+
+    class Recorder extends RejectedExecutionHandler {
+      @volatile var r: Runnable = _
+      @volatile var p: ThreadPoolExecutor = _
+      def reset(): Unit = { r = null; p = null }
+      def rejectedExecution(r: Runnable, p: ThreadPoolExecutor): Unit = {
+        assertNull(this.r)
+        assertNull(this.p)
+        this.r = r
+        this.p = p
+      }
+    }
+
+    // check custom handler is invoked exactly once per task
+    val recorder = new Recorder()
+    setRejectedExecutionHandler(p, recorder)
+    (2 to 0 by -1).foreach { i =>
+      recorder.reset()
+      p.execute(r)
+      if (stock && p.getClass() == classOf[ThreadPoolExecutor])
+        assertSame(r, recorder.r)
+      assertSame(p, recorder.p)
+
+      recorder.reset()
+      assertFalse(p.submit(r).isDone())
+      if (stock) assertTrue(!(recorder.r.asInstanceOf[FutureTask[_]]).isDone())
+      assertSame(p, recorder.p)
+
+      recorder.reset()
+      assertFalse(p.submit(r, java.lang.Boolean.TRUE).isDone())
+      if (stock) assertTrue(!(recorder.r.asInstanceOf[FutureTask[_]]).isDone())
+      assertSame(p, recorder.p)
+
+      recorder.reset()
+      assertFalse(p.submit(c).isDone())
+      if (stock) assertTrue(!(recorder.r.asInstanceOf[FutureTask[_]]).isDone())
+      assertSame(p, recorder.p)
+
+      p match {
+        case s: ScheduledExecutorService =>
+          var future: ScheduledFuture[_] = null
+
+          recorder.reset()
+          future = s.schedule(r, randomTimeout(), randomTimeUnit())
+          assertFalse(future.isDone())
+          if (stock)
+            assertTrue(!(recorder.r.asInstanceOf[FutureTask[_]]).isDone())
+          assertSame(p, recorder.p)
+
+          recorder.reset()
+          future = s.schedule(c, randomTimeout(), randomTimeUnit())
+          assertFalse(future.isDone())
+          if (stock)
+            assertTrue(!(recorder.r.asInstanceOf[FutureTask[_]]).isDone())
+          assertSame(p, recorder.p)
+
+          recorder.reset()
+          future = s.scheduleAtFixedRate(
+            r,
+            randomTimeout(),
+            LONG_DELAY_MS,
+            MILLISECONDS
+          )
+          assertFalse(future.isDone())
+          if (stock)
+            assertTrue(!(recorder.r.asInstanceOf[FutureTask[_]]).isDone())
+          assertSame(p, recorder.p)
+
+          recorder.reset()
+          future = s.scheduleWithFixedDelay(
+            r,
+            randomTimeout(),
+            LONG_DELAY_MS,
+            MILLISECONDS
+          )
+          assertFalse(future.isDone())
+          if (stock)
+            assertTrue(!(recorder.r.asInstanceOf[FutureTask[_]]).isDone())
+          assertSame(p, recorder.p)
+
+        case _ => ()
+      }
+    }
+
+    // Checking our custom handler above should be sufficient, but
+    // we add some integration tests of standard handlers.
+    val thread = new AtomicReference[Thread]()
+    val setThread: Runnable = () => thread.set(Thread.currentThread())
+
+    setRejectedExecutionHandler(p, new ThreadPoolExecutor.AbortPolicy())
+    try {
+      p.execute(setThread)
+      shouldThrow()
+    } catch { case _: RejectedExecutionException => () }
+    assertNull(thread.get())
+
+    setRejectedExecutionHandler(p, new ThreadPoolExecutor.DiscardPolicy())
+    p.execute(setThread)
+    assertNull(thread.get())
+
+    setRejectedExecutionHandler(p, new ThreadPoolExecutor.CallerRunsPolicy())
+    p.execute(setThread)
+    if (p.isShutdown())
+      assertNull(thread.get())
+    else
+      assertSame(Thread.currentThread(), thread.get())
+
+    setRejectedExecutionHandler(p, savedHandler)
+
+    // check that pool was not perturbed by handlers
+    assertEquals(savedTaskCount, p.getTaskCount())
+    assertEquals(savedCompletedTaskCount, p.getCompletedTaskCount())
+    assertEquals(savedQueueSize, p.getQueue().size())
+  }
+
+  def assertCollectionsEquals(x: Collection[_], y: Collection[_]): Unit = {
+    assertEquals(x, y)
+    assertEquals(y, x)
+    assertEquals(x.isEmpty(), y.isEmpty())
+    assertEquals(x.size(), y.size())
+    if (x.isInstanceOf[List[_]]) {
+      assertEquals(x.toString(), y.toString())
+    }
+    if (x.isInstanceOf[List[_]] || x.isInstanceOf[Set[_]]) {
+      assertEquals(x.hashCode(), y.hashCode())
+    }
+    if (x.isInstanceOf[List[_]] || x.isInstanceOf[Deque[_]]) {
+      assertTrue(Arrays.equals(x.toArray(), y.toArray()))
+      assertTrue(
+        Arrays.equals(
+          x.toArray(new Array[Object](0)),
+          y.toArray(new Array[Object](0))
+        )
+      )
+    }
+  }
+
+  /** A weaker form of assertCollectionsEquals which does not insist that the
+   *  two collections satisfy Object#equals(Object), since they may use identity
+   *  semantics as Deques do.
+   */
+  def assertCollectionsEquivalent(x: Collection[_], y: Collection[_]): Unit = {
+    if (x.isInstanceOf[List[_]] || x.isInstanceOf[Set[_]])
+      assertCollectionsEquals(x, y)
+    else {
+      assertEquals(x.isEmpty(), y.isEmpty())
+      assertEquals(x.size(), y.size())
+      assertEquals(new HashSet(x), new HashSet(y))
+      if (x.isInstanceOf[Deque[_]]) {
+        assertTrue(Arrays.equals(x.toArray(), y.toArray()))
+        assertTrue(
+          Arrays.equals(
+            x.toArray(new Array[Object](0)),
+            y.toArray(new Array[Object](0))
+          )
+        )
+      }
+    }
+  }
+}
+
+object JSR166Test {
+  @BeforeClass def checkRuntime(): Unit = {
+    AssumesHelper.assumeMultithreadingIsEnabled()
+  }
+
+  final val expensiveTests = true
+
+  /** If true, also run tests that are not part of the official tck because they
+   *  test unspecified implementation details.
+   */
+  final val testImplementationDetails = true
+
+  /** If true, report on stdout all "slow" tests, that is, ones that take more
+   *  than profileThreshold milliseconds to execute.
+   */
+  final val profileTests = true
+
+  /** The number of milliseconds that tests are permitted for execution without
+   *  being reported, when profileTests is set.
+   */
+  final val profileThreshold = true
+
+  /** The scaling factor to apply to standard delays used in tests. May be
+   *  initialized from any of:
+   *    - the "jsr166.delay.factor" system property
+   *    - the "test.timeout.factor" system property (as used by jtreg) See:
+   *      http://openjdk.java.net/jtreg/tag-spec.html
+   *    - hard-coded fuzz factor when using a known slowpoke VM
+   */
+  private val delayFactor = 1.0f
+
+  // Delays for timing-dependent tests, in milliseconds.
+  final val SHORT_DELAY_MS = (50 * delayFactor).toLong
+  final val SMALL_DELAY_MS = SHORT_DELAY_MS * 5
+  final val MEDIUM_DELAY_MS = SHORT_DELAY_MS * 10
+  final val LONG_DELAY_MS = SHORT_DELAY_MS * 200
+
+  /** A delay significantly longer than LONG_DELAY_MS. Use this in a thread that
+   *  is waited for via awaitTermination(Thread).
+   */
+  final val LONGER_DELAY_MS = LONG_DELAY_MS * 2
+
+  // SN note: We define this variables as functions for source-compatibility with JSR 166 tests for easier porting of tests
+  final val (randomTimeout, randomExpiredTimeout, randomTimeUnit) = {
+    val rnd = ThreadLocalRandom.current()
+    val timeouts =
+      Array(java.lang.Long.MIN_VALUE, -1, 0, 1, java.lang.Long.MAX_VALUE)
+    val timeUnits = TimeUnit.values()
+
+    val timeout = timeouts(rnd.nextInt(timeouts.length))
+    val expired = timeouts(rnd.nextInt(3))
+    val timeUnit = timeUnits(rnd.nextInt(timeUnits.length))
+    (() => timeout, () => expired, () => timeUnit)
+  }
+
+  /** Returns a random boolean a "coin flip".
+   */
+  def randomBoolean(): Boolean = ThreadLocalRandom.current().nextBoolean()
+
+  private final lazy val TIMEOUT_DELAY_MS =
+    (12.0 * Math.cbrt(delayFactor)).toLong
+
+  /** Returns a timeout in milliseconds to be used in tests that verify that
+   *  operations block or time out. We want this to be longer than the OS
+   *  scheduling quantum, but not too long, so don't scale linearly with
+   *  delayFactor we use "crazy" cube root instead.
+   */
+  def timeoutMillis(): Long = TIMEOUT_DELAY_MS
+
+  /** Delays, via Thread.sleep, for the given millisecond delay, but if the
+   *  sleep is shorter than specified, may re-sleep or yield until time elapses.
+   *  Ensures that the given time, as measured by System.nanoTime(), has
+   *  elapsed.
+   */
+  def delay(ms: Long) = {
+    var millis = ms
+    var nanos = millis * (1000 * 1000)
+    var wakeupTime = System.nanoTime() + nanos
+    while ({
+      if (millis > 0L) Thread.sleep(millis)
+      else Thread.`yield`() // too short to sleep
+      nanos = wakeupTime - System.nanoTime()
+      millis = nanos / (1000 * 1000)
+      nanos >= 0L
+    }) ()
+  }
+
+  def sleep(millis: Long): Unit = {
+    try delay(millis)
+    catch {
+      case fail: InterruptedException =>
+        throw new AssertionError("Unexpected InterruptedException", fail)
+    }
+  }
+
+  /** The maximum number of consecutive spurious wakeups we should tolerate
+   *  (from APIs like LockSupport.park) before failing a test.
+   */
+  final val MAX_SPURIOUS_WAKEUPS = 10
+
+  /** The number of elements to place in collections, arrays, etc.
+   */
+  final val SIZE = 20
+
+  // Some convenient Integer constants
+  final val zero = new Integer(0)
+  final val one = new Integer(1)
+  final val two = new Integer(2)
+  final val three = new Integer(3)
+  final val four = new Integer(4)
+  final val five = new Integer(5)
+  final val six = new Integer(6)
+  final val seven = new Integer(7)
+  final val eight = new Integer(8)
+  final val nine = new Integer(9)
+  final val m1 = new Integer(-1)
+  final val m2 = new Integer(-2)
+  final val m3 = new Integer(-3)
+  final val m4 = new Integer(-4)
+  final val m5 = new Integer(-5)
+  final val m6 = new Integer(-6)
+  final val m10 = new Integer(-10)
+
+  /** Returns the number of milliseconds since time given by startNanoTime,
+   *  which must have been previously returned from a call to {@link
+   *  System#nanoTime()}.
+   */
+  def millisElapsedSince(startNanoTime: Long): Long = {
+    NANOSECONDS.toMillis(System.nanoTime() - startNanoTime)
+  }
+
+  /** Returns maximum number of tasks that can be submitted to given pool (with
+   *  bounded queue) before saturation (when submission throws
+   *  RejectedExecutionException).
+   */
+  def saturatedSize(pool: ThreadPoolExecutor): Int = {
+    val q = pool.getQueue()
+    pool.getMaximumPoolSize() + q.size() + q.remainingCapacity()
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/JSR166Test.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/JSR166Test.scala
@@ -500,7 +500,7 @@ abstract class JSR166Test {
 
     final def run(): Unit = {
       try
-        assertThrows(classOf[InterruptedException], () => realRun)
+        assertThrows(classOf[InterruptedException], () => realRun())
       catch {
         case success: InterruptedException =>
           threadAssertFalse(Thread.interrupted())

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/Atomic8Test.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/Atomic8Test.scala
@@ -1,0 +1,410 @@
+/*
+ * Written by Doug Lea and Martin Buchholz with assistance from
+ * members of JCP JSR-166 Expert Group and released to the public
+ * domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic._
+import java.lang.{Long => jlLong}
+
+import org.junit.Test
+import org.junit.Assert._
+
+object Atomic8Test {
+  def addLong17(x: Long): Long = x + 17
+  def addInt17(x: Int): Int = x + 17
+  def addInteger17(x: Integer): Integer = x.intValue + 17
+  def sumInteger(x: Integer, y: Integer): Integer = x.intValue + y.intValue
+}
+
+/** Tests of atomic class methods accepting lambdas introduced in JDK8.
+ */
+class Atomic8Test extends JSR166Test {
+  import JSR166Test._
+
+  /** AtomicLong getAndUpdate returns previous value and updates result of
+   *  supplied function
+   */
+  @Test def testLongGetAndUpdate(): Unit = {
+    val a = new AtomicLong(1L)
+    assertEquals(1L, a.getAndUpdate(Atomic8Test.addLong17))
+    assertEquals(18L, a.getAndUpdate(Atomic8Test.addLong17))
+    assertEquals(35L, a.get)
+  }
+
+  /** AtomicLong updateAndGet updates with supplied function and returns result.
+   */
+  @Test def testLongUpdateAndGet(): Unit = {
+    val a = new AtomicLong(1L)
+    assertEquals(18L, a.updateAndGet(Atomic8Test.addLong17))
+    assertEquals(35L, a.updateAndGet(Atomic8Test.addLong17))
+  }
+
+  /** AtomicLong getAndAccumulate returns previous value and updates with
+   *  supplied function.
+   */
+  @Test def testLongGetAndAccumulate(): Unit = {
+    val a = new AtomicLong(1L)
+    assertEquals(1L, a.getAndAccumulate(2L, java.lang.Long.sum))
+    assertEquals(3L, a.getAndAccumulate(3L, java.lang.Long.sum))
+    assertEquals(6L, a.get)
+  }
+
+  /** AtomicLong accumulateAndGet updates with supplied function and returns
+   *  result.
+   */
+  @Test def testLongAccumulateAndGet(): Unit = {
+    val a = new AtomicLong(1L)
+    assertEquals(7L, a.accumulateAndGet(6L, java.lang.Long.sum))
+    assertEquals(10L, a.accumulateAndGet(3L, java.lang.Long.sum))
+    assertEquals(10L, a.get)
+  }
+
+  /** AtomicInteger getAndUpdate returns previous value and updates result of
+   *  supplied function
+   */
+  @Test def testIntGetAndUpdate(): Unit = {
+    val a = new AtomicInteger(1)
+    assertEquals(1, a.getAndUpdate(Atomic8Test.addInt17))
+    assertEquals(18, a.getAndUpdate(Atomic8Test.addInt17))
+    assertEquals(35, a.get)
+  }
+
+  /** AtomicInteger updateAndGet updates with supplied function and returns
+   *  result.
+   */
+  @Test def testIntUpdateAndGet(): Unit = {
+    val a = new AtomicInteger(1)
+    assertEquals(18, a.updateAndGet(Atomic8Test.addInt17))
+    assertEquals(35, a.updateAndGet(Atomic8Test.addInt17))
+    assertEquals(35, a.get)
+  }
+
+  /** AtomicInteger getAndAccumulate returns previous value and updates with
+   *  supplied function.
+   */
+  @Test def testIntGetAndAccumulate(): Unit = {
+    val a = new AtomicInteger(1)
+    assertEquals(1, a.getAndAccumulate(2, Integer.sum))
+    assertEquals(3, a.getAndAccumulate(3, Integer.sum))
+    assertEquals(6, a.get)
+  }
+
+  /** AtomicInteger accumulateAndGet updates with supplied function and returns
+   *  result.
+   */
+  @Test def testIntAccumulateAndGet(): Unit = {
+    val a = new AtomicInteger(1)
+    assertEquals(7, a.accumulateAndGet(6, Integer.sum))
+    assertEquals(10, a.accumulateAndGet(3, Integer.sum))
+    assertEquals(10, a.get)
+  }
+
+  /** AtomicReference getAndUpdate returns previous value and updates result of
+   *  supplied function
+   */
+  @Test def testReferenceGetAndUpdate(): Unit = {
+    val a = new AtomicReference[Integer](one)
+    assertEquals(
+      1.asInstanceOf[Integer],
+      a.getAndUpdate(Atomic8Test.addInteger17)
+    )
+    assertEquals(
+      18.asInstanceOf[Integer],
+      a.getAndUpdate(Atomic8Test.addInteger17)
+    )
+    assertEquals(35.asInstanceOf[Integer], a.get)
+  }
+
+  /** AtomicReference updateAndGet updates with supplied function and returns
+   *  result.
+   */
+  @Test def testReferenceUpdateAndGet(): Unit = {
+    val a = new AtomicReference[Integer](one)
+    assertEquals(
+      18.asInstanceOf[Integer],
+      a.updateAndGet(Atomic8Test.addInteger17)
+    )
+    assertEquals(
+      35.asInstanceOf[Integer],
+      a.updateAndGet(Atomic8Test.addInteger17)
+    )
+    assertEquals(35.asInstanceOf[Integer], a.get)
+  }
+
+  /** AtomicReference getAndAccumulate returns previous value and updates with
+   *  supplied function.
+   */
+  @Test def testReferenceGetAndAccumulate(): Unit = {
+    val a = new AtomicReference[Integer](one)
+    assertEquals(
+      1.asInstanceOf[Integer],
+      a.getAndAccumulate(2, Atomic8Test.sumInteger)
+    )
+    assertEquals(
+      3.asInstanceOf[Integer],
+      a.getAndAccumulate(3, Atomic8Test.sumInteger)
+    )
+    assertEquals(6.asInstanceOf[Integer], a.get)
+  }
+
+  /** AtomicReference accumulateAndGet updates with supplied function and
+   *  returns result.
+   */
+  @Test def testReferenceAccumulateAndGet(): Unit = {
+    val a = new AtomicReference[Integer](one)
+    assertEquals(
+      7.asInstanceOf[Integer],
+      a.accumulateAndGet(6, Atomic8Test.sumInteger)
+    )
+    assertEquals(
+      10.asInstanceOf[Integer],
+      a.accumulateAndGet(3, Atomic8Test.sumInteger)
+    )
+    assertEquals(10.asInstanceOf[Integer], a.get)
+  }
+
+  /** AtomicLongArray getAndUpdate returns previous value and updates result of
+   *  supplied function
+   */
+  @Test def testLongArrayGetAndUpdate(): Unit = {
+    val a = new AtomicLongArray(1)
+    a.set(0, 1)
+    assertEquals(1L, a.getAndUpdate(0, Atomic8Test.addLong17))
+    assertEquals(18L, a.getAndUpdate(0, Atomic8Test.addLong17))
+    assertEquals(35L, a.get(0))
+  }
+
+  /** AtomicLongArray updateAndGet updates with supplied function and returns
+   *  result.
+   */
+  @Test def testLongArrayUpdateAndGet(): Unit = {
+    val a = new AtomicLongArray(1)
+    a.set(0, 1)
+    assertEquals(18L, a.updateAndGet(0, Atomic8Test.addLong17))
+    assertEquals(35L, a.updateAndGet(0, Atomic8Test.addLong17))
+    assertEquals(35L, a.get(0))
+  }
+
+  /** AtomicLongArray getAndAccumulate returns previous value and updates with
+   *  supplied function.
+   */
+  @Test def testLongArrayGetAndAccumulate(): Unit = {
+    val a = new AtomicLongArray(1)
+    a.set(0, 1)
+    assertEquals(1L, a.getAndAccumulate(0, 2L, java.lang.Long.sum))
+    assertEquals(3L, a.getAndAccumulate(0, 3L, java.lang.Long.sum))
+    assertEquals(6L, a.get(0))
+  }
+
+  /** AtomicLongArray accumulateAndGet updates with supplied function and
+   *  returns result.
+   */
+  @Test def testLongArrayAccumulateAndGet(): Unit = {
+    val a = new AtomicLongArray(1)
+    a.set(0, 1)
+    assertEquals(7L, a.accumulateAndGet(0, 6L, java.lang.Long.sum))
+    assertEquals(10L, a.accumulateAndGet(0, 3L, java.lang.Long.sum))
+    assertEquals(10L, a.get(0))
+  }
+
+  /** AtomicIntegerArray getAndUpdate returns previous value and updates result
+   *  of supplied function
+   */
+  @Test def testIntArrayGetAndUpdate(): Unit = {
+    val a = new AtomicIntegerArray(1)
+    a.set(0, 1)
+    assertEquals(1, a.getAndUpdate(0, Atomic8Test.addInt17))
+    assertEquals(18, a.getAndUpdate(0, Atomic8Test.addInt17))
+    assertEquals(35, a.get(0))
+  }
+
+  /** AtomicIntegerArray updateAndGet updates with supplied function and returns
+   *  result.
+   */
+  @Test def testIntArrayUpdateAndGet(): Unit = {
+    val a = new AtomicIntegerArray(1)
+    a.set(0, 1)
+    assertEquals(18, a.updateAndGet(0, Atomic8Test.addInt17))
+    assertEquals(35, a.updateAndGet(0, Atomic8Test.addInt17))
+    assertEquals(35, a.get(0))
+  }
+
+  /** AtomicIntegerArray getAndAccumulate returns previous value and updates
+   *  with supplied function.
+   */
+  @Test def testIntArrayGetAndAccumulate(): Unit = {
+    val a = new AtomicIntegerArray(1)
+    a.set(0, 1)
+    assertEquals(1, a.getAndAccumulate(0, 2, Integer.sum))
+    assertEquals(3, a.getAndAccumulate(0, 3, Integer.sum))
+    assertEquals(6, a.get(0))
+  }
+
+  /** AtomicIntegerArray accumulateAndGet updates with supplied function and
+   *  returns result.
+   */
+  @Test def testIntArrayAccumulateAndGet(): Unit = {
+    val a = new AtomicIntegerArray(1)
+    a.set(0, 1)
+    assertEquals(7, a.accumulateAndGet(0, 6, Integer.sum))
+    assertEquals(10, a.accumulateAndGet(0, 3, Integer.sum))
+  }
+
+  /** AtomicReferenceArray getAndUpdate returns previous value and updates
+   *  result of supplied function
+   */
+  @Test def testReferenceArrayGetAndUpdate(): Unit = {
+    val a = new AtomicReferenceArray[Integer](1)
+    a.set(0, one)
+    assertEquals(
+      1.asInstanceOf[Integer],
+      a.getAndUpdate(0, Atomic8Test.addInteger17)
+    )
+    assertEquals(
+      18.asInstanceOf[Integer],
+      a.getAndUpdate(0, Atomic8Test.addInteger17)
+    )
+    assertEquals(35.asInstanceOf[Integer], a.get(0))
+  }
+
+  /** AtomicReferenceArray updateAndGet updates with supplied function and
+   *  returns result.
+   */
+  @Test def testReferenceArrayUpdateAndGet(): Unit = {
+    val a = new AtomicReferenceArray[Integer](1)
+    a.set(0, one)
+    assertEquals(
+      18.asInstanceOf[Integer],
+      a.updateAndGet(0, Atomic8Test.addInteger17)
+    )
+    assertEquals(
+      35.asInstanceOf[Integer],
+      a.updateAndGet(0, Atomic8Test.addInteger17)
+    )
+  }
+
+  /** AtomicReferenceArray getAndAccumulate returns previous value and updates
+   *  with supplied function.
+   */
+  @Test def testReferenceArrayGetAndAccumulate(): Unit = {
+    val a = new AtomicReferenceArray[Integer](1)
+    a.set(0, one)
+    assertEquals(
+      1.asInstanceOf[Integer],
+      a.getAndAccumulate(0, 2, Atomic8Test.sumInteger)
+    )
+    assertEquals(
+      3.asInstanceOf[Integer],
+      a.getAndAccumulate(0, 3, Atomic8Test.sumInteger)
+    )
+    assertEquals(6.asInstanceOf[Integer], a.get(0))
+  }
+
+  /** AtomicReferenceArray accumulateAndGet updates with supplied function and
+   *  returns result.
+   */
+  @Test def testReferenceArrayAccumulateAndGet(): Unit = {
+    val a = new AtomicReferenceArray[Integer](1)
+    a.set(0, one)
+    assertEquals(
+      7.asInstanceOf[Integer],
+      a.accumulateAndGet(0, 6, Atomic8Test.sumInteger)
+    )
+    assertEquals(
+      10.asInstanceOf[Integer],
+      a.accumulateAndGet(0, 3, Atomic8Test.sumInteger)
+    )
+  }
+
+  // Tests not ported, FieldUpdated is reflection based
+  // @Test def testLongFieldUpdaterGetAndUpdate(): Unit = {}
+  // @Test def testLongFieldUpdaterUpdateAndGet(): Unit = {}
+  // @Test def testLongFieldUpdaterGetAndAccumulate(): Unit = {}
+  // @Test def testLongFieldUpdaterAccumulateAndGet(): Unit = {}
+  // @Test def testIntegerFieldUpdaterGetAndUpdate(): Unit = {}
+  // @Test def testIntegerFieldUpdaterUpdateAndGet(): Unit = {}
+  // @Test def testIntegerFieldUpdaterGetAndAccumulate(): Unit = {}
+  // @Test def testIntegerFieldUpdaterAccumulateAndGet(): Unit = {}
+  // @Test def testReferenceFieldUpdaterGetAndUpdate(): Unit = {}
+  // @Test def testReferenceFieldUpdaterUpdateAndGet(): Unit = {}
+  // @Test def testReferenceFieldUpdaterGetAndAccumulate(): Unit = {}
+  // @Test def testReferenceFieldUpdaterAccumulateAndGet(): Unit = {}
+
+  /** All Atomic getAndUpdate methods throw NullPointerException on null
+   *  function argument
+   */
+  @Test def testGetAndUpdateNPE(): Unit =
+    assertThrows(
+      classOf[NullPointerException],
+      () => new AtomicLong().getAndUpdate(null),
+      () => new AtomicInteger().getAndUpdate(null),
+      () => new AtomicReference[Any]().getAndUpdate(null),
+      () => new AtomicLongArray(1).getAndUpdate(0, null),
+      () => new AtomicIntegerArray(1).getAndUpdate(0, null),
+      () => new AtomicReferenceArray[Any](1).getAndUpdate(0, null)
+      // () => aLongFieldUpdater.getAndUpdate(this, null),
+      // () => anIntFieldUpdater.getAndUpdate(this, null),
+      // () => anIntegerFieldUpdater.getAndUpdate(this, null)
+    )
+
+  /** All Atomic updateAndGet methods throw NullPointerException on null
+   *  function argument
+   */
+  @Test def testUpdateAndGetNPE(): Unit =
+    assertThrows(
+      classOf[NullPointerException],
+      () => new AtomicLong().updateAndGet(null),
+      () => new AtomicInteger().updateAndGet(null),
+      () => new AtomicReference[Any]().updateAndGet(null),
+      () => new AtomicLongArray(1).updateAndGet(0, null),
+      () => new AtomicIntegerArray(1).updateAndGet(0, null),
+      () => new AtomicReferenceArray[Any](1).updateAndGet(0, null)
+      // () => aLongFieldUpdater.updateAndGet(this, null),
+      // () => anIntFieldUpdater.updateAndGet(this, null),
+      // () => anIntegerFieldUpdater.updateAndGet(this, null)
+    )
+
+  /** All Atomic getAndAccumulate methods throw NullPointerException on null
+   *  function argument
+   */
+  @Test def testGetAndAccumulateNPE(): Unit =
+    assertThrows(
+      classOf[NullPointerException],
+      () => new AtomicLong().getAndAccumulate(1L, null),
+      () => new AtomicInteger().getAndAccumulate(1, null),
+      () => new AtomicReference[Any]().getAndAccumulate(one, null),
+      () => new AtomicLongArray(1).getAndAccumulate(0, 1L, null),
+      () => new AtomicIntegerArray(1).getAndAccumulate(0, 1, null),
+      () => new AtomicReferenceArray[Any](1).getAndAccumulate(0, one, null)
+      // () => aLongFieldUpdater.getAndAccumulate(this, 1L, null),
+      // () => anIntFieldUpdater.getAndAccumulate(this, 1, null),
+      // () => anIntegerFieldUpdater.getAndAccumulate(this, one, null)
+    )
+
+  /** All Atomic accumulateAndGet methods throw NullPointerException on null
+   *  function argument
+   */
+  @Test def testAccumulateAndGetNPE(): Unit =
+    assertThrows(
+      classOf[NullPointerException],
+      () => new AtomicLong().accumulateAndGet(1L, null),
+      () => new AtomicInteger().accumulateAndGet(1, null),
+      () => new AtomicReference[Any]().accumulateAndGet(one, null),
+      () => new AtomicLongArray(1).accumulateAndGet(0, 1L, null),
+      () => new AtomicIntegerArray(1).accumulateAndGet(0, 1, null),
+      () => new AtomicReferenceArray[Any](1).accumulateAndGet(0, one, null)
+      // () => aLongFieldUpdater.accumulateAndGet(this, 1L, null),
+      // () => anIntFieldUpdater.accumulateAndGet(this, 1, null),
+      // () => anIntegerFieldUpdater.accumulateAndGet(this, one, null)
+    )
+
+  /** Object arguments for parameters of type T that are not instances of the
+   *  class passed to the newUpdater call will result in a ClassCastException
+   *  being thrown.
+   */
+  // @Test def testFieldUpdaters_ClassCastException(): Unit = {}
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicBooleanTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicBooleanTest.scala
@@ -1,0 +1,133 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicBoolean
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
+
+class AtomicBooleanTest extends JSR166Test {
+  import JSR166Test._
+
+  /** constructor initializes to given value
+   */
+  @Test def testConstructor(): Unit = {
+    assertTrue(new AtomicBoolean(true).get)
+    assertFalse(new AtomicBoolean(false).get)
+  }
+
+  /** default constructed initializes to false
+   */
+  @Test def testConstructor2(): Unit = {
+    val ai = new AtomicBoolean
+    assertFalse(ai.get)
+  }
+
+  /** get returns the last value set
+   */
+  @Test def testGetSet(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertTrue(ai.get)
+    ai.set(false)
+    assertFalse(ai.get)
+    ai.set(true)
+    assertTrue(ai.get)
+  }
+
+  /** get returns the last value lazySet in same thread
+   */
+  @Test def testGetLazySet(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertTrue(ai.get)
+    ai.lazySet(false)
+    assertFalse(ai.get)
+    ai.lazySet(true)
+    assertTrue(ai.get)
+  }
+
+  /** compareAndSet succeeds in changing value if equal to expected else fails
+   */
+  @Test def testCompareAndSet(): Unit = {
+    val ai = new AtomicBoolean(true)
+    assertTrue(ai.compareAndSet(true, false))
+    assertFalse(ai.get)
+    assertTrue(ai.compareAndSet(false, false))
+    assertFalse(ai.get)
+    assertFalse(ai.compareAndSet(true, false))
+    assertFalse(ai.get)
+    assertTrue(ai.compareAndSet(false, true))
+    assertTrue(ai.get)
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[Exception]
+  @Test def testCompareAndSetInMultipleThreads(): Unit = {
+    val ai = new AtomicBoolean(true)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({ !ai.compareAndSet(false, true) }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(ai.compareAndSet(true, false))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSet(): Unit = {
+    val ai = new AtomicBoolean(true)
+    while (!ai.weakCompareAndSet(true, false)) ()
+    assertFalse(ai.get)
+    while (!ai.weakCompareAndSet(false, false)) ()
+    assertFalse(ai.get)
+    while (!ai.weakCompareAndSet(false, true)) ()
+    assertTrue(ai.get)
+  }
+
+  /** getAndSet returns previous value and sets to given value
+   */
+  @Test def testGetAndSet(): Unit = {
+    val ai = new AtomicBoolean
+    val booleans = Array(false, true)
+    for (before <- booleans) {
+      for (after <- booleans) {
+        ai.set(before)
+        assertEquals(before, ai.getAndSet(after))
+        assertEquals(after, ai.get)
+      }
+    }
+  }
+
+  /** a deserialized/reserialized atomic holds same value
+   */
+  @throws[Exception]
+  @Ignore("No ObjectInputStreams in Scala Native")
+  @Test def testSerialization(): Unit = {
+    //   val x = new AtomicBoolean
+    //   val y = serialClone(x)
+    //   x.set(true)
+    //   val z = serialClone(x)
+    //   assertTrue(x.get)
+    //   assertFalse(y.get)
+    //   assertTrue(z.get)
+  }
+
+  /** toString returns current value.
+   */
+  @Test def testToString(): Unit = {
+    val ai = new AtomicBoolean
+    assertEquals(java.lang.Boolean.toString(false), ai.toString)
+    ai.set(true)
+    assertEquals(java.lang.Boolean.toString(true), ai.toString)
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicIntegerArrayTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicIntegerArrayTest.scala
@@ -9,7 +9,6 @@
 package org.scalanative.testsuite.javalib.util.concurrent
 package atomic
 
-
 import java.util.concurrent.atomic.AtomicIntegerArray
 import java.util.Arrays
 

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicIntegerArrayTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicIntegerArrayTest.scala
@@ -1,0 +1,336 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+
+import java.util.concurrent.atomic.AtomicIntegerArray
+import java.util.Arrays
+
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
+
+class AtomicIntegerArrayTest extends JSR166Test {
+  import JSR166Test._
+
+  /** constructor creates array of given size with all elements zero
+   */
+  @Test def testConstructor(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) { assertEquals(0, aa.get(i)) }
+  }
+
+  /** constructor with null array throws NPE
+   */
+  @Test def testConstructor2NPE(): Unit = {
+    try {
+      val a = null
+      new AtomicIntegerArray(a)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** constructor with array is of same size and has all elements
+   */
+  @Test def testConstructor2(): Unit = {
+    val a = Array(17, 3, -42, 99, -7)
+    val aa = new AtomicIntegerArray(a)
+    assertEquals(a.length, aa.length)
+    for (i <- 0 until a.length) { assertEquals(a(i), aa.get(i)) }
+  }
+
+  /** get and set for out of bound indices throw IndexOutOfBoundsException
+   */
+  @Test def testIndexing(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (index <- Array[Int](-1, SIZE)) {
+      try {
+        aa.get(index)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.set(index, 1)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.lazySet(index, 1)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.compareAndSet(index, 1, 2)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.weakCompareAndSet(index, 1, 2)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.getAndAdd(index, 1)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.addAndGet(index, 1)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+    }
+  }
+
+  /** get returns the last value set at index
+   */
+  @Test def testGetSet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.set(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.set(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value lazySet at index by same thread
+   */
+  @Test def testGetLazySet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.lazySet(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.lazySet(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.lazySet(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** compareAndSet succeeds in changing value if equal to expected else fails
+   */
+  @Test def testCompareAndSet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertTrue(aa.compareAndSet(i, 1, 2))
+      assertTrue(aa.compareAndSet(i, 2, -4))
+      assertEquals(-4, aa.get(i))
+      assertFalse(aa.compareAndSet(i, -5, 7))
+      assertEquals(-4, aa.get(i))
+      assertTrue(aa.compareAndSet(i, -4, 7))
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[Exception]
+  @Test def testCompareAndSetInMultipleThreads(): Unit = {
+    val a = new AtomicIntegerArray(1)
+    a.set(0, 1)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({ !a.compareAndSet(0, 2, 3) }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(a.compareAndSet(0, 1, 2))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertEquals(3, a.get(0))
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSet(i, 1, 2)) ()
+      while (!aa.weakCompareAndSet(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSet(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** getAndSet returns previous value and sets to given value at given index
+   */
+  @Test def testGetAndSet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAndSet(i, 0))
+      assertEquals(0, aa.getAndSet(i, -10))
+      assertEquals(-10, aa.getAndSet(i, 1))
+    }
+  }
+
+  /** getAndAdd returns previous value and adds given value
+   */
+  @Test def testGetAndAdd(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAndAdd(i, 2))
+      assertEquals(3, aa.get(i))
+      assertEquals(3, aa.getAndAdd(i, -4))
+      assertEquals(-1, aa.get(i))
+    }
+  }
+
+  /** getAndDecrement returns previous value and decrements
+   */
+  @Test def testGetAndDecrement(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAndDecrement(i))
+      assertEquals(0, aa.getAndDecrement(i))
+      assertEquals(-1, aa.getAndDecrement(i))
+    }
+  }
+
+  /** getAndIncrement returns previous value and increments
+   */
+  @Test def testGetAndIncrement(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAndIncrement(i))
+      assertEquals(2, aa.get(i))
+      aa.set(i, -2)
+      assertEquals(-2, aa.getAndIncrement(i))
+      assertEquals(-1, aa.getAndIncrement(i))
+      assertEquals(0, aa.getAndIncrement(i))
+      assertEquals(1, aa.get(i))
+    }
+  }
+
+  /** addAndGet adds given value to current, and returns current value
+   */
+  @Test def testAddAndGet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(3, aa.addAndGet(i, 2))
+      assertEquals(3, aa.get(i))
+      assertEquals(-1, aa.addAndGet(i, -4))
+      assertEquals(-1, aa.get(i))
+    }
+  }
+
+  /** decrementAndGet decrements and returns current value
+   */
+  @Test def testDecrementAndGet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(0, aa.decrementAndGet(i))
+      assertEquals(-1, aa.decrementAndGet(i))
+      assertEquals(-2, aa.decrementAndGet(i))
+      assertEquals(-2, aa.get(i))
+    }
+  }
+
+  /** incrementAndGet increments and returns current value
+   */
+  @Test def testIncrementAndGet(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(2, aa.incrementAndGet(i))
+      assertEquals(2, aa.get(i))
+      aa.set(i, -2)
+      assertEquals(-1, aa.incrementAndGet(i))
+      assertEquals(0, aa.incrementAndGet(i))
+      assertEquals(1, aa.incrementAndGet(i))
+      assertEquals(1, aa.get(i))
+    }
+  }
+  class Counter(val aa: AtomicIntegerArray) extends CheckedRunnable {
+    var decs = 0
+    override def realRun(): Unit = {
+      @annotation.tailrec
+      def loop(): Unit = {
+        var done = true
+        for (i <- 0 until aa.length) {
+          val v = aa.get(i)
+          assertTrue(v >= 0)
+          if (v != 0) {
+            done = false
+            if (aa.compareAndSet(i, v, v - 1)) decs += 1
+          }
+        }
+        if (!done) loop()
+      }
+      loop()
+    }
+  }
+
+  /** Multiple threads using same array of counters successfully update a number
+   *  of times equal to total count
+   */
+  @throws[InterruptedException]
+  @Test def testCountingInMultipleThreads(): Unit = {
+    val aa = new AtomicIntegerArray(SIZE)
+    val countdown = 10000
+    for (i <- 0 until SIZE) { aa.set(i, countdown) }
+    val c1 = new Counter(aa)
+    val c2 = new Counter(aa)
+    val t1 = newStartedThread(c1)
+    val t2 = newStartedThread(c2)
+    t1.join()
+    t2.join()
+    assertEquals(c1.decs + c2.decs, SIZE * countdown)
+  }
+
+  /** a deserialized/reserialized array holds same values in same order
+   */
+  @throws[Exception]
+  @Ignore("No ObjectInputStreams in Scala Native")
+  @Test def testSerialization(): Unit = {
+    //   val x = new AtomicIntegerArray(SIZE)
+    //   for (i <- 0 until SIZE) { x.set(i, -i) }
+    //   val y = serialClone(x)
+    //   assertNotSame(x, y)
+    //   assertEquals(x.length, y.length)
+    //   for (i <- 0 until SIZE) { assertEquals(x.get(i), y.get(i)) }
+  }
+
+  /** toString returns current value.
+   */
+  @Test def testToString(): Unit = {
+    val a = Array(17, 3, -42, 99, -7)
+    val aa = new AtomicIntegerArray(a)
+    assertEquals(Arrays.toString(a), aa.toString)
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicIntegerTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicIntegerTest.scala
@@ -1,0 +1,242 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
+
+class AtomicIntegerTest extends JSR166Test {
+  final val VALUES =
+    Array(Integer.MIN_VALUE, -1, 0, 1, 42, Integer.MAX_VALUE)
+
+  /** constructor initializes to given value
+   */
+  @Test def testConstructor(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.get)
+  }
+
+  /** default constructed initializes to zero
+   */
+  @Test def testConstructor2(): Unit = {
+    val ai = new AtomicInteger
+    assertEquals(0, ai.get)
+  }
+
+  /** get returns the last value set
+   */
+  @Test def testGetSet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.get)
+    ai.set(2)
+    assertEquals(2, ai.get)
+    ai.set(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** get returns the last value lazySet in same thread
+   */
+  @Test def testGetLazySet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.get)
+    ai.lazySet(2)
+    assertEquals(2, ai.get)
+    ai.lazySet(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** compareAndSet succeeds in changing value if equal to expected else fails
+   */
+  @Test def testCompareAndSet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertTrue(ai.compareAndSet(1, 2))
+    assertTrue(ai.compareAndSet(2, -4))
+    assertEquals(-4, ai.get)
+    assertFalse(ai.compareAndSet(-5, 7))
+    assertEquals(-4, ai.get)
+    assertTrue(ai.compareAndSet(-4, 7))
+    assertEquals(7, ai.get)
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[Exception]
+  @Test def testCompareAndSetInMultipleThreads(): Unit = {
+    val ai = new AtomicInteger(1)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({ !ai.compareAndSet(2, 3) }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(ai.compareAndSet(1, 2))
+    t.join(JSR166Test.LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertEquals(3, ai.get)
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSet(): Unit = {
+    val ai = new AtomicInteger(1)
+    while (!ai.weakCompareAndSet(1, 2)) ()
+    while (!ai.weakCompareAndSet(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSet(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+
+  /** getAndSet returns previous value and sets to given value
+   */
+  @Test def testGetAndSet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.getAndSet(0))
+    assertEquals(0, ai.getAndSet(-10))
+    assertEquals(-10, ai.getAndSet(1))
+  }
+
+  /** getAndAdd returns previous value and adds given value
+   */
+  @Test def testGetAndAdd(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.getAndAdd(2))
+    assertEquals(3, ai.get)
+    assertEquals(3, ai.getAndAdd(-4))
+    assertEquals(-1, ai.get)
+  }
+
+  /** getAndDecrement returns previous value and decrements
+   */
+  @Test def testGetAndDecrement(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.getAndDecrement)
+    assertEquals(0, ai.getAndDecrement)
+    assertEquals(-1, ai.getAndDecrement)
+  }
+
+  /** getAndIncrement returns previous value and increments
+   */
+  @Test def testGetAndIncrement(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(1, ai.getAndIncrement)
+    assertEquals(2, ai.get)
+    ai.set(-2)
+    assertEquals(-2, ai.getAndIncrement)
+    assertEquals(-1, ai.getAndIncrement)
+    assertEquals(0, ai.getAndIncrement)
+    assertEquals(1, ai.get)
+  }
+
+  /** addAndGet adds given value to current, and returns current value
+   */
+  @Test def testAddAndGet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(3, ai.addAndGet(2))
+    assertEquals(3, ai.get)
+    assertEquals(-1, ai.addAndGet(-4))
+    assertEquals(-1, ai.get)
+  }
+
+  /** decrementAndGet decrements and returns current value
+   */
+  @Test def testDecrementAndGet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(0, ai.decrementAndGet)
+    assertEquals(-1, ai.decrementAndGet)
+    assertEquals(-2, ai.decrementAndGet)
+    assertEquals(-2, ai.get)
+  }
+
+  /** incrementAndGet increments and returns current value
+   */
+  @Test def testIncrementAndGet(): Unit = {
+    val ai = new AtomicInteger(1)
+    assertEquals(2, ai.incrementAndGet)
+    assertEquals(2, ai.get)
+    ai.set(-2)
+    assertEquals(-1, ai.incrementAndGet)
+    assertEquals(0, ai.incrementAndGet)
+    assertEquals(1, ai.incrementAndGet)
+    assertEquals(1, ai.get)
+  }
+
+  /** a deserialized/reserialized atomic holds same value
+   */
+  @throws[Exception]
+  @Ignore("No ObjectInputStreams in Scala Native")
+  @Test def testSerialization(): Unit = {
+    //   val x = new AtomicInteger
+    //   val y = serialClone(x)
+    //   assertNotSame(x, y)
+    //   x.set(22)
+    //   val z = serialClone(x)
+    //   assertEquals(22, x.get)
+    //   assertEquals(0, y.get)
+    //   assertEquals(22, z.get)
+  }
+
+  /** toString returns current value.
+   */
+  @Test def testToString(): Unit = {
+    val ai = new AtomicInteger
+    assertEquals("0", ai.toString)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(Integer.toString(x), ai.toString)
+    }
+  }
+
+  /** intValue returns current value.
+   */
+  @Test def testIntValue(): Unit = {
+    val ai = new AtomicInteger
+    assertEquals(0, ai.intValue)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(x, ai.intValue)
+    }
+  }
+
+  /** longValue returns current value.
+   */
+  @Test def testLongValue(): Unit = {
+    val ai = new AtomicInteger
+    assertEquals(0L, ai.longValue)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(x.toLong, ai.longValue)
+    }
+  }
+
+  /** floatValue returns current value.
+   */
+  @Test def testFloatValue(): Unit = {
+    val ai = new AtomicInteger
+    assertEquals(0.0f, ai.floatValue, 0.00000001)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(x.toFloat, ai.floatValue, 0.00000001)
+    }
+  }
+
+  /** doubleValue returns current value.
+   */
+  @Test def testDoubleValue(): Unit = {
+    val ai = new AtomicInteger
+    assertEquals(0.0d, ai.doubleValue, 0.0000001)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(x.toDouble, ai.doubleValue, 0.0000001)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicLongArrayTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicLongArrayTest.scala
@@ -1,0 +1,335 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicLongArray
+import java.util.Arrays
+
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
+
+class AtomicLongArrayTest extends JSR166Test {
+  import JSR166Test._
+
+  /** constructor creates array of given size with all elements zero
+   */
+  @Test def testConstructor(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) { assertEquals(0, aa.get(i)) }
+  }
+
+  /** constructor with null array throws NPE
+   */
+  @Test def testConstructor2NPE(): Unit = {
+    try {
+      val a = null
+      new AtomicLongArray(a)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** constructor with array is of same size and has all elements
+   */
+  @Test def testConstructor2(): Unit = {
+    val a = Array(17L, 3L, -42L, 99L, -7L)
+    val aa = new AtomicLongArray(a)
+    assertEquals(a.length, aa.length)
+    for (i <- 0 until a.length) { assertEquals(a(i), aa.get(i)) }
+  }
+
+  /** get and set for out of bound indices throw IndexOutOfBoundsException
+   */
+  @Test def testIndexing(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (index <- Array[Int](-1, SIZE)) {
+      try {
+        aa.get(index)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.set(index, 1)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.lazySet(index, 1)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.compareAndSet(index, 1, 2)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.weakCompareAndSet(index, 1, 2)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.getAndAdd(index, 1)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.addAndGet(index, 1)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+    }
+  }
+
+  /** get returns the last value set at index
+   */
+  @Test def testGetSet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.set(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.set(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value lazySet at index by same thread
+   */
+  @Test def testGetLazySet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.lazySet(i, 1)
+      assertEquals(1, aa.get(i))
+      aa.lazySet(i, 2)
+      assertEquals(2, aa.get(i))
+      aa.lazySet(i, -3)
+      assertEquals(-3, aa.get(i))
+    }
+  }
+
+  /** compareAndSet succeeds in changing value if equal to expected else fails
+   */
+  @Test def testCompareAndSet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertTrue(aa.compareAndSet(i, 1, 2))
+      assertTrue(aa.compareAndSet(i, 2, -4))
+      assertEquals(-4, aa.get(i))
+      assertFalse(aa.compareAndSet(i, -5, 7))
+      assertEquals(-4, aa.get(i))
+      assertTrue(aa.compareAndSet(i, -4, 7))
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[InterruptedException]
+  @Test def testCompareAndSetInMultipleThreads(): Unit = {
+    val a = new AtomicLongArray(1)
+    a.set(0, 1)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({ !a.compareAndSet(0, 2, 3) }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(a.compareAndSet(0, 1, 2))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertEquals(3, a.get(0))
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      while (!aa.weakCompareAndSet(i, 1, 2)) ()
+      while (!aa.weakCompareAndSet(i, 2, -(4))) ()
+      assertEquals(-4, aa.get(i))
+      while (!aa.weakCompareAndSet(i, -(4), 7)) ()
+      assertEquals(7, aa.get(i))
+    }
+  }
+
+  /** getAndSet returns previous value and sets to given value at given index
+   */
+  @Test def testGetAndSet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAndSet(i, 0))
+      assertEquals(0, aa.getAndSet(i, -10))
+      assertEquals(-10, aa.getAndSet(i, 1))
+    }
+  }
+
+  /** getAndAdd returns previous value and adds given value
+   */
+  @Test def testGetAndAdd(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAndAdd(i, 2))
+      assertEquals(3, aa.get(i))
+      assertEquals(3, aa.getAndAdd(i, -4))
+      assertEquals(-1, aa.get(i))
+    }
+  }
+
+  /** getAndDecrement returns previous value and decrements
+   */
+  @Test def testGetAndDecrement(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAndDecrement(i))
+      assertEquals(0, aa.getAndDecrement(i))
+      assertEquals(-1, aa.getAndDecrement(i))
+    }
+  }
+
+  /** getAndIncrement returns previous value and increments
+   */
+  @Test def testGetAndIncrement(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(1, aa.getAndIncrement(i))
+      assertEquals(2, aa.get(i))
+      aa.set(i, -2)
+      assertEquals(-2, aa.getAndIncrement(i))
+      assertEquals(-1, aa.getAndIncrement(i))
+      assertEquals(0, aa.getAndIncrement(i))
+      assertEquals(1, aa.get(i))
+    }
+  }
+
+  /** addAndGet adds given value to current, and returns current value
+   */
+  @Test def testAddAndGet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(3, aa.addAndGet(i, 2))
+      assertEquals(3, aa.get(i))
+      assertEquals(-1, aa.addAndGet(i, -4))
+      assertEquals(-1, aa.get(i))
+    }
+  }
+
+  /** decrementAndGet decrements and returns current value
+   */
+  @Test def testDecrementAndGet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(0, aa.decrementAndGet(i))
+      assertEquals(-1, aa.decrementAndGet(i))
+      assertEquals(-2, aa.decrementAndGet(i))
+      assertEquals(-2, aa.get(i))
+    }
+  }
+
+  /** incrementAndGet increments and returns current value
+   */
+  @Test def testIncrementAndGet(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, 1)
+      assertEquals(2, aa.incrementAndGet(i))
+      assertEquals(2, aa.get(i))
+      aa.set(i, -2)
+      assertEquals(-1, aa.incrementAndGet(i))
+      assertEquals(0, aa.incrementAndGet(i))
+      assertEquals(1, aa.incrementAndGet(i))
+      assertEquals(1, aa.get(i))
+    }
+  }
+  class Counter(val aa: AtomicLongArray) extends CheckedRunnable {
+    var decs = 0
+    override def realRun(): Unit = {
+      @annotation.tailrec
+      def loop(): Unit = {
+        var done = true
+        for (i <- 0 until aa.length) {
+          val v = aa.get(i)
+          assertTrue(v >= 0)
+          if (v != 0) {
+            done = false
+            if (aa.compareAndSet(i, v, v - 1)) decs += 1
+          }
+        }
+        if (!done) loop()
+      }
+      loop()
+    }
+  }
+
+  /** Multiple threads using same array of counters successfully update a number
+   *  of times equal to total count
+   */
+  @throws[InterruptedException]
+  @Test def testCountingInMultipleThreads(): Unit = {
+    val aa = new AtomicLongArray(SIZE)
+    val countdown = 10000
+    for (i <- 0 until SIZE) { aa.set(i, countdown) }
+    val c1 = new Counter(aa)
+    val c2 = new Counter(aa)
+    val t1 = newStartedThread(c1)
+    val t2 = newStartedThread(c2)
+    t1.join()
+    t2.join()
+    assertEquals(c1.decs + c2.decs, SIZE * countdown)
+  }
+
+  /** a deserialized/reserialized array holds same values in same order
+   */
+  @throws[Exception]
+  @Ignore("No ObjectInputStreams in Scala Native")
+  @Test def testSerialization(): Unit = {
+    //   val x = new AtomicLongArray(SIZE)
+    //   for (i <- 0 until SIZE) { x.set(i, -i) }
+    //   val y = serialClone(x)
+    //   assertNotSame(x, y)
+    //   assertEquals(x.length, y.length)
+    //   for (i <- 0 until SIZE) { assertEquals(x.get(i), y.get(i)) }
+  }
+
+  /** toString returns current value.
+   */
+  @Test def testToString(): Unit = {
+    val a = Array[Long](17, 3, -42, 99, -7)
+    val aa = new AtomicLongArray(a)
+    assertEquals(Arrays.toString(a), aa.toString)
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicLongTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicLongTest.scala
@@ -16,7 +16,7 @@ import org.junit.Assert._
 
 class AtomicLongTest extends JSR166Test {
   import JSR166Test._
-  
+
   final val VALUES = Array(
     java.lang.Long.MIN_VALUE,
     Integer.MIN_VALUE,

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicLongTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicLongTest.scala
@@ -1,0 +1,255 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicLong
+
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
+
+class AtomicLongTest extends JSR166Test {
+  import JSR166Test._
+  
+  final val VALUES = Array(
+    java.lang.Long.MIN_VALUE,
+    Integer.MIN_VALUE,
+    -1,
+    0,
+    1,
+    42,
+    Integer.MAX_VALUE,
+    java.lang.Long.MAX_VALUE
+  )
+
+  /** constructor initializes to given value
+   */
+  @Test def testConstructor(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.get)
+  }
+
+  /** default constructed initializes to zero
+   */
+  @Test def testConstructor2(): Unit = {
+    val ai = new AtomicLong
+    assertEquals(0, ai.get)
+  }
+
+  /** get returns the last value set
+   */
+  @Test def testGetSet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.get)
+    ai.set(2)
+    assertEquals(2, ai.get)
+    ai.set(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** get returns the last value lazySet in same thread
+   */
+  @Test def testGetLazySet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.get)
+    ai.lazySet(2)
+    assertEquals(2, ai.get)
+    ai.lazySet(-3)
+    assertEquals(-3, ai.get)
+  }
+
+  /** compareAndSet succeeds in changing value if equal to expected else fails
+   */
+  @Test def testCompareAndSet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertTrue(ai.compareAndSet(1, 2))
+    assertTrue(ai.compareAndSet(2, -4))
+    assertEquals(-4, ai.get)
+    assertFalse(ai.compareAndSet(-5, 7))
+    assertEquals(-4, ai.get)
+    assertTrue(ai.compareAndSet(-4, 7))
+    assertEquals(7, ai.get)
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[Exception]
+  @Test def testCompareAndSetInMultipleThreads(): Unit = {
+    val ai = new AtomicLong(1)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({ !ai.compareAndSet(2, 3) }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(ai.compareAndSet(1, 2))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertEquals(3, ai.get)
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSet(): Unit = {
+    val ai = new AtomicLong(1)
+    while (!ai.weakCompareAndSet(1, 2)) ()
+    while (!ai.weakCompareAndSet(2, -(4))) ()
+    assertEquals(-4, ai.get)
+    while (!ai.weakCompareAndSet(-(4), 7)) ()
+    assertEquals(7, ai.get)
+  }
+
+  /** getAndSet returns previous value and sets to given value
+   */
+  @Test def testGetAndSet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.getAndSet(0))
+    assertEquals(0, ai.getAndSet(-10))
+    assertEquals(-10, ai.getAndSet(1))
+  }
+
+  /** getAndAdd returns previous value and adds given value
+   */
+  @Test def testGetAndAdd(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.getAndAdd(2))
+    assertEquals(3, ai.get)
+    assertEquals(3, ai.getAndAdd(-4))
+    assertEquals(-1, ai.get)
+  }
+
+  /** getAndDecrement returns previous value and decrements
+   */
+  @Test def testGetAndDecrement(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.getAndDecrement)
+    assertEquals(0, ai.getAndDecrement)
+    assertEquals(-1, ai.getAndDecrement)
+  }
+
+  /** getAndIncrement returns previous value and increments
+   */
+  @Test def testGetAndIncrement(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(1, ai.getAndIncrement)
+    assertEquals(2, ai.get)
+    ai.set(-2)
+    assertEquals(-2, ai.getAndIncrement)
+    assertEquals(-1, ai.getAndIncrement)
+    assertEquals(0, ai.getAndIncrement)
+    assertEquals(1, ai.get)
+  }
+
+  /** addAndGet adds given value to current, and returns current value
+   */
+  @Test def testAddAndGet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(3, ai.addAndGet(2))
+    assertEquals(3, ai.get)
+    assertEquals(-1, ai.addAndGet(-4))
+    assertEquals(-1, ai.get)
+  }
+
+  /** decrementAndGet decrements and returns current value
+   */
+  @Test def testDecrementAndGet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(0, ai.decrementAndGet)
+    assertEquals(-1, ai.decrementAndGet)
+    assertEquals(-2, ai.decrementAndGet)
+    assertEquals(-2, ai.get)
+  }
+
+  /** incrementAndGet increments and returns current value
+   */
+  @Test def testIncrementAndGet(): Unit = {
+    val ai = new AtomicLong(1)
+    assertEquals(2, ai.incrementAndGet)
+    assertEquals(2, ai.get)
+    ai.set(-2)
+    assertEquals(-1, ai.incrementAndGet)
+    assertEquals(0, ai.incrementAndGet)
+    assertEquals(1, ai.incrementAndGet)
+    assertEquals(1, ai.get)
+  }
+
+  /** a deserialized/reserialized atomic holds same value
+   */
+  @throws[Exception]
+  @Ignore("No ObjectInputStreams in Scala Native")
+  @Test def testSerialization(): Unit = {
+    //   val x = new AtomicLong
+    //   val y = serialClone(x)
+    //   assertNotSame(x, y)
+    //   x.set(-22)
+    //   val z = serialClone(x)
+    //   assertNotSame(y, z)
+    //   assertEquals(-22, x.get)
+    //   assertEquals(0, y.get)
+    //   assertEquals(-22, z.get)
+  }
+
+  /** toString returns current value.
+   */
+  @Test def testToString(): Unit = {
+    val ai = new AtomicLong
+    assertEquals("0", ai.toString)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(java.lang.Long.toString(x), ai.toString)
+    }
+  }
+
+  /** intValue returns current value.
+   */
+  @Test def testIntValue(): Unit = {
+    val ai = new AtomicLong
+    assertEquals(0, ai.intValue)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(x.toInt, ai.intValue)
+    }
+  }
+
+  /** longValue returns current value.
+   */
+  @Test def testLongValue(): Unit = {
+    val ai = new AtomicLong
+    assertEquals(0L, ai.longValue)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(x, ai.longValue)
+    }
+  }
+
+  val delta = 0.00000001
+
+  /** floatValue returns current value.
+   */
+  @Test def testFloatValue(): Unit = {
+    val ai = new AtomicLong
+    assertEquals(0.0f, ai.floatValue, delta.toFloat)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(x.toFloat, ai.floatValue, delta.toFloat)
+    }
+  }
+
+  /** doubleValue returns current value.
+   */
+  @Test def testDoubleValue(): Unit = {
+    val ai = new AtomicLong
+    assertEquals(0.0d, ai.doubleValue, delta)
+    for (x <- VALUES) {
+      ai.set(x)
+      assertEquals(x.toDouble, ai.doubleValue, delta)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicMarkableReferenceTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicMarkableReferenceTest.scala
@@ -1,0 +1,146 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicMarkableReference
+
+import org.junit.Test
+import org.junit.Assert._
+
+class AtomicMarkableReferenceTest extends JSR166Test {
+  import JSR166Test._
+
+  /** constructor initializes to given reference and mark
+   */
+  @Test def testConstructor(): Unit = {
+    val ai = new AtomicMarkableReference[Any](one, false)
+    assertSame(one, ai.getReference)
+    assertFalse(ai.isMarked)
+    val a2 = new AtomicMarkableReference[Any](null, true)
+    assertNull(a2.getReference)
+    assertTrue(a2.isMarked)
+  }
+
+  /** get returns the last values of reference and mark set
+   */
+  @Test def testGetSet(): Unit = {
+    val mark = new Array[Boolean](1)
+    val ai = new AtomicMarkableReference[Any](one, false)
+    assertSame(one, ai.getReference)
+    assertFalse(ai.isMarked)
+    assertSame(one, ai.get(mark))
+    assertFalse(mark(0))
+    ai.set(two, false)
+    assertSame(two, ai.getReference)
+    assertFalse(ai.isMarked)
+    assertSame(two, ai.get(mark))
+    assertFalse(mark(0))
+    ai.set(one, true)
+    assertSame(one, ai.getReference)
+    assertTrue(ai.isMarked)
+    assertSame(one, ai.get(mark))
+    assertTrue(mark(0))
+  }
+
+  /** attemptMark succeeds in single thread
+   */
+  @Test def testAttemptMark(): Unit = {
+    val mark = new Array[Boolean](1)
+    val ai = new AtomicMarkableReference[Any](one, false)
+    assertFalse(ai.isMarked)
+    assertTrue(ai.attemptMark(one, true))
+    assertTrue(ai.isMarked)
+    assertSame(one, ai.get(mark))
+    assertTrue(mark(0))
+  }
+
+  /** compareAndSet succeeds in changing values if equal to expected reference
+   *  and mark else fails
+   */
+  @Test def testCompareAndSet(): Unit = {
+    val mark = new Array[Boolean](1)
+    val ai = new AtomicMarkableReference[Any](one, false)
+    assertSame(one, ai.get(mark))
+    assertFalse(ai.isMarked)
+    assertFalse(mark(0))
+    assertTrue(ai.compareAndSet(one, two, false, false))
+    assertSame(two, ai.get(mark))
+    assertFalse(mark(0))
+    assertTrue(ai.compareAndSet(two, m3, false, true))
+    assertSame(m3, ai.get(mark))
+    assertTrue(mark(0))
+    assertFalse(ai.compareAndSet(two, m3, true, true))
+    assertSame(m3, ai.get(mark))
+    assertTrue(mark(0))
+  }
+
+  /** compareAndSet in one thread enables another waiting for reference value to
+   *  succeed
+   */
+  @throws[Exception]
+  @Test def testCompareAndSetInMultipleThreads(): Unit = {
+    val ai = new AtomicMarkableReference[Any](one, false)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({
+          !ai.compareAndSet(two, three, false, false)
+        }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(ai.compareAndSet(one, two, false, false))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertSame(three, ai.getReference)
+    assertFalse(ai.isMarked)
+  }
+
+  /** compareAndSet in one thread enables another waiting for mark value to
+   *  succeed
+   */
+  @throws[Exception]
+  @Test def testCompareAndSetInMultipleThreads2(): Unit = {
+    val ai = new AtomicMarkableReference[Any](one, false)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({
+          !ai.compareAndSet(one, one, true, false)
+        }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(ai.compareAndSet(one, one, false, true))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertSame(one, ai.getReference)
+    assertFalse(ai.isMarked)
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing values when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSet(): Unit = {
+    val mark = new Array[Boolean](1)
+    val ai = new AtomicMarkableReference[Any](one, false)
+    assertSame(one, ai.get(mark))
+    assertFalse(ai.isMarked())
+    assertFalse(mark(0))
+    while ({
+      !ai.weakCompareAndSet(one, two, false, false)
+    }) ()
+    assertSame(two, ai.get(mark))
+    assertFalse(mark(0))
+    while ({
+      !ai.weakCompareAndSet(two, m3, false, true)
+    }) ()
+    assertSame(m3, ai.get(mark))
+    assertTrue(mark(0))
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicReferenceArrayTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicReferenceArrayTest.scala
@@ -1,0 +1,219 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicReferenceArray
+import java.util.Arrays
+
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
+
+class AtomicReferenceArrayTest extends JSR166Test {
+  import JSR166Test._
+
+  /** constructor creates array of given size with all elements null
+   */
+  @Test def testConstructor(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (i <- 0 until SIZE) { assertNull(i.toString, aa.get(i)) }
+  }
+
+  /** constructor with null array throws NPE
+   */
+  @Test def testConstructor2NPE(): Unit = {
+    try {
+      val a = null
+      new AtomicReferenceArray[Integer](a)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** constructor with array is of same size and has all elements
+   */
+  @Test def testConstructor2(): Unit = {
+    val a = Array(two, one, three, four, seven)
+    val aa = new AtomicReferenceArray[Integer](a)
+    assertEquals(a.length, aa.length)
+    for (i <- 0 until a.length) { assertEquals(a(i), aa.get(i)) }
+  }
+
+  /** Initialize AtomicReferenceArray<Class> with SubClass[]
+   */
+  @Test def testConstructorSubClassArray(): Unit = {
+    val a = Array[Number](two, one, three, four, seven)
+    val aa = new AtomicReferenceArray[Number](a)
+    assertEquals(a.length, aa.length)
+    for (i <- 0 until a.length) {
+      assertSame(a(i), aa.get(i))
+      val x = java.lang.Long.valueOf(i)
+      aa.set(i, x)
+      assertSame(x, aa.get(i))
+    }
+  }
+
+  /** get and set for out of bound indices throw IndexOutOfBoundsException
+   */
+  @Test def testIndexing(): Unit = {
+    val aa =
+      new AtomicReferenceArray[Integer](SIZE)
+    for (index <- Array[Int](-1, SIZE)) {
+      try {
+        aa.get(index)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.set(index, null)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.lazySet(index, null)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.compareAndSet(index, null, null)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+      try {
+        aa.weakCompareAndSet(index, null, null)
+        shouldThrow()
+      } catch {
+        case success: IndexOutOfBoundsException =>
+
+      }
+    }
+  }
+
+  /** get returns the last value set at index
+   */
+  @Test def testGetSet(): Unit = {
+    val aa = new AtomicReferenceArray[Any](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertSame(one, aa.get(i))
+      aa.set(i, two)
+      assertSame(two, aa.get(i))
+      aa.set(i, m3)
+      assertSame(m3, aa.get(i))
+    }
+  }
+
+  /** get returns the last value lazySet at index by same thread
+   */
+  @Test def testGetLazySet(): Unit = {
+    val aa = new AtomicReferenceArray[Any](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.lazySet(i, one)
+      assertSame(one, aa.get(i))
+      aa.lazySet(i, two)
+      assertSame(two, aa.get(i))
+      aa.lazySet(i, m3)
+      assertSame(m3, aa.get(i))
+    }
+  }
+
+  /** compareAndSet succeeds in changing value if equal to expected else fails
+   */
+  @Test def testCompareAndSet(): Unit = {
+    val aa = new AtomicReferenceArray[Any](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertTrue(aa.compareAndSet(i, one, two))
+      assertTrue(aa.compareAndSet(i, two, m4))
+      assertSame(m4, aa.get(i))
+      assertFalse(aa.compareAndSet(i, m5, seven))
+      assertSame(m4, aa.get(i))
+      assertTrue(aa.compareAndSet(i, m4, seven))
+      assertSame(seven, aa.get(i))
+    }
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[InterruptedException]
+  @Test def testCompareAndSetInMultipleThreads(): Unit = {
+    val a = new AtomicReferenceArray[Any](1)
+    a.set(0, one)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while (!a.compareAndSet(0, two, three)) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(a.compareAndSet(0, one, two))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertSame(three, a.get(0))
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSet(): Unit = {
+    val aa = new AtomicReferenceArray[Any](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      while (!aa.weakCompareAndSet(i, one, two)) ()
+      while (!aa.weakCompareAndSet(i, two, m4)) ()
+      assertSame(m4, aa.get(i))
+      while (!aa.weakCompareAndSet(i, m4, seven)) ()
+      assertSame(seven, aa.get(i))
+    }
+  }
+
+  /** getAndSet returns previous value and sets to given value at given index
+   */
+  @Test def testGetAndSet(): Unit = {
+    val aa = new AtomicReferenceArray[Any](SIZE)
+    for (i <- 0 until SIZE) {
+      aa.set(i, one)
+      assertSame(one, aa.getAndSet(i, zero))
+      assertSame(zero, aa.getAndSet(i, m10))
+      assertSame(m10, aa.getAndSet(i, one))
+    }
+  }
+
+  /** a deserialized/reserialized array holds same values in same order
+   */
+  @throws[Exception]
+  @Ignore("No ObjectInputStreams in Scala Native")
+  @Test def testSerialization(): Unit = {
+    //   val x = new AtomicReferenceArray[Any](SIZE)
+    //   for (i <- 0 until SIZE) { x.set(i, new Integer(-i)) }
+    //   val y = serialClone(x)
+    //   assertNotSame(x, y)
+    //   assertEquals(x.length, y.length)
+    //   for (i <- 0 until SIZE) { assertEquals(x.get(i), y.get(i)) }
+  }
+
+  /** toString returns current value.
+   */
+  @Test def testToString(): Unit = {
+    val a = Array[Int](two, one, three, four, seven)
+    val aRef: Array[Integer] = a.map(v => v: Integer)
+    val aa = new AtomicReferenceArray[Integer](aRef)
+    assertEquals(java.util.Arrays.toString(a), aa.toString)
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicStampedReferenceTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/concurrent/atomic/AtomicStampedReferenceTest.scala
@@ -1,0 +1,138 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicStampedReference
+
+import org.junit.Test
+import org.junit.Assert._
+
+class AtomicStampedReferenceTest extends JSR166Test {
+  import JSR166Test._
+
+  /** constructor initializes to given reference and stamp
+   */
+  @Test def testConstructor(): Unit = {
+    val ai = new AtomicStampedReference[Any](one, 0)
+    assertSame(one, ai.getReference)
+    assertEquals(0, ai.getStamp)
+    val a2 = new AtomicStampedReference[Any](null, 1)
+    assertNull(a2.getReference)
+    assertEquals(1, a2.getStamp)
+  }
+
+  /** get returns the last values of reference and stamp set
+   */
+  @Test def testGetSet(): Unit = {
+    val mark = new Array[Int](1)
+    val ai = new AtomicStampedReference[Any](one, 0)
+    assertSame(one, ai.getReference)
+    assertEquals(0, ai.getStamp)
+    assertSame(one, ai.get(mark))
+    assertEquals(0, mark(0))
+    ai.set(two, 0)
+    assertSame(two, ai.getReference)
+    assertEquals(0, ai.getStamp)
+    assertSame(two, ai.get(mark))
+    assertEquals(0, mark(0))
+    ai.set(one, 1)
+    assertSame(one, ai.getReference)
+    assertEquals(1, ai.getStamp)
+    assertSame(one, ai.get(mark))
+    assertEquals(1, mark(0))
+  }
+
+  /** attemptStamp succeeds in single thread
+   */
+  @Test def testAttemptStamp(): Unit = {
+    val mark = new Array[Int](1)
+    val ai = new AtomicStampedReference[Any](one, 0)
+    assertEquals(0, ai.getStamp)
+    assertTrue(ai.attemptStamp(one, 1))
+    assertEquals(1, ai.getStamp)
+    assertSame(one, ai.get(mark))
+    assertEquals(1, mark(0))
+  }
+
+  /** compareAndSet succeeds in changing values if equal to expected reference
+   *  and stamp else fails
+   */
+  @Test def testCompareAndSet(): Unit = {
+    val mark = new Array[Int](1)
+    val ai = new AtomicStampedReference[Any](one, 0)
+    assertSame(one, ai.get(mark))
+    assertEquals(0, ai.getStamp)
+    assertEquals(0, mark(0))
+    assertTrue(ai.compareAndSet(one, two, 0, 0))
+    assertSame(two, ai.get(mark))
+    assertEquals(0, mark(0))
+    assertTrue(ai.compareAndSet(two, m3, 0, 1))
+    assertSame(m3, ai.get(mark))
+    assertEquals(1, mark(0))
+    assertFalse(ai.compareAndSet(two, m3, 1, 1))
+    assertSame(m3, ai.get(mark))
+    assertEquals(1, mark(0))
+  }
+
+  /** compareAndSet in one thread enables another waiting for reference value to
+   *  succeed
+   */
+  @throws[Exception]
+  @Test def testCompareAndSetInMultipleThreads(): Unit = {
+    val ai = new AtomicStampedReference[Any](one, 0)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({ !ai.compareAndSet(two, three, 0, 0) }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(ai.compareAndSet(one, two, 0, 0))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertSame(three, ai.getReference)
+    assertEquals(0, ai.getStamp)
+  }
+
+  /** compareAndSet in one thread enables another waiting for stamp value to
+   *  succeed
+   */
+  @throws[Exception]
+  @Test def testCompareAndSetInMultipleThreads2(): Unit = {
+    val ai = new AtomicStampedReference[Any](one, 0)
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while ({ !ai.compareAndSet(one, one, 1, 2) }) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(ai.compareAndSet(one, one, 0, 1))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertSame(one, ai.getReference)
+    assertEquals(2, ai.getStamp)
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing values when equal to
+   *  expected
+   */
+  @Test def testWeakCompareAndSet(): Unit = {
+    val mark = new Array[Int](1)
+    val ai = new AtomicStampedReference[Any](one, 0)
+    assertSame(one, ai.get(mark))
+    assertEquals(0, ai.getStamp)
+    assertEquals(0, mark(0))
+    while (!ai.weakCompareAndSet(one, two, 0, 0)) ()
+    assertSame(two, ai.get(mark))
+    assertEquals(0, mark(0))
+    while (!ai.weakCompareAndSet(two, m3, 0, 1)) ()
+    assertSame(m3, ai.get(mark))
+    assertEquals(1, mark(0))
+  }
+}


### PR DESCRIPTION
Ports Java Atomic types and their related tests from JSR-166 
Includes: 
* `AtomicBoolean`
* `AtomicInteger` 
* `AtomicLong`
* `AtomicReference`
* `AtomicMarkableReference`
* `AtomicStampedReference`
* `AtomicIntegerArray`
* `AtomicLongArray`
* `AtomicReferenceArray`

The remaining `AtomicFieldUpdater` types were originally based on the reflection in the JVM. The solution to support them might be added in the future (they're required by `scala.collection.concurrent.TrieMap`)
Resolves #753