### PR TITLE
Port `java.util.concurrent.ThreadLocalRandom` from JSR-166

### DIFF
--- a/javalib/src/main/scala/java/util/Spliterator.scala
+++ b/javalib/src/main/scala/java/util/Spliterator.scala
@@ -1,6 +1,6 @@
 package java.util
 
-import java.util.function.Consumer
+import java.util.function._
 
 import Spliterator._
 
@@ -13,6 +13,78 @@ object Spliterator {
   final val IMMUTABLE = 0x00000400
   final val CONCURRENT = 0x00001000
   final val SUBSIZED = 0x00004000
+
+  trait OfPrimitive[
+      T,
+      T_CONS,
+      T_SPLITR <: Spliterator.OfPrimitive[T, T_CONS, T_SPLITR]
+  ] extends Spliterator[T] {
+    override def trySplit(): T_SPLITR
+    def tryAdvance(action: T_CONS): Boolean
+    def forEachRemaining(action: T_CONS): Unit = {
+      while (tryAdvance(action)) ()
+    }
+  }
+
+  trait OfInt
+      extends OfPrimitive[java.lang.Integer, IntConsumer, Spliterator.OfInt] {
+    override def trySplit(): OfInt
+    override def tryAdvance(action: IntConsumer): Boolean
+    override def forEachRemaining(action: IntConsumer): Unit =
+      while (tryAdvance(action)) ()
+    override def tryAdvance(action: Consumer[_ >: Integer]): Boolean =
+      action match {
+        case action: IntConsumer => tryAdvance(action: IntConsumer)
+        case _                   => tryAdvance((action.accept(_)): IntConsumer)
+      }
+    override def forEachRemaining(action: Consumer[_ >: Integer]): Unit =
+      action match {
+        case action: IntConsumer => forEachRemaining(action: IntConsumer)
+        case _ => forEachRemaining((action.accept(_)): IntConsumer)
+      }
+
+  }
+  trait OfLong
+      extends OfPrimitive[java.lang.Long, LongConsumer, Spliterator.OfLong] {
+    override def trySplit(): OfLong
+    override def tryAdvance(action: LongConsumer): Boolean
+    override def forEachRemaining(action: LongConsumer): Unit =
+      while (tryAdvance(action)) ()
+    override def tryAdvance(action: Consumer[_ >: java.lang.Long]): Boolean =
+      action match {
+        case action: LongConsumer => tryAdvance(action: LongConsumer)
+        case _ => tryAdvance((action.accept(_)): LongConsumer)
+      }
+    override def forEachRemaining(action: Consumer[_ >: java.lang.Long]): Unit =
+      action match {
+        case action: LongConsumer => forEachRemaining(action: LongConsumer)
+        case _ => forEachRemaining((action.accept(_)): LongConsumer)
+      }
+  }
+  trait OfDouble
+      extends OfPrimitive[
+        java.lang.Double,
+        DoubleConsumer,
+        Spliterator.OfDouble
+      ] {
+    override def trySplit(): OfDouble
+    override def tryAdvance(action: DoubleConsumer): Boolean
+    override def forEachRemaining(action: DoubleConsumer): Unit =
+      while (tryAdvance(action)) ()
+    override def tryAdvance(action: Consumer[_ >: java.lang.Double]): Boolean =
+      action match {
+        case action: DoubleConsumer => tryAdvance(action: DoubleConsumer)
+        case _ => tryAdvance((action.accept(_)): DoubleConsumer)
+      }
+    override def forEachRemaining(
+        action: Consumer[_ >: java.lang.Double]
+    ): Unit =
+      action match {
+        case action: DoubleConsumer => forEachRemaining(action: DoubleConsumer)
+        case _ => forEachRemaining((action.accept(_)): DoubleConsumer)
+      }
+  }
+
 }
 
 trait Spliterator[T] {

--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -2,126 +2,637 @@
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
  * http://creativecommons.org/publicdomain/zero/1.0/
- *
- * and translated to Scala
- * Ported from Scala.js commit: bbf0314 dated: Mon, 13 Jun 2022
  */
 
 package java.util.concurrent
 
-import java.util.Random
-import scala.annotation.tailrec
+import java.util._
+import java.util.function._
+import java.util.stream._
+import java.util.concurrent.atomic._
 
-class ThreadLocalRandom extends Random {
-
-  private var initialized: Boolean = _
-  initialized = true
-
-  override def setSeed(seed: Long): Unit = {
-    if (initialized)
-      throw new UnsupportedOperationException()
-
-    super.setSeed(seed)
+@SerialVersionUID(-5851777807851030925L)
+object ThreadLocalRandom {
+  private def mix64(z0: Long) = {
+    var z = z0
+    z = (z ^ (z >>> 33)) * 0xff51afd7ed558ccdL
+    z = (z ^ (z >>> 33)) * 0xc4ceb9fe1a85ec53L
+    z ^ (z >>> 33)
   }
 
-  def nextInt(least: Int, bound: Int): Int = {
-    if (least >= bound)
-      throw new IllegalArgumentException()
+  private def mix32(z0: Long) = {
+    var z = z0
+    z = (z ^ (z >>> 33)) * 0xff51afd7ed558ccdL
+    (((z ^ (z >>> 33)) * 0xc4ceb9fe1a85ec53L) >>> 32).toInt
+  }
 
-    val difference = bound - least
-    if (difference > 0) {
-      nextInt(difference) + least
-    } else {
-      /* The interval size here is greater than Int.MaxValue,
-       * so the loop will exit with a probability of at least 1/2.
-       */
-      @tailrec
-      def loop(): Int = {
-        val n = nextInt()
-        if (n >= least && n < bound) n
-        else loop()
+  private[concurrent] def localInit(): Unit = {
+    val p = probeGenerator.addAndGet(PROBE_INCREMENT)
+    val probe =
+      if (p == 0) 1
+      else p // skip 0
+    val seed = mix64(seeder.getAndAdd(SEEDER_INCREMENT))
+    val t = Thread.currentThread()
+    t.threadLocalRandomSeed = seed
+    t.threadLocalRandomProbe = probe
+  }
+
+  def current(): ThreadLocalRandom = {
+    if (Thread.currentThread().threadLocalRandomProbe == 0)
+      localInit()
+    instance
+  }
+
+  /** Spliterator for int streams. We multiplex the four int versions into one
+   *  class by treating a bound less than origin as unbounded, and also by
+   *  treating "infinite" as equivalent to Long.MAX_VALUE. For splits, it uses
+   *  the standard divide-by-two approach. The long and double versions of this
+   *  class are identical except for types.
+   */
+  final private class RandomIntsSpliterator(
+      var index: Long,
+      fence: Long,
+      origin: Int,
+      bound: Int
+  ) extends Spliterator.OfInt {
+    override def trySplit(): ThreadLocalRandom.RandomIntsSpliterator = {
+      val i = index
+      val m = (i + fence) >>> 1
+      if (m <= i) null
+      else {
+        index = m
+        new ThreadLocalRandom.RandomIntsSpliterator(i, m, origin, bound)
       }
-
-      loop()
     }
-  }
 
-  def nextLong(_n: Long): Long = {
-    if (_n <= 0)
-      throw new IllegalArgumentException("n must be positive")
+    override def estimateSize(): Long = fence - index
 
-    /*
-     * Divide n by two until small enough for nextInt. On each
-     * iteration (at most 31 of them but usually much less),
-     * randomly choose both whether to include high bit in result
-     * (offset) and whether to continue with the lower vs upper
-     * half (which makes a difference only if odd).
-     */
-
-    var offset = 0L
-    var n = _n
-
-    while (n >= Integer.MAX_VALUE) {
-      val bits = next(2)
-      val halfn = n >>> 1
-      val nextn =
-        if ((bits & 2) == 0) halfn
-        else n - halfn
-      if ((bits & 1) == 0)
-        offset += n - nextn
-      n = nextn
+    override def characteristics(): Int = {
+      Spliterator.SIZED |
+        Spliterator.SUBSIZED |
+        Spliterator.NONNULL |
+        Spliterator.IMMUTABLE
     }
-    offset + nextInt(n.toInt)
-  }
 
-  def nextLong(least: Long, bound: Long): Long = {
-    if (least >= bound)
-      throw new IllegalArgumentException()
+    override def tryAdvance(consumer: IntConsumer): Boolean = {
+      if (consumer == null)
+        throw new NullPointerException
 
-    val difference = bound - least
-    if (difference > 0) {
-      nextLong(difference) + least
-    } else {
-      /* The interval size here is greater than Long.MaxValue,
-       * so the loop will exit with a probability of at least 1/2.
-       */
-      @tailrec
-      def loop(): Long = {
-        val n = nextLong()
-        if (n >= least && n < bound) n
-        else loop()
+      if (index < fence) {
+        consumer.accept(
+          ThreadLocalRandom.current().internalNextInt(origin, bound)
+        )
+        index += 1
+        return true
       }
+      false
+    }
 
-      loop()
+    override def forEachRemaining(consumer: IntConsumer): Unit = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      if (index < fence) {
+        var i = index
+
+        index = fence
+        val rng = ThreadLocalRandom.current()
+
+        while ({
+          consumer.accept(rng.internalNextInt(origin, bound))
+          i += 1
+          i < fence
+        }) ()
+      }
     }
   }
 
-  def nextDouble(n: Double): Double = {
-    if (n <= 0)
-      throw new IllegalArgumentException("n must be positive")
+  final private class RandomLongsSpliterator(
+      var index: Long,
+      fence: Long,
+      origin: Long,
+      bound: Long
+  ) extends Spliterator.OfLong {
 
-    nextDouble() * n
+    override def trySplit(): ThreadLocalRandom.RandomLongsSpliterator = {
+      val i = index
+      val m = (i + fence) >>> 1
+      if (m <= index) null
+      else {
+        index = m
+        new ThreadLocalRandom.RandomLongsSpliterator(i, m, origin, bound)
+      }
+    }
+
+    override def estimateSize(): Long = fence - index
+    override def characteristics(): Int = {
+      Spliterator.SIZED |
+        Spliterator.SUBSIZED |
+        Spliterator.NONNULL |
+        Spliterator.IMMUTABLE
+    }
+
+    override def tryAdvance(consumer: LongConsumer): Boolean = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      if (index < fence) {
+        consumer.accept(
+          ThreadLocalRandom.current().internalNextLong(origin, bound)
+        )
+        index += 1
+        return true
+      }
+      false
+    }
+
+    override def forEachRemaining(consumer: LongConsumer): Unit = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      if (index < fence) {
+        val rng = ThreadLocalRandom.current()
+
+        var i = index
+        index = fence
+        while ({
+          consumer.accept(rng.internalNextLong(origin, bound))
+          i += 1
+          i < fence
+        }) ()
+      }
+    }
   }
 
-  def nextDouble(least: Double, bound: Double): Double = {
-    if (least >= bound)
-      throw new IllegalArgumentException()
+  final private class RandomDoublesSpliterator(
+      var index: Long,
+      fence: Long,
+      origin: Double,
+      bound: Double
+  ) extends Spliterator.OfDouble {
 
-    /* Based on documentation for Random.doubles to avoid issue #2144 and other
-     * possible rounding up issues:
-     * https://docs.oracle.com/javase/8/docs/api/java/util/Random.html#doubles-double-double-
-     */
-    val next = nextDouble() * (bound - least) + least
-    if (next < bound) next
-    else Math.nextAfter(bound, Double.NegativeInfinity)
+    override def trySplit(): ThreadLocalRandom.RandomDoublesSpliterator = {
+      val m = (index + fence) >>> 1
+      if (m <= index) null
+      else {
+        val i = index
+        index = m
+        new ThreadLocalRandom.RandomDoublesSpliterator(i, m, origin, bound)
+      }
+    }
+    override def estimateSize(): Long = fence - index
+    override def characteristics(): Int = {
+      Spliterator.SIZED |
+        Spliterator.SUBSIZED |
+        Spliterator.NONNULL |
+        Spliterator.IMMUTABLE
+    }
+    override def tryAdvance(consumer: DoubleConsumer): Boolean = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      if (index < fence) {
+        consumer.accept(
+          ThreadLocalRandom.current().internalNextDouble()(origin, bound)
+        )
+        index += 1
+        return true
+      }
+      false
+    }
+    override def forEachRemaining(consumer: DoubleConsumer): Unit = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      var i = index
+      if (index < fence) {
+        val rng = ThreadLocalRandom.current()
+        var i = index
+        index = fence
+        while ({
+          rng.internalNextDouble()(origin, bound)
+          i += 1
+          i < fence
+        }) ()
+      }
+    }
   }
+
+  private[concurrent] def getProbe(): Int =
+    Thread.currentThread().threadLocalRandomProbe
+
+  private[concurrent] def advanceProbe(probe0: Int) = {
+    var probe = probe0
+    probe ^= probe << 13 // xorshift
+    probe ^= probe >>> 17
+    probe ^= probe << 5
+    Thread.currentThread().threadLocalRandomProbe = probe
+    probe
+  }
+
+  private[concurrent] def nextSecondarySeed = {
+    val t = Thread.currentThread()
+    var r: Int = t.threadLocalRandomSecondarySeed
+    if (r != 0) {
+      r ^= r << 13
+      r ^= r >>> 17
+      r ^= r << 5
+    } else {
+      r = mix32(seeder.getAndAdd(SEEDER_INCREMENT))
+      if (r == 0) r = 1 // avoid zero
+    }
+    // U.putInt(t, SECONDARY, r)
+    t.threadLocalRandomSecondarySeed = r
+    r
+  }
+
+  private val GAMMA = 0x9e3779b97f4a7c15L
+
+  private val PROBE_INCREMENT = 0x9e3779b9
+  private val SEEDER_INCREMENT = 0xbb67ae8584caa73bL
+
+  private val DOUBLE_UNIT = 1.0 / (1L << 53)
+  private val FLOAT_UNIT = 1.0f / (1 << 24)
+
+  // IllegalArgumentException messages
+  private[concurrent] val BAD_BOUND = "bound must be positive"
+  private[concurrent] val BAD_RANGE = "bound must be greater than origin"
+  private[concurrent] val BAD_SIZE = "size must be non-negative"
+
+  private val nextLocalGaussian = new ThreadLocal[java.lang.Double]
+
+  private val probeGenerator = new AtomicInteger
+
+  private[concurrent] val instance = new ThreadLocalRandom
+
+  private val seeder = new AtomicLong(
+    mix64(System.currentTimeMillis()) ^ mix64(System.nanoTime())
+  )
 }
 
-object ThreadLocalRandom {
+@SerialVersionUID(-5851777807851030925L)
+class ThreadLocalRandom private () extends Random {
 
-  private val _current =
-    new ThreadLocalRandom()
+  private[concurrent] var initialized = true
 
-  def current(): ThreadLocalRandom = _current
+  override def setSeed(seed: Long): Unit = { // only allow call from super() constructor
+    if (initialized)
+      throw new UnsupportedOperationException
+  }
+  final private[concurrent] def nextSeed(): Long = {
+    val t = Thread.currentThread()
+    t.threadLocalRandomSeed += ThreadLocalRandom.GAMMA // read and update per-thread seed
+    t.threadLocalRandomSeed
+  }
+
+  override protected def next(bits: Int): Int = nextInt() >>> (32 - bits)
+
+  final private[concurrent] def internalNextLong(origin: Long, bound: Long) = {
+    var r = ThreadLocalRandom.mix64(nextSeed())
+    if (origin < bound) {
+      val n = bound - origin
+      val m = n - 1
+      if ((n & m) == 0L) { // power of two
+        r = (r & m) + origin
+      } else if (n > 0L) { // reject over-represented candidates
+        var u = r >>> 1 // ensure nonnegative
+        r = u % n
+        while ((u + m - r) < 0L) { // rejection check
+          // retry
+          u = ThreadLocalRandom.mix64(nextSeed()) >>> 1
+        }
+        r += origin
+      } else { // range not representable as long
+        while ({ r < origin || r >= bound }) {
+          r = ThreadLocalRandom.mix64(nextSeed())
+        }
+      }
+    }
+    r
+  }
+
+  final private[concurrent] def internalNextInt(origin: Int, bound: Int) = {
+    var r = ThreadLocalRandom.mix32(nextSeed())
+    if (origin < bound) {
+      val n = bound - origin
+      val m = n - 1
+      if ((n & m) == 0) r = (r & m) + origin
+      else if (n > 0) {
+        var u = r >>> 1
+        r = u % n
+        while ((u + m - r) < 0)
+          u = ThreadLocalRandom.mix32(nextSeed()) >>> 1
+        r += origin
+      } else
+        while ({ r < origin || r >= bound }) {
+          r = ThreadLocalRandom.mix32(nextSeed())
+        }
+    }
+    r
+  }
+
+  final private[concurrent] def internalNextDouble()(
+      origin: Double,
+      bound: Double
+  ) = {
+    var r = (nextLong() >>> 11) * ThreadLocalRandom.DOUBLE_UNIT
+    if (origin < bound) {
+      r = r * (bound - origin) + origin
+      if (r >= bound) { // correct for rounding
+        r = java.lang.Double.longBitsToDouble(
+          java.lang.Double.doubleToLongBits(bound) - 1
+        )
+      }
+    }
+    r
+  }
+
+  override def nextInt(): Int = ThreadLocalRandom.mix32(nextSeed())
+
+  override def nextInt(bound: Int): Int = {
+    if (bound <= 0)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_BOUND)
+    var r = ThreadLocalRandom.mix32(nextSeed())
+    val m = bound - 1
+    if ((bound & m) == 0) // power of two
+      r &= m
+    else { // reject over-represented candidates
+      var u = r >>> 1
+      while ({
+        r = u % bound
+        (u + m - r) < 0
+      }) {
+        u = ThreadLocalRandom.mix32(nextSeed()) >>> 1
+      }
+    }
+    assert(r < bound, s"r:$r < bound: $bound")
+    r
+  }
+
+  def nextInt(origin: Int, bound: Int): Int = {
+    if (origin >= bound)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+    internalNextInt(origin, bound)
+  }
+
+  override def nextLong(): Long = ThreadLocalRandom.mix64(nextSeed())
+
+  def nextLong(bound: Long): Long = {
+    if (bound <= 0)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_BOUND)
+    var r = ThreadLocalRandom.mix64(nextSeed())
+    val m = bound - 1
+    if ((bound & m) == 0L) r &= m
+    else {
+      var u: Long = r >>> 1
+      r = u % bound
+      while ({
+        r = u % bound
+        (u + m - r) < 0L
+      })
+        u = ThreadLocalRandom.mix64(nextSeed()) >>> 1
+    }
+    r
+  }
+
+  def nextLong(origin: Long, bound: Long): Long = {
+    if (origin >= bound)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+    internalNextLong(origin, bound)
+  }
+
+  override def nextDouble(): Double =
+    (ThreadLocalRandom.mix64(nextSeed()) >>> 11) * ThreadLocalRandom.DOUBLE_UNIT
+
+  def nextDouble(bound: Double): Double = {
+    if (!(bound > 0.0))
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_BOUND)
+    val result =
+      (ThreadLocalRandom.mix64(
+        nextSeed()
+      ) >>> 11) * ThreadLocalRandom.DOUBLE_UNIT * bound
+    if (result < bound) result
+    else
+      java.lang.Double
+        .longBitsToDouble(java.lang.Double.doubleToLongBits(bound) - 1)
+  }
+
+  def nextDouble(origin: Double, bound: Double): Double = {
+    if (!(origin < bound))
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+    internalNextDouble()(origin, bound)
+  }
+
+  override def nextBoolean(): Boolean = ThreadLocalRandom.mix32(nextSeed()) < 0
+
+  override def nextFloat(): Float =
+    (ThreadLocalRandom.mix32(nextSeed()) >>> 8) * ThreadLocalRandom.FLOAT_UNIT
+  override def nextGaussian()
+      : Double = { // Use nextLocalGaussian instead of nextGaussian field
+    val d =
+      ThreadLocalRandom.nextLocalGaussian.get().asInstanceOf[java.lang.Double]
+    if (d != null) {
+      ThreadLocalRandom.nextLocalGaussian.set(null.asInstanceOf[Double])
+      return d.doubleValue()
+    }
+    var v1 = .0
+    var v2 = .0
+    var s = .0
+    while ({
+      v1 = 2 * nextDouble() - 1 // between -1 and 1
+
+      v2 = 2 * nextDouble() - 1
+      s = v1 * v1 + v2 * v2
+      s >= 1 || s == 0
+    }) ()
+
+    val multiplier = Math.sqrt(-2 * Math.log(s) / s)
+    ThreadLocalRandom.nextLocalGaussian.set(
+      java.lang.Double.valueOf(v2 * multiplier).doubleValue()
+    )
+    v1 * multiplier
+  }
+
+  def ints(streamSize: Long): IntStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_SIZE)
+    StreamSupport.intStream(
+      new ThreadLocalRandom.RandomIntsSpliterator(
+        0L,
+        streamSize,
+        Integer.MAX_VALUE,
+        0
+      ),
+      false
+    )
+  }
+
+  def ints(): IntStream =
+    StreamSupport.intStream(
+      new ThreadLocalRandom.RandomIntsSpliterator(
+        0L,
+        java.lang.Long.MAX_VALUE,
+        Integer.MAX_VALUE,
+        0
+      ),
+      false
+    )
+
+  def ints(
+      streamSize: Long,
+      randomNumberOrigin: Int,
+      randomNumberBound: Int
+  ): IntStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_SIZE)
+    if (randomNumberOrigin >= randomNumberBound)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+    StreamSupport.intStream(
+      new ThreadLocalRandom.RandomIntsSpliterator(
+        0L,
+        streamSize,
+        randomNumberOrigin,
+        randomNumberBound
+      ),
+      false
+    )
+  }
+
+  def ints(randomNumberOrigin: Int, randomNumberBound: Int): IntStream = {
+    if (randomNumberOrigin >= randomNumberBound)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+    StreamSupport.intStream(
+      new ThreadLocalRandom.RandomIntsSpliterator(
+        0L,
+        java.lang.Long.MAX_VALUE,
+        randomNumberOrigin,
+        randomNumberBound
+      ),
+      false
+    )
+  }
+
+  def longs(streamSize: Long): LongStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_SIZE)
+    StreamSupport.longStream(
+      new ThreadLocalRandom.RandomLongsSpliterator(
+        0L,
+        streamSize,
+        java.lang.Long.MAX_VALUE,
+        0L
+      ),
+      false
+    )
+  }
+
+  def longs(): LongStream =
+    StreamSupport.longStream(
+      new ThreadLocalRandom.RandomLongsSpliterator(
+        0L,
+        java.lang.Long.MAX_VALUE,
+        java.lang.Long.MAX_VALUE,
+        0L
+      ),
+      false
+    )
+
+  def longs(
+      streamSize: Long,
+      randomNumberOrigin: Long,
+      randomNumberBound: Long
+  ): LongStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_SIZE)
+    if (randomNumberOrigin >= randomNumberBound)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+    StreamSupport.longStream(
+      new ThreadLocalRandom.RandomLongsSpliterator(
+        0L,
+        streamSize,
+        randomNumberOrigin,
+        randomNumberBound
+      ),
+      false
+    )
+  }
+
+  def longs(randomNumberOrigin: Long, randomNumberBound: Long): LongStream = {
+    if (randomNumberOrigin >= randomNumberBound)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+    StreamSupport.longStream(
+      new ThreadLocalRandom.RandomLongsSpliterator(
+        0L,
+        java.lang.Long.MAX_VALUE,
+        randomNumberOrigin,
+        randomNumberBound
+      ),
+      false
+    )
+  }
+
+  def doubles(streamSize: Long): DoubleStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_SIZE)
+    StreamSupport.doubleStream(
+      new ThreadLocalRandom.RandomDoublesSpliterator(
+        0L,
+        streamSize,
+        java.lang.Double.MAX_VALUE,
+        0.0
+      ),
+      false
+    )
+  }
+
+  def doubles(): DoubleStream =
+    StreamSupport.doubleStream(
+      new ThreadLocalRandom.RandomDoublesSpliterator(
+        0L,
+        java.lang.Long.MAX_VALUE,
+        java.lang.Double.MAX_VALUE,
+        0.0
+      ),
+      false
+    )
+
+  def doubles(
+      streamSize: Long,
+      randomNumberOrigin: Double,
+      randomNumberBound: Double
+  ): DoubleStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_SIZE)
+
+    if (!(randomNumberOrigin < randomNumberBound))
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+
+    StreamSupport.doubleStream(
+      new ThreadLocalRandom.RandomDoublesSpliterator(
+        0L,
+        streamSize,
+        randomNumberOrigin,
+        randomNumberBound
+      ),
+      false
+    )
+  }
+
+  def doubles(
+      randomNumberOrigin: Double,
+      randomNumberBound: Double
+  ): DoubleStream = {
+    if (!(randomNumberOrigin < randomNumberBound))
+      throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
+    StreamSupport.doubleStream(
+      new ThreadLocalRandom.RandomDoublesSpliterator(
+        0L,
+        java.lang.Long.MAX_VALUE,
+        randomNumberOrigin,
+        randomNumberBound
+      ),
+      false
+    )
+  }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
@@ -2,6 +2,8 @@
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
  * http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * It also contains tests ported from Scala.js
  */
 package org.scalanative.testsuite.javalib.util.concurrent
 
@@ -10,7 +12,6 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 import JSR166Test._
-import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform._
 
 import org.junit.{Test, Ignore}
@@ -408,20 +409,17 @@ class ThreadLocalRandomTest extends JSR166Test {
     ThreadLocalRandom.current.nextBytes(new Array[Byte](0))
   }
   @Test def testNextBytes_nullArray(): Unit = {
-    try {
-      ThreadLocalRandom.current.nextBytes(null)
-      shouldThrow()
-    } catch {
-      case success: NullPointerException =>
-
-    }
+    assertThrows(
+      classOf[NullPointerException],
+      () => ThreadLocalRandom.current.nextBytes(null)
+    )
   }
 
   // Tests ported from Scala.js commit: bbf0314 dated: Mon, 13 Jun 2022
   @Test def setSeedThrows(): Unit = {
     val tlr = ThreadLocalRandom.current()
 
-    assertThrows(classOf[UnsupportedOperationException], tlr.setSeed(1))
+    assertThrows(classOf[UnsupportedOperationException], () => tlr.setSeed(1))
   }
 
   def checkIntBounds(b1: Int, b2: Int)(implicit
@@ -540,8 +538,8 @@ class ThreadLocalRandomTest extends JSR166Test {
     checkIntBounds(658643437, 315920491)
     checkIntBounds(-1507203912, -507923122)
 
-    assertThrows(classOf[IllegalArgumentException], tlr.nextInt(2, 1))
-    assertThrows(classOf[IllegalArgumentException], tlr.nextInt(1, 1))
+    assertThrows(classOf[IllegalArgumentException], () => tlr.nextInt(2, 1))
+    assertThrows(classOf[IllegalArgumentException], () => tlr.nextInt(1, 1))
   }
 
   def checkLongUpperBound(
@@ -656,9 +654,12 @@ class ThreadLocalRandomTest extends JSR166Test {
     checkLongUpperBound(7594229781671800374L)
     checkLongUpperBound(358723396249334066L)
 
-    assertThrows(classOf[IllegalArgumentException], tlr.nextLong(0L))
-    assertThrows(classOf[IllegalArgumentException], tlr.nextLong(-1L))
-    assertThrows(classOf[IllegalArgumentException], tlr.nextLong(Long.MinValue))
+    assertThrows(classOf[IllegalArgumentException], () => tlr.nextLong(0L))
+    assertThrows(classOf[IllegalArgumentException], () => tlr.nextLong(-1L))
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => tlr.nextLong(Long.MinValue)
+    )
   }
 
   def checkLongBounds(b1: Long, b2: Long)(implicit
@@ -778,8 +779,8 @@ class ThreadLocalRandomTest extends JSR166Test {
     checkLongBounds(5611183948112311940L, 5576981966367959141L)
     checkLongBounds(7501725046819604868L, 2498819089300049836L)
 
-    assertThrows(classOf[IllegalArgumentException], tlr.nextLong(2L, 1L))
-    assertThrows(classOf[IllegalArgumentException], tlr.nextLong(1L, 1L))
+    assertThrows(classOf[IllegalArgumentException], () => tlr.nextLong(2L, 1L))
+    assertThrows(classOf[IllegalArgumentException], () => tlr.nextLong(1L, 1L))
   }
 
   def checkDoubleUpperBound(
@@ -895,11 +896,11 @@ class ThreadLocalRandomTest extends JSR166Test {
     checkDoubleUpperBound(0.6316252201145239)
     checkDoubleUpperBound(0.10185176522791717)
 
-    assertThrows(classOf[IllegalArgumentException], tlr.nextDouble(0.0))
-    assertThrows(classOf[IllegalArgumentException], tlr.nextDouble(-1.0))
+    assertThrows(classOf[IllegalArgumentException], () => tlr.nextDouble(0.0))
+    assertThrows(classOf[IllegalArgumentException], () => tlr.nextDouble(-1.0))
     assertThrows(
       classOf[IllegalArgumentException],
-      tlr.nextDouble(Double.MinValue)
+      () => tlr.nextDouble(Double.MinValue)
     )
   }
 
@@ -1023,8 +1024,17 @@ class ThreadLocalRandomTest extends JSR166Test {
     checkDoubleBounds(0.5887579571381444, 0.27451268823686337)
     checkDoubleBounds(0.5533138714786693, 0.5329471271772576)
 
-    assertThrows(classOf[IllegalArgumentException], tlr.nextDouble(2.0, 1.0))
-    assertThrows(classOf[IllegalArgumentException], tlr.nextDouble(1.0, 1.0))
-    assertThrows(classOf[IllegalArgumentException], tlr.nextDouble(0.0, 0.0))
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => tlr.nextDouble(2.0, 1.0)
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => tlr.nextDouble(1.0, 1.0)
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => tlr.nextDouble(0.0, 0.0)
+    )
   }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
@@ -1,18 +1,423 @@
-// Ported from Scala.js commit: bbf0314 dated: Mon, 13 Jun 2022
-
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
 package org.scalanative.testsuite.javalib.util.concurrent
 
-import org.junit.Test
-import org.junit.Assert._
-
 import java.util.concurrent.ThreadLocalRandom
-import scala.math.{max, min}
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
+import JSR166Test._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform._
 
-class ThreadLocalRandomTest {
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
 
+import scala.math.{max, min}
+
+object ThreadLocalRandomTest {
+  // max numbers of calls to detect getting stuck on one value
+  /*
+   * Testing coverage notes:
+   *
+   * We don't test randomness properties, but only that repeated
+   * calls, up to NCALLS tries, produce at least one different
+   * result.  For bounded versions, we sample various intervals
+   * across multiples of primes.
+   */
+  val NCALLS = 10000
+  // max sampled int bound
+  val MAX_INT_BOUND: Int = 1 << 28
+  // max sampled long bound
+  val MAX_LONG_BOUND: Long = 1L << 42
+  // Number of replications for other checks
+  val REPS = 20
+}
+class ThreadLocalRandomTest extends JSR166Test {
+
+  /** setSeed throws UnsupportedOperationException
+   */
+  @Test def testSetSeed(): Unit = {
+    try {
+      ThreadLocalRandom.current.setSeed(17)
+      shouldThrow()
+    } catch {
+      case success: UnsupportedOperationException =>
+
+    }
+  }
+
+  /** Repeated calls to next (only accessible via reflection) produce at least
+   *  two distinct results, and repeated calls produce all possible values.
+   */
+  @throws[ReflectiveOperationException]
+  @Ignore("Test needs reflective access to 'next' method")
+  @Test def testNext(): Unit = {}
+
+  /** Repeated calls to nextInt produce at least two distinct results
+   */
+  @Test def testNextInt(): Unit = {
+    val f = ThreadLocalRandom.current.nextInt
+    var i = 0
+    while ({
+      i < ThreadLocalRandomTest.NCALLS && ThreadLocalRandom.current.nextInt == f
+    }) i += 1
+    assertTrue(i < ThreadLocalRandomTest.NCALLS)
+  }
+
+  /** Repeated calls to nextLong produce at least two distinct results
+   */
+  @Test def testNextLong(): Unit = {
+    val f = ThreadLocalRandom.current.nextLong
+    var i = 0
+    while ({
+      i < ThreadLocalRandomTest.NCALLS && ThreadLocalRandom.current.nextLong == f
+    }) i += 1
+    assertTrue(i < ThreadLocalRandomTest.NCALLS)
+  }
+
+  /** Repeated calls to nextBoolean produce at least two distinct results
+   */
+  @Test def testNextBoolean(): Unit = {
+    val f = ThreadLocalRandom.current.nextBoolean
+    var i = 0
+    while ({
+      i < ThreadLocalRandomTest.NCALLS && ThreadLocalRandom.current.nextBoolean == f
+    }) i += 1
+    assertTrue(i < ThreadLocalRandomTest.NCALLS)
+  }
+
+  /** Repeated calls to nextFloat produce at least two distinct results
+   */
+  @Test def testNextFloat(): Unit = {
+    val f = ThreadLocalRandom.current.nextFloat
+    var i = 0
+    while ({
+      i < ThreadLocalRandomTest.NCALLS && ThreadLocalRandom.current.nextFloat == f
+    }) i += 1
+    assertTrue(i < ThreadLocalRandomTest.NCALLS)
+  }
+
+  /** Repeated calls to nextDouble produce at least two distinct results
+   */
+  @Test def testNextDouble(): Unit = {
+    val f = ThreadLocalRandom.current.nextDouble
+    var i = 0
+    while ({
+      i < ThreadLocalRandomTest.NCALLS && ThreadLocalRandom.current.nextDouble == f
+    }) i += 1
+    assertTrue(i < ThreadLocalRandomTest.NCALLS)
+  }
+
+  /** Repeated calls to nextGaussian produce at least two distinct results
+   */
+  @Test def testNextGaussian(): Unit = {
+    val f = ThreadLocalRandom.current.nextGaussian
+    var i = 0
+    while ({
+      i < ThreadLocalRandomTest.NCALLS && ThreadLocalRandom.current.nextGaussian == f
+    }) i += 1
+    assertTrue(i < ThreadLocalRandomTest.NCALLS)
+  }
+
+  /** nextInt(non-positive) throws IllegalArgumentException
+   */
+  @Test def testNextIntBoundNonPositive(): Unit = {
+    val rnd = ThreadLocalRandom.current
+    for (bound <- Array[Int](0, -17, Integer.MIN_VALUE)) {
+      try {
+        rnd.nextInt(bound)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** nextInt(least >= bound) throws IllegalArgumentException
+   */
+  @Test def testNextIntBadBounds(): Unit = {
+    val badBoundss = Array(
+      Array(17, 2),
+      Array(-42, -42),
+      Array(Integer.MAX_VALUE, Integer.MIN_VALUE)
+    )
+    val rnd = ThreadLocalRandom.current
+    for (badBounds <- badBoundss) {
+      try {
+        rnd.nextInt(badBounds(0), badBounds(1))
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** nextInt(bound) returns 0 <= value < bound; repeated calls produce at least
+   *  two distinct results
+   */
+  @Test def testNextIntBounded()
+      : Unit = { // sample bound space across prime number increments
+    var bound = 2
+    while ({ bound < ThreadLocalRandomTest.MAX_INT_BOUND }) {
+      val f = ThreadLocalRandom.current.nextInt(bound)
+      assertTrue(0 <= f && f < bound)
+      var i = 0
+      var j = 0
+      while (i < ThreadLocalRandomTest.NCALLS && {
+            j = ThreadLocalRandom.current.nextInt(bound)
+            j == f
+          }) {
+        assertTrue(0 <= j && j < bound)
+        i += 1
+      }
+      assertTrue(i < ThreadLocalRandomTest.NCALLS)
+
+      bound += 524959
+    }
+  }
+
+  /** nextInt(least, bound) returns least <= value < bound; repeated calls
+   *  produce at least two distinct results
+   */
+  @Test def testNextIntBounded2(): Unit = {
+    var least = -15485863
+    while ({ least < ThreadLocalRandomTest.MAX_INT_BOUND }) {
+      var bound = least + 2
+      while ({ bound > least && bound < ThreadLocalRandomTest.MAX_INT_BOUND }) {
+        val f = ThreadLocalRandom.current.nextInt(least, bound)
+        assertTrue(least <= f && f < bound)
+        var i = 0
+        var j = 0
+        while (i < ThreadLocalRandomTest.NCALLS && {
+              j = ThreadLocalRandom.current.nextInt(least, bound)
+              j == f
+            }) {
+          assertTrue(least <= j && j < bound)
+          i += 1
+        }
+        assertTrue(i < ThreadLocalRandomTest.NCALLS)
+
+        bound += 49979687
+      }
+
+      least += 524959
+    }
+  }
+
+  /** nextLong(non-positive) throws IllegalArgumentException
+   */
+  @Test def testNextLongBoundNonPositive(): Unit = {
+    val rnd = ThreadLocalRandom.current
+    for (bound <- Array[Long](0L, -17L, java.lang.Long.MIN_VALUE)) {
+      try {
+        rnd.nextLong(bound)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** nextLong(least >= bound) throws IllegalArgumentException
+   */
+  @Test def testNextLongBadBounds(): Unit = {
+    val badBoundss = Array(
+      Array(17L, 2L),
+      Array(-42L, -42L),
+      Array(java.lang.Long.MAX_VALUE, java.lang.Long.MIN_VALUE)
+    )
+    val rnd = ThreadLocalRandom.current
+    for (badBounds <- badBoundss) {
+      try {
+        rnd.nextLong(badBounds(0), badBounds(1))
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** nextLong(bound) returns 0 <= value < bound; repeated calls produce at
+   *  least two distinct results
+   */
+  @Test def testNextLongBounded(): Unit = {
+    var bound = 2L
+    while (bound < ThreadLocalRandomTest.MAX_LONG_BOUND) {
+      val f = ThreadLocalRandom.current.nextLong(bound)
+      assertTrue(0 <= f && f < bound)
+      var i = 0
+      var j = 0L
+      while (i < ThreadLocalRandomTest.NCALLS && {
+            j = ThreadLocalRandom.current.nextLong(bound)
+            j == f
+          }) {
+        assertTrue(0 <= j && j < bound)
+        i += 1
+      }
+      assertTrue(i < ThreadLocalRandomTest.NCALLS)
+
+      bound += 15485863
+    }
+  }
+
+  /** nextLong(least, bound) returns least <= value < bound; repeated calls
+   *  produce at least two distinct results
+   */
+  @Test def testNextLongBounded2(): Unit = {
+    var least: Long = -86028121
+    while (least < ThreadLocalRandomTest.MAX_LONG_BOUND) {
+      var bound = least + 2
+      while (bound > least && bound < ThreadLocalRandomTest.MAX_LONG_BOUND) {
+        val f = ThreadLocalRandom.current.nextLong(least, bound)
+        assertTrue(least <= f && f < bound)
+        var i = 0
+        var j = 0L
+        while (i < ThreadLocalRandomTest.NCALLS && {
+              j = ThreadLocalRandom.current.nextLong(least, bound)
+              j == f
+            }) {
+          assertTrue(least <= j && j < bound)
+          i += 1
+        }
+        assertTrue(i < ThreadLocalRandomTest.NCALLS)
+
+        bound += Math.abs(bound * 7919)
+      }
+
+      least += 982451653L
+    }
+  }
+
+  /** nextDouble(non-positive) throws IllegalArgumentException
+   */
+  @Test def testNextDoubleBoundNonPositive(): Unit = {
+    val rnd = ThreadLocalRandom.current
+    val badBounds = Array(
+      0.0d,
+      -17.0d,
+      -java.lang.Double.MIN_VALUE,
+      java.lang.Double.NEGATIVE_INFINITY,
+      java.lang.Double.NaN
+    )
+    for (bound <- badBounds) {
+      try {
+        rnd.nextDouble(bound)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** nextDouble(least, bound) returns least <= value < bound; repeated calls
+   *  produce at least two distinct results
+   */
+  @Test def testNextDoubleBounded2(): Unit = {
+    var least = 0.0001
+    while ({ least < 1.0e20 }) {
+      var bound = least * 1.001
+      while ({ bound < 1.0e20 }) {
+        val f = ThreadLocalRandom.current.nextDouble(least, bound)
+        assertTrue(least <= f && f < bound)
+        var i = 0
+        var j = .0
+        while (i < ThreadLocalRandomTest.NCALLS && {
+              j = ThreadLocalRandom.current.nextDouble(least, bound)
+              j == f
+            }) {
+          assertTrue(least <= j && j < bound)
+          i += 1
+        }
+        assertTrue(i < ThreadLocalRandomTest.NCALLS)
+
+        bound *= 16
+      }
+
+      least *= 8
+    }
+  }
+
+  /** Different threads produce different pseudo-random sequences
+   */
+  @Test def testDifferentSequences()
+      : Unit = { // Don't use main thread's ThreadLocalRandom - it is likely to
+    // be polluted by previous tests.
+    val threadLocalRandom =
+      new AtomicReference[ThreadLocalRandom]
+    val rand = new AtomicLong
+    var firstRand = 0L
+    var firstThreadLocalRandom: ThreadLocalRandom = null
+    val getRandomState = new CheckedRunnable() {
+      override def realRun(): Unit = {
+        val current = ThreadLocalRandom.current
+        assertSame(current, ThreadLocalRandom.current)
+        // test bug: the following is not guaranteed and not true in JDK8
+        //                assertNotSame(current, threadLocalRandom.get());
+        rand.set(current.nextLong)
+        threadLocalRandom.set(current)
+      }
+    }
+    val first = newStartedThread(getRandomState)
+    awaitTermination(first)
+    firstRand = rand.get
+    firstThreadLocalRandom = threadLocalRandom.get
+    var i = 0
+    while (i < ThreadLocalRandomTest.NCALLS) {
+      val t = newStartedThread(getRandomState)
+      awaitTermination(t)
+      if (firstRand != rand.get) return
+      i += 1
+    }
+    fail("all threads generate the same pseudo-random sequence")
+  }
+
+  /** Repeated calls to nextBytes produce at least values of different signs for
+   *  every byte
+   */
+  @Test def testNextBytes(): Unit = {
+    import scala.util.control.Breaks._
+    val rnd = ThreadLocalRandom.current
+    val n = rnd.nextInt(1, 20)
+    val bytes = new Array[Byte](n)
+    breakable {
+      for (i <- 0 until n) {
+        var tries = ThreadLocalRandomTest.NCALLS
+        while ({ { tries -= 1; tries + 1 } > 0 }) {
+          val before = bytes(i)
+          rnd.nextBytes(bytes)
+          val after = bytes(i)
+          if (after * before < 0) break()
+        }
+        fail("not enough variation in random bytes")
+      }
+    }
+  }
+
+  /** Filling an empty array with random bytes succeeds without effect.
+   */
+  @Test def testNextBytes_emptyArray(): Unit = {
+    ThreadLocalRandom.current.nextBytes(new Array[Byte](0))
+  }
+  @Test def testNextBytes_nullArray(): Unit = {
+    try {
+      ThreadLocalRandom.current.nextBytes(null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  // Tests ported from Scala.js commit: bbf0314 dated: Mon, 13 Jun 2022
   @Test def setSeedThrows(): Unit = {
     val tlr = ThreadLocalRandom.current()
 


### PR DESCRIPTION
* Port `java.util.concurrent.ThreadLocalRandom` and related tests
* Add missing `java.util.Spliterator.OfPrimitive` types used in the TLR implementation