### PR TITLE
Port `java.util.concurrent.ForkJoinPool` from JSR-166

### DIFF
--- a/javalib/src/main/scala-2/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala-2/java/util/concurrent/TimeUnit.scala
@@ -16,6 +16,13 @@ abstract class TimeUnit private (name: String, ordinal: Int)
   def toMinutes(a: Long): Long
   def toHours(a: Long): Long
   def toDays(a: Long): Long
+
+  def sleep(timeout: Long): Unit =
+    if (timeout > 0) Thread.sleep(toMillis(timeout))
+  def timedJoin(thread: Thread, timeout: Long) =
+    if (timeout > 0) thread.join(toMillis(timeout))
+  def timedWait(obj: Object, timeout: Long) =
+    if (timeout > 0) obj.wait(toMillis(timeout))
 }
 
 object TimeUnit {

--- a/javalib/src/main/scala-3/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala-3/java/util/concurrent/TimeUnit.scala
@@ -16,6 +16,13 @@ enum TimeUnit extends Enum[TimeUnit] {
   case HOURS extends TimeUnit
   case DAYS extends TimeUnit
 
+  def sleep(timeout: Long): Unit =
+    if (timeout > 0) Thread.sleep(toMillis(timeout))
+  def timedJoin(thread: Thread, timeout: Long) =
+    if (timeout > 0) thread.join(toMillis(timeout))
+  def timedWait(obj: Object, timeout: Long) =
+    if (timeout > 0) obj.wait(toMillis(timeout))
+
   def convert(a: Long, u: TimeUnit): Long = this match {
     case TimeUnit.NANOSECONDS  => u.toNanos(a)
     case TimeUnit.MICROSECONDS => u.toMicros(a)

--- a/javalib/src/main/scala/java/util/concurrent/AbstractExecutorService.scala
+++ b/javalib/src/main/scala/java/util/concurrent/AbstractExecutorService.scala
@@ -1,0 +1,248 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+import java.util
+import java.lang
+import java.util.concurrent.TimeUnit._
+import scala.annotation.tailrec
+
+abstract class AbstractExecutorService() extends ExecutorService {
+
+  protected[concurrent] def newTaskFor[T <: AnyRef](
+      runnable: Runnable,
+      value: T
+  ): RunnableFuture[T] =
+    new FutureTask[T](runnable, value)
+
+  protected[concurrent] def newTaskFor[T <: AnyRef](
+      callable: Callable[T]
+  ): RunnableFuture[T] =
+    new FutureTask[T](callable)
+
+  @throws[NullPointerException]
+  @throws[java.lang.RejectedExecutionException]
+  override def submit(task: Runnable): Future[_] = {
+    if (task == null) throw new NullPointerException()
+    val ftask: RunnableFuture[Object] = newTaskFor(task, null)
+    execute(ftask)
+    ftask
+  }
+
+  @throws[NullPointerException]
+  @throws[java.lang.RejectedExecutionException]
+  override def submit[T <: AnyRef](task: Runnable, result: T): Future[T] = {
+    if (task == null) throw new NullPointerException()
+    val ftask: RunnableFuture[T] = newTaskFor(task, result)
+    execute(ftask)
+    ftask
+  }
+
+  @throws[NullPointerException]
+  @throws[java.lang.RejectedExecutionException]
+  override def submit[T <: AnyRef](task: Callable[T]): Future[T] = {
+    if (task == null) throw new NullPointerException()
+    val ftask: RunnableFuture[T] = newTaskFor(task)
+    execute(ftask)
+    ftask
+  }
+
+  @throws[InterruptedException]
+  @throws[TimeoutException]
+  @throws[ExecutionException]
+  private def doInvokeAny[T <: AnyRef](
+      tasks: util.Collection[_ <: Callable[T]],
+      timed: Boolean,
+      n: Long
+  ): T = {
+    var nanos: Long = n
+    if (tasks == null)
+      throw new NullPointerException()
+
+    var ntasks: Int = tasks.size()
+    if (ntasks == 0)
+      throw new IllegalArgumentException()
+
+    val futures = new util.ArrayList[Future[T]](ntasks)
+    val ecs = new ExecutorCompletionService[T](this)
+
+    // For efficiency, especially in executors with limited
+    // parallelism, check to see if previously submitted tasks are
+    // done before submitting more of them. This interleaving
+    // plus the exception mechanics account for messiness of main
+    // loop.
+
+    try {
+      // Record exceptions so that if we fail to obtain any
+      // result, we can throw the last exception we got.
+      var ee: ExecutionException = null
+      val deadline = if (timed) System.nanoTime() + nanos else 0L
+      val it = tasks.iterator()
+
+      // Start one task for sure; the rest incrementally
+      futures.add(ecs.submit(it.next()))
+      ntasks -= 1
+      var active: Int = 1
+
+      var break: Boolean = false
+      while (!break) {
+        val f: Future[T] = ecs.poll() match {
+          case null =>
+            if (ntasks > 0) {
+              ntasks -= 1
+              futures.add(ecs.submit(it.next()))
+              active += 1
+              null
+            } else if (active == 0) {
+              break = true
+              null
+            } else if (timed)
+              ecs.poll(nanos, TimeUnit.NANOSECONDS) match {
+                case null => throw new TimeoutException()
+                case f =>
+                  nanos = deadline - System.nanoTime()
+                  f
+              }
+            else ecs.take()
+
+          case f => f
+        }
+        if (!break && f != null) {
+          active -= 1
+          try {
+            return f.get()
+          } catch {
+            case eex: ExecutionException => ee = eex
+            case rex: RuntimeException   => ee = new ExecutionException(rex)
+          }
+        }
+      }
+      if (ee == null) ee = new ExecutionException(null: Throwable)
+      throw ee
+    } finally cancelAll(futures)
+  }
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  override def invokeAny[T <: AnyRef](
+      tasks: util.Collection[_ <: Callable[T]]
+  ): T =
+    doInvokeAny(tasks, false, 0)
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  @throws[TimeoutException]
+  override def invokeAny[T <: AnyRef](
+      tasks: java.util.Collection[_ <: Callable[T]],
+      timeout: Long,
+      unit: TimeUnit
+  ): T = doInvokeAny(tasks, true, unit.toNanos(timeout))
+
+  @throws[InterruptedException]
+  override def invokeAll[T <: AnyRef](
+      tasks: java.util.Collection[_ <: Callable[T]]
+  ): java.util.List[Future[T]] = {
+    if (tasks == null) throw new NullPointerException()
+    val futures: util.List[Future[T]] =
+      new util.ArrayList[Future[T]](tasks.size())
+    var done: Boolean = false
+    try {
+      val it = tasks.iterator()
+      while (it.hasNext()) {
+        val f: RunnableFuture[T] = newTaskFor(it.next())
+        futures.add(f)
+        execute(f)
+      }
+
+      val it1 = futures.iterator()
+      while (it1.hasNext()) {
+        val f = it1.next()
+        if (!f.isDone()) {
+          try {
+            f.get()
+          } catch {
+            case ignore: CancellationException =>
+            case ignore: ExecutionException    =>
+          }
+        }
+      }
+      done = true
+      futures
+    } finally if (!done) cancelAll(futures)
+  }
+
+  @throws[InterruptedException]
+  override def invokeAll[T <: AnyRef](
+      tasks: util.Collection[_ <: Callable[T]],
+      timeout: Long,
+      unit: TimeUnit
+  ): util.List[Future[T]] = {
+    if (tasks == null || unit == null)
+      throw new NullPointerException()
+    val nanos: Long = unit.toNanos(timeout)
+    val deadline = System.nanoTime() + nanos
+    val futures = new util.ArrayList[Future[T]](tasks.size())
+    var lastIdx = 0
+
+    try {
+      val it = tasks.iterator()
+      while (it.hasNext()) {
+        futures.add(newTaskFor(it.next()))
+      }
+      val size = futures.size()
+
+      // Interleave time checks and calls to execute in case
+      // executor doesn't have any/much parallelism.
+      @tailrec def executeLoop(i: Int): Boolean =
+        if (i >= size) false
+        else {
+          val remainingTime =
+            if (i == 0) nanos
+            else deadline - System.nanoTime()
+          if (remainingTime <= 0) true // timeout
+          else {
+            execute(futures.get(i).asInstanceOf[Runnable])
+            executeLoop(i + 1)
+          }
+        }
+
+      @tailrec def awaitLoop(i: Int): Boolean =
+        if (i >= size) false
+        else {
+          val f = futures.get(i)
+          val timedOut =
+            if (f.isDone()) false
+            else
+              try {
+                f.get(deadline - System.nanoTime(), NANOSECONDS)
+                false
+              } catch {
+                case _: CancellationException | _: ExecutionException => false
+                case _: TimeoutException =>
+                  lastIdx = i
+                  true
+              }
+          if (timedOut) timedOut
+          else awaitLoop(i + 1)
+        }
+
+      val timedOut = executeLoop(0) || awaitLoop(0)
+      if (timedOut) cancelAll(futures, lastIdx)
+    } catch {
+      case t: Throwable =>
+        cancelAll(futures)
+        throw t
+    }
+    futures
+  }
+
+  private def cancelAll[T](futures: util.List[Future[T]], from: Int = 0) =
+    for (i <- from until futures.size()) {
+      futures.get(i).cancel(true)
+    }
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/Callable.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Callable.scala
@@ -1,3 +1,9 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
 package java.util.concurrent
 
 trait Callable[V] {

--- a/javalib/src/main/scala/java/util/concurrent/CompletionService.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CompletionService.scala
@@ -1,0 +1,21 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+trait CompletionService[V] {
+
+  def submit(task: Callable[V]): Future[V]
+
+  def submit(task: Runnable, result: V): Future[V]
+
+  def take(): Future[V]
+
+  def poll(): Future[V]
+
+  def poll(timeout: Long, unit: TimeUnit): Future[V]
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/CountedCompleter.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CountedCompleter.scala
@@ -1,0 +1,170 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package java.util.concurrent
+
+import scala.scalanative.runtime.{Intrinsics, fromRawPtr}
+import scala.scalanative.libc.atomic.CAtomicInt
+import scala.annotation.tailrec
+
+abstract class CountedCompleter[T] protected (
+    final private[concurrent] val completer: CountedCompleter[_],
+    initialPendingCount: Int
+) extends ForkJoinTask[T] {
+
+  @volatile private var pending = initialPendingCount
+  private val atomicPending = new CAtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "pending"))
+  )
+
+  protected def this(completer: CountedCompleter[_]) = this(completer, 0)
+
+  protected def this() = this(null, 0)
+
+  def compute(): Unit
+
+  def onCompletion(caller: CountedCompleter[_]): Unit = {}
+
+  def onExceptionalCompletion(
+      ex: Throwable,
+      caller: CountedCompleter[_]
+  ) = true
+
+  final def getCompleter(): CountedCompleter[_] = completer
+
+  final def getPendingCount(): Int = pending
+
+  final def setPendingCount(count: Int): Unit = pending = count
+
+  final def addToPendingCount(delta: Int): Unit = atomicPending.fetchAdd(delta)
+
+  final def compareAndSetPendingCount(expected: Int, count: Int): Boolean =
+    atomicPending.compareExchangeStrong(expected, count)
+
+  // internal-only weak version
+  final private[concurrent] def weakCompareAndSetPendingCount(
+      expected: Int,
+      count: Int
+  ) = atomicPending.compareExchangeWeak(expected, count)
+
+  final def decrementPendingCountUnlessZero: Int = {
+    var c = 0
+    while ({
+      c = pending
+      pending != 0 && !weakCompareAndSetPendingCount(c, c - 1)
+    }) ()
+    c
+  }
+
+  final def getRoot(): CountedCompleter[_] = {
+    @tailrec def loop(a: CountedCompleter[_]): CountedCompleter[_] =
+      a.completer match {
+        case null => a
+        case p    => loop(p)
+      }
+    loop(this)
+  }
+
+  final def tryComplete(): Unit = {
+    var a: CountedCompleter[_] = this
+    var s = a
+    var c = 0
+    while (true) {
+      c = a.pending
+      if (c == 0) {
+        a.onCompletion(s)
+        s = a
+        a = a.completer
+        if (a == null) {
+          s.quietlyComplete()
+          return
+        }
+      } else if (a.weakCompareAndSetPendingCount(c, c - 1)) return
+    }
+  }
+
+  final def propagateCompletion(): Unit = {
+    var a: CountedCompleter[_] = this
+    var s = null: CountedCompleter[_]
+    var c = 0
+    while (true) {
+      c = a.pending
+      if (c == 0) {
+        s = a
+        a = a.completer
+        if (a == null) {
+          s.quietlyComplete()
+          return
+        }
+      } else if (a.weakCompareAndSetPendingCount(c, c - 1)) return
+    }
+  }
+
+  override def complete(rawResult: T): Unit = {
+    setRawResult(rawResult)
+    onCompletion(this)
+    quietlyComplete()
+    val p = completer
+    if (p != null) p.tryComplete()
+  }
+
+  final def firstComplete(): CountedCompleter[_] = {
+    var c = 0
+    while (true) {
+      c = pending
+      if (c == 0) return this
+      else if (weakCompareAndSetPendingCount(c, c - 1)) return null
+    }
+    null // unreachable
+  }
+
+  final def nextComplete(): CountedCompleter[_] =
+    completer match {
+      case null => quietlyComplete(); null
+      case p    => p.firstComplete()
+    }
+
+  final def quietlyCompleteRoot(): Unit = {
+    var a: CountedCompleter[_] = this
+    while (true) {
+      a.completer match {
+        case null => a.quietlyComplete(); return
+        case p    => a = p
+      }
+    }
+  }
+
+  final def helpComplete(maxTasks: Int): Unit = {
+    val t = Thread.currentThread()
+    val owned = t.isInstanceOf[ForkJoinWorkerThread]
+    val q =
+      if (owned) t.asInstanceOf[ForkJoinWorkerThread].workQueue
+      else ForkJoinPool.commonQueue()
+
+    if (q != null && maxTasks > 0) q.helpComplete(this, owned, maxTasks)
+  }
+
+  override final private[concurrent] def trySetException(ex: Throwable): Int = {
+    var a: CountedCompleter[_] = this
+    var p = a
+    while ({
+      ForkJoinTask.isExceptionalStatus(a.trySetThrown(ex)) &&
+      a.onExceptionalCompletion(ex, p) && {
+        p = a; a = a.completer; a != null
+      } &&
+      a.status >= 0
+    }) ()
+    status
+  }
+
+  override final protected def exec(): Boolean = {
+    compute()
+    false
+  }
+
+  override def getRawResult(): T = null.asInstanceOf[T]
+
+  override protected def setRawResult(t: T): Unit = {}
+}

--- a/javalib/src/main/scala/java/util/concurrent/Executor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Executor.scala
@@ -1,5 +1,12 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
 package java.util.concurrent
 
 trait Executor {
+
   def execute(command: Runnable): Unit
 }

--- a/javalib/src/main/scala/java/util/concurrent/ExecutorCompletionService.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ExecutorCompletionService.scala
@@ -1,0 +1,67 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+class ExecutorCompletionService[V <: AnyRef](
+    val executor: Executor,
+    val completionQueue: BlockingQueue[Future[V]]
+) extends CompletionService[V] {
+  import ExecutorCompletionService._
+
+  if (executor == null || completionQueue == null)
+    throw new NullPointerException()
+
+  def this(executor: Executor) = {
+    this(executor, new LinkedBlockingQueue[Future[V]])
+  }
+
+  private final val aes: AbstractExecutorService = executor match {
+    case exc: AbstractExecutorService => exc
+    case _                            => null
+  }
+
+  private def newTaskFor(task: Callable[V]): RunnableFuture[V] = {
+    if (aes == null) new FutureTask[V](task)
+    else aes.newTaskFor(task)
+  }
+
+  private def newTaskFor(task: Runnable, result: V): RunnableFuture[V] = {
+    if (aes == null) new FutureTask[V](task, result)
+    else aes.newTaskFor(task, result)
+  }
+
+  override def submit(task: Callable[V]): Future[V] = {
+    if (task == null) throw new NullPointerException()
+    val f: RunnableFuture[V] = newTaskFor(task)
+    executor.execute(new QueueingFuture(f, completionQueue))
+    f
+  }
+
+  override def submit(task: Runnable, result: V): Future[V] = {
+    if (task == null) throw new NullPointerException()
+    val f: RunnableFuture[V] = newTaskFor(task, result)
+    executor.execute(new QueueingFuture(f, completionQueue))
+    f
+  }
+
+  override def take(): Future[V] = completionQueue.take()
+
+  override def poll(): Future[V] = completionQueue.poll()
+
+  override def poll(timeout: Long, unit: TimeUnit): Future[V] =
+    completionQueue.poll(timeout, unit)
+
+}
+
+object ExecutorCompletionService {
+  private class QueueingFuture[V <: AnyRef](
+      task: RunnableFuture[V],
+      completionQueue: BlockingQueue[Future[V]]
+  ) extends FutureTask(task, null.asInstanceOf[V]) {
+    override protected def done(): Unit = completionQueue.add(task)
+  }
+}

--- a/javalib/src/main/scala/java/util/concurrent/ExecutorService.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ExecutorService.scala
@@ -1,0 +1,48 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util
+package concurrent
+
+import java.security.{PrivilegedAction, PrivilegedExceptionAction}
+
+trait ExecutorService extends Executor {
+
+  def shutdown(): Unit
+
+  def shutdownNow(): java.util.List[Runnable]
+
+  def isShutdown(): Boolean
+
+  def isTerminated(): Boolean
+
+  def awaitTermination(timeout: Long, unit: TimeUnit): Boolean
+
+  def submit[T <: AnyRef](task: Callable[T]): Future[T]
+
+  def submit[T <: AnyRef](task: Runnable, result: T): Future[T]
+
+  def submit(task: Runnable): Future[_]
+
+  def invokeAll[T <: AnyRef](
+      tasks: java.util.Collection[_ <: Callable[T]]
+  ): java.util.List[Future[T]]
+
+  def invokeAll[T <: AnyRef](
+      tasks: java.util.Collection[_ <: Callable[T]],
+      timeout: Long,
+      unit: TimeUnit
+  ): java.util.List[Future[T]]
+
+  def invokeAny[T <: AnyRef](tasks: java.util.Collection[_ <: Callable[T]]): T
+
+  def invokeAny[T <: AnyRef](
+      tasks: java.util.Collection[_ <: Callable[T]],
+      timeout: Long,
+      unit: TimeUnit
+  ): T
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/Executors.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Executors.scala
@@ -20,7 +20,7 @@ object Executors {
       true
     )
 
-  def newWorkStealingPool(): ExecutorService = 
+  def newWorkStealingPool(): ExecutorService =
     newWorkStealingPool(Runtime.getRuntime().availableProcessors())
 
   def unconfigurableExecutorService(

--- a/javalib/src/main/scala/java/util/concurrent/Executors.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Executors.scala
@@ -1,0 +1,256 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+import java.util.Collection
+import java.util.List
+import java.util.concurrent.atomic.AtomicInteger
+import scala.scalanative.annotation.alwaysinline
+import java.security.{PrivilegedAction, PrivilegedExceptionAction}
+
+object Executors {
+  def newWorkStealingPool(parallelism: Int): ExecutorService =
+    new ForkJoinPool(
+      parallelism,
+      ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+      null,
+      true
+    )
+
+  def newWorkStealingPool(): ExecutorService = 
+    newWorkStealingPool(Runtime.getRuntime().availableProcessors())
+
+  def unconfigurableExecutorService(
+      executor: ExecutorService
+  ): ExecutorService = {
+    if (executor == null) throw new NullPointerException
+    new Executors.DelegatedExecutorService(executor)
+  }
+
+  def defaultThreadFactory(): ThreadFactory = {
+    return new Executors.DefaultThreadFactory
+  }
+
+  def privilegedThreadFactory(): ThreadFactory = {
+    new Executors.PrivilegedThreadFactory
+  }
+
+  def callable[T](task: Runnable, result: T): Callable[T] = {
+    if (task == null) throw new NullPointerException
+    new Executors.RunnableAdapter[T](task, result)
+  }
+
+  def callable(task: Runnable): Callable[AnyRef] = {
+    if (task == null) throw new NullPointerException
+    new Executors.RunnableAdapter[AnyRef](task, null)
+  }
+
+  def callable(action: PrivilegedAction[_]): Callable[Any] = {
+    if (action == null) throw new NullPointerException
+    new Callable[Any]() {
+      override def call(): Any = { action.run() }
+    }
+  }
+
+  def callable(action: PrivilegedExceptionAction[_]): Callable[Any] = {
+    if (action == null) { throw new NullPointerException }
+    new Callable[Any]() {
+      @throws[Exception]
+      override def call(): Any = { action.run() }
+    }
+  }
+
+  def privilegedCallable[T](callable: Callable[T]): Callable[T] = {
+    if (callable == null) { throw new NullPointerException }
+    new Executors.PrivilegedCallable[T](callable)
+  }
+
+  def privilegedCallableUsingCurrentClassLoader[T](
+      callable: Callable[T]
+  ): Callable[T] = {
+    if (callable == null) { throw new NullPointerException }
+    new Executors.PrivilegedCallableUsingCurrentClassLoader[T](callable)
+  }
+
+  final private class RunnableAdapter[T](
+      val task: Runnable,
+      val result: T
+  ) extends Callable[T] {
+    override def call(): T = {
+      task.run()
+      result
+    }
+    override def toString(): String = {
+      super.toString + "[Wrapped task = " + task + "]"
+    }
+  }
+
+  final private class PrivilegedCallable[T](
+      val task: Callable[T]
+  ) extends Callable[T] {
+    @throws[Exception]
+    override def call(): T = task.call()
+
+    override def toString(): String = {
+      super.toString + "[Wrapped task = " + task + "]"
+    }
+  }
+
+  final private class PrivilegedCallableUsingCurrentClassLoader[T](
+      val task: Callable[T]
+  ) extends Callable[T] {
+
+    @throws[Exception]
+    override def call(): T = task.call()
+
+    override def toString(): String = {
+      return super.toString + "[Wrapped task = " + task + "]"
+    }
+  }
+
+  private object DefaultThreadFactory {
+    private val poolNumber: AtomicInteger = new AtomicInteger(1)
+  }
+  private class DefaultThreadFactory() extends ThreadFactory {
+    // Originally SecurityManager threadGroup was tried first
+    final private val group: ThreadGroup =
+      Thread.currentThread().getThreadGroup()
+
+    final private val threadNumber: AtomicInteger = new AtomicInteger(1)
+    final private var namePrefix: String =
+      "pool-" + DefaultThreadFactory.poolNumber.getAndIncrement() + "-thread-"
+
+    override def newThread(r: Runnable): Thread = {
+      val t: Thread =
+        new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0)
+      if (t.isDaemon()) { t.setDaemon(false) }
+      if (t.getPriority() != Thread.NORM_PRIORITY) {
+        t.setPriority(Thread.NORM_PRIORITY)
+      }
+      return t
+    }
+  }
+
+  private class PrivilegedThreadFactory()
+      extends Executors.DefaultThreadFactory {
+    override def newThread(r: Runnable): Thread =
+      super.newThread(new Runnable() {
+        override def run(): Unit = r.run()
+      })
+  }
+
+  private class DelegatedExecutorService(
+      val executor: ExecutorService
+  ) extends ExecutorService {
+
+    // Stub used in place of JVM intrinsic
+    @alwaysinline
+    private def reachabilityFence(target: Any): Unit = ()
+
+    override def execute(command: Runnable): Unit = {
+      try executor.execute(command)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    override def shutdown(): Unit = { executor.shutdown() }
+    override def shutdownNow(): List[Runnable] = {
+      try return executor.shutdownNow()
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    override def isShutdown(): Boolean = {
+      try return executor.isShutdown()
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    override def isTerminated(): Boolean = {
+      try return executor.isTerminated()
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    @throws[InterruptedException]
+    override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+      try return executor.awaitTermination(timeout, unit)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    override def submit(task: Runnable): Future[_] = {
+      try return executor.submit(task)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    override def submit[T <: AnyRef](task: Callable[T]): Future[T] = {
+      try return executor.submit(task)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    override def submit[T <: AnyRef](task: Runnable, result: T): Future[T] = {
+      try return executor.submit(task, result)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    @throws[InterruptedException]
+    override def invokeAll[T <: AnyRef](
+        tasks: Collection[_ <: Callable[T]]
+    ): List[Future[T]] = {
+      try return executor.invokeAll(tasks)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    @throws[InterruptedException]
+    override def invokeAll[T <: AnyRef](
+        tasks: Collection[_ <: Callable[T]],
+        timeout: Long,
+        unit: TimeUnit
+    ): List[Future[T]] = {
+      try return executor.invokeAll(tasks, timeout, unit)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    @throws[InterruptedException]
+    @throws[ExecutionException]
+    override def invokeAny[T <: AnyRef](
+        tasks: Collection[_ <: Callable[T]]
+    ): T = {
+      try return executor.invokeAny(tasks)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+    @throws[InterruptedException]
+    @throws[ExecutionException]
+    @throws[TimeoutException]
+    override def invokeAny[T <: AnyRef](
+        tasks: Collection[_ <: Callable[T]],
+        timeout: Long,
+        unit: TimeUnit
+    ): T = {
+      try return executor.invokeAny(tasks, timeout, unit)
+      finally {
+        reachabilityFence(this)
+      }
+    }
+  }
+  private class FinalizableDelegatedExecutorService(
+      executor: ExecutorService
+  ) extends Executors.DelegatedExecutorService(executor) {
+    override protected def finalize(): Unit = { super.shutdown() }
+  }
+
+}
+
+// Cannot instantiate.
+class Executors private ()

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -5,22 +5,2153 @@
  */
 package java.util.concurrent
 
-object ForkJoinPool {
+import java.lang.Thread.UncaughtExceptionHandler
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.VarHandle
+import java.util.concurrent.ForkJoinPool.WorkQueue.getAndClearSlot
+import java.util.{ArrayList, Collection, Collections, List, concurrent}
+import java.util.function.Predicate
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.locks.LockSupport
+import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.locks.Condition
+import scala.annotation._
+import scala.scalanative.annotation._
+import scala.scalanative.unsafe._
+import scala.scalanative.libc.atomic.{CAtomicInt, CAtomicLongLong, CAtomicRef}
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics, ObjectArray}
 
-  trait ManagedBlocker {
-    @throws[InterruptedException]
-    def block(): Boolean
-    def isReleasable(): Boolean
+class ForkJoinPool private (
+    factory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+    val ueh: UncaughtExceptionHandler,
+    saturate: Predicate[ForkJoinPool],
+    keepAlive: Long,
+    workerNamePrefix: String
+) extends AbstractExecutorService {
+  import ForkJoinPool._
+
+  @volatile private[concurrent] var stealCount: Long = 0
+  @volatile private[concurrent] var threadIds: Int = 0
+  @volatile private[concurrent] var mode: Int = 0
+  @volatile private[concurrent] var ctl: Long = 0L // main pool control
+
+  final private[concurrent] var bounds: Int = 0
+  final private[concurrent] val registrationLock = new ReentrantLock()
+
+  private[concurrent] var scanRover: Int = 0 // advances across pollScan calls
+  private[concurrent] var queues: Array[WorkQueue] = _ // main registry
+  private[concurrent] var termination: Condition = _
+
+  private val modeAtomic = new CAtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "mode"))
+  )
+  private val ctlAtomic = new CAtomicLongLong(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "ctl"))
+  )
+  private val stealCountAtomic = new CAtomicLongLong(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "stealCount"))
+  )
+  private val threadIdsAtomic = new CAtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "threadIds"))
+  )
+
+  @alwaysinline
+  private def compareAndSetCtl(c: Long, v: Long): Boolean =
+    ctlAtomic.compareExchangeStrong(c, v)
+  @alwaysinline
+  private def compareAndExchangeCtl(c: Long, v: Long): Long = {
+    val expected = stackalloc[Long]()
+    !expected = c
+    ctlAtomic.compareExchangeStrong(expected, v)
+    !expected
   }
-  def managedBlock(blocker: ManagedBlocker): Unit = {
-    // TODO: ForkJoinPool impl
-    unmanagedBlock(blocker)
+  @alwaysinline
+  private def getAndAddCtl(v: Long): Long = ctlAtomic.fetchAdd(v)
+  @alwaysinline
+  private def getAndBitwiseOrMode(v: Int): Int = modeAtomic.fetchOr(v)
+  @alwaysinline
+  private def getAndAddThreadIds(v: Int): Int = threadIdsAtomic.fetchAdd(v)
+
+  private def createWorker(): Boolean = {
+    var ex: Throwable = null
+    var wt: ForkJoinWorkerThread = null
+
+    try {
+      if (factory != null) {
+        wt = factory.newThread(this)
+        if (wt != null) {
+          wt.start()
+          return true
+        }
+      }
+    } catch {
+      case rex: Throwable =>
+        ex = rex
+    }
+    deregisterWorker(wt, ex)
+    false
   }
 
-  private def unmanagedBlock(blocker: ManagedBlocker): Unit = {
-    if (blocker == null) throw new NullPointerException()
-    while (!blocker.isReleasable() && !blocker.block()) {
-      Thread.onSpinWait()
+  final private[concurrent] def nextWorkerThreadName(): String = {
+    val tid = getAndAddThreadIds(1) + 1
+    val prefix = Option(workerNamePrefix)
+      .getOrElse("ForkJoinPool.commonPool-worker-") // commonPool has no prefix
+    prefix + tid
+  }
+
+  final private[concurrent] def registerWorker(w: WorkQueue): Unit = {
+    val lock = registrationLock
+    ThreadLocalRandom.localInit()
+    val seed = ThreadLocalRandom.getProbe()
+    if (w != null && lock != null) {
+      val modebits: Int = (mode & FIFO) | w.config
+      w.array = new Array[ForkJoinTask[_]](INITIAL_QUEUE_CAPACITY)
+      w.stackPred = seed // stash for runWorker
+
+      if ((modebits & INNOCUOUS) != 0)
+        w.initializeInnocuousWorker()
+      var id: Int = (seed << 1) | 1 // initial index guess
+      lock.lock()
+      try {
+        val qs = queues
+        var n: Int = if (qs != null) qs.length else 0 // find queue index
+        if (n > 0) {
+          var k: Int = n
+          val m: Int = n - 1
+
+          while ({ id &= m; qs(id) != null && k > 0 }) {
+            id -= 2
+            k -= 2
+          }
+          if (k == 0) id = n | 1 // resize below
+          w.config = id | modebits // now publishable
+          w.phase = w.config
+
+          if (id < n) qs(id) = w
+          else { // expand array
+            val an: Int = n << 1
+            val am: Int = an - 1
+            val as: Array[WorkQueue] = new Array[WorkQueue](an)
+            as(id & am) = w
+            for (j <- 1 until n by 2) as(j) = qs(j)
+            for (j <- 0 until n by 2) {
+              val q: WorkQueue = qs(j)
+              if (q != null) { // shared queues may move
+                as(q.config & am) = q
+              }
+            }
+            VarHandle.releaseFence() // fill before publish
+            queues = as
+          }
+        }
+      } finally lock.unlock()
     }
   }
+
+  final private[concurrent] def deregisterWorker(
+      wt: ForkJoinWorkerThread,
+      ex: Throwable
+  ): Unit = {
+    val lock: ReentrantLock = registrationLock
+    val w: WorkQueue = if (wt != null) wt.workQueue else null
+    var cfg: Int = 0
+    if (w != null && lock != null) {
+      cfg = w.config
+      val ns: Long = w.nsteals & 0xffffffffL
+      lock.lock() // remove index from array
+      val qs = queues
+      val n: Int = if (qs != null) qs.length else 0
+      val i: Int = cfg & (n - 1)
+      if (n > 0 && qs(i) == w)
+        qs(i) = null
+      stealCount += ns // accumulate steals
+
+      lock.unlock()
+      var c: Long = ctl
+      if (w.phase != QUIET) { // decrement counts
+        while ({
+          val c0 = c
+          val newC = (RC_MASK & (c - RC_UNIT)) |
+            (TC_MASK & (c - TC_UNIT)) |
+            (SP_MASK & c)
+          c = compareAndExchangeCtl(c, newC)
+          c0 != c
+        }) ()
+      } else if (c.toInt == 0) { // was dropped on timeout
+        cfg = 0 // suppress signal if last
+      }
+      while (w.pop() match {
+            case null => false
+            case t =>
+              ForkJoinTask.cancelIgnoringExceptions(t)
+              true
+          }) ()
+    }
+    if (!tryTerminate(false, false) && w != null && (cfg & SRC) != 0)
+      signalWork() // possibly replace worker
+    if (ex != null) ForkJoinTask.rethrow(ex)
+  }
+
+  /*
+   * Tries to create or release a worker if too few are running.
+   */
+  final private[concurrent] def signalWork(): Unit = {
+    var c: Long = ctl
+    while (c < 0L) {
+      ((c.toInt & ~UNSIGNALLED): @switch) match {
+        case 0 => // no idle workers
+          if ((c & ADD_WORKER) == 0L) return // enough total workers
+          else {
+            val prevC = c
+            c = compareAndExchangeCtl(
+              c,
+              (RC_MASK & (c + RC_UNIT)) | (TC_MASK & (c + TC_UNIT))
+            )
+            if (c == prevC) {
+              createWorker()
+              return
+            }
+          }
+
+        case sp =>
+          val i = sp & SMASK
+          val qs = queues
+          def unstartedOrTerminated = qs == null
+          def terminated = qs.length <= i
+          def terminating = qs(i) == null
+
+          if (unstartedOrTerminated || terminated || terminating)
+            return // break
+          else {
+            val v = qs(i)
+            val vt = v.owner
+            val nc = (v.stackPred & SP_MASK) | (UC_MASK & (c + RC_UNIT))
+            val prevC = c
+            c = compareAndExchangeCtl(c, nc)
+            if (c == prevC) {
+              // release idle worker
+              v.phase = sp
+              vt.foreach(LockSupport.unpark)
+              return
+            }
+          }
+      }
+    }
+  }
+
+  final private[concurrent] def runWorker(w: WorkQueue): Unit = {
+    if (w != null) { // skip on failed init
+      w.config |= SRC // mark as valid source
+
+      var r: Int = w.stackPred
+      var src: Int = 0 // use seed from registerWorker
+
+      @inline def tryScan(): Boolean = {
+        src = scan(w, src, r)
+        src >= 0
+      }
+
+      @inline def tryAwaitWork(): Boolean = {
+        src = awaitWork(w)
+        src == 0
+      }
+
+      while ({
+        r ^= r << 13
+        r ^= r >>> 17
+        r ^= r << 5 // xorshift
+        tryScan() || tryAwaitWork()
+      }) ()
+    }
+  }
+
+  private def scan(w: WorkQueue, prevSrc: Int, r0: Int): Int = {
+    val qs: Array[WorkQueue] = queues
+    val n: Int = if (w == null || qs == null) 0 else qs.length
+    var r = r0
+    val step: Int = (r >>> 16) | 1
+    var i: Int = n
+    while (i > 0) {
+      val j = r & (n - 1)
+      val q = qs(j)
+      val a = if (q != null) q.array else null
+      val cap = if (a != null) a.length else 0
+      if (cap > 0) {
+        val b = q.base
+        val k: Int = (cap - 1) & b
+        val nextBase: Int = b + 1
+        val nextIndex: Int = (cap - 1) & nextBase
+        val src: Int = j | SRC
+        val t: ForkJoinTask[_] = WorkQueue.getSlot(a, k)
+        if (q.base != b) { // inconsistent
+          return prevSrc
+        } else if (t != null && WorkQueue.casSlotToNull(a, k, t)) {
+          q.base = nextBase
+          val next: ForkJoinTask[_] = a(nextIndex)
+          w.source = src
+          if (src != prevSrc && next != null)
+            signalWork() // propagate
+          w.topLevelExec(t, q)
+          return src
+        } else if (a(nextIndex) != null) { // revisit
+          return prevSrc
+        }
+      }
+
+      i -= 1
+      r += step
+    }
+    if (queues != qs) prevSrc
+    else -1 // possibly resized
+  }
+
+  private def awaitWork(w: WorkQueue): Int = {
+    if (w == null) return -1 // already terminated
+    val phase = (w.phase + SS_SEQ) & ~UNSIGNALLED
+    w.phase = phase | UNSIGNALLED // advance phase
+
+    var prevCtl: Long = ctl
+    var c: Long = 0L // enqueue
+    while ({
+      w.stackPred = prevCtl.toInt
+      c = ((prevCtl - RC_UNIT) & UC_MASK) | (phase & SP_MASK)
+      val prev = prevCtl
+      prevCtl = compareAndExchangeCtl(prevCtl, c)
+      prev != prevCtl
+    }) ()
+
+    Thread.interrupted() // clear status
+
+    LockSupport.setCurrentBlocker(this) // prepare to block (exit also OK)
+
+    var deadline = 0L // nonzero if possibly quiescent
+    def setDeadline(v: Long): Unit = {
+      deadline = v match {
+        case 0L => 1L
+        case _  => v
+      }
+    }
+
+    var ac = (c >> RC_SHIFT).toInt
+    val md = mode
+    if (md < 0) { // pool is terminating
+      return -1
+    } else if ((md & SMASK) + ac <= 0) {
+      var checkTermination = (md & SHUTDOWN) != 0
+      setDeadline(System.currentTimeMillis() + keepAlive)
+      val qs = queues // check for racing submission
+      val n = if (qs == null) 0 else qs.length
+      var i = 0
+      var break = false
+      while (!break && i < n) {
+        if (ctl != c) { // already signalled
+          checkTermination = false
+          break = true
+        } else {
+          val q = qs(i)
+          val a = if (q != null) q.array else null
+          val cap = if (a != null) a.length else 0
+          if (cap > 0) {
+            val b = q.base
+            if (b != q.top ||
+                a((cap - 1) & b) != null ||
+                q.source != 0) {
+              if (compareAndSetCtl(c, prevCtl)) w.phase = phase // self-signal
+              checkTermination = false
+              break = true
+            }
+          }
+        }
+
+        i += 2
+      }
+      if (checkTermination && tryTerminate(false, false))
+        return -1 // trigger quiescent termination
+    }
+
+    var alt = false
+    var break = false
+    while (!break) {
+      val currentCtl = ctl
+      if (w.phase >= 0) break = true
+      else if (mode < 0) return -1
+      else if ((ctl >> RC_SHIFT).toInt > ac)
+        Thread.onSpinWait() // signal in progress
+      else if (deadline != 0L &&
+          deadline - System.currentTimeMillis() <= TIMEOUT_SLOP) {
+        val prevC = c
+        c = ctl
+        if (prevC != c) { // ensure consistent
+          ac = (c >> RC_SHIFT).toInt
+        } else if (compareAndSetCtl(
+              c,
+              ((UC_MASK & (c - TC_UNIT)) | (w.stackPred & SP_MASK))
+            )) {
+          w.phase = QUIET
+          return -1 // drop on timeout
+        }
+      } else if ({ alt = !alt; !alt }) { // check between parks
+        Thread.interrupted()
+      } else if (deadline != 0L) LockSupport.parkUntil(deadline)
+      else LockSupport.park()
+    }
+    LockSupport.setCurrentBlocker(null)
+    0
+  }
+
+  final private[concurrent] def isSaturated(): Boolean = {
+    val maxTotal: Int = bounds >>> SWIDTH
+    @tailrec
+    def loop(): Boolean = {
+      val c = ctl
+      if ((c.toInt & ~UNSIGNALLED) != 0) false
+      else if ((c >>> TC_SHIFT).toShort >= maxTotal) true
+      else {
+        val nc: Long = ((c + TC_UNIT) & TC_MASK) | (c & ~TC_MASK)
+        if (compareAndSetCtl(c, nc)) !createWorker()
+        else loop()
+      }
+    }
+    loop()
+  }
+
+  final private[concurrent] def canStop(): Boolean = {
+    var oldSum: Long = 0L
+    var break = false
+    while (!break) { // repeat until stable
+      val qs = queues
+      var md = mode
+      if (qs == null || (md & STOP) != 0) return true
+      val c = ctl
+      if ((md & SMASK) + (ctl >> RC_SHIFT).toInt > 0) break = true
+      else {
+        var checkSum: Long = c
+        var i = 1
+        while (!break && i < qs.length) { // scan submitters
+          val q = qs(i)
+          val a = if (q != null) q.array else null
+          val cap = if (a != null) a.length else 0
+          if (cap > 0) {
+            val s = q.top
+            if (s != q.base ||
+                a((cap - 1) & s) != null ||
+                q.source != 0)
+              break = true
+            else checkSum += (i.toLong << 32) ^ s
+          }
+          i += 2
+        }
+        if (oldSum == checkSum && (queues eq qs)) return true
+        else oldSum = checkSum
+      }
+    }
+    (mode & STOP) != 0 // recheck mode on false return
+  }
+
+  private def tryCompensate(c: Long): Int = {
+    val md = mode
+    val b = bounds
+    // counts are signed centered at parallelism level == 0
+    val minActive: Int = (b & SMASK).toShort
+    val maxTotal: Int = b >>> SWIDTH
+    val active: Int = (c >> RC_SHIFT).toInt
+    val total: Int = (c >>> TC_SHIFT).toShort
+    val sp: Int = c.toInt & ~UNSIGNALLED
+
+    if (total >= 0) {
+      if (sp != 0) { // activate idle worker
+        val qs = queues
+        val n = if (qs != null) qs.length else 0
+        val v: WorkQueue = if (n > 0) qs(sp & (n - 1)) else null
+        if (v != null) {
+          val nc: Long = (v.stackPred.toLong & SP_MASK) | (UC_MASK & c)
+          if (compareAndSetCtl(c, nc)) {
+            v.phase = sp
+            v.owner.foreach(LockSupport.unpark)
+            return UNCOMPENSATE
+          }
+        }
+        return -1 // retry
+      } else if (active > minActive) { // reduce parallelism
+        val nc: Long = (RC_MASK & (c - RC_UNIT)) | (~RC_MASK & c)
+        return if (compareAndSetCtl(c, nc)) UNCOMPENSATE
+        else -1
+      }
+    }
+    if (total < maxTotal) { // expand pool
+      val nc: Long = ((c + TC_UNIT) & TC_MASK) | (c & ~TC_MASK)
+      return if (!compareAndSetCtl(c, nc)) -1
+      else {
+        if (!createWorker()) 0
+        else UNCOMPENSATE
+      }
+    } else if (!compareAndSetCtl(c, c)) return -1
+    else if (saturate != null && saturate.test(this)) return 0
+    else
+      throw new RejectedExecutionException(
+        "Thread limit exceeded replacing blocked worker"
+      )
+  }
+
+  final private[concurrent] def uncompensate(): Unit = {
+    getAndAddCtl(RC_UNIT)
+  }
+
+  final private[concurrent] def helpJoin(
+      task: ForkJoinTask[_],
+      w: WorkQueue
+  ): Int = {
+    var s = 0
+    if (task != null && w != null) {
+      val wsrc: Int = w.source
+      val wid: Int = w.config & SMASK
+      var r: Int = wid + 2
+      var scan: Boolean = true
+      var c: Long = 0L // track ctl stability
+
+      var counter = 0
+      while (true) {
+        counter += 1
+        s = task.status
+        if (s < 0) return s
+        else if ({ scan = !scan; scan }) { // previous scan was empty
+          if (mode < 0) ForkJoinTask.cancelIgnoringExceptions(task)
+          else if ({
+            val prevC = c; c = ctl;
+            c == prevC && { s = tryCompensate(c); s >= 0 }
+          }) return s // block
+        } else { // scan for subtasks
+          val qs: Array[WorkQueue] = queues
+          val n: Int =
+            if (qs == null) 0
+            else qs.length
+          val m: Int = n - 1
+          var i: Int = n
+          var break = false
+          while (!break && i > 0) {
+            val j: Int = r & m
+            val q: WorkQueue = qs(j)
+            if (q != null) {
+              val a = q.array
+              val cap = if (a != null) a.length else 0
+              if (cap > 0) {
+                val b: Int = q.base
+                val k: Int = (cap - 1) & b
+                val nextBase: Int = b + 1
+                val src: Int = j | SRC
+                val t: ForkJoinTask[_] = WorkQueue.getSlot(a, k)
+                val sq: Int = q.source & SMASK
+                val eligible: Boolean =
+                  sq == wid || {
+                    val x = qs(sq & m)
+                    x != null && {
+                      val sx = x.source & SMASK
+                      sx == wid || { // indirect
+                        val y = qs(sx & m)
+                        (y != null && (y.source & SMASK) == wid) // 2-indirect
+                      }
+                    }
+                  }
+
+                if ({ s = task.status; s < 0 }) return s
+                else if ((q.source & SMASK) != sq || q.base != b) {
+                  scan = true
+                } else if (t == null) {
+                  scan |=
+                    a(nextBase & (cap - 1)) != null || q.top != b // lagging
+                } else if (eligible) {
+                  if (WorkQueue.casSlotToNull(a, k, t)) {
+                    q.base = nextBase
+                    w.source = src
+                    t.doExec()
+                    w.source = wsrc
+                  }
+                  scan = true
+                  break = true
+                }
+              }
+            }
+
+            i -= 2
+            r += 2
+          }
+        }
+      }
+    }
+    s
+  }
+
+  final private[concurrent] def helpComplete(
+      task: ForkJoinTask[_],
+      w: WorkQueue,
+      owned: Boolean
+  ): Int = {
+    var s: Int = 0
+    if (task != null && w != null) {
+      var r: Int = w.config
+      var scan: Boolean = true
+      var locals: Boolean = true
+      var c: Long = 0L
+      var breakOuter = false
+      while (!breakOuter) {
+        if (locals) { // try locals before scanning
+          if ({ s = w.helpComplete(task, owned, 0); s < 0 }) breakOuter = true
+          locals = false
+        } else if ({ s = task.status; s < 0 }) breakOuter = true
+        else if ({ scan = !scan; scan })
+          if ({ val prevC = c; c = ctl; prevC == c }) breakOuter = true
+          else {
+            val qs: Array[WorkQueue] = queues
+            val n: Int =
+              if ((qs == null)) 0
+              else qs.length
+            var i: Int = n
+            var break = false
+            while (!break && !breakOuter && i > 0) {
+              var j: Int = r & (n - 1)
+              val q = qs(j)
+              val a = if (q != null) q.array else null
+              val b: Int = if (q != null) q.base else 0
+              val cap: Int = if (a != null) a.length else 0
+              var eligible: Boolean = false
+              if (cap > 0) {
+                val k: Int = (cap - 1) & b
+                val nextBase: Int = b + 1
+                val t: ForkJoinTask[_] = WorkQueue.getSlot(a, k)
+                t match {
+                  case cc: CountedCompleter[_] =>
+                    var f: CountedCompleter[_] = cc
+                    while ({
+                      eligible = (f eq task)
+                      !eligible && { f = f.completer; f != null }
+                    }) ()
+                  case _ => ()
+                }
+                if ({ s = task.status; s < 0 }) breakOuter = true
+                else if (q.base != b) scan = true
+                else if (t == null)
+                  scan |= (a(nextBase & (cap - 1)) != null || q.top != b)
+                else if (eligible) {
+                  if (WorkQueue.casSlotToNull(a, k, t)) {
+                    q.setBaseOpaque(nextBase)
+                    t.doExec()
+                    locals = true
+                  }
+                  scan = true
+                  break = true
+                }
+              }
+
+              i -= 1
+              r += 1
+            }
+          }
+      }
+    }
+    s
+  }
+
+  private def pollScan(submissionsOnly: Boolean): ForkJoinTask[_] = {
+    VarHandle.acquireFence()
+    scanRover += 0x61c88647 // Weyl increment raciness OK
+    val r =
+      if (submissionsOnly) scanRover & ~1 // even indices only
+      else scanRover
+    val step = if (submissionsOnly) 2 else 1
+    var qs = queues
+    var n = 0
+    var break = false
+    while (!break && { qs = queues; qs != null } && {
+          n = qs.length; n > 0
+        }) {
+      var scan = false
+      var i = 0
+      while (i < n) {
+        val j: Int = (n - 1) & (r + i)
+        val q: WorkQueue = qs(j)
+        val a = if (q != null) q.array else null
+        val cap = if (a != null) a.length else 0
+        if (cap > 0) {
+          val b = q.base
+          val k: Int = (cap - 1) & b
+          val nextBase: Int = b + 1
+          val t: ForkJoinTask[_] = WorkQueue.getSlot(a, k)
+          if (q.base != b) scan = true
+          else if (t == null)
+            scan |= (q.top != b || a(nextBase & (cap - 1)) != null)
+          else if (!WorkQueue.casSlotToNull(a, k, t)) scan = true
+          else {
+            q.setBaseOpaque(nextBase)
+            return t
+          }
+        }
+
+        i += step
+      }
+      if (!scan && (queues eq qs)) break = true
+    }
+    null
+  }
+
+  final private[concurrent] def helpQuiescePool(
+      w: WorkQueue,
+      nanos: Long,
+      interruptible: Boolean
+  ): Int = {
+    if (w == null) return 0
+    val startTime = System.nanoTime()
+    var parkTime = 0L
+    val prevSrc = w.source
+    var wsrc = prevSrc
+    val cfg = w.config
+    var r = cfg + 1
+    var active = true
+    var locals = true
+    while (true) {
+      var busy = false
+      var scan = false
+      if (locals) { // run local tasks before (re)polling
+        locals = false
+        var u = null: ForkJoinTask[_]
+        while ({
+          u = w.nextLocalTask(cfg)
+          u != null
+        }) u.doExec()
+      }
+      val qs = queues
+      val n = if (qs == null) 0 else qs.length
+      var break = false
+      var i = n
+      while (!break && i > 0) {
+        val j = (n - 1) & r
+        val q = qs(j)
+        val a = if (q != null) q.array else null
+        val cap = if (a != null) a.length else 0
+        if (q != w && cap > 0) {
+          val b = q.base
+          val k = (cap - 1) & b
+          val nextBase = b + 1
+          val src = j | SRC
+          val t = WorkQueue.getSlot(a, k)
+          if (q.base != b) {
+            busy = true
+            scan = true
+          } else if (t != null) {
+            busy = true
+            scan = true
+            if (!active) { // increment before taking
+              active = true
+              getAndAddCtl(RC_UNIT)
+            }
+            if (WorkQueue.casSlotToNull(a, k, t)) {
+              q.base = nextBase
+              w.source = src
+              t.doExec()
+              wsrc = prevSrc
+              w.source = wsrc
+              locals = true
+            }
+            break = true
+          } else if (!busy) {
+            if (q.top != b || a(nextBase & (cap - 1)) != null) {
+              busy = true
+              scan = true
+            } else if (q.source != QUIET && q.phase >= 0)
+              busy = true
+          }
+        }
+        i -= 1
+        r += 1
+      }
+      VarHandle.acquireFence()
+      if (!scan && (queues eq qs)) {
+        if (!busy) {
+          w.source = prevSrc
+          if (!active) getAndAddCtl(RC_UNIT)
+          return 1
+        }
+        if (wsrc != QUIET) {
+          wsrc = QUIET
+          w.source = wsrc
+        }
+        if (active) { // decrement
+          active = false
+          parkTime = 0L
+          getAndAddCtl(RC_MASK & -RC_UNIT)
+        } else if (parkTime == 0L) {
+          parkTime = 1L << 10 // initially about 1 usec
+          Thread.`yield`()
+        } else {
+          val interrupted = interruptible && Thread.interrupted()
+          if (interrupted || System.nanoTime() - startTime > nanos) {
+            getAndAddCtl(RC_UNIT)
+            return if (interrupted) -1 else 0
+          } else {
+            LockSupport.parkNanos(this, parkTime)
+            if (parkTime < (nanos >>> 8) && parkTime < (1L << 20))
+              parkTime <<= 1 // max sleep approx 1 sec or 1% nanos
+          }
+        }
+      }
+    }
+    -1 // unreachable
+  }
+
+  final private[concurrent] def externalHelpQuiescePool(
+      nanos: Long,
+      interruptible: Boolean
+  ): Int = {
+    val startTime = System.nanoTime()
+    var parkTime = 0L
+    while (true) {
+      val t = pollScan(false)
+      if (t != null) {
+        t.doExec()
+        parkTime = 0L
+      } else if (canStop()) return 1
+      else if (parkTime == 0L) {
+        parkTime = 1L << 10
+        Thread.`yield`()
+      } else if ((System.nanoTime() - startTime) > nanos) return 0
+      else if (interruptible && Thread.interrupted()) return -1
+      else {
+        LockSupport.parkNanos(this, parkTime)
+        if (parkTime < (nanos >>> 8) && parkTime < (1L << 20))
+          parkTime <<= 1
+      }
+    }
+    -1 // unreachable
+  }
+
+  final private[concurrent] def nextTaskFor(w: WorkQueue): ForkJoinTask[_] =
+    if (w == null) pollScan(false)
+    else
+      w.nextLocalTask(w.config) match {
+        case null => pollScan(false)
+        case t    => t
+      }
+
+  // External operations
+
+  final private[concurrent] def submissionQueue(): WorkQueue = {
+
+    @tailrec
+    def loop(r: Int): WorkQueue = {
+      val qs = queues
+      val n = if (qs != null) qs.length else 0
+      if ((mode & SHUTDOWN) != 0 || n <= 0) return null
+
+      val id = r << 1
+      val i = (n - 1) & id
+      qs(i) match {
+        case null =>
+          Option(registrationLock)
+            .foreach { lock =>
+              val w = new WorkQueue(id | SRC)
+              lock.lock() // install under lock
+              if (qs(i) == null)
+                qs(i) = w // else lost race discard
+              lock.unlock()
+            }
+          loop(r)
+        case q if !q.tryLock() => // move and restart
+          loop(ThreadLocalRandom.advanceProbe(r))
+        case q => q
+      }
+    }
+
+    val r = ThreadLocalRandom.getProbe() match {
+      case 0 => // initialize caller's probe
+        ThreadLocalRandom.localInit()
+        ThreadLocalRandom.getProbe()
+      case probe => probe
+    }
+    loop(r) // even indices only
+  }
+
+  final private[concurrent] def externalPush(task: ForkJoinTask[_]): Unit = {
+    submissionQueue() match {
+      case null =>
+        throw new RejectedExecutionException // shutdown or disabled
+      case q =>
+        if (q.lockedPush(task)) signalWork()
+    }
+  }
+
+  private def externalSubmit[T](task: ForkJoinTask[T]): ForkJoinTask[T] = {
+    if (task == null) throw new NullPointerException()
+
+    Thread.currentThread() match {
+      case worker: ForkJoinWorkerThread
+          if worker.workQueue != null && (worker.pool eq this) =>
+        worker.workQueue.push(task, this)
+      case _ =>
+        externalPush(task)
+    }
+    task
+  }
+
+  // Termination
+
+  private def tryTerminate(now: Boolean, enable: Boolean): Boolean = {
+    // try to set SHUTDOWN, then STOP, then help terminate
+    var md: Int = mode
+    if ((md & SHUTDOWN) == 0) {
+      if (!enable) return false
+      md = getAndBitwiseOrMode(SHUTDOWN)
+    }
+    if ((md & STOP) == 0) {
+      if (!now && !canStop()) return false
+      md = getAndBitwiseOrMode(STOP)
+    }
+    if ((md & TERMINATED) == 0) {
+      while (pollScan(false) match {
+            case null => false
+            case t    => ForkJoinTask.cancelIgnoringExceptions(t); true
+          }) ()
+
+      // unblock other workers
+      val qs = queues
+      val n = if (qs != null) qs.length else 0
+      if (n > 0) {
+        for {
+          j <- 1 until n by 2
+          q = qs(j) if q != null
+          thread <- q.owner if !thread.isInterrupted()
+        } {
+          try thread.interrupt()
+          catch {
+            case ignore: Throwable => ()
+          }
+        }
+      }
+
+      // signal when no workers
+      if ((md & SMASK) + (ctl >>> TC_SHIFT).toShort <= 0 &&
+          (getAndBitwiseOrMode(TERMINATED) & TERMINATED) == 0) {
+        val lock = registrationLock
+        lock.lock()
+        if (termination != null) {
+          termination.signalAll()
+        }
+        lock.unlock()
+      }
+    }
+    true
+  }
+
+  def this(
+      parallelism: Int,
+      factory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+      handler: UncaughtExceptionHandler,
+      asyncMode: Boolean,
+      corePoolSize: Int,
+      maximumPoolSize: Int,
+      minimumRunnable: Int,
+      saturate: Predicate[ForkJoinPool],
+      keepAliveTime: Long,
+      unit: TimeUnit
+  ) = {
+    this(
+      factory = factory,
+      ueh = handler,
+      saturate = saturate,
+      keepAlive =
+        Math.max(unit.toMillis(keepAliveTime), ForkJoinPool.TIMEOUT_SLOP),
+      workerNamePrefix = {
+        val pid: String = Integer.toString(ForkJoinPool.getAndAddPoolIds(1) + 1)
+        s"$pid-worker-"
+      }
+    )
+    if (factory == null || unit == null) throw new NullPointerException
+    val p: Int = parallelism
+    if (p <= 0 || p > MAX_CAP || p > maximumPoolSize || keepAliveTime <= 0L)
+      throw new IllegalArgumentException
+    val size: Int = 1 << (33 - Integer.numberOfLeadingZeros(p - 1))
+    val corep: Int = Math.min(Math.max(corePoolSize, p), MAX_CAP)
+    val maxSpares: Int = Math.min(maximumPoolSize, MAX_CAP) - p
+    val minAvail: Int =
+      Math.min(Math.max(minimumRunnable, 0), MAX_CAP)
+    this.bounds = ((minAvail - p) & SMASK) | (maxSpares << SWIDTH)
+    this.mode = p | (if (asyncMode) FIFO else 0)
+    this.ctl = ((((-corep).toLong << TC_SHIFT) & TC_MASK) |
+      ((-p.toLong << RC_SHIFT) & RC_MASK))
+    this.queues = new Array[WorkQueue](size)
+  }
+
+  def this(parallelism: Int) = {
+    this(
+      parallelism,
+      ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+      null,
+      false,
+      0,
+      ForkJoinPool.MAX_CAP,
+      1,
+      null,
+      ForkJoinPool.DEFAULT_KEEPALIVE,
+      TimeUnit.MILLISECONDS
+    )
+  }
+
+  def this() = this(
+    parallelism =
+      Math.min(ForkJoinPool.MAX_CAP, Runtime.getRuntime().availableProcessors())
+  )
+
+  def this(
+      parallelism: Int,
+      factory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+      handler: UncaughtExceptionHandler,
+      asyncMode: Boolean
+  ) = {
+    this(
+      parallelism,
+      factory,
+      handler,
+      asyncMode,
+      0,
+      ForkJoinPool.MAX_CAP,
+      1,
+      null,
+      ForkJoinPool.DEFAULT_KEEPALIVE,
+      TimeUnit.MILLISECONDS
+    )
+  }
+
+  def invoke[T](task: ForkJoinTask[T]): T = {
+    externalSubmit(task)
+    task.join()
+  }
+
+  def execute(task: ForkJoinTask[_]): Unit = {
+    externalSubmit(task)
+  }
+
+  // AbstractExecutorService methods
+
+  override def execute(task: Runnable): Unit = {
+    // Scala3 compiler has problems with type intererenfe when passed to externalSubmit directlly
+    val taskToUse: ForkJoinTask[_] = task match {
+      case task: ForkJoinTask[_] => task
+      case _                     => new ForkJoinTask.RunnableExecuteAction(task)
+    }
+    externalSubmit(taskToUse)
+  }
+
+  def submit[T](task: ForkJoinTask[T]): ForkJoinTask[T] = {
+    externalSubmit(task)
+  }
+
+  override def submit[T](task: Callable[T]): ForkJoinTask[T] = {
+    externalSubmit(new ForkJoinTask.AdaptedCallable[T](task))
+  }
+
+  override def submit[T](task: Runnable, result: T): ForkJoinTask[T] = {
+    externalSubmit(new ForkJoinTask.AdaptedRunnable[T](task, result))
+  }
+
+  override def submit(task: Runnable): ForkJoinTask[_] = {
+    val taskToUse = task match {
+      case task: ForkJoinTask[_] => task
+      case _ => new ForkJoinTask.AdaptedRunnableAction(task): ForkJoinTask[_]
+    }
+    externalSubmit(taskToUse)
+  }
+
+  override def invokeAll[T](
+      tasks: Collection[_ <: Callable[T]]
+  ): List[Future[T]] = {
+    val futures = new ArrayList[Future[T]](tasks.size())
+    try {
+      val it = tasks.iterator()
+      while (it.hasNext()) {
+        val f = new ForkJoinTask.AdaptedInterruptibleCallable[T](it.next())
+        futures.add(f)
+        externalSubmit(f)
+      }
+      for (i <- futures.size() - 1 to 0 by -1) {
+        futures.get(i).asInstanceOf[ForkJoinTask[_]].quietlyJoin()
+      }
+      futures
+    } catch {
+      case t: Throwable =>
+        val it = futures.iterator()
+        while (it.hasNext()) ForkJoinTask.cancelIgnoringExceptions(it.next())
+        throw t
+    }
+  }
+
+  @throws[InterruptedException]
+  override def invokeAll[T](
+      tasks: Collection[_ <: Callable[T]],
+      timeout: Long,
+      unit: TimeUnit
+  ): List[Future[T]] = {
+    val nanos = unit.toNanos(timeout)
+    val futures = new ArrayList[Future[T]](tasks.size())
+    try {
+      val it = tasks.iterator()
+      while (it.hasNext()) {
+        val f = new ForkJoinTask.AdaptedInterruptibleCallable[T](it.next())
+        futures.add(f)
+        externalSubmit(f)
+      }
+      val startTime = System.nanoTime()
+      var ns = nanos
+      def timedOut = ns < 0L
+      for (i <- futures.size() - 1 to 0 by -1) {
+        val f = futures.get(i)
+        if (!f.isDone()) {
+          if (timedOut)
+            ForkJoinTask.cancelIgnoringExceptions(f)
+          else {
+            try f.get(ns, TimeUnit.NANOSECONDS)
+            catch {
+              case _: CancellationException | _: TimeoutException |
+                  _: ExecutionException =>
+                ()
+            }
+            ns = nanos - (System.nanoTime() - startTime)
+          }
+        }
+      }
+      futures
+    } catch {
+      case t: Throwable =>
+        val it = futures.iterator()
+        while (it.hasNext()) ForkJoinTask.cancelIgnoringExceptions(it.next())
+        throw t
+    }
+  }
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  override def invokeAny[T](tasks: Collection[_ <: Callable[T]]): T = {
+    if (tasks.isEmpty()) throw new IllegalArgumentException()
+    val n = tasks.size()
+    val root = new InvokeAnyRoot[T](n)
+    val fs = new ArrayList[InvokeAnyTask[T]](n)
+    var break = false
+    val it = tasks.iterator()
+    while (!break && it.hasNext()) {
+      it.next() match {
+        case null => throw new NullPointerException()
+        case c =>
+          val f = new InvokeAnyTask[T](root, c)
+          fs.add(f)
+          if (isSaturated()) f.doExec()
+          else externalSubmit(f)
+          if (root.isDone()) break = true
+      }
+    }
+    try root.get()
+    finally {
+      val it = fs.iterator()
+      while (it.hasNext()) ForkJoinTask.cancelIgnoringExceptions(it.next())
+    }
+  }
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  @throws[TimeoutException]
+  override def invokeAny[T](
+      tasks: Collection[_ <: Callable[T]],
+      timeout: Long,
+      unit: TimeUnit
+  ): T = {
+    val nanos = unit.toNanos(timeout)
+    val n = tasks.size()
+    if (n <= 0) throw new IllegalArgumentException()
+    val root = new InvokeAnyRoot[T](n)
+    val fs = new ArrayList[InvokeAnyTask[T]](n)
+    var break = false
+    val it = tasks.iterator()
+    while (it.hasNext()) {
+      it.next() match {
+        case null => throw new NullPointerException()
+        case c =>
+          val f = new InvokeAnyTask(root, c)
+          fs.add(f)
+          if (isSaturated()) f.doExec()
+          else externalSubmit(f)
+          if (root.isDone()) break = true
+      }
+    }
+    try root.get(nanos, TimeUnit.NANOSECONDS)
+    finally {
+      val it = fs.iterator()
+      while (it.hasNext()) ForkJoinTask.cancelIgnoringExceptions(it.next())
+    }
+  }
+
+  def getFactory(): ForkJoinWorkerThreadFactory = factory
+
+  def getUncaughtExceptionHandler(): UncaughtExceptionHandler = ueh
+
+  def getParallelism(): Int = {
+    (mode & SMASK).max(1)
+  }
+
+  def getPoolSize(): Int = {
+    ((mode & SMASK) + (ctl >>> TC_SHIFT).toShort)
+  }
+
+  def getAsyncMode(): Boolean = {
+    (mode & FIFO) != 0
+  }
+
+  def getRunningThreadCount: Int = {
+    VarHandle.acquireFence()
+    val qs = queues
+    var rc = 0
+    if (queues != null) {
+      for (i <- 1 until qs.length by 2) {
+        val q = qs(i)
+        if (q != null && q.isApparentlyUnblocked()) rc += 1
+      }
+    }
+    rc
+  }
+
+  def getActiveThreadCount(): Int = {
+    val r = (mode & SMASK) + (ctl >> RC_SHIFT).toInt
+    r.max(0) // suppress momentarily negative values
+  }
+
+  def isQuiescent(): Boolean = canStop()
+
+  def getStealCount(): Long = {
+    var count = stealCount
+    val qs = queues
+    if (queues != null) {
+      for {
+        i <- 1 until qs.length by 2
+        q = qs(i) if q != null
+      } count += q.nsteals.toLong & 0xffffffffL
+    }
+    count
+  }
+
+  def getQueuedTaskCount(): Long = {
+    VarHandle.acquireFence()
+    var count = 0
+    val qs = queues
+    if (qs != null) {
+      for {
+        i <- 1 until qs.length by 2
+        q = qs(i) if q != null
+      } count += q.queueSize()
+    }
+    count
+  }
+
+  def getQueuedSubmissionCount(): Int = {
+    VarHandle.acquireFence()
+    var count = 0
+    val qs = queues
+    if (qs != null) {
+      for {
+        i <- 0 until qs.length by 2
+        q = qs(i) if q != null
+      } count += q.queueSize()
+    }
+    count
+  }
+
+  def hasQueuedSubmissions(): Boolean = {
+
+    VarHandle.acquireFence()
+    val qs = queues
+    if (qs != null) {
+      var i = 0
+      while (i < qs.length) {
+        val q = qs(i)
+        if (q != null && !q.isEmpty()) return true
+        i += 2
+      }
+    }
+    false
+  }
+
+  protected[concurrent] def pollSubmission(): ForkJoinTask[_] = pollScan(true)
+
+  protected def drainTasksTo(c: Collection[_ >: ForkJoinTask[_]]): Int = {
+    var count = 0
+    while ({
+      val t = pollScan(false)
+      t match {
+        case null => false
+        case t =>
+          c.add(t)
+          true
+      }
+    }) {
+      count += 1
+    }
+    count
+  }
+
+  override def toString(): String = {
+    // Use a single pass through queues to collect counts
+    val md: Int = mode // read volatile fields first
+    val c: Long = ctl
+    var st: Long = stealCount
+    var ss, qt: Long = 0L
+    var rc = 0
+    if (queues != null) {
+      queues.indices.foreach { i =>
+        val q = queues(i)
+        if (q != null) {
+          val size = q.queueSize()
+          if ((i & 1) == 0)
+            ss += size
+          else {
+            qt += size
+            st += q.nsteals.toLong & 0xffffffffL
+            if (q.isApparentlyUnblocked()) { rc += 1 }
+          }
+        }
+      }
+    }
+
+    val pc = md & SMASK
+    val tc = pc + (c >>> TC_SHIFT).toShort
+    val ac = (pc + (c >> RC_SHIFT).toInt) match {
+      case n if n < 0 => 0 // ignore transient negative
+      case n          => n
+    }
+
+    @alwaysinline
+    def modeSetTo(mode: Int): Boolean = (md & mode) != 0
+    val level =
+      if (modeSetTo(TERMINATED)) "Terminated"
+      else if (modeSetTo(STOP)) "Terminating"
+      else if (modeSetTo(SHUTDOWN)) "Shutting down"
+      else "Running"
+
+    return super.toString() +
+      "[" + level +
+      ", parallelism = " + pc +
+      ", size = " + tc +
+      ", active = " + ac +
+      ", running = " + rc +
+      ", steals = " + st +
+      ", tasks = " + qt +
+      ", submissions = " + ss +
+      "]"
+  }
+
+  override def shutdown(): Unit = {
+    if (this != common) tryTerminate(false, true)
+  }
+
+  override def shutdownNow(): List[Runnable] = {
+    if (this ne common) tryTerminate(true, true)
+    Collections.emptyList()
+  }
+
+  def isTerminated(): Boolean = {
+    (mode & TERMINATED) != 0
+  }
+
+  def isTerminating(): Boolean = {
+    (mode & (STOP | TERMINATED)) == STOP
+  }
+
+  override def isShutdown(): Boolean = {
+    (mode & SHUTDOWN) != 0
+  }
+
+  @throws[InterruptedException]
+  override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+    var nanos = unit.toNanos(timeout)
+    var terminated = false
+    if (this eq common) {
+      val q = Thread.currentThread() match {
+        case worker: ForkJoinWorkerThread if (worker.pool eq this) =>
+          helpQuiescePool(worker.workQueue, nanos, true)
+        case _ =>
+          externalHelpQuiescePool(nanos, true)
+      }
+      if (q < 0) throw new InterruptedException()
+    } else {
+      def isTerminated() = (mode & TERMINATED) != 0
+      terminated = isTerminated()
+      val lock = registrationLock
+      if (!terminated && lock != null) {
+        lock.lock()
+        if (termination == null) {
+          termination = lock.newCondition()
+        }
+        try
+          while ({
+            terminated = isTerminated()
+            !terminated && nanos > 0L
+          }) {
+            nanos = termination.awaitNanos(nanos)
+          }
+        finally lock.unlock()
+      }
+    }
+    terminated
+  }
+
+  def awaitQuiescence(timeout: Long, unit: TimeUnit): Boolean = {
+    val nanos: Long = unit.toNanos(timeout)
+    val q = Thread.currentThread() match {
+      case wt: ForkJoinWorkerThread if (wt.pool eq this) =>
+        helpQuiescePool(wt.workQueue, nanos, false)
+      case _ => externalHelpQuiescePool(nanos, false)
+    }
+    q > 0
+  }
+
+  @throws[InterruptedException]
+  private def compensatedBlock(blocker: ManagedBlocker): Unit = {
+    if (blocker == null) throw new NullPointerException()
+
+    @tailrec
+    def loop(): Unit = {
+      val c = ctl
+      if (blocker.isReleasable()) return ()
+
+      val comp = tryCompensate(c)
+      if (comp >= 0) {
+        val post = if (comp == 0) 0L else RC_UNIT
+        val done =
+          try blocker.block()
+          finally getAndAddCtl(post)
+        if (done) return ()
+        else loop()
+      }
+    }
+
+    loop()
+  }
+
+  // AbstractExecutorService.newTaskFor overrides rely on
+  // undocumented fact that ForkJoinTask.adapt returns ForkJoinTasks
+  // that also implement RunnableFuture.
+
+  override protected[concurrent] def newTaskFor[T](
+      runnable: Runnable,
+      value: T
+  ): RunnableFuture[T] =
+    new ForkJoinTask.AdaptedRunnable[T](runnable, value)
+
+  override protected[concurrent] def newTaskFor[T](
+      callable: Callable[T]
+  ): RunnableFuture[T] =
+    new ForkJoinTask.AdaptedCallable[T](callable)
+}
+
+object ForkJoinPool {
+
+  trait ForkJoinWorkerThreadFactory {
+
+    def newThread(pool: ForkJoinPool): ForkJoinWorkerThread
+  }
+
+  final class DefaultForkJoinWorkerThreadFactory
+      extends ForkJoinWorkerThreadFactory {
+    override final def newThread(pool: ForkJoinPool): ForkJoinWorkerThread =
+      new ForkJoinWorkerThread(null, pool, true, false)
+  }
+
+  final private[concurrent] class DefaultCommonPoolForkJoinWorkerThreadFactory
+      extends ForkJoinWorkerThreadFactory {
+
+    override final def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
+      // if (System.getSecurityManager() == null)
+      new ForkJoinWorkerThread(null, pool, true, true)
+      // else
+      // new ForkJoinWorkerThread.InnocuousForkJoinWorkerThread(pool)
+    }
+  }
+  // Constants shared across ForkJoinPool and WorkQueue
+
+// Bounds
+  private[concurrent] final val SWIDTH = 16 // width of short
+  private[concurrent] final val SMASK = 0xffff // short bits == max index
+  private[concurrent] final val MAX_CAP = 0x7fff // max #workers - 1
+// Masks and units for WorkQueue.phase and ctl sp subfield
+  final val UNSIGNALLED = 1 << 31 // must be negative
+  final val SS_SEQ = 1 << 16 // version count
+
+  // Mode bits and sentinels, some also used in WorkQueue fields
+  final val FIFO = 1 << 16 // fifo queue or access mode
+  final val SRC = 1 << 17 // set for valid queue ids
+  final val INNOCUOUS = 1 << 18 // set for Innocuous workers
+  final val QUIET = 1 << 19 // quiescing phase or source
+  final val SHUTDOWN = 1 << 24
+  final val TERMINATED = 1 << 25
+  final val STOP = 1 << 31 // must be negative
+  final val UNCOMPENSATE = 1 << 16 // tryCompensate return
+
+  private[concurrent] final val INITIAL_QUEUE_CAPACITY: Int = 1 << 8
+
+  private[concurrent] object WorkQueue {
+    // Support for atomic operations
+    import scala.scalanative.libc.atomic.memory_order._
+    @alwaysinline
+    private def arraySlotAtomicAccess[T <: AnyRef](
+        a: Array[T],
+        idx: Int
+    ): CAtomicRef[T] = {
+      val nativeArray = a.asInstanceOf[ObjectArray]
+      val elemRef = nativeArray.at(idx).asInstanceOf[Ptr[T]]
+      new CAtomicRef[T](elemRef)
+    }
+
+    private[concurrent] def getSlot(
+        a: Array[ForkJoinTask[_]],
+        i: Int
+    ): ForkJoinTask[_] = {
+      arraySlotAtomicAccess(a, i).load(memory_order_acquire)
+    }
+
+    @alwaysinline
+    private[concurrent] def getAndClearSlot(
+        a: Array[ForkJoinTask[_]],
+        i: Int
+    ): ForkJoinTask[_] = {
+      arraySlotAtomicAccess(a, i).exchange(null: ForkJoinTask[_])
+    }
+
+    private[concurrent] def setSlotVolatile(
+        a: Array[ForkJoinTask[_]],
+        i: Int,
+        v: ForkJoinTask[_]
+    ): Unit = {
+      arraySlotAtomicAccess(a, i).store(v)
+    }
+
+    private[concurrent] def casSlotToNull(
+        a: Array[ForkJoinTask[_]],
+        i: Int,
+        c: ForkJoinTask[_]
+    ): Boolean = {
+      arraySlotAtomicAccess(a, i)
+        .compareExchangeWeak(c, null: ForkJoinTask[_])
+    }
+  }
+
+  final class WorkQueue private (
+      private[concurrent] val owner: Option[ForkJoinWorkerThread]
+  ) {
+    // versioned, negative if inactive
+    @volatile private[concurrent] var phase: Int = 0
+    // source queue id, lock, or sentinel
+    @volatile private[concurrent] var source: Int = 0
+    private val sourceAtomic = new CAtomicInt(
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "source"))
+    )
+
+    // index, mode, ORed with SRC after init
+    private[concurrent] var config: Int = 0
+
+    // the queued tasks power of 2 size
+    private[concurrent] var array: Array[ForkJoinTask[_]] = _
+
+    // pool stack (ctl) predecessor link
+    private[concurrent] var stackPred: Int = 0
+    // index of next slot for poll
+    @volatile private[concurrent] var base: Int = 0
+    private[ForkJoinPool] val baseAtomic = new CAtomicInt(
+      fromRawPtr[Int](Intrinsics.classFieldRawPtr(this, "base"))
+    )
+    private[concurrent] var top: Int = 0 // index of next slot for push
+    private[concurrent] var nsteals: Int = 0 // steals from other queues
+
+    def this(owner: ForkJoinWorkerThread, isInnocuous: Boolean) = {
+      this(Some(owner))
+      this.config = if (isInnocuous) INNOCUOUS else 0
+    }
+
+    def this(config: Int) = {
+      this(owner = None)
+      this.array = new Array[ForkJoinTask[_]](INITIAL_QUEUE_CAPACITY)
+      this.config = config
+      this.phase = -1
+    }
+
+    @alwaysinline
+    final def tryLock(): Boolean = sourceAtomic.compareExchangeStrong(0, 1)
+
+    @alwaysinline
+    final def setBaseOpaque(b: Int): Unit = {
+      import scala.scalanative.libc.atomic.memory_order.memory_order_relaxed
+      baseAtomic.store(b, memory_order_relaxed)
+    }
+
+    final def getPoolIndex(): Int =
+      (config & 0xffff) >>> 1 // ignore odd/even tag bit
+
+    final def queueSize(): Int = {
+      VarHandle.acquireFence() // ensure fresh reads by external callers
+      val n = top - base
+      n.max(0) // ignore transient negative
+    }
+
+    final def isEmpty(): Boolean =
+      !((source != 0 && owner.isEmpty) || top - base > 0)
+
+    final def push(task: ForkJoinTask[_], pool: ForkJoinPool): Unit = {
+      val a = array
+      val s = top
+      top += 1
+      val d = s - base
+      val cap = if (a != null) a.length else 0
+      // skip insert if disabled
+      if (pool != null && cap > 0) {
+        val m = cap - 1
+        WorkQueue.setSlotVolatile(a, m & s, task)
+        val shouldGrowArray = d == m
+        if (shouldGrowArray)
+          growArray()
+        if (shouldGrowArray || a(m & (s - 1)) == null)
+          pool.signalWork() // signal if was empty or resized
+      }
+    }
+
+    final def lockedPush(task: ForkJoinTask[_]): Boolean = {
+      val a = array
+      val s = top
+      top += 1
+      val d = s - base
+      val cap = if (a != null) a.length else 0
+      if (cap > 0) {
+        val m = cap - 1
+        a(m & s) = task
+        def shouldGrowArray = d == m
+        if (shouldGrowArray) growArray()
+        source = 0 // unlock
+        if (shouldGrowArray || a(m & (s - 1)) == null)
+          return true
+      }
+      false
+    }
+
+    final def growArray(): Unit = {
+      val oldArray = array
+      val oldCap = if (oldArray != null) oldArray.length else 0
+      val newCap = oldCap << 1
+      val s = top - 1
+      if (oldCap > 0 && newCap > 0) { // skip if disabled
+        val newArray: Array[ForkJoinTask[_]] =
+          try new Array[ForkJoinTask[_]](newCap)
+          catch {
+            case ex: Throwable =>
+              top = s
+              if (owner.isEmpty) {
+                source = 0 // unlock
+              }
+              throw new RejectedExecutionException("Queue capacity exceeded")
+          }
+
+        val newMask = newCap - 1
+        val oldMask = oldCap - 1
+
+        @tailrec
+        def loop(k: Int, s: Int): Unit = {
+          if (k > 0) {
+            // poll old, push to new
+            getAndClearSlot(oldArray, s & oldMask) match {
+              case null => () // break, others already taken
+              case task =>
+                newArray(s & newMask) = task
+                loop(k = k - 1, s = s - 1)
+            }
+          }
+        }
+
+        loop(oldCap, s)
+
+        VarHandle.releaseFence() // fill before publish
+        array = newArray
+      }
+    }
+
+    private[concurrent] def pop(): ForkJoinTask[_] = {
+      val a = array
+      val cap = if (a != null) a.length else 0
+      val curTop = top
+      val s = curTop - 1
+      val t =
+        if (cap > 0 && base != curTop)
+          WorkQueue.getAndClearSlot(a, (cap - 1) & s)
+        else null
+      if (t != null) top = s
+      t
+    }
+
+    final def tryUnpush(task: ForkJoinTask[_]): Boolean = {
+      val s = top
+      val newS = s - 1
+      val a = array
+      val cap = if (a != null) a.length else 0
+      if (cap > 0 &&
+          base != s &&
+          WorkQueue.casSlotToNull(a, (cap - 1) & newS, task)) {
+        top = newS
+        true
+      } else false
+    }
+
+    final def externalTryUnpush(task: ForkJoinTask[_]): Boolean = {
+      while (true) {
+        val s = top
+        val a = array
+        val cap = if (a != null) a.length else 0
+        val k = (cap - 1) & (s - 1)
+        if (cap <= 0 || a(k) != task) return false
+        else if (tryLock()) {
+          if (top == s && array == a) {
+            if (WorkQueue.casSlotToNull(a, k, task))
+              top = s - 1
+            source = 0
+            return true
+          }
+          source = 0 // release lock for retry
+        }
+        Thread.`yield`() // trylock failure
+      }
+      false
+    }
+
+    final def tryRemove(task: ForkJoinTask[_], owned: Boolean): Boolean = {
+      val p = top
+      val a = array
+      val cap = if (a != null) a.length else 0
+      var taken = false
+
+      if (task != null && cap > 0) {
+        val m = cap - 1
+        val s = p - 1
+        val d = p - base
+
+        @tailrec
+        def loop(i: Int, d: Int): Unit = {
+          val k = i & m
+          a(k) match {
+            case `task` =>
+              if (owned || tryLock()) {
+                if ((owned || (array == a && top == p)) &&
+                    WorkQueue.casSlotToNull(a, k, task)) {
+                  for (j <- i.until(s)) {
+                    a(j & m) = getAndClearSlot(a, (j + 1) & m)
+                  }
+                  top = s
+                  taken = true
+                }
+                if (!owned) source = 0
+              }
+
+            case _ =>
+              if (d > 0) loop(i - 1, d - 1)
+          }
+        }
+
+        loop(i = s, d = d)
+      }
+
+      taken
+    }
+
+    // variants of poll
+
+    final def tryPoll(): ForkJoinTask[_] = {
+      val a = array
+      val cap = if (a != null) a.length else 0
+
+      val b = base
+      val k = (cap - 1) & b
+      if (cap > 0) {
+        val task = WorkQueue.getSlot(a, k)
+        if (base == b &&
+            task != null &&
+            WorkQueue.casSlotToNull(a, k, task)) {
+          setBaseOpaque(b + 1)
+          return task
+        }
+      }
+      null
+    }
+
+    final def nextLocalTask(cfg: Int): ForkJoinTask[_] = {
+      val a = array
+      val cap = if (a != null) a.length else 0
+      val mask = cap - 1
+      var currentTop = top
+
+      @tailrec
+      def loop(): ForkJoinTask[_] = {
+        var currentBase = base
+
+        val d = currentTop - currentBase
+        if (d <= 0) null
+        else {
+          def tryTopSlot(): Option[ForkJoinTask[_]] = {
+            currentTop -= 1
+            Option(getAndClearSlot(a, currentTop & mask))
+              .map { task =>
+                top = currentTop
+                task
+              }
+          }
+
+          def tryBaseSlot(): Option[ForkJoinTask[_]] = {
+            val b = currentBase
+            currentBase += 1
+            Option(getAndClearSlot(a, b & mask))
+              .map { task =>
+                setBaseOpaque(currentBase)
+                task
+              }
+          }
+
+          if (d == 1 || (cfg & FIFO) == 0)
+            tryTopSlot().orNull
+          else
+            tryBaseSlot() match {
+              case Some(value) => value
+              case None        => loop()
+            }
+        }
+      }
+
+      if (cap > 0) loop()
+      else null
+    }
+
+    final def nextLocalTask(): ForkJoinTask[_] =
+      nextLocalTask(config)
+
+    final def peek(): ForkJoinTask[_] = {
+      VarHandle.acquireFence()
+      // int cap Array[ForkJoinTask[_]]()  a
+      val a = array
+      val cap = if (a != null) a.length else 0
+      if (cap > 0) {
+        val mask = if ((config & FIFO) != 0) base else top - 1
+        a((cap - 1) & mask)
+      } else null: ForkJoinTask[_]
+    }
+
+    // specialized execution methods
+
+    final def topLevelExec(task: ForkJoinTask[_], q: WorkQueue): Unit = {
+      val cfg = config
+      var currentTask = task
+      var nStolen = 1
+      while (currentTask != null) {
+        currentTask.doExec()
+        currentTask = nextLocalTask(cfg)
+        currentTask match {
+          case null if q != null =>
+            currentTask = q.tryPoll()
+            if (currentTask != null) {
+              nStolen += 1
+            }
+          case _ => ()
+        }
+      }
+      nsteals += nStolen
+      source = 0
+      if ((cfg & INNOCUOUS) != 0) {
+        ThreadLocalRandom.eraseThreadLocals(Thread.currentThread())
+      }
+    }
+
+    final private[concurrent] def helpComplete(
+        task: ForkJoinTask[_],
+        owned: Boolean,
+        limit: Int
+    ): Int = {
+      var taken = false
+
+      @tailrec def loop(limit: Int): Int = {
+        val status = task.status
+        val a = array
+        val cap = if (a != null) a.length else 0
+        val p = top
+        val s = p - 1
+        val k = (cap - 1) & s
+        val t = if (cap > 0) a(k) else null
+
+        @tailrec
+        def doTryComplete(current: CountedCompleter[_]): Unit =
+          current match {
+            case `task` =>
+              @alwaysinline def tryTakeTask() = {
+                taken = WorkQueue.casSlotToNull(a, k, t); taken
+              }
+              if (owned) {
+                if (tryTakeTask()) top = s
+              } else if (tryLock()) {
+                if (top == p && array == a && tryTakeTask()) top = s
+                source = 0
+              }
+
+            case _ =>
+              val next = current.completer
+              if (next != null) doTryComplete(next)
+          }
+
+        t match {
+          case completer: CountedCompleter[_] if status >= 0 =>
+            taken = false
+            doTryComplete(completer)
+            if (!taken) status
+            else {
+              t.doExec()
+              val nextLimit = limit - 1
+              if (limit != 0 && nextLimit == 0) status
+              else loop(nextLimit)
+            }
+
+          case _ => status
+        }
+      }
+
+      if (task == null) 0
+      else loop(limit)
+    }
+
+    final private[concurrent] def helpAsyncBlocker(
+        blocker: ManagedBlocker
+    ): Unit = {
+      var cap: Int = 0
+      var b: Int = 0
+      var d: Int = 0
+      var k: Int = 0
+      var a: Array[ForkJoinTask[_]] = null
+      var t: ForkJoinTask[_] = null
+      while ({
+        blocker != null && { b = base; d = top - b; d > 0 } && {
+          a = array; a != null
+        } && { cap = a.length; cap > 0 } && {
+          k = (cap - 1) & b; t = WorkQueue.getSlot(a, k);
+          t == null && d > 1 || t
+            .isInstanceOf[CompletableFuture.AsynchronousCompletionTask]
+        } && !blocker.isReleasable()
+      }) {
+        if (t != null &&
+            base == { val b2 = b; b += 1; b2 } &&
+            WorkQueue.casSlotToNull(a, k, t)) {
+          setBaseOpaque(b)
+          t.doExec()
+        }
+      }
+    }
+
+    // misc
+
+    final def initializeInnocuousWorker(): Unit = {
+      val t = Thread.currentThread()
+      ThreadLocalRandom.eraseThreadLocals(t)
+    }
+
+    final def isApparentlyUnblocked(): Boolean = {
+      owner
+        .map(_.getState())
+        .exists { s =>
+          s != Thread.State.BLOCKED &&
+          s != Thread.State.WAITING &&
+          s != Thread.State.TIMED_WAITING
+        }
+    }
+  }
+
+  // TODO should be final, but it leads to problems with static forwarders
+  final val defaultForkJoinWorkerThreadFactory: ForkJoinWorkerThreadFactory =
+    new DefaultForkJoinWorkerThreadFactory()
+
+  private[concurrent] object common
+      extends ForkJoinPool(
+        factory = new DefaultCommonPoolForkJoinWorkerThreadFactory(),
+        ueh = null,
+        saturate = null,
+        keepAlive = DEFAULT_KEEPALIVE,
+        workerNamePrefix = null
+      ) {
+    val parallelism = Runtime.getRuntime().availableProcessors() - 1
+    this.mode = Math.min(Math.max(parallelism, 0), MAX_CAP)
+    val p = this.mode
+    val size = 1 << (33 - Integer.numberOfLeadingZeros((p - 1)))
+    this.bounds = ((1 - p) & SMASK) | (COMMON_MAX_SPARES << SWIDTH)
+    this.ctl = ((((-p).toLong) << TC_SHIFT) & TC_MASK) |
+      ((((-p).toLong) << RC_SHIFT) & RC_MASK)
+    this.queues = new Array[WorkQueue](size)
+  }
+
+  private[concurrent] lazy val COMMON_PARALLELISM =
+    Math.max(common.mode & SMASK, 1)
+
+  private[concurrent] lazy val COMMON_MAX_SPARES = DEFAULT_COMMON_MAX_SPARES
+
+  private val poolIds: AtomicInteger = new AtomicInteger(0)
+
+  private final val DEFAULT_KEEPALIVE = 60000L
+
+  private final val TIMEOUT_SLOP = 20L
+
+  /** The default value for COMMON_MAX_SPARES. Overridable using the
+   *  "java.util.concurrent.common.maximumSpares" system property. The default
+   *  value is far in excess of normal requirements, but also far short of
+   *  MAX_CAP and typical OS thread limits, so allows JVMs to catch misuse/abuse
+   *  before running out of resources needed to do so.
+   */
+  private val DEFAULT_COMMON_MAX_SPARES: Int = 256
+  // Lower and upper word masks
+  private val SP_MASK: Long = 0xffffffffL
+  private val UC_MASK: Long = ~(SP_MASK)
+  // Release counts
+  private val RC_SHIFT: Int = 48
+  private val RC_UNIT: Long = 0x0001L << RC_SHIFT
+  private val RC_MASK: Long = 0xffffL << RC_SHIFT
+  // Total counts
+  private val TC_SHIFT: Int = 32
+  private val TC_UNIT: Long = 0x0001L << TC_SHIFT
+  private val TC_MASK: Long = 0xffffL << TC_SHIFT
+  private val ADD_WORKER: Long = 0x0001L << (TC_SHIFT + 15) // sign
+
+  private def getAndAddPoolIds(x: Int): Int =
+    poolIds.getAndAdd(x)
+
+  private[concurrent] def commonQueue(): WorkQueue = {
+    val p = common
+    val qs = if (p != null) p.queues else null
+    val r: Int = ThreadLocalRandom.getProbe()
+    var n: Int = if (qs != null) qs.length else 0
+    if (n > 0 && r != 0) qs((n - 1) & (r << 1))
+    else null
+  }
+
+  private[concurrent] def helpAsyncBlocker(
+      e: Executor,
+      blocker: ManagedBlocker
+  ): Unit = {
+    Thread.currentThread() match {
+      case wt: ForkJoinWorkerThread =>
+        val w =
+          if (wt.pool eq e) wt.workQueue
+          else if (e eq common) commonQueue()
+          else null
+        if (w != null) w.helpAsyncBlocker(blocker)
+    }
+  }
+
+  private[concurrent] def getSurplusQueuedTaskCount(): Int = {
+    Thread.currentThread() match {
+      case wt: ForkJoinWorkerThread
+          if wt.pool != null && wt.workQueue != null =>
+        val pool = wt.pool
+        val q = wt.workQueue
+        var p: Int = pool.mode & SMASK
+        val a: Int = p + (pool.ctl >> RC_SHIFT).toInt
+        val n: Int = q.top - q.base
+        n - (if (a > { p >>>= 1; p }) 0
+             else if (a > { p >>>= 1; p }) 1
+             else if (a > { p >>>= 1; p }) 2
+             else if (a > { p >>>= 1; p }) 4
+             else 8)
+      case _ => 0
+    }
+  }
+
+  def commonPool(): ForkJoinPool = common
+  // assert common != null : "static init error";
+
+  // Task to hold results from InvokeAnyTasks
+  @SerialVersionUID(2838392045355241008L)
+  final private[concurrent] class InvokeAnyRoot[E](val n: Int)
+      extends ForkJoinTask[E] {
+    @volatile private[concurrent] var result: E = _
+    final private[concurrent] val count: AtomicInteger = new AtomicInteger(n)
+    final private[concurrent] def tryComplete(c: Callable[E]): Unit = { // called by InvokeAnyTasks
+      var ex: Throwable = null
+      var failed: Boolean = false
+      if (c != null) { // raciness OK
+        if (isCancelled()) failed = true
+        else if (!isDone())
+          try complete(c.call())
+          catch {
+            case tx: Throwable =>
+              ex = tx
+              failed = true
+          }
+      }
+      if (failed && count.getAndDecrement() <= 1) {
+        trySetThrown(
+          if (ex != null) ex
+          else new CancellationException
+        )
+      }
+    }
+    override final def exec(): Boolean = false // never forked
+    override final def getRawResult(): E = result
+    override final def setRawResult(v: E): Unit = result = v
+  }
+
+// Variant of AdaptedInterruptibleCallable with results in InvokeAnyRoot
+  @SerialVersionUID(2838392045355241008L)
+  final private[concurrent] class InvokeAnyTask[E](
+      root: InvokeAnyRoot[E],
+      callable: Callable[E]
+  ) extends ForkJoinTask[E] {
+    @volatile var runner: Thread = _
+
+    override final def exec(): Boolean = {
+      Thread.interrupted()
+      runner = Thread.currentThread()
+      root.tryComplete(callable)
+      runner = null
+      Thread.interrupted()
+      true
+    }
+
+    override final def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      val stat = super.cancel(false)
+      if (mayInterruptIfRunning) runner match {
+        case null => ()
+        case t =>
+          try t.interrupt()
+          catch { case ignore: Throwable => () }
+      }
+      stat
+    }
+    override final def setRawResult(v: E): Unit = () // unused
+    override final def getRawResult(): E = null.asInstanceOf[E]
+  }
+
+  def getCommonPoolParallelism(): Int = COMMON_PARALLELISM
+
+  trait ManagedBlocker {
+
+    @throws[InterruptedException]
+    def block(): Boolean
+
+    def isReleasable(): Boolean
+  }
+
+  @throws[InterruptedException]
+  def managedBlock(blocker: ManagedBlocker): Unit = {
+    Thread.currentThread() match {
+      case thread: ForkJoinWorkerThread if thread.pool != null =>
+        thread.pool.compensatedBlock(blocker)
+      case _ => unmanagedBlock(blocker)
+    }
+  }
+
+  @throws[InterruptedException]
+  private def unmanagedBlock(blocker: ManagedBlocker): Unit = {
+    if (blocker == null) throw new NullPointerException()
+
+    while (!blocker.isReleasable() && !blocker.block()) {
+      ()
+    }
+  }
+
 }

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
@@ -1,0 +1,757 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+import java.io.Serializable
+import java.util._
+import java.util.RandomAccess
+import java.util.concurrent.locks.LockSupport
+
+import scala.scalanative.libc.atomic._
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
+import scala.scalanative.unsafe.{Ptr, stackalloc}
+
+import scala.annotation.tailrec
+
+abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
+  import ForkJoinTask._
+
+  // Fields
+  // accessed directly by pool and workers
+  @volatile private[concurrent] var status: Int = 0
+  @volatile private var aux: Aux = _ // either waiters or thrown Exception
+
+  // Support for atomic operations
+  private val statusAtomic = new CAtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "status"))
+  )
+  private val auxAtomic = new CAtomicRef[Aux](
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "aux"))
+  )
+  private def casStatus(expected: Int, value: Int): Boolean =
+    statusAtomic.compareExchangeWeak(expected, value)
+  private def getAndBitwiseOrStatus(v: Int): Int = statusAtomic.fetchOr(v)
+  private def casAux(c: Aux, v: Aux): Boolean =
+    auxAtomic.compareExchangeStrong(c, v)
+
+  @tailrec
+  private def signalWaiters(): Unit = {
+    @tailrec
+    def unparkThreads(a: Aux): Unit = {
+      if (a != null) {
+        val t = a.thread
+        if (t != Thread.currentThread() && t != null) {
+          LockSupport.unpark(t)
+        }
+        unparkThreads(a.next)
+      }
+    }
+
+    aux match {
+      case null => ()
+      case a =>
+        if (a.ex == null) {
+          if (casAux(a, null)) unparkThreads(a)
+          else signalWaiters()
+        }
+    }
+  }
+
+  private def setDone() = {
+    val s = getAndBitwiseOrStatus(DONE) | DONE
+    signalWaiters()
+    s
+  }
+
+  private def trySetCancelled(): Int = {
+    var s = status
+    while ({
+      s = status
+      s >= 0 && {
+        val prevStatus = s
+        s |= (DONE | ABNORMAL)
+        !casStatus(prevStatus, s)
+      }
+    }) ()
+    signalWaiters()
+    s
+  }
+
+  private[concurrent] final def trySetThrown(ex: Throwable): Int = {
+    val h = new Aux(Thread.currentThread(), ex)
+    var p: Aux = null
+    var installed = false
+    var s = status
+    var break = false
+    while (!break && { s = status; s >= 0 }) {
+      val a = aux
+      if (!installed && {
+            (a == null || a.ex == null) && {
+              installed = casAux(a, h)
+              installed
+            }
+          }) p = a // list of waiters replaced by h
+      if (installed && casStatus(s, { s |= (DONE | ABNORMAL | THROWN); s }))
+        break = true
+    }
+    while (p != null) {
+      LockSupport.unpark(p.thread)
+      p = p.next
+    }
+    s
+  }
+
+  private[concurrent] def trySetException(ex: Throwable) = trySetThrown(ex)
+
+  private[concurrent] final def doExec(): Int = {
+    var s = status
+    if (s >= 0) {
+      val completed =
+        try exec()
+        catch {
+          case rex: Throwable =>
+            s = trySetException(rex)
+            false
+        }
+      if (completed) s = setDone()
+    }
+    s
+  }
+
+  private def awaitJoin(
+      ran: Boolean,
+      _interruptible: Boolean,
+      timed: Boolean,
+      nanos: Long
+  ): Int = {
+    var interruptible = _interruptible
+    val (internal, p, q) = Thread.currentThread() match {
+      case wt: ForkJoinWorkerThread => (true, wt.pool, wt.workQueue)
+      case _ =>
+        if (interruptible && Thread.interrupted()) return ABNORMAL
+        (false, ForkJoinPool.common, ForkJoinPool.commonQueue())
+    }
+    var s = status
+    if (s < 0) return s
+    var deadline = 0L
+    if (timed) {
+      if (nanos <= 0L) return 0
+      else deadline = (nanos + System.nanoTime()).max(1L)
+    }
+
+    var uncompensate: ForkJoinPool = null
+    if (q != null && p != null) { // try helping
+      if ((!timed || p.isSaturated()) && {
+            this match {
+              case c: CountedCompleter[_] =>
+                s = p.helpComplete(this, q, internal)
+                s < 0
+              case _ =>
+                q.tryRemove(this, internal) && {
+                  s = doExec()
+                  s < 0
+                }
+            }
+          }) return s
+
+      if (internal) {
+        s = p.helpJoin(this, q)
+        if (s < 0) return s
+        if (s == UNCOMPENSATE) uncompensate = p
+        interruptible = false;
+      }
+    }
+    awaitDone(interruptible, deadline, uncompensate)
+  }
+
+  private def awaitDone(
+      interruptible: Boolean,
+      deadline: Long,
+      pool: ForkJoinPool
+  ): Int = {
+    var s = 0
+    var interrupted = false
+    var queued = false
+    var parked = false
+    var node: Aux = null
+    var break = false
+    while (!break && { s = status; s >= 0 }) {
+      if (parked && Thread.interrupted()) {
+        if (interruptible) {
+          s = ABNORMAL
+          break = true
+        } else
+          interrupted = true
+      } else if (queued) {
+        if (deadline != 0L) {
+          val ns = deadline - System.nanoTime()
+          if (ns <= 0L) break = true
+          else LockSupport.parkNanos(ns)
+        } else LockSupport.park()
+        parked = true
+      } else if (node != null) {
+        val a = aux
+        if (a != null && a.ex != null)
+          Thread.onSpinWait() // exception in progress
+        else {
+          node.next = a
+          queued = casAux(a, node)
+          if (queued) LockSupport.setCurrentBlocker(this)
+        }
+      } else {
+        try node = new Aux(Thread.currentThread(), null)
+        catch {
+          // try to cancel if cannot create
+          case ex: Throwable => casStatus(s, s | DONE | ABNORMAL)
+        }
+      }
+    }
+
+    if (pool != null) pool.uncompensate()
+    if (queued) {
+      LockSupport.setCurrentBlocker(null)
+      if (s >= 0) { // cancellation similar to AbstractQueuedSynchronizer
+        // outer // todo: labels are not supported
+        var a = aux
+        var breakOuter = false
+        while (!breakOuter && { a = aux; a != null && a.ex == null }) {
+          var trail: Aux = null
+          var break = false
+          while (!break || !breakOuter) {
+            val next = a.next
+            if (a == node) {
+              if (trail != null) trail.casNext(trail, next)
+              else if (casAux(a, next)) breakOuter = true
+              break = true // restart
+            } else {
+
+              trail = a
+              a = next
+              if (next == null) breakOuter = true
+            }
+          }
+        }
+      } else {
+        signalWaiters() // help clean or signal
+        if (interrupted) Thread.currentThread().interrupt()
+      }
+    }
+    s
+  }
+
+  private def getThrowableException(): Throwable = {
+    val a = aux
+    val ex = if (a != null) a.ex else null
+    // if(ex != nulll && a.thread != Thread.currentThread()){
+    //   // JSR166 used reflective initialization here
+    // }
+    ex
+  }
+
+  private def getException(s: Int): Throwable = {
+    var ex: Throwable = null
+    if ((s & ABNORMAL) != 0 && {
+          (s & THROWN) == 0 || {
+            ex = getThrowableException()
+            ex == null
+          }
+        }) ex = new CancellationException()
+    ex
+  }
+
+  private def reportException(s: Int): Unit = {
+    uncheckedThrow[RuntimeException](
+      if ((s & THROWN) != 0) getThrowableException()
+      else null
+    )
+  }
+
+  private def reportExecutionException(s: Int): Unit = {
+    val exception: Throwable =
+      if (s == ABNORMAL) new InterruptedException()
+      else if (s >= 0) new TimeoutException()
+      else if ((s & THROWN) != 0) {
+        getThrowableException() match {
+          case null => null
+          case ex   => new ExecutionException(ex)
+        }
+      } else null
+    uncheckedThrow[RuntimeException](exception)
+  }
+
+  final def fork(): ForkJoinTask[V] = {
+    Thread.currentThread() match {
+      case worker: ForkJoinWorkerThread =>
+        worker.workQueue.push(this, worker.pool)
+      case _ =>
+        ForkJoinPool.commonPool().externalPush(this)
+    }
+    this
+  }
+
+  final def join(): V = {
+    var s = status
+    if (s >= 0) s = awaitJoin(false, false, false, 0L)
+    if ((s & ABNORMAL) != 0) reportException(s)
+    getRawResult()
+  }
+
+  final def invoke(): V = {
+    var s = doExec()
+    if (s >= 0) {
+      s = awaitJoin(true, false, false, 0L)
+    }
+    if ((s & ABNORMAL) != 0) reportException(s)
+    getRawResult()
+  }
+
+  override def cancel(mayInterruptIfRunning: Boolean): Boolean =
+    (trySetCancelled() & (ABNORMAL | THROWN)) == ABNORMAL
+  override final def isDone(): Boolean = status < 0
+  override final def isCancelled(): Boolean =
+    (status & (ABNORMAL | THROWN)) == ABNORMAL
+
+  final def isCompletedAbnormally(): Boolean = (status & ABNORMAL) != 0
+
+  final def isCompletedNormally(): Boolean =
+    (status & (DONE | ABNORMAL)) == DONE
+
+  final def getException(): Throwable = getException(status)
+
+  def completeExceptionally(ex: Throwable): Unit = trySetException {
+    ex match {
+      case _: RuntimeException | _: Error => ex
+      case ex                             => new RuntimeException(ex)
+    }
+  }
+
+  def complete(value: V): Unit = {
+    try {
+      setRawResult(value)
+      setDone()
+    } catch {
+      case rex: Throwable => trySetException(rex)
+    }
+  }
+
+  final def quietlyComplete(): Unit = setDone()
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  override final def get(): V = {
+    val s = awaitJoin(false, true, false, 0L)
+    if ((s & ABNORMAL) != 0) reportExecutionException(s)
+    getRawResult()
+  }
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  @throws[TimeoutException]
+  override final def get(timeout: Long, unit: TimeUnit): V = {
+    val s = awaitJoin(false, true, true, unit.toNanos(timeout))
+    if (s >= 0 || (s & ABNORMAL) != 0) reportExecutionException(s)
+    getRawResult()
+  }
+
+  final def quietlyJoin(): Unit = {
+    if (status >= 0) awaitJoin(false, false, false, 0L)
+  }
+
+  final def quietlyInvoke(): Unit = {
+    if (doExec() >= 0) awaitJoin(true, false, false, 0L)
+  }
+
+  def reinitialize(): Unit = {
+    aux = null
+    status = 0
+  }
+
+  def tryUnfork(): Boolean = Thread.currentThread() match {
+    case worker: ForkJoinWorkerThread =>
+      val q = worker.workQueue
+      q != null && q.tryUnpush(this)
+    case _ =>
+      val q = ForkJoinPool.commonQueue()
+      q != null && q.externalTryUnpush(this)
+  }
+
+  def getRawResult(): V
+
+  protected def setRawResult(value: V): Unit
+
+  protected def exec(): Boolean
+
+  final def getForkJoinTaskTag(): Short = status.toShort
+
+  @tailrec
+  final def setForkJoinTaskTag(newValue: Short): Short = {
+    val s = status
+    if (casStatus(s, (s & ~SMASK) | (newValue & SMASK))) s.toShort
+    else setForkJoinTaskTag(newValue)
+  }
+
+  @tailrec
+  final def compareAndSetForkJoinTaskTag(
+      expect: Short,
+      update: Short
+  ): Boolean = {
+    val s = status
+    if (s.toShort != expect) false
+    else if (casStatus(s, (s & ~SMASK) | (update & SMASK))) true
+    else compareAndSetForkJoinTaskTag(expect, update)
+  }
+
+  @throws[java.io.IOException]
+  private def writeObject(s: java.io.ObjectOutputStream): Unit = {
+    val a = aux
+    s.defaultWriteObject()
+    s.writeObject(
+      if (a == null) null
+      else a.ex
+    )
+  }
+
+  @throws[java.io.IOException]
+  @throws[ClassNotFoundException]
+  private def readObject(s: java.io.ObjectInputStream): Unit = {
+    s.defaultReadObject()
+    val ex = s.readObject
+    if (ex != null) trySetThrown(ex.asInstanceOf[Throwable])
+  }
+}
+
+object ForkJoinTask {
+
+  final private[concurrent] class Aux private[concurrent] (
+      val thread: Thread,
+      val ex: Throwable // null if a waiter
+  ) {
+    @volatile var next: Aux = _
+    final private val nextAtomic =
+      new CAtomicRef[Aux](fromRawPtr(Intrinsics.classFieldRawPtr(this, "next")))
+    final def casNext(c: Aux, v: Aux) = nextAtomic.compareExchangeStrong(c, v)
+  }
+
+  private final val DONE = 1 << 31 // must be negative
+  private final val ABNORMAL = 1 << 16
+  private final val THROWN = 1 << 17
+  private final val SMASK = 0xffff // short bits for tags
+  private final val UNCOMPENSATE = 1 << 16 // helpJoin return sentinel
+
+  private[concurrent] def isExceptionalStatus(s: Int) = (s & THROWN) != 0
+
+  private[concurrent] def cancelIgnoringExceptions(t: Future[_]): Unit = {
+    if (t != null)
+      try t.cancel(true)
+      catch { case _: Throwable => () }
+  }
+
+  /** A version of "sneaky throw" to relay exceptions in other contexts.
+   */
+  private[concurrent] def rethrow(ex: Throwable): Unit = {
+    uncheckedThrow[RuntimeException](ex)
+  }
+
+  private[concurrent] def uncheckedThrow[T <: Throwable](t: Throwable): Unit = {
+    // In the Java t would need to be casted to T to satisfy exceptions handling
+    // however in Scala we don't have a checked exceptions so throw exception as it is
+    t match {
+      case null => throw new CancellationException()
+      case _    => throw t
+    }
+  }
+
+  def invokeAll(t1: ForkJoinTask[_], t2: ForkJoinTask[_]): Unit = {
+    if (t1 == null || t2 == null) throw new NullPointerException
+    t2.fork()
+    var s1 = t1.doExec()
+    if (s1 >= 0) s1 = t1.awaitJoin(true, false, false, 0L)
+    if ((s1 & ABNORMAL) != 0) {
+      cancelIgnoringExceptions(t2)
+      t1.reportException(s1)
+    } else {
+      var s2 = t2.awaitJoin(false, false, false, 0L)
+      if ((s2 & ABNORMAL) != 0)
+        t2.reportException(s2)
+    }
+  }
+
+  def invokeAll(tasks: Array[ForkJoinTask[_]]): Unit = {
+    var ex = null: Throwable
+    val last = tasks.length - 1
+    (last to 0 by -1).takeWhile { i =>
+      val t = tasks(i)
+      if (t == null) {
+        ex = new NullPointerException()
+        false
+      } else if (i == 0) {
+        var s = t.doExec()
+        if (s >= 0) s = t.awaitJoin(true, false, false, 0L)
+        if ((s & ABNORMAL) != 0) ex = t.getException(s)
+        false
+      } else {
+        t.fork()
+        true
+      }
+    }
+
+    if (ex == null) (1 to last).takeWhile { i =>
+      val t = tasks(i)
+      t == null || {
+        var s = t.status
+        if (s >= 0) s = t.awaitJoin(false, false, false, 0L)
+        if ((s & ABNORMAL) != 0) ex = t.getException(s)
+        ex == null
+      }
+    }
+    if (ex != null) {
+      for (i <- 1 to last) { cancelIgnoringExceptions(tasks(i)) }
+      rethrow(ex)
+    }
+  }
+
+  def invokeAll[T <: ForkJoinTask[_]](tasks: Collection[T]): Collection[T] = {
+    def invokeAllImpl(ts: java.util.List[_ <: ForkJoinTask[_]]): Unit = {
+      var ex: Throwable = null
+      val last = ts.size() - 1 // nearly same as array version
+      (last to 0 by -1).takeWhile { i =>
+        ts.get(i) match {
+          case null =>
+            ex = new NullPointerException()
+            false
+
+          case t if i == 0 =>
+            var s = t.doExec()
+            if (s >= 0) s = t.awaitJoin(true, false, false, 0L)
+            if ((s & ABNORMAL) != 0) ex = t.getException(s)
+            false
+
+          case t =>
+            t.fork()
+            true
+        }
+      }
+      if (ex == null) (1 to last).takeWhile { i =>
+        val t = ts.get(i)
+        t == null || {
+          var s = t.status
+          if (s >= 0) s = t.awaitJoin(false, false, false, 0L)
+          if ((s & ABNORMAL) != 0) {
+            ex = t.getException(s)
+          }
+          ex == null
+        }
+      }
+      if (ex != null) {
+        for (i <- 1 to last) cancelIgnoringExceptions((ts.get(i)))
+        rethrow(ex)
+      }
+    }
+
+    tasks match {
+      case list: java.util.List[T] with RandomAccess @unchecked =>
+        invokeAllImpl(list)
+      case _ =>
+        invokeAll(tasks.toArray(Array.empty[ForkJoinTask[_]]))
+    }
+    tasks
+  }
+
+  def helpQuiesce(): Unit = {
+    Thread.currentThread() match {
+      case t: ForkJoinWorkerThread if t.pool != null =>
+        t.pool.helpQuiescePool(t.workQueue, java.lang.Long.MAX_VALUE, false)
+      case _ =>
+        ForkJoinPool.common
+          .externalHelpQuiescePool(
+            java.lang.Long.MAX_VALUE,
+            false
+          )
+    }
+  }
+
+  def getPool(): ForkJoinPool = {
+    Thread.currentThread() match {
+      case t: ForkJoinWorkerThread => t.pool
+      case _                       => null
+    }
+  }
+
+  def inForkJoinPool(): Boolean =
+    Thread.currentThread().isInstanceOf[ForkJoinWorkerThread]
+
+  def getQueuedTaskCount(): Int = {
+    val q = Thread.currentThread() match {
+      case t: ForkJoinWorkerThread => t.workQueue
+      case _                       => ForkJoinPool.commonQueue()
+    }
+    if (q == null) 0 else q.queueSize()
+  }
+
+  def getSurplusQueuedTaskCount(): Int =
+    ForkJoinPool.getSurplusQueuedTaskCount()
+
+  protected def peekNextLocalTask(): ForkJoinTask[_] = {
+    val q = Thread.currentThread() match {
+      case t: ForkJoinWorkerThread => t.workQueue
+      case _                       => ForkJoinPool.commonQueue()
+    }
+    if (q == null) null else q.peek()
+  }
+
+  protected def pollNextLocalTask(): ForkJoinTask[_] = {
+    Thread.currentThread() match {
+      case t: ForkJoinWorkerThread => t.workQueue.nextLocalTask()
+      case _                       => null
+    }
+  }
+
+  protected def pollTask(): ForkJoinTask[_] =
+    Thread.currentThread() match {
+      case wt: ForkJoinWorkerThread => wt.pool.nextTaskFor(wt.workQueue)
+      case _                        => null
+    }
+
+  protected def pollSubmission(): ForkJoinTask[_] =
+    Thread.currentThread() match {
+      case t: ForkJoinWorkerThread => t.pool.pollSubmission()
+      case _                       => null
+    }
+
+  @SerialVersionUID(5232453952276885070L)
+  final private[concurrent] class AdaptedRunnable[T] private[concurrent] (
+      val runnable: Runnable,
+      var result: T
+  ) // OK to set this even before completion
+      extends ForkJoinTask[T]
+      with RunnableFuture[T] {
+    if (runnable == null) throw new NullPointerException
+    override final def getRawResult(): T = result
+    override final def setRawResult(v: T): Unit = { result = v }
+    override final def exec(): Boolean = {
+      runnable.run()
+      true
+    }
+    override final def run(): Unit = invoke()
+    override def toString(): String =
+      super.toString + "[Wrapped task = " + runnable + "]"
+  }
+
+  @SerialVersionUID(5232453952276885070L)
+  final private[concurrent] class AdaptedRunnableAction private[concurrent] (
+      val runnable: Runnable
+  ) extends ForkJoinTask[Void]
+      with RunnableFuture[Void] {
+    if (runnable == null) throw new NullPointerException
+    override final def getRawResult(): Void = null
+    override final def setRawResult(v: Void): Unit = {}
+    override final def exec(): Boolean = {
+      runnable.run()
+      true
+    }
+    override final def run(): Unit = invoke()
+    override def toString(): String =
+      super.toString + "[Wrapped task = " + runnable + "]"
+  }
+
+  @SerialVersionUID(5232453952276885070L)
+  final private[concurrent] class RunnableExecuteAction private[concurrent] (
+      val runnable: Runnable
+  ) extends ForkJoinTask[Void] {
+    if (runnable == null) throw new NullPointerException
+    override final def getRawResult(): Void = null
+    override final def setRawResult(v: Void): Unit = ()
+    override final def exec(): Boolean = {
+      runnable.run()
+      true
+    }
+    override private[concurrent] def trySetException(ex: Throwable) = {
+// if a handler, invoke it
+      val s: Int = trySetThrown(ex)
+      if (isExceptionalStatus(s)) {
+        val t: Thread = Thread.currentThread()
+        val h: Thread.UncaughtExceptionHandler = t.getUncaughtExceptionHandler()
+        if (h != null)
+          try h.uncaughtException(t, ex)
+          catch { case _: Throwable => () }
+      }
+      s
+    }
+  }
+
+  @SerialVersionUID(2838392045355241008L)
+  final private[concurrent] class AdaptedCallable[T] private[concurrent] (
+      val callable: Callable[T]
+  ) extends ForkJoinTask[T]
+      with RunnableFuture[T] {
+    if (callable == null) throw new NullPointerException
+    private[concurrent] var result: T = _
+    override final def getRawResult() = result
+    override final def setRawResult(v: T): Unit = result = v
+    override final def exec(): Boolean = try {
+      result = callable.call()
+      true
+    } catch {
+      case rex: RuntimeException => throw rex
+      case ex: Exception         => throw new RuntimeException(ex)
+    }
+    override final def run(): Unit = invoke()
+    override def toString(): String =
+      super.toString + "[Wrapped task = " + callable + "]"
+  }
+  @SerialVersionUID(2838392045355241008L)
+  final private[concurrent] class AdaptedInterruptibleCallable[T](
+      val callable: Callable[T]
+  ) extends ForkJoinTask[T]
+      with RunnableFuture[T] {
+    if (callable == null) throw new NullPointerException
+    @volatile var runner: Thread = _
+    private var result: T = _
+    override final def getRawResult(): T = result
+    override final def setRawResult(v: T): Unit = result = v
+    override final def exec(): Boolean = {
+      Thread.interrupted()
+      runner = Thread.currentThread()
+      try {
+        if (!isDone()) result = callable.call()
+        true
+      } catch {
+        case rex: RuntimeException => throw rex
+        case ex: Exception         => throw new RuntimeException(ex)
+      } finally {
+        runner = null
+        Thread.interrupted()
+      }
+    }
+    override final def run(): Unit = invoke()
+    override final def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      val status = super.cancel(false)
+      if (mayInterruptIfRunning) runner match {
+        case null => ()
+        case t =>
+          try t.interrupt()
+          catch { case _: Throwable => () }
+      }
+      status
+    }
+    override def toString(): String =
+      super.toString + "[Wrapped task = " + callable + "]"
+  }
+
+  def adapt(runnable: Runnable): ForkJoinTask[_] = new AdaptedRunnableAction(
+    runnable
+  )
+
+  def adapt[T](runnable: Runnable, result: T): ForkJoinTask[T] =
+    new AdaptedRunnable[T](runnable, result)
+
+  def adapt[T](callable: Callable[T]): ForkJoinTask[T] =
+    new AdaptedCallable[T](callable)
+
+  def adaptInterruptible[T](callable: Callable[T]): ForkJoinTask[T] =
+    new AdaptedInterruptibleCallable[T](callable)
+}

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinWorkerThread.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinWorkerThread.scala
@@ -1,0 +1,69 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+class ForkJoinWorkerThread private[concurrent] (
+    group: ThreadGroup,
+    private[concurrent] val pool: ForkJoinPool,
+    useSystemClassLoader: Boolean,
+    isInnocuous: Boolean
+) extends Thread(group, null, pool.nextWorkerThreadName(), 0L) {
+  super.setDaemon(true)
+  if (pool.ueh != null) {
+    super.setUncaughtExceptionHandler(pool.ueh)
+  }
+  private[concurrent] val workQueue =
+    new ForkJoinPool.WorkQueue(this, isInnocuous);
+
+  private[concurrent] def this(group: ThreadGroup, pool: ForkJoinPool) = {
+    this(group, pool, false, false);
+  }
+
+  protected def this(pool: ForkJoinPool) = {
+    this(null, pool, false, false);
+  }
+
+  def getPool(): ForkJoinPool = {
+    pool;
+  }
+
+  def getPoolIndex(): Int = {
+    workQueue.getPoolIndex();
+  }
+
+  protected def onStart(): Unit = ()
+
+  protected def onTermination(exception: Throwable): Unit = ()
+
+  override def run(): Unit = {
+    var exception: Throwable = null;
+    val p = pool;
+    val w = workQueue;
+    if (p != null && w != null) { // skip on failed initialization
+      try {
+        p.registerWorker(w)
+        onStart()
+        p.runWorker(w)
+      } catch {
+        case ex: Throwable => exception = ex
+      } finally {
+        try onTermination(exception)
+        catch {
+          case ex: Throwable =>
+            if (exception == null)
+              exception = ex;
+        } finally {
+          p.deregisterWorker(this, exception);
+        }
+      }
+    }
+  }
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/Future.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Future.scala
@@ -1,0 +1,26 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+trait Future[V] {
+
+  def cancel(mayInterruptIfRunning: Boolean): Boolean
+
+  def isCancelled(): Boolean
+
+  def isDone(): Boolean
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  def get(): V
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  @throws[TimeoutException]
+  def get(timeout: Long, unit: TimeUnit): V
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/FutureTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/FutureTask.scala
@@ -1,0 +1,302 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.VarHandle
+import java.util.concurrent.locks.LockSupport
+import scalanative.libc.atomic.{CAtomicInt, CAtomicRef}
+import scalanative.libc.atomic.memory_order._
+
+import scalanative.runtime.{fromRawPtr, Intrinsics}
+
+object FutureTask {
+  private final val NEW = 0
+  private final val COMPLETING = 1
+  private final val NORMAL = 2
+  private final val EXCEPTIONAL = 3
+  private final val CANCELLED = 4
+  private final val INTERRUPTING = 5
+  private final val INTERRUPTED = 6
+
+  final private[concurrent] class WaitNode(@volatile var thread: Thread) {
+    @volatile var next: WaitNode = _
+    def this() = this(Thread.currentThread())
+  }
+}
+
+class FutureTask[V <: AnyRef](private var callable: Callable[V])
+    extends RunnableFuture[V] {
+  if (callable == null) throw new NullPointerException()
+  import FutureTask._
+
+  @volatile private var state = NEW
+
+  @volatile private var runner: Thread = _
+
+  @volatile private var waiters: WaitNode = _
+
+  private var outcome: AnyRef = _
+
+  private val atomicState = new CAtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "state"))
+  )
+  private val atomicRunner = new CAtomicRef[Thread](
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "runner"))
+  )
+  private val atomicWaiters = new CAtomicRef[WaitNode](
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "waiters"))
+  )
+
+  @throws[ExecutionException]
+  private def report(s: Int): V = {
+    val x = outcome
+    if (s == NORMAL) return x.asInstanceOf[V]
+    if (s >= CANCELLED) throw new CancellationException
+    throw new ExecutionException(x.asInstanceOf[Throwable])
+  }
+
+  def this(runnable: Runnable, result: V) =
+    this(Executors.callable(runnable, result))
+
+  override def isCancelled(): Boolean = state >= CANCELLED
+  override def isDone(): Boolean = state != NEW
+  override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+    def newState = if (mayInterruptIfRunning) INTERRUPTING else CANCELLED
+    if (!(state == NEW &&
+          atomicState.compareExchangeStrong(NEW, newState))) return false
+    try { // in case call to interrupt throws exception
+      if (mayInterruptIfRunning) try {
+        val t = runner
+        if (t != null) t.interrupt()
+      } finally atomicState.store(INTERRUPTED, memory_order_release)
+    } finally finishCompletion()
+    true
+  }
+
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  override def get(): V = {
+    var s = state
+    if (s <= COMPLETING) s = awaitDone(false, 0L)
+    report(s)
+  }
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  @throws[TimeoutException]
+  override def get(timeout: Long, unit: TimeUnit): V = {
+    if (unit == null) throw new NullPointerException
+    var s = state
+    if (s <= COMPLETING && {
+          s = awaitDone(true, unit.toNanos(timeout))
+          s <= COMPLETING
+        }) throw new TimeoutException
+    report(s)
+  }
+
+  protected def done(): Unit = {}
+
+  protected def set(v: V): Unit = {
+    if (atomicState.compareExchangeStrong(NEW, COMPLETING)) {
+      outcome = v
+      atomicState.store(NORMAL, memory_order_release)
+      finishCompletion()
+    }
+  }
+
+  protected def setException(t: Throwable): Unit = {
+    if (atomicState.compareExchangeStrong(NEW, COMPLETING)) {
+      outcome = t
+      atomicState.store(EXCEPTIONAL, memory_order_release)
+      finishCompletion()
+    }
+  }
+  override def run(): Unit = {
+    if (state != NEW || !atomicRunner.compareExchangeStrong(
+          null: Thread,
+          Thread.currentThread()
+        )) return ()
+    try {
+      val c = callable
+      if (c != null && state == NEW) {
+        var result: V = null.asInstanceOf[V]
+        var ran = false
+        try {
+          result = c.call()
+          ran = true
+        } catch {
+          case ex: Throwable =>
+            ran = false
+            setException(ex)
+        }
+        if (ran) set(result)
+      }
+    } finally {
+      // runner must be non-null until state is settled to
+      // prevent concurrent calls to run()
+      runner = null
+      // state must be re-read after nulling runner to prevent
+      // leaked interrupts
+      val s = state
+      if (s >= INTERRUPTING) handlePossibleCancellationInterrupt(s)
+    }
+  }
+
+  protected def runAndReset(): Boolean = {
+    if (state != NEW || !atomicRunner.compareExchangeStrong(
+          null: Thread,
+          Thread.currentThread()
+        )) return false
+    var ran = false
+    var s = state
+    try {
+      val c = callable
+      if (c != null && s == NEW) try {
+        c.call() // don't set result
+
+        ran = true
+      } catch { case ex: Throwable => setException(ex) }
+    } finally {
+      runner = null
+      s = state
+      if (s >= INTERRUPTING) handlePossibleCancellationInterrupt(s)
+    }
+    ran && s == NEW
+  }
+
+  private def handlePossibleCancellationInterrupt(s: Int): Unit = {
+    // It is possible for our interrupter to stall before getting a
+    // chance to interrupt us.  Let's spin-wait patiently.
+    if (s == INTERRUPTING)
+      while (state == INTERRUPTING)
+        Thread.`yield`() // wait out pending interrupt
+    // assert state == INTERRUPTED;
+    // We want to clear any interrupt we may have received from
+    // cancel(true).  However, it is permissible to use interrupts
+    // as an independent mechanism for a task to communicate with
+    // its caller, and there is no way to clear only the
+    // cancellation interrupt.
+    //
+    // Thread.interrupted();
+  }
+
+  private def finishCompletion(): Unit = {
+    // assert state > COMPLETING;
+    var q = waiters
+    var break = false
+    while (!break && { q = waiters; q != null })
+      if (atomicWaiters.compareExchangeWeak(q, null: WaitNode)) {
+        while (!break) {
+          val t = q.thread
+          if (t != null) {
+            q.thread = null
+            LockSupport.unpark(t)
+          }
+          val next = q.next
+          if (next == null) break = true
+          else {
+            q.next = null // unlink to help gc
+            q = next
+          }
+        }
+      }
+    done()
+    callable = null // to reduce footprint
+  }
+
+  @throws[InterruptedException]
+  private def awaitDone(timed: Boolean, nanos: Long): Int = {
+    // The code below is very delicate, to achieve these goals:
+    // - call nanoTime exactly once for each call to park
+    // - if nanos <= 0L, return promptly without allocation or nanoTime
+    // - if nanos == Long.MIN_VALUE, don't underflow
+    // - if nanos == Long.MAX_VALUE, and nanoTime is non-monotonic
+    //   and we suffer a spurious wakeup, we will do no worse than
+    //   to park-spin for a while
+    var startTime = 0L // Special value 0L means not yet parked
+    var q = null.asInstanceOf[WaitNode]
+    var queued = false
+
+    while (true) {
+      val s = state
+      if (s > COMPLETING) {
+        if (q != null) q.thread = null
+        return s
+      } else if (s == COMPLETING) { // We may have already promised (via isDone) that we are done
+        // so never return empty-handed or throw InterruptedException
+        Thread.`yield`()
+      } else if (Thread.interrupted()) {
+        removeWaiter(q)
+        throw new InterruptedException
+      } else if (q == null) {
+        if (timed && nanos <= 0L) return s
+        q = new WaitNode
+      } else if (!queued) {
+        q.next = waiters
+        queued = atomicWaiters.compareExchangeWeak(waiters, q)
+      } else if (timed) {
+        var parkNanos = 0L
+        if (startTime == 0L) { // first time
+          startTime = System.nanoTime()
+          if (startTime == 0L) startTime = 1L
+          parkNanos = nanos
+        } else {
+          val elapsed = System.nanoTime() - startTime
+          if (elapsed >= nanos) {
+            removeWaiter(q)
+            return state
+          }
+          parkNanos = nanos - elapsed
+        }
+        // nanoTime may be slow; recheck before parking
+        if (state < COMPLETING) LockSupport.parkNanos(this, parkNanos)
+      } else LockSupport.park(this)
+    }
+    -1 // unreachable
+  }
+
+  private def removeWaiter(node: WaitNode): Unit = {
+    if (node != null) {
+      node.thread = null
+      var break = false
+      while (!break) { // restart on removeWaiter race
+        var pred = null.asInstanceOf[WaitNode]
+        var s = null.asInstanceOf[WaitNode]
+        var q = waiters
+        while (q != null) {
+          var continue = false
+          s = q.next
+          if (q.thread != null) pred = q
+          else if (pred != null) {
+            pred.next = s
+            if (pred.thread == null) { // check for race
+              continue = true
+            }
+          } else if (!atomicWaiters.compareExchangeStrong(q, s))
+            continue = true // todo: continue is not supported
+
+          if (!continue) {
+            q = s
+          }
+        }
+        break = true
+      }
+    }
+  }
+
+  override def toString: String = {
+    val status = state match {
+      case NORMAL      => "[Completed normally]"
+      case EXCEPTIONAL => "[Completed exceptionally: " + outcome + "]"
+      case CANCELLED | INTERRUPTED | INTERRUPTING => "[Cancelled]"
+      case _ =>
+        val callable = this.callable
+        if (callable == null) "[Not completed]"
+        else "[Not completed, task = " + callable + "]"
+    }
+    super.toString + status
+  }
+}

--- a/javalib/src/main/scala/java/util/concurrent/RecursiveAction.scala
+++ b/javalib/src/main/scala/java/util/concurrent/RecursiveAction.scala
@@ -1,0 +1,22 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent;
+
+abstract class RecursiveAction() extends ForkJoinTask[Void] {
+
+  protected def compute(): Unit
+
+  final def getRawResult(): Void = null
+
+  protected final def setRawResult(mustBeNull: Void): Unit = ()
+
+  protected final def exec(): Boolean = {
+    compute()
+    true
+  }
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/RecursiveTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/RecursiveTask.scala
@@ -1,0 +1,24 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */ /*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+abstract class RecursiveTask[V]() extends ForkJoinTask[V] {
+  private[concurrent] var result: V = _
+
+  protected def compute(): V
+  override final def getRawResult(): V = result
+  override final protected def setRawResult(value: V): Unit = result = value
+
+  override final protected def exec(): Boolean = {
+    result = compute()
+    true
+  }
+}

--- a/javalib/src/main/scala/java/util/concurrent/RejectedExecutionHandler.scala
+++ b/javalib/src/main/scala/java/util/concurrent/RejectedExecutionHandler.scala
@@ -4,9 +4,9 @@
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
 
-package java.util.concurrent
+package java.util.concurrent;
 
-trait ThreadFactory {
+trait RejectedExecutionHandler {
 
-  def newThread(runnable: Runnable): Thread
+  def rejectedExecution(r: Runnable, executor: ThreadPoolExecutor): Unit
 }

--- a/javalib/src/main/scala/java/util/concurrent/RunnableFuture.scala
+++ b/javalib/src/main/scala/java/util/concurrent/RunnableFuture.scala
@@ -6,7 +6,8 @@
 
 package java.util.concurrent
 
-trait ThreadFactory {
+trait RunnableFuture[V] extends Runnable with Future[V] {
 
-  def newThread(runnable: Runnable): Thread
+  def run(): Unit
+
 }

--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -246,6 +246,12 @@ object ThreadLocalRandom {
     r
   }
 
+  private[concurrent] def eraseThreadLocals(thread: Thread): Unit = {
+    // TOOD: Adapt ThreadLocal implementation
+    // thread.localValues = null
+    // thread.inheritableValues = null
+  }
+
   private val GAMMA = 0x9e3779b97f4a7c15L
 
   private val PROBE_INCREMENT = 0x9e3779b9

--- a/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -14,6 +14,7 @@ object Platform {
   final val hasCompliantArrayIndexOutOfBounds = true
 
   final val executingInJVMOnJDK8OrLower = jdkVersion <= 8
+  final val executingInJVMOnLowerThenJDK11 = jdkVersion < 11
   final val executingInJVMOnLowerThanJDK15 = jdkVersion < 15
   final val executingInJVMOnLowerThanJDK17 = jdkVersion < 17
   final val executingInJVMOnJDK17 = jdkVersion == 17

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -19,6 +19,7 @@ object Platform {
   final val hasCompliantArrayIndexOutOfBounds = true
 
   final val executingInJVMOnJDK8OrLower = false
+  final val executingInJVMOnLowerThenJDK11 = false
   final val executingInJVMOnLowerThanJDK15 = false
   final val executingInJVMOnLowerThanJDK17 = false
   final val executingInJVMOnJDK17 = false

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTask9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTask9Test.scala
@@ -1,0 +1,50 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util
+import java.util.concurrent._
+
+import org.junit._
+import org.junit.Assert._
+
+class ForkJoinTask9Test extends JSR166Test {
+  import JSR166Test._
+  import ForkJoinTask8Test._
+
+  /** pollSubmission returns unexecuted submitted task, if present */
+  @Test def testPollSubmission(): Unit = {
+    val done = new CountDownLatch(1)
+    val a = ForkJoinTask.adapt(awaiter(done))
+    val b = ForkJoinTask.adapt(awaiter(done))
+    val c = ForkJoinTask.adapt(awaiter(done))
+    val p = singletonPool
+    usingWrappedPoolCleaner(singletonPool)(cleaner(_, done)) { p =>
+      val external = new Thread({ () =>
+        p.execute(a)
+        p.execute(b)
+        p.execute(c)
+      }: CheckedRunnable)
+      val s = new CheckedRecursiveAction() {
+        protected def realCompute(): Unit = {
+          external.start()
+          try external.join()
+          catch {
+            case ex: Exception =>
+              threadUnexpectedException(ex)
+          }
+          assertTrue(p.hasQueuedSubmissions)
+          assertTrue(Thread.currentThread.isInstanceOf[ForkJoinWorkerThread])
+          val r = ForkJoinTask.pollSubmission()
+          assertTrue((r eq a) || (r eq b) || (r eq c))
+          assertFalse(r.isDone)
+        }
+      }
+      p.invoke(s)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThreadTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThreadTest.scala
@@ -104,7 +104,7 @@ class ThreadTest {
   /** getDefaultUncaughtExceptionHandler returns value of last
    *  setDefaultUncaughtExceptionHandler.
    */
-  def testGetAndSetDefaultUncaughtExceptionHandler(): Unit = {
+  @deprecated def testGetAndSetDefaultUncaughtExceptionHandler(): Unit = {
     assertNull(Thread.getDefaultUncaughtExceptionHandler())
     // failure due to SecurityException is OK.
     // Would be nice to explicitly test both ways, but cannot yet.

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/AbstractExecutorServiceTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/AbstractExecutorServiceTest.scala
@@ -1,0 +1,534 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.{ArrayList, Collection, Collections, List}
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicBoolean
+
+object AbstractExecutorServiceTest {
+
+  /** A no-frills implementation of AbstractExecutorService, designed to test
+   *  the submit methods only.
+   */
+  class DirectExecutorService extends AbstractExecutorService {
+    override def execute(r: Runnable): Unit = r.run()
+    override def shutdown(): Unit = inShutdown = true
+    override def shutdownNow: util.List[Runnable] = {
+      inShutdown = true
+      Collections.EMPTY_LIST.asInstanceOf[util.List[Runnable]]
+    }
+    override def isShutdown: Boolean = inShutdown
+    override def isTerminated: Boolean = inShutdown
+    override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean =
+      isShutdown
+    private var inShutdown: Boolean = false
+  }
+}
+
+class AbstractExecutorServiceTest extends JSR166Test {
+  import JSR166Test._
+
+  /** execute(runnable) runs it to completion
+   */
+  @throws[Exception]
+  @Test def testExecuteRunnable(): Unit = {
+    val e = new AbstractExecutorServiceTest.DirectExecutorService
+    val done = new AtomicBoolean(false)
+    val future = e.submit(new CheckedRunnable() {
+      override def realRun(): Unit = { done.set(true) }
+    })
+    assertNull(future.get)
+    assertNull(future.get(0, MILLISECONDS))
+    assertTrue(done.get)
+    assertTrue(future.isDone)
+    assertFalse(future.isCancelled)
+  }
+
+  /** Completed submit(callable) returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitCallable(): Unit = {
+    val e = new AbstractExecutorServiceTest.DirectExecutorService
+    val future = e.submit(new StringTask)
+    val result = future.get
+    assertEquals(TEST_STRING, result)
+  }
+
+  /** Completed submit(runnable) returns successfully
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable(): Unit = {
+    val e = new AbstractExecutorServiceTest.DirectExecutorService
+    val future = e.submit(new NoOpRunnable)
+    future.get
+    assertTrue(future.isDone)
+  }
+
+  /** Completed submit(runnable, result) returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable2(): Unit = {
+    val e = new AbstractExecutorServiceTest.DirectExecutorService
+    val future = e.submit(new NoOpRunnable, TEST_STRING)
+    val result = future.get
+    assertEquals(TEST_STRING, result)
+  }
+
+  // No PrivilegedAction in Scala Native
+  // @Test def testSubmitPrivilegedAction(): Unit = {}
+  // @Test def testSubmitPrivilegedExceptionAction(): Unit = {}
+  // @Test def testSubmitFailedPrivilegedExceptionAction(): Unit = {}
+
+  /** Submitting null tasks throws NullPointerException
+   */
+  @Test def testNullTaskSubmission(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { assertNullTaskSubmissionThrowsNullPointerException }
+
+  // TODO: ThreadPoolExecutor
+  // /** submit(callable).get() throws InterruptedException if interrupted
+  //  */
+  // @throws[InterruptedException]
+  // @Test def testInterruptedSubmit(): Unit = {
+  //   val submitted = new CountDownLatch(1)
+  //   val quittingTime = new CountDownLatch(1)
+  //   val awaiter = new CheckedCallable[Void]() {
+  //     @throws[InterruptedException]
+  //     override def realCall(): Void = {
+  //       assertTrue(quittingTime.await(2 * LONG_DELAY_MS, MILLISECONDS))
+  //       null
+  //     }
+  //   }
+  //   usingPoolCleaner[ThreadPoolExecutor, Unit](
+  //     new ThreadPoolExecutor(
+  //       1,
+  //       1,
+  //       60,
+  //       TimeUnit.SECONDS,
+  //       new ArrayBlockingQueue[Runnable](10)
+  //     ),
+  //     cleaner(_, quittingTime)
+  //   ) { p =>
+  //     val t = newStartedThread(
+  //       new CheckedInterruptedRunnable() {
+  //         @throws[Exception]
+  //         override def realRun(): Unit = {
+  //           val future = p.submit(awaiter)
+  //           submitted.countDown()
+  //           future.get
+  //         }
+  //       }
+  //     )
+  //     await(submitted)
+  //     t.interrupt()
+  //     awaitTermination(t)
+  //   }
+  // }
+  // /** get of submit(callable) throws ExecutionException if callable throws
+  //  *  exception
+  //  */
+  // @throws[InterruptedException]
+  // @Test def testSubmitEE(): Unit = usingPoolCleaner(
+  //   new ThreadPoolExecutor(
+  //     1,
+  //     1,
+  //     60,
+  //     TimeUnit.SECONDS,
+  //     new ArrayBlockingQueue[Runnable](10)
+  //   )
+  // ) { p =>
+  //   val c = new Callable[Any]() {
+  //     override def call = throw new ArithmeticException
+  //   }
+  //   try {
+  //     p.submit(c).get
+  //     shouldThrow()
+  //   } catch {
+  //     case success: ExecutionException =>
+  //       assertTrue(success.getCause.isInstanceOf[ArithmeticException])
+  //   }
+  // }
+
+  /** invokeAny(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testInvokeAny1(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    try {
+      e.invokeAny(null)
+      shouldThrow()
+    } catch { case success: NullPointerException => () }
+  }
+
+  /** invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testInvokeAny2(): Unit =
+    usingPoolCleaner(new AbstractExecutorServiceTest.DirectExecutorService) {
+      e =>
+        val emptyCollection = Collections.emptyList
+        try {
+          e.invokeAny(emptyCollection)
+          shouldThrow()
+        } catch { case success: IllegalArgumentException => () }
+    }
+
+  /** invokeAny(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAny3(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[Long]]
+    l.add(new Callable[Long]() {
+      override def call = throw new ArithmeticException
+    })
+    l.add(null)
+    try {
+      e.invokeAny(l)
+      shouldThrow()
+    } catch { case success: NullPointerException => () }
+  }
+
+  /** invokeAny(c) throws ExecutionException if no task in c completes
+   */
+  @throws[InterruptedException]
+  @Test def testInvokeAny4(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new NPETask)
+    try {
+      e.invokeAny(l)
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertTrue(success.getCause.isInstanceOf[NullPointerException])
+    }
+  }
+
+  /** invokeAny(c) returns result of some task in c if at least one completes
+   */
+  @throws[Exception]
+  @Test def testInvokeAny5(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new StringTask)
+    l.add(new StringTask)
+    val result = e.invokeAny(l)
+    assertEquals(TEST_STRING, result)
+  }
+
+  /** invokeAll(null) throws NPE
+   */
+  @throws[InterruptedException]
+  @Test def testInvokeAll1(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    try {
+      e.invokeAll(null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException => ()
+    }
+  }
+
+  /** invokeAll(empty collection) returns empty list
+   */
+  @throws[InterruptedException]
+  @Test def testInvokeAll2(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val emptyCollection = Collections.emptyList
+    val r = e.invokeAll(emptyCollection)
+    assertTrue(r.isEmpty)
+  }
+
+  /** invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[InterruptedException]
+  @Test def testInvokeAll3(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new StringTask)
+    l.add(null)
+    try {
+      e.invokeAll(l)
+      shouldThrow()
+    } catch { case success: NullPointerException => () }
+  }
+
+  /** get of returned element of invokeAll(c) throws exception on failed task
+   */
+  @throws[Exception]
+  @Test def testInvokeAll4(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new NPETask)
+    val futures = e.invokeAll(l)
+    assertEquals(1, futures.size)
+    try {
+      futures.get(0).get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertTrue(success.getCause.isInstanceOf[NullPointerException])
+    }
+  }
+
+  /** invokeAll(c) returns results of all completed tasks in c
+   */
+  @throws[Exception]
+  @Test def testInvokeAll5(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new StringTask)
+    l.add(new StringTask)
+    val futures = e.invokeAll(l)
+    assertEquals(2, futures.size)
+    futures.forEach { future => assertEquals(TEST_STRING, future.get) }
+  }
+
+  /** timed invokeAny(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny1(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    try {
+      e.invokeAny(null, randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: NullPointerException => ()
+    }
+  }
+
+  /** timed invokeAny(null time unit) throws NullPointerException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAnyNullTimeUnit(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new StringTask)
+    try {
+      e.invokeAny(l, randomTimeout(), null)
+      shouldThrow()
+    } catch { case success: NullPointerException => () }
+  }
+
+  /** timed invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny2(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val emptyCollection = Collections.emptyList
+    try {
+      e.invokeAny(emptyCollection, randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch { case success: IllegalArgumentException => () }
+  }
+
+  /** timed invokeAny(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny3(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[Long]]
+    l.add(new Callable[Long]() {
+      override def call = throw new ArithmeticException
+    })
+    l.add(null)
+    try {
+      e.invokeAny(l, randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: NullPointerException => ()
+    }
+  }
+
+  /** timed invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny4(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val startTime = System.nanoTime
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new NPETask)
+    try {
+      e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertTrue(success.getCause.isInstanceOf[NullPointerException])
+    }
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+  }
+
+  /** timed invokeAny(c) returns result of some task in c
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny5(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val startTime = System.nanoTime
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new StringTask)
+    l.add(new StringTask)
+    val result = e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+    assertEquals(TEST_STRING, result)
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+  }
+
+  /** timed invokeAll(null) throws NullPointerException
+   */
+  @throws[InterruptedException]
+  @Test def testTimedInvokeAll1(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    try {
+      e.invokeAll(null, randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch { case success: NullPointerException => () }
+  }
+
+  /** timed invokeAll(null time unit) throws NPE
+   */
+  @throws[InterruptedException]
+  @Test def testTimedInvokeAllNullTimeUnit(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new StringTask)
+    try {
+      e.invokeAll(l, randomTimeout(), null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** timed invokeAll(empty collection) returns empty list
+   */
+  @throws[InterruptedException]
+  @Test def testTimedInvokeAll2(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val emptyCollection = Collections.emptyList
+    val r = e.invokeAll(emptyCollection, randomTimeout(), randomTimeUnit())
+    assertTrue(r.isEmpty)
+  }
+
+  /** timed invokeAll(c) throws NullPointerException if c has null elements
+   */
+  @throws[InterruptedException]
+  @Test def testTimedInvokeAll3(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new StringTask)
+    l.add(null)
+    try {
+      e.invokeAll(l, randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: NullPointerException => ()
+    }
+  }
+
+  @throws[Exception]
+  @Test def testTimedInvokeAll4(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new NPETask)
+    val futures = e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+    assertEquals(1, futures.size)
+    try {
+      futures.get(0).get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertTrue(success.getCause.isInstanceOf[NullPointerException])
+    }
+  }
+
+  /** timed invokeAll(c) returns results of all completed tasks in c
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll5(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    val l = new util.ArrayList[Callable[String]]
+    l.add(new StringTask)
+    l.add(new StringTask)
+    val futures = e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+    assertEquals(2, futures.size)
+    futures.forEach { future => assertEquals(TEST_STRING, future.get) }
+  }
+
+  /** timed invokeAll cancels tasks not completed by timeout
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll6(): Unit = usingPoolCleaner(
+    new AbstractExecutorServiceTest.DirectExecutorService
+  ) { e =>
+    var timeout = timeoutMillis()
+    import scala.util.control.Breaks
+    val outer = new Breaks()
+    val continue = new Breaks()
+    outer.breakable {
+      while (true) {
+        continue.breakable {
+          val tasks = new util.ArrayList[Callable[String]]
+          tasks.add(new StringTask("0"))
+          tasks.add(
+            Executors.callable(
+              possiblyInterruptedRunnable(timeout),
+              TEST_STRING
+            )
+          )
+          tasks.add(new StringTask("2"))
+          val startTime = System.nanoTime
+          val futures = e.invokeAll(tasks, timeout, MILLISECONDS)
+          assertEquals(tasks.size, futures.size)
+          assertTrue(millisElapsedSince(startTime) >= timeout)
+          futures.forEach { future => assertTrue(future.isDone) }
+          try {
+            assertEquals("0", futures.get(0).get)
+            assertEquals(TEST_STRING, futures.get(1).get)
+          } catch {
+            case retryWithLongerTimeout: CancellationException =>
+              // unusual delay before starting second task
+              timeout *= 2
+              if (timeout >= LONG_DELAY_MS / 2)
+                fail("expected exactly one task to be cancelled")
+              continue.break()
+          }
+          assertTrue(futures.get(2).isCancelled)
+          outer.break()
+        }
+      }
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/CountedCompleter8Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/CountedCompleter8Test.scala
@@ -1,0 +1,119 @@
+/*
+ * Written by Doug Lea and Martin Buchholz with assistance from
+ * members of JCP JSR-166 Expert Group and released to the public
+ * domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function._
+
+import org.junit._
+import org.junit.Assert._
+
+object CountedCompleter8Test {
+
+  /** CountedCompleter class javadoc code sample, version 1. */
+  def forEach1[E](array: Array[E], action: Consumer[E]): Unit = {
+    class Task(parent: Task, val lo: Int, val hi: Int)
+        extends CountedCompleter[Void](parent) {
+      override def compute(): Unit = {
+        if (hi - lo >= 2) {
+          val mid = (lo + hi) >>> 1
+          // must set pending count before fork
+          setPendingCount(2)
+          new Task(this, mid, hi).fork // right child
+
+          new Task(this, lo, mid).fork // left child
+
+        } else if (hi > lo) action.accept(array(lo))
+        tryComplete()
+      }
+    }
+    new Task(null, 0, array.length).invoke
+  }
+
+  /** CountedCompleter class javadoc code sample, version 2. */
+  def forEach2[E](array: Array[E], action: Consumer[E]): Unit = {
+    class Task(parent: Task, val lo: Int, val hi: Int)
+        extends CountedCompleter[Void](parent) {
+      override def compute(): Unit = {
+        if (hi - lo >= 2) {
+          val mid = (lo + hi) >>> 1
+          setPendingCount(1) // looks off by one, but correct!
+          new Task(this, mid, hi).fork // right child
+          new Task(this, lo, mid).compute() // direct invoke
+        } else {
+          if (hi > lo) action.accept(array(lo))
+          tryComplete()
+        }
+      }
+    }
+    new Task(null, 0, array.length).invoke
+  }
+
+  /** CountedCompleter class javadoc code sample, version 3. */
+  def forEach3[E](array: Array[E], action: Consumer[E]): Unit = {
+    class Task(parent: Task, val lo: Int, val hi: Int)
+        extends CountedCompleter[Void](parent) {
+      override def compute(): Unit = {
+        var n = hi - lo
+
+        while (n >= 2) {
+          addToPendingCount(1)
+          new Task(this, lo + n / 2, lo + n).fork
+          n /= 2
+        }
+        if (n > 0) action.accept(array(lo))
+        propagateCompletion()
+      }
+    }
+    new Task(null, 0, array.length).invoke
+  }
+
+  /** CountedCompleter class javadoc code sample, version 4. */
+  def forEach4[E](array: Array[E], action: Consumer[E]): Unit = {
+    class Task(parent: Task, val lo: Int, val hi: Int)
+        extends CountedCompleter[Void](
+          parent,
+          31 - Integer.numberOfLeadingZeros(hi - lo)
+        ) {
+      override def compute(): Unit = {
+        var n = hi - lo
+        while (n >= 2) {
+          new Task(this, lo + n / 2, lo + n).fork
+          n /= 2
+        }
+        action.accept(array(lo))
+        propagateCompletion()
+      }
+    }
+    if (array.length > 0) new Task(null, 0, array.length).invoke
+  }
+}
+class CountedCompleter8Test extends JSR166Test {
+  def testRecursiveDecomposition(
+      action: BiConsumer[Array[Integer], Consumer[Integer]]
+  ): Unit = {
+    val n = ThreadLocalRandom.current.nextInt(8)
+    val a = Array.tabulate[Integer](n)(_ + 1)
+    // val a = new Array[Integer](n)
+    // for (i <- 0 until n) { a(i) = i + 1 }
+    val ai = new AtomicInteger(0)
+    action.accept(a, ai.addAndGet(_))
+    assertEquals(n * (n + 1) / 2, ai.get())
+  }
+
+  /** Variants of divide-by-two recursive decomposition into leaf tasks, as
+   *  described in the CountedCompleter class javadoc code samples
+   */
+  @Test def testRecursiveDecomposition(): Unit = {
+    testRecursiveDecomposition(CountedCompleter8Test.forEach1)
+    testRecursiveDecomposition(CountedCompleter8Test.forEach2)
+    testRecursiveDecomposition(CountedCompleter8Test.forEach3)
+    testRecursiveDecomposition(CountedCompleter8Test.forEach4)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/CountedCompleterTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/CountedCompleterTest.scala
@@ -1,0 +1,1938 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import org.junit.Assert._
+import org.junit.{Test, Ignore}
+import JSR166Test._
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.atomic._
+import java.util.function._
+
+object CountedCompleterTest {
+  // Runs with "mainPool" use > 1 thread. singletonPool tests use 1
+  val mainPoolSize: Int = Math.max(2, Runtime.getRuntime.availableProcessors)
+  private def mainPool = new ForkJoinPool(mainPoolSize)
+  private def singletonPool = new ForkJoinPool(1)
+  private def asyncSingletonPool = new ForkJoinPool(
+    1,
+    ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+    null,
+    true
+  )
+  final class FJException() extends RuntimeException {}
+}
+class CountedCompleterTest extends JSR166Test {
+  private def testInvokeOnPool(pool: ForkJoinPool, a: ForkJoinTask[_]): Unit =
+    usingPoolCleaner(pool) { pool =>
+      assertFalse(a.isDone)
+      assertFalse(a.isCompletedNormally)
+      assertFalse(a.isCompletedAbnormally)
+      assertFalse(a.isCancelled)
+      assertNull(a.getException)
+      assertNull(a.getRawResult)
+      assertNull(pool.invoke(a))
+      assertTrue(a.isDone)
+      assertTrue(a.isCompletedNormally)
+      assertFalse(a.isCompletedAbnormally)
+      assertFalse(a.isCancelled)
+      assertNull(a.getException)
+      assertNull(a.getRawResult)
+    }
+
+  def checkNotDone(a: CountedCompleter[Any]): Unit = {
+    assertFalse(a.isDone)
+    assertFalse(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertFalse(a.isCancelled)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    try {
+      a.get(randomExpiredTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: TimeoutException => ()
+      case fail: Throwable           => threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedNormally(a: CountedCompleter[Any]): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertTrue(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    locally {
+      Thread.currentThread.interrupt()
+      val startTime = System.nanoTime
+      assertNull(a.join)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+      Thread.interrupted
+      Thread.currentThread.interrupt()
+    }
+    locally {
+      val startTime = System.nanoTime
+      a.quietlyJoin() // should be no-op
+
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+      Thread.interrupted
+    }
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    var v1 = null.asInstanceOf[Any]
+    var v2 = null.asInstanceOf[Any]
+    try {
+      v1 = a.get
+      v2 = a.get(randomTimeout(), randomTimeUnit())
+    } catch {
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    assertNull(v1)
+    assertNull(v2)
+  }
+
+  def checkCancelled(a: CountedCompleter[Any]): Unit = {
+    assertTrue(a.isDone)
+    assertTrue(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertTrue(a.getException.isInstanceOf[CancellationException])
+    assertNull(a.getRawResult)
+    assertTrue(a.cancel(false))
+    assertTrue(a.cancel(true))
+    try {
+      Thread.currentThread.interrupt()
+      a.join
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    Thread.interrupted
+    val startTime = System.nanoTime
+    a.quietlyJoin()
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedAbnormally(a: CountedCompleter[Any], t: Throwable): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertSame(t.getClass, a.getException.getClass)
+    assertNull(a.getRawResult)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    try {
+      Thread.currentThread.interrupt()
+      a.join
+      shouldThrow()
+    } catch {
+      case expected: Throwable =>
+        assertEquals(t.getClass, expected.getClass)
+    }
+    Thread.interrupted
+    val startTime = System.nanoTime
+    a.quietlyJoin()
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertEquals(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertEquals(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.invoke
+      shouldThrow()
+    } catch {
+      case success: Throwable => t.getClass == success.getClass
+    }
+  }
+
+  abstract class CheckedCC(p: CountedCompleter[Any], n: Int)
+      extends CountedCompleter[Any](p, n) {
+    def this(p: CountedCompleter[Any]) = this(p, 0)
+    def this() = this(null)
+    final val computeNAtomic = new AtomicInteger(0)
+    final val onCompletionNAtomic = new AtomicInteger(0)
+    final val onExceptionalCompletionNAtomic = new AtomicInteger(0)
+    final val setRawResultNAtomic = new AtomicInteger(0)
+    final val rawResultAtomic = new AtomicReference[Any](null)
+    def computeN: Int = computeNAtomic.get
+    def onCompletionN: Int = onCompletionNAtomic.get
+    def onExceptionalCompletionN: Int = onExceptionalCompletionNAtomic.get
+    def setRawResultN: Int = setRawResultNAtomic.get
+
+    protected def realCompute(): Unit
+
+    override final def compute(): Unit = {
+      computeNAtomic.incrementAndGet
+      realCompute()
+    }
+
+    override def toString(): String = super
+      .toString() + s"[$n, ${computeNAtomic.get()}, ${onCompletionNAtomic.get()}, ${onExceptionalCompletionNAtomic
+        .get()}, ${setRawResultNAtomic.get()}, ${rawResultAtomic.get()}]"
+
+    override def onCompletion(caller: CountedCompleter[_]): Unit = {
+      onCompletionNAtomic.incrementAndGet
+      super.onCompletion(caller)
+    }
+
+    override def onExceptionalCompletion(
+        ex: Throwable,
+        caller: CountedCompleter[_]
+    ): Boolean = {
+      onExceptionalCompletionNAtomic.incrementAndGet
+      assertNotNull(ex)
+      assertTrue(isCompletedAbnormally)
+      assertTrue(super.onExceptionalCompletion(ex, caller))
+      true
+    }
+    override protected def setRawResult(t: Any): Unit = {
+      setRawResultNAtomic.incrementAndGet
+      rawResultAtomic.set(t)
+      super.setRawResult(t)
+    }
+    def checkIncomplete(): Unit = {
+      assertEquals(0, computeN)
+      assertEquals(0, onCompletionN)
+      assertEquals(0, onExceptionalCompletionN)
+      assertEquals(0, setRawResultN)
+      checkNotDone(this)
+    }
+    def checkCompletes(rawResult: Any): Unit = {
+      checkIncomplete()
+      val pendingCount = getPendingCount
+      complete(rawResult)
+      assertEquals(pendingCount, getPendingCount)
+      assertEquals(0, computeN)
+      assertEquals(1, onCompletionN)
+      assertEquals(0, onExceptionalCompletionN)
+      assertEquals(1, setRawResultN)
+      assertSame(rawResult, this.rawResultAtomic.get)
+      checkCompletedNormally(this)
+    }
+    def checkCompletesExceptionally(ex: Throwable): Unit = {
+      checkIncomplete()
+      completeExceptionally(ex)
+      checkCompletedExceptionally(ex)
+    }
+    def checkCompletedExceptionally(ex: Throwable): Unit = {
+      assertEquals(0, computeN)
+      assertEquals(0, onCompletionN)
+      assertEquals(1, onExceptionalCompletionN)
+      assertEquals(0, setRawResultN)
+      assertNull(this.rawResultAtomic.get)
+      checkCompletedAbnormally(this, ex)
+    }
+  }
+  final class NoopCC(
+      p: CountedCompleter[Any] = null,
+      initialPendingCount: Int = 0
+  ) extends CheckedCC(p, initialPendingCount) {
+    override protected def realCompute(): Unit = ()
+  }
+
+  /** A newly constructed CountedCompleter is not completed; complete() causes
+   *  completion. pendingCount is ignored.
+   */
+  @Test def testComplete(): Unit = {
+    for (x <- Array[Any](java.lang.Boolean.TRUE, null)) {
+      for (pendingCount <- Array[Int](0, 42)) {
+        testComplete(new NoopCC(), x, pendingCount)
+        testComplete(new NoopCC(new NoopCC), x, pendingCount)
+      }
+    }
+  }
+  def testComplete(cc: NoopCC, x: Any, pendingCount: Int): Unit = {
+    cc.setPendingCount(pendingCount)
+    cc.checkCompletes(x)
+    assertEquals(pendingCount, cc.getPendingCount)
+  }
+
+  /** completeExceptionally completes exceptionally
+   */
+  @Test def testCompleteExceptionally(): Unit = {
+    new NoopCC()
+      .checkCompletesExceptionally(new CountedCompleterTest.FJException)
+    new NoopCC(new NoopCC)
+      .checkCompletesExceptionally(new CountedCompleterTest.FJException)
+  }
+
+  /** completeExceptionally(null) surprisingly has the same effect as
+   *  completeExceptionally(new RuntimeException())
+   */
+  @Test def testCompleteExceptionally_null(): Unit = {
+    val a = new NoopCC
+    a.completeExceptionally(null)
+    try {
+      a.invoke
+      shouldThrow()
+    } catch {
+      case success: RuntimeException =>
+        assertSame(success.getClass, classOf[RuntimeException])
+        assertNull(success.getCause)
+        a.checkCompletedExceptionally(success)
+    }
+  }
+
+  /** setPendingCount sets the reported pending count
+   */
+  @Test def testSetPendingCount(): Unit = {
+    val a = new NoopCC
+    assertEquals(0, a.getPendingCount)
+    val vals = Array(-1, 0, 1, Integer.MIN_VALUE, Integer.MAX_VALUE)
+    for (`val` <- vals) {
+      a.setPendingCount(`val`)
+      assertEquals(`val`, a.getPendingCount)
+    }
+  }
+
+  /** addToPendingCount adds to the reported pending count
+   */
+  @Test def testAddToPendingCount(): Unit = {
+    val a = new NoopCC
+    assertEquals(0, a.getPendingCount)
+    a.addToPendingCount(1)
+    assertEquals(1, a.getPendingCount)
+    a.addToPendingCount(27)
+    assertEquals(28, a.getPendingCount)
+    a.addToPendingCount(-28)
+    assertEquals(0, a.getPendingCount)
+  }
+
+  /** decrementPendingCountUnlessZero decrements reported pending count unless
+   *  zero
+   */
+  @Test def testDecrementPendingCountUnlessZero(): Unit = {
+    val a = new NoopCC(null, 2)
+    assertEquals(2, a.getPendingCount)
+    assertEquals(2, a.decrementPendingCountUnlessZero)
+    assertEquals(1, a.getPendingCount)
+    assertEquals(1, a.decrementPendingCountUnlessZero)
+    assertEquals(0, a.getPendingCount)
+    assertEquals(0, a.decrementPendingCountUnlessZero)
+    assertEquals(0, a.getPendingCount)
+    a.setPendingCount(-1)
+    assertEquals(-1, a.decrementPendingCountUnlessZero)
+    assertEquals(-2, a.getPendingCount)
+  }
+
+  /** compareAndSetPendingCount compares and sets the reported pending count
+   */
+  @Test def testCompareAndSetPendingCount(): Unit = {
+    val a = new NoopCC
+    assertEquals(0, a.getPendingCount)
+    assertTrue(a.compareAndSetPendingCount(0, 1))
+    assertEquals(1, a.getPendingCount)
+    assertTrue(a.compareAndSetPendingCount(1, 2))
+    assertEquals(2, a.getPendingCount)
+    assertFalse(a.compareAndSetPendingCount(1, 3))
+    assertEquals(2, a.getPendingCount)
+  }
+
+  /** getCompleter returns parent or null if at root
+   */
+  @Test def testGetCompleter(): Unit = {
+    val a = new NoopCC
+    assertNull(a.getCompleter)
+    val b = new NoopCC(a)
+    assertSame(a, b.getCompleter)
+    val c = new NoopCC(b)
+    assertSame(b, c.getCompleter)
+  }
+
+  /** getRoot returns self if no parent, else parent's root
+   */
+  @Test def testGetRoot(): Unit = {
+    val a = new NoopCC
+    val b = new NoopCC(a)
+    val c = new NoopCC(b)
+    assertSame(a, a.getRoot)
+    assertSame(a, b.getRoot)
+    assertSame(a, c.getRoot)
+  }
+
+  /** tryComplete decrements pending count unless zero, in which case causes
+   *  completion
+   */
+  @Test def testTryComplete(): Unit = {
+    val a = new NoopCC
+    assertEquals(0, a.getPendingCount)
+    var n = 3
+    a.setPendingCount(n)
+
+    while ({ n > 0 }) {
+      assertEquals(n, a.getPendingCount)
+      a.tryComplete()
+      a.checkIncomplete()
+      assertEquals(n - 1, a.getPendingCount)
+
+      n -= 1
+    }
+    a.tryComplete()
+    assertEquals(0, a.computeN)
+    assertEquals(1, a.onCompletionN)
+    assertEquals(0, a.onExceptionalCompletionN)
+    assertEquals(0, a.setRawResultN)
+    checkCompletedNormally(a)
+  }
+
+  /** propagateCompletion decrements pending count unless zero, in which case
+   *  causes completion, without invoking onCompletion
+   */
+  @Test def testPropagateCompletion(): Unit = {
+    val a = new NoopCC
+    assertEquals(0, a.getPendingCount)
+    var n = 3
+    a.setPendingCount(n)
+
+    while ({ n > 0 }) {
+      assertEquals(n, a.getPendingCount)
+      a.propagateCompletion()
+      a.checkIncomplete()
+      assertEquals(n - 1, a.getPendingCount)
+
+      n -= 1
+    }
+    a.propagateCompletion()
+    assertEquals(0, a.computeN)
+    assertEquals(0, a.onCompletionN)
+    assertEquals(0, a.onExceptionalCompletionN)
+    assertEquals(0, a.setRawResultN)
+    checkCompletedNormally(a)
+  }
+
+  /** firstComplete returns this if pending count is zero else null
+   */
+  @Test def testFirstComplete(): Unit = {
+    val a = new NoopCC
+    a.setPendingCount(1)
+    assertNull(a.firstComplete)
+    a.checkIncomplete()
+    assertSame(a, a.firstComplete)
+    a.checkIncomplete()
+  }
+
+  /** firstComplete.nextComplete returns parent if pending count is zero else
+   *  null
+   */
+  @Test def testNextComplete(): Unit = {
+    val a = new NoopCC
+    val b = new NoopCC(a)
+    a.setPendingCount(1)
+    b.setPendingCount(1)
+    assertNull(b.firstComplete)
+    assertSame(b, b.firstComplete)
+    assertNull(b.nextComplete)
+    a.checkIncomplete()
+    b.checkIncomplete()
+    assertSame(a, b.nextComplete)
+    assertSame(a, b.nextComplete)
+    a.checkIncomplete()
+    b.checkIncomplete()
+    assertNull(a.nextComplete)
+    b.checkIncomplete()
+    checkCompletedNormally(a)
+  }
+
+  /** quietlyCompleteRoot completes root task and only root task
+   */
+  @Test def testQuietlyCompleteRoot(): Unit = {
+    val a = new NoopCC
+    val b = new NoopCC(a)
+    val c = new NoopCC(b)
+    a.setPendingCount(1)
+    b.setPendingCount(1)
+    c.setPendingCount(1)
+    c.quietlyCompleteRoot()
+    assertTrue(a.isDone)
+    assertFalse(b.isDone)
+    assertFalse(c.isDone)
+  }
+
+  /** Version of Fibonacci with different classes for left vs right forks
+   */
+  // Invocation tests use some interdependent task classes
+  // to better test propagation etc
+  abstract class CCF(
+      val parent: CountedCompleter[Any],
+      @volatile var number: Int
+  ) extends CheckedCC(parent, 1) {
+    @volatile var rnumber = 0
+
+    override final protected def realCompute(): Unit = {
+      var f = this
+      var n = number
+      while (n >= 2) {
+        new RCCF(f, n - 2).fork()
+        n -= 1
+        f = new LCCF(f, n)
+      }
+      f.complete(null)
+    }
+    override def toString(): String =
+      super.toString() + s" n=$number, rn=${rnumber}"
+  }
+  final class LCCF(parent: CountedCompleter[Any], val n: Int)
+      extends CCF(parent, n) {
+    def this(n: Int) = this(null, n)
+    override final def onCompletion(caller: CountedCompleter[_]): Unit = {
+      super.onCompletion(caller)
+      val p = getCompleter.asInstanceOf[CCF]
+      val n = number + rnumber
+      if (p != null) p.number = n
+      else number = n
+    }
+  }
+  final class RCCF(parent: CountedCompleter[Any], val n: Int)
+      extends CCF(parent, n) {
+    override final def onCompletion(caller: CountedCompleter[_]): Unit = {
+      super.onCompletion(caller)
+      val p = getCompleter.asInstanceOf[CCF]
+      val n = number + rnumber
+      if (p != null) p.rnumber = n
+      else number = n
+    }
+  }
+  // Version of CCF with forced failure in left completions
+  abstract class FailingCCF(parent: CountedCompleter[Any], var number: Int)
+      extends CheckedCC(parent, 1) {
+    val rnumber = 0
+    override final protected def realCompute(): Unit = {
+      var f = this
+      var n = number
+      while ({ n >= 2 }) {
+        new RFCCF(f, n - 2).fork
+        f = new LFCCF(f, { n -= 1; n })
+      }
+      f.complete(null)
+    }
+  }
+  final class LFCCF(val parent: CountedCompleter[Any], val n: Int)
+      extends FailingCCF(parent, n) {
+    def this(n: Int) = this(null, n)
+
+    override final def onCompletion(caller: CountedCompleter[_]): Unit = {
+      super.onCompletion(caller)
+      val p = getCompleter.asInstanceOf[FailingCCF]
+      val n = number + rnumber
+      if (p != null) p.number = n
+      else number = n
+    }
+  }
+  final class RFCCF(val parent: CountedCompleter[Any], val n: Int)
+      extends FailingCCF(parent, n) {
+    override final def onCompletion(caller: CountedCompleter[_]): Unit = {
+      super.onCompletion(caller)
+      completeExceptionally(new CountedCompleterTest.FJException)
+    }
+  }
+
+  /** invoke returns when task completes normally. isCompletedAbnormally and
+   *  isCancelled return false for normally completed tasks; getRawResult
+   *  returns null.
+   */
+  @Test def testInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertNull(f.invoke)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** quietlyInvoke task returns when task completes normally.
+   *  isCompletedAbnormally and isCancelled return false for normally completed
+   *  tasks
+   */
+  @Test def testQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        f.quietlyInvoke()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** join of a forked task returns when task completes
+   */
+  @Test def testForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** get of a forked task returns when task completes
+   */
+  @Test def testForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertNull(f.get)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** timed get of a forked task returns when task completes
+   */
+  @Test def testForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** timed get with null time unit throws NPE
+   */
+  @Test def testForkTimedGetNPE(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(randomTimeout(), null)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes
+   */
+  @Test def testForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** helpQuiesce returns when tasks are complete. getQueuedTaskCount returns 0
+   *  when quiescent
+   */
+  @Test def testForkHelpQuiesce(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        helpQuiesce()
+        while ({ !f.isDone }) { // wait out race
+        }
+        assertEquals(21, f.number)
+        assertEquals(0, getQueuedTaskCount)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invoke task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  @Test def testAbnormalQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        f.quietlyInvoke()
+        assertTrue(
+          f.getException.isInstanceOf[CountedCompleterTest.FJException]
+        )
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** join of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[CountedCompleterTest.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** timed get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[CountedCompleterTest.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes abnormally
+   */
+  @Test def testAbnormalForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertTrue(
+          f.getException.isInstanceOf[CountedCompleterTest.FJException]
+        )
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invoke task throws exception when task cancelled
+   */
+  @Test def testCancelledInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** join of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** get of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** timed get of a forked task throws exception when task cancelled
+   */
+  @throws[Exception]
+  @Test def testCancelledForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task cancelled
+   */
+  @Test def testCancelledForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        checkCancelled(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** getPool of executing task returns its pool
+   */
+  @Test def testGetPool(): Unit = {
+    import ForkJoinTask._
+    val mainPool = CountedCompleterTest.mainPool
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        assertSame(mainPool, getPool)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** getPool of non-FJ task returns null
+   */
+  @Ignore(
+    "Test-infrastructure limitation, all tests are executed in ForkJoinPool due to usage of Future in RPCCore"
+  )
+  @Test def testGetPool2(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = { assertNull(getPool) }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** inForkJoinPool of executing task returns true
+   */
+  @Test def testInForkJoinPool(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        assertTrue(inForkJoinPool)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** inForkJoinPool of non-FJ task returns false
+   */
+  @Ignore(
+    "Test-infrastructure limitation, all tests are executed in ForkJoinPool due to usage of Future in RPCCore"
+  )
+  @Test def testInForkJoinPool2(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        assertFalse(inForkJoinPool)
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** setRawResult(null) succeeds
+   */
+  @Test def testSetRawResult(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        setRawResult(null.asInstanceOf[Void])
+        assertNull(getRawResult)
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** invoke task throws exception after invoking completeExceptionally
+   */
+  @Test def testCompleteExceptionally2(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val n = new LCCF(8)
+        val f = new LCCF(n, 8)
+        val ex = new CountedCompleterTest.FJException
+        f.completeExceptionally(ex)
+        f.checkCompletedExceptionally(ex)
+        n.checkCompletedExceptionally(ex)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(t1, t2) invokes all task arguments
+   */
+  @Test def testInvokeAll2(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LCCF(9)
+        invokeAll(f, g)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with 1 argument invokes task
+   */
+  @Test def testInvokeAll1(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        invokeAll(f)
+        checkCompletedNormally(f)
+        assertEquals(21, f.number)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with > 2 argument invokes tasks
+   */
+  @Test def testInvokeAll3(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LCCF(9)
+        val h = new LCCF(7)
+        invokeAll(f, g, h)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(collection) invokes all tasks in the collection
+   */
+  @Test def testInvokeAllCollection(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LCCF(9)
+        val h = new LCCF(7)
+        val set = new HashSet[ForkJoinTask[_]]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        invokeAll(set)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with any null task throws NPE
+   */
+  @Test def testInvokeAllNPE(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LCCF(9)
+        val h = null
+        try {
+          invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(t1, t2) throw exception if any task does
+   */
+  @Test def testAbnormalInvokeAll2(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LFCCF(9)
+        try {
+          invokeAll(f, g)
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with 1 argument throws exception if task does
+   */
+  @Test def testAbnormalInvokeAll1(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LFCCF(9)
+        try {
+          invokeAll(g)
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with > 2 argument throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAll3(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LFCCF(9)
+        val h = new LCCF(7)
+        try {
+          invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** invokeAll(collection) throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAllCollection(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        val g = new LCCF(9)
+        val h = new LCCF(7)
+        val set = new HashSet[ForkJoinTask[_]]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        try {
+          invokeAll(set)
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.mainPool, a)
+  }
+
+  /** tryUnfork returns true for most recent unexecuted task, and suppresses
+   *  execution
+   */
+  @Test def testTryUnfork(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LCCF(9)
+        assertSame(g, g.fork)
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertTrue(f.tryUnfork)
+        helpQuiesce()
+        checkNotDone(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  /** getSurplusQueuedTaskCount returns > 0 when there are more tasks than
+   *  threads
+   */
+  @Test def testGetSurplusQueuedTaskCount(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val h = new LCCF(7)
+        assertSame(h, h.fork)
+        val g = new LCCF(9)
+        assertSame(g, g.fork)
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertTrue(getSurplusQueuedTaskCount > 0)
+        helpQuiesce()
+        assertEquals(0, getSurplusQueuedTaskCount)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  /** peekNextLocalTask returns most recent unexecuted task.
+   */
+  @Test def testPeekNextLocalTask(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LCCF(9)
+        assertSame(g, g.fork)
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertSame(f, peekNextLocalTask)
+        assertNull(f.join)
+        checkCompletedNormally(f)
+        helpQuiesce()
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  /** pollNextLocalTask returns most recent unexecuted task without executing it
+   */
+  @Test def testPollNextLocalTask(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LCCF(9)
+        assertSame(g, g.fork)
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertSame(f, pollNextLocalTask)
+        helpQuiesce()
+        checkNotDone(f)
+        assertEquals(34, g.number)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  /** pollTask returns an unexecuted task without executing it
+   */
+  @Test def testPollTask(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LCCF(9)
+        assertSame(g, g.fork)
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertSame(f, pollTask)
+        helpQuiesce()
+        checkNotDone(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  /** peekNextLocalTask returns least recent unexecuted task in async mode
+   */
+  @Test def testPeekNextLocalTaskAsync(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LCCF(9)
+        assertSame(g, g.fork)
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertSame(g, peekNextLocalTask)
+        assertNull(f.join)
+        helpQuiesce()
+        checkCompletedNormally(f)
+        assertEquals(34, g.number)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.asyncSingletonPool, a)
+  }
+
+  /** pollNextLocalTask returns least recent unexecuted task without executing
+   *  it, in async mode
+   */
+  @Test def testPollNextLocalTaskAsync(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LCCF(9)
+        assertSame(g, g.fork)
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertSame(g, pollNextLocalTask)
+        helpQuiesce()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+        checkNotDone(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.asyncSingletonPool, a)
+  }
+
+  /** pollTask returns an unexecuted task without executing it, in async mode
+   */
+  @Test def testPollTaskAsync(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LCCF(9)
+        assertSame(g, g.fork)
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertSame(g, pollTask)
+        helpQuiesce()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+        checkNotDone(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.asyncSingletonPool, a)
+  }
+  // versions for singleton pools
+  @Test def testInvokeSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertNull(f.invoke)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testQuietlyInvokeSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        f.quietlyInvoke()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testForkJoinSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testForkGetSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertNull(f.get)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testForkTimedGetSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testForkTimedGetNPESingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(randomTimeout(), null)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testForkQuietlyJoinSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testForkHelpQuiesceSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertSame(f, f.fork)
+        helpQuiesce()
+        assertEquals(0, getQueuedTaskCount)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testAbnormalInvokeSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testAbnormalQuietlyInvokeSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        f.quietlyInvoke()
+        assertTrue(
+          f.getException.isInstanceOf[CountedCompleterTest.FJException]
+        )
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  @Test def testAbnormalForkJoinSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testAbnormalForkGetSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[CountedCompleterTest.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  @Test def testAbnormalForkTimedGetSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[CountedCompleterTest.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testAbnormalForkQuietlyJoinSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertTrue(
+          f.getException.isInstanceOf[CountedCompleterTest.FJException]
+        )
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testCancelledInvokeSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testCancelledForkJoinSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testCancelledForkGetSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @throws[Exception]
+  @Test def testCancelledForkTimedGetSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testCancelledForkQuietlyJoinSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        checkCancelled(f)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testCompleteExceptionallySingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val n = new LCCF(8)
+        val f = new LCCF(n, 8)
+        val ex = new CountedCompleterTest.FJException
+        f.completeExceptionally(ex)
+        f.checkCompletedExceptionally(ex)
+        n.checkCompletedExceptionally(ex)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testInvokeAll2Singleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LCCF(9)
+        invokeAll(f, g)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testInvokeAll1Singleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        invokeAll(f)
+        checkCompletedNormally(f)
+        assertEquals(21, f.number)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testInvokeAll3Singleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LCCF(9)
+        val h = new LCCF(7)
+        invokeAll(f, g, h)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testInvokeAllCollectionSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LCCF(9)
+        val h = new LCCF(7)
+        val set = new HashSet[ForkJoinTask[_]]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        invokeAll(set)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testInvokeAllNPESingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LCCF(9)
+        val h = null
+        try {
+          invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  @Test def testAbnormalInvokeAll2Singleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LFCCF(9)
+        try {
+          invokeAll(f, g)
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testAbnormalInvokeAll1Singleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new LFCCF(9)
+        try {
+          invokeAll(g)
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testAbnormalInvokeAll3Singleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LCCF(8)
+        val g = new LFCCF(9)
+        val h = new LCCF(7)
+        try {
+          invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+  @Test def testAbnormalInvokeAllCollectionSingleton(): Unit = {
+    import ForkJoinTask._
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new LFCCF(8)
+        val g = new LCCF(9)
+        val h = new LCCF(7)
+        val set = new HashSet[ForkJoinTask[_]]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        try {
+          invokeAll(set)
+          shouldThrow()
+        } catch {
+          case success: CountedCompleterTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(CountedCompleterTest.singletonPool, a)
+  }
+
+  // Since Java 8
+
+  /** CountedCompleter class javadoc code sample, version 1. */
+  def forEach1[E](array: Array[E], action: Consumer[E]): Unit = {
+    class Task(val parent: Task, val lo: Int, val hi: Int)
+        extends CountedCompleter[Void](parent) {
+      override def compute(): Unit = {
+        if (hi - lo >= 2) {
+          val mid = (lo + hi) >>> 1
+          // must set pending count before fork
+          setPendingCount(2)
+          new Task(this, mid, hi).fork // right child
+
+          new Task(this, lo, mid).fork // left child
+
+        } else if (hi > lo) action.accept(array(lo))
+        tryComplete()
+      }
+    }
+    new Task(null, 0, array.length).invoke
+  }
+
+  /** CountedCompleter class javadoc code sample, version 2. */
+  def forEach2[E](array: Array[E], action: Consumer[E]): Unit = {
+    class Task(val parent: Task, val lo: Int, val hi: Int)
+        extends CountedCompleter[Void](parent) {
+      override def compute(): Unit = {
+        if (hi - lo >= 2) {
+          val mid = (lo + hi) >>> 1
+          setPendingCount(1) // looks off by one, but correct!
+
+          new Task(this, mid, hi).fork
+          new Task(this, lo, mid).compute() // direct invoke
+
+        } else {
+          if (hi > lo) action.accept(array(lo))
+          tryComplete()
+        }
+      }
+    }
+    new Task(null, 0, array.length).invoke
+  }
+
+  /** CountedCompleter class javadoc code sample, version 3. */
+  def forEach3[E](array: Array[E], action: Consumer[E]): Unit = {
+    class Task(val parent: Task, val lo: Int, val hi: Int)
+        extends CountedCompleter[Void](parent) {
+      override def compute(): Unit = {
+        var n = hi - lo
+
+        while ({
+          n >= 2
+        }) {
+          addToPendingCount(1)
+          new Task(this, lo + n / 2, lo + n).fork
+
+          n /= 2
+        }
+        if (n > 0) action.accept(array(lo))
+        propagateCompletion()
+      }
+    }
+    new Task(null, 0, array.length).invoke
+  }
+
+  /** CountedCompleter class javadoc code sample, version 4. */
+  def forEach4[E](array: Array[E], action: Consumer[E]): Unit = {
+    class Task(val parent: Task, val lo: Int, val hi: Int)
+        extends CountedCompleter[Void](
+          parent,
+          31 - Integer.numberOfLeadingZeros(hi - lo)
+        ) {
+      override def compute(): Unit = {
+        var n = hi - lo
+        while ({
+          n >= 2
+        }) {
+          new Task(this, lo + n / 2, lo + n).fork
+          n /= 2
+        }
+        action.accept(array(lo))
+        propagateCompletion()
+      }
+    }
+    if (array.length > 0) new Task(null, 0, array.length).invoke
+  }
+
+  def testRecursiveDecomposition(
+      action: BiConsumer[Array[Integer], Consumer[Integer]]
+  ): Unit = {
+    val n = ThreadLocalRandom.current.nextInt(8)
+    val a = new Array[Integer](n)
+    for (i <- 0 until n) {
+      a(i) = i + 1
+    }
+    val ai = new AtomicInteger(0)
+    action.accept(a, ai.addAndGet(_))
+    assertEquals(n * (n + 1) / 2, ai.get)
+  }
+
+  /** Variants of divide-by-two recursive decomposition into leaf tasks, as
+   *  described in the CountedCompleter class javadoc code samples
+   */
+  @Test def testRecursiveDecomposition(): Unit = {
+    testRecursiveDecomposition(forEach1)
+    testRecursiveDecomposition(forEach2)
+    testRecursiveDecomposition(forEach3)
+    testRecursiveDecomposition(forEach4)
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorCompletionServiceTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorCompletionServiceTest.scala
@@ -1,0 +1,261 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.TimeUnit._
+import java.util.concurrent.atomic.AtomicBoolean
+
+import org.junit.Test
+import org.junit.Assert._
+
+class ExecutorCompletionServiceTest extends JSR166Test {
+  import JSR166Test._
+
+  /** new ExecutorCompletionService(null) throws NullPointerException
+   */
+  @Test def testConstructorNPE(): Unit = {
+    try {
+      new ExecutorCompletionService[Any](null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+    }
+  }
+
+  // TODO: ThreadPoolExecutor
+  // /** new ExecutorCompletionService(e, null) throws NullPointerException
+  //  */
+  // @Test def testConstructorNPE2(): Unit = {
+  //   try {
+  //     new ExecutorCompletionService[Any](cachedThreadPool, null)
+  //     shouldThrow()
+  //   } catch {
+  //     case success: NullPointerException =>
+
+  //   }
+  // }
+
+  // /** ecs.submit(null) throws NullPointerException
+  //  */
+  // @Test def testSubmitNullCallable(): Unit = {
+  //   val cs =
+  //     new ExecutorCompletionService[Any](cachedThreadPool)
+  //   try {
+  //     cs.submit(null.asInstanceOf[Callable[Any]])
+  //     shouldThrow()
+  //   } catch {
+  //     case success: NullPointerException =>
+
+  //   }
+  // }
+
+  // /** ecs.submit(null, val) throws NullPointerException
+  //  */
+  // @Test def testSubmitNullRunnable(): Unit = {
+  //   val cs =
+  //     new ExecutorCompletionService[Any](cachedThreadPool)
+  //   try {
+  //     cs.submit(null.asInstanceOf[Runnable], java.lang.Boolean.TRUE)
+  //     shouldThrow()
+  //   } catch {
+  //     case success: NullPointerException => ()
+  //   }
+  // }
+
+  // /** A taken submitted task is completed
+  //  */
+  // @throws[Exception]
+  // @Test def testTake(): Unit = {
+  //   val cs = new ExecutorCompletionService[String](cachedThreadPool)
+  //   cs.submit(new StringTask)
+  //   val f = cs.take
+  //   assertTrue(f.isDone)
+  //   assertEquals(TEST_STRING, f.get)
+  // }
+
+  // /** Take returns the same future object returned by submit
+  //  */
+  // @throws[InterruptedException]
+  // @Test def testTake2(): Unit = {
+  //   val cs = new ExecutorCompletionService[String](cachedThreadPool)
+  //   val f1 = cs.submit(new StringTask)
+  //   val f2 = cs.take
+  //   assertEquals(f1, f2)
+  // }
+
+  // /** poll returns non-null when the returned task is completed
+  //  */
+  // @throws[Exception]
+  // @Test def testPoll1(): Unit = {
+  //   val cs =
+  //     new ExecutorCompletionService[String](cachedThreadPool)
+  //   assertNull(cs.poll)
+  //   cs.submit(new StringTask)
+  //   val startTime = System.nanoTime
+  //   var f: Future[String] = null
+  //   while ({ f = cs.poll(); f == null }) {
+  //     if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
+  //     Thread.`yield`()
+  //   }
+  //   assertTrue(f.isDone)
+  //   assertEquals(TEST_STRING, f.get)
+  // }
+
+  // /** timed poll returns non-null when the returned task is completed
+  //  */
+  // @throws[Exception]
+  // @Test def testPoll2(): Unit = {
+  //   val cs =
+  //     new ExecutorCompletionService[String](cachedThreadPool)
+  //   assertNull(cs.poll)
+  //   cs.submit(new StringTask)
+  //   val startTime = System.nanoTime
+  //   var f: Future[String] = null
+  //   while ({ f = cs.poll(timeoutMillis(), MILLISECONDS); f == null }) {
+  //     assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+  //     if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
+  //     Thread.`yield`()
+  //   }
+  //   assertTrue(f.isDone)
+  //   assertEquals(TEST_STRING, f.get)
+  // }
+
+  // /** poll returns null before the returned task is completed
+  //  */
+  // @throws[Exception]
+  // @Test def testPollReturnsNullBeforeCompletion(): Unit = {
+  //   val cs =
+  //     new ExecutorCompletionService[String](cachedThreadPool)
+  //   val proceed = new CountDownLatch(1)
+  //   cs.submit(new Callable[String]() {
+  //     @throws[Exception]
+  //     override def call: String = {
+  //       await(proceed)
+  //       TEST_STRING
+  //     }
+  //   })
+  //   assertNull(cs.poll)
+  //   assertNull(cs.poll(0L, MILLISECONDS))
+  //   assertNull(cs.poll(java.lang.Long.MIN_VALUE, MILLISECONDS))
+  //   val startTime = System.nanoTime
+  //   assertNull(cs.poll(timeoutMillis(), MILLISECONDS))
+  //   assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+  //   proceed.countDown()
+  //   assertEquals(TEST_STRING, cs.take.get)
+  // }
+
+  // /** successful and failed tasks are both returned
+  //  */
+  // @throws[Exception]
+  // @Test def testTaskAssortment(): Unit = {
+  //   val cs =
+  //     new ExecutorCompletionService[String](cachedThreadPool)
+  //   val ex = new ArithmeticException
+  //   val rounds = 2
+  //   locally {
+  //     var i = rounds
+  //     while (i > 0) {
+  //       i -= 1
+  //       cs.submit(new StringTask)
+  //       cs.submit(callableThrowing(ex))
+  //       cs.submit(runnableThrowing(ex), null)
+  //     }
+  //   }
+  //   locally {
+  //     var normalCompletions = 0
+  //     var exceptionalCompletions = 0
+  //     var i = 3 * rounds
+  //     while (i > 0) try {
+  //       i -= 1
+  //       assertEquals(TEST_STRING, cs.take.get)
+  //       normalCompletions += 1
+  //     } catch {
+  //       case expected: ExecutionException =>
+  //         assertEquals(ex, expected.getCause)
+  //         exceptionalCompletions += 1
+  //     }
+  //     assertEquals(1 * rounds, normalCompletions)
+  //     assertEquals(2 * rounds, exceptionalCompletions)
+  //   }
+  //   assertNull(cs.poll)
+  // }
+  // /** Submitting to underlying AES that overrides newTaskFor(Callable) returns
+  //  *  and eventually runs Future returned by newTaskFor.
+  //  */
+  // @throws[InterruptedException]
+  // @Test def testNewTaskForCallable(): Unit = {
+  //   val _done = new AtomicBoolean(false)
+  //   class MyCallableFuture[V](val c: Callable[V]) extends FutureTask[V](c) {
+  //     override protected def done(): Unit = _done.set(true)
+  //   }
+  //   val e = new ThreadPoolExecutor(
+  //     1,
+  //     1,
+  //     30L,
+  //     TimeUnit.SECONDS,
+  //     new ArrayBlockingQueue[Runnable](1)
+  //   ) {
+  //     override protected def newTaskFor[T](c: Callable[T]) =
+  //       new MyCallableFuture[T](c)
+  //   }
+
+  //   val cs = new ExecutorCompletionService[String](e)
+  //   usingPoolCleaner(e) { e =>
+  //     assertNull(cs.poll)
+  //     val c = new StringTask
+  //     val f1 = cs.submit(c)
+  //     assertTrue(
+  //       "submit must return MyCallableFuture",
+  //       f1.isInstanceOf[MyCallableFuture[_]]
+  //     )
+  //     val f2 = cs.take
+  //     assertEquals("submit and take must return same objects", f1, f2)
+  //     assertTrue("completed task must have set done", _done.get)
+  //   }
+  // }
+  // /** Submitting to underlying AES that overrides newTaskFor(Runnable,T) returns
+  //  *  and eventually runs Future returned by newTaskFor.
+  //  */
+  // @throws[InterruptedException]
+  // @Test def testNewTaskForRunnable(): Unit = {
+  //   val _done = new AtomicBoolean(false)
+  //   class MyRunnableFuture[V](val t: Runnable, val r: V)
+  //       extends FutureTask[V](t, r) {
+  //     override protected def done(): Unit = _done.set(true)
+  //   }
+  //   val e = new ThreadPoolExecutor(
+  //     1,
+  //     1,
+  //     30L,
+  //     TimeUnit.SECONDS,
+  //     new ArrayBlockingQueue[Runnable](1)
+  //   ) {
+  //     override protected def newTaskFor[T](
+  //         t: Runnable,
+  //         r: T
+  //     ) = new MyRunnableFuture[T](t, r)
+  //   }
+
+  //   val cs = new ExecutorCompletionService[String](e)
+  //   usingPoolCleaner(e) { e =>
+  //     assertNull(cs.poll)
+  //     val r = new NoOpRunnable
+  //     val f1 = cs.submit(r, null)
+  //     assertTrue(
+  //       "submit must return MyRunnableFuture",
+  //       f1.isInstanceOf[MyRunnableFuture[_]]
+  //     )
+  //     val f2 = cs.take
+  //     assertEquals("submit and take must return same objects", f1, f2)
+  //     assertTrue("completed task must have set done", _done.get)
+  //   }
+  // }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool8Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool8Test.scala
@@ -1,0 +1,1582 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util._
+import java.util.concurrent._
+
+import org.junit._
+import org.junit.Assert._
+
+import JSR166Test._
+
+object ForkJoinPool8Test {
+  final class FJException(cause: Throwable) extends RuntimeException {
+    def this() = this(null)
+  }
+
+  /** A recursive action failing in base case. */
+  final class FailingFibAction(val number: Int) extends RecursiveAction {
+    var result = 0
+    override def compute(): Unit = {
+      val n = number
+      if (n <= 1) throw new ForkJoinPool8Test.FJException
+      else {
+        val f1 = new ForkJoinPool8Test.FailingFibAction(n - 1)
+        val f2 = new ForkJoinPool8Test.FailingFibAction(n - 2)
+        ForkJoinTask.invokeAll(f1, f2)
+        result = f1.result + f2.result
+      }
+    }
+  }
+  // CountedCompleter versions
+  abstract class CCF(parent: CountedCompleter[_], var number: Int)
+      extends CountedCompleter[AnyRef](parent, 1) {
+    var rnumber = 0
+    override final def compute(): Unit = {
+      var p: CountedCompleter[_] = null
+      var f = this
+      var n = number
+      while (n >= 2) {
+        new ForkJoinPool8Test.RCCF(f, n - 2).fork
+        f = new ForkJoinPool8Test.LCCF(f, { n -= 1; n })
+      }
+      f.number = n
+      f.onCompletion(f)
+      p = f.getCompleter()
+      if (p != null) p.tryComplete()
+      else f.quietlyComplete()
+    }
+  }
+  final class LCCF(parent: CountedCompleter[_], n: Int)
+      extends ForkJoinPool8Test.CCF(parent, n) {
+    override final def onCompletion(caller: CountedCompleter[_]): Unit = {
+      val p = getCompleter.asInstanceOf[ForkJoinPool8Test.CCF]
+      val n = number + rnumber
+      if (p != null) p.number = n
+      else number = n
+    }
+  }
+  final class RCCF(parent: CountedCompleter[_], n: Int)
+      extends ForkJoinPool8Test.CCF(parent, n) {
+    override final def onCompletion(caller: CountedCompleter[_]): Unit = {
+      val p = getCompleter.asInstanceOf[ForkJoinPool8Test.CCF]
+      val n = number + rnumber
+      if (p != null) p.rnumber = n
+      else number = n
+    }
+  }
+
+  /** Version of CCF with forced failure in left completions. */
+  abstract class FailingCCF(parent: CountedCompleter[_], var number: Int)
+      extends CountedCompleter[AnyRef](parent, 1) {
+    val rnumber = 0
+    override final def compute(): Unit = {
+      var p: CountedCompleter[_] = null
+      var f = this
+      var n = number
+      while (n >= 2) {
+        new ForkJoinPool8Test.RFCCF(f, n - 2).fork
+        f = new ForkJoinPool8Test.LFCCF(f, { n -= 1; n })
+      }
+      f.number = n
+      f.onCompletion(f)
+      p = f.getCompleter
+      if (p != null) p.tryComplete()
+      else f.quietlyComplete()
+    }
+  }
+  final class LFCCF(parent: CountedCompleter[_], n: Int)
+      extends ForkJoinPool8Test.FailingCCF(parent, n) {
+    override final def onCompletion(caller: CountedCompleter[_]): Unit = {
+      val p = getCompleter.asInstanceOf[ForkJoinPool8Test.FailingCCF]
+      val n = number + rnumber
+      if (p != null) p.number = n
+      else number = n
+    }
+  }
+  final class RFCCF(parent: CountedCompleter[_], n: Int)
+      extends ForkJoinPool8Test.FailingCCF(parent, n) {
+    override final def onCompletion(caller: CountedCompleter[_]): Unit = {
+      completeExceptionally(new ForkJoinPool8Test.FJException)
+    }
+  }
+}
+
+class ForkJoinPool8Test extends JSR166Test {
+  import ForkJoinPool8Test._
+
+  /** Common pool exists and has expected parallelism.
+   */
+  @Test def testCommonPoolParallelism(): Unit = {
+    assertEquals(
+      ForkJoinPool.getCommonPoolParallelism,
+      ForkJoinPool.commonPool.getParallelism
+    )
+  }
+
+  /** Common pool cannot be shut down
+   */
+  @Test def testCommonPoolShutDown(): Unit = {
+    assertFalse(ForkJoinPool.commonPool.isShutdown)
+    assertFalse(ForkJoinPool.commonPool.isTerminating)
+    assertFalse(ForkJoinPool.commonPool.isTerminated)
+    ForkJoinPool.commonPool.shutdown()
+    assertFalse(ForkJoinPool.commonPool.isShutdown)
+    assertFalse(ForkJoinPool.commonPool.isTerminating)
+    assertFalse(ForkJoinPool.commonPool.isTerminated)
+    ForkJoinPool.commonPool.shutdownNow
+    assertFalse(ForkJoinPool.commonPool.isShutdown)
+    assertFalse(ForkJoinPool.commonPool.isTerminating)
+    assertFalse(ForkJoinPool.commonPool.isTerminated)
+  }
+  /*
+   * All of the following test methods are adaptations of those for
+   * RecursiveAction and CountedCompleter, but with all actions
+   * executed in the common pool, generally implicitly via
+   * checkInvoke.
+   */
+  private def checkInvoke(a: ForkJoinTask[_]): Unit = {
+    checkNotDone(a)
+    assertNull(a.invoke)
+    checkCompletedNormally(a)
+  }
+  def checkNotDone(a: ForkJoinTask[_]): Unit = {
+    assertFalse(a.isDone)
+    assertFalse(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertFalse(a.isCancelled)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    if (!ForkJoinTask.inForkJoinPool) {
+      Thread.currentThread.interrupt()
+      try {
+        a.get
+        shouldThrow()
+      } catch {
+        case success: InterruptedException =>
+
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+      Thread.currentThread.interrupt()
+      try {
+        a.get(randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: InterruptedException =>
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+    }
+    try {
+      a.get(randomExpiredTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: TimeoutException =>
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedNormally(a: ForkJoinTask[_]): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertTrue(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    assertNull(a.join)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    try {
+      assertNull(a.get())
+      assertNull(a.get(randomTimeout(), randomTimeUnit()))
+    } catch {
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCancelled(a: ForkJoinTask[_]): Unit = {
+    assertTrue(a.isDone)
+    assertTrue(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertTrue(a.getException.isInstanceOf[CancellationException])
+    assertNull(a.getRawResult)
+    try {
+      a.join()
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedAbnormally(a: ForkJoinTask[_], t: Throwable): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertSame(t.getClass, a.getException.getClass)
+    assertNull(a.getRawResult)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    try {
+      a.join
+      shouldThrow()
+    } catch {
+      case expected: Throwable =>
+        assertSame(expected.getClass, t.getClass)
+    }
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  /** A simple recursive action for testing. */
+  final class FibAction(val number: Int) extends CheckedRecursiveAction {
+    var result = 0
+    protected def realCompute(): Unit = {
+      val n = number
+      if (n <= 1) result = n
+      else {
+        val f1 = new FibAction(n - 1)
+        val f2 = new FibAction(n - 2)
+        ForkJoinTask.invokeAll(f1, f2)
+        result = f1.result + f2.result
+      }
+    }
+  }
+
+  /** invoke returns when task completes normally. isCompletedAbnormally and
+   *  isCancelled return false for normally completed tasks. getRawResult of a
+   *  RecursiveAction returns null;
+   */
+  @Test def testInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertNull(f.invoke)
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyInvoke task returns when task completes normally.
+   *  isCompletedAbnormally and isCancelled return false for normally completed
+   *  tasks
+   */
+  @Test def testQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        f.quietlyInvoke
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** join of a forked task returns when task completes
+   */
+  @Test def testForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** join/quietlyJoin of a forked task succeeds in the presence of interrupts
+   */
+  @Test def testJoinIgnoresInterrupts(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        var f = new FibAction(8)
+        val currentThread = Thread.currentThread
+        // test join()
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        assertNull(f.join)
+        Thread.interrupted
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+        f = new FibAction(8)
+        f.cancel(true)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            Thread.interrupted
+            checkCancelled(f)
+        }
+        f = new FibAction(8)
+        f.completeExceptionally(new ForkJoinPool8Test.FJException)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            Thread.interrupted
+            checkCompletedAbnormally(f, success)
+        }
+        // test quietlyJoin()
+        f = new FibAction(8)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoin
+        Thread.interrupted
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+        f = new FibAction(8)
+        f.cancel(true)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoin
+        Thread.interrupted
+        checkCancelled(f)
+        f = new FibAction(8)
+        f.completeExceptionally(new ForkJoinPool8Test.FJException)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoin
+        Thread.interrupted
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    checkInvoke(a)
+    a.reinitialize()
+    checkInvoke(a)
+  }
+
+  /** get of a forked task returns when task completes
+   */
+  @Test def testForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertNull(f.get)
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed get of a forked task returns when task completes
+   */
+  @Test def testForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed get with null time unit throws NPE
+   */
+  @Test def testForkTimedGetNPE(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertThrows(
+          classOf[NullPointerException],
+          () => f.get(randomTimeout(), null)
+        )
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes
+   */
+  @Test def testForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** invoke task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.FailingFibAction(8)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  @Test def testAbnormalQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.FailingFibAction(8)
+        f.quietlyInvoke()
+        assertTrue(f.getException.isInstanceOf[ForkJoinPool8Test.FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** join of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.FailingFibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.FailingFibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[ForkJoinPool8Test.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.FailingFibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[ForkJoinPool8Test.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes abnormally
+   */
+  @Test def testAbnormalForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.FailingFibAction(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertTrue(f.getException.isInstanceOf[ForkJoinPool8Test.FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** invoke task throws exception when task cancelled
+   */
+  @Test def testCancelledInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** join of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** get of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed get of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyJoin of a forked task returns when task cancelled
+   */
+  @Test def testCancelledForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        f.quietlyJoin
+        checkCancelled(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** inForkJoinPool of non-FJ task returns false
+   */
+  @Test def testInForkJoinPool2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        assertFalse(ForkJoinTask.inForkJoinPool)
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** A reinitialized normally completed task may be re-invoked
+   */
+  @Test def testReinitialize(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        checkNotDone(f)
+        for (i <- 0 until 3) {
+          assertNull(f.invoke)
+          assertEquals(21, f.result)
+          checkCompletedNormally(f)
+          f.reinitialize
+          checkNotDone(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** A reinitialized abnormally completed task may be re-invoked
+   */
+  @Test def testReinitializeAbnormal(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.FailingFibAction(8)
+        checkNotDone(f)
+        for (i <- 0 until 3) {
+          try {
+            f.invoke
+            shouldThrow()
+          } catch {
+            case success: ForkJoinPool8Test.FJException =>
+              checkCompletedAbnormally(f, success)
+          }
+          f.reinitialize()
+          checkNotDone(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** invoke task throws exception after invoking completeExceptionally
+   */
+  @Test def testCompleteExceptionally(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        f.completeExceptionally(new ForkJoinPool8Test.FJException)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** invoke task suppresses execution invoking complete
+   */
+  @Test def testComplete(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        f.complete(null)
+        assertNull(f.invoke)
+        assertEquals(0, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(t1, t2) invokes all task arguments
+   */
+  @Test def testInvokeAll2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new FibAction(9)
+        ForkJoinTask.invokeAll(f, g)
+        checkCompletedNormally(f)
+        assertEquals(21, f.result)
+        checkCompletedNormally(g)
+        assertEquals(34, g.result)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with 1 argument invokes task
+   */
+  @Test def testInvokeAll1(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        ForkJoinTask.invokeAll(f)
+        checkCompletedNormally(f)
+        assertEquals(21, f.result)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with > 2 argument invokes tasks
+   */
+  @Test def testInvokeAll3(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new FibAction(9)
+        val h = new FibAction(7)
+        ForkJoinTask.invokeAll(f, g, h)
+        assertTrue(f.isDone)
+        assertTrue(g.isDone)
+        assertTrue(h.isDone)
+        checkCompletedNormally(f)
+        assertEquals(21, f.result)
+        checkCompletedNormally(g)
+        assertEquals(34, g.result)
+        checkCompletedNormally(g)
+        assertEquals(13, h.result)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(collection) invokes all tasks in the collection
+   */
+  @Test def testInvokeAllCollection(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new FibAction(9)
+        val h = new FibAction(7)
+        val set = new HashSet[RecursiveAction]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        ForkJoinTask.invokeAll(set)
+        assertTrue(f.isDone)
+        assertTrue(g.isDone)
+        assertTrue(h.isDone)
+        checkCompletedNormally(f)
+        assertEquals(21, f.result)
+        checkCompletedNormally(g)
+        assertEquals(34, g.result)
+        checkCompletedNormally(g)
+        assertEquals(13, h.result)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with any null task throws NPE
+   */
+  @Test def testInvokeAllNPE(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new FibAction(9)
+        val h: FibAction = null
+        try {
+          ForkJoinTask.invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(t1, t2) throw exception if any task does
+   */
+  @Test def testAbnormalInvokeAll2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new ForkJoinPool8Test.FailingFibAction(9)
+        try {
+          ForkJoinTask.invokeAll(f, g)
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with 1 argument throws exception if task
+   *  does
+   */
+  @Test def testAbnormalInvokeAll1(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new ForkJoinPool8Test.FailingFibAction(9)
+        try {
+          ForkJoinTask.invokeAll(g)
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with > 2 argument throws exception if any
+   *  task does
+   */
+  @Test def testAbnormalInvokeAll3(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new ForkJoinPool8Test.FailingFibAction(9)
+        val h = new FibAction(7)
+        try {
+          ForkJoinTask.invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(collection) throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAllCollection(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.FailingFibAction(8)
+        val g = new FibAction(9)
+        val h = new FibAction(7)
+        val set = new HashSet[RecursiveAction]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        try {
+          ForkJoinTask.invokeAll(set)
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** invoke returns when task completes normally. isCompletedAbnormally and
+   *  isCancelled return false for normally completed tasks; getRawResult
+   *  returns null.
+   */
+  @Test def testInvokeCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertNull(f.invoke)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyInvoke task returns when task completes normally.
+   *  isCompletedAbnormally and isCancelled return false for normally completed
+   *  tasks
+   */
+  @Test def testQuietlyInvokeCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        f.quietlyInvoke()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** join of a forked task returns when task completes
+   */
+  @Test def testForkJoinCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** get of a forked task returns when task completes
+   */
+  @Test def testForkGetCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertSame(f, f.fork)
+        assertNull(f.get)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed get of a forked task returns when task completes
+   */
+  @Test def testForkTimedGetCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertSame(f, f.fork)
+        assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed get with null time unit throws NPE
+   */
+  @Test def testForkTimedGetNPECC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertSame(f, f.fork)
+        assertThrows(
+          classOf[java.lang.NullPointerException],
+          () => f.get(randomTimeout(), null)
+        )
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes
+   */
+  @Test def testForkQuietlyJoinCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** invoke task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalInvokeCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LFCCF(null, 8)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  @Test def testAbnormalQuietlyInvokeCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LFCCF(null, 8)
+        f.quietlyInvoke()
+        assertTrue(f.getException.isInstanceOf[ForkJoinPool8Test.FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** join of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkJoinCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LFCCF(null, 8)
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkGetCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LFCCF(null, 8)
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[ForkJoinPool8Test.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkTimedGetCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LFCCF(null, 8)
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[ForkJoinPool8Test.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes abnormally
+   */
+  @Test def testAbnormalForkQuietlyJoinCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LFCCF(null, 8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertTrue(f.getException.isInstanceOf[ForkJoinPool8Test.FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** invoke task throws exception when task cancelled
+   */
+  @Test def testCancelledInvokeCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertTrue(f.cancel(true))
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** join of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkJoinCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** get of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkGetCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed get of a forked task throws exception when task cancelled
+   */
+  @throws[Exception]
+  @Test def testCancelledForkTimedGetCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyJoin of a forked task returns when task cancelled
+   */
+  @Test def testCancelledForkQuietlyJoinCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        checkCancelled(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** getPool of non-FJ task returns null
+   */
+  @Test def testGetPool2CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertNull(ForkJoinTask.getPool) }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** inForkJoinPool of non-FJ task returns false
+   */
+  @Test def testInForkJoinPool2CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        assertFalse(ForkJoinTask.inForkJoinPool)
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** setRawResult(null) succeeds
+   */
+  @Test def testSetRawResultCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        setRawResult(null)
+        assertNull(getRawResult)
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** invoke task throws exception after invoking completeExceptionally
+   */
+  @Test def testCompleteExceptionally2CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        f.completeExceptionally(new ForkJoinPool8Test.FJException)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(t1, t2) invokes all task arguments
+   */
+  @Test def testInvokeAll2CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        val g = new ForkJoinPool8Test.LCCF(null, 9)
+        ForkJoinTask.invokeAll(f, g)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with 1 argument invokes task
+   */
+  @Test def testInvokeAll1CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        ForkJoinTask.invokeAll(f)
+        checkCompletedNormally(f)
+        assertEquals(21, f.number)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with > 2 argument invokes tasks
+   */
+  @Test def testInvokeAll3CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        val g = new ForkJoinPool8Test.LCCF(null, 9)
+        val h = new ForkJoinPool8Test.LCCF(null, 7)
+        ForkJoinTask.invokeAll(f, g, h)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(collection) invokes all tasks in the collection
+   */
+  @Test def testInvokeAllCollectionCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        val g = new ForkJoinPool8Test.LCCF(null, 9)
+        val h = new ForkJoinPool8Test.LCCF(null, 7)
+        val set = new HashSet[CountedCompleter[_]]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        ForkJoinTask.invokeAll(set)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with any null task throws NPE
+   */
+  @Test def testInvokeAllNPECC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        val g = new ForkJoinPool8Test.LCCF(null, 9)
+        val h: ForkJoinPool8Test.CCF = null
+        assertThrows(
+          classOf[NullPointerException],
+          () => ForkJoinTask.invokeAll(f, g, h)
+        )
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(t1, t2) throw exception if any task does
+   */
+  @Test def testAbnormalInvokeAll2CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        val g = new ForkJoinPool8Test.LFCCF(null, 9)
+        try {
+          ForkJoinTask.invokeAll(f, g)
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with 1 argument throws exception if task
+   *  does
+   */
+  @Test def testAbnormalInvokeAll1CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new ForkJoinPool8Test.LFCCF(null, 9)
+        try {
+          ForkJoinTask.invokeAll(g)
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with > 2 argument throws exception if any
+   *  task does
+   */
+  @Test def testAbnormalInvokeAll3CC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LCCF(null, 8)
+        val g = new ForkJoinPool8Test.LFCCF(null, 9)
+        val h = new ForkJoinPool8Test.LCCF(null, 7)
+        try {
+          ForkJoinTask.invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: ForkJoinPool8Test.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** ForkJoinTask.invokeAll(collection) throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAllCollectionCC(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new ForkJoinPool8Test.LFCCF(null, 8)
+        val g = new ForkJoinPool8Test.LCCF(null, 9)
+        val h = new ForkJoinPool8Test.LCCF(null, 7)
+        val set = new HashSet[CountedCompleter[_]]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        val ex = assertThrows(
+          classOf[ForkJoinPool8Test.FJException],
+          () => ForkJoinTask.invokeAll(set)
+        )
+        checkCompletedAbnormally(f, ex)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** awaitQuiescence by a worker is equivalent in effect to
+   *  ForkJoinTask.helpQuiesce()
+   */
+  @throws[Exception]
+  @Test def testAwaitQuiescence1(): Unit =
+    usingPoolCleaner(new ForkJoinPool()) { p =>
+      val startTime = System.nanoTime
+      assertTrue(p.isQuiescent)
+      val a: CheckedRecursiveAction = () => {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertSame(p, ForkJoinTask.getPool)
+        val quiescent = p.awaitQuiescence(LONG_DELAY_MS, MILLISECONDS)
+        assertTrue(quiescent)
+        assertFalse(p.isQuiescent)
+        while (!f.isDone) {
+          assertFalse(p.getAsyncMode)
+          assertFalse(p.isShutdown)
+          assertFalse(p.isTerminating)
+          assertFalse(p.isTerminated)
+          Thread.`yield`()
+        }
+        assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+        assertFalse(p.isQuiescent)
+        assertEquals(0, ForkJoinTask.getQueuedTaskCount)
+        assertEquals(21, f.result)
+      }
+      p.execute(a)
+      while (!a.isDone || !p.isQuiescent) {
+        assertFalse(p.getAsyncMode)
+        assertFalse(p.isShutdown)
+        assertFalse(p.isTerminating)
+        assertFalse(p.isTerminated)
+        Thread.`yield`()
+      }
+      assertEquals(0, p.getQueuedTaskCount)
+      assertFalse(p.getAsyncMode)
+      assertEquals(0, p.getQueuedSubmissionCount)
+      assertFalse(p.hasQueuedSubmissions)
+      while (p.getActiveThreadCount != 0 &&
+          millisElapsedSince(startTime) < LONG_DELAY_MS) Thread.`yield`()
+      assertFalse(p.isShutdown)
+      assertFalse(p.isTerminating)
+      assertFalse(p.isTerminated)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+
+  /** awaitQuiescence returns when pool isQuiescent() or the indicated timeout
+   *  elapsed
+   */
+  @throws[Exception]
+  @Test def testAwaitQuiescence2(): Unit = {
+    /*
+     * """It is possible to disable or limit the use of threads in the
+     * common pool by setting the parallelism property to zero. However
+     * doing so may cause unjoined tasks to never be executed."""
+     */
+    if ("0" == System.getProperty(
+          "java.util.concurrent.ForkJoinPool.common.parallelism"
+        )) return
+    usingPoolCleaner(new ForkJoinPool()) { p =>
+      assertTrue(p.isQuiescent)
+      val startTime = System.nanoTime
+      val a: CheckedRecursiveAction = () => {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        while (!f.isDone && millisElapsedSince(startTime) < LONG_DELAY_MS) {
+          assertFalse(p.getAsyncMode)
+          assertFalse(p.isShutdown)
+          assertFalse(p.isTerminating)
+          assertFalse(p.isTerminated)
+          Thread.`yield`()
+        }
+        assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+        assertEquals(0, ForkJoinTask.getQueuedTaskCount)
+        assertEquals(21, f.result)
+      }
+      p.execute(a)
+      assertTrue(p.awaitQuiescence(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isQuiescent)
+      assertTrue(a.isDone)
+      assertEquals(0, p.getQueuedTaskCount)
+      assertFalse(p.getAsyncMode)
+      assertEquals(0, p.getQueuedSubmissionCount)
+      assertFalse(p.hasQueuedSubmissions)
+      while (p.getActiveThreadCount != 0 &&
+          millisElapsedSince(startTime) < LONG_DELAY_MS) {
+        Thread.`yield`()
+      }
+      assertFalse(p.isShutdown)
+      assertFalse(p.isTerminating)
+      assertFalse(p.isTerminated)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPoolTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPoolTest.scala
@@ -1,0 +1,724 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.TimeUnit._
+import java.util.concurrent.atomic._
+import java.util.concurrent.locks._
+
+import org.junit.Test
+import org.junit.Assert._
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+object ForkJoinPoolTest {
+  class MyError extends Error {}
+
+  // to test handlers
+  class FailingFJWSubclass(p: ForkJoinPool) extends ForkJoinWorkerThread(p) {
+    override protected def onStart(): Unit = {
+      super.onStart()
+      throw new MyError()
+    }
+  }
+
+  class FailingThreadFactory()
+      extends ForkJoinPool.ForkJoinWorkerThreadFactory {
+    final val calls = new AtomicInteger(0)
+    override def newThread(p: ForkJoinPool): ForkJoinWorkerThread = {
+      if (calls.incrementAndGet() > 1) null
+      else new FailingFJWSubclass(p)
+    }
+  }
+
+  class SubFJP() extends ForkJoinPool(1) {
+    // to expose protected
+    def drainTasks[T](c: Collection[_ >: ForkJoinTask[_]]) =
+      super.drainTasksTo(c)
+    // def drainTasksTo(c: Collection[ForkJoinTask[_]]) = super.drainTasksTo(c)
+    override def pollSubmission() = super.pollSubmission()
+  }
+
+  class ManagedLocker(lock: ReentrantLock) extends ForkJoinPool.ManagedBlocker {
+    var hasLock = false
+    def block(): Boolean = {
+      if (!hasLock) lock.lock()
+      true
+    }
+    def isReleasable(): Boolean = hasLock || {
+      hasLock = lock.tryLock()
+      hasLock
+    }
+  }
+
+  // A simple recursive task for testing
+  final class FibTask(number: Int) extends RecursiveTask[Int] {
+    override protected def compute(): Int = {
+      val n = number
+      if (n <= 1) n
+      else {
+        val f1 = new FibTask(n - 1)
+        f1.fork()
+        new FibTask(n - 2).compute() + f1.join()
+      }
+    }
+  }
+
+  //  // A failing task for testing
+  //  static final class FailingTask extends ForkJoinTask<Void> {
+  //      public final Void getRawResult() { return null }
+  //      protected final void setRawResult(Void mustBeNull) { }
+  //      protected final boolean exec() { throw new Error() }
+  //      FailingTask() {}
+  //  }
+
+  // Fib needlessly using locking to test ManagedBlockers
+  final class LockingFibTask(
+      number: Int,
+      locker: ManagedLocker,
+      lock: ReentrantLock
+  ) extends RecursiveTask[Int] {
+    override protected def compute(): Int = {
+      var f1: LockingFibTask = null
+      var f2: LockingFibTask = null
+      locker.block()
+      val n = number
+      if (n > 1) {
+        f1 = new LockingFibTask(n - 1, locker, lock)
+        f2 = new LockingFibTask(n - 2, locker, lock)
+      }
+      lock.unlock()
+      if (n <= 1) n
+      else {
+        f1.fork()
+        f2.compute() + f1.join()
+      }
+    }
+  }
+}
+
+class ForkJoinPoolTest extends JSR166Test {
+  import JSR166Test._
+  import ForkJoinPoolTest._
+  /*
+   * Testing coverage notes:
+   *
+   * 1. shutdown and related methods are tested via super.joinPool.
+   *
+   * 2. newTaskFor and adapters are tested in submit/invoke tests
+   *
+   * 3. We cannot portably test monitoring methods such as
+   * getStealCount() since they rely ultimately on random task
+   * stealing that may cause tasks not to be stolen/propagated
+   * across threads, especially on uniprocessors.
+   *
+   * 4. There are no independently testable ForkJoinWorkerThread
+   * methods, but they are covered here and in task tests.
+   */
+
+  // Some classes to test extension and factory methods
+
+  /** Successfully constructed pool reports default factory, parallelism and
+   *  async mode policies, no active threads or tasks, and quiescent running
+   *  state.
+   */
+  @Test def testDefaultInitialState(): Unit = {
+    usingPoolCleaner(new ForkJoinPool(1)) { p =>
+      assertSame(
+        ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+        p.getFactory()
+      )
+      assertFalse(p.getAsyncMode())
+      assertEquals(0, p.getActiveThreadCount())
+      assertEquals(0, p.getStealCount())
+      assertEquals(0, p.getQueuedTaskCount())
+      assertEquals(0, p.getQueuedSubmissionCount())
+      assertFalse(p.hasQueuedSubmissions())
+      assertFalse(p.isShutdown())
+      assertFalse(p.isTerminating())
+      assertFalse(p.isTerminated())
+    }
+  }
+
+  /** Constructor throws if size argument is less than zero
+   */
+  @Test def testConstructor1(): Unit = assertThrows(
+    classOf[IllegalArgumentException],
+    new ForkJoinPool(-1)
+  )
+
+  /** Constructor throws if factory argument is null
+   */
+  @Test def testConstructor2(): Unit = assertThrows(
+    classOf[NullPointerException],
+    new ForkJoinPool(1, null, null, false)
+  )
+
+  /** getParallelism returns size set in constructor
+   */
+  @Test def testGetParallelism(): Unit = {
+    usingPoolCleaner(new ForkJoinPool(1)) { p =>
+      assertEquals(1, p.getParallelism())
+    }
+  }
+
+  /** getPoolSize returns number of started workers.
+   */
+  @Test def testGetPoolSize(): Unit = {
+    val taskStarted = new CountDownLatch(1)
+    val done = new CountDownLatch(1)
+    val p = usingPoolCleaner(new ForkJoinPool(1)) { p =>
+      assertEquals(0, p.getActiveThreadCount())
+      val task: CheckedRunnable = () => {
+        taskStarted.countDown()
+        assertEquals(1, p.getPoolSize())
+        assertEquals(1, p.getActiveThreadCount())
+        await(done)
+      }
+      val future = p.submit(task)
+      await(taskStarted)
+      assertEquals(1, p.getPoolSize())
+      assertEquals(1, p.getActiveThreadCount())
+      done.countDown()
+      p
+    }
+    assertEquals(0, p.getPoolSize())
+    assertEquals(0, p.getActiveThreadCount())
+  }
+
+  // awaitTermination on a non-shutdown pool times out
+  @Test def testAwaitTerminationTimesOut(): Unit = {
+    usingPoolCleaner(new ForkJoinPool(1)) { p =>
+      assertFalse(p.isTerminated())
+      assertFalse(p.awaitTermination(java.lang.Long.MIN_VALUE, NANOSECONDS))
+      assertFalse(p.awaitTermination(java.lang.Long.MIN_VALUE, MILLISECONDS))
+      assertFalse(p.awaitTermination(-1L, NANOSECONDS))
+      assertFalse(p.awaitTermination(-1L, MILLISECONDS))
+      assertFalse(p.awaitTermination(randomExpiredTimeout(), randomTimeUnit()))
+
+      locally {
+        val timeoutNanos = 999999L
+        val startTime = System.nanoTime()
+        assertFalse(p.awaitTermination(timeoutNanos, NANOSECONDS))
+        assertTrue(System.nanoTime() - startTime >= timeoutNanos)
+        assertFalse(p.isTerminated())
+      }
+      locally {
+        val startTime = System.nanoTime()
+        val timeoutMillis = JSR166Test.timeoutMillis()
+        assertFalse(p.awaitTermination(timeoutMillis, MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis)
+      }
+      assertFalse(p.isTerminated())
+      p.shutdown()
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated())
+    }
+  }
+
+  /** setUncaughtExceptionHandler changes handler for uncaught exceptions.
+   *
+   *  Additionally tests: Overriding ForkJoinWorkerThread.onStart performs its
+   *  defined action
+   */
+  @Test def testSetUncaughtExceptionHandler(): Unit = {
+    val uehInvoked = new CountDownLatch(1)
+    val ueh: Thread.UncaughtExceptionHandler = (t: Thread, e: Throwable) => {
+      threadAssertTrue(e.isInstanceOf[MyError])
+      threadAssertTrue(t.isInstanceOf[FailingFJWSubclass])
+      uehInvoked.countDown()
+    }
+    usingPoolCleaner(
+      new ForkJoinPool(1, new FailingThreadFactory(), ueh, false)
+    ) { p =>
+      assertSame(ueh, p.getUncaughtExceptionHandler())
+      try {
+        p.execute(new FibTask(8))
+        await(uehInvoked)
+      } finally p.shutdownNow() // failure might have prevented processing task
+    }
+  }
+
+  /** After invoking a single task, isQuiescent eventually becomes true, at
+   *  which time queues are empty, threads are not active, the task has
+   *  completed successfully, and construction parameters continue to hold
+   */
+  @Test def testIsQuiescent(): Unit = usingPoolCleaner(new ForkJoinPool(2)) {
+    p =>
+      assertTrue(p.isQuiescent())
+      val startTime = System.nanoTime()
+      val f = new FibTask(20)
+      p.invoke(f)
+      assertSame(
+        ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+        p.getFactory()
+      )
+      while (!p.isQuiescent()) {
+        if (millisElapsedSince(startTime) > LONG_DELAY_MS)
+          throw new AssertionError("timed out")
+        assertFalse(p.getAsyncMode())
+        assertFalse(p.isShutdown())
+        assertFalse(p.isTerminating())
+        assertFalse(p.isTerminated())
+        Thread.`yield`()
+      }
+
+      assertTrue(p.isQuiescent())
+      assertFalse(p.getAsyncMode())
+      assertEquals(0, p.getQueuedTaskCount())
+      assertEquals(0, p.getQueuedSubmissionCount())
+      assertFalse(p.hasQueuedSubmissions())
+      while (p.getActiveThreadCount() != 0
+          && millisElapsedSince(startTime) < LONG_DELAY_MS) {
+        Thread.`yield`()
+      }
+      assertFalse(p.isShutdown())
+      assertFalse(p.isTerminating())
+      assertFalse(p.isTerminated())
+      assertTrue(f.isDone())
+      assertEquals(6765, f.get())
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+  }
+
+  /** Completed submit(ForkJoinTask) returns result
+   */
+  @Test def testSubmitForkJoinTask(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { p =>
+      val f = p.submit(new FibTask(8))
+      assertEquals(21, f.get())
+    }
+
+  /** A task submitted after shutdown is rejected
+   */
+  @Test def testSubmitAfterShutdown(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { p =>
+      p.shutdown()
+      assertTrue(p.isShutdown())
+      assertThrows(
+        classOf[RejectedExecutionException],
+        p.submit(new FibTask(8))
+      )
+    }
+
+  /** Pool maintains parallelism when using ManagedBlocker
+   */
+  @Test def testBlockingForkJoinTask(): Unit =
+    usingPoolCleaner(new ForkJoinPool(4)) { p =>
+      val lock = new ReentrantLock()
+      val locker = new ManagedLocker(lock)
+      val f = new LockingFibTask(20, locker, lock)
+      p.execute(f)
+      assertEquals(6765, f.get())
+    }
+
+  /** pollSubmission returns unexecuted submitted task, if present
+   */
+  @Test def testPollSubmission(): Unit =
+    usingPoolCleaner(new SubFJP()) { p =>
+      val done = new CountDownLatch(1)
+      val a = p.submit(awaiter(done))
+      val b = p.submit(awaiter(done))
+      val c = p.submit(awaiter(done))
+      val r = p.pollSubmission()
+      assertTrue(r == a || r == b || r == c)
+      assertFalse(r.isDone())
+      done.countDown()
+    }
+
+  /** drainTasksTo transfers unexecuted submitted tasks, if present
+   */
+  @Test def testDrainTasksTo(): Unit = usingPoolCleaner(new SubFJP()) { p =>
+    val done = new CountDownLatch(1)
+    val a = p.submit(awaiter(done))
+    val b = p.submit(awaiter(done))
+    val c = p.submit(awaiter(done))
+    val al = new ArrayList[ForkJoinTask[_]]()
+    p.drainTasks(al)
+    assertTrue("was empty", al.size() > 0)
+    al.forEach { r =>
+      assertTrue(r == a || r == b || r == c)
+      assertFalse(r.isDone())
+    }
+    done.countDown()
+  }
+
+  // FJ Versions of AbstractExecutorService tests
+
+  /** execute(runnable) runs it to completion
+   */
+  @Test def testExecuteRunnable(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val done = new AtomicBoolean(false)
+      val future = e.submit(new CheckedRunnable {
+        override def realRun() = done.set(true)
+      })
+      assertNull(future.get())
+      assertNull(future.get(randomExpiredTimeout(), randomTimeUnit()))
+      assertTrue(done.get())
+      assertTrue(future.isDone())
+      assertFalse(future.isCancelled())
+    }
+
+  /** Completed submit(callable) returns result
+   */
+  @Test def testSubmitCallable(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      val future = e.submit(new StringTask())
+      assertEquals(TEST_STRING, future.get())
+      assertTrue(future.isDone())
+      assertFalse(future.isCancelled())
+  }
+
+  /** Completed submit(runnable) returns successfully
+   */
+  @Test def testSubmitRunnable(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      val future = e.submit(new NoOpRunnable())
+      assertNull(future.get())
+      assertTrue(future.isDone())
+      assertFalse(future.isCancelled())
+  }
+
+  /** Completed submit(runnable, result) returns result
+   */
+  @Test def testSubmitRunnable2(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val future = e.submit(new NoOpRunnable(), TEST_STRING)
+      assertEquals(TEST_STRING, future.get())
+      assertTrue(future.isDone())
+      assertFalse(future.isCancelled())
+    }
+
+  // tests not making sense in Scala Native due to java.lang.security.PrivilagedAction
+  // @Test def testSubmitPrivilegedAction(): Unit = ()
+  // @Test def testSubmitPrivilegedExceptionAction(): Unit = ()
+  // @Test def testSubmitFailedPrivilegedExceptionAction(): Unit = ()
+
+  @Test def testExecuteNullRunnable(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      assertThrows(classOf[NullPointerException], e.submit(null: Runnable))
+    }
+
+  /** submit(null callable) throws NullPointerException
+   */
+  @Test def testSubmitNullCallable(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      assertThrows(classOf[NullPointerException], e.submit(null: Callable[_]))
+    }
+
+  /** submit(callable).get() throws InterruptedException if interrupted
+   */
+  @Test def testInterruptedSubmit(): Unit = {
+    val submitted = new CountDownLatch(1)
+    val quittingTime = new CountDownLatch(1)
+    val awaiter: CheckedCallable[Unit] = { () =>
+      assertTrue(quittingTime.await(2 * LONG_DELAY_MS, MILLISECONDS))
+    }
+    usingPoolCleaner(
+      new ForkJoinPool(1),
+      cleaner(_: ForkJoinPool, quittingTime)
+    ) { p =>
+      val t = new Thread(new CheckedInterruptedRunnable() {
+        def realRun() = {
+          val future = p.submit(awaiter)
+          submitted.countDown()
+          future.get()
+        }
+      })
+      t.start()
+      await(submitted)
+      t.interrupt()
+      awaitTermination(t)
+    }
+  }
+
+  /** get of submit(callable) throws ExecutionException if callable throws
+   *  exception
+   */
+  @Test def testSubmitEE(): Unit = {
+    usingPoolCleaner(new ForkJoinPool(1)) { p =>
+      val ex = assertThrows(
+        classOf[ExecutionException],
+        p.submit {
+          new Callable[Any] {
+            def call(): Any = throw new ArithmeticException()
+          }
+        }.get()
+      )
+      assertTrue(ex.getCause().isInstanceOf[ArithmeticException])
+    }
+  }
+
+  /** invokeAny(null) throws NullPointerException
+   */
+  @Test def testInvokeAny1(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      assertThrows(classOf[NullPointerException], e.invokeAny(null))
+    }
+
+  /** invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Throwable]
+  @Test def testInvokeAny2(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      assertThrows(
+        classOf[IllegalArgumentException],
+        e.invokeAny(new ArrayList[Callable[String]]())
+      )
+  }
+
+  /** invokeAny(c) throws NullPointerException if c has a single null element
+   */
+  @throws[Throwable]
+  @Test def testInvokeAny3(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(null)
+      assertThrows(classOf[NullPointerException], e.invokeAny(l))
+  }
+
+  /** invokeAny(c) throws NullPointerException if c has null elements
+   */
+  @Test def testInvokeAny4(): Unit = {
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val latch = new CountDownLatch(1)
+      val l = new ArrayList[Callable[String]]()
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      assertThrows(
+        classOf[NullPointerException],
+        e.invokeAny(l)
+      )
+      latch.countDown()
+    }
+  }
+
+  @Test def testInvokeAny5(): Unit = {
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new NPETask())
+      val ex = assertThrows(
+        classOf[ExecutionException],
+        e.invokeAny(l)
+      )
+      assertTrue(ex.getCause().isInstanceOf[NullPointerException])
+    }
+  }
+
+  /** invokeAny(c) returns result of some task in c if at least one completes
+   */
+  @Test def testInvokeAny6(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new StringTask())
+      l.add(new StringTask())
+      val result = e.invokeAny(l)
+      assertEquals(TEST_STRING, result)
+  }
+
+  /** invokeAll(null) throws NullPointerException
+   */
+  @Test def testInvokeAll1(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      assertThrows(classOf[NullPointerException], e.invokeAll(null))
+  }
+
+  /** invokeAll(empty collection) returns empty list
+   */
+  @Test def testInvokeAll2(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      val emptyCollection = Collections.emptyList[Callable[String]]()
+      val r = e.invokeAll(emptyCollection)
+      assertTrue(r.isEmpty())
+  }
+
+  /** invokeAll(c) throws NullPointerException if c has null elements
+   */
+  @throws[InterruptedException]
+  @Test def testInvokeAll3(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new StringTask())
+      l.add(null)
+      assertThrows(classOf[NullPointerException], e.invokeAll(l))
+  }
+
+  /** get of returned element of invokeAll(c) throws ExecutionException on
+   *  failed task
+   */
+  @Test def testInvokeAll4(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new NPETask())
+      val futures = e.invokeAll(l)
+      assertEquals(1, futures.size())
+      val ex = assertThrows(classOf[ExecutionException], futures.get(0).get())
+      assertTrue(ex.getCause().isInstanceOf[NullPointerException])
+    }
+
+  /** invokeAll(c) returns results of all completed tasks in c
+   */
+  @Test def testInvokeAll5(): Unit = usingPoolCleaner(new ForkJoinPool(1)) {
+    (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new StringTask())
+      l.add(new StringTask())
+      val futures = e.invokeAll(l)
+      assertEquals(2, futures.size())
+      futures.forEach(f => assertEquals(TEST_STRING, f.get()))
+  }
+
+  /** timed invokeAny(null) throws NullPointerException
+   */
+  @Test def testTimedInvokeAny1(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      assertThrows(
+        classOf[NullPointerException],
+        e.invokeAny(null, randomTimeout(), randomTimeUnit())
+      )
+    }
+
+  /** timed invokeAny(null time unit) throws NullPointerException
+   */
+  @Test def testTimedInvokeAnyNullTimeUnit(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new StringTask())
+      assertThrows(
+        classOf[NullPointerException],
+        e.invokeAny(l, randomTimeout(), null)
+      )
+    }
+
+  /** timed invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @Test def testTimedInvokeAny2(): Unit = {
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      assertThrows(
+        classOf[IllegalArgumentException],
+        e.invokeAny(new ArrayList(), randomTimeout(), randomTimeUnit())
+      )
+    }
+  }
+
+  /** timed invokeAny(c) throws NullPointerException if c has null elements
+   */
+  @Test def testTimedInvokeAny3(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val latch = new CountDownLatch(1)
+      val l = new ArrayList[Callable[String]]()
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      assertThrows(
+        classOf[NullPointerException],
+        e.invokeAny(l, randomTimeout(), randomTimeUnit())
+      )
+      latch.countDown()
+    }
+
+  /** timed invokeAny(c) throws ExecutionException if no task completes
+   */
+  @Test def testTimedInvokeAny4(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val startTime = System.nanoTime()
+      val l = new ArrayList[Callable[String]]()
+      l.add(new NPETask())
+      val ex = assertThrows(
+        classOf[ExecutionException],
+        e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+      )
+      assertTrue(ex.getCause().isInstanceOf[NullPointerException])
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+
+  /** timed invokeAny(c) returns result of some task in c
+   */
+  @Test def testTimedInvokeAny5(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val startTime = System.nanoTime()
+      val l = new ArrayList[Callable[String]]()
+      l.add(new StringTask())
+      l.add(new StringTask())
+      val result = e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(TEST_STRING, result)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+
+  /** timed invokeAll(null) throws NullPointerException
+   */
+  @Test def testTimedInvokeAll1(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      assertThrows(
+        classOf[NullPointerException],
+        e.invokeAll(null, randomTimeout(), randomTimeUnit())
+      )
+    }
+
+  /** timed invokeAll(null time unit) throws NullPointerException
+   */
+  @Test def testTimedInvokeAllNullTimeUnit(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new StringTask())
+      assertThrows(
+        classOf[NullPointerException],
+        e.invokeAll(l, randomTimeout(), null)
+      )
+    }
+
+  /** timed invokeAll(empty collection) returns empty list
+   */
+  @Test def testTimedInvokeAll2(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val r = e.invokeAll(
+        Collections.emptyList(),
+        randomTimeout(),
+        randomTimeUnit()
+      )
+      assertTrue(r.isEmpty())
+    }
+
+  /** timed invokeAll(c) throws NullPointerException if c has null elements
+   */
+  @Test def testTimedInvokeAll3(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new StringTask())
+      l.add(null)
+      assertThrows(
+        classOf[NullPointerException],
+        e.invokeAll(l, randomTimeout(), randomTimeUnit())
+      )
+    }
+
+  /** get of returned element of invokeAll(c) throws exception on failed task
+   */
+  @throws[Throwable]
+  @Test def testTimedInvokeAll4(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new NPETask())
+      val futures = e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(1, futures.size())
+      val ex = assertThrows(classOf[ExecutionException], futures.get(0).get())
+      assertTrue(ex.getCause().isInstanceOf[NullPointerException])
+    }
+
+  /** timed invokeAll(c) returns results of all completed tasks in c
+   */
+  @Test def testTimedInvokeAll5(): Unit =
+    usingPoolCleaner(new ForkJoinPool(1)) { (e: ExecutorService) =>
+      val l = new ArrayList[Callable[String]]()
+      l.add(new StringTask())
+      l.add(new StringTask())
+      val futures = e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(2, futures.size())
+      futures.forEach(f => assertEquals(TEST_STRING, f.get()))
+    }
+
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTask8Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTask8Test.scala
@@ -1,0 +1,1150 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util
+import java.util.concurrent._
+
+import org.junit._
+import org.junit.Assert._
+import JSR166Test._
+
+import scala.util.control.Breaks._
+
+object ForkJoinTask8Test {
+  /*
+   * Testing notes: This differs from ForkJoinTaskTest mainly by
+   * defining a version of BinaryAsyncAction that uses JDK8 task
+   * tags for control state, thereby testing getForkJoinTaskTag,
+   * setForkJoinTaskTag, and compareAndSetForkJoinTaskTag across
+   * various contexts. Most of the test methods using it are
+   * otherwise identical, but omitting retest of those dealing with
+   * cancellation, which is not represented in this tag scheme.
+   */
+  val INITIAL_STATE: Short = -1
+  val COMPLETE_STATE: Short = 0
+  val EXCEPTION_STATE: Short = 1
+
+  // Runs with "mainPool" use > 1 thread. singletonPool tests use 1
+  val mainPoolSize: Int = Math.max(2, Runtime.getRuntime.availableProcessors)
+
+  def mainPool = new ForkJoinPool(mainPoolSize)
+  def singletonPool = new ForkJoinPool(1)
+  def asyncSingletonPool = new ForkJoinPool(
+    1,
+    ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+    null,
+    true
+  )
+  final class FJException extends RuntimeException {}
+
+  abstract class BinaryAsyncAction protected extends ForkJoinTask[Void] {
+    setForkJoinTaskTag(INITIAL_STATE)
+    @volatile private var parent: BinaryAsyncAction = _
+    @volatile private var sibling: BinaryAsyncAction = _
+    override final def getRawResult: Void = null
+    override final protected def setRawResult(mustBeNull: Void): Unit = {}
+    final def linkSubtasks(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = {
+      y.parent = this
+      x.parent = this
+      x.sibling = y
+      y.sibling = x
+    }
+    protected def onComplete(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = {
+      if (this.getForkJoinTaskTag != COMPLETE_STATE || x.getForkJoinTaskTag != COMPLETE_STATE || y.getForkJoinTaskTag != COMPLETE_STATE) {
+        completeThisExceptionally(new FJException)
+      }
+    }
+    protected def onException = true
+    def linkAndForkSubtasks(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = {
+      linkSubtasks(x, y)
+      y.fork
+      x.fork
+    }
+    private def completeThis(): Unit = {
+      setForkJoinTaskTag(COMPLETE_STATE)
+      super.complete(null)
+    }
+    private def completeThisExceptionally(ex: Throwable): Unit = {
+      setForkJoinTaskTag(EXCEPTION_STATE)
+      super.completeExceptionally(ex)
+    }
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      if (super.cancel(mayInterruptIfRunning)) {
+        completeExceptionally(new FJException)
+        return true
+      }
+      false
+    }
+    final def complete(): Unit = {
+      var a = this
+      var break = false
+      while (!break) {
+        val s = a.sibling
+        val p = a.parent
+        a.sibling = null
+        a.parent = null
+        a.completeThis()
+        if (p == null ||
+            p.compareAndSetForkJoinTaskTag(INITIAL_STATE, COMPLETE_STATE)) {
+          break = true
+        }
+        if (!break) {
+          try p.onComplete(a, s)
+          catch {
+            case rex: Throwable =>
+              p.completeExceptionally(rex)
+              break = true
+          }
+          a = p
+        }
+      }
+    }
+    override final def completeExceptionally(ex: Throwable): Unit = {
+      var a = this
+      breakable {
+        while (true) {
+          a.completeThisExceptionally(ex)
+          val s = a.sibling
+          if (s != null && !s.isDone) s.completeExceptionally(ex)
+          a = a.parent
+          if (a == null) break()
+        }
+      }
+    }
+    final def getParent: BinaryAsyncAction = parent
+    def getSibling: BinaryAsyncAction = sibling
+    override def reinitialize(): Unit = {
+      sibling = null
+      parent = sibling
+      super.reinitialize()
+    }
+  }
+  final class FailingAsyncFib(var number: Int) extends BinaryAsyncAction {
+    override final def exec: Boolean = {
+      try {
+        var f = this
+        var n = f.number
+        while (n > 1) {
+          val p = f
+          val r = new FailingAsyncFib(n - 2)
+          f = new FailingAsyncFib({ n -= 1; n })
+          p.linkSubtasks(r, f)
+          r.fork
+        }
+        f.complete()
+      } catch {
+        case ex: Throwable =>
+          compareAndSetForkJoinTaskTag(INITIAL_STATE, EXCEPTION_STATE)
+      }
+      if (getForkJoinTaskTag == EXCEPTION_STATE)
+        throw new FJException
+      false
+    }
+    override protected def onComplete(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = { completeExceptionally(new FJException) }
+  }
+}
+
+class ForkJoinTask8Test extends JSR166Test {
+  import ForkJoinTask._
+  import ForkJoinTask8Test._
+
+  // Compute fib naively and efficiently
+  final val fib: Array[Int] = {
+    val fib = new Array[Int](10)
+    fib(0) = 0
+    fib(1) = 1
+    for (i <- 2 until fib.length) { fib(i) = fib(i - 1) + fib(i - 2) }
+    fib
+  }
+
+  private def testInvokeOnPool(pool: ForkJoinPool, a: RecursiveAction): Unit =
+    usingPoolCleaner(pool) { pool =>
+      assertFalse(a.isDone)
+      assertFalse(a.isCompletedNormally)
+      assertFalse(a.isCompletedAbnormally)
+      assertFalse(a.isCancelled)
+      assertNull(a.getException)
+      assertNull(a.getRawResult)
+
+      assertNull(pool.invoke(a))
+
+      assertTrue(a.isDone)
+      assertTrue(a.isCompletedNormally)
+      assertFalse(a.isCompletedAbnormally)
+      assertFalse(a.isCancelled)
+      assertNull(a.getException)
+      assertNull(a.getRawResult)
+    }
+
+  def checkNotDone(a: ForkJoinTask[_]): Unit = {
+    assertFalse(a.isDone)
+    assertFalse(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertFalse(a.isCancelled)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    if (a.isInstanceOf[BinaryAsyncAction])
+      assertEquals(
+        INITIAL_STATE,
+        a.asInstanceOf[BinaryAsyncAction].getForkJoinTaskTag
+      )
+    try {
+      a.get(randomExpiredTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: TimeoutException =>
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedNormally[T](a: ForkJoinTask[T]): Unit = {
+    checkCompletedNormally(a, null.asInstanceOf[T])
+  }
+
+  def checkCompletedNormally[T](a: ForkJoinTask[T], expectedValue: T): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertTrue(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertNull(a.getException)
+    assertSame(expectedValue, a.getRawResult)
+    if (a.isInstanceOf[BinaryAsyncAction])
+      assertEquals(
+        COMPLETE_STATE,
+        a.asInstanceOf[BinaryAsyncAction].getForkJoinTaskTag
+      )
+    locally {
+      Thread.currentThread.interrupt()
+      val startTime = System.nanoTime
+      assertSame(expectedValue, a.join)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+      Thread.interrupted
+    }
+
+    locally {
+      Thread.currentThread.interrupt()
+      val startTime = System.nanoTime
+      a.quietlyJoin() // should be no-op
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+      Thread.interrupted
+    }
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    try {
+      assertSame(expectedValue, a.get())
+      assertSame(expectedValue, a.get(randomTimeout(), randomTimeUnit()))
+    } catch {
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedAbnormally(a: ForkJoinTask[_], t: Throwable): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertSame(t.getClass, a.getException.getClass)
+    assertNull(a.getRawResult)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    if (a.isInstanceOf[BinaryAsyncAction])
+      assertTrue(
+        a.asInstanceOf[BinaryAsyncAction].getForkJoinTaskTag != INITIAL_STATE
+      )
+    try {
+      Thread.currentThread.interrupt()
+      a.join
+      shouldThrow()
+    } catch {
+      case expected: Throwable =>
+        assertSame(t.getClass, expected.getClass)
+    }
+    Thread.interrupted
+    val startTime = System.nanoTime
+    a.quietlyJoin() // should be no-op
+
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+  final class AsyncFib(var number: Int) extends BinaryAsyncAction {
+    val expectedResult = fib(number)
+    override final def exec: Boolean = {
+      try {
+        var f = this
+        var n = f.number
+        while (n > 1) {
+          val p = f
+          val r = new AsyncFib(n - 2)
+          f = new AsyncFib({ n -= 1; n })
+          p.linkSubtasks(r, f)
+          r.fork
+        }
+        f.complete()
+      } catch {
+        case ex: Throwable =>
+          compareAndSetForkJoinTaskTag(
+            INITIAL_STATE,
+            EXCEPTION_STATE
+          )
+      }
+      if (getForkJoinTaskTag == EXCEPTION_STATE)
+        throw new FJException
+      false
+    }
+    override protected def onComplete(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = {
+      number = x.asInstanceOf[AsyncFib].number + y
+        .asInstanceOf[AsyncFib]
+        .number
+      super.onComplete(x, y)
+    }
+    def checkCompletedNormally(): Unit = {
+      assertEquals(expectedResult, number)
+      ForkJoinTask8Test.this.checkCompletedNormally(this)
+    }
+  }
+
+  /** invoke returns when task completes normally. isCompletedAbnormally and
+   *  isCancelled return false for normally completed tasks; getRawResult
+   *  returns null.
+   */
+  @Test def testInvoke(): Unit = { testInvoke(mainPool) }
+  @Test def testInvoke_Singleton(): Unit = {
+    testInvoke(singletonPool)
+  }
+  def testInvoke(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertNull(f.invoke)
+        f.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** quietlyInvoke task returns when task completes normally.
+   *  isCompletedAbnormally and isCancelled return false for normally completed
+   *  tasks
+   */
+  @Test def testQuietlyInvoke(): Unit = {
+    testQuietlyInvoke(mainPool)
+  }
+  @Test def testQuietlyInvoke_Singleton(): Unit = {
+    testQuietlyInvoke(singletonPool)
+  }
+  def testQuietlyInvoke(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.quietlyInvoke()
+        f.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** join of a forked task returns when task completes
+   */
+  @Test def testForkJoin(): Unit = { testForkJoin(mainPool) }
+  @Test def testForkJoin_Singleton(): Unit = {
+    testForkJoin(singletonPool)
+  }
+  def testForkJoin(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        f.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** get of a forked task returns when task completes
+   */
+  @Test def testForkGet(): Unit = { testForkGet(mainPool) }
+  @Test def testForkGet_Singleton(): Unit = {
+    testForkGet(singletonPool)
+  }
+  def testForkGet(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.get)
+        f.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** timed get of a forked task returns when task completes
+   */
+  @Test def testForkTimedGet(): Unit = {
+    testForkTimedGet(mainPool)
+  }
+  @Test def testForkTimedGet_Singleton(): Unit = {
+    testForkTimedGet(singletonPool)
+  }
+  def testForkTimedGet(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+        f.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** timed get with null time unit throws NullPointerException
+   */
+  @Test def testForkTimedGetNullTimeUnit(): Unit = {
+    testForkTimedGetNullTimeUnit(mainPool)
+  }
+  @Test def testForkTimedGetNullTimeUnit_Singleton(): Unit = {
+    testForkTimedGet(singletonPool)
+  }
+  def testForkTimedGetNullTimeUnit(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertThrows(
+          classOf[NullPointerException],
+          () => f.get(randomTimeout(), null)
+        )
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes
+   */
+  @Test def testForkQuietlyJoin(): Unit = {
+    testForkQuietlyJoin(mainPool)
+  }
+  @Test def testForkQuietlyJoin_Singleton(): Unit = {
+    testForkQuietlyJoin(singletonPool)
+  }
+  def testForkQuietlyJoin(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        f.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** helpQuiesce returns when tasks are complete. getQueuedTaskCount returns 0
+   *  when quiescent
+   */
+  @Test def testForkHelpQuiesce(): Unit = {
+    testForkHelpQuiesce(mainPool)
+  }
+  @Test def testForkHelpQuiesce_Singleton(): Unit = {
+    testForkHelpQuiesce(singletonPool)
+  }
+  def testForkHelpQuiesce(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        helpQuiesce
+        while (!f.isDone) { // wait out race
+        }
+        assertEquals(0, getQueuedTaskCount)
+        f.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invoke task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalInvoke(): Unit = {
+    testAbnormalInvoke(mainPool)
+  }
+  @Test def testAbnormalInvoke_Singleton(): Unit = {
+    testAbnormalInvoke(singletonPool)
+  }
+  def testAbnormalInvoke(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  @Test def testAbnormalQuietlyInvoke(): Unit = {
+    testAbnormalQuietlyInvoke(mainPool)
+  }
+  @Test def testAbnormalQuietlyInvoke_Singleton(): Unit = {
+    testAbnormalQuietlyInvoke(singletonPool)
+  }
+  def testAbnormalQuietlyInvoke(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        f.quietlyInvoke()
+        assertTrue(f.getException.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** join of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkJoin(): Unit = {
+    testAbnormalForkJoin(mainPool)
+  }
+  @Test def testAbnormalForkJoin_Singleton(): Unit = {
+    testAbnormalForkJoin(singletonPool)
+  }
+  def testAbnormalForkJoin(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkGet(): Unit = {
+    testAbnormalForkGet(mainPool)
+  }
+  @Test def testAbnormalForkGet_Singleton(): Unit = {
+    testAbnormalForkJoin(singletonPool)
+  }
+  def testAbnormalForkGet(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** timed get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkTimedGet(): Unit = {
+    testAbnormalForkTimedGet(mainPool)
+  }
+  @Test def testAbnormalForkTimedGet_Singleton(): Unit = {
+    testAbnormalForkTimedGet(singletonPool)
+  }
+  def testAbnormalForkTimedGet(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes abnormally
+   */
+  @Test def testAbnormalForkQuietlyJoin(): Unit = {
+    testAbnormalForkQuietlyJoin(mainPool)
+  }
+  @Test def testAbnormalForkQuietlyJoin_Singleton(): Unit = {
+    testAbnormalForkQuietlyJoin(singletonPool)
+  }
+  def testAbnormalForkQuietlyJoin(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertTrue(f.getException.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** getPool of executing task returns its pool
+   */
+  @Test def testGetPool(): Unit = { testGetPool(mainPool) }
+  @Test def testGetPool_Singleton(): Unit = {
+    testGetPool(singletonPool)
+  }
+  def testGetPool(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertSame(pool, getPool) }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** getPool of non-FJ task returns null
+   */
+  @Test def testGetPool2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertNull(getPool) }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** inForkJoinPool of executing task returns true
+   */
+  @Test def testInForkJoinPool(): Unit = {
+    testInForkJoinPool(mainPool)
+  }
+  @Test def testInForkJoinPool_Singleton(): Unit = {
+    testInForkJoinPool(singletonPool)
+  }
+  def testInForkJoinPool(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertTrue(inForkJoinPool) }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** inForkJoinPool of non-FJ task returns false
+   */
+  @Test def testInForkJoinPool2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertFalse(inForkJoinPool) }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** setRawResult(null) succeeds
+   */
+  @Test def testSetRawResult(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        setRawResult(null)
+        assertNull(getRawResult)
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** invoke task throws exception after invoking completeExceptionally
+   */
+  @Test def testCompleteExceptionally(): Unit = {
+    testCompleteExceptionally(mainPool)
+  }
+  @Test def testCompleteExceptionally_Singleton(): Unit = {
+    testCompleteExceptionally(singletonPool)
+  }
+  def testCompleteExceptionally(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.completeExceptionally(new FJException)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(tasks) with 1 argument invokes task
+   */
+  @Test def testInvokeAll1(): Unit = {
+    testInvokeAll1(mainPool)
+  }
+  @Test def testInvokeAll1_Singleton(): Unit = {
+    testInvokeAll1(singletonPool)
+  }
+  def testInvokeAll1(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        invokeAll(f)
+        f.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(t1, t2) invokes all task arguments
+   */
+  @Test def testInvokeAll2(): Unit = {
+    testInvokeAll2(mainPool)
+  }
+  @Test def testInvokeAll2_Singleton(): Unit = {
+    testInvokeAll2(singletonPool)
+  }
+  def testInvokeAll2(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val tasks = Array(
+          new AsyncFib(8),
+          new AsyncFib(9)
+        )
+        invokeAll(tasks(0), tasks(1))
+        for (task <- tasks) { assertTrue(task.isDone) }
+        for (task <- tasks) { task.checkCompletedNormally() }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(tasks) with > 2 argument invokes tasks
+   */
+  @Test def testInvokeAll3(): Unit = {
+    testInvokeAll3(mainPool)
+  }
+  @Test def testInvokeAll3_Singleton(): Unit = {
+    testInvokeAll3(singletonPool)
+  }
+  def testInvokeAll3(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val tasks = Array(
+          new AsyncFib(8),
+          new AsyncFib(9),
+          new AsyncFib(7)
+        )
+        invokeAll(tasks(0), tasks(1), tasks(2))
+        for (task <- tasks) { assertTrue(task.isDone) }
+        for (task <- tasks) { task.checkCompletedNormally() }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(collection) invokes all tasks in the collection
+   */
+  @Test def testInvokeAllCollection(): Unit = {
+    testInvokeAllCollection(mainPool)
+  }
+  @Test def testInvokeAllCollection_Singleton(): Unit = {
+    testInvokeAllCollection(singletonPool)
+  }
+  def testInvokeAllCollection(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val tasks = Array(
+          new AsyncFib(8),
+          new AsyncFib(9),
+          new AsyncFib(7)
+        )
+        invokeAll(util.Arrays.asList(tasks: _*))
+        for (task <- tasks) { assertTrue(task.isDone) }
+        for (task <- tasks) { task.checkCompletedNormally() }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(tasks) with any null task throws NullPointerException
+   */
+  @Test def testInvokeAllNullTask(): Unit = {
+    testInvokeAllNullTask(mainPool)
+  }
+  @Test def testInvokeAllNullTask_Singleton(): Unit = {
+    testInvokeAllNullTask(singletonPool)
+  }
+  def testInvokeAllNullTask(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val nul: AsyncFib = null
+        assertEachThrows(
+          classOf[NullPointerException],
+          () => invokeAll(nul),
+          () => invokeAll(nul, nul),
+          () =>
+            invokeAll(
+              new AsyncFib(8),
+              new AsyncFib(9),
+              nul
+            ),
+          () =>
+            invokeAll(
+              new AsyncFib(8),
+              nul,
+              new AsyncFib(9)
+            ),
+          () =>
+            invokeAll(
+              nul,
+              new AsyncFib(8),
+              new AsyncFib(9)
+            )
+        )
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(tasks) with 1 argument throws exception if task does
+   */
+  @Test def testAbnormalInvokeAll1(): Unit = {
+    testAbnormalInvokeAll1(mainPool)
+  }
+  @Test def testAbnormalInvokeAll1_Singleton(): Unit = {
+    testAbnormalInvokeAll1(singletonPool)
+  }
+  def testAbnormalInvokeAll1(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new FailingAsyncFib(9)
+        try {
+          invokeAll(g)
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(t1, t2) throw exception if any task does
+   */
+  @Test def testAbnormalInvokeAll2(): Unit = {
+    testAbnormalInvokeAll2(mainPool)
+  }
+  @Test def testAbnormalInvokeAll2_Singleton(): Unit = {
+    testAbnormalInvokeAll2(singletonPool)
+  }
+  def testAbnormalInvokeAll2(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new FailingAsyncFib(9)
+        val tasks = Array(f, g)
+        shuffle(tasks)
+        try {
+          invokeAll(tasks(0), tasks(1))
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(tasks) with > 2 argument throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAll3(): Unit = {
+    testAbnormalInvokeAll3(mainPool)
+  }
+  @Test def testAbnormalInvokeAll3_Singleton(): Unit = {
+    testAbnormalInvokeAll3(singletonPool)
+  }
+  def testAbnormalInvokeAll3(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new FailingAsyncFib(9)
+        val h = new AsyncFib(7)
+        val tasks = Array(f, g, h)
+        shuffle(tasks)
+        try {
+          invokeAll(tasks(0), tasks(1), tasks(2))
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** invokeAll(collection) throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAllCollection(): Unit = {
+    testAbnormalInvokeAllCollection(mainPool)
+  }
+  @Test def testAbnormalInvokeAllCollection_Singleton(): Unit = {
+    testAbnormalInvokeAllCollection(singletonPool)
+  }
+  def testAbnormalInvokeAllCollection(pool: ForkJoinPool): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = new AsyncFib(7)
+        val tasks: Array[BinaryAsyncAction] = Array(f, g, h)
+        shuffle(tasks)
+        try {
+          ForkJoinTask.invokeAll(util.Arrays.asList(tasks: _*))
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(pool, a)
+  }
+
+  /** tryUnfork returns true for most recent unexecuted task, and suppresses
+   *  execution
+   */
+  @Test def testTryUnfork(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertTrue(f.tryUnfork)
+        helpQuiesce
+        checkNotDone(f)
+        g.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** getSurplusQueuedTaskCount returns > 0 when there are more tasks than
+   *  threads
+   */
+  @Test def testGetSurplusQueuedTaskCount(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val h = new AsyncFib(7)
+        assertSame(h, h.fork)
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertTrue(getSurplusQueuedTaskCount > 0)
+        helpQuiesce
+        assertEquals(0, getSurplusQueuedTaskCount)
+        f.checkCompletedNormally()
+        g.checkCompletedNormally()
+        h.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** peekNextLocalTask returns most recent unexecuted task.
+   */
+  @Test def testPeekNextLocalTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(f, peekNextLocalTask)
+        assertNull(f.join)
+        f.checkCompletedNormally()
+        helpQuiesce
+        g.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** pollNextLocalTask returns most recent unexecuted task without executing it
+   */
+  @Test def testPollNextLocalTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(f, pollNextLocalTask)
+        helpQuiesce
+        checkNotDone(f)
+        g.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** pollTask returns an unexecuted task without executing it
+   */
+  @Test def testPollTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(f, pollTask)
+        helpQuiesce
+        checkNotDone(f)
+        g.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** peekNextLocalTask returns least recent unexecuted task in async mode
+   */
+  @Test def testPeekNextLocalTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(g, peekNextLocalTask)
+        assertNull(f.join)
+        helpQuiesce
+        f.checkCompletedNormally()
+        g.checkCompletedNormally()
+      }
+    }
+    testInvokeOnPool(asyncSingletonPool, a)
+  }
+
+  /** pollNextLocalTask returns least recent unexecuted task without executing
+   *  it, in async mode
+   */
+  @Test def testPollNextLocalTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(g, pollNextLocalTask)
+        helpQuiesce
+        f.checkCompletedNormally()
+        checkNotDone(g)
+      }
+    }
+    testInvokeOnPool(asyncSingletonPool, a)
+  }
+
+  /** pollTask returns an unexecuted task without executing it, in async mode
+   */
+  @Test def testPollTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(g, pollTask)
+        helpQuiesce()
+        f.checkCompletedNormally()
+        checkNotDone(g)
+      }
+    }
+    testInvokeOnPool(asyncSingletonPool, a)
+  }
+
+  /** ForkJoinTask.quietlyComplete returns when task completes normally without
+   *  setting a value. The most recent value established by setRawResult(V) (or
+   *  null by default) is returned from invoke.
+   */
+  @Test def testQuietlyComplete(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.quietlyComplete()
+        assertEquals(8, f.number)
+        assertTrue(f.isDone)
+        assertFalse(f.isCancelled)
+        assertTrue(f.isCompletedNormally)
+        assertFalse(f.isCompletedAbnormally)
+        assertNull(f.getException)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTaskTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTaskTest.scala
@@ -1,0 +1,1662 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import org.junit.Assert._
+import org.junit.{Test, Ignore}
+import JSR166Test._
+
+import java.util.concurrent.TimeUnit._
+import java.util
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.atomic._
+
+object ForkJoinTaskTest {
+  // Runs with "mainPool" use > 1 thread. singletonPool tests use 1
+  val mainPoolSize: Int = Math.max(2, Runtime.getRuntime.availableProcessors)
+  private def mainPool = new ForkJoinPool(mainPoolSize)
+  private def singletonPool = new ForkJoinPool(1)
+  private def asyncSingletonPool = new ForkJoinPool(
+    1,
+    ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+    null,
+    true
+  )
+  /*
+   * Testing coverage notes:
+   *
+   * To test extension methods and overrides, most tests use
+   * BinaryAsyncAction extension class that processes joins
+   * differently than supplied Recursive forms.
+   */
+  final class FJException() extends RuntimeException {}
+  object BinaryAsyncAction {
+    val controlStateUpdater: AtomicIntegerFieldUpdater[BinaryAsyncAction] =
+      AtomicIntegerFieldUpdater.newUpdater(
+        classOf[BinaryAsyncAction],
+        "controlState"
+      )
+  }
+  abstract class BinaryAsyncAction protected () extends ForkJoinTask[Void] {
+    private var atomicControlState = new AtomicInteger(0)
+    def controlState = atomicControlState.get()
+    private var parent: BinaryAsyncAction = _
+    private var sibling: BinaryAsyncAction = _
+    override final def getRawResult(): Void = null
+    override final protected def setRawResult(mustBeNull: Void): Unit = {}
+    final def linkSubtasks(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = {
+      x.parent = this
+      y.parent = this
+      x.sibling = y
+      y.sibling = x
+    }
+    protected def onComplete(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = {}
+    protected def onException = true
+    def linkAndForkSubtasks(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = {
+      linkSubtasks(x, y)
+      y.fork
+      x.fork
+    }
+    private def completeThis(): Unit = { super.complete(null) }
+    private def completeThisExceptionally(ex: Throwable): Unit = {
+      super.completeExceptionally(ex)
+    }
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      if (super.cancel(mayInterruptIfRunning)) {
+        completeExceptionally(new FJException)
+        return true
+      }
+      false
+    }
+    final def complete(): Unit = {
+      var a = this
+      var break = false
+      while (!break) {
+        val s = a.sibling
+        val p = a.parent
+        a.sibling = null
+        a.parent = null
+        a.completeThis()
+        if (p == null || p.compareAndSetControlState(0, 1))
+          break = true
+        else {
+          try p.onComplete(a, s)
+          catch {
+            case rex: Throwable =>
+              p.completeExceptionally(rex)
+              return
+          }
+          a = p
+        }
+      }
+    }
+    override final def completeExceptionally(ex: Throwable): Unit = {
+      var a = this
+      var break = false
+      while (!break) {
+        a.completeThisExceptionally(ex)
+        val s = a.sibling
+        if (s != null && !s.isDone) s.completeExceptionally(ex)
+        a = a.parent
+        if (a == null) break = true
+      }
+    }
+    final def getParent: BinaryAsyncAction = parent
+    def getSibling: BinaryAsyncAction = sibling
+    override def reinitialize(): Unit = {
+      parent = null
+      sibling = null
+      super.reinitialize()
+    }
+    final protected def getControlState: Int = controlState
+    final protected def compareAndSetControlState(
+        expect: Int,
+        update: Int
+    ): Boolean = atomicControlState.compareAndSet(expect, update)
+    final protected def setControlState(value: Int): Unit =
+      atomicControlState.set(value)
+    final protected def incrementControlState(): Unit = {
+      BinaryAsyncAction.controlStateUpdater.incrementAndGet(this)
+    }
+    final protected def decrementControlState(): Unit = {
+      BinaryAsyncAction.controlStateUpdater.decrementAndGet(this)
+    }
+  }
+  final case class AsyncFib(var number: Int) extends BinaryAsyncAction {
+    val startNumber = number
+    override final def exec(): Boolean = {
+      var f = this
+      var n = f.number
+      while (n > 1) {
+        val p = f
+        val r = new AsyncFib(n - 2)
+        n -= 1
+        f = new AsyncFib(n)
+        p.linkSubtasks(r, f)
+        r.fork()
+      }
+      f.complete()
+      false
+    }
+    override protected def onComplete(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = {
+      val (AsyncFib(xNum), AsyncFib(yNum)) = (x, y): @unchecked
+      this.number = xNum + yNum
+    }
+  }
+  final class FailingAsyncFib(var number: Int) extends BinaryAsyncAction {
+    override final def exec: Boolean = {
+      var f = this
+      var n = f.number
+      while (n > 1) {
+        val p = f
+        val r =
+          new FailingAsyncFib(n - 2)
+        f = new FailingAsyncFib({ n -= 1; n })
+        p.linkSubtasks(r, f)
+        r.fork
+      }
+      f.complete()
+      false
+    }
+    override protected def onComplete(
+        x: BinaryAsyncAction,
+        y: BinaryAsyncAction
+    ): Unit = { completeExceptionally(new FJException) }
+  }
+}
+
+class ForkJoinTaskTest extends JSR166Test {
+  import ForkJoinTaskTest._
+  private def testInvokeOnPool(pool: ForkJoinPool, a: RecursiveAction): Unit =
+    usingPoolCleaner(pool) { pool =>
+      assertFalse("isDone", a.isDone())
+      assertFalse("isCompletedNormally", a.isCompletedNormally())
+      assertFalse("isCompletedAbnormally", a.isCompletedAbnormally())
+      assertFalse("isCancelled", a.isCancelled())
+      assertNull("getException", a.getException())
+      assertNull("getRawResult", a.getRawResult())
+
+      assertNull("pool invoke", pool.invoke(a))
+
+      assertTrue("isDone 2", a.isDone())
+      assertTrue("isCompletedNormally 2", a.isCompletedNormally())
+      assertFalse("isCompletedAbnormally 2", a.isCompletedAbnormally())
+      assertFalse("isCancelled 2", a.isCancelled())
+      assertNull("getException 2", a.getException())
+      assertNull("getRawResult 2", a.getRawResult())
+    }
+
+  def checkNotDone(a: ForkJoinTask[_]): Unit = {
+    assertFalse(a.isDone)
+    assertFalse(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertFalse(a.isCancelled)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    try {
+      a.get(randomExpiredTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: TimeoutException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+  def checkCompletedNormally[T](a: ForkJoinTask[T]): Unit = {
+    checkCompletedNormally(a.asInstanceOf[ForkJoinTask[Any]], null)
+  }
+  def checkCompletedNormally[T](a: ForkJoinTask[T], expectedValue: T): Unit = {
+    assertTrue("isDone", a.isDone)
+    assertFalse("isCancelled", a.isCancelled)
+    assertTrue("isCompletedNormally", a.isCompletedNormally)
+    assertFalse("isCompletedNormally", a.isCompletedAbnormally)
+    assertNull("getException", a.getException)
+    assertSame("getRawResult", expectedValue, a.getRawResult)
+    locally {
+      Thread.currentThread.interrupt()
+      val startTime = System.nanoTime
+      assertSame("join", expectedValue, a.join)
+      assertTrue("timeout", millisElapsedSince(startTime) < LONG_DELAY_MS)
+      Thread.interrupted
+    }
+    locally {
+      Thread.currentThread.interrupt()
+      val startTime = System.nanoTime
+      a.quietlyJoin() // should be no-op
+
+      assertTrue("timeout 2", millisElapsedSince(startTime) < LONG_DELAY_MS)
+      Thread.interrupted
+    }
+    assertFalse("cancel", a.cancel(false))
+    assertFalse("cancel force", a.cancel(true))
+    try {
+      val v1 = a.get
+      val v2 = a.get(randomTimeout(), randomTimeUnit())
+      assertSame("v1", expectedValue, v1)
+      assertSame("v2", expectedValue, v2)
+    } catch {
+      case fail: Throwable => threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCancelled(a: ForkJoinTask[_]): Unit = {
+    assertTrue("isDone", a.isDone)
+    assertTrue("isCanceled", a.isCancelled)
+    assertFalse("isCompletedNormally", a.isCompletedNormally)
+    assertTrue("isCompletedAbnormally", a.isCompletedAbnormally)
+    assertTrue(
+      "isCancellationException",
+      a.getException.isInstanceOf[CancellationException]
+    )
+    assertNull("result is null", a.getRawResult)
+    assertTrue("cancel", a.cancel(false))
+    assertTrue("cancel force", a.cancel(true))
+    try {
+      Thread.currentThread.interrupt()
+      a.join
+      shouldThrow()
+    } catch {
+      case success: CancellationException => ()
+      case fail: Throwable                => threadUnexpectedException(fail)
+    }
+    Thread.interrupted()
+    val startTime = System.nanoTime()
+    a.quietlyJoin()
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: CancellationException => ()
+      case fail: Throwable                => threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: CancellationException => ()
+      case fail: Throwable                => threadUnexpectedException(fail)
+    }
+  }
+  def checkCompletedAbnormally(a: ForkJoinTask[_], t: Throwable): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertSame(t.getClass, a.getException.getClass)
+    assertNull(a.getRawResult)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    try {
+      Thread.currentThread.interrupt()
+      a.join
+      shouldThrow()
+    } catch {
+      case expected: Throwable =>
+        assertSame(t.getClass, expected.getClass)
+    }
+    Thread.interrupted
+    val startTime = System.nanoTime
+    a.quietlyJoin()
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  /** invoke returns when task completes normally. isCompletedAbnormally and
+   *  isCancelled return false for normally completed tasks; getRawResult
+   *  returns null.
+   */
+  @Test def testInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertNull("invoke", f.invoke())
+        assertEquals(21, f.number)
+        checkCompletedNormally(f) // TODO: fails in one of the checks
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** quietlyInvoke task returns when task completes normally.
+   *  isCompletedAbnormally and isCancelled return false for normally completed
+   *  tasks
+   */
+  @Test def testQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.quietlyInvoke()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** join of a forked task returns when task completes
+   */
+  @Test def testForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** get of a forked task returns when task completes
+   */
+  @Test def testForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.get)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** timed get of a forked task returns when task completes
+   */
+  @Test def testForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** timed get with null time unit throws NPE
+   */
+  @Test def testForkTimedGetNPE(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(randomTimeout(), null)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes
+   */
+  @Test def testForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** helpQuiesce returns when tasks are complete.
+   *  ForkJoinTask.getQueuedTaskCount() returns 0 when quiescent
+   */
+  @Test def testForkHelpQuiesce(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        ForkJoinTask.helpQuiesce()
+        while ({ !f.isDone }) { // wait out race
+        }
+        assertEquals(21, f.number)
+        assertEquals(0, ForkJoinTask.getQueuedTaskCount())
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** invoke task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  @Test def testAbnormalQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        f.quietlyInvoke()
+        assertTrue(f.getException.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** join of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** timed get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes abnormally
+   */
+  @Test def testAbnormalForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertTrue(f.getException.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** invoke task throws exception when task cancelled
+   */
+  @Test def testCancelledInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** join of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** get of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** timed get of a forked task throws exception when task cancelled
+   */
+  @throws[Exception]
+  @Test def testCancelledForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task cancelled
+   */
+  @Test def testCancelledForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        checkCancelled(f)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.getPool() of executing task returns its pool
+   */
+  @Test def testGetPool(): Unit = {
+    val mainPool = ForkJoinTaskTest.mainPool
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        assertSame(mainPool, ForkJoinTask.getPool())
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.getPool() of non-FJ task returns null
+   */
+  @Ignore(
+    "Test-infrastructure limitation, all tests are executed in ForkJoinPool due to usage of Future in RPCCore"
+  )
+  @Test def testGetPool2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        assertNull(ForkJoinTask.getPool())
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** inForkJoinPool of executing task returns true
+   */
+  @Test def testInForkJoinPool(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        assertTrue(ForkJoinTask.inForkJoinPool())
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** inForkJoinPool of non-FJ task returns false
+   */
+  @Ignore("Test-infrastructure limitation, see testGetPool2")
+  @Test def testInForkJoinPool2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        assertFalse(ForkJoinTask.inForkJoinPool())
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** setRawResult(null) succeeds
+   */
+  @Test def testSetRawResult(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        setRawResult(null)
+        assertNull(getRawResult)
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** invoke task throws exception after invoking completeExceptionally
+   */
+  @Test def testCompleteExceptionally(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.completeExceptionally(new FJException)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** completeExceptionally(null) surprisingly has the same effect as
+   *  completeExceptionally(new RuntimeException())
+   */
+  @Test def testCompleteExceptionally_null(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.completeExceptionally(null)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: RuntimeException =>
+            assertSame(success.getClass, classOf[RuntimeException])
+            assertNull(success.getCause)
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(t1, t2) invokes all task arguments
+   */
+  @Test def testInvokeAll2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new AsyncFib(9)
+        ForkJoinTask.invokeAll(f, g)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with 1 argument invokes task
+   */
+  @Test def testInvokeAll1(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        ForkJoinTask.invokeAll(f)
+        checkCompletedNormally(f)
+        assertEquals(21, f.number)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with > 2 argument invokes tasks
+   */
+  @Test def testInvokeAll3(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = new AsyncFib(7)
+        ForkJoinTask.invokeAll(f, g, h)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(collection) invokes all tasks in the collection
+   */
+  @Test def testInvokeAllCollection(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = new AsyncFib(7)
+        val set = new HashSet[ForkJoinTask[_]]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        ForkJoinTask.invokeAll(set)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with any null task throws NPE
+   */
+  @Test def testInvokeAllNPE(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = null
+        try {
+          ForkJoinTask.invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(t1, t2) throw exception if any task does
+   */
+  @Test def testAbnormalInvokeAll2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new FailingAsyncFib(9)
+        val tasks = Array(f, g)
+        shuffle(tasks)
+        try {
+          ForkJoinTask.invokeAll(tasks: _*)
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with 1 argument throws exception if task
+   *  does
+   */
+  @Test def testAbnormalInvokeAll1(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new FailingAsyncFib(9)
+        try {
+          ForkJoinTask.invokeAll(g)
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(tasks) with > 2 argument throws exception if any
+   *  task does
+   */
+  @Test def testAbnormalInvokeAll3(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g =
+          new FailingAsyncFib(9)
+        val h = new AsyncFib(7)
+        val tasks = Array(f, g, h)
+        shuffle(tasks)
+        try {
+          ForkJoinTask.invokeAll(tasks: _*)
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** ForkJoinTask.invokeAll(collection) throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAllCollection(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = new AsyncFib(7)
+        val tasks = Array(f, g, h)
+        shuffle(tasks)
+        try {
+          ForkJoinTask.invokeAll(Arrays.asList(tasks: _*))
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** tryUnfork returns true for most recent unexecuted task, and suppresses
+   *  execution
+   */
+  @Test def testTryUnfork(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertTrue(f.tryUnfork)
+        ForkJoinTask.helpQuiesce()
+        checkNotDone(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** getSurplusQueuedTaskCount returns > 0 when there are more tasks than
+   *  threads
+   */
+  @Test def testGetSurplusQueuedTaskCount(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val h = new AsyncFib(7)
+        assertSame(h, h.fork)
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertTrue(ForkJoinTask.getSurplusQueuedTaskCount > 0)
+        ForkJoinTask.helpQuiesce()
+        assertEquals(0, ForkJoinTask.getSurplusQueuedTaskCount)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** peekNextLocalTask returns most recent unexecuted task.
+   */
+  @Test def testPeekNextLocalTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(f, ForkJoinTask.peekNextLocalTask)
+        assertNull(f.join)
+        checkCompletedNormally(f)
+        ForkJoinTask.helpQuiesce()
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** pollNextLocalTask returns most recent unexecuted task without executing it
+   */
+  @Test def testPollNextLocalTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(f, ForkJoinTask.pollNextLocalTask)
+        ForkJoinTask.helpQuiesce()
+        checkNotDone(f)
+        assertEquals(34, g.number)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** pollTask returns an unexecuted task without executing it
+   */
+  @Test def testPollTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(f, ForkJoinTask.pollTask)
+        ForkJoinTask.helpQuiesce()
+        checkNotDone(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** peekNextLocalTask returns least recent unexecuted task in async mode
+   */
+  @Test def testPeekNextLocalTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(g, ForkJoinTask.peekNextLocalTask)
+        assertNull(f.join)
+        ForkJoinTask.helpQuiesce()
+        checkCompletedNormally(f)
+        assertEquals(34, g.number)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(asyncSingletonPool, a)
+  }
+
+  /** pollNextLocalTask returns least recent unexecuted task without executing
+   *  it, in async mode
+   */
+  @Test def testPollNextLocalTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(g, ForkJoinTask.pollNextLocalTask)
+        ForkJoinTask.helpQuiesce()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+        checkNotDone(g)
+      }
+    }
+    testInvokeOnPool(asyncSingletonPool, a)
+  }
+
+  /** pollTask returns an unexecuted task without executing it, in async mode
+   */
+  @Test def testPollTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g = new AsyncFib(9)
+        assertSame(g, g.fork)
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertSame(g, ForkJoinTask.pollTask)
+        ForkJoinTask.helpQuiesce()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+        checkNotDone(g)
+      }
+    }
+    testInvokeOnPool(asyncSingletonPool, a)
+  }
+  // versions for singleton pools
+  @Test def testInvokeSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertNull(f.invoke)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testQuietlyInvokeSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.quietlyInvoke()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testForkJoinSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testForkGetSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.get)
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testForkTimedGetSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testForkTimedGetNPESingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(randomTimeout(), null)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testForkQuietlyJoinSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testForkHelpQuiesceSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertSame(f, f.fork)
+        ForkJoinTask.helpQuiesce()
+        assertEquals(0, ForkJoinTask.getQueuedTaskCount())
+        assertEquals(21, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalInvokeSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalQuietlyInvokeSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        f.quietlyInvoke()
+        assertTrue(f.getException.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalForkJoinSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalForkGetSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalForkTimedGetSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalForkQuietlyJoinSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f =
+          new FailingAsyncFib(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertTrue(f.getException.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testCancelledInvokeSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testCancelledForkJoinSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testCancelledForkGetSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+  @throws[Exception]
+  @Test def testCancelledForkTimedGetSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testCancelledForkQuietlyJoinSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        checkCancelled(f)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testCompleteExceptionallySingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.completeExceptionally(new FJException())
+        try {
+          f.invoke()
+          shouldThrow()
+        } catch {
+          case success: FJException => checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testInvokeAll2Singleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new AsyncFib(9)
+        ForkJoinTask.invokeAll(f, g)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testInvokeAll1Singleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        ForkJoinTask.invokeAll(f)
+        checkCompletedNormally(f)
+        assertEquals(21, f.number)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testInvokeAll3Singleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = new AsyncFib(7)
+        ForkJoinTask.invokeAll(f, g, h)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testInvokeAllCollectionSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = new AsyncFib(7)
+        val set = new HashSet[ForkJoinTask[_]]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        ForkJoinTask.invokeAll(set)
+        assertEquals(21, f.number)
+        assertEquals(34, g.number)
+        assertEquals(13, h.number)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testInvokeAllNPESingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = null
+        try {
+          ForkJoinTask.invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException => ()
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalInvokeAll2Singleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new FailingAsyncFib(9)
+        val tasks = Array(f, g)
+        shuffle(tasks)
+        try {
+          ForkJoinTask.invokeAll(tasks: _*)
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalInvokeAll1Singleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val g =
+          new FailingAsyncFib(9)
+        try {
+          ForkJoinTask.invokeAll(g)
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalInvokeAll3Singleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        val g = new FailingAsyncFib(9)
+        val h = new AsyncFib(7)
+        val tasks = Array(f, g, h)
+        shuffle(tasks)
+        try {
+          ForkJoinTask.invokeAll(tasks: _*)
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  @Test def testAbnormalInvokeAllCollectionSingleton(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new FailingAsyncFib(8)
+        val g = new AsyncFib(9)
+        val h = new AsyncFib(7)
+        val tasks = Array(f, g, h)
+        shuffle(tasks)
+        try {
+          ForkJoinTask.invokeAll(Arrays.asList(tasks: _*))
+          shouldThrow()
+        } catch {
+          case success: FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(singletonPool, a)
+  }
+
+  /** ForkJoinTask.quietlyComplete returns when task completes normally without
+   *  setting a value. The most recent value established by setRawResult(V) (or
+   *  null by default) is returned from invoke.
+   */
+  @Test def testQuietlyComplete(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      override protected def realCompute(): Unit = {
+        val f = new AsyncFib(8)
+        f.quietlyComplete()
+        assertEquals(8, f.number)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** adapt(runnable).toString() contains toString of wrapped task
+   */
+  @Test def testAdapt_Runnable_toString(): Unit = {
+    if (testImplementationDetails) {
+      val r: Runnable = () => {
+        def foo() = {}
+        foo()
+      }
+      val task = ForkJoinTask.adapt(r)
+      assertEquals(
+        identityString(task) + "[Wrapped task = " + r.toString + "]",
+        task.toString
+      )
+    }
+  }
+
+  /** adapt(runnable, x).toString() contains toString of wrapped task
+   */
+  @Test def testAdapt_Runnable_withResult_toString(): Unit = {
+    if (testImplementationDetails) {
+      val r: Runnable = () => {
+        def foo() = {}
+        foo()
+      }
+      val task = ForkJoinTask.adapt(r, "")
+      assertEquals(
+        identityString(task) + "[Wrapped task = " + r.toString + "]",
+        task.toString
+      )
+    }
+  }
+
+  /** adapt(callable).toString() contains toString of wrapped task
+   */
+  @Test def testAdapt_Callable_toString(): Unit = {
+    if (testImplementationDetails) {
+      val c: Callable[String] = () => ""
+      val task = ForkJoinTask.adapt(c)
+      assertEquals(
+        identityString(task) + "[Wrapped task = " + c.toString + "]",
+        task.toString
+      )
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTaskTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTaskTest.scala
@@ -6,6 +6,7 @@
 package org.scalanative.testsuite.javalib.util.concurrent
 
 import org.junit.Assert._
+import org.junit.Assume._
 import org.junit.{Test, Ignore}
 import JSR166Test._
 
@@ -14,6 +15,7 @@ import java.util
 import java.util._
 import java.util.concurrent._
 import java.util.concurrent.atomic._
+import org.scalanative.testsuite.utils.Platform
 
 object ForkJoinTaskTest {
   // Runs with "mainPool" use > 1 thread. singletonPool tests use 1
@@ -1618,6 +1620,10 @@ class ForkJoinTaskTest extends JSR166Test {
   /** adapt(runnable).toString() contains toString of wrapped task
    */
   @Test def testAdapt_Runnable_toString(): Unit = {
+    assumeFalse(
+      "Output difference since JDK11",
+      Platform.executingInJVMOnLowerThenJDK11
+    )
     if (testImplementationDetails) {
       val r: Runnable = () => {
         def foo() = {}
@@ -1634,6 +1640,10 @@ class ForkJoinTaskTest extends JSR166Test {
   /** adapt(runnable, x).toString() contains toString of wrapped task
    */
   @Test def testAdapt_Runnable_withResult_toString(): Unit = {
+    assumeFalse(
+      "Output difference since JDK11",
+      Platform.executingInJVMOnLowerThenJDK11
+    )
     if (testImplementationDetails) {
       val r: Runnable = () => {
         def foo() = {}
@@ -1650,6 +1660,10 @@ class ForkJoinTaskTest extends JSR166Test {
   /** adapt(callable).toString() contains toString of wrapped task
    */
   @Test def testAdapt_Callable_toString(): Unit = {
+    assumeFalse(
+      "Output difference since JDK11",
+      Platform.executingInJVMOnLowerThenJDK11
+    )
     if (testImplementationDetails) {
       val c: Callable[String] = () => ""
       val task = ForkJoinTask.adapt(c)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/FutureTaskTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/FutureTaskTest.scala
@@ -1,0 +1,981 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{Test, Ignore}
+import org.scalanative.testsuite.utils.Platform
+import JSR166Test._
+
+import java.util.concurrent.TimeUnit._
+import java.util
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.FutureTask
+
+object FutureTaskTest {
+
+  /** Subclass to expose protected methods
+   */
+  object PublicFutureTask {
+    def apply[T](callable: Callable[T]) = new PublicCallableTask(callable)
+    def apply(runnable: Runnable, result: AnyRef = seven) =
+      new PublicRunnableTask(runnable, result)
+  }
+
+  sealed trait PublicFutureTask { self: FutureTask[AnyRef] =>
+    val runCounter: AtomicInteger
+    final protected val doneCounter = new AtomicInteger(0)
+    final protected val runAndResetCounter = new AtomicInteger(0)
+    final protected val setCounter = new AtomicInteger(0)
+    final protected val setExceptionCounter = new AtomicInteger(0)
+    def runCount(): Int = this.runCounter.get()
+    def doneCount(): Int = this.doneCounter.get()
+    def runAndResetCount(): Int = runAndResetCounter.get()
+    def setCount(): Int = setCounter.get()
+    def setExceptionCount(): Int = setExceptionCounter.get()
+    def doDone(): Unit
+    def doRunAndReset(): Boolean
+    def doSet(x: AnyRef): Unit
+    def doSetException(t: Throwable): Unit
+  }
+
+  final class PublicRunnableTask(
+      runnable: Runnable,
+      result: AnyRef,
+      val runCounter: AtomicInteger = new AtomicInteger(0)
+  ) extends FutureTask(
+        new Runnable() {
+          override def run(): Unit = {
+            runCounter.getAndIncrement()
+            runnable.run()
+          }
+        },
+        result
+      )
+      with PublicFutureTask {
+    def doDone(): Unit = done()
+    override protected def done(): Unit = {
+      assertTrue(isDone())
+      doneCounter.incrementAndGet()
+      super.done()
+    }
+
+    def doRunAndReset(): Boolean = runAndReset()
+    override protected def runAndReset(): Boolean = {
+      runAndResetCounter.incrementAndGet()
+      super.runAndReset()
+    }
+
+    def doSet(x: AnyRef): Unit = set(x)
+    override protected def set(x: AnyRef): Unit = {
+      setCounter.incrementAndGet()
+      super.set(x)
+    }
+
+    def doSetException(t: Throwable): Unit = setException(t)
+    override protected def setException(t: Throwable): Unit = {
+      setExceptionCounter.incrementAndGet()
+      super.setException(t)
+    }
+
+  }
+
+  final class PublicCallableTask[T](
+      callable: Callable[T],
+      val runCounter: AtomicInteger = new AtomicInteger(0)
+  ) extends FutureTask[AnyRef](
+        new Callable[AnyRef]() {
+          override def call(): AnyRef = {
+            runCounter.getAndIncrement()
+            callable.call().asInstanceOf[AnyRef]
+          }
+        }
+      )
+      with PublicFutureTask {
+    def doDone(): Unit = done()
+    override protected def done(): Unit = {
+      assertTrue(isDone())
+      doneCounter.incrementAndGet()
+      super.done()
+    }
+
+    def doRunAndReset(): Boolean = runAndReset()
+    override protected def runAndReset(): Boolean = {
+      runAndResetCounter.incrementAndGet()
+      super.runAndReset()
+    }
+
+    def doSet(x: AnyRef): Unit = set(x)
+    override protected def set(x: AnyRef): Unit = {
+      setCounter.incrementAndGet()
+      super.set(x)
+    }
+
+    def doSetException(t: Throwable): Unit = setException(t)
+    override protected def setException(t: Throwable): Unit = {
+      setExceptionCounter.incrementAndGet()
+      super.setException(t)
+    }
+  }
+}
+
+class FutureTaskTest extends JSR166Test {
+  type PublicFutureTask = FutureTask[AnyRef]
+    with FutureTaskTest.PublicFutureTask
+
+  def checkIsDone[T <: AnyRef](f: Future[T]): Unit = {
+    assertTrue(f.isDone())
+    assertFalse(f.cancel(false))
+    assertFalse(f.cancel(true))
+    f match {
+      case pf: PublicFutureTask @unchecked =>
+        assertEquals(1, pf.doneCount())
+        assertFalse(pf.doRunAndReset())
+        assertEquals(1, pf.doneCount())
+        var r = null: AnyRef
+        var exInfo = null: AnyRef
+        try r = f.get
+        catch {
+          case t: CancellationException =>
+            exInfo = classOf[CancellationException]
+          case t: ExecutionException =>
+            exInfo = t.getCause
+          case t: Throwable =>
+            threadUnexpectedException(t)
+        }
+        // Check that run and runAndReset have no effect.
+        val savedRunCount = pf.runCount()
+        pf.run()
+        pf.doRunAndReset()
+        assertEquals(savedRunCount, pf.runCount())
+        var r2 = null: AnyRef
+        try r2 = f.get
+        catch {
+          case t: CancellationException =>
+            assertSame(exInfo, classOf[CancellationException])
+          case t: ExecutionException =>
+            assertSame(exInfo, t.getCause)
+          case t: Throwable =>
+            threadUnexpectedException(t)
+        }
+        if (exInfo == null) assertSame(r, r2)
+        assertTrue(f.isDone())
+
+      case _ => ()
+    }
+
+  }
+  def checkNotDone[T](f: Future[T]): Unit = {
+    assertFalse(f.isDone())
+    assertFalse(f.isCancelled)
+    f match {
+      case pf: PublicFutureTask @unchecked =>
+        assertEquals(0, pf.doneCount())
+        assertEquals(0, pf.setCount())
+        assertEquals(0, pf.setExceptionCount())
+      case _ => ()
+    }
+  }
+
+  def checkIsRunning(f: Future[AnyRef]): Unit = {
+    checkNotDone(f)
+    f match {
+      case ft: FutureTask[_] =>
+        // Check that run methods do nothing
+        ft.run()
+        f match {
+          case pf: PublicFutureTask =>
+            val savedRunCount = pf.runCount()
+            pf.run()
+            assertFalse(pf.doRunAndReset())
+            assertEquals(savedRunCount, pf.runCount())
+          case _ => ()
+        }
+        checkNotDone(f)
+      case _ => ()
+    }
+  }
+
+  def checkCompletedNormally[T <: AnyRef](
+      f: Future[T],
+      expectedValue: T
+  ): Unit = {
+    checkIsDone(f)
+    assertFalse(f.isCancelled)
+    var v1 = null: AnyRef
+    var v2 = null: AnyRef
+    try {
+      v1 = f.get
+      v2 = f.get(randomTimeout(), randomTimeUnit())
+    } catch {
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    assertSame(expectedValue, v1)
+    assertSame(expectedValue, v2)
+  }
+
+  def checkCancelled(f: Future[AnyRef]): Unit = {
+    checkIsDone(f)
+    assertTrue(f.isCancelled)
+    try {
+      f.get
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      f.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+  def tryToConfuseDoneTask(pf: PublicFutureTask): Unit = {
+    pf.doSet(new Object {})
+    pf.doSetException(new Error)
+    for (mayInterruptIfRunning <- Array[java.lang.Boolean](true, false)) {
+      pf.cancel(mayInterruptIfRunning)
+    }
+  }
+  def checkCompletedAbnormally(f: Future[AnyRef], t: Throwable): Unit = {
+    checkIsDone(f)
+    assertFalse(f.isCancelled)
+    try {
+      f.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t, success.getCause)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      f.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t, success.getCause)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+  class Counter extends CheckedRunnable {
+    final val count = new AtomicInteger(0)
+    def get: Int = count.get
+    override def realRun(): Unit = { count.getAndIncrement }
+  }
+
+  /** creating a future with a null callable throws NullPointerException
+   */
+  @Test def testConstructor(): Unit = {
+    try {
+      new FutureTask(null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** creating a future with null runnable throws NullPointerException
+   */
+  @Test def testConstructor2(): Unit = {
+    try {
+      new FutureTask(null, java.lang.Boolean.TRUE)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** isDone is true when a task completes
+   */
+  @Test def testIsDone(): Unit = {
+    val task =
+      FutureTaskTest.PublicFutureTask(new NoOpCallable)
+    assertFalse(task.isDone())
+    task.run()
+    assertTrue(task.isDone())
+    checkCompletedNormally(task, java.lang.Boolean.TRUE)
+    assertEquals(1, task.runCount())
+  }
+
+  /** runAndReset of a non-cancelled task succeeds
+   */
+  @Test def testRunAndReset(): Unit = {
+    val task =
+      FutureTaskTest.PublicFutureTask(new NoOpCallable)
+    for (i <- 0 until 3) {
+      assertTrue(task.doRunAndReset())
+      checkNotDone(task)
+      assertEquals(i + 1, task.runCount())
+      assertEquals(i + 1, task.runAndResetCount())
+      assertEquals(0, task.setCount())
+      assertEquals(0, task.setExceptionCount())
+    }
+  }
+
+  /** runAndReset after cancellation fails
+   */
+  @Test def testRunAndResetAfterCancel(): Unit = {
+    for (mayInterruptIfRunning <- Array[java.lang.Boolean](true, false)) {
+      val task =
+        FutureTaskTest.PublicFutureTask(new NoOpCallable)
+      assertTrue(task.cancel(mayInterruptIfRunning))
+      for (i <- 0 until 3) {
+        assertFalse(task.doRunAndReset())
+        assertEquals(0, task.runCount())
+        assertEquals(i + 1, task.runAndResetCount())
+        assertEquals(0, task.setCount())
+        assertEquals(0, task.setExceptionCount())
+      }
+      tryToConfuseDoneTask(task)
+      checkCancelled(task)
+    }
+  }
+
+  /** setting value causes get to return it
+   */
+  @throws[Exception]
+  @Test def testSet(): Unit = {
+    val task =
+      FutureTaskTest.PublicFutureTask(new NoOpCallable)
+    task.doSet(one)
+    for (i <- 0 until 3) {
+      assertSame(one, task.get)
+      assertSame(one, task.get(LONG_DELAY_MS, MILLISECONDS))
+      assertEquals(1, task.setCount())
+    }
+    tryToConfuseDoneTask(task)
+    checkCompletedNormally(task, one)
+    assertEquals(0, task.runCount())
+  }
+
+  /** setException causes get to throw ExecutionException
+   */
+  @throws[Exception]
+  @Test def testSetException_get(): Unit = {
+    val nse = new NoSuchElementException
+    val task =
+      FutureTaskTest.PublicFutureTask(new NoOpCallable)
+    task.doSetException(nse)
+    try {
+      task.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(nse, success.getCause)
+        checkCompletedAbnormally(task, nse)
+    }
+    try {
+      task.get(LONG_DELAY_MS, MILLISECONDS)
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(nse, success.getCause)
+        checkCompletedAbnormally(task, nse)
+    }
+    assertEquals(1, task.setExceptionCount())
+    assertEquals(0, task.setCount())
+    tryToConfuseDoneTask(task)
+    checkCompletedAbnormally(task, nse)
+    assertEquals(0, task.runCount())
+  }
+
+  /** cancel(false) before run succeeds
+   */
+  @Test def testCancelBeforeRun(): Unit = {
+    val task =
+      FutureTaskTest.PublicFutureTask(new NoOpCallable)
+    assertTrue(task.cancel(false))
+    task.run()
+    assertEquals(0, task.runCount())
+    assertEquals(0, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    assertTrue(task.isCancelled)
+    assertTrue(task.isDone())
+    tryToConfuseDoneTask(task)
+    assertEquals(0, task.runCount())
+    checkCancelled(task)
+  }
+
+  /** cancel(true) before run succeeds
+   */
+  @Test def testCancelBeforeRun2(): Unit = {
+    val task =
+      FutureTaskTest.PublicFutureTask(new NoOpCallable)
+    assertTrue(task.cancel(true))
+    task.run()
+    assertEquals(0, task.runCount())
+    assertEquals(0, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    assertTrue(task.isCancelled)
+    assertTrue(task.isDone())
+    tryToConfuseDoneTask(task)
+    assertEquals(0, task.runCount())
+    checkCancelled(task)
+  }
+
+  /** cancel(false) of a completed task fails
+   */
+  @Test def testCancelAfterRun(): Unit = {
+    val task =
+      FutureTaskTest.PublicFutureTask(new NoOpCallable)
+    task.run()
+    assertFalse(task.cancel(false))
+    assertEquals(1, task.runCount())
+    assertEquals(1, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    tryToConfuseDoneTask(task)
+    checkCompletedNormally(task, java.lang.Boolean.TRUE)
+    assertEquals(1, task.runCount())
+  }
+
+  /** cancel(true) of a completed task fails
+   */
+  @Test def testCancelAfterRun2(): Unit = {
+    val task =
+      FutureTaskTest.PublicFutureTask(new NoOpCallable)
+    task.run()
+    assertFalse(task.cancel(true))
+    assertEquals(1, task.runCount())
+    assertEquals(1, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    tryToConfuseDoneTask(task)
+    checkCompletedNormally(task, java.lang.Boolean.TRUE)
+    assertEquals(1, task.runCount())
+  }
+
+  /** cancel(true) interrupts a running task that subsequently succeeds
+   */
+  @Test def testCancelInterrupt(): Unit = {
+    val pleaseCancel = new CountDownLatch(1)
+    val task =
+      FutureTaskTest.PublicFutureTask(new CheckedRunnable() {
+        override def realRun(): Unit = {
+          pleaseCancel.countDown()
+          try {
+            delay(LONG_DELAY_MS)
+            shouldThrow()
+          } catch {
+            case success: InterruptedException =>
+
+          }
+          assertFalse(Thread.interrupted)
+        }
+      })
+    val t = newStartedThread(task)
+    await(pleaseCancel)
+    assertTrue(task.cancel(true))
+    assertTrue(task.isCancelled)
+    assertTrue(task.isDone())
+    awaitTermination(t)
+    assertEquals(1, task.runCount())
+    assertEquals(1, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    tryToConfuseDoneTask(task)
+    checkCancelled(task)
+  }
+
+  /** cancel(true) tries to interrupt a running task, but Thread.interrupt
+   *  throws (simulating a restrictive security manager)
+   */
+  @Test def testCancelInterrupt_ThrowsSecurityException(): Unit = {
+    val pleaseCancel = new CountDownLatch(1)
+    val cancelled = new CountDownLatch(1)
+    val task =
+      FutureTaskTest.PublicFutureTask(new CheckedRunnable() {
+        override def realRun(): Unit = {
+          pleaseCancel.countDown()
+          await(cancelled)
+          assertFalse(Thread.interrupted)
+        }
+      })
+    val t = new Thread(task) { // Simulate a restrictive security manager.
+      override def interrupt(): Unit = { throw new SecurityException }
+    }
+    t.setDaemon(true)
+    t.start()
+    await(pleaseCancel)
+    try {
+      task.cancel(true)
+      shouldThrow()
+    } catch {
+      case success: SecurityException =>
+
+    }
+    // We failed to deliver the interrupt, but the world retains
+    // its sanity, as if we had done task.cancel(false)
+    assertTrue(task.isCancelled)
+    assertTrue(task.isDone())
+    assertEquals(1, task.runCount())
+    assertEquals(1, task.doneCount())
+    assertEquals(0, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    cancelled.countDown()
+    awaitTermination(t)
+    assertEquals(1, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    tryToConfuseDoneTask(task)
+    checkCancelled(task)
+  }
+
+  /** cancel(true) interrupts a running task that subsequently throws
+   */
+  @Test def testCancelInterrupt_taskFails(): Unit = {
+    val pleaseCancel = new CountDownLatch(1)
+    val task = FutureTaskTest.PublicFutureTask(new Runnable() {
+      override def run(): Unit = {
+        pleaseCancel.countDown()
+        try {
+          delay(LONG_DELAY_MS)
+          threadShouldThrow()
+        } catch {
+          case success: InterruptedException => ()
+          case t: Throwable                  => threadUnexpectedException(t)
+        }
+        throw new RuntimeException
+      }
+    })
+    val t = newStartedThread(task)
+    await(pleaseCancel)
+    assertTrue(task.cancel(true))
+    assertTrue(task.isCancelled)
+    awaitTermination(t)
+    assertEquals(1, task.runCount())
+    assertEquals(0, task.setCount())
+    assertEquals(1, task.setExceptionCount())
+    tryToConfuseDoneTask(task)
+    checkCancelled(task)
+  }
+
+  /** cancel(false) does not interrupt a running task
+   */
+  @Test def testCancelNoInterrupt(): Unit = {
+    val pleaseCancel = new CountDownLatch(1)
+    val cancelled = new CountDownLatch(1)
+    val task = FutureTaskTest.PublicFutureTask(
+      new CheckedCallable[java.lang.Boolean]() {
+        override def realCall(): java.lang.Boolean = {
+          pleaseCancel.countDown()
+          await(cancelled)
+          assertFalse(Thread.interrupted)
+          java.lang.Boolean.TRUE
+        }
+      }
+    )
+    val t = newStartedThread(task)
+    await(pleaseCancel)
+    assertTrue(task.cancel(false))
+    assertTrue(task.isCancelled)
+    cancelled.countDown()
+    awaitTermination(t)
+    assertEquals(1, task.runCount())
+    assertEquals(1, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    tryToConfuseDoneTask(task)
+    checkCancelled(task)
+  }
+
+  /** run in one thread causes get in another thread to retrieve value
+   */
+  @Test def testGetRun(): Unit = {
+    val pleaseRun = new CountDownLatch(2)
+    val task = FutureTaskTest.PublicFutureTask(
+      new CheckedCallable[AnyRef]() {
+        override def realCall(): AnyRef = two
+      }
+    )
+    val t1 = newStartedThread(new CheckedRunnable() {
+      @throws[Exception]
+      override def realRun(): Unit = {
+        pleaseRun.countDown()
+        assertSame(two, task.get)
+      }
+    })
+    val t2 = newStartedThread(new CheckedRunnable() {
+      @throws[Exception]
+      override def realRun(): Unit = {
+        pleaseRun.countDown()
+        assertSame(two, task.get(2 * LONG_DELAY_MS, MILLISECONDS))
+      }
+    })
+    await(pleaseRun)
+    checkNotDone(task)
+    assertTrue(t1.isAlive)
+    assertTrue(t2.isAlive)
+    task.run()
+    checkCompletedNormally(task, two)
+    assertEquals(1, task.runCount())
+    assertEquals(1, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    awaitTermination(t1)
+    awaitTermination(t2)
+    tryToConfuseDoneTask(task)
+    checkCompletedNormally(task, two)
+  }
+
+  /** set in one thread causes get in another thread to retrieve value
+   */
+  @Test def testdoSet(): Unit = {
+    val pleaseSet = new CountDownLatch(2)
+    val task = FutureTaskTest.PublicFutureTask(
+      new CheckedCallable[AnyRef]() {
+        @throws[InterruptedException]
+        override def realCall(): AnyRef = two
+      }
+    )
+    val t1 = newStartedThread(new CheckedRunnable() {
+      @throws[Exception]
+      override def realRun(): Unit = {
+        pleaseSet.countDown()
+        assertSame(two, task.get)
+      }
+    })
+    val t2 = newStartedThread(new CheckedRunnable() {
+      @throws[Exception]
+      override def realRun(): Unit = {
+        pleaseSet.countDown()
+        assertSame(two, task.get(2 * LONG_DELAY_MS, MILLISECONDS))
+      }
+    })
+    await(pleaseSet)
+    checkNotDone(task)
+    assertTrue(t1.isAlive)
+    assertTrue(t2.isAlive)
+    task.doSet(two)
+    assertEquals(0, task.runCount())
+    assertEquals(1, task.setCount())
+    assertEquals(0, task.setExceptionCount())
+    tryToConfuseDoneTask(task)
+    checkCompletedNormally(task, two)
+    awaitTermination(t1)
+    awaitTermination(t2)
+  }
+
+  /** Cancelling a task causes timed get in another thread to throw
+   *  CancellationException
+   */
+  @Test def testTimedGet_Cancellation(): Unit = {
+    testTimedGet_Cancellation(false)
+  }
+  @Test def testTimedGet_Cancellation_interrupt(): Unit = {
+    testTimedGet_Cancellation(true)
+  }
+
+  def testTimedGet_Cancellation(
+      mayInterruptIfRunning: java.lang.Boolean
+  ): Unit = {
+    val pleaseCancel = new CountDownLatch(3)
+    val cancelled = new CountDownLatch(1)
+    val callable = new CheckedCallable[AnyRef]() {
+      @throws[InterruptedException]
+      override def realCall(): AnyRef = {
+        pleaseCancel.countDown()
+        if (mayInterruptIfRunning)
+          try delay(2 * LONG_DELAY_MS)
+          catch {
+            case success: InterruptedException =>
+
+          }
+        else await(cancelled)
+        two
+      }
+    }
+    val task = FutureTaskTest.PublicFutureTask(callable)
+    val t1 = new ThreadShouldThrow(classOf[CancellationException]) {
+      @throws[Exception]
+      override def realRun(): Unit = {
+        pleaseCancel.countDown()
+        task.get
+      }
+    }
+    val t2 = new ThreadShouldThrow(classOf[CancellationException]) {
+      @throws[Exception]
+      override def realRun(): Unit = {
+        pleaseCancel.countDown()
+        task.get(2 * LONG_DELAY_MS, MILLISECONDS)
+      }
+    }
+    t1.start()
+    t2.start()
+    val t3 = newStartedThread(task)
+    await(pleaseCancel)
+    checkIsRunning(task)
+    task.cancel(mayInterruptIfRunning)
+    checkCancelled(task)
+    awaitTermination(t1)
+    awaitTermination(t2)
+    cancelled.countDown()
+    awaitTermination(t3)
+    assertEquals("runCount", 1, task.runCount())
+    assertEquals("setCunt", 1, task.setCount())
+    assertEquals("exceptionCount", 0, task.setExceptionCount())
+    tryToConfuseDoneTask(task)
+    checkCancelled(task)
+  }
+
+  /** A runtime exception in task causes get to throw ExecutionException
+   */
+  @throws[InterruptedException]
+  @Test def testGet_ExecutionException(): Unit = {
+    val e = new ArithmeticException
+    val task = FutureTaskTest.PublicFutureTask(new Callable[Any]() {
+      override def call = throw e
+    })
+    task.run()
+    assertEquals(1, task.runCount())
+    assertEquals(0, task.setCount())
+    assertEquals(1, task.setExceptionCount())
+    try {
+      task.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(e, success.getCause)
+        tryToConfuseDoneTask(task)
+        checkCompletedAbnormally(task, success.getCause)
+    }
+  }
+
+  /** A runtime exception in task causes timed get to throw ExecutionException
+   */
+  @throws[Exception]
+  @Test def testTimedGet_ExecutionException2(): Unit = {
+    val e = new ArithmeticException
+    val task = FutureTaskTest.PublicFutureTask(new Callable[Any]() {
+      override def call = throw e
+    })
+    task.run()
+    try {
+      task.get(LONG_DELAY_MS, MILLISECONDS)
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(e, success.getCause)
+        tryToConfuseDoneTask(task)
+        checkCompletedAbnormally(task, success.getCause)
+    }
+  }
+
+  /** get is interruptible
+   */
+  @Test def testGet_Interruptible(): Unit = {
+    val pleaseInterrupt = new CountDownLatch(1)
+    val task = new FutureTask(new NoOpCallable)
+    val t = newStartedThread(new CheckedRunnable() {
+      @throws[Exception]
+      override def realRun(): Unit = {
+        Thread.currentThread.interrupt()
+        try {
+          task.get
+          shouldThrow()
+        } catch {
+          case success: InterruptedException =>
+
+        }
+        assertFalse(Thread.interrupted)
+        pleaseInterrupt.countDown()
+        try {
+          task.get
+          shouldThrow()
+        } catch {
+          case success: InterruptedException =>
+
+        }
+        assertFalse(Thread.interrupted)
+      }
+    })
+    await(pleaseInterrupt)
+    t.interrupt()
+    awaitTermination(t)
+    checkNotDone(task)
+  }
+
+  /** timed get is interruptible
+   */
+  @Test def testTimedGet_Interruptible(): Unit = {
+    val pleaseInterrupt = new CountDownLatch(1)
+    val task = new FutureTask(new NoOpCallable)
+    val t = newStartedThread(new CheckedRunnable() {
+      @throws[Exception]
+      override def realRun(): Unit = {
+        Thread.currentThread.interrupt()
+        try {
+          task.get(randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case success: InterruptedException =>
+
+        }
+        assertFalse(Thread.interrupted)
+        pleaseInterrupt.countDown()
+        try {
+          task.get(LONGER_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: InterruptedException =>
+
+        }
+        assertFalse(Thread.interrupted)
+      }
+    })
+    await(pleaseInterrupt)
+    if (randomBoolean())
+      assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    checkNotDone(task)
+  }
+
+  /** A timed out timed get throws TimeoutException
+   */
+  @throws[Exception]
+  @Test def testGet_TimeoutException(): Unit = {
+    val task = new FutureTask(new NoOpCallable)
+    val startTime = System.nanoTime
+    try {
+      task.get(timeoutMillis(), MILLISECONDS)
+      shouldThrow()
+    } catch {
+      case success: TimeoutException =>
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
+  }
+
+  /** timed get with null TimeUnit throws NullPointerException
+   */
+  @throws[Exception]
+  @Test def testGet_NullTimeUnit(): Unit = {
+    val task = new FutureTask(new NoOpCallable)
+    val timeouts = Array(java.lang.Long.MIN_VALUE, 0L, java.lang.Long.MAX_VALUE)
+    for (timeout <- timeouts) {
+      try {
+        task.get(timeout, null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+    }
+    task.run()
+    for (timeout <- timeouts) {
+      try {
+        task.get(timeout, null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+    }
+  }
+
+  // TODO: ThreadPoolExecutor
+  // /** timed get with most negative timeout works correctly (i.e. no underflow
+  //  *  bug)
+  //  */
+  // @throws[Exception]
+  // @Test def testGet_NegativeInfinityTimeout(): Unit = {
+  //   assumeFalse(
+  //     "Fails due to bug in the JVM",
+  //     Platform.executingInJVMOnJDK8OrLower
+  //   )
+  //   val pool = Executors.newFixedThreadPool(10)
+  //   val nop = new Runnable() { override def run(): Unit = {} }
+  //   val task = new FutureTask[Void](nop, null)
+  //   val futures = new util.ArrayList[Future[AnyRef]]
+  //   val r: Runnable = new Runnable() {
+  //     override def run(): Unit = {
+  //       for (timeout <- Array[Long](0L, -1L, java.lang.Long.MIN_VALUE)) {
+  //         try {
+  //           task.get(timeout, NANOSECONDS)
+  //           shouldThrow()
+  //         } catch {
+  //           case success: TimeoutException => ()
+  //           case fail: Throwable           => threadUnexpectedException(fail)
+  //         }
+  //       }
+  //     }
+  //   }
+  //   for (i <- 0 until 10) {
+  //     val f = pool.submit(r)
+  //     futures.add(f.asInstanceOf[Future[AnyRef]])
+  //   }
+  //   try {
+  //     joinPool(pool)
+  //     futures.forEach(checkCompletedNormally(_, null))
+  //   } finally task.run() // last resort to help terminate
+  // }
+
+  /** toString indicates current completion state
+   */
+  @Test def testToString_incomplete(): Unit = {
+    assumeFalse(
+      "Fails due to bug in the JVM",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+    val f = new FutureTask[String](() => "")
+    assertTrue(f.toString.matches(".*\\[.*Not completed.*\\]"))
+    if (testImplementationDetails)
+      assertTrue(
+        f.toString.startsWith(identityString(f) + "[Not completed, task =")
+      )
+  }
+  @Test def testToString_normal(): Unit = {
+    assumeFalse(
+      "Fails due to bug in the JVM",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+    val f = new FutureTask[String](() => "")
+    f.run()
+    assertTrue(f.toString.matches(".*\\[.*Completed normally.*\\]"))
+    if (testImplementationDetails)
+      assertEquals(identityString(f) + "[Completed normally]", f.toString)
+  }
+  @Test def testToString_exception(): Unit = {
+    assumeFalse(
+      "Fails due to bug in the JVM",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+    val f = new FutureTask[String](() => {
+      def foo() =
+        throw new ArithmeticException
+      foo()
+    })
+    f.run()
+    assertTrue(f.toString.matches(".*\\[.*Completed exceptionally.*\\]"))
+    if (testImplementationDetails)
+      assertTrue(
+        f.toString.startsWith(identityString(f) + "[Completed exceptionally: ")
+      )
+  }
+  @Test def testToString_cancelled(): Unit = {
+    assumeFalse(
+      "Fails due to bug in the JVM",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+    for (mayInterruptIfRunning <- Array[java.lang.Boolean](true, false)) {
+      val f = new FutureTask[String](() => "")
+      assertTrue(f.cancel(mayInterruptIfRunning))
+      assertTrue(f.toString.matches(".*\\[.*Cancelled.*\\]"))
+      if (testImplementationDetails)
+        assertEquals(identityString(f) + "[Cancelled]", f.toString)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
@@ -815,7 +815,7 @@ abstract class JSR166Test {
           es.submit(nullCallable)
           shouldThrow()
         } catch { case sucess: NullPointerException => () }
-        
+
       case _ => ()
     }
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/RecursiveActionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/RecursiveActionTest.scala
@@ -1,0 +1,1232 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util
+import java.util.concurrent._
+
+import org.junit._
+import org.junit.Assert._
+
+object RecursiveActionTest {
+  private def mainPool = new ForkJoinPool
+  private def singletonPool = new ForkJoinPool(1)
+  private def asyncSingletonPool = new ForkJoinPool(
+    1,
+    ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+    null,
+    true
+  )
+  final class FJException(cause: Throwable) extends RuntimeException {
+    def this() = this(null)
+  }
+
+  /** A recursive action failing in base case. */
+  final class FailingFibAction(val number: Int) extends RecursiveAction {
+    var result = 0
+    override def compute(): Unit = {
+      val n = number
+      if (n <= 1) throw new RecursiveActionTest.FJException
+      else {
+        val f1 = new RecursiveActionTest.FailingFibAction(n - 1)
+        val f2 = new RecursiveActionTest.FailingFibAction(n - 2)
+        ForkJoinTask.invokeAll(f1, f2)
+        result = f1.result + f2.result
+      }
+    }
+  }
+
+  /** Demo from RecursiveAction javadoc */
+  object SortTask { // implementation details follow:
+    val THRESHOLD = 100
+  }
+  class SortTask(val array: Array[Long], val lo: Int, val hi: Int)
+      extends RecursiveAction {
+    def this(array: Array[Long]) = this(array, 0, array.length)
+    override protected def compute(): Unit = {
+      if (hi - lo < SortTask.THRESHOLD) sortSequentially(lo, hi)
+      else {
+        val mid = (lo + hi) >>> 1
+        ForkJoinTask.invokeAll(
+          new RecursiveActionTest.SortTask(array, lo, mid),
+          new RecursiveActionTest.SortTask(array, mid, hi)
+        )
+        merge(lo, mid, hi)
+      }
+    }
+    def sortSequentially(lo: Int, hi: Int): Unit = {
+      util.Arrays.sort(array, lo, hi)
+    }
+    def merge(lo: Int, mid: Int, hi: Int): Unit = {
+      val buf = util.Arrays.copyOfRange(array, lo, mid)
+      var i = 0
+      var j = lo
+      var k = mid
+      while (i < buf.length) {
+        array(j) =
+          if (k == hi || buf(i) < array(k)) buf({ i += 1; i - 1 })
+          else array({ k += 1; k - 1 })
+        j += 1
+      }
+    }
+  }
+}
+class RecursiveActionTest extends JSR166Test {
+  import RecursiveActionTest._
+  import JSR166Test._
+  import ForkJoinTask._
+
+  private def testInvokeOnPool(pool: ForkJoinPool, a: RecursiveAction): Unit = {
+    usingPoolCleaner(pool) { p =>
+      checkNotDone(a)
+      assertNull(pool.invoke(a))
+      checkCompletedNormally(a)
+    }
+  }
+  def checkNotDone(a: RecursiveAction): Unit = {
+    assertFalse(a.isDone)
+    assertFalse(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertFalse(a.isCancelled)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    if (!ForkJoinTask.inForkJoinPool) {
+      Thread.currentThread.interrupt()
+      try {
+        a.get
+        shouldThrow()
+      } catch {
+        case success: InterruptedException =>
+
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+      Thread.currentThread.interrupt()
+      try {
+        a.get(randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: InterruptedException =>
+
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+    }
+    try {
+      a.get(randomExpiredTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: TimeoutException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+  def checkCompletedNormally(a: RecursiveAction): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertTrue(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    assertNull(a.join)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    var v1: AnyRef = null
+    var v2: AnyRef = null
+    try {
+      v1 = a.get
+      v2 = a.get(randomTimeout(), randomTimeUnit())
+    } catch {
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    assertNull(v1)
+    assertNull(v2)
+  }
+  def checkCancelled(a: RecursiveAction): Unit = {
+    assertTrue(a.isDone)
+    assertTrue(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertTrue(a.getException.isInstanceOf[CancellationException])
+    assertNull(a.getRawResult)
+    try {
+      a.join
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+  def checkCompletedAbnormally(a: RecursiveAction, t: Throwable): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertSame(t.getClass, a.getException.getClass)
+    assertNull(a.getRawResult)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    try {
+      a.join
+      shouldThrow()
+    } catch {
+      case expected: Throwable =>
+        assertSame(expected.getClass, t.getClass)
+    }
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  /** A simple recursive action for testing. */
+  final class FibAction(val number: Int) extends CheckedRecursiveAction {
+    var result = 0
+    protected def realCompute(): Unit = {
+      val n = number
+      if (n <= 1) result = n
+      else {
+        val f1 = new FibAction(n - 1)
+        val f2 = new FibAction(n - 2)
+        invokeAll(f1, f2)
+        result = f1.result + f2.result
+      }
+    }
+  }
+
+  /** invoke returns when task completes normally. isCompletedAbnormally and
+   *  isCancelled return false for normally completed tasks. getRawResult of a
+   *  RecursiveAction returns null;
+   */
+  def testInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertNull(f.invoke)
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** quietlyInvoke task returns when task completes normally.
+   *  isCompletedAbnormally and isCancelled return false for normally completed
+   *  tasks
+   */
+  def testQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        f.quietlyInvoke
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** join of a forked task returns when task completes
+   */
+  def testForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** join/quietlyJoin of a forked task succeeds in the presence of interrupts
+   */
+  def testJoinIgnoresInterrupts(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        var f = new FibAction(8)
+        val currentThread = Thread.currentThread
+        // test join()
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        assertNull(f.join)
+        Thread.interrupted
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+        f = new FibAction(8)
+        f.cancel(true)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            Thread.interrupted
+            checkCancelled(f)
+        }
+        f = new FibAction(8)
+        f.completeExceptionally(new RecursiveActionTest.FJException)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: RecursiveActionTest.FJException =>
+            Thread.interrupted
+            checkCompletedAbnormally(f, success)
+        }
+        // test quietlyJoin()
+        f = new FibAction(8)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoin
+        Thread.interrupted
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+        f = new FibAction(8)
+        f.cancel(true)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoin
+        Thread.interrupted
+        checkCancelled(f)
+        f = new FibAction(8)
+        f.completeExceptionally(new RecursiveActionTest.FJException)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoin
+        Thread.interrupted
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+    a.reinitialize()
+    testInvokeOnPool(RecursiveActionTest.singletonPool, a)
+  }
+
+  /** join/quietlyJoin of a forked task when not in ForkJoinPool succeeds in the
+   *  presence of interrupts
+   */
+  def testJoinIgnoresInterruptsOutsideForkJoinPool(): Unit = {
+    val sq = new SynchronousQueue[Array[FibAction]]
+    val a = new CheckedRecursiveAction() {
+      @throws[InterruptedException]
+      protected def realCompute(): Unit = {
+        val fibActions = new Array[FibAction](6)
+        for (i <- 0 until fibActions.length) {
+          fibActions(i) = new FibAction(8)
+        }
+        fibActions(1).cancel(false)
+        fibActions(2).completeExceptionally(new RecursiveActionTest.FJException)
+        fibActions(4).cancel(true)
+        fibActions(5).completeExceptionally(new RecursiveActionTest.FJException)
+        for (fibAction <- fibActions) { fibAction.fork }
+        sq.put(fibActions)
+        helpQuiesce
+      }
+    }
+    val r: CheckedRunnable = () => {
+      val fibActions = sq.take
+      var f: FibAction = null
+      val currentThread = Thread.currentThread
+      // test join() ------------
+      f = fibActions(0)
+      assertFalse(ForkJoinTask.inForkJoinPool)
+      currentThread.interrupt()
+      assertNull(f.join)
+      assertTrue(Thread.interrupted)
+      assertEquals(21, f.result)
+      checkCompletedNormally(f)
+      f = fibActions(1)
+      currentThread.interrupt()
+      try {
+        f.join
+        shouldThrow()
+      } catch {
+        case success: CancellationException =>
+          assertTrue(Thread.interrupted)
+          checkCancelled(f)
+      }
+      f = fibActions(2)
+      currentThread.interrupt()
+      try {
+        f.join
+        shouldThrow()
+      } catch {
+        case success: RecursiveActionTest.FJException =>
+          assertTrue(Thread.interrupted)
+          checkCompletedAbnormally(f, success)
+      }
+      // test quietlyJoin() ---------
+      f = fibActions(3)
+      currentThread.interrupt()
+      f.quietlyJoin
+      assertTrue(Thread.interrupted)
+      assertEquals(21, f.result)
+      checkCompletedNormally(f)
+      f = fibActions(4)
+      currentThread.interrupt()
+      f.quietlyJoin
+      assertTrue(Thread.interrupted)
+      checkCancelled(f)
+      f = fibActions(5)
+      currentThread.interrupt()
+      f.quietlyJoin
+      assertTrue(Thread.interrupted)
+      assertTrue(f.getException.isInstanceOf[RecursiveActionTest.FJException])
+      checkCompletedAbnormally(f, f.getException)
+    }
+    locally {
+      val t: Thread = newStartedThread(r)
+      testInvokeOnPool(RecursiveActionTest.mainPool, a)
+      awaitTermination(t)
+    }
+    a.reinitialize()
+    locally {
+      val t = newStartedThread(r)
+      testInvokeOnPool(RecursiveActionTest.singletonPool, a)
+      awaitTermination(t)
+    }
+  }
+
+  /** get of a forked task returns when task completes
+   */
+  def testForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertNull(f.get)
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** timed get of a forked task returns when task completes
+   */
+  def testForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** timed get with null time unit throws NPE
+   */
+  def testForkTimedGetNPE(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(randomTimeout(), null)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes
+   */
+  def testForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** helpQuiesce returns when tasks are complete. getQueuedTaskCount returns 0
+   *  when quiescent
+   */
+  def testForkHelpQuiesce(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        helpQuiesce
+        while (!f.isDone) { // wait out race
+        }
+        assertEquals(21, f.result)
+        assertEquals(0, getQueuedTaskCount)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invoke task throws exception when task completes abnormally
+   */
+  def testAbnormalInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new RecursiveActionTest.FailingFibAction(8)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: RecursiveActionTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  def testAbnormalQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new RecursiveActionTest.FailingFibAction(8)
+        f.quietlyInvoke()
+        assertTrue(f.getException.isInstanceOf[RecursiveActionTest.FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** join of a forked task throws exception when task completes abnormally
+   */
+  def testAbnormalForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new RecursiveActionTest.FailingFibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: RecursiveActionTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** get of a forked task throws exception when task completes abnormally
+   */
+  def testAbnormalForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new RecursiveActionTest.FailingFibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[RecursiveActionTest.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** timed get of a forked task throws exception when task completes abnormally
+   */
+  def testAbnormalForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new RecursiveActionTest.FailingFibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: ExecutionException =>
+            val cause = success.getCause
+            assertTrue(cause.isInstanceOf[RecursiveActionTest.FJException])
+            checkCompletedAbnormally(f, cause)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task completes abnormally
+   */
+  def testAbnormalForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new RecursiveActionTest.FailingFibAction(8)
+        assertSame(f, f.fork)
+        f.quietlyJoin()
+        assertTrue(f.getException.isInstanceOf[RecursiveActionTest.FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invoke task throws exception when task cancelled
+   */
+  def testCancelledInvoke(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** join of a forked task throws exception when task cancelled
+   */
+  def testCancelledForkJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.join
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** get of a forked task throws exception when task cancelled
+   */
+  def testCancelledForkGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** timed get of a forked task throws exception when task cancelled
+   */
+  def testCancelledForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        try {
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+            checkCancelled(f)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** quietlyJoin of a forked task returns when task cancelled
+   */
+  def testCancelledForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork)
+        f.quietlyJoin
+        checkCancelled(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** getPool of executing task returns its pool
+   */
+  def testGetPool(): Unit = {
+    val mainPool = RecursiveActionTest.mainPool
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertSame(mainPool, getPool) }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** getPool of non-FJ task returns null
+   */
+  def testGetPool2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertNull(getPool) }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** inForkJoinPool of executing task returns true
+   */
+  def testInForkJoinPool(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertTrue(inForkJoinPool) }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** inForkJoinPool of non-FJ task returns false
+   */
+  def testInForkJoinPool2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = { assertFalse(inForkJoinPool) }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** getPool of current thread in pool returns its pool
+   */
+  def testWorkerGetPool(): Unit = {
+    val mainPool = RecursiveActionTest.mainPool
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val w = Thread.currentThread.asInstanceOf[ForkJoinWorkerThread]
+        assertSame(mainPool, w.getPool)
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** getPoolIndex of current thread in pool returns 0 <= value < poolSize
+   */
+  def testWorkerGetPoolIndex(): Unit = {
+    val mainPool = RecursiveActionTest.mainPool
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val w = Thread.currentThread.asInstanceOf[ForkJoinWorkerThread]
+        assertTrue(w.getPoolIndex >= 0)
+        // pool size can shrink after assigning index, so cannot check
+        // assertTrue(w.getPoolIndex() < mainPool.getPoolSize());
+      }
+    }
+    testInvokeOnPool(mainPool, a)
+  }
+
+  /** setRawResult(null) succeeds
+   */
+  def testSetRawResult(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        setRawResult(null)
+        assertNull(getRawResult)
+      }
+    }
+    assertNull(a.invoke)
+  }
+
+  /** A reinitialized normally completed task may be re-invoked
+   */
+  def testReinitialize(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        checkNotDone(f)
+        for (i <- 0 until 3) {
+          assertNull(f.invoke)
+          assertEquals(21, f.result)
+          checkCompletedNormally(f)
+          f.reinitialize
+          checkNotDone(f)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** A reinitialized abnormally completed task may be re-invoked
+   */
+  def testReinitializeAbnormal(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new RecursiveActionTest.FailingFibAction(8)
+        checkNotDone(f)
+        for (i <- 0 until 3) {
+          try {
+            f.invoke
+            shouldThrow()
+          } catch {
+            case success: RecursiveActionTest.FJException =>
+              checkCompletedAbnormally(f, success)
+          }
+          f.reinitialize()
+          checkNotDone(f)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invoke task throws exception after invoking completeExceptionally
+   */
+  def testCompleteExceptionally(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        f.completeExceptionally(new RecursiveActionTest.FJException)
+        try {
+          f.invoke
+          shouldThrow()
+        } catch {
+          case success: RecursiveActionTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invoke task suppresses execution invoking complete
+   */
+  def testComplete(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        f.complete(null)
+        assertNull(f.invoke)
+        assertEquals(0, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(t1, t2) invokes all task arguments
+   */
+  def testInvokeAll2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new FibAction(9)
+        invokeAll(f, g)
+        checkCompletedNormally(f)
+        assertEquals(21, f.result)
+        checkCompletedNormally(g)
+        assertEquals(34, g.result)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with 1 argument invokes task
+   */
+  def testInvokeAll1(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        invokeAll(f)
+        checkCompletedNormally(f)
+        assertEquals(21, f.result)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with > 2 argument invokes tasks
+   */
+  def testInvokeAll3(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new FibAction(9)
+        val h = new FibAction(7)
+        invokeAll(f, g, h)
+        assertTrue(f.isDone)
+        assertTrue(g.isDone)
+        assertTrue(h.isDone)
+        checkCompletedNormally(f)
+        assertEquals(21, f.result)
+        checkCompletedNormally(g)
+        assertEquals(34, g.result)
+        checkCompletedNormally(g)
+        assertEquals(13, h.result)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(collection) invokes all tasks in the collection
+   */
+  def testInvokeAllCollection(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new FibAction(9)
+        val h = new FibAction(7)
+        val set = new util.HashSet[FibAction]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        invokeAll(set)
+        assertTrue(f.isDone)
+        assertTrue(g.isDone)
+        assertTrue(h.isDone)
+        checkCompletedNormally(f)
+        assertEquals(21, f.result)
+        checkCompletedNormally(g)
+        assertEquals(34, g.result)
+        checkCompletedNormally(g)
+        assertEquals(13, h.result)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with any null task throws NPE
+   */
+  def testInvokeAllNPE(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new FibAction(9)
+        val h: FibAction = null
+        try {
+          invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(t1, t2) throw exception if any task does
+   */
+  def testAbnormalInvokeAll2(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new RecursiveActionTest.FailingFibAction(9)
+        try {
+          invokeAll(f, g)
+          shouldThrow()
+        } catch {
+          case success: RecursiveActionTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with 1 argument throws exception if task does
+   */
+  def testAbnormalInvokeAll1(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new RecursiveActionTest.FailingFibAction(9)
+        try {
+          invokeAll(g)
+          shouldThrow()
+        } catch {
+          case success: RecursiveActionTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(tasks) with > 2 argument throws exception if any task does
+   */
+  def testAbnormalInvokeAll3(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        val g = new RecursiveActionTest.FailingFibAction(9)
+        val h = new FibAction(7)
+        try {
+          invokeAll(f, g, h)
+          shouldThrow()
+        } catch {
+          case success: RecursiveActionTest.FJException =>
+            checkCompletedAbnormally(g, success)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** invokeAll(collection) throws exception if any task does
+   */
+  def testAbnormalInvokeAllCollection(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new RecursiveActionTest.FailingFibAction(8)
+        val g = new FibAction(9)
+        val h = new FibAction(7)
+        val set = new util.HashSet[RecursiveAction]
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        try {
+          invokeAll(set)
+          shouldThrow()
+        } catch {
+          case success: RecursiveActionTest.FJException =>
+            checkCompletedAbnormally(f, success)
+        }
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.mainPool, a)
+  }
+
+  /** tryUnfork returns true for most recent unexecuted task, and suppresses
+   *  execution
+   */
+  def testTryUnfork(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new FibAction(9)
+        assertSame(g, g.fork)
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertTrue(f.tryUnfork)
+        helpQuiesce
+        checkNotDone(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.singletonPool, a)
+  }
+
+  /** getSurplusQueuedTaskCount returns > 0 when there are more tasks than
+   *  threads
+   */
+  def testGetSurplusQueuedTaskCount(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val h = new FibAction(7)
+        assertSame(h, h.fork)
+        val g = new FibAction(9)
+        assertSame(g, g.fork)
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertTrue(getSurplusQueuedTaskCount > 0)
+        helpQuiesce
+        assertEquals(0, getSurplusQueuedTaskCount)
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+        checkCompletedNormally(h)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.singletonPool, a)
+  }
+
+  /** peekNextLocalTask returns most recent unexecuted task.
+   */
+  def testPeekNextLocalTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new FibAction(9)
+        assertSame(g, g.fork)
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertSame(f, peekNextLocalTask)
+        assertNull(f.join)
+        checkCompletedNormally(f)
+        helpQuiesce
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.singletonPool, a)
+  }
+
+  /** pollNextLocalTask returns most recent unexecuted task without executing it
+   */
+  def testPollNextLocalTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new FibAction(9)
+        assertSame(g, g.fork)
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertSame(f, pollNextLocalTask)
+        helpQuiesce
+        checkNotDone(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.singletonPool, a)
+  }
+
+  /** pollTask returns an unexecuted task without executing it
+   */
+  def testPollTask(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new FibAction(9)
+        assertSame(g, g.fork)
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertSame(f, pollTask)
+        helpQuiesce
+        checkNotDone(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.singletonPool, a)
+  }
+
+  /** peekNextLocalTask returns least recent unexecuted task in async mode
+   */
+  def testPeekNextLocalTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new FibAction(9)
+        assertSame(g, g.fork)
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertSame(g, peekNextLocalTask)
+        assertNull(f.join)
+        helpQuiesce
+        checkCompletedNormally(f)
+        checkCompletedNormally(g)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.asyncSingletonPool, a)
+  }
+
+  /** pollNextLocalTask returns least recent unexecuted task without executing
+   *  it, in async mode
+   */
+  def testPollNextLocalTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new FibAction(9)
+        assertSame(g, g.fork)
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertSame(g, pollNextLocalTask)
+        helpQuiesce
+        checkCompletedNormally(f)
+        checkNotDone(g)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.asyncSingletonPool, a)
+  }
+
+  /** pollTask returns an unexecuted task without executing it, in async mode
+   */
+  def testPollTaskAsync(): Unit = {
+    val a = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val g = new FibAction(9)
+        assertSame(g, g.fork)
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertSame(g, pollTask)
+        helpQuiesce
+        checkCompletedNormally(f)
+        checkNotDone(g)
+      }
+    }
+    testInvokeOnPool(RecursiveActionTest.asyncSingletonPool, a)
+  }
+
+  /** SortTask demo works as advertised
+   */
+  def testSortTaskDemo(): Unit = {
+    val rnd = ThreadLocalRandom.current
+    val array = new Array[Long](1007)
+    for (i <- 0 until array.length) { array(i) = rnd.nextLong }
+    val arrayClone = array.clone
+    testInvokeOnPool(
+      RecursiveActionTest.mainPool,
+      new RecursiveActionTest.SortTask(array)
+    )
+    util.Arrays.sort(arrayClone)
+    assertTrue(util.Arrays.equals(array, arrayClone))
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/RecursiveTaskTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/RecursiveTaskTest.scala
@@ -1,0 +1,982 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit._
+import java.util.concurrent._
+import java.util.HashSet
+
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class RecursiveTaskTest extends JSR166Test {
+  import JSR166Test._
+
+  final class FJException() extends RuntimeException()
+
+  /** An invalid return value for Fib. */
+  final val NoResult = -17
+
+  private def mainPool() = new ForkJoinPool()
+  private def singletonPool() = new ForkJoinPool(1)
+  private def asyncSingletonPool() =
+    new ForkJoinPool(
+      1,
+      ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+      null,
+      true
+    )
+
+  private def testInvokeOnPool[T](pool: ForkJoinPool, a: RecursiveTask[T]): T =
+    usingPoolCleaner(pool) { pool =>
+      checkNotDone(a)
+      val result = pool.invoke(a)
+      checkCompletedNormally(a, result)
+      result
+    }
+
+  def checkNotDone(a: RecursiveTask[_]) = {
+    assertFalse("isDone", a.isDone())
+    assertFalse("isCompletedNormally", a.isCompletedNormally())
+    assertFalse("isCompletedAbnormally", a.isCompletedAbnormally())
+    assertFalse("isCancelled", a.isCancelled())
+    assertNull("exception", a.getException())
+    assertNull("rawResult", a.getRawResult())
+
+    if (!ForkJoinTask.inForkJoinPool()) {
+      Thread.currentThread().interrupt()
+      try {
+        a.get()
+        shouldThrow()
+      } catch {
+        case _: InterruptedException => ()
+        case fail: Throwable         => threadUnexpectedException(fail)
+      }
+
+      Thread.currentThread().interrupt()
+      try {
+        a.get(randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case _: InterruptedException => ()
+        case fail: Throwable         => threadUnexpectedException(fail)
+      }
+    }
+
+    try {
+      a.get(randomExpiredTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: TimeoutException => ()
+      case fail: Throwable           => threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedNormally[T](a: RecursiveTask[T], expectedValue: T) = {
+    assertTrue(a.isDone())
+    assertFalse(a.isCancelled())
+    assertTrue(a.isCompletedNormally())
+    assertFalse(a.isCompletedAbnormally())
+    assertNull(a.getException())
+    assertSame(expectedValue, a.getRawResult())
+    assertSame(expectedValue, a.join())
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    try {
+      val v1 = a.get()
+      val v2 = a.get(randomTimeout(), randomTimeUnit())
+      assertSame(expectedValue, v1)
+      assertSame(expectedValue, v2)
+    } catch {
+      case fail: Throwable => threadUnexpectedException(fail)
+    }
+  }
+
+  /** Waits for the task to complete, and checks that when it does, it will have
+   *  an Integer result equals to the given int.
+   */
+  def checkCompletesNormally(a: RecursiveTask[Integer], expectedValue: Int) = {
+    val r = a.join()
+    assertEquals(expectedValue, r)
+    checkCompletedNormally(a, r)
+  }
+
+  /** Like checkCompletesNormally, but verifies that the task has already
+   *  completed.
+   */
+  def checkCompletedNormally(
+      a: RecursiveTask[Integer],
+      expectedValue: Int
+  ): Unit = {
+    val r = a.getRawResult()
+    assertEquals(expectedValue, r)
+    checkCompletedNormally(a, r: Integer)
+  }
+
+  def checkCancelled(a: RecursiveTask[_]) = {
+    assertTrue(a.isDone())
+    assertTrue(a.isCancelled())
+    assertFalse(a.isCompletedNormally())
+    assertTrue(a.isCompletedAbnormally())
+    assertTrue(a.getException().isInstanceOf[CancellationException])
+    assertNull(a.getRawResult())
+    try {
+      a.join()
+      shouldThrow()
+    } catch {
+      case success: CancellationException => ()
+      case fail: Throwable                => threadUnexpectedException(fail)
+    }
+    try {
+      a.get()
+      shouldThrow()
+    } catch {
+      case success: CancellationException => ()
+      case fail: Throwable                => threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: CancellationException => ()
+      case fail: Throwable                => threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedAbnormally(a: RecursiveTask[_], t: Throwable) = {
+    assertTrue(a.isDone())
+    assertFalse(a.isCancelled())
+    assertFalse(a.isCompletedNormally())
+    assertTrue(a.isCompletedAbnormally())
+    assertSame(t.getClass(), a.getException().getClass())
+    assertNull(a.getRawResult())
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+
+    assertThrows(t.getClass(), a.join())
+    try {
+      a.get()
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass(), success.getCause().getClass())
+      case fail: Throwable => threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass(), success.getCause().getClass())
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  /** A simple recursive task for testing. */
+  final class FibTask(val number: Int) extends CheckedRecursiveTask[Integer] {
+    // public accessor
+    def doCompute(): Integer = compute()
+    def realCompute(): Integer = {
+      val n = number
+      if (n <= 1) n
+      else {
+        val f1 = new FibTask(n - 1)
+        f1.fork()
+        new FibTask(n - 2).compute() + f1.join()
+      }
+    }
+    def publicSetRawResult(result: Integer): Unit = setRawResult(result)
+  }
+
+  /** A recursive action failing in base case. */
+  final class FailingFibTask(val number: Int) extends RecursiveTask[Integer] {
+    this.setRawResult(null)
+
+    override def compute(): Integer = {
+      val n = number
+      if (n <= 1) throw new FJException()
+      val f1 = new FailingFibTask(n - 1)
+      f1.fork()
+      new FibTask(n - 2).doCompute() + f1.join()
+    }
+  }
+
+  /** invoke returns value when task completes normally. isCompletedAbnormally
+   *  and isCancelled return false for normally completed tasks. getRawResult of
+   *  a completed non-null task returns value;
+   */
+  @Test def testInvoke(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        val r = f.invoke()
+        assertEquals(21, r)
+        checkCompletedNormally(f, r)
+        r
+      }
+    }
+    assertEquals(
+      21,
+      testInvokeOnPool(mainPool(), a).toInt
+    )
+  }
+
+  /** quietlyInvoke task returns when task completes normally.
+   *  isCompletedAbnormally and isCancelled return false for normally completed
+   *  tasks
+   */
+  @Test def testQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        f.quietlyInvoke()
+        checkCompletedNormally(f, 21)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** join of a forked task returns when task completes
+   */
+  @Test def testForkJoin(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        val r = f.join
+        assertEquals(21, r)
+        checkCompletedNormally(f, r)
+        r
+      }
+    }
+    assertEquals(21, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** get of a forked task returns when task completes
+   */
+  def testForkGet(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        val r = f.get()
+        assertEquals(21, r)
+        checkCompletedNormally(f, r)
+        r
+      }
+    }
+    assertEquals(21, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** timed get of a forked task returns when task completes
+   */
+  @Test def testForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        val r = f.get(LONG_DELAY_MS, MILLISECONDS)
+        assertEquals(21, r)
+        checkCompletedNormally(f, r)
+        r
+      }
+    }
+    assertEquals(21, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** quietlyJoin of a forked task returns when task completes
+   */
+  @Test def testForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        f.quietlyJoin()
+        val r = f.getRawResult()
+        assertEquals(21, r)
+        checkCompletedNormally(f, r)
+        r
+      }
+    }
+    assertEquals(21, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** helpQuiesce returns when tasks are complete. getQueuedTaskCount returns 0
+   *  when quiescent
+   */
+  @Test def testhelpQuiesce(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        ForkJoinTask.helpQuiesce()
+        while (!f.isDone()) () // wait out race
+        assertEquals(0, ForkJoinTask.getQueuedTaskCount())
+        checkCompletedNormally(f, 21)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invoke task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalInvoke(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FailingFibTask(8)
+        checkCompletedAbnormally(
+          f,
+          assertThrows(classOf[FJException], f.invoke())
+        )
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  @Test def testAbnormalQuietlyInvoke(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FailingFibTask(8)
+        f.quietlyInvoke()
+        assertTrue(f.getException().isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException())
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** join of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkJoin(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FailingFibTask(8)
+        assertSame(f, f.fork())
+        checkCompletedAbnormally(
+          f,
+          assertThrows(classOf[FJException], f.join())
+        )
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkGet(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FailingFibTask(8)
+        assertSame(f, f.fork())
+        val ex = assertThrows(classOf[ExecutionException], f.get())
+        val cause = ex.getCause()
+        assertTrue(cause.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, cause)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** timed get of a forked task throws exception when task completes abnormally
+   */
+  @Test def testAbnormalForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FailingFibTask(8)
+        assertSame(f, f.fork())
+        val ex = assertThrows(
+          classOf[ExecutionException],
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+        )
+        val cause = ex.getCause()
+        assertTrue(cause.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, cause)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** quietlyJoin of a forked task returns when task completes abnormally
+   */
+  @Test def testAbnormalForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FailingFibTask(8)
+        assertSame(f, f.fork())
+        f.quietlyJoin()
+        assertTrue(f.getException().isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException())
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invoke task throws exception when task cancelled
+   */
+  @Test def testCancelledInvoke(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertTrue(f.cancel(true))
+        assertThrows(classOf[CancellationException], f.invoke())
+        checkCancelled(f)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** join of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkJoin(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork())
+        assertThrows(classOf[CancellationException], f.join())
+        checkCancelled(f)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** get of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkGet(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork())
+        assertThrows(classOf[CancellationException], f.get())
+        checkCancelled(f)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** timed get of a forked task throws exception when task cancelled
+   */
+  @Test def testCancelledForkTimedGet(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork())
+        assertThrows(
+          classOf[CancellationException],
+          f.get(LONG_DELAY_MS, MILLISECONDS)
+        )
+        checkCancelled(f)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** quietlyJoin of a forked task returns when task cancelled
+   */
+  @Test def testCancelledForkQuietlyJoin(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        assertTrue(f.cancel(true))
+        assertSame(f, f.fork())
+        f.quietlyJoin()
+        checkCancelled(f)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** getPool of executing task returns its pool
+   */
+  @Test def testGetPool(): Unit = {
+    val mainPool = this.mainPool()
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        assertSame(mainPool, ForkJoinTask.getPool())
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool, a))
+  }
+
+  /** getPool of non-FJ task returns null
+   */
+  @Ignore(
+    "Test-infrastructure limitation, all tests are executed in ForkJoinPool due to usage of Future in RPCCore"
+  )
+  @Test def testGetPool2(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        assertNull(ForkJoinTask.getPool())
+        NoResult
+      }
+    }
+    assertSame(NoResult, a.invoke)
+  }
+
+  /** inForkJoinPool of executing task returns true
+   */
+  @Test def testInForkJoinPool(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        assertTrue(ForkJoinTask.inForkJoinPool())
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** inForkJoinPool of non-FJ task returns false
+   */
+  @Ignore(
+    "Test-infrastructure limitation, all tests are executed in ForkJoinPool due to usage of Future in RPCCore"
+  )
+  @Test def testInForkJoinPool2(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        assertFalse(ForkJoinTask.inForkJoinPool())
+        NoResult
+      }
+    }
+    assertSame(NoResult, a.invoke)
+  }
+
+  /** The value set by setRawResult is returned by getRawResult
+   */
+  @Test def testSetRawResult(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        setRawResult(NoResult)
+        assertSame(NoResult, getRawResult())
+        NoResult
+      }
+    }
+    assertSame(NoResult, a.invoke)
+  }
+
+  /** A reinitialized normally completed task may be re-invoked
+   */
+  @Test def testReinitialize(): Unit = {
+    val a: RecursiveTask[Integer] = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+
+        val f = new FibTask(8)
+        checkNotDone(f)
+        for (i <- 0 until 3) {
+          val r = f.invoke()
+          assertEquals(21, r)
+          checkCompletedNormally(f, r)
+          f.reinitialize()
+          f.publicSetRawResult(null: Integer)
+          checkNotDone(f)
+        }
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** A reinitialized abnormally completed task may be re-invoked
+   */
+  @Test def testReinitializeAbnormal(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FailingFibTask(8)
+        checkNotDone(f)
+        for (i <- 0 until 3) {
+          checkCompletedAbnormally(
+            f,
+            assertThrows(classOf[FJException], f.invoke())
+          )
+          f.reinitialize()
+          checkNotDone(f)
+        }
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invoke task throws exception after invoking completeExceptionally
+   */
+  @Test def testCompleteExceptionally(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        f.completeExceptionally(new FJException())
+        checkCompletedAbnormally(
+          f,
+          assertThrows(classOf[FJException], f.invoke())
+        )
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invoke task suppresses execution invoking complete
+   */
+  @Test def testComplete(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        f.complete(NoResult)
+        val r = f.invoke()
+        assertSame(NoResult, r)
+        checkCompletedNormally(f, NoResult)
+        r
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(t1, t2) invokes all task arguments
+   */
+  @Test def testInvokeAll2(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        val g = new FibTask(9)
+        ForkJoinTask.invokeAll(f, g)
+        checkCompletedNormally(f, 21)
+        checkCompletedNormally(g, 34)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(tasks) with 1 argument invokes task
+   */
+  @Test def testInvokeAll1(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        ForkJoinTask.invokeAll(f)
+        checkCompletedNormally(f, 21)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(tasks) with > 2 argument invokes tasks
+   */
+  @Test def testInvokeAll3(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        val g = new FibTask(9)
+        val h = new FibTask(7)
+        ForkJoinTask.invokeAll(f, g, h)
+        assertTrue(f.isDone())
+        assertTrue(g.isDone())
+        assertTrue(h.isDone())
+        checkCompletedNormally(f, 21)
+        checkCompletedNormally(g, 34)
+        checkCompletedNormally(h, 13)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(collection) invokes all tasks in the collection
+   */
+  @Test def testInvokeAllCollection(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        val g = new FibTask(9)
+        val h = new FibTask(7)
+        val set = new HashSet[RecursiveTask[Integer]]()
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        ForkJoinTask.invokeAll(set)
+        assertTrue(f.isDone())
+        assertTrue(g.isDone())
+        assertTrue(h.isDone())
+        checkCompletedNormally(f, 21)
+        checkCompletedNormally(g, 34)
+        checkCompletedNormally(h, 13)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(tasks) with any null task throws NPE
+   */
+  @Test def testInvokeAllNPE(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        val g = new FibTask(9)
+        val h = null: FibTask
+        assertThrows(
+          classOf[NullPointerException],
+          ForkJoinTask.invokeAll(f, g, h)
+        )
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(t1, t2) throw exception if any task does
+   */
+  @Test def testAbnormalInvokeAll2(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        val g = new FailingFibTask(9)
+        checkCompletedAbnormally(
+          g,
+          assertThrows(classOf[FJException], ForkJoinTask.invokeAll(f, g))
+        )
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(tasks) with 1 argument throws exception if task does
+   */
+  @Test def testAbnormalInvokeAll1(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val g = new FailingFibTask(9)
+        checkCompletedAbnormally(
+          g,
+          assertThrows(classOf[FJException], ForkJoinTask.invokeAll(g))
+        )
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(tasks) with > 2 argument throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAll3(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FibTask(8)
+        val g = new FailingFibTask(9)
+        val h = new FibTask(7)
+        checkCompletedAbnormally(
+          g,
+          assertThrows(classOf[FJException], ForkJoinTask.invokeAll(f, g, h))
+        )
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** invokeAll(collection) throws exception if any task does
+   */
+  @Test def testAbnormalInvokeAllCollection(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val f = new FailingFibTask(8)
+        val g = new FibTask(9)
+        val h = new FibTask(7)
+        val set = new HashSet[RecursiveTask[Integer]]()
+        set.add(f)
+        set.add(g)
+        set.add(h)
+        checkCompletedAbnormally(
+          f,
+          assertThrows(classOf[FJException], ForkJoinTask.invokeAll(set))
+        )
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(mainPool(), a))
+  }
+
+  /** tryUnfork returns true for most recent unexecuted task, and suppresses
+   *  execution
+   */
+  @Test def testTryUnfork(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val g = new FibTask(9)
+        assertSame(g, g.fork())
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        assertTrue(f.tryUnfork())
+        ForkJoinTask.helpQuiesce()
+        checkNotDone(f)
+        checkCompletedNormally(g, 34)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(singletonPool(), a))
+  }
+
+  /** getSurplusQueuedTaskCount returns > 0 when there are more tasks than
+   *  threads
+   */
+  @Test def testGetSurplusQueuedTaskCount(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val h = new FibTask(7)
+        assertSame(h, h.fork())
+        val g = new FibTask(9)
+        assertSame(g, g.fork())
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        assertTrue(ForkJoinTask.getSurplusQueuedTaskCount() > 0)
+        ForkJoinTask.helpQuiesce()
+        assertEquals(0, ForkJoinTask.getSurplusQueuedTaskCount())
+        checkCompletedNormally(f, 21)
+        checkCompletedNormally(g, 34)
+        checkCompletedNormally(h, 13)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(singletonPool(), a))
+  }
+
+  /** peekNextLocalTask returns most recent unexecuted task.
+   */
+  @Test def testPeekNextLocalTask(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val g = new FibTask(9)
+        assertSame(g, g.fork())
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        assertSame(f, ForkJoinTask.peekNextLocalTask())
+        checkCompletesNormally(f, 21)
+        ForkJoinTask.helpQuiesce()
+        checkCompletedNormally(g, 34)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(singletonPool(), a))
+  }
+
+  /** pollNextLocalTask returns most recent unexecuted task without executing it
+   */
+  @Test def testPollNextLocalTask(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val g = new FibTask(9)
+        assertSame(g, g.fork())
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        assertSame(f, ForkJoinTask.pollNextLocalTask())
+        ForkJoinTask.helpQuiesce()
+        checkNotDone(f)
+        checkCompletedNormally(g, 34)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(singletonPool(), a))
+  }
+
+  /** pollTask returns an unexecuted task without executing it
+   */
+  @Test def testPollTask(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val g = new FibTask(9)
+        assertSame(g, g.fork())
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        assertSame(f, ForkJoinTask.pollTask())
+        ForkJoinTask.helpQuiesce()
+        checkNotDone(f)
+        checkCompletedNormally(g, 34)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(singletonPool(), a))
+  }
+
+  /** peekNextLocalTask returns least recent unexecuted task in async mode
+   */
+  @Test def testPeekNextLocalTaskAsync(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val g = new FibTask(9)
+        assertSame(g, g.fork())
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        assertSame(g, ForkJoinTask.peekNextLocalTask())
+        assertEquals(21, f.join())
+        ForkJoinTask.helpQuiesce()
+        checkCompletedNormally(f, 21)
+        checkCompletedNormally(g, 34)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(asyncSingletonPool(), a))
+  }
+
+  /** pollNextLocalTask returns least recent unexecuted task without executing
+   *  it, in async mode
+   */
+  @Test def testPollNextLocalTaskAsync(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+        val g = new FibTask(9)
+        assertSame(g, g.fork())
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        assertSame(g, ForkJoinTask.pollNextLocalTask())
+        ForkJoinTask.helpQuiesce()
+        checkCompletedNormally(f, 21)
+        checkNotDone(g)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(asyncSingletonPool(), a))
+  }
+
+  /** pollTask returns an unexecuted task without executing it, in async mode
+   */
+  @Test def testPollTaskAsync(): Unit = {
+    val a = new CheckedRecursiveTask[Integer] {
+      protected def realCompute(): Integer = {
+
+        val g = new FibTask(9)
+        assertSame(g, g.fork())
+        val f = new FibTask(8)
+        assertSame(f, f.fork())
+        assertSame(g, ForkJoinTask.pollTask())
+        ForkJoinTask.helpQuiesce()
+        checkCompletedNormally(f, 21)
+        checkNotDone(g)
+        NoResult
+      }
+    }
+    assertSame(NoResult, testInvokeOnPool(asyncSingletonPool(), a))
+  }
+}


### PR DESCRIPTION
Ports `ForkJoinPool` and other required types from `java.util.concurrent` types: 
* `AbstractExecutorService`
* `Callable` 
* `CompletionService`
* `CountedCompleter`
* `Executor`
* `ExecutorCompletionService`
* `ExecutorService`
* `Executors` (partially)
* `ForkJoinPool`
* `ForkJoinTask`
* `ForkJoinWorkerThread`
* `Future`
* `FutureTask`
* `RecursiveAction`
* `RecursiveTask`
* `RejectedExecutionHandler`
* `RunnableFuture`
* `ThreadFactory`
* `TimeUnit` (adds missing methods)
