### PR TITLE
Fix #3131: javalib ServerSocket should now be more accepting

### DIFF
--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -119,7 +119,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
      */
 
     sa6.sin6_family = socket.AF_INET6.toUShort
-    sa6.sin6_port = inet.< htons (port.toUShort)
+    sa6.sin6_port = inet.htons(port.toUShort)
 
     val src = inetAddress.getAddress()
 

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -221,7 +221,7 @@ object InetAddress {
       new Inet4Address(addrinfoToByteArray(addrinfoP), effectiveHost)
     } else if (addrinfoP.ai_family == AF_INET6) {
       val addr = addrinfoP.ai_addr.asInstanceOf[Ptr[sockaddr_in6]]
-      val addrBytes = addr.sin6_addr.at1.asInstanceOf[Ptr[Byte]]
+      val addrBytes = addr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
 
       // Scala JVM down-converts even when preferIPv6Addresses is "true"
       if (isIPv4MappedAddress(addrBytes)) {
@@ -271,16 +271,11 @@ object InetAddress {
   }
 
   private def formatIn4Addr(pb: Ptr[Byte]): String = {
-    val addr = pb.asInstanceOf[Ptr[in_addr]]
+    // By contract, pb isInstanceOf[Ptr[in_addr]]
     val dstSize = INET_ADDRSTRLEN
     val dst = stackalloc[Byte](dstSize.toUSize)
 
-    val result = inet_ntop(
-      AF_INET,
-      addr.at1.asInstanceOf[Ptr[Byte]],
-      dst,
-      dstSize.toUInt
-    )
+    val result = inet_ntop(AF_INET, pb, dst, dstSize.toUInt)
 
     if (result == null)
       throw new IOException(

--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -262,7 +262,7 @@ object NetworkInterface {
         } else if (sa.sa_family.toInt == AF_INET6) {
           val sin6 = sa.asInstanceOf[Ptr[sockaddr_in6]]
           val longs =
-            sin6.sin6_addr.at1.asInstanceOf[Ptr[scala.Long]]
+            sin6.sin6_addr.at1.at(0).asInstanceOf[Ptr[scala.Long]]
           java.lang.Long.bitCount(longs(0)) + java.lang.Long.bitCount(longs(1))
         } else {
           0 // Blivet! Unknown address family, assume zero length prefix.
@@ -321,7 +321,7 @@ object NetworkInterface {
         if (addrLen != 16) false
         else {
           val sa6 = sa.asInstanceOf[Ptr[sockaddr_in6]]
-          val sin6Addr = sa6.sin6_addr.at1.asInstanceOf[Ptr[Byte]]
+          val sin6Addr = sa6.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
           memcmp(addr.at(0), sin6Addr, addrLen.toUInt) == 0
         }
       } else if (sa_family == AF_INET) {


### PR DESCRIPTION
Fix #3131 

javalib `java.net.ServerSocket#accept` now accepts new connections without
the cast errors.

##### Collaboration

User devlam, the author of PR #3131, deserves "co-authored-by" recognition for the
precise localization & reproducing code provided in that PR. 

Of course, all bugs remain  "authored-by" user LeeTibbert.

##### Backport 
This PR is a candidate for backport to the SN 0.4.x series.  I believe/hope it
will backport cleanly. I checked the dates for the IPv6 backport to the SN 0.4.x series and
these changes are relevant to 0.4.x.  

Later:  I have not been able to get a private baseline (pre-changes of this PR) SN 0.4.x out-of-the-box 
Scala 3.2.2, Java 8 build to work after several hours invested.  I'll try again if/when my patience recovers.

Given that network code is notorious for being difficult to backport, I will be
trying a private build whilst this PR is in CI.

Later yet:  I got a baseline SN 0.4.x out-of-the-box build to work and tried to apply
                   the` fixes in this PR.   Using only the one file with the effective change
                   caused compilation errors due to differences in 0.4.x. 

                   I think the best thing for me to do is create a separate 0.4.x PR.
                   I already have the minimal change and have tested it.  No IPv6
                   on SN 0.4.n, so testing takes less time.  I want to create the
                   PR at the beginning, not the end, of a sprint.



##### Testing:

This PR has been manually tested with both IPv6 & IPv4 connections and passes.
scripted-test `java-net-server-socket` is intended to exercise `accept()` but appears
totally non-functional; see Issue #3139.

