### PR TITLE
Improve stablity of multithreading builds

### DIFF
--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -7,8 +7,10 @@ import scalanative.runtime.unwind
 import scala.scalanative.meta.LinktimeInfo
 
 private[lang] object StackTrace {
-  private val cache =
+  // TODO: Replace s.c.c.TrieMap/j.u.c.ConcurrentHashMap
+  private val cache = ThreadLocal.withInitial { () =>
     collection.mutable.HashMap.empty[CUnsignedLong, StackTraceElement]
+  }
 
   private def makeStackTraceElement(
       cursor: Ptr[scala.Byte]
@@ -35,7 +37,7 @@ private[lang] object StackTrace {
       cursor: Ptr[scala.Byte],
       ip: CUnsignedLong
   ): StackTraceElement =
-    cache.getOrElseUpdate(ip, makeStackTraceElement(cursor))
+    cache.get().getOrElseUpdate(ip, makeStackTraceElement(cursor))
 
   @noinline private[lang] def currentStackTrace(): Array[StackTraceElement] = {
     var buffer = mutable.ArrayBuffer.empty[StackTraceElement]

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -34,7 +34,6 @@ void Marker_markObject(Heap *heap, Stack *stack, Bytemap *bytemap,
     Stack_Push(stack, object);
 }
 
-
 static inline void Marker_markField(Heap *heap, Stack *stack, Field_t field) {
     if (Heap_IsWordInHeap(heap, field)) {
         ObjectMeta *fieldMeta = Bytemap_Get(heap->bytemap, field);

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -15,11 +15,15 @@ extern int __modules_size;
 
 #define LAST_FIELD_OFFSET -1
 
+static inline void Marker_markLockWords(Heap *heap, Stack *stack,
+                                        Object *object);
+
 void Marker_markObject(Heap *heap, Stack *stack, Bytemap *bytemap,
                        Object *object, ObjectMeta *objectMeta) {
     assert(ObjectMeta_IsAllocated(objectMeta));
     assert(object->rtti != NULL);
 
+    Marker_markLockWords(heap, stack, object);
     if (Object_IsWeakReference(object)) {
         // Added to the WeakReference stack for additional later visit
         Stack_Push(&weakRefStack, object);
@@ -30,8 +34,6 @@ void Marker_markObject(Heap *heap, Stack *stack, Bytemap *bytemap,
     Stack_Push(stack, object);
 }
 
-static inline void Marker_markLockWords(Heap *heap, Stack *stack,
-                                        Object *object);
 
 static inline void Marker_markField(Heap *heap, Stack *stack, Field_t field) {
     if (Heap_IsWordInHeap(heap, field)) {
@@ -39,7 +41,6 @@ static inline void Marker_markField(Heap *heap, Stack *stack, Field_t field) {
         if (ObjectMeta_IsAllocated(fieldMeta)) {
             Object *object = (Object *)field;
             Marker_markObject(heap, stack, heap->bytemap, object, fieldMeta);
-            Marker_markLockWords(heap, stack, object);
         }
     }
 }

--- a/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.c
@@ -12,6 +12,21 @@ bool thread_create(thread_t *ref, routine_fn routine, void *data) {
 #endif
 }
 
+INLINE thread_t thread_getid() {
+#ifdef _WIN32
+    return GetCurrentThreadId()
+#else
+    return pthread_self();
+#endif
+}
+INLINE bool thread_equals(thread_t l, thread_t r) {
+#ifdef _WIN32
+    return l == r;
+#else
+    return pthread_equal(l, r);
+#endif
+}
+
 INLINE
 void thread_yield() {
 #ifdef _WIN32

--- a/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.c
@@ -12,14 +12,14 @@ bool thread_create(thread_t *ref, routine_fn routine, void *data) {
 #endif
 }
 
-INLINE thread_t thread_getid() {
+INLINE thread_id thread_getid() {
 #ifdef _WIN32
-    return GetCurrentThreadId()
+    return GetCurrentThreadId();
 #else
     return pthread_self();
 #endif
 }
-INLINE bool thread_equals(thread_t l, thread_t r) {
+INLINE bool thread_equals(thread_id l, thread_id r) {
 #ifdef _WIN32
     return l == r;
 #else

--- a/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
@@ -32,16 +32,20 @@
 typedef void *(*routine_fn)(void *);
 #ifdef _WIN32
 typedef HANDLE thread_t;
+typedef DWORD thread_id;
 typedef HANDLE mutex_t;
 typedef HANDLE semaphore_t;
 typedef int pid_t;
 #else
 typedef pthread_t thread_t;
+typedef pthread_t thread_id;
 typedef pthread_mutex_t mutex_t;
 typedef sem_t *semaphore_t;
 #endif
 
 bool thread_create(thread_t *ref, routine_fn routine, void *data);
+thread_id thread_getid();
+bool thread_equals(thread_id l, thread_id r);
 void thread_yield();
 
 pid_t process_getid();

--- a/nativelib/src/main/resources/scala-native/module_load.c
+++ b/nativelib/src/main/resources/scala-native/module_load.c
@@ -1,6 +1,6 @@
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #include "stdatomic.h"
-#include "ThreadUtil.h"
+#include "gc/shared/ThreadUtil.h"
 #include "gc/shared/ScalaNativeGC.h"
 
 #ifdef _WIN32

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
@@ -2,6 +2,22 @@ package scala.scalanative.runtime
 
 import scala.scalanative.annotation._
 import scala.runtime.LazyVals.{BITS_PER_LAZY_VAL, STATE}
+import scala.scalanative.runtime.libc._
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
+import scala.scalanative.runtime.Intrinsics._
+import scala.scalanative.runtime.libc.memory_order._
+import scala.scalanative.unsafe.sizeof
+import scala.scalanative.unsigned._
+
+// Factored out LazyVals immutable state, allowing to treat LazyVals as constant module,
+// alowing to skip loading of the module on each call to its methods
+private object LazyValsState {
+  val base: Int = {
+    val processors = java.lang.Runtime.getRuntime().nn.availableProcessors()
+    8 * processors * processors
+  }
+  val monitors = scala.Array.tabulate(base)(_ => new Object)
+}
 
 /** Helper methods used in thread-safe lazy vals adapted for Scala Native usage
  *  Make sure to sync them with the logic defined in Scala 3
@@ -9,7 +25,14 @@ import scala.runtime.LazyVals.{BITS_PER_LAZY_VAL, STATE}
  */
 private object LazyVals {
 
-  private final val LAZY_VAL_MASK = 3L
+  private def getMonitor(bitMap: RawPtr, fieldId: Int = 0) = {
+    import LazyValsState._
+    var id = (castRawPtrToInt(bitMap) + fieldId) % base
+    if (id < 0) id += base
+    monitors(id)
+  }
+
+  @alwaysinline def LAZY_VAL_MASK = 3L
 
   /* ------------- Start of public API ------------- */
 
@@ -17,41 +40,87 @@ private object LazyVals {
   def CAS(bitmap: RawPtr, e: Long, v: Int, ord: Int): Boolean = {
     val mask = ~(LAZY_VAL_MASK << ord * BITS_PER_LAZY_VAL)
     val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
-    // Todo: with multithreading use atomic cas
-    if (get(bitmap) != e) false
-    else {
-      Intrinsics.storeLong(bitmap, n)
-      true
+    if (isMultithreadingEnabled) {
+      // multi-threaded
+      val expected = stackalloc(sizeof[Long])
+      storeLong(expected, e)
+      atomic_compare_exchange_llong(bitmap, expected, n)
+    } else {
+      // single-threaded
+      if (get(bitmap) != e) false
+      else {
+        storeLong(bitmap, n)
+        true
+      }
     }
   }
 
-  @`inline`
   def objCAS(objPtr: RawPtr, exp: Object, n: Object): Boolean = {
-    // Todo: with multithreading use atomic cas
-    if (Intrinsics.loadObject(objPtr) ne exp) false
-    else {
-      Intrinsics.storeObject(objPtr, n)
-      true
+    if (isMultithreadingEnabled) {
+      // multi-threaded
+      val expected = stackalloc(new USize(sizeOfPtr))
+      storeObject(expected, exp)
+      atomic_compare_exchange_intptr(objPtr, expected, castObjectToRawPtr(n))
+    } else {
+      if (loadObject(objPtr) ne exp) false
+      else {
+        storeObject(objPtr, n)
+        true
+      }
     }
   }
 
   @`inline`
-  def setFlag(bitmap: RawPtr, v: Int, ord: Int): Unit = {
-    val cur = get(bitmap)
-    // TODO: with multithreading add waiting for notifications
-    CAS(bitmap, cur, v, ord)
-  }
+  def setFlag(bitmap: RawPtr, v: Int, ord: Int): Unit =
+    if (!isMultithreadingEnabled) {
+      // single-threaded
+      val cur = get(bitmap)
+      CAS(bitmap, cur, v, ord)
+    } else {
+      // multi-threaded
+      var retry = true
+      while (retry) {
+        val cur = get(bitmap)
+        if (STATE(cur, ord) == 1) retry = !CAS(bitmap, cur, v, ord)
+        else {
+          // cur == 2, somebody is waiting on monitor
+          if (CAS(bitmap, cur, v, ord)) {
+            val monitor = getMonitor(bitmap, ord)
+            monitor.synchronized {
+              monitor.notifyAll()
+            }
+            retry = false
+          }
+        }
+      }
+    }
 
   def wait4Notification(bitmap: RawPtr, cur: Long, ord: Int): Unit = {
-    throw new IllegalStateException(
-      "wait4Notification not supported in single-threaded Scala Native runtime"
-    )
+    if (!isMultithreadingEnabled)
+      throw new IllegalStateException(
+        "wait4Notification not supported in single-threaded Scala Native runtime"
+      )
+
+    var retry = true
+    while (retry) {
+      val cur = get(bitmap)
+      val state = STATE(cur, ord)
+      if (state == 1) CAS(bitmap, cur, 2, ord)
+      else if (state == 2) {
+        val monitor = getMonitor(bitmap, ord)
+        monitor.synchronized {
+          // make sure notification did not happen yet.
+          if (STATE(get(bitmap), ord) == 2)
+            monitor.wait()
+        }
+      } else retry = false
+    }
   }
 
   @alwaysinline
   def get(bitmap: RawPtr): Long = {
-    // Todo: make it volatile read with multithreading
-    Intrinsics.loadLong(bitmap)
+    if (!isMultithreadingEnabled) Intrinsics.loadLong(bitmap)
+    else atomic_load_llong(bitmap, memory_order_acquire)
   }
 
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
@@ -50,6 +50,12 @@ object libc {
       memoryOrder: memory_order
   ): Long = extern
 
+  @name("scalanative_atomic_load_explicit_intptr")
+  private[runtime] def atomic_load_intptr(
+      ptr: RawPtr,
+      memoryOrder: memory_order
+  ): RawPtr = extern
+
   @name("scalanative_atomic_store_explicit_intptr")
   private[runtime] def atomic_store_intptr(
       ptr: RawPtr,

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1349,7 +1349,7 @@ object Lower {
           rtti(CharArrayCls).const ::
             meta.lockWordVals :::
             charsLength ::
-            Val.Int(2) :: // stride is used only by GC, global instances use it as padding
+            Val.Int(2) :: // stride is used only by GC
             Val.ArrayValue(Type.Char, chars.toSeq.map(Val.Char(_))) :: Nil
         )
       )

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1349,7 +1349,7 @@ object Lower {
           rtti(CharArrayCls).const ::
             meta.lockWordVals :::
             charsLength ::
-            zero :: // stride is used only by GC, global instances use it as padding
+            Val.Int(2) :: // stride is used only by GC, global instances use it as padding
             Val.ArrayValue(Type.Char, chars.toSeq.map(Val.Char(_))) :: Nil
         )
       )

--- a/tools/src/main/scala/scala/scalanative/interflow/Whitelist.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Whitelist.scala
@@ -9,10 +9,16 @@ object Whitelist {
   val constantModules = {
     val out = collection.mutable.Set.empty[Global]
     out += Global.Top("scala.scalanative.runtime.BoxedUnit$")
+    out += Global.Top("scala.scalanative.runtime.LazyVals$")
     out += Global.Top("scala.scalanative.runtime.MemoryLayout$")
     out += Global.Top("scala.scalanative.runtime.MemoryLayout$Array$")
     out += Global.Top("scala.scalanative.runtime.MemoryLayout$Object$")
     out += Global.Top("scala.scalanative.runtime.MemoryLayout$Rtti$")
+    out += Global.Top("scala.scalanative.runtime.monitor.BasicMonitor$")
+    out += Global.Top("scala.scalanative.runtime.monitor.package$LockWord")
+    out += Global.Top("scala.scalanative.runtime.monitor.package$LockWord$")
+    out += Global.Top("scala.scalanative.runtime.monitor.package$LockWord32$")
+    out += Global.Top("scala.scalanative.runtime.monitor.package$LockType$")
     out += Global.Top("scala.scalanative.unsafe.Tag$")
     out += Global.Top("scala.scalanative.unsafe.Tag$Unit$")
     out += Global.Top("scala.scalanative.unsafe.Tag$Boolean$")


### PR DESCRIPTION
* Provide proper implementation for Scala 3 lazy vals
* Fix marking of (inflated) ObjectMonitors in Immix
* Use ThreadLocal cache for stack traces
* Use OS thread identity to compare threads in `scalanative_module_load` instead of TLS nativeThread handles
* Use atomic load/store when interacting with `BasicMonitor.lockWordRef` 