### PR TITLE
Port `java.util.concurrent.ThreadPoolExecutor` from JSR-166

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/Executors.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Executors.scala
@@ -23,6 +23,62 @@ object Executors {
   def newWorkStealingPool(): ExecutorService =
     newWorkStealingPool(Runtime.getRuntime().availableProcessors())
 
+  def newFixedThreadPool(
+      nThreads: Int,
+      threadFactory: ThreadFactory
+  ): ExecutorService = {
+    new ThreadPoolExecutor(
+      nThreads,
+      nThreads,
+      0L,
+      TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue[Runnable],
+      threadFactory
+    )
+  }
+
+  def newFixedThreadPool(nThreads: Int): ExecutorService =
+    new ThreadPoolExecutor(
+      nThreads,
+      nThreads,
+      0L,
+      TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue[Runnable]
+    )
+
+  def newSingleThreadExecutor(): ExecutorService = {
+    new Executors.FinalizableDelegatedExecutorService(
+      newFixedThreadPool(1)
+    )
+  }
+
+  def newSingleThreadExecutor(threadFactory: ThreadFactory): ExecutorService = {
+    new Executors.FinalizableDelegatedExecutorService(
+      newFixedThreadPool(1, threadFactory)
+    )
+  }
+
+  def newCachedThreadPool(): ExecutorService = {
+    new ThreadPoolExecutor(
+      0,
+      Integer.MAX_VALUE,
+      60L,
+      TimeUnit.SECONDS,
+      new SynchronousQueue[Runnable]
+    )
+  }
+
+  def newCachedThreadPool(threadFactory: ThreadFactory): ExecutorService = {
+    new ThreadPoolExecutor(
+      0,
+      Integer.MAX_VALUE,
+      60L,
+      TimeUnit.SECONDS,
+      new SynchronousQueue[Runnable],
+      threadFactory
+    )
+  }
+
   def unconfigurableExecutorService(
       executor: ExecutorService
   ): ExecutorService = {

--- a/javalib/src/main/scala/java/util/concurrent/FutureTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/FutureTask.scala
@@ -275,9 +275,9 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
             if (pred.thread == null) { // check for race
               continue = true
             }
-          } else if (!atomicWaiters.compareExchangeStrong(q, s))
-            continue = true // todo: continue is not supported
-
+          } else if (!atomicWaiters.compareExchangeStrong(q, s)) {
+            continue = true
+          }
           if (!continue) {
             q = s
           }

--- a/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
@@ -1,0 +1,840 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package java.util.concurrent
+
+import java.util
+import java.util.ConcurrentModificationException
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks._
+import scala.annotation.tailrec
+
+object ThreadPoolExecutor {
+  private val COUNT_BITS: Int = Integer.SIZE - 3
+  private val COUNT_MASK: Int = (1 << COUNT_BITS) - 1
+// runState is stored in the high-order bits
+  private val RUNNING: Int = -(1) << COUNT_BITS
+  private val SHUTDOWN: Int = 0 << COUNT_BITS
+  private val STOP: Int = 1 << COUNT_BITS
+  private val TIDYING: Int = 2 << COUNT_BITS
+  private val TERMINATED: Int = 3 << COUNT_BITS
+// Packing and unpacking ctl
+  private def runStateOf(c: Int): Int = c & ~(COUNT_MASK)
+  private def workerCountOf(c: Int): Int = c & COUNT_MASK
+  private def ctlOf(rs: Int, wc: Int): Int = rs | wc
+  private def runStateLessThan(c: Int, s: Int): Boolean = c < s
+  private def runStateAtLeast(c: Int, s: Int): Boolean = c >= s
+  private def isRunning(c: Int): Boolean = c < SHUTDOWN
+
+  private[concurrent] val defaultHandler: RejectedExecutionHandler =
+    new AbortPolicy
+
+  private val ONLY_ONE: Boolean = true
+
+  class CallerRunsPolicy() extends RejectedExecutionHandler {
+    def rejectedExecution(r: Runnable, e: ThreadPoolExecutor): Unit = {
+      if (!e.isShutdown()) r.run()
+    }
+  }
+
+  class AbortPolicy() extends RejectedExecutionHandler {
+    def rejectedExecution(r: Runnable, e: ThreadPoolExecutor): Unit = {
+      throw new RejectedExecutionException(
+        "Task " + r.toString + " rejected from " + e.toString
+      )
+    }
+  }
+
+  class DiscardPolicy() extends RejectedExecutionHandler {
+    def rejectedExecution(r: Runnable, e: ThreadPoolExecutor): Unit = {}
+  }
+
+  class DiscardOldestPolicy() extends RejectedExecutionHandler {
+    def rejectedExecution(r: Runnable, e: ThreadPoolExecutor): Unit = {
+      if (!e.isShutdown()) {
+        e.getQueue().poll()
+        e.execute(r)
+      }
+    }
+  }
+}
+
+class ThreadPoolExecutor(
+    /** Core pool size is the minimum number of workers to keep alive (and not
+     *  allow to time out etc) unless allowCoreThreadTimeOut is set, in which
+     *  case the minimum is zero.
+     *
+     *  Since the worker count is actually stored in COUNT_BITS bits, the
+     *  effective limit is {@code corePoolSize & COUNT_MASK}.
+     */
+    var corePoolSize: Int,
+    /** Maximum pool size.
+     *
+     *  Since the worker count is actually stored in COUNT_BITS bits, the
+     *  effective limit is {@code maximumPoolSize & COUNT_MASK}.
+     */
+    var maximumPoolSize: Int,
+    var keepAliveTime: Long,
+    val unit: TimeUnit,
+    val workQueue: BlockingQueue[Runnable],
+    var threadFactory: ThreadFactory,
+    var handler: RejectedExecutionHandler
+) extends AbstractExecutorService {
+  import ThreadPoolExecutor._
+
+  if (corePoolSize < 0 || maximumPoolSize <= 0 || maximumPoolSize < corePoolSize || keepAliveTime < 0)
+    throw new IllegalArgumentException
+  if (workQueue == null || threadFactory == null || handler == null)
+    throw new NullPointerException
+  this.keepAliveTime = unit.toNanos(keepAliveTime)
+
+  /** The main pool control state, ctl, is an atomic integer packing two
+   *  conceptual fields workerCount, indicating the effective number of threads
+   *  runState, indicating whether running, shutting down etc
+   *
+   *  In order to pack them into one int, we limit workerCount to (2^29)-1
+   *  (about 500 million) threads rather than (2^31)-1 (2 billion) otherwise
+   *  representable. If this is ever an issue in the future, the variable can be
+   *  changed to be an AtomicLong, and the shift/mask constants below adjusted.
+   *  But until the need arises, this code is a bit faster and simpler using an
+   *  int.
+   *
+   *  The workerCount is the number of workers that have been permitted to start
+   *  and not permitted to stop. The value may be transiently different from the
+   *  actual number of live threads, for example when a ThreadFactory fails to
+   *  create a thread when asked, and when exiting threads are still performing
+   *  bookkeeping before terminating. The user-visible pool size is reported as
+   *  the current size of the workers set.
+   *
+   *  The runState provides the main lifecycle control, taking on values:
+   *
+   *  RUNNING: Accept new tasks and process queued tasks SHUTDOWN: Don't accept
+   *  new tasks, but process queued tasks STOP: Don't accept new tasks, don't
+   *  process queued tasks, and interrupt in-progress tasks TIDYING: All tasks
+   *  have terminated, workerCount is zero, the thread transitioning to state
+   *  TIDYING will run the terminated() hook method TERMINATED: terminated() has
+   *  completed
+   *
+   *  The numerical order among these values matters, to allow ordered
+   *  comparisons. The runState monotonically increases over time, but need not
+   *  hit each state. The transitions are:
+   *
+   *  RUNNING -> SHUTDOWN On invocation of shutdown() (RUNNING or SHUTDOWN) ->
+   *  STOP On invocation of shutdownNow() SHUTDOWN -> TIDYING When both queue
+   *  and pool are empty STOP -> TIDYING When pool is empty TIDYING ->
+   *  TERMINATED When the terminated() hook method has completed
+   *
+   *  Threads waiting in awaitTermination() will return when the state reaches
+   *  TERMINATED.
+   *
+   *  Detecting the transition from SHUTDOWN to TIDYING is less straightforward
+   *  than you'd like because the queue may become empty after non-empty and
+   *  vice versa during SHUTDOWN state, but we can only terminate if, after
+   *  seeing that it is empty, we see that workerCount is 0 (which sometimes
+   *  entails a recheck -- see below).
+   */
+  final private val ctl: AtomicInteger = new AtomicInteger(ctlOf(RUNNING, 0))
+
+  private def compareAndIncrementWorkerCount(expect: Int): Boolean =
+    ctl.compareAndSet(expect, expect + 1)
+
+  private def compareAndDecrementWorkerCount(expect: Int): Boolean =
+    ctl.compareAndSet(expect, expect - 1)
+
+  private def decrementWorkerCount(): Unit = ctl.addAndGet(-(1))
+
+  final private val mainLock: ReentrantLock = new ReentrantLock
+
+  final private val workers: util.HashSet[Worker] = new util.HashSet[Worker]
+
+  final private val termination: Condition = mainLock.newCondition()
+
+  private var largestPoolSize: Int = 0
+
+  private var completedTaskCount: Long = 0L
+
+  private var allowCoreThreadTimeOut: Boolean = false
+
+  @SerialVersionUID(6138294804551838833L)
+  final private[concurrent] class Worker private[concurrent] (
+      var firstTask: Runnable
+  ) extends AbstractQueuedSynchronizer
+      with Runnable {
+    setState(-1) // inhibit interrupts until runWorker
+
+    final private[concurrent] var thread: Thread =
+      getThreadFactory().newThread(this)
+
+    private[concurrent] var completedTasks: Long = 0L
+
+    override def run(): Unit = runWorker(this)
+    override protected def isHeldExclusively(): Boolean = getState() != 0
+    override protected def tryAcquire(unused: Int): Boolean = {
+      if (compareAndSetState(0, 1)) {
+        setExclusiveOwnerThread(Thread.currentThread())
+        true
+      } else false
+    }
+    override protected def tryRelease(unused: Int): Boolean = {
+      setExclusiveOwnerThread(null)
+      setState(0)
+      true
+    }
+
+    def lock(): Unit = acquire(1)
+    def tryLock(): Boolean = tryAcquire(1)
+    def unlock(): Unit = release(1)
+    def isLocked(): Boolean = isHeldExclusively()
+
+    private[concurrent] def interruptIfStarted(): Unit = {
+      var t: Thread = null
+      if (getState() >= 0 && { t = thread; t != null } && !t.isInterrupted())
+        try t.interrupt()
+        catch {
+          case ignore: SecurityException =>
+
+        }
+    }
+  }
+
+  @tailrec private def advanceRunState(targetState: Int): Unit = {
+    // assert targetState == SHUTDOWN || targetState == STOP;
+    val c: Int = ctl.get()
+    def setNewState =
+      ctl.compareAndSet(
+        c,
+        ctlOf(
+          targetState,
+          workerCountOf(c)
+        )
+      )
+    if (runStateAtLeast(c, targetState) || setNewState) ()
+    else advanceRunState(targetState)
+  }
+
+  final private[concurrent] def tryTerminate(): Unit = {
+    while (true) {
+      val c: Int = ctl.get()
+      if (isRunning(c) ||
+          runStateAtLeast(c, TIDYING) || {
+            runStateLessThan(c, STOP) && !(workQueue.isEmpty())
+          }) return ()
+      if (workerCountOf(c) != 0) { // Eligible to terminate
+        interruptIdleWorkers(ONLY_ONE)
+        return ()
+      }
+      val mainLock: ReentrantLock = this.mainLock
+      mainLock.lock()
+      try
+        if (ctl.compareAndSet(c, ctlOf(TIDYING, 0))) {
+          try terminated()
+          finally {
+            ctl.set(ctlOf(TERMINATED, 0))
+            termination.signalAll()
+          }
+          return
+        }
+      finally mainLock.unlock()
+      // else retry on failed CAS
+    }
+  }
+
+  private def interruptWorkers(): Unit = workers.forEach(_.interruptIfStarted())
+
+  private def interruptIdleWorkers(onlyOne: Boolean): Unit = {
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    def interruptWorker(w: Worker) = {
+      val t: Thread = w.thread
+      if (!t.isInterrupted() && w.tryLock()) {
+        try t.interrupt()
+        catch { case ignore: SecurityException => () }
+        finally w.unlock()
+      }
+    }
+    val it = workers.iterator()
+    try {
+      if (onlyOne) {
+        if (it.hasNext()) interruptWorker(it.next())
+      } else it.forEachRemaining(interruptWorker(_))
+    } finally mainLock.unlock()
+  }
+
+  private def interruptIdleWorkers(): Unit = interruptIdleWorkers(false)
+
+  final private[concurrent] def reject(command: Runnable): Unit =
+    handler.rejectedExecution(command, this)
+
+  private[concurrent] def onShutdown(): Unit = {}
+
+  private def drainQueue(): util.List[Runnable] = {
+    val q: BlockingQueue[Runnable] = workQueue
+    val taskList: util.ArrayList[Runnable] = new util.ArrayList[Runnable]
+    q.drainTo(taskList)
+    if (!(q.isEmpty())) for (r <- q.toArray(new Array[Runnable](0))) {
+      if (q.remove(r)) taskList.add(r)
+    }
+    return taskList
+  }
+
+  private def addWorker(firstTask: Runnable, core: Boolean): Boolean = {
+    // retry
+    var c: Int = ctl.get()
+    var break = false
+    while (!break) {
+      // Check if queue empty only if necessary.
+      if (runStateAtLeast(c, SHUTDOWN) && {
+            runStateAtLeast(c, STOP) ||
+            firstTask != null ||
+            workQueue.isEmpty()
+          }) return false
+
+      var retry = true
+      while (retry && !break) {
+        val maxSize = if (core) corePoolSize else maximumPoolSize
+        if (workerCountOf(c) >= (maxSize & COUNT_MASK)) return false
+        if (compareAndIncrementWorkerCount(c)) break = true
+        else {
+          c = ctl.get() // Re-read ctl
+          if (runStateAtLeast(c, SHUTDOWN)) retry = false
+          // else CAS failed due to workerCount change; retry inner loop
+        }
+      }
+    }
+
+    var workerStarted = false
+    var workerAdded = false
+    lazy val w = new Worker(firstTask)
+    try {
+      val t = w.thread
+      if (t != null) {
+        val mainLock = this.mainLock
+        mainLock.lock()
+        // Recheck while holding lock.
+        // Back out on ThreadFactory failure or if
+        // shut down before lock acquired.
+        try {
+          val c = ctl.get()
+          if (isRunning(c) ||
+              (runStateLessThan(c, STOP) && firstTask == null)) {
+            if (t.getState() != Thread.State.NEW)
+              throw new IllegalThreadStateException()
+            workers.add(w)
+            workerAdded = true
+            val s = workers.size()
+            if (s > largestPoolSize) largestPoolSize = s
+          }
+        } finally mainLock.unlock();
+        if (workerAdded) {
+          t.start()
+          workerStarted = true
+        }
+      }
+    } finally
+      if (!workerStarted)
+        addWorkerFailed(w)
+    workerStarted
+  }
+
+  private def addWorkerFailed(w: Worker): Unit = {
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      if (w != null) workers.remove(w)
+      decrementWorkerCount()
+      tryTerminate()
+    } finally mainLock.unlock()
+  }
+
+  private def processWorkerExit(
+      w: ThreadPoolExecutor#Worker,
+      completedAbruptly: Boolean
+  ): Unit = {
+    if (completedAbruptly) { // If abrupt, then workerCount wasn't adjusted
+      decrementWorkerCount()
+    }
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      completedTaskCount += w.completedTasks
+      workers.remove(w)
+    } finally mainLock.unlock()
+    tryTerminate()
+    val c: Int = ctl.get()
+    if (runStateLessThan(c, STOP)) {
+      if (!(completedAbruptly)) {
+        var min: Int =
+          if (allowCoreThreadTimeOut) 0
+          else corePoolSize
+        if (min == 0 && !(workQueue.isEmpty())) min = 1
+        if (workerCountOf(c) >= min)
+          return // replacement not needed
+      }
+      addWorker(null, false)
+    }
+  }
+
+  private def getTask(): Runnable = {
+    var timedOut: Boolean = false // Did the last poll() time out?
+    while (true) {
+      val c: Int = ctl.get()
+      if (runStateAtLeast(c, SHUTDOWN) &&
+          (runStateAtLeast(c, STOP) || workQueue.isEmpty())) {
+        decrementWorkerCount()
+        return null
+      }
+      val wc: Int = workerCountOf(c)
+      // Are workers subject to culling?
+      val timed: Boolean = allowCoreThreadTimeOut || wc > corePoolSize
+      val shouldSkip =
+        if ((wc > maximumPoolSize || (timed && timedOut)) && (wc > 1 || workQueue
+              .isEmpty())) {
+          if (compareAndDecrementWorkerCount(c)) return null
+          true // continue
+        } else false
+      if (!shouldSkip) {
+        try {
+          val r: Runnable =
+            if (timed) workQueue.poll(keepAliveTime, TimeUnit.NANOSECONDS)
+            else workQueue.take()
+          if (r != null) return r
+          timedOut = true
+        } catch { case retry: InterruptedException => timedOut = false }
+      }
+    }
+    null // unreachable
+  }
+
+  final private[concurrent] def runWorker(
+      w: ThreadPoolExecutor#Worker
+  ): Unit = {
+    val wt: Thread = Thread.currentThread()
+    var task: Runnable = w.firstTask
+    w.firstTask = null
+    w.unlock() // allow interrupts
+
+    var completedAbruptly: Boolean = true
+    try {
+      while (task != null || { task = getTask(); task != null }) {
+        w.lock()
+        // If pool is stopping, ensure thread is interrupted;
+        // if not, ensure thread is not interrupted.  This
+        // requires a recheck in second case to deal with
+        // shutdownNow race while clearing interrupt
+        if ({
+          runStateAtLeast(ctl.get(), STOP) ||
+          (Thread.interrupted() && runStateAtLeast(ctl.get(), STOP))
+        } && !(wt.isInterrupted())) wt.interrupt()
+        try {
+          beforeExecute(wt, task)
+          try {
+            task.run()
+            afterExecute(task, null)
+          } catch {
+            case ex: Throwable =>
+              afterExecute(task, ex)
+              throw ex
+          }
+        } finally {
+          task = null
+          w.completedTasks += 1
+          w.unlock()
+        }
+      }
+      completedAbruptly = false
+    } finally processWorkerExit(w, completedAbruptly)
+  }
+
+  def this(
+      corePoolSize: Int,
+      maximumPoolSize: Int,
+      keepAliveTime: Long,
+      unit: TimeUnit,
+      workQueue: BlockingQueue[Runnable]
+  ) = {
+    this(
+      corePoolSize,
+      maximumPoolSize,
+      keepAliveTime,
+      unit,
+      workQueue,
+      Executors.defaultThreadFactory(),
+      ThreadPoolExecutor.defaultHandler
+    )
+  }
+
+  def this(
+      corePoolSize: Int,
+      maximumPoolSize: Int,
+      keepAliveTime: Long,
+      unit: TimeUnit,
+      workQueue: BlockingQueue[Runnable],
+      threadFactory: ThreadFactory
+  ) = {
+    this(
+      corePoolSize,
+      maximumPoolSize,
+      keepAliveTime,
+      unit,
+      workQueue,
+      threadFactory,
+      ThreadPoolExecutor.defaultHandler
+    )
+  }
+
+  def this(
+      corePoolSize: Int,
+      maximumPoolSize: Int,
+      keepAliveTime: Long,
+      unit: TimeUnit,
+      workQueue: BlockingQueue[Runnable],
+      handler: RejectedExecutionHandler
+  ) = {
+    this(
+      corePoolSize,
+      maximumPoolSize,
+      keepAliveTime,
+      unit,
+      workQueue,
+      Executors.defaultThreadFactory(),
+      handler
+    )
+  }
+
+  override def execute(command: Runnable): Unit = {
+    if (command == null) { throw new NullPointerException }
+    /*
+     * Proceed in 3 steps:
+     *
+     * 1. If fewer than corePoolSize threads are running, try to
+     * start a new thread with the given command as its first
+     * task.  The call to addWorker atomically checks runState and
+     * workerCount, and so prevents false alarms that would add
+     * threads when it shouldn't, by returning false.
+     *
+     * 2. If a task can be successfully queued, then we still need
+     * to double-check whether we should have added a thread
+     * (because existing ones died since last checking) or that
+     * the pool shut down since entry into this method. So we
+     * recheck state and if necessary roll back the enqueuing if
+     * stopped, or start a new thread if there are none.
+     *
+     * 3. If we cannot queue task, then we try to add a new
+     * thread.  If it fails, we know we are shut down or saturated
+     * and so reject the task.
+     */
+    var c: Int = ctl.get()
+    if (workerCountOf(c) < corePoolSize) {
+      if (addWorker(command, true)) { return }
+      c = ctl.get()
+    }
+    if (isRunning(c) && workQueue.offer(command)) {
+      val recheck: Int = ctl.get()
+      if (!(isRunning(recheck)) && remove(command)) {
+        reject(command)
+      } else {
+        if (workerCountOf(recheck) == 0) {
+          addWorker(null, false)
+        }
+      }
+    } else { if (!(addWorker(command, false))) { reject(command) } }
+  }
+
+  override def shutdown(): Unit = {
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      //  checkShutdownAccess()
+      advanceRunState(SHUTDOWN)
+      interruptIdleWorkers()
+      onShutdown() // hook for ScheduledThreadPoolExecutor
+    } finally {
+      mainLock.unlock()
+    }
+    tryTerminate()
+  }
+
+  override def shutdownNow(): util.List[Runnable] = {
+    var tasks: util.List[Runnable] = null
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      //  checkShutdownAccess()
+      advanceRunState(STOP)
+      interruptWorkers()
+      tasks = drainQueue()
+    } finally {
+      mainLock.unlock()
+    }
+    tryTerminate()
+    return tasks
+  }
+  override def isShutdown(): Boolean = {
+    return runStateAtLeast(
+      ctl.get(),
+      SHUTDOWN
+    )
+  }
+
+  private[concurrent] def isStopped(): Boolean = {
+    return runStateAtLeast(ctl.get(), STOP)
+  }
+
+  def isTerminating(): Boolean = {
+    val c: Int = ctl.get()
+    return runStateAtLeast(
+      c,
+      SHUTDOWN
+    ) && runStateLessThan(c, TERMINATED)
+  }
+  override def isTerminated(): Boolean = {
+    return runStateAtLeast(
+      ctl.get(),
+      TERMINATED
+    )
+  }
+  @throws[InterruptedException]
+  override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+    var nanos: Long = unit.toNanos(timeout)
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      while ({
+        runStateLessThan(
+          ctl.get(),
+          TERMINATED
+        )
+      }) {
+        if (nanos <= 0L) { return false }
+        nanos = termination.awaitNanos(nanos)
+      }
+      return true
+    } finally {
+      mainLock.unlock()
+    }
+  }
+
+  def setThreadFactory(threadFactory: ThreadFactory): Unit = {
+    if (threadFactory == null) { throw new NullPointerException }
+    this.threadFactory = threadFactory
+  }
+
+  def getThreadFactory(): ThreadFactory = threadFactory
+
+  def setRejectedExecutionHandler(handler: RejectedExecutionHandler): Unit = {
+    if (handler == null) throw new NullPointerException
+    this.handler = handler
+  }
+
+  def getRejectedExecutionHandler(): RejectedExecutionHandler = handler
+
+  def setCorePoolSize(corePoolSize: Int): Unit = {
+    if (corePoolSize < 0 || maximumPoolSize < corePoolSize) {
+      throw new IllegalArgumentException
+    }
+    val delta: Int = corePoolSize - this.corePoolSize
+    this.corePoolSize = corePoolSize
+    if (ThreadPoolExecutor.workerCountOf(ctl.get()) > corePoolSize)
+      interruptIdleWorkers()
+    else {
+      if (delta > 0) {
+        // We don't really know how many new threads are "needed".
+        // As a heuristic, prestart enough new workers (up to new
+        // core size) to handle the current number of tasks in
+        // queue, but stop if queue becomes empty while doing so.
+        var k: Int = delta min workQueue.size()
+        while ({
+          var idx = k
+          k -= 1
+          k > 0 && addWorker(null, true) && !workQueue.isEmpty()
+        }) ()
+      }
+    }
+  }
+
+  def getCorePoolSize(): Int = { return corePoolSize }
+
+  def prestartCoreThread(): Boolean = {
+    return workerCountOf(
+      ctl.get()
+    ) < corePoolSize && addWorker(null, true)
+  }
+
+  private[concurrent] def ensurePrestart(): Unit = {
+    val wc: Int = workerCountOf(ctl.get())
+    if (wc < corePoolSize) { addWorker(null, true) }
+    else { if (wc == 0) { addWorker(null, false) } }
+  }
+
+  def prestartAllCoreThreads(): Int = {
+    var n: Int = 0
+    while ({ addWorker(null, true) }) { n += 1 }
+    return n
+  }
+
+  def allowsCoreThreadTimeOut(): Boolean = { return allowCoreThreadTimeOut }
+
+  def allowCoreThreadTimeOut(value: Boolean): Unit = {
+    if (value && keepAliveTime <= 0) {
+      throw new IllegalArgumentException(
+        "Core threads must have nonzero keep alive times"
+      )
+    }
+    if (value != allowCoreThreadTimeOut) {
+      allowCoreThreadTimeOut = value
+      if (value) { interruptIdleWorkers() }
+    }
+  }
+
+  def setMaximumPoolSize(maximumPoolSize: Int): Unit = {
+    if (maximumPoolSize <= 0 || maximumPoolSize < corePoolSize) {
+      throw new IllegalArgumentException
+    }
+    this.maximumPoolSize = maximumPoolSize
+    if (workerCountOf(ctl.get()) > maximumPoolSize) {
+      interruptIdleWorkers()
+    }
+  }
+
+  def getMaximumPoolSize(): Int = { return maximumPoolSize }
+
+  def setKeepAliveTime(time: Long, unit: TimeUnit): Unit = {
+    if (time < 0) { throw new IllegalArgumentException }
+    if (time == 0 && allowsCoreThreadTimeOut()) {
+      throw new IllegalArgumentException(
+        "Core threads must have nonzero keep alive times"
+      )
+    }
+    val keepAliveTime: Long = unit.toNanos(time)
+    val delta: Long = keepAliveTime - this.keepAliveTime
+    this.keepAliveTime = keepAliveTime
+    if (delta < 0) interruptIdleWorkers()
+  }
+
+  def getKeepAliveTime(unit: TimeUnit): Long =
+    unit.convert(keepAliveTime, TimeUnit.NANOSECONDS)
+
+  def getQueue(): BlockingQueue[Runnable] = { return workQueue }
+
+  def remove(task: Runnable): Boolean = {
+    val removed: Boolean = workQueue.remove(task)
+    tryTerminate() // In case SHUTDOWN and now empty
+
+    removed
+  }
+
+  def purge(): Unit = {
+    val q: BlockingQueue[Runnable] = workQueue
+    try {
+      val it: util.Iterator[Runnable] = q.iterator()
+      while (it.hasNext()) {
+        it.next() match {
+          case r: Future[_] if r.isCancelled() => it.remove()
+          case _                               => ()
+        }
+      }
+    } catch {
+      case fallThrough: ConcurrentModificationException =>
+        // Take slow path if we encounter interference during traversal.
+        // Make copy for traversal and call remove for cancelled entries.
+        // The slow path is more likely to be O(N*N).
+        for (r <- q.toArray()) {
+          r match {
+            case r: Future[_] if r.isCancelled() => q.remove(r)
+            case _                               => ()
+          }
+        }
+    }
+    // In case SHUTDOWN and now empty
+    tryTerminate()
+  }
+
+  def getPoolSize(): Int = {
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    // Remove rare and surprising possibility of isTerminated() && getPoolSize() > 0
+    try
+      if (runStateAtLeast(ctl.get(), TIDYING)) 0
+      else workers.size()
+    finally mainLock.unlock()
+  }
+
+  def getActiveCount(): Int = {
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      var n: Int = 0
+      workers.forEach { w =>
+        if (w.isLocked()) n += 1
+      }
+      n
+    } finally mainLock.unlock()
+  }
+
+  def getLargestPoolSize(): Int = {
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try return largestPoolSize
+    finally {
+      mainLock.unlock()
+    }
+  }
+
+  def getTaskCount(): Long = {
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      var n: Long = completedTaskCount
+      workers.forEach { w =>
+        n += w.completedTasks
+        if (w.isLocked()) n += 1
+
+      }
+      n + workQueue.size()
+    } finally mainLock.unlock()
+  }
+
+  def getCompletedTaskCount(): Long = {
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      var n: Long = completedTaskCount
+      workers.forEach(n += _.completedTasks)
+      n
+    } finally mainLock.unlock()
+  }
+
+  override def toString(): String = {
+    var ncompleted: Long = 0L
+    var nworkers: Int = 0
+    var nactive: Int = 0
+    val mainLock: ReentrantLock = this.mainLock
+    mainLock.lock()
+    try {
+      ncompleted = completedTaskCount
+      nactive = 0
+      nworkers = workers.size()
+      workers.forEach { w =>
+        ncompleted += w.completedTasks
+        if (w.isLocked()) { nactive += 1 }
+      }
+    } finally mainLock.unlock()
+    val c: Int = ctl.get()
+    val runState: String =
+      if (isRunning(c)) "Running"
+      else if (runStateAtLeast(c, TERMINATED)) "Terminated"
+      else "Shutting down"
+
+    return super
+      .toString() + "[" + runState + ", pool size = " + nworkers + ", active threads = " + nactive + ", queued tasks = " + workQueue
+      .size() + ", completed tasks = " + ncompleted + "]"
+  }
+
+  protected def beforeExecute(t: Thread, r: Runnable): Unit = {}
+
+  protected def afterExecute(r: Runnable, t: Throwable): Unit = {}
+
+  protected def terminated(): Unit = {}
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThreadLocalTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThreadLocalTest.scala
@@ -10,17 +10,11 @@ package org.scalanative.testsuite.javalib.lang
 import org.junit.{Test, Ignore, BeforeClass}
 import org.junit.Assert._
 import scala.scalanative.junit.utils.AssumesHelper
+import org.scalanative.testsuite.javalib.util.concurrent.JSR166Test
 
-// TODO: JSR166, make part of JSR166Test
+import JSR166Test._
+
 object ThreadLocalTest {
-  @BeforeClass def checkRuntime(): Unit = {
-    AssumesHelper.assumeMultithreadingIsEnabled()
-  }
-
-  final val zero = 0: Integer
-  final val one = 1: Integer
-  final val two = 2: Integer
-
   val tl = new ThreadLocal[Integer]() {
     override def initialValue: Integer = one
   }
@@ -29,7 +23,7 @@ object ThreadLocalTest {
     override def childValue(parentValue: Integer): Integer = parentValue + 1
   }
 }
-class ThreadLocalTest {
+class ThreadLocalTest extends JSR166Test {
   import ThreadLocalTest._
 
   /** remove causes next access to return initial value

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/AbstractExecutorServiceTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/AbstractExecutorServiceTest.scala
@@ -96,69 +96,69 @@ class AbstractExecutorServiceTest extends JSR166Test {
     new AbstractExecutorServiceTest.DirectExecutorService
   ) { assertNullTaskSubmissionThrowsNullPointerException }
 
-  // TODO: ThreadPoolExecutor
-  // /** submit(callable).get() throws InterruptedException if interrupted
-  //  */
-  // @throws[InterruptedException]
-  // @Test def testInterruptedSubmit(): Unit = {
-  //   val submitted = new CountDownLatch(1)
-  //   val quittingTime = new CountDownLatch(1)
-  //   val awaiter = new CheckedCallable[Void]() {
-  //     @throws[InterruptedException]
-  //     override def realCall(): Void = {
-  //       assertTrue(quittingTime.await(2 * LONG_DELAY_MS, MILLISECONDS))
-  //       null
-  //     }
-  //   }
-  //   usingPoolCleaner[ThreadPoolExecutor, Unit](
-  //     new ThreadPoolExecutor(
-  //       1,
-  //       1,
-  //       60,
-  //       TimeUnit.SECONDS,
-  //       new ArrayBlockingQueue[Runnable](10)
-  //     ),
-  //     cleaner(_, quittingTime)
-  //   ) { p =>
-  //     val t = newStartedThread(
-  //       new CheckedInterruptedRunnable() {
-  //         @throws[Exception]
-  //         override def realRun(): Unit = {
-  //           val future = p.submit(awaiter)
-  //           submitted.countDown()
-  //           future.get
-  //         }
-  //       }
-  //     )
-  //     await(submitted)
-  //     t.interrupt()
-  //     awaitTermination(t)
-  //   }
-  // }
-  // /** get of submit(callable) throws ExecutionException if callable throws
-  //  *  exception
-  //  */
-  // @throws[InterruptedException]
-  // @Test def testSubmitEE(): Unit = usingPoolCleaner(
-  //   new ThreadPoolExecutor(
-  //     1,
-  //     1,
-  //     60,
-  //     TimeUnit.SECONDS,
-  //     new ArrayBlockingQueue[Runnable](10)
-  //   )
-  // ) { p =>
-  //   val c = new Callable[Any]() {
-  //     override def call = throw new ArithmeticException
-  //   }
-  //   try {
-  //     p.submit(c).get
-  //     shouldThrow()
-  //   } catch {
-  //     case success: ExecutionException =>
-  //       assertTrue(success.getCause.isInstanceOf[ArithmeticException])
-  //   }
-  // }
+  /** submit(callable).get() throws InterruptedException if interrupted
+   */
+  @throws[InterruptedException]
+  @Test def testInterruptedSubmit(): Unit = {
+    val submitted = new CountDownLatch(1)
+    val quittingTime = new CountDownLatch(1)
+    val awaiter = new CheckedCallable[Void]() {
+      @throws[InterruptedException]
+      override def realCall(): Void = {
+        assertTrue(quittingTime.await(2 * LONG_DELAY_MS, MILLISECONDS))
+        null
+      }
+    }
+    usingPoolCleaner[ThreadPoolExecutor, Unit](
+      new ThreadPoolExecutor(
+        1,
+        1,
+        60,
+        TimeUnit.SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      ),
+      cleaner(_, quittingTime)
+    ) { p =>
+      val t = newStartedThread(
+        new CheckedInterruptedRunnable() {
+          @throws[Exception]
+          override def realRun(): Unit = {
+            val future = p.submit(awaiter)
+            submitted.countDown()
+            future.get
+          }
+        }
+      )
+      await(submitted)
+      t.interrupt()
+      awaitTermination(t)
+    }
+  }
+
+  /** get of submit(callable) throws ExecutionException if callable throws
+   *  exception
+   */
+  @throws[InterruptedException]
+  @Test def testSubmitEE(): Unit = usingPoolCleaner(
+    new ThreadPoolExecutor(
+      1,
+      1,
+      60,
+      TimeUnit.SECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+  ) { p =>
+    val c = new Callable[Any]() {
+      override def call = throw new ArithmeticException
+    }
+    try {
+      p.submit(c).get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertTrue(success.getCause.isInstanceOf[ArithmeticException])
+    }
+  }
 
   /** invokeAny(null) throws NPE
    */

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ArrayBlockingQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ArrayBlockingQueueTest.scala
@@ -821,57 +821,56 @@ class ArrayBlockingQueueTest extends JSR166Test {
     for (i <- 0 until SIZE) { assertTrue(s.contains(String.valueOf(i))) }
   }
 
-  // TODO: ThreadPoolExecutor
-  // /** offer transfers elements across Executor tasks
-  //  */
-  // @Test def testOfferInExecutor(): Unit =
-  //   usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
-  //     val q = new ArrayBlockingQueue[Any](2)
-  //     q.add(one)
-  //     q.add(two)
-  //     val threadsStarted: CheckedBarrier = new CheckedBarrier(2)
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         assertFalse(q.offer(three))
-  //         threadsStarted.await
-  //         assertTrue(q.offer(three, LONG_DELAY_MS, MILLISECONDS))
-  //         assertEquals(0, q.remainingCapacity)
-  //       }
-  //     })
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         threadsStarted.await
-  //         assertEquals(0, q.remainingCapacity)
-  //         assertSame(one, q.take)
-  //       }
-  //     })
-  //   }
+  /** offer transfers elements across Executor tasks
+   */
+  @Test def testOfferInExecutor(): Unit =
+    usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
+      val q = new ArrayBlockingQueue[Any](2)
+      q.add(one)
+      q.add(two)
+      val threadsStarted: CheckedBarrier = new CheckedBarrier(2)
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(q.offer(three))
+          threadsStarted.await
+          assertTrue(q.offer(three, LONG_DELAY_MS, MILLISECONDS))
+          assertEquals(0, q.remainingCapacity)
+        }
+      })
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadsStarted.await
+          assertEquals(0, q.remainingCapacity)
+          assertSame(one, q.take)
+        }
+      })
+    }
 
-  // /** timed poll retrieves elements across Executor threads
-  //  */
-  // @Test def testPollInExecutor(): Unit =
-  //   usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
-  //     val q = new ArrayBlockingQueue[Any](2)
-  //     val threadsStarted = new CheckedBarrier(2)
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         assertNull(q.poll)
-  //         threadsStarted.await
-  //         assertSame(one, q.poll(LONG_DELAY_MS, MILLISECONDS))
-  //         checkEmpty(q)
-  //       }
-  //     })
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         threadsStarted.await
-  //         q.put(one)
-  //       }
-  //     })
-  //   }
+  /** timed poll retrieves elements across Executor threads
+   */
+  @Test def testPollInExecutor(): Unit =
+    usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
+      val q = new ArrayBlockingQueue[Any](2)
+      val threadsStarted = new CheckedBarrier(2)
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertNull(q.poll)
+          threadsStarted.await
+          assertSame(one, q.poll(LONG_DELAY_MS, MILLISECONDS))
+          checkEmpty(q)
+        }
+      })
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadsStarted.await
+          q.put(one)
+        }
+      })
+    }
 
   /** A deserialized/reserialized queue has same elements in same order
    */

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/BlockingQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/BlockingQueueTest.scala
@@ -332,9 +332,7 @@ abstract class BlockingQueueTest extends JSR166Test {
     awaitTermination(t)
   }
 
-  /** remove(x) removes x and returns true if present TODO: move to superclass
-   *  CollectionTest.java
-   */
+  /** remove(x) removes x and returns true if present */
   @Test def testRemoveElement(): Unit = {
     val q = emptyCollection()
     val size = Math.min(q.remainingCapacity, SIZE)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/CyclicBarrierTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/CyclicBarrierTest.scala
@@ -482,36 +482,35 @@ class CyclicBarrierTest extends JSR166Test {
     }
   }
 
-  // TODO: ThreadPoolExecutor
-  // /** There can be more threads calling await() than parties, as long as each
-  //  *  task only calls await once and the task count is a multiple of parties.
-  //  */
-  // @throws[Exception]
-  // @Test def testMoreTasksThanParties(): Unit = {
-  //   val rnd = ThreadLocalRandom.current
-  //   val parties = rnd.nextInt(1, 5)
-  //   val nTasks = rnd.nextInt(1, 5) * parties
-  //   val tripCount = new AtomicInteger(0)
-  //   val awaitCount = new AtomicInteger(0)
-  //   val barrier = new CyclicBarrier(parties, () => tripCount.getAndIncrement)
-  //   val awaiter: Runnable = () => {
-  //     def foo() =
-  //       try {
-  //         if (randomBoolean()) barrier.await
-  //         else barrier.await(LONG_DELAY_MS, MILLISECONDS)
-  //         awaitCount.getAndIncrement
-  //       } catch {
-  //         case fail: Throwable =>
-  //           threadUnexpectedException(fail)
-  //       }
-  //     foo()
-  //   }
-  //   usingPoolCleaner(Executors.newFixedThreadPool(nTasks)) { e =>
-  //     var i = nTasks
-  //     while ({ i -= 1; i + 1 > 0 }) e.execute(awaiter)
-  //   }
-  //   assertEquals(nTasks / parties, tripCount.get)
-  //   assertEquals(nTasks, awaitCount.get)
-  //   assertEquals(0, barrier.getNumberWaiting)
-  // }
+  /** There can be more threads calling await() than parties, as long as each
+   *  task only calls await once and the task count is a multiple of parties.
+   */
+  @throws[Exception]
+  @Test def testMoreTasksThanParties(): Unit = {
+    val rnd = ThreadLocalRandom.current
+    val parties = rnd.nextInt(1, 5)
+    val nTasks = rnd.nextInt(1, 5) * parties
+    val tripCount = new AtomicInteger(0)
+    val awaitCount = new AtomicInteger(0)
+    val barrier = new CyclicBarrier(parties, () => tripCount.getAndIncrement)
+    val awaiter: Runnable = () => {
+      def foo() =
+        try {
+          if (randomBoolean()) barrier.await
+          else barrier.await(LONG_DELAY_MS, MILLISECONDS)
+          awaitCount.getAndIncrement
+        } catch {
+          case fail: Throwable =>
+            threadUnexpectedException(fail)
+        }
+      foo()
+    }
+    usingPoolCleaner(Executors.newFixedThreadPool(nTasks)) { e =>
+      var i = nTasks
+      while ({ i -= 1; i + 1 > 0 }) e.execute(awaiter)
+    }
+    assertEquals(nTasks / parties, tripCount.get)
+    assertEquals(nTasks, awaitCount.get)
+    assertEquals(0, barrier.getNumberWaiting)
+  }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorCompletionServiceTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorCompletionServiceTest.scala
@@ -30,232 +30,233 @@ class ExecutorCompletionServiceTest extends JSR166Test {
     }
   }
 
-  // TODO: ThreadPoolExecutor
-  // /** new ExecutorCompletionService(e, null) throws NullPointerException
-  //  */
-  // @Test def testConstructorNPE2(): Unit = {
-  //   try {
-  //     new ExecutorCompletionService[Any](cachedThreadPool, null)
-  //     shouldThrow()
-  //   } catch {
-  //     case success: NullPointerException =>
+  /** new ExecutorCompletionService(e, null) throws NullPointerException
+   */
+  @Test def testConstructorNPE2(): Unit = {
+    try {
+      new ExecutorCompletionService[Any](cachedThreadPool, null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
 
-  //   }
-  // }
+    }
+  }
 
-  // /** ecs.submit(null) throws NullPointerException
-  //  */
-  // @Test def testSubmitNullCallable(): Unit = {
-  //   val cs =
-  //     new ExecutorCompletionService[Any](cachedThreadPool)
-  //   try {
-  //     cs.submit(null.asInstanceOf[Callable[Any]])
-  //     shouldThrow()
-  //   } catch {
-  //     case success: NullPointerException =>
+  /** ecs.submit(null) throws NullPointerException
+   */
+  @Test def testSubmitNullCallable(): Unit = {
+    val cs =
+      new ExecutorCompletionService[Any](cachedThreadPool)
+    try {
+      cs.submit(null.asInstanceOf[Callable[Any]])
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
 
-  //   }
-  // }
+    }
+  }
 
-  // /** ecs.submit(null, val) throws NullPointerException
-  //  */
-  // @Test def testSubmitNullRunnable(): Unit = {
-  //   val cs =
-  //     new ExecutorCompletionService[Any](cachedThreadPool)
-  //   try {
-  //     cs.submit(null.asInstanceOf[Runnable], java.lang.Boolean.TRUE)
-  //     shouldThrow()
-  //   } catch {
-  //     case success: NullPointerException => ()
-  //   }
-  // }
+  /** ecs.submit(null, val) throws NullPointerException
+   */
+  @Test def testSubmitNullRunnable(): Unit = {
+    val cs =
+      new ExecutorCompletionService[Any](cachedThreadPool)
+    try {
+      cs.submit(null.asInstanceOf[Runnable], java.lang.Boolean.TRUE)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException => ()
+    }
+  }
 
-  // /** A taken submitted task is completed
-  //  */
-  // @throws[Exception]
-  // @Test def testTake(): Unit = {
-  //   val cs = new ExecutorCompletionService[String](cachedThreadPool)
-  //   cs.submit(new StringTask)
-  //   val f = cs.take
-  //   assertTrue(f.isDone)
-  //   assertEquals(TEST_STRING, f.get)
-  // }
+  /** A taken submitted task is completed
+   */
+  @throws[Exception]
+  @Test def testTake(): Unit = {
+    val cs = new ExecutorCompletionService[String](cachedThreadPool)
+    cs.submit(new StringTask)
+    val f = cs.take
+    assertTrue(f.isDone)
+    assertEquals(TEST_STRING, f.get)
+  }
 
-  // /** Take returns the same future object returned by submit
-  //  */
-  // @throws[InterruptedException]
-  // @Test def testTake2(): Unit = {
-  //   val cs = new ExecutorCompletionService[String](cachedThreadPool)
-  //   val f1 = cs.submit(new StringTask)
-  //   val f2 = cs.take
-  //   assertEquals(f1, f2)
-  // }
+  /** Take returns the same future object returned by submit
+   */
+  @throws[InterruptedException]
+  @Test def testTake2(): Unit = {
+    val cs = new ExecutorCompletionService[String](cachedThreadPool)
+    val f1 = cs.submit(new StringTask)
+    val f2 = cs.take
+    assertEquals(f1, f2)
+  }
 
-  // /** poll returns non-null when the returned task is completed
-  //  */
-  // @throws[Exception]
-  // @Test def testPoll1(): Unit = {
-  //   val cs =
-  //     new ExecutorCompletionService[String](cachedThreadPool)
-  //   assertNull(cs.poll)
-  //   cs.submit(new StringTask)
-  //   val startTime = System.nanoTime
-  //   var f: Future[String] = null
-  //   while ({ f = cs.poll(); f == null }) {
-  //     if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
-  //     Thread.`yield`()
-  //   }
-  //   assertTrue(f.isDone)
-  //   assertEquals(TEST_STRING, f.get)
-  // }
+  /** poll returns non-null when the returned task is completed
+   */
+  @throws[Exception]
+  @Test def testPoll1(): Unit = {
+    val cs =
+      new ExecutorCompletionService[String](cachedThreadPool)
+    assertNull(cs.poll)
+    cs.submit(new StringTask)
+    val startTime = System.nanoTime
+    var f: Future[String] = null
+    while ({ f = cs.poll(); f == null }) {
+      if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
+      Thread.`yield`()
+    }
+    assertTrue(f.isDone)
+    assertEquals(TEST_STRING, f.get)
+  }
 
-  // /** timed poll returns non-null when the returned task is completed
-  //  */
-  // @throws[Exception]
-  // @Test def testPoll2(): Unit = {
-  //   val cs =
-  //     new ExecutorCompletionService[String](cachedThreadPool)
-  //   assertNull(cs.poll)
-  //   cs.submit(new StringTask)
-  //   val startTime = System.nanoTime
-  //   var f: Future[String] = null
-  //   while ({ f = cs.poll(timeoutMillis(), MILLISECONDS); f == null }) {
-  //     assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
-  //     if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
-  //     Thread.`yield`()
-  //   }
-  //   assertTrue(f.isDone)
-  //   assertEquals(TEST_STRING, f.get)
-  // }
+  /** timed poll returns non-null when the returned task is completed
+   */
+  @throws[Exception]
+  @Test def testPoll2(): Unit = {
+    val cs =
+      new ExecutorCompletionService[String](cachedThreadPool)
+    assertNull(cs.poll)
+    cs.submit(new StringTask)
+    val startTime = System.nanoTime
+    var f: Future[String] = null
+    while ({ f = cs.poll(timeoutMillis(), MILLISECONDS); f == null }) {
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
+      Thread.`yield`()
+    }
+    assertTrue(f.isDone)
+    assertEquals(TEST_STRING, f.get)
+  }
 
-  // /** poll returns null before the returned task is completed
-  //  */
-  // @throws[Exception]
-  // @Test def testPollReturnsNullBeforeCompletion(): Unit = {
-  //   val cs =
-  //     new ExecutorCompletionService[String](cachedThreadPool)
-  //   val proceed = new CountDownLatch(1)
-  //   cs.submit(new Callable[String]() {
-  //     @throws[Exception]
-  //     override def call: String = {
-  //       await(proceed)
-  //       TEST_STRING
-  //     }
-  //   })
-  //   assertNull(cs.poll)
-  //   assertNull(cs.poll(0L, MILLISECONDS))
-  //   assertNull(cs.poll(java.lang.Long.MIN_VALUE, MILLISECONDS))
-  //   val startTime = System.nanoTime
-  //   assertNull(cs.poll(timeoutMillis(), MILLISECONDS))
-  //   assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
-  //   proceed.countDown()
-  //   assertEquals(TEST_STRING, cs.take.get)
-  // }
+  /** poll returns null before the returned task is completed
+   */
+  @throws[Exception]
+  @Test def testPollReturnsNullBeforeCompletion(): Unit = {
+    val cs =
+      new ExecutorCompletionService[String](cachedThreadPool)
+    val proceed = new CountDownLatch(1)
+    cs.submit(new Callable[String]() {
+      @throws[Exception]
+      override def call: String = {
+        await(proceed)
+        TEST_STRING
+      }
+    })
+    assertNull(cs.poll)
+    assertNull(cs.poll(0L, MILLISECONDS))
+    assertNull(cs.poll(java.lang.Long.MIN_VALUE, MILLISECONDS))
+    val startTime = System.nanoTime
+    assertNull(cs.poll(timeoutMillis(), MILLISECONDS))
+    assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    proceed.countDown()
+    assertEquals(TEST_STRING, cs.take.get)
+  }
 
-  // /** successful and failed tasks are both returned
-  //  */
-  // @throws[Exception]
-  // @Test def testTaskAssortment(): Unit = {
-  //   val cs =
-  //     new ExecutorCompletionService[String](cachedThreadPool)
-  //   val ex = new ArithmeticException
-  //   val rounds = 2
-  //   locally {
-  //     var i = rounds
-  //     while (i > 0) {
-  //       i -= 1
-  //       cs.submit(new StringTask)
-  //       cs.submit(callableThrowing(ex))
-  //       cs.submit(runnableThrowing(ex), null)
-  //     }
-  //   }
-  //   locally {
-  //     var normalCompletions = 0
-  //     var exceptionalCompletions = 0
-  //     var i = 3 * rounds
-  //     while (i > 0) try {
-  //       i -= 1
-  //       assertEquals(TEST_STRING, cs.take.get)
-  //       normalCompletions += 1
-  //     } catch {
-  //       case expected: ExecutionException =>
-  //         assertEquals(ex, expected.getCause)
-  //         exceptionalCompletions += 1
-  //     }
-  //     assertEquals(1 * rounds, normalCompletions)
-  //     assertEquals(2 * rounds, exceptionalCompletions)
-  //   }
-  //   assertNull(cs.poll)
-  // }
-  // /** Submitting to underlying AES that overrides newTaskFor(Callable) returns
-  //  *  and eventually runs Future returned by newTaskFor.
-  //  */
-  // @throws[InterruptedException]
-  // @Test def testNewTaskForCallable(): Unit = {
-  //   val _done = new AtomicBoolean(false)
-  //   class MyCallableFuture[V](val c: Callable[V]) extends FutureTask[V](c) {
-  //     override protected def done(): Unit = _done.set(true)
-  //   }
-  //   val e = new ThreadPoolExecutor(
-  //     1,
-  //     1,
-  //     30L,
-  //     TimeUnit.SECONDS,
-  //     new ArrayBlockingQueue[Runnable](1)
-  //   ) {
-  //     override protected def newTaskFor[T](c: Callable[T]) =
-  //       new MyCallableFuture[T](c)
-  //   }
+  /** successful and failed tasks are both returned
+   */
+  @throws[Exception]
+  @Test def testTaskAssortment(): Unit = {
+    val cs =
+      new ExecutorCompletionService[String](cachedThreadPool)
+    val ex = new ArithmeticException
+    val rounds = 2
+    locally {
+      var i = rounds
+      while (i > 0) {
+        i -= 1
+        cs.submit(new StringTask)
+        cs.submit(callableThrowing(ex))
+        cs.submit(runnableThrowing(ex), null)
+      }
+    }
+    locally {
+      var normalCompletions = 0
+      var exceptionalCompletions = 0
+      var i = 3 * rounds
+      while (i > 0) try {
+        i -= 1
+        assertEquals(TEST_STRING, cs.take.get)
+        normalCompletions += 1
+      } catch {
+        case expected: ExecutionException =>
+          assertEquals(ex, expected.getCause)
+          exceptionalCompletions += 1
+      }
+      assertEquals(1 * rounds, normalCompletions)
+      assertEquals(2 * rounds, exceptionalCompletions)
+    }
+    assertNull(cs.poll)
+  }
 
-  //   val cs = new ExecutorCompletionService[String](e)
-  //   usingPoolCleaner(e) { e =>
-  //     assertNull(cs.poll)
-  //     val c = new StringTask
-  //     val f1 = cs.submit(c)
-  //     assertTrue(
-  //       "submit must return MyCallableFuture",
-  //       f1.isInstanceOf[MyCallableFuture[_]]
-  //     )
-  //     val f2 = cs.take
-  //     assertEquals("submit and take must return same objects", f1, f2)
-  //     assertTrue("completed task must have set done", _done.get)
-  //   }
-  // }
-  // /** Submitting to underlying AES that overrides newTaskFor(Runnable,T) returns
-  //  *  and eventually runs Future returned by newTaskFor.
-  //  */
-  // @throws[InterruptedException]
-  // @Test def testNewTaskForRunnable(): Unit = {
-  //   val _done = new AtomicBoolean(false)
-  //   class MyRunnableFuture[V](val t: Runnable, val r: V)
-  //       extends FutureTask[V](t, r) {
-  //     override protected def done(): Unit = _done.set(true)
-  //   }
-  //   val e = new ThreadPoolExecutor(
-  //     1,
-  //     1,
-  //     30L,
-  //     TimeUnit.SECONDS,
-  //     new ArrayBlockingQueue[Runnable](1)
-  //   ) {
-  //     override protected def newTaskFor[T](
-  //         t: Runnable,
-  //         r: T
-  //     ) = new MyRunnableFuture[T](t, r)
-  //   }
+  /** Submitting to underlying AES that overrides newTaskFor(Callable) returns
+   *  and eventually runs Future returned by newTaskFor.
+   */
+  @throws[InterruptedException]
+  @Test def testNewTaskForCallable(): Unit = {
+    val _done = new AtomicBoolean(false)
+    class MyCallableFuture[V](val c: Callable[V]) extends FutureTask[V](c) {
+      override protected def done(): Unit = _done.set(true)
+    }
+    val e = new ThreadPoolExecutor(
+      1,
+      1,
+      30L,
+      TimeUnit.SECONDS,
+      new ArrayBlockingQueue[Runnable](1)
+    ) {
+      override protected def newTaskFor[T](c: Callable[T]) =
+        new MyCallableFuture[T](c)
+    }
 
-  //   val cs = new ExecutorCompletionService[String](e)
-  //   usingPoolCleaner(e) { e =>
-  //     assertNull(cs.poll)
-  //     val r = new NoOpRunnable
-  //     val f1 = cs.submit(r, null)
-  //     assertTrue(
-  //       "submit must return MyRunnableFuture",
-  //       f1.isInstanceOf[MyRunnableFuture[_]]
-  //     )
-  //     val f2 = cs.take
-  //     assertEquals("submit and take must return same objects", f1, f2)
-  //     assertTrue("completed task must have set done", _done.get)
-  //   }
-  // }
+    val cs = new ExecutorCompletionService[String](e)
+    usingPoolCleaner(e) { e =>
+      assertNull(cs.poll)
+      val c = new StringTask
+      val f1 = cs.submit(c)
+      assertTrue(
+        "submit must return MyCallableFuture",
+        f1.isInstanceOf[MyCallableFuture[_]]
+      )
+      val f2 = cs.take
+      assertEquals("submit and take must return same objects", f1, f2)
+      assertTrue("completed task must have set done", _done.get)
+    }
+  }
+
+  /** Submitting to underlying AES that overrides newTaskFor(Runnable,T) returns
+   *  and eventually runs Future returned by newTaskFor.
+   */
+  @throws[InterruptedException]
+  @Test def testNewTaskForRunnable(): Unit = {
+    val _done = new AtomicBoolean(false)
+    class MyRunnableFuture[V](val t: Runnable, val r: V)
+        extends FutureTask[V](t, r) {
+      override protected def done(): Unit = _done.set(true)
+    }
+    val e = new ThreadPoolExecutor(
+      1,
+      1,
+      30L,
+      TimeUnit.SECONDS,
+      new ArrayBlockingQueue[Runnable](1)
+    ) {
+      override protected def newTaskFor[T](
+          t: Runnable,
+          r: T
+      ) = new MyRunnableFuture[T](t, r)
+    }
+
+    val cs = new ExecutorCompletionService[String](e)
+    usingPoolCleaner(e) { e =>
+      assertNull(cs.poll)
+      val r = new NoOpRunnable
+      val f1 = cs.submit(r, null)
+      assertTrue(
+        "submit must return MyRunnableFuture",
+        f1.isInstanceOf[MyRunnableFuture[_]]
+      )
+      val f2 = cs.take
+      assertEquals("submit and take must return same objects", f1, f2)
+      assertTrue("completed task must have set done", _done.get)
+    }
+  }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorsTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorsTest.scala
@@ -159,94 +159,95 @@ class ExecutorsTest extends JSR166Test {
     }
   }
 
-  /** unconfigurableScheduledExecutorService(null) throws NPE
-   */
-  @Test def testUnconfigurableScheduledExecutorServiceNPE(): Unit = {
-    try {
-      val unused =
-        Executors.unconfigurableScheduledExecutorService(null)
-      shouldThrow()
-    } catch {
-      case success: NullPointerException =>
+  // TODO: ScheduledExecutor
+  // /** unconfigurableScheduledExecutorService(null) throws NPE
+  //  */
+  // @Test def testUnconfigurableScheduledExecutorServiceNPE(): Unit = {
+  //   try {
+  //     val unused =
+  //       Executors.unconfigurableScheduledExecutorService(null)
+  //     shouldThrow()
+  //   } catch {
+  //     case success: NullPointerException =>
 
-    }
-  }
+  //   }
+  // }
 
-  /** a newSingleThreadScheduledExecutor successfully runs delayed task
-   */
-  @throws[Exception]
-  @Test def testNewSingleThreadScheduledExecutor(): Unit =
-    usingPoolCleaner(Executors.newSingleThreadScheduledExecutor) { p =>
-      val proceed = new CountDownLatch(1)
-      val task = new CheckedRunnable() {
-        override def realRun(): Unit = { await(proceed) }
-      }
-      val startTime = System.nanoTime
-      val f = p.schedule(
-        Executors.callable(task, java.lang.Boolean.TRUE),
-        timeoutMillis(),
-        MILLISECONDS
-      )
-      assertFalse(f.isDone)
-      proceed.countDown()
-      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
-      assertSame(java.lang.Boolean.TRUE, f.get)
-      assertTrue(f.isDone)
-      assertFalse(f.isCancelled)
-      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
-    }
+  // /** a newSingleThreadScheduledExecutor successfully runs delayed task
+  //  */
+  // @throws[Exception]
+  // @Test def testNewSingleThreadScheduledExecutor(): Unit =
+  //   usingPoolCleaner(Executors.newSingleThreadScheduledExecutor) { p =>
+  //     val proceed = new CountDownLatch(1)
+  //     val task = new CheckedRunnable() {
+  //       override def realRun(): Unit = { await(proceed) }
+  //     }
+  //     val startTime = System.nanoTime
+  //     val f = p.schedule(
+  //       Executors.callable(task, java.lang.Boolean.TRUE),
+  //       timeoutMillis(),
+  //       MILLISECONDS
+  //     )
+  //     assertFalse(f.isDone)
+  //     proceed.countDown()
+  //     assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+  //     assertSame(java.lang.Boolean.TRUE, f.get)
+  //     assertTrue(f.isDone)
+  //     assertFalse(f.isCancelled)
+  //     assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+  //   }
 
-  /** a newScheduledThreadPool successfully runs delayed task
-   */
-  @throws[Exception]
-  @Test def testNewScheduledThreadPool(): Unit =
-    usingPoolCleaner(Executors.newScheduledThreadPool(2)) { p =>
-      val proceed = new CountDownLatch(1)
-      val task = new CheckedRunnable() {
-        override def realRun(): Unit = { await(proceed) }
-      }
-      val startTime = System.nanoTime
-      val f = p.schedule(
-        Executors.callable(task, java.lang.Boolean.TRUE),
-        timeoutMillis(),
-        MILLISECONDS
-      )
-      assertFalse(f.isDone)
-      proceed.countDown()
-      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
-      assertSame(java.lang.Boolean.TRUE, f.get)
-      assertTrue(f.isDone)
-      assertFalse(f.isCancelled)
-      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
-    }
+  // /** a newScheduledThreadPool successfully runs delayed task
+  //  */
+  // @throws[Exception]
+  // @Test def testNewScheduledThreadPool(): Unit =
+  //   usingPoolCleaner(Executors.newScheduledThreadPool(2)) { p =>
+  //     val proceed = new CountDownLatch(1)
+  //     val task = new CheckedRunnable() {
+  //       override def realRun(): Unit = { await(proceed) }
+  //     }
+  //     val startTime = System.nanoTime
+  //     val f = p.schedule(
+  //       Executors.callable(task, java.lang.Boolean.TRUE),
+  //       timeoutMillis(),
+  //       MILLISECONDS
+  //     )
+  //     assertFalse(f.isDone)
+  //     proceed.countDown()
+  //     assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+  //     assertSame(java.lang.Boolean.TRUE, f.get)
+  //     assertTrue(f.isDone)
+  //     assertFalse(f.isCancelled)
+  //     assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+  //   }
 
-  /** an unconfigurable newScheduledThreadPool successfully runs delayed task
-   */
-  @throws[Exception]
-  @Test def testUnconfigurableScheduledExecutorService(): Unit =
-    usingPoolCleaner(
-      Executors.unconfigurableScheduledExecutorService(
-        Executors.newScheduledThreadPool(2)
-      )
-    ) { p =>
-      val proceed = new CountDownLatch(1)
-      val task = new CheckedRunnable() {
-        override def realRun(): Unit = { await(proceed) }
-      }
-      val startTime = System.nanoTime
-      val f = p.schedule(
-        Executors.callable(task, java.lang.Boolean.TRUE),
-        timeoutMillis(),
-        MILLISECONDS
-      )
-      assertFalse(f.isDone)
-      proceed.countDown()
-      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
-      assertSame(java.lang.Boolean.TRUE, f.get)
-      assertTrue(f.isDone)
-      assertFalse(f.isCancelled)
-      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
-    }
+  // /** an unconfigurable newScheduledThreadPool successfully runs delayed task
+  //  */
+  // @throws[Exception]
+  // @Test def testUnconfigurableScheduledExecutorService(): Unit =
+  //   usingPoolCleaner(
+  //     Executors.unconfigurableScheduledExecutorService(
+  //       Executors.newScheduledThreadPool(2)
+  //     )
+  //   ) { p =>
+  //     val proceed = new CountDownLatch(1)
+  //     val task = new CheckedRunnable() {
+  //       override def realRun(): Unit = { await(proceed) }
+  //     }
+  //     val startTime = System.nanoTime
+  //     val f = p.schedule(
+  //       Executors.callable(task, java.lang.Boolean.TRUE),
+  //       timeoutMillis(),
+  //       MILLISECONDS
+  //     )
+  //     assertFalse(f.isDone)
+  //     proceed.countDown()
+  //     assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+  //     assertSame(java.lang.Boolean.TRUE, f.get)
+  //     assertTrue(f.isDone)
+  //     assertFalse(f.isCancelled)
+  //     assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+  //   }
 
   /** Future.get on submitted tasks will time out if they compute too long.
    */
@@ -255,8 +256,9 @@ class ExecutorsTest extends JSR166Test {
     val executors = Array(
       Executors.newSingleThreadExecutor,
       Executors.newCachedThreadPool,
-      Executors.newFixedThreadPool(2),
-      Executors.newScheduledThreadPool(2)
+      Executors.newFixedThreadPool(2)
+      // TODO
+      // Executors.newScheduledThreadPool(2)
     )
     val done = new CountDownLatch(1)
     val sleeper = new CheckedRunnable() {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorsTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorsTest.scala
@@ -1,0 +1,430 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.TimeUnit._
+
+import org.junit.Test
+import org.junit.Assert._
+import JSR166Test._
+
+class ExecutorsTest extends JSR166Test {
+
+  /** A newCachedThreadPool can execute runnables
+   */
+  @Test def testNewCachedThreadPool1(): Unit =
+    usingPoolCleaner(Executors.newCachedThreadPool) { e =>
+      e.execute(new NoOpRunnable)
+      e.execute(new NoOpRunnable)
+      e.execute(new NoOpRunnable)
+    }
+
+  /** A newCachedThreadPool with given ThreadFactory can execute runnables
+   */
+  @Test def testNewCachedThreadPool2(): Unit = usingPoolCleaner(
+    Executors.newCachedThreadPool(new SimpleThreadFactory)
+  ) { e =>
+    e.execute(new NoOpRunnable)
+    e.execute(new NoOpRunnable)
+    e.execute(new NoOpRunnable)
+  }
+
+  /** A newCachedThreadPool with null ThreadFactory throws NPE
+   */
+  @Test def testNewCachedThreadPool3(): Unit = {
+    try {
+      val unused = Executors.newCachedThreadPool(null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** A new SingleThreadExecutor can execute runnables
+   */
+  @Test def testNewSingleThreadExecutor1(): Unit =
+    usingPoolCleaner(Executors.newSingleThreadExecutor) { e =>
+      e.execute(new NoOpRunnable)
+      e.execute(new NoOpRunnable)
+      e.execute(new NoOpRunnable)
+    }
+
+  /** A new SingleThreadExecutor with given ThreadFactory can execute runnables
+   */
+  @Test def testNewSingleThreadExecutor2(): Unit = usingPoolCleaner(
+    Executors.newSingleThreadExecutor(new SimpleThreadFactory)
+  ) { e =>
+    e.execute(new NoOpRunnable)
+    e.execute(new NoOpRunnable)
+    e.execute(new NoOpRunnable)
+  }
+
+  /** A new SingleThreadExecutor with null ThreadFactory throws NPE
+   */
+  @Test def testNewSingleThreadExecutor3(): Unit = {
+    try {
+      val unused = Executors.newSingleThreadExecutor(null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** A new SingleThreadExecutor cannot be casted to concrete implementation
+   */
+  @Test def testCastNewSingleThreadExecutor(): Unit =
+    usingPoolCleaner(Executors.newSingleThreadExecutor) { e =>
+      try {
+        val tpe = e.asInstanceOf[ThreadPoolExecutor]
+        shouldThrow()
+      } catch {
+        case success: ClassCastException => ()
+      }
+    }
+
+  /** A new newFixedThreadPool can execute runnables
+   */
+  @Test def testNewFixedThreadPool1(): Unit =
+    usingPoolCleaner(Executors.newFixedThreadPool(2)) { e =>
+      e.execute(new NoOpRunnable)
+      e.execute(new NoOpRunnable)
+      e.execute(new NoOpRunnable)
+    }
+
+  /** A new newFixedThreadPool with given ThreadFactory can execute runnables
+   */
+  @Test def testNewFixedThreadPool2(): Unit = usingPoolCleaner(
+    Executors.newFixedThreadPool(2, new SimpleThreadFactory)
+  ) { e =>
+    e.execute(new NoOpRunnable)
+    e.execute(new NoOpRunnable)
+    e.execute(new NoOpRunnable)
+  }
+
+  /** A new newFixedThreadPool with null ThreadFactory throws
+   *  NullPointerException
+   */
+  @Test def testNewFixedThreadPool3(): Unit = {
+    try {
+      val unused = Executors.newFixedThreadPool(2, null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** A new newFixedThreadPool with 0 threads throws IllegalArgumentException
+   */
+  @Test def testNewFixedThreadPool4(): Unit = {
+    try {
+      val unused = Executors.newFixedThreadPool(0)
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** An unconfigurable newFixedThreadPool can execute runnables
+   */
+  @Test def testUnconfigurableExecutorService(): Unit = usingPoolCleaner(
+    Executors.unconfigurableExecutorService(Executors.newFixedThreadPool(2))
+  ) { e =>
+    e.execute(new NoOpRunnable)
+    e.execute(new NoOpRunnable)
+    e.execute(new NoOpRunnable)
+  }
+
+  /** unconfigurableExecutorService(null) throws NPE
+   */
+  @Test def testUnconfigurableExecutorServiceNPE(): Unit = {
+    try {
+      val unused =
+        Executors.unconfigurableExecutorService(null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** unconfigurableScheduledExecutorService(null) throws NPE
+   */
+  @Test def testUnconfigurableScheduledExecutorServiceNPE(): Unit = {
+    try {
+      val unused =
+        Executors.unconfigurableScheduledExecutorService(null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** a newSingleThreadScheduledExecutor successfully runs delayed task
+   */
+  @throws[Exception]
+  @Test def testNewSingleThreadScheduledExecutor(): Unit =
+    usingPoolCleaner(Executors.newSingleThreadScheduledExecutor) { p =>
+      val proceed = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = { await(proceed) }
+      }
+      val startTime = System.nanoTime
+      val f = p.schedule(
+        Executors.callable(task, java.lang.Boolean.TRUE),
+        timeoutMillis(),
+        MILLISECONDS
+      )
+      assertFalse(f.isDone)
+      proceed.countDown()
+      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+      assertSame(java.lang.Boolean.TRUE, f.get)
+      assertTrue(f.isDone)
+      assertFalse(f.isCancelled)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
+
+  /** a newScheduledThreadPool successfully runs delayed task
+   */
+  @throws[Exception]
+  @Test def testNewScheduledThreadPool(): Unit =
+    usingPoolCleaner(Executors.newScheduledThreadPool(2)) { p =>
+      val proceed = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = { await(proceed) }
+      }
+      val startTime = System.nanoTime
+      val f = p.schedule(
+        Executors.callable(task, java.lang.Boolean.TRUE),
+        timeoutMillis(),
+        MILLISECONDS
+      )
+      assertFalse(f.isDone)
+      proceed.countDown()
+      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+      assertSame(java.lang.Boolean.TRUE, f.get)
+      assertTrue(f.isDone)
+      assertFalse(f.isCancelled)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
+
+  /** an unconfigurable newScheduledThreadPool successfully runs delayed task
+   */
+  @throws[Exception]
+  @Test def testUnconfigurableScheduledExecutorService(): Unit =
+    usingPoolCleaner(
+      Executors.unconfigurableScheduledExecutorService(
+        Executors.newScheduledThreadPool(2)
+      )
+    ) { p =>
+      val proceed = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = { await(proceed) }
+      }
+      val startTime = System.nanoTime
+      val f = p.schedule(
+        Executors.callable(task, java.lang.Boolean.TRUE),
+        timeoutMillis(),
+        MILLISECONDS
+      )
+      assertFalse(f.isDone)
+      proceed.countDown()
+      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+      assertSame(java.lang.Boolean.TRUE, f.get)
+      assertTrue(f.isDone)
+      assertFalse(f.isCancelled)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
+
+  /** Future.get on submitted tasks will time out if they compute too long.
+   */
+  @throws[Exception]
+  @Test def testTimedCallable(): Unit = {
+    val executors = Array(
+      Executors.newSingleThreadExecutor,
+      Executors.newCachedThreadPool,
+      Executors.newFixedThreadPool(2),
+      Executors.newScheduledThreadPool(2)
+    )
+    val done = new CountDownLatch(1)
+    val sleeper = new CheckedRunnable() {
+      @throws[InterruptedException]
+      override def realRun(): Unit = { done.await(LONG_DELAY_MS, MILLISECONDS) }
+    }
+    val threads = new ArrayList[Thread]
+    executors.foreach { executor =>
+      threads.add(newStartedThread(new CheckedRunnable() {
+        override def realRun(): Unit = {
+          val future = executor.submit(sleeper)
+          assertFutureTimesOut(future)
+        }
+      }))
+    }
+    threads.forEach(awaitTermination(_))
+    done.countDown()
+    executors.foreach(joinPool(_))
+  }
+
+  /** ThreadPoolExecutor using defaultThreadFactory has specified group,
+   *  priority, daemon status, and name
+   */
+  @throws[Exception]
+  @Test def testDefaultThreadFactory(): Unit = {
+    val egroup = Thread.currentThread.getThreadGroup
+    val done = new CountDownLatch(1)
+    val r = new CheckedRunnable() {
+      override def realRun(): Unit = {
+        try {
+          val current = Thread.currentThread
+          assertFalse(current.isDaemon)
+          assertTrue(current.getPriority <= Thread.NORM_PRIORITY)
+          // val s = System.getSecurityManager
+          assertSame(
+            current.getThreadGroup,
+            // if (s == null)
+            egroup
+            // else s.getThreadGroup
+          )
+          assertTrue(current.getName.endsWith("thread-1"))
+        } catch {
+          case ok: SecurityException =>
+
+          // Also pass if not allowed to change setting
+        }
+        done.countDown()
+      }
+    }
+    usingPoolCleaner(
+      Executors.newSingleThreadExecutor(Executors.defaultThreadFactory)
+    ) { e =>
+      e.execute(r)
+      await(done)
+    }
+  }
+
+  // @Test def testPrivilegedThreadFactory(): Unit = ???
+  // @Test def testCreatePrivilegedCallableUsingCCLWithNoPrivs(): Unit = ???
+  // @Test def testPrivilegedCallableUsingCCLWithPrivs(): Unit = ???
+  // @Test def testPrivilegedCallableWithNoPrivs(): Unit = ???
+  // @Test def testPrivilegedCallableWithPrivs(): Unit = ???
+
+  /** callable(Runnable) returns null when called
+   */
+  @throws[Exception]
+  @Test def testCallable1(): Unit = {
+    val c = Executors.callable(new NoOpRunnable)
+    assertNull(c.call)
+  }
+
+  /** callable(Runnable, result) returns result when called
+   */
+  @throws[Exception]
+  @Test def testCallable2(): Unit = {
+    val c =
+      Executors.callable(new NoOpRunnable, one)
+    assertSame(one, c.call)
+  }
+
+  // privilagged callable
+  // @Test def testCallable3(): Unit = ???
+  // @Test def testCallable4(): Unit = ???
+
+  /** callable(null Runnable) throws NPE
+   */
+  @Test def testCallableNPE1(): Unit = {
+    try {
+      val unused = Executors.callable(null.asInstanceOf[Runnable])
+      shouldThrow()
+    } catch {
+      case success: NullPointerException => ()
+    }
+  }
+
+  /** callable(null, result) throws NPE
+   */
+  @Test def testCallableNPE2(): Unit = {
+    try {
+      val unused = Executors.callable(null.asInstanceOf[Runnable], one)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException => ()
+    }
+  }
+
+  // privilleged
+  // @Test def testCallableNPE3(): Unit = ???
+  // @Test def testCallableNPE4(): Unit = ???
+
+  /** callable(runnable, x).toString() contains toString of wrapped task
+   */
+  @Test def testCallable_withResult_toString(): Unit = {
+    if (testImplementationDetails) {
+      val r: Runnable = () => {
+        def foo() = {}
+        foo()
+      }
+      val c = Executors.callable(r, "")
+      assertEquals(
+        identityString(c) + "[Wrapped task = " + r.toString + "]",
+        c.toString
+      )
+    }
+  }
+
+  /** callable(runnable).toString() contains toString of wrapped task
+   */
+  @Test def testCallable_toString(): Unit = {
+    if (testImplementationDetails) {
+      val r: Runnable = () => {
+        def foo() = {}
+        foo()
+      }
+      val c = Executors.callable(r)
+      assertEquals(
+        identityString(c) + "[Wrapped task = " + r.toString + "]",
+        c.toString
+      )
+    }
+  }
+
+  /** privilegedCallable(callable).toString() contains toString of wrapped task
+   */
+  @deprecated @Test def testPrivilegedCallable_toString(): Unit = {
+    if (testImplementationDetails) {
+      val c: Callable[String] = () => ""
+      val priv = Executors.privilegedCallable(c)
+      assertEquals(
+        identityString(priv) + "[Wrapped task = " + c.toString + "]",
+        priv.toString
+      )
+    }
+  }
+
+  /** privilegedCallableUsingCurrentClassLoader(callable).toString() contains
+   *  toString of wrapped task
+   */
+  @deprecated @Test def testPrivilegedCallableUsingCurrentClassLoader_toString()
+      : Unit = {
+    if (testImplementationDetails) {
+      val c: Callable[String] = () => ""
+      val priv =
+        Executors.privilegedCallableUsingCurrentClassLoader(c)
+      assertEquals(
+        identityString(priv) + "[Wrapped task = " + c.toString + "]",
+        priv.toString
+      )
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTaskTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTaskTest.scala
@@ -350,7 +350,7 @@ class ForkJoinTaskTest extends JSR166Test {
         val f = new AsyncFib(8)
         assertNull("invoke", f.invoke())
         assertEquals(21, f.number)
-        checkCompletedNormally(f) // TODO: fails in one of the checks
+        checkCompletedNormally(f)
       }
     }
     testInvokeOnPool(mainPool, a)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/FutureTaskTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/FutureTaskTest.scala
@@ -886,42 +886,41 @@ class FutureTaskTest extends JSR166Test {
     }
   }
 
-  // TODO: ThreadPoolExecutor
-  // /** timed get with most negative timeout works correctly (i.e. no underflow
-  //  *  bug)
-  //  */
-  // @throws[Exception]
-  // @Test def testGet_NegativeInfinityTimeout(): Unit = {
-  //   assumeFalse(
-  //     "Fails due to bug in the JVM",
-  //     Platform.executingInJVMOnJDK8OrLower
-  //   )
-  //   val pool = Executors.newFixedThreadPool(10)
-  //   val nop = new Runnable() { override def run(): Unit = {} }
-  //   val task = new FutureTask[Void](nop, null)
-  //   val futures = new util.ArrayList[Future[AnyRef]]
-  //   val r: Runnable = new Runnable() {
-  //     override def run(): Unit = {
-  //       for (timeout <- Array[Long](0L, -1L, java.lang.Long.MIN_VALUE)) {
-  //         try {
-  //           task.get(timeout, NANOSECONDS)
-  //           shouldThrow()
-  //         } catch {
-  //           case success: TimeoutException => ()
-  //           case fail: Throwable           => threadUnexpectedException(fail)
-  //         }
-  //       }
-  //     }
-  //   }
-  //   for (i <- 0 until 10) {
-  //     val f = pool.submit(r)
-  //     futures.add(f.asInstanceOf[Future[AnyRef]])
-  //   }
-  //   try {
-  //     joinPool(pool)
-  //     futures.forEach(checkCompletedNormally(_, null))
-  //   } finally task.run() // last resort to help terminate
-  // }
+  /** timed get with most negative timeout works correctly (i.e. no underflow
+   *  bug)
+   */
+  @throws[Exception]
+  @Test def testGet_NegativeInfinityTimeout(): Unit = {
+    assumeFalse(
+      "Fails due to bug in the JVM",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+    val pool = Executors.newFixedThreadPool(10)
+    val nop = new Runnable() { override def run(): Unit = {} }
+    val task = new FutureTask[Void](nop, null)
+    val futures = new util.ArrayList[Future[AnyRef]]
+    val r: Runnable = new Runnable() {
+      override def run(): Unit = {
+        for (timeout <- Array[Long](0L, -1L, java.lang.Long.MIN_VALUE)) {
+          try {
+            task.get(timeout, NANOSECONDS)
+            shouldThrow()
+          } catch {
+            case success: TimeoutException => ()
+            case fail: Throwable           => threadUnexpectedException(fail)
+          }
+        }
+      }
+    }
+    for (i <- 0 until 10) {
+      val f = pool.submit(r)
+      futures.add(f.asInstanceOf[Future[AnyRef]])
+    }
+    try {
+      joinPool(pool)
+      futures.forEach(checkCompletedNormally(_, null))
+    } finally task.run() // last resort to help terminate
+  }
 
   /** toString indicates current completion state
    */

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
@@ -909,46 +909,47 @@ abstract class JSR166Test {
       assertSame(p, recorder.p)
 
       p match {
-        case s: ScheduledExecutorService =>
-          var future: ScheduledFuture[_] = null
+        // TODO: ScheduledExecutor
+        // case s: ScheduledExecutorService =>
+        //   var future: ScheduledFuture[_] = null
 
-          recorder.reset()
-          future = s.schedule(r, randomTimeout(), randomTimeUnit())
-          assertFalse(future.isDone())
-          if (stock)
-            assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
-          assertSame(p, recorder.p)
+        //   recorder.reset()
+        //   future = s.schedule(r, randomTimeout(), randomTimeUnit())
+        //   assertFalse(future.isDone())
+        //   if (stock)
+        //     assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
+        //   assertSame(p, recorder.p)
 
-          recorder.reset()
-          future = s.schedule(c, randomTimeout(), randomTimeUnit())
-          assertFalse(future.isDone())
-          if (stock)
-            assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
-          assertSame(p, recorder.p)
+        //   recorder.reset()
+        //   future = s.schedule(c, randomTimeout(), randomTimeUnit())
+        //   assertFalse(future.isDone())
+        //   if (stock)
+        //     assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
+        //   assertSame(p, recorder.p)
 
-          recorder.reset()
-          future = s.scheduleAtFixedRate(
-            r,
-            randomTimeout(),
-            LONG_DELAY_MS,
-            MILLISECONDS
-          )
-          assertFalse(future.isDone())
-          if (stock)
-            assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
-          assertSame(p, recorder.p)
+        //   recorder.reset()
+        //   future = s.scheduleAtFixedRate(
+        //     r,
+        //     randomTimeout(),
+        //     LONG_DELAY_MS,
+        //     MILLISECONDS
+        //   )
+        //   assertFalse(future.isDone())
+        //   if (stock)
+        //     assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
+        //   assertSame(p, recorder.p)
 
-          recorder.reset()
-          future = s.scheduleWithFixedDelay(
-            r,
-            randomTimeout(),
-            LONG_DELAY_MS,
-            MILLISECONDS
-          )
-          assertFalse(future.isDone())
-          if (stock)
-            assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
-          assertSame(p, recorder.p)
+        //   recorder.reset()
+        //   future = s.scheduleWithFixedDelay(
+        //     r,
+        //     randomTimeout(),
+        //     LONG_DELAY_MS,
+        //     MILLISECONDS
+        //   )
+        //   assertFalse(future.isDone())
+        //   if (stock)
+        //     assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
+        //   assertSame(p, recorder.p)
 
         case _ => ()
       }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/LinkedBlockingQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/LinkedBlockingQueueTest.scala
@@ -718,58 +718,57 @@ class LinkedBlockingQueueTest extends JSR166Test {
     for (i <- 0 until SIZE) { assertTrue(s.contains(String.valueOf(i))) }
   }
 
-  // TODO: ThreadPoolExecutor
-  // /** offer transfers elements across Executor tasks
-  //  */
-  // @Test def testOfferInExecutor(): Unit = {
-  //   val q = new LinkedBlockingQueue[Integer](2)
-  //   q.add(one)
-  //   q.add(two)
-  //   val threadsStarted = new CheckedBarrier(2)
-  //   usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         assertFalse(q.offer(three))
-  //         threadsStarted.await
-  //         assertTrue(q.offer(three, LONG_DELAY_MS, MILLISECONDS))
-  //         assertEquals(0, q.remainingCapacity)
-  //       }
-  //     })
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         threadsStarted.await
-  //         assertSame(one, q.take)
-  //       }
-  //     })
-  //   }
-  // }
+  /** offer transfers elements across Executor tasks
+   */
+  @Test def testOfferInExecutor(): Unit = {
+    val q = new LinkedBlockingQueue[Integer](2)
+    q.add(one)
+    q.add(two)
+    val threadsStarted = new CheckedBarrier(2)
+    usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(q.offer(three))
+          threadsStarted.await
+          assertTrue(q.offer(three, LONG_DELAY_MS, MILLISECONDS))
+          assertEquals(0, q.remainingCapacity)
+        }
+      })
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadsStarted.await
+          assertSame(one, q.take)
+        }
+      })
+    }
+  }
 
-  // /** timed poll retrieves elements across Executor threads
-  //  */
-  // @Test def testPollInExecutor(): Unit = {
-  //   val q = new LinkedBlockingQueue[Integer](2)
-  //   val threadsStarted = new CheckedBarrier(2)
-  //   usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         assertNull(q.poll)
-  //         threadsStarted.await
-  //         assertSame(one, q.poll(LONG_DELAY_MS, MILLISECONDS))
-  //         checkEmpty(q)
-  //       }
-  //     })
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         threadsStarted.await
-  //         q.put(one)
-  //       }
-  //     })
-  //   }
-  // }
+  /** timed poll retrieves elements across Executor threads
+   */
+  @Test def testPollInExecutor(): Unit = {
+    val q = new LinkedBlockingQueue[Integer](2)
+    val threadsStarted = new CheckedBarrier(2)
+    usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertNull(q.poll)
+          threadsStarted.await
+          assertSame(one, q.poll(LONG_DELAY_MS, MILLISECONDS))
+          checkEmpty(q)
+        }
+      })
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadsStarted.await
+          q.put(one)
+        }
+      })
+    }
+  }
 
   /** A deserialized/reserialized queue has same elements in same order
    */

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/PriorityBlockingQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/PriorityBlockingQueueTest.scala
@@ -527,30 +527,28 @@ class PriorityBlockingQueueTest extends JSR166Test {
     for (i <- 0 until SIZE) { assertTrue(s.contains(String.valueOf(i))) }
   }
 
-  // TODO: ThreadPoolExecutor
-  //
-  // @Test def testPollInExecutor(): Unit = {
-  //   val q = new PriorityBlockingQueue[Integer](2)
-  //   val threadsStarted: CheckedBarrier = new CheckedBarrier(2)
-  //   usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         assertNull(q.poll)
-  //         threadsStarted.await
-  //         assertSame(one, q.poll(LONG_DELAY_MS, MILLISECONDS))
-  //         checkEmpty(q)
-  //       }
-  //     })
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         threadsStarted.await
-  //         q.put(one)
-  //       }
-  //     })
-  //   }
-  // }
+  @Test def testPollInExecutor(): Unit = {
+    val q = new PriorityBlockingQueue[Integer](2)
+    val threadsStarted: CheckedBarrier = new CheckedBarrier(2)
+    usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertNull(q.poll)
+          threadsStarted.await
+          assertSame(one, q.poll(LONG_DELAY_MS, MILLISECONDS))
+          checkEmpty(q)
+        }
+      })
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadsStarted.await
+          q.put(one)
+        }
+      })
+    }
+  }
 
   @throws[Exception]
   @Ignore("No ObjectInputStream in Scala Native")

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/SynchronousQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/SynchronousQueueTest.scala
@@ -422,58 +422,55 @@ class SynchronousQueueTest extends JSR166Test {
     assertNotNull(s)
   }
 
-  // TODO: ThreadPoolExecutor
-  //
-  // @Test def testOfferInExecutor(): Unit = testOfferInExecutor(false)
-  // @Test def testOfferInExecutor_fair(): Unit = testOfferInExecutor(true)
-  // def testOfferInExecutor(fair: Boolean): Unit = {
-  //   val q = new SynchronousQueue[Any](fair)
-  //   val threadsStarted = new CheckedBarrier(2)
-  //   usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         assertFalse(q.offer(one))
-  //         threadsStarted.await
-  //         assertTrue(q.offer(one, LONG_DELAY_MS, MILLISECONDS))
-  //         assertEquals(0, q.remainingCapacity)
-  //       }
-  //     })
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         threadsStarted.await
-  //         assertSame(one, q.take)
-  //       }
-  //     })
-  //   }
-  // }
+  @Test def testOfferInExecutor(): Unit = testOfferInExecutor(false)
+  @Test def testOfferInExecutor_fair(): Unit = testOfferInExecutor(true)
+  def testOfferInExecutor(fair: Boolean): Unit = {
+    val q = new SynchronousQueue[Any](fair)
+    val threadsStarted = new CheckedBarrier(2)
+    usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(q.offer(one))
+          threadsStarted.await
+          assertTrue(q.offer(one, LONG_DELAY_MS, MILLISECONDS))
+          assertEquals(0, q.remainingCapacity)
+        }
+      })
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadsStarted.await
+          assertSame(one, q.take)
+        }
+      })
+    }
+  }
 
-  //
-  // @Test def testPollInExecutor(): Unit = testPollInExecutor(false)
-  // @Test def testPollInExecutor_fair(): Unit = testPollInExecutor(true)
-  // def testPollInExecutor(fair: Boolean): Unit = {
-  //   val q = new SynchronousQueue[Any](fair)
-  //   val threadsStarted = new CheckedBarrier(2)
-  //   usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         assertNull(q.poll)
-  //         threadsStarted.await
-  //         assertSame(one, q.poll(LONG_DELAY_MS, MILLISECONDS))
-  //         assertTrue(q.isEmpty)
-  //       }
-  //     })
-  //     executor.execute(new CheckedRunnable() {
-  //       @throws[InterruptedException]
-  //       override def realRun(): Unit = {
-  //         threadsStarted.await
-  //         q.put(one)
-  //       }
-  //     })
-  //   }
-  // }
+  @Test def testPollInExecutor(): Unit = testPollInExecutor(false)
+  @Test def testPollInExecutor_fair(): Unit = testPollInExecutor(true)
+  def testPollInExecutor(fair: Boolean): Unit = {
+    val q = new SynchronousQueue[Any](fair)
+    val threadsStarted = new CheckedBarrier(2)
+    usingPoolCleaner(Executors.newFixedThreadPool(2)) { executor =>
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertNull(q.poll)
+          threadsStarted.await
+          assertSame(one, q.poll(LONG_DELAY_MS, MILLISECONDS))
+          assertTrue(q.isEmpty)
+        }
+      })
+      executor.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadsStarted.await
+          q.put(one)
+        }
+      })
+    }
+  }
 
   @Ignore("No Object Input Streams in Scala Native")
   @Test def testSerialization(): Unit = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ThreadPoolExecutorSubclassTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ThreadPoolExecutorSubclassTest.scala
@@ -1,0 +1,2458 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit._
+import java.util
+import java.util._
+import java.util.Collections
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks._
+
+import org.junit._
+import org.junit.Assert._
+
+import JSR166Test._
+
+object ThreadPoolExecutorSubclassTest {
+  class CustomTask[V](callable: Callable[V]) extends RunnableFuture[V] {
+    if (callable == null) throw new NullPointerException
+    def this(r: Runnable, res: V) = this({
+      if (r == null) throw new NullPointerException
+      () => {
+        r.run()
+        res
+      }
+    }: Callable[V])
+    var result: V = _
+    var exception: Exception = _
+    var thread: Thread = _
+
+    final val lock = new ReentrantLock
+    final val cond = lock.newCondition
+    var done = false
+    var cancelled = false
+    override def isDone: Boolean = {
+      lock.lock()
+      try done
+      finally lock.unlock()
+    }
+    override def isCancelled: Boolean = {
+      lock.lock()
+      try cancelled
+      finally lock.unlock()
+    }
+    override def cancel(mayInterrupt: Boolean): Boolean = {
+      lock.lock()
+      try {
+        if (!done) {
+          cancelled = true
+          done = true
+          if (mayInterrupt && thread != null) thread.interrupt()
+          return true
+        }
+        false
+      } finally lock.unlock()
+    }
+    override def run(): Unit = {
+      lock.lock()
+      try {
+        if (done) return
+        thread = Thread.currentThread
+      } finally lock.unlock()
+
+      var v: V = null.asInstanceOf[V]
+      var e: Exception = null
+      try v = callable.call()
+      catch {
+        case ex: Exception =>
+          e = ex
+      }
+      lock.lock()
+      try
+        if (!done) {
+          result = v
+          exception = e
+          done = true
+          thread = null
+          cond.signalAll()
+        }
+      finally lock.unlock()
+    }
+    @throws[InterruptedException]
+    @throws[ExecutionException]
+    override def get: V = {
+      lock.lock()
+      try {
+        while (!done) cond.await()
+        if (cancelled) throw new CancellationException
+        if (exception != null) throw new ExecutionException(exception)
+        result
+      } finally lock.unlock()
+    }
+    @throws[InterruptedException]
+    @throws[ExecutionException]
+    @throws[TimeoutException]
+    override def get(timeout: Long, unit: TimeUnit): V = {
+      var nanos = unit.toNanos(timeout)
+      lock.lock()
+      try {
+        while (!done) {
+          if (nanos <= 0L) throw new TimeoutException
+          nanos = cond.awaitNanos(nanos)
+        }
+        if (cancelled) throw new CancellationException
+        if (exception != null) throw new ExecutionException(exception)
+        result
+      } finally lock.unlock()
+    }
+  }
+  class CustomTPE(
+      corePoolSize: Int,
+      maximumPoolSize: Int,
+      keepAliveTime: Long,
+      unit: TimeUnit,
+      workQueue: BlockingQueue[Runnable],
+      threadFactory: ThreadFactory,
+      handler: RejectedExecutionHandler
+  ) extends ThreadPoolExecutor(
+        corePoolSize,
+        maximumPoolSize,
+        keepAliveTime,
+        unit,
+        workQueue,
+        threadFactory,
+        handler
+      ) {
+    override protected def newTaskFor[V](c: Callable[V]) =
+      new CustomTask[V](c)
+    override protected def newTaskFor[V](r: Runnable, v: V) =
+      new CustomTask[V](r, v)
+    def this(
+        corePoolSize: Int,
+        maximumPoolSize: Int,
+        keepAliveTime: Long,
+        unit: TimeUnit,
+        workQueue: BlockingQueue[Runnable],
+        threadFactory: ThreadFactory
+    ) =
+      this(
+        corePoolSize,
+        maximumPoolSize,
+        keepAliveTime,
+        unit,
+        workQueue,
+        threadFactory,
+        new ThreadPoolExecutor.AbortPolicy()
+      )
+    def this(
+        corePoolSize: Int,
+        maximumPoolSize: Int,
+        keepAliveTime: Long,
+        unit: TimeUnit,
+        workQueue: BlockingQueue[Runnable]
+    ) = this(
+      corePoolSize,
+      maximumPoolSize,
+      keepAliveTime,
+      unit,
+      workQueue,
+      Executors.defaultThreadFactory()
+    )
+    def this(
+        corePoolSize: Int,
+        maximumPoolSize: Int,
+        keepAliveTime: Long,
+        unit: TimeUnit,
+        workQueue: BlockingQueue[Runnable],
+        handler: RejectedExecutionHandler
+    ) =
+      this(
+        corePoolSize,
+        maximumPoolSize,
+        keepAliveTime,
+        unit,
+        workQueue,
+        Executors.defaultThreadFactory(),
+        handler
+      )
+    def this() =
+      this(1, 1, LONG_DELAY_MS, MILLISECONDS, new SynchronousQueue[Runnable])
+    final val beforeCalledLatch = new CountDownLatch(1)
+    final val afterCalledLatch = new CountDownLatch(1)
+    final val terminatedCalledLatch = new CountDownLatch(1)
+    override protected def beforeExecute(t: Thread, r: Runnable): Unit = {
+      beforeCalledLatch.countDown()
+    }
+    override protected def afterExecute(r: Runnable, t: Throwable): Unit = {
+      afterCalledLatch.countDown()
+    }
+    override protected def terminated(): Unit = {
+      terminatedCalledLatch.countDown()
+    }
+    def beforeCalled: Boolean = beforeCalledLatch.getCount == 0
+    def afterCalled: Boolean = afterCalledLatch.getCount == 0
+    def terminatedCalled: Boolean = terminatedCalledLatch.getCount == 0
+  }
+  class FailingThreadFactory extends ThreadFactory {
+    var calls = 0
+    override def newThread(r: Runnable): Thread = {
+      if ({ calls += 1; calls } > 1) return null
+      new Thread(r)
+    }
+  }
+}
+class ThreadPoolExecutorSubclassTest extends JSR166Test {
+  import JSR166Test._
+  import ThreadPoolExecutorSubclassTest._
+
+  /** execute successfully executes a runnable
+   */
+  @throws[InterruptedException]
+  @Test def testExecute(): Unit = {
+    val p = new CustomTPE(
+      1,
+      1,
+      2 * LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val done = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = { done.countDown() }
+      }
+      p.execute(task)
+      await(done)
+
+    }
+  }
+
+  /** getActiveCount increases but doesn't overestimate, when a thread becomes
+   *  active
+   */
+  @throws[InterruptedException]
+  @Test def testGetActiveCount(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getActiveCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getActiveCount)
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getActiveCount)
+    }
+  }
+
+  /** prestartCoreThread starts a thread if under corePoolSize, else doesn't
+   */
+  @Test def testPrestartCoreThread(): Unit = {
+    val p = new CustomTPE(
+      2,
+      6,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertEquals(0, p.getPoolSize)
+      assertTrue(p.prestartCoreThread)
+      assertEquals(1, p.getPoolSize)
+      assertTrue(p.prestartCoreThread)
+      assertEquals(2, p.getPoolSize)
+      assertFalse(p.prestartCoreThread)
+      assertEquals(2, p.getPoolSize)
+      p.setCorePoolSize(4)
+      assertTrue(p.prestartCoreThread)
+      assertEquals(3, p.getPoolSize)
+      assertTrue(p.prestartCoreThread)
+      assertEquals(4, p.getPoolSize)
+      assertFalse(p.prestartCoreThread)
+      assertEquals(4, p.getPoolSize)
+
+    }
+  }
+
+  /** prestartAllCoreThreads starts all corePoolSize threads
+   */
+  @Test def testPrestartAllCoreThreads(): Unit = {
+    val p = new CustomTPE(
+      2,
+      6,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertEquals(0, p.getPoolSize)
+      p.prestartAllCoreThreads
+      assertEquals(2, p.getPoolSize)
+      p.prestartAllCoreThreads
+      assertEquals(2, p.getPoolSize)
+      p.setCorePoolSize(4)
+      p.prestartAllCoreThreads
+      assertEquals(4, p.getPoolSize)
+      p.prestartAllCoreThreads
+      assertEquals(4, p.getPoolSize)
+
+    }
+  }
+
+  /** getCompletedTaskCount increases, but doesn't overestimate, when tasks
+   *  complete
+   */
+  @throws[InterruptedException]
+  @Test def testGetCompletedTaskCount(): Unit = {
+    val p = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val threadProceed = new CountDownLatch(1)
+      val threadDone = new CountDownLatch(1)
+      assertEquals(0, p.getCompletedTaskCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(0, p.getCompletedTaskCount)
+          await(threadProceed)
+          threadDone.countDown()
+        }
+      })
+      await(threadStarted)
+      assertEquals(0, p.getCompletedTaskCount)
+      threadProceed.countDown()
+      await(threadDone)
+      val startTime = System.nanoTime
+      while (p.getCompletedTaskCount != 1) {
+        if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
+        Thread.`yield`()
+      }
+
+    }
+  }
+
+  /** getCorePoolSize returns size given in constructor if not otherwise set
+   */
+  @Test def testGetCorePoolSize(): Unit = {
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p => assertEquals(1, p.getCorePoolSize) }
+  }
+
+  /** getKeepAliveTime returns value given in constructor if not otherwise set
+   */
+  @Test def testGetKeepAliveTime(): Unit = {
+    val p = new CustomTPE(
+      2,
+      2,
+      1000,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p => assertEquals(1, p.getKeepAliveTime(SECONDS)) }
+  }
+
+  /** getThreadFactory returns factory in constructor if not set
+   */
+  @Test def testGetThreadFactory(): Unit = {
+    val threadFactory = new SimpleThreadFactory
+    val p = new CustomTPE(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10),
+      threadFactory,
+      new NoOpREHandler
+    )
+    usingPoolCleaner(p) { p => assertSame(threadFactory, p.getThreadFactory) }
+  }
+
+  /** setThreadFactory sets the thread factory returned by getThreadFactory
+   */
+  @Test def testSetThreadFactory(): Unit = {
+    val p = new CustomTPE(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadFactory = new SimpleThreadFactory
+      p.setThreadFactory(threadFactory)
+      assertSame(threadFactory, p.getThreadFactory)
+
+    }
+  }
+
+  /** setThreadFactory(null) throws NPE
+   */
+  @Test def testSetThreadFactoryNull(): Unit = {
+    val p = new CustomTPE(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setThreadFactory(null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+  }
+
+  /** getRejectedExecutionHandler returns handler in constructor if not set
+   */
+  @Test def testGetRejectedExecutionHandler(): Unit = {
+    val handler = new NoOpREHandler
+    val p = new CustomTPE(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10),
+      handler
+    )
+    usingPoolCleaner(p) { p =>
+      assertSame(handler, p.getRejectedExecutionHandler)
+
+    }
+  }
+
+  /** setRejectedExecutionHandler sets the handler returned by
+   *  getRejectedExecutionHandler
+   */
+  @Test def testSetRejectedExecutionHandler(): Unit = {
+    val p = new CustomTPE(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val handler = new NoOpREHandler
+      p.setRejectedExecutionHandler(handler)
+      assertSame(handler, p.getRejectedExecutionHandler)
+
+    }
+  }
+
+  /** setRejectedExecutionHandler(null) throws NPE
+   */
+  @Test def testSetRejectedExecutionHandlerNull(): Unit = {
+    val p = new CustomTPE(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setRejectedExecutionHandler(null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+
+    }
+  }
+
+  /** getLargestPoolSize increases, but doesn't overestimate, when multiple
+   *  threads active
+   */
+  @throws[InterruptedException]
+  @Test def testGetLargestPoolSize(): Unit = {
+    val THREADS = 3
+    val done = new CountDownLatch(1)
+    val p = new CustomTPE(
+      THREADS,
+      THREADS,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      assertEquals(0, p.getLargestPoolSize)
+      val threadsStarted = new CountDownLatch(THREADS)
+      for (i <- 0 until THREADS) {
+        p.execute(new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadsStarted.countDown()
+            await(done)
+            assertEquals(THREADS, p.getLargestPoolSize)
+          }
+        })
+      }
+      await(threadsStarted)
+      assertEquals(THREADS, p.getLargestPoolSize)
+
+    }
+    assertEquals(THREADS, p.getLargestPoolSize)
+  }
+
+  /** getMaximumPoolSize returns value given in constructor if not otherwise set
+   */
+  @Test def testGetMaximumPoolSize(): Unit = {
+    val p = new CustomTPE(
+      2,
+      3,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertEquals(3, p.getMaximumPoolSize)
+      p.setMaximumPoolSize(5)
+      assertEquals(5, p.getMaximumPoolSize)
+      p.setMaximumPoolSize(4)
+      assertEquals(4, p.getMaximumPoolSize)
+
+    }
+  }
+
+  /** getPoolSize increases, but doesn't overestimate, when threads become
+   *  active
+   */
+  @throws[InterruptedException]
+  @Test def testGetPoolSize(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      assertEquals(0, p.getPoolSize)
+      val threadStarted = new CountDownLatch(1)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getPoolSize)
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getPoolSize)
+
+    }
+  }
+
+  /** getTaskCount increases, but doesn't overestimate, when tasks submitted
+   */
+  @throws[InterruptedException]
+  @Test def testGetTaskCount(): Unit = {
+    val TASKS = 3
+    val done = new CountDownLatch(1)
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+      for (i <- 0 until TASKS) {
+        assertEquals(1 + i, p.getTaskCount)
+        p.execute(new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            assertEquals(1 + TASKS, p.getTaskCount)
+            await(done)
+          }
+        })
+      }
+      assertEquals(1 + TASKS, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+
+    }
+    assertEquals(1 + TASKS, p.getTaskCount)
+    assertEquals(1 + TASKS, p.getCompletedTaskCount)
+  }
+
+  /** isShutdown is false before shutdown, true after
+   */
+  @Test def testIsShutdown(): Unit = {
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertFalse(p.isShutdown)
+      try p.shutdown()
+      catch { case ok: SecurityException => () }
+      assertTrue(p.isShutdown)
+
+    }
+  }
+
+  /** isTerminated is false before termination, true after
+   */
+  @throws[InterruptedException]
+  @Test def testIsTerminated(): Unit = {
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val done = new CountDownLatch(1)
+      assertFalse(p.isTerminating)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(p.isTerminating)
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertFalse(p.isTerminating)
+      done.countDown()
+      try p.shutdown()
+      catch { case ok: SecurityException => }
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated)
+      assertFalse(p.isTerminating)
+
+    }
+  }
+
+  /** isTerminating is not true when running or when terminated
+   */
+  @throws[InterruptedException]
+  @Test def testIsTerminating(): Unit = {
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val done = new CountDownLatch(1)
+      assertFalse(p.isTerminating)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(p.isTerminating)
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertFalse(p.isTerminating)
+      done.countDown()
+      try p.shutdown()
+      catch { case ok: SecurityException => }
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated)
+      assertFalse(p.isTerminating)
+
+    }
+  }
+
+  /** getQueue returns the work queue, which contains queued tasks
+   */
+  @throws[InterruptedException]
+  @Test def testGetQueue(): Unit = {
+    val done = new CountDownLatch(1)
+    val q = new ArrayBlockingQueue[Runnable](10)
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      q
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val tasks = new Array[FutureTask[_]](5)
+      for (i <- 0 until tasks.length) {
+        val task = new CheckedCallable[Boolean]() {
+          @throws[InterruptedException]
+          override def realCall(): Boolean = {
+            threadStarted.countDown()
+            assertSame(q, p.getQueue)
+            await(done)
+            java.lang.Boolean.TRUE
+          }
+        }
+        tasks(i) = new FutureTask(task)
+        p.execute(tasks(i))
+      }
+      await(threadStarted)
+      assertSame(q, p.getQueue)
+      assertFalse(q.contains(tasks(0)))
+      assertTrue(q.contains(tasks(tasks.length - 1)))
+      assertEquals(tasks.length - 1, q.size)
+
+    }
+  }
+
+  /** remove(task) removes queued task, and fails to remove active task
+   */
+  @throws[InterruptedException]
+  @Test def testRemove(): Unit = {
+    val done = new CountDownLatch(1)
+    val q = new ArrayBlockingQueue[Runnable](10)
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      q
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val tasks = new Array[Runnable](6)
+      val threadStarted = new CountDownLatch(1)
+      for (i <- 0 until tasks.length) {
+        tasks(i) = new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            await(done)
+          }
+        }
+        p.execute(tasks(i))
+      }
+      await(threadStarted)
+      assertFalse(p.remove(tasks(0)))
+      assertTrue(q.contains(tasks(4)))
+      assertTrue(q.contains(tasks(3)))
+      assertTrue(p.remove(tasks(4)))
+      assertFalse(p.remove(tasks(4)))
+      assertFalse(q.contains(tasks(4)))
+      assertTrue(q.contains(tasks(3)))
+      assertTrue(p.remove(tasks(3)))
+      assertFalse(q.contains(tasks(3)))
+
+    }
+  }
+
+  /** purge removes cancelled tasks from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testPurge(): Unit = {
+    val threadStarted = new CountDownLatch(1)
+    val done = new CountDownLatch(1)
+    val q = new ArrayBlockingQueue[Runnable](10)
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      q
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val tasks = new Array[FutureTask[_]](5)
+      for (i <- 0 until tasks.length) {
+        val task = new CheckedCallable[Boolean]() {
+          @throws[InterruptedException]
+          override def realCall(): Boolean = {
+            threadStarted.countDown()
+            await(done)
+            java.lang.Boolean.TRUE
+          }
+        }
+        tasks(i) = new FutureTask(task)
+        p.execute(tasks(i))
+      }
+      await(threadStarted)
+      assertEquals(tasks.length, p.getTaskCount)
+      assertEquals(tasks.length - 1, q.size)
+      assertEquals(1L, p.getActiveCount)
+      assertEquals(0L, p.getCompletedTaskCount)
+      tasks(4).cancel(true)
+      tasks(3).cancel(false)
+      p.purge()
+      assertEquals(tasks.length - 3, q.size)
+      assertEquals(tasks.length - 2, p.getTaskCount)
+      p.purge() // Nothing to do
+
+      assertEquals(tasks.length - 3, q.size)
+      assertEquals(tasks.length - 2, p.getTaskCount)
+
+    }
+  }
+
+  /** shutdownNow returns a list containing tasks that were not run, and those
+   *  tasks are drained from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testShutdownNow(): Unit = {
+    val poolSize = 2
+    val count = 5
+    val ran = new AtomicInteger(0)
+    val p = new CustomTPE(
+      poolSize,
+      poolSize,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    val threadsStarted = new CountDownLatch(poolSize)
+    val waiter = new CheckedRunnable() {
+      override def realRun(): Unit = {
+        threadsStarted.countDown()
+        try MILLISECONDS.sleep(LONGER_DELAY_MS)
+        catch {
+          case success: InterruptedException =>
+
+        }
+        ran.getAndIncrement
+      }
+    }
+    for (i <- 0 until count) { p.execute(waiter) }
+    await(threadsStarted)
+    assertEquals(poolSize, p.getActiveCount)
+    assertEquals(0, p.getCompletedTaskCount)
+    try {
+      val queuedTasks = p.shutdownNow
+      assertTrue(p.isShutdown)
+      assertTrue(p.getQueue.isEmpty)
+      assertEquals(count - poolSize, queuedTasks.size)
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated)
+      assertEquals(poolSize, ran.get)
+      assertEquals(poolSize, p.getCompletedTaskCount)
+    } catch {
+      case ok: SecurityException => // Allowed in case test doesn't have privs
+    }
+
+  }
+
+  /** Constructor throws if corePoolSize argument is less than zero
+   */
+  // Exception Tests
+  @Test def testConstructor1(): Unit = {
+    try {
+      new CustomTPE(
+        -1,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is less than zero
+   */
+  @Test def testConstructor2(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        -1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is equal to zero
+   */
+  @Test def testConstructor3(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        0,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if keepAliveTime is less than zero
+   */
+  @Test def testConstructor4(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        -1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if corePoolSize is greater than the maximumPoolSize
+   */
+  @Test def testConstructor5(): Unit = {
+    try {
+      new CustomTPE(
+        2,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if workQueue is set to null
+   */
+  @Test def testConstructorNullPointerException(): Unit = {
+    try {
+      new CustomTPE(1, 2, 1L, SECONDS, null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if corePoolSize argument is less than zero
+   */
+  @Test def testConstructor6(): Unit = {
+    try {
+      new CustomTPE(
+        -1,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is less than zero
+   */
+  @Test def testConstructor7(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        -1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is equal to zero
+   */
+  @Test def testConstructor8(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        0,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if keepAliveTime is less than zero
+   */
+  @Test def testConstructor9(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        -1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if corePoolSize is greater than the maximumPoolSize
+   */
+  @Test def testConstructor10(): Unit = {
+    try {
+      new CustomTPE(
+        2,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if workQueue is set to null
+   */
+  @Test def testConstructorNullPointerException2(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        1L,
+        SECONDS,
+        null,
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if threadFactory is set to null
+   */
+  @Test def testConstructorNullPointerException3(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        null.asInstanceOf[ThreadFactory]
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if corePoolSize argument is less than zero
+   */
+  @Test def testConstructor11(): Unit = {
+    try {
+      new CustomTPE(
+        -1,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is less than zero
+   */
+  @Test def testConstructor12(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        -1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is equal to zero
+   */
+  @Test def testConstructor13(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        0,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if keepAliveTime is less than zero
+   */
+  @Test def testConstructor14(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        -1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if corePoolSize is greater than the maximumPoolSize
+   */
+  @Test def testConstructor15(): Unit = {
+    try {
+      new CustomTPE(
+        2,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if workQueue is set to null
+   */
+  @Test def testConstructorNullPointerException4(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        1L,
+        SECONDS,
+        null,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if handler is set to null
+   */
+  @Test def testConstructorNullPointerException5(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        null.asInstanceOf[RejectedExecutionHandler]
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if corePoolSize argument is less than zero
+   */
+  @Test def testConstructor16(): Unit = {
+    try {
+      new CustomTPE(
+        -1,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is less than zero
+   */
+  @Test def testConstructor17(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        -1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is equal to zero
+   */
+  @Test def testConstructor18(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        0,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if keepAliveTime is less than zero
+   */
+  @Test def testConstructor19(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        -1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if corePoolSize is greater than the maximumPoolSize
+   */
+  @Test def testConstructor20(): Unit = {
+    try {
+      new CustomTPE(
+        2,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if workQueue is null
+   */
+  @Test def testConstructorNullPointerException6(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        1L,
+        SECONDS,
+        null,
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if handler is null
+   */
+  @Test def testConstructorNullPointerException7(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        null.asInstanceOf[RejectedExecutionHandler]
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if ThreadFactory is null
+   */
+  @Test def testConstructorNullPointerException8(): Unit = {
+    try {
+      new CustomTPE(
+        1,
+        2,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        null.asInstanceOf[ThreadFactory],
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Submitted tasks are rejected when saturated or shutdown
+   */
+  @throws[InterruptedException]
+  @Test def testSubmittedTasksRejectedWhenSaturatedOrShutdown(): Unit = {
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](1)
+    )
+    val saturatedSize = JSR166Test.saturatedSize(p)
+    val rnd = ThreadLocalRandom.current()
+    val threadsStarted = new CountDownLatch(p.getMaximumPoolSize())
+    val done = new CountDownLatch(1)
+    val r: CheckedRunnable = () => {
+      threadsStarted.countDown()
+      var break = false
+      while (!break)
+        try {
+          done.await()
+          break = true
+        } catch { case shutdownNowDeliberatelyIgnored: InterruptedException => }
+    }
+    val c: CheckedCallable[java.lang.Boolean] = () => {
+      threadsStarted.countDown()
+      var break = false
+      while (!break) try {
+        done.await()
+        break = true
+      } catch { case shutdownNowDeliberatelyIgnored: InterruptedException => }
+      java.lang.Boolean.TRUE
+    }
+    val shutdownNow = rnd.nextBoolean()
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      // saturate
+      for (i <- saturatedSize until 0 by -1) {
+        rnd.nextInt(4) match {
+          case 0 => p.execute(r)
+          case 1 => assertFalse(p.submit(r).isDone)
+          case 2 => assertFalse(p.submit(r, java.lang.Boolean.TRUE).isDone)
+          case 3 => assertFalse(p.submit(c).isDone)
+        }
+      }
+      await(threadsStarted)
+      assertTaskSubmissionsAreRejected(p)
+      if (shutdownNow) p.shutdownNow
+      else p.shutdown()
+      // Pool is shutdown, but not yet terminated
+      assertTaskSubmissionsAreRejected(p)
+      assertFalse(p.isTerminated)
+      done.countDown() // release blocking tasks
+
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTaskSubmissionsAreRejected(p)
+
+    }
+    assertEquals(
+      JSR166Test.saturatedSize(p) -
+        (if (shutdownNow) p.getQueue.remainingCapacity else 0),
+      p.getCompletedTaskCount
+    )
+  }
+
+  /** executor using DiscardOldestPolicy drops oldest task if saturated.
+   */
+  @Test def testSaturatedExecute_DiscardOldestPolicy(): Unit = {
+    val done = new CountDownLatch(1)
+    val r1 = awaiter(done)
+    val r2 = awaiter(done)
+    val r3 = awaiter(done)
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](1),
+      new ThreadPoolExecutor.DiscardOldestPolicy
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      assertEquals(LatchAwaiter.NEW, r1.state)
+      assertEquals(LatchAwaiter.NEW, r2.state)
+      assertEquals(LatchAwaiter.NEW, r3.state)
+      p.execute(r1)
+      p.execute(r2)
+      assertTrue(p.getQueue.contains(r2))
+      p.execute(r3)
+      assertFalse(p.getQueue.contains(r2))
+      assertTrue(p.getQueue.contains(r3))
+
+    }
+    assertEquals(LatchAwaiter.DONE, r1.state)
+    assertEquals(LatchAwaiter.NEW, r2.state)
+    assertEquals(LatchAwaiter.DONE, r3.state)
+  }
+
+  /** execute using DiscardOldestPolicy drops task on shutdown
+   */
+  @Test def testDiscardOldestOnShutdown(): Unit = {
+    val p = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](1),
+      new ThreadPoolExecutor.DiscardOldestPolicy
+    )
+    try p.shutdown()
+    catch {
+      case ok: SecurityException =>
+        return
+    }
+    usingPoolCleaner(p) { p =>
+      val r = new TrackedNoOpRunnable
+      p.execute(r)
+      assertFalse(r.done)
+
+    }
+  }
+
+  /** Submitting null tasks throws NullPointerException
+   */
+  @Test def testNullTaskSubmission(): Unit = {
+    val p = new CustomTPE(
+      1,
+      2,
+      1L,
+      SECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertNullTaskSubmissionThrowsNullPointerException(p)
+
+    }
+  }
+
+  /** setCorePoolSize of negative value throws IllegalArgumentException
+   */
+  @Test def testCorePoolSizeIllegalArgumentException(): Unit = {
+    val p = new CustomTPE(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setCorePoolSize(-1)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** setMaximumPoolSize(int) throws IllegalArgumentException if given a value
+   *  less the core pool size
+   */
+  @Test def testMaximumPoolSizeIllegalArgumentException(): Unit = {
+    val p = new CustomTPE(
+      2,
+      3,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setMaximumPoolSize(1)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** setMaximumPoolSize throws IllegalArgumentException if given a negative
+   *  value
+   */
+  @Test def testMaximumPoolSizeIllegalArgumentException2(): Unit = {
+    val p = new CustomTPE(
+      2,
+      3,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setMaximumPoolSize(-1)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** setKeepAliveTime throws IllegalArgumentException when given a negative
+   *  value
+   */
+  @Test def testKeepAliveTimeIllegalArgumentException(): Unit = {
+    val p = new CustomTPE(
+      2,
+      3,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setKeepAliveTime(-1, MILLISECONDS)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** terminated() is called on termination
+   */
+  @Test def testTerminated(): Unit = {
+    val p = new CustomTPE
+    usingPoolCleaner(p) { p =>
+      try p.shutdown()
+      catch { case ok: SecurityException => }
+      assertTrue(p.terminatedCalled)
+      assertTrue(p.isShutdown)
+
+    }
+  }
+
+  /** beforeExecute and afterExecute are called when executing task
+   */
+  @throws[InterruptedException]
+  @Test def testBeforeAfter(): Unit = {
+    val p = new CustomTPE
+    usingPoolCleaner(p) { p =>
+      val done = new CountDownLatch(1)
+      p.execute(new CheckedRunnable() {
+        override def realRun(): Unit = { done.countDown() }
+      })
+      await(p.afterCalledLatch)
+      assertEquals(0, done.getCount)
+      assertTrue(p.afterCalled)
+      assertTrue(p.beforeCalled)
+
+    }
+  }
+
+  /** completed submit of callable returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitCallable(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val future = e.submit(new StringTask)
+      val result = future.get
+      assertSame(TEST_STRING, result)
+
+    }
+  }
+
+  /** completed submit of runnable returns successfully
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val future = e.submit(new NoOpRunnable)
+      future.get
+      assertTrue(future.isDone)
+
+    }
+  }
+
+  /** completed submit of (runnable, result) returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable2(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val future = e.submit(new NoOpRunnable, TEST_STRING)
+      val result = future.get
+      assertSame(TEST_STRING, result)
+
+    }
+  }
+
+  /** invokeAny(null) throws NullPointerException
+   */
+  @throws[Exception]
+  @Test def testInvokeAny1(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAny(null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+    }
+  }
+
+  /** invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testInvokeAny2(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAny(new util.ArrayList[Callable[String]])
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** invokeAny(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAny3(): Unit = {
+    val latch = new CountDownLatch(1)
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      try {
+        e.invokeAny(l)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+      latch.countDown()
+
+    }
+  }
+
+  /** invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testInvokeAny4(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new NPETask)
+      try {
+        e.invokeAny(l)
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+
+    }
+  }
+
+  /** invokeAny(c) returns result of some task
+   */
+  @throws[Exception]
+  @Test def testInvokeAny5(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val result = e.invokeAny(l)
+      assertSame(TEST_STRING, result)
+
+    }
+  }
+
+  /** invokeAll(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testInvokeAll1(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAll(null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+    }
+  }
+
+  /** invokeAll(empty collection) returns empty list
+   */
+  @throws[Exception]
+  @Test def testInvokeAll2(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    val emptyCollection = Collections.emptyList
+    usingPoolCleaner(e) { e =>
+      val r = e.invokeAll(emptyCollection)
+      assertTrue(r.isEmpty)
+
+    }
+  }
+
+  /** invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAll3(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(null)
+      try {
+        e.invokeAll(l)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+
+    }
+  }
+
+  /** get of element of invokeAll(c) throws exception on failed task
+   */
+  @throws[Exception]
+  @Test def testInvokeAll4(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val futures = e.invokeAll(l)
+      assertEquals(1, futures.size)
+      try {
+        futures.get(0).get
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+
+    }
+  }
+
+  /** invokeAll(c) returns results of all completed tasks
+   */
+  @throws[Exception]
+  @Test def testInvokeAll5(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val futures = e.invokeAll(l)
+      assertEquals(2, futures.size)
+      futures.forEach { future => assertSame(TEST_STRING, future.get) }
+
+    }
+  }
+
+  /** timed invokeAny(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny1(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAny(null, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+  }
+
+  /** timed invokeAny(,,null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAnyNullTimeUnit(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      try {
+        e.invokeAny(l, randomTimeout(), null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+
+    }
+  }
+
+  /** timed invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny2(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    val emptyCollection = Collections.emptyList
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAny(emptyCollection, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+      }
+
+    }
+  }
+
+  /** timed invokeAny(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny3(): Unit = {
+    val latch = new CountDownLatch(1)
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      try {
+        e.invokeAny(l, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+      latch.countDown()
+
+    }
+  }
+
+  /** timed invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny4(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val startTime = System.nanoTime
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new NPETask)
+      try {
+        e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    }
+  }
+
+  /** timed invokeAny(c) returns result of some task
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny5(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val startTime = System.nanoTime
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val result = e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+      assertSame(TEST_STRING, result)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    }
+  }
+
+  /** timed invokeAll(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll1(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAll(null, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+  }
+
+  /** timed invokeAll(,,null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAllNullTimeUnit(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      try {
+        e.invokeAll(l, randomTimeout(), null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+  }
+
+  /** timed invokeAll(empty collection) returns empty list
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll2(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    val emptyCollection = Collections.emptyList
+    usingPoolCleaner(e) { e =>
+      val r = e.invokeAll(emptyCollection, randomTimeout(), randomTimeUnit())
+      assertTrue(r.isEmpty)
+
+    }
+  }
+
+  /** timed invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll3(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(null)
+      try {
+        e.invokeAll(l, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+
+    }
+  }
+
+  /** get of element of invokeAll(c) throws exception on failed task
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll4(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val futures = e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(1, futures.size)
+      try {
+        futures.get(0).get
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+
+    }
+  }
+
+  /** timed invokeAll(c) returns results of all completed tasks
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll5(): Unit = {
+    val e = new CustomTPE(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val futures = e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(2, futures.size)
+      futures.forEach { future => assertSame(TEST_STRING, future.get) }
+
+    }
+  }
+
+  /** timed invokeAll(c) cancels tasks not completed by timeout
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll6(): Unit = {
+    var timeout = timeoutMillis()
+    var break = false
+    while (!break) {
+      val done = new CountDownLatch(1)
+      val waiter = new CheckedCallable[String]() {
+        override def realCall(): String = {
+          try done.await(LONG_DELAY_MS, MILLISECONDS)
+          catch {
+            case ok: InterruptedException =>
+
+          }
+          "1"
+        }
+      }
+      val p = new CustomTPE(
+        2,
+        2,
+        LONG_DELAY_MS,
+        MILLISECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+        val tasks = new util.ArrayList[Callable[String]]
+        tasks.add(new StringTask("0"))
+        tasks.add(waiter)
+        tasks.add(new StringTask("2"))
+        val startTime = System.nanoTime
+        val futures = p.invokeAll(tasks, timeout, MILLISECONDS)
+        assertEquals(tasks.size, futures.size)
+        assertTrue(millisElapsedSince(startTime) >= timeout)
+        futures.forEach { future => assertTrue(future.isDone) }
+        assertTrue(futures.get(1).isCancelled)
+        try {
+          assertEquals("0", futures.get(0).get)
+          assertEquals("2", futures.get(2).get)
+          break = true
+        } catch {
+          case retryWithLongerTimeout: CancellationException =>
+            timeout *= 2
+            if (timeout >= LONG_DELAY_MS / 2)
+              fail("expected exactly one task to be cancelled")
+        }
+
+      }
+    }
+  }
+
+  /** Execution continues if there is at least one thread even if thread factory
+   *  fails to create more
+   */
+  @throws[InterruptedException]
+  @Test def testFailingThreadFactory(): Unit = {
+    val e = new CustomTPE(
+      100,
+      100,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new LinkedBlockingQueue[Runnable],
+      new FailingThreadFactory
+    )
+    usingPoolCleaner(e) { e =>
+      val TASKS = 100
+      val done = new CountDownLatch(TASKS)
+      for (k <- 0 until TASKS) {
+        e.execute(new CheckedRunnable() {
+          override def realRun(): Unit = { done.countDown() }
+        })
+      }
+      await(done)
+    }
+  }
+
+  /** allowsCoreThreadTimeOut is by default false.
+   */
+  @Test def testAllowsCoreThreadTimeOut(): Unit = {
+    val p = new CustomTPE(
+      2,
+      2,
+      1000,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p => assertFalse(p.allowsCoreThreadTimeOut) }
+  }
+
+  /** allowCoreThreadTimeOut(true) causes idle threads to time out
+   */
+  @throws[Exception]
+  @Test def testAllowCoreThreadTimeOut_true(): Unit = {
+    val keepAliveTime = timeoutMillis()
+    val p = new CustomTPE(
+      2,
+      10,
+      keepAliveTime,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      p.allowCoreThreadTimeOut(true)
+      p.execute(new CheckedRunnable() {
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getPoolSize)
+        }
+      })
+      await(threadStarted)
+      delay(keepAliveTime)
+      val startTime = System.nanoTime
+      while (p.getPoolSize > 0 && millisElapsedSince(
+            startTime
+          ) < LONG_DELAY_MS) Thread.`yield`()
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+      assertEquals(0, p.getPoolSize)
+
+    }
+  }
+
+  /** allowCoreThreadTimeOut(false) causes idle threads not to time out
+   */
+  @throws[Exception]
+  @Test def testAllowCoreThreadTimeOut_false(): Unit = {
+    val keepAliveTime = timeoutMillis()
+    val p = new CustomTPE(
+      2,
+      10,
+      keepAliveTime,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      p.allowCoreThreadTimeOut(false)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertTrue(p.getPoolSize >= 1)
+        }
+      })
+      delay(2 * keepAliveTime)
+      assertTrue(p.getPoolSize >= 1)
+
+    }
+  }
+
+  /** get(cancelled task) throws CancellationException (in part, a test of
+   *  CustomTPE itself)
+   */
+  @throws[Exception]
+  @Test def testGet_cancelled(): Unit = {
+    val done = new CountDownLatch(1)
+    val e = new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new LinkedBlockingQueue[Runnable]
+    )
+    usingWrappedPoolCleaner(e)(cleaner(_, done)) { e =>
+      val blockerStarted = new CountDownLatch(1)
+      val futures = new util.ArrayList[Future[_]]
+      for (i <- 0 until 2) {
+        val r = new CheckedRunnable() {
+          @throws[Throwable]
+          override def realRun(): Unit = {
+            blockerStarted.countDown()
+            assertTrue(done.await(2 * LONG_DELAY_MS, MILLISECONDS))
+          }
+        }
+        futures.add(e.submit(r))
+      }
+      await(blockerStarted)
+      futures.forEach(_.cancel(false))
+      futures.forEach { future =>
+        try {
+          future.get
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+        }
+        try {
+          future.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case success: CancellationException =>
+        }
+        assertTrue(future.isCancelled)
+        assertTrue(future.isDone)
+      }
+    }
+  }
+
+  @deprecated @Test def testFinalizeMethodCallsSuperFinalize(): Unit = {
+    new CustomTPE(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new LinkedBlockingQueue[Runnable]
+    ) {
+
+      /** A finalize method without "throws Throwable", that calls
+       *  super.finalize().
+       */
+      override protected def finalize(): Unit = { super.finalize() }
+    }.shutdown()
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ThreadPoolExecutorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ThreadPoolExecutorTest.scala
@@ -1,0 +1,2524 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit._
+import java.util
+import java.util._
+import java.util.Collections
+import java.util.concurrent._
+import java.util.concurrent.ThreadPoolExecutor._
+import java.util.concurrent.atomic._
+
+import scala.util.control.Breaks._
+
+import org.junit._
+import org.junit.Assert._
+
+object ThreadPoolExecutorTest {
+  import JSR166Test._
+
+  class ExtendedTPE()
+      extends ThreadPoolExecutor(
+        1,
+        1,
+        LONG_DELAY_MS,
+        MILLISECONDS,
+        new SynchronousQueue[Runnable]
+      ) {
+    final val beforeCalledLatch = new CountDownLatch(1)
+    final val afterCalledLatch = new CountDownLatch(1)
+    final val terminatedCalledLatch = new CountDownLatch(1)
+    override protected def beforeExecute(t: Thread, r: Runnable): Unit = {
+      beforeCalledLatch.countDown()
+    }
+    override protected def afterExecute(r: Runnable, t: Throwable): Unit = {
+      afterCalledLatch.countDown()
+    }
+    override protected def terminated(): Unit = {
+      terminatedCalledLatch.countDown()
+    }
+    def beforeCalled: Boolean = beforeCalledLatch.getCount == 0
+    def afterCalled: Boolean = afterCalledLatch.getCount == 0
+    def terminatedCalled: Boolean = terminatedCalledLatch.getCount == 0
+  }
+
+  class FailingThreadFactory extends ThreadFactory {
+    var calls = 0
+    override def newThread(r: Runnable): Thread = {
+      if (calls > 1) return null
+      calls += 1
+      new Thread(r)
+    }
+  }
+}
+class ThreadPoolExecutorTest extends JSR166Test {
+  import JSR166Test._
+
+  def defaltExecutor(
+      queue: ArrayBlockingQueue[Runnable] = new ArrayBlockingQueue[Runnable](10)
+  ) = new ThreadPoolExecutor(
+    1,
+    1,
+    LONG_DELAY_MS,
+    MILLISECONDS,
+    queue
+  )
+
+  /** execute successfully executes a runnable
+   */
+  @throws[InterruptedException]
+  @Test def testExecute(): Unit = usingPoolCleaner(defaltExecutor()) { p =>
+    val done = new CountDownLatch(1)
+    val task = new CheckedRunnable() {
+      override def realRun(): Unit = { done.countDown() }
+    }
+    p.execute(task)
+    await(done)
+  }
+
+  /** getActiveCount increases but doesn't overestimate, when a thread becomes
+   *  active
+   */
+  @throws[InterruptedException]
+  @Test def testGetActiveCount(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { _ =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getActiveCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getActiveCount)
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getActiveCount)
+    }
+  }
+
+  /** prestartCoreThread starts a thread if under corePoolSize, else doesn't
+   */
+  @Test def testPrestartCoreThread(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      6,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertEquals(0, p.getPoolSize)
+      assertTrue(p.prestartCoreThread)
+      assertEquals(1, p.getPoolSize)
+      assertTrue(p.prestartCoreThread)
+      assertEquals(2, p.getPoolSize)
+      assertFalse(p.prestartCoreThread)
+      assertEquals(2, p.getPoolSize)
+      p.setCorePoolSize(4)
+      assertTrue(p.prestartCoreThread)
+      assertEquals(3, p.getPoolSize)
+      assertTrue(p.prestartCoreThread)
+      assertEquals(4, p.getPoolSize)
+      assertFalse(p.prestartCoreThread)
+      assertEquals(4, p.getPoolSize)
+
+    }
+  }
+
+  /** prestartAllCoreThreads starts all corePoolSize threads
+   */
+  @Test def testPrestartAllCoreThreads(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      6,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertEquals(0, p.getPoolSize)
+      p.prestartAllCoreThreads
+      assertEquals(2, p.getPoolSize)
+      p.prestartAllCoreThreads
+      assertEquals(2, p.getPoolSize)
+      p.setCorePoolSize(4)
+      p.prestartAllCoreThreads
+      assertEquals(4, p.getPoolSize)
+      p.prestartAllCoreThreads
+      assertEquals(4, p.getPoolSize)
+
+    }
+  }
+
+  /** getCompletedTaskCount increases, but doesn't overestimate, when tasks
+   *  complete
+   */
+  @throws[InterruptedException]
+  @Test def testGetCompletedTaskCount(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val threadProceed = new CountDownLatch(1)
+      val threadDone = new CountDownLatch(1)
+      assertEquals(0, p.getCompletedTaskCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(0, p.getCompletedTaskCount)
+          await(threadProceed)
+          threadDone.countDown()
+        }
+      })
+      await(threadStarted)
+      assertEquals(0, p.getCompletedTaskCount)
+      threadProceed.countDown()
+      await(threadDone)
+      val startTime = System.nanoTime
+      while ({ p.getCompletedTaskCount != 1 }) {
+        if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
+        Thread.`yield`()
+      }
+    }
+  }
+
+  /** getCorePoolSize returns size given in constructor if not otherwise set
+   */
+  @Test def testGetCorePoolSize(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p => assertEquals(1, p.getCorePoolSize) }
+  }
+
+  /** getKeepAliveTime returns value given in constructor if not otherwise set
+   */
+  @Test def testGetKeepAliveTime(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      2,
+      1000,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { _ => assertEquals(1, p.getKeepAliveTime(SECONDS)) }
+  }
+
+  /** getThreadFactory returns factory in constructor if not set
+   */
+  @Test def testGetThreadFactory(): Unit = {
+    val threadFactory = new SimpleThreadFactory
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10),
+      threadFactory,
+      new NoOpREHandler
+    )
+    usingPoolCleaner(p) { p => assertSame(threadFactory, p.getThreadFactory) }
+  }
+
+  /** setThreadFactory sets the thread factory returned by getThreadFactory
+   */
+  @Test def testSetThreadFactory(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadFactory =
+        new SimpleThreadFactory
+      p.setThreadFactory(threadFactory)
+      assertSame(threadFactory, p.getThreadFactory)
+
+    }
+  }
+
+  /** setThreadFactory(null) throws NPE
+   */
+  @Test def testSetThreadFactoryNull(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setThreadFactory(null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+    }
+  }
+
+  /** The default rejected execution handler is AbortPolicy.
+   */
+  @Test def testDefaultRejectedExecutionHandler(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertTrue(
+        p.getRejectedExecutionHandler
+          .isInstanceOf[ThreadPoolExecutor.AbortPolicy]
+      )
+    }
+  }
+
+  /** getRejectedExecutionHandler returns handler in constructor if not set
+   */
+  @Test def testGetRejectedExecutionHandler(): Unit = {
+    val handler = new NoOpREHandler
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10),
+      handler
+    )
+    usingPoolCleaner(p) { p =>
+      assertSame(handler, p.getRejectedExecutionHandler)
+    }
+  }
+
+  /** setRejectedExecutionHandler sets the handler returned by
+   *  getRejectedExecutionHandler
+   */
+  @Test def testSetRejectedExecutionHandler(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val handler = new NoOpREHandler
+      p.setRejectedExecutionHandler(handler)
+      assertSame(handler, p.getRejectedExecutionHandler)
+
+    }
+  }
+
+  /** setRejectedExecutionHandler(null) throws NPE
+   */
+  @Test def testSetRejectedExecutionHandlerNull(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertThrows(
+        classOf[NullPointerException],
+        () => p.setRejectedExecutionHandler(null)
+      )
+    }
+  }
+
+  /** getLargestPoolSize increases, but doesn't overestimate, when multiple
+   *  threads active
+   */
+  @throws[InterruptedException]
+  @Test def testGetLargestPoolSize(): Unit = {
+    val THREADS = 3
+    val done = new CountDownLatch(1)
+    val p = new ThreadPoolExecutor(
+      THREADS,
+      THREADS,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { _ =>
+      assertEquals(0, p.getLargestPoolSize)
+      val threadsStarted = new CountDownLatch(THREADS)
+      for (i <- 0 until THREADS) {
+        p.execute(new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadsStarted.countDown()
+            await(done)
+            assertEquals(THREADS, p.getLargestPoolSize)
+          }
+        })
+      }
+      await(threadsStarted)
+      assertEquals(THREADS, p.getLargestPoolSize)
+    }
+    assertEquals(THREADS, p.getLargestPoolSize)
+  }
+
+  /** getMaximumPoolSize returns value given in constructor if not otherwise set
+   */
+  @Test def testGetMaximumPoolSize(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      3,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertEquals(3, p.getMaximumPoolSize)
+      p.setMaximumPoolSize(5)
+      assertEquals(5, p.getMaximumPoolSize)
+      p.setMaximumPoolSize(4)
+      assertEquals(4, p.getMaximumPoolSize)
+
+    }
+  }
+
+  /** getPoolSize increases, but doesn't overestimate, when threads become
+   *  active
+   */
+  @throws[InterruptedException]
+  @Test def testGetPoolSize(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      assertEquals(0, p.getPoolSize)
+      val threadStarted = new CountDownLatch(1)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getPoolSize)
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getPoolSize)
+
+    }
+  }
+
+  /** getTaskCount increases, but doesn't overestimate, when tasks submitted
+   */
+  @throws[InterruptedException]
+  @Test def testGetTaskCount(): Unit = {
+    val TASKS = 3
+    val done = new CountDownLatch(1)
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+      for (i <- 0 until TASKS) {
+        assertEquals(1 + i, p.getTaskCount)
+        p.execute(new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            assertEquals(1 + TASKS, p.getTaskCount)
+            await(done)
+          }
+        })
+      }
+      assertEquals(1 + TASKS, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+
+    }
+    assertEquals(1 + TASKS, p.getTaskCount)
+    assertEquals(1 + TASKS, p.getCompletedTaskCount)
+  }
+
+  /** isShutdown is false before shutdown, true after
+   */
+  @Test def testIsShutdown(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertFalse(p.isShutdown)
+      try {
+        p.shutdown()
+        assertTrue(p.isShutdown)
+      } catch { case ok: SecurityException => () }
+    }
+  }
+
+  /** awaitTermination on a non-shutdown pool times out
+   */
+  @throws[InterruptedException]
+  @Test def testAwaitTermination_timesOut(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertFalse(p.isTerminated)
+      assertFalse(p.awaitTermination(java.lang.Long.MIN_VALUE, NANOSECONDS))
+      assertFalse(p.awaitTermination(java.lang.Long.MIN_VALUE, MILLISECONDS))
+      assertFalse(p.awaitTermination(-1L, NANOSECONDS))
+      assertFalse(p.awaitTermination(-1L, MILLISECONDS))
+      assertFalse(p.awaitTermination(randomExpiredTimeout(), randomTimeUnit()))
+      val timeoutNanos = 999999L
+      var startTime = System.nanoTime
+      assertFalse(p.awaitTermination(timeoutNanos, NANOSECONDS))
+      assertTrue(System.nanoTime - startTime >= timeoutNanos)
+      assertFalse(p.isTerminated)
+      startTime = System.nanoTime
+      val timeoutMs = timeoutMillis()
+      assertFalse(p.awaitTermination(timeoutMillis(), MILLISECONDS))
+      assertTrue(millisElapsedSince(startTime) >= timeoutMs)
+      assertFalse(p.isTerminated)
+      try {
+        p.shutdown()
+        assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+        assertTrue(p.isTerminated)
+      } catch { case ok: SecurityException => () }
+    }
+  }
+
+  /** isTerminated is false before termination, true after
+   */
+  @throws[InterruptedException]
+  @Test def testIsTerminated(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val done = new CountDownLatch(1)
+      assertFalse(p.isTerminating)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(p.isTerminating)
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertFalse(p.isTerminating)
+      done.countDown()
+      try {
+        p.shutdown()
+        assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+        assertTrue(p.isTerminated)
+        assertFalse(p.isTerminating)
+      } catch { case ok: SecurityException => }
+
+    }
+  }
+
+  /** isTerminating is not true when running or when terminated
+   */
+  @throws[InterruptedException]
+  @Test def testIsTerminating(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val done = new CountDownLatch(1)
+      assertFalse(p.isTerminating)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(p.isTerminating)
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertFalse(p.isTerminating)
+      done.countDown()
+      try {
+        p.shutdown()
+        assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+        assertTrue(p.isTerminated)
+        assertFalse(p.isTerminating)
+      } catch { case ok: SecurityException => () }
+
+    }
+  }
+
+  /** getQueue returns the work queue, which contains queued tasks
+   */
+  @throws[InterruptedException]
+  @Test def testGetQueue(): Unit = {
+    val done = new CountDownLatch(1)
+    val q = new ArrayBlockingQueue[Runnable](10)
+    val p =
+      new ThreadPoolExecutor(1, 1, LONG_DELAY_MS, MILLISECONDS, q)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val tasks = new Array[FutureTask[_]](5)
+      for (i <- 0 until tasks.length) {
+        val task =
+          new CheckedCallable[java.lang.Boolean]() {
+            @throws[InterruptedException]
+            override def realCall(): java.lang.Boolean = {
+              threadStarted.countDown()
+              assertSame(q, p.getQueue)
+              await(done)
+              java.lang.Boolean.TRUE
+            }
+          }
+        tasks(i) = new FutureTask[java.lang.Boolean](task)
+        p.execute(tasks(i))
+      }
+      await(threadStarted)
+      assertSame(q, p.getQueue)
+      assertFalse(q.contains(tasks(0)))
+      assertTrue(q.contains(tasks(tasks.length - 1)))
+      assertEquals(tasks.length - 1, q.size)
+
+    }
+  }
+
+  /** remove(task) removes queued task, and fails to remove active task
+   */
+  @throws[InterruptedException]
+  @Test def testRemove(): Unit = {
+    val done = new CountDownLatch(1)
+    val q = new ArrayBlockingQueue[Runnable](10)
+    val p =
+      new ThreadPoolExecutor(1, 1, LONG_DELAY_MS, MILLISECONDS, q)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val tasks = new Array[Runnable](6)
+      val threadStarted = new CountDownLatch(1)
+      for (i <- 0 until tasks.length) {
+        tasks(i) = new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            await(done)
+          }
+        }
+        p.execute(tasks(i))
+      }
+      await(threadStarted)
+      assertFalse(p.remove(tasks(0)))
+      assertTrue(q.contains(tasks(4)))
+      assertTrue(q.contains(tasks(3)))
+      assertTrue(p.remove(tasks(4)))
+      assertFalse(p.remove(tasks(4)))
+      assertFalse(q.contains(tasks(4)))
+      assertTrue(q.contains(tasks(3)))
+      assertTrue(p.remove(tasks(3)))
+      assertFalse(q.contains(tasks(3)))
+
+    }
+  }
+
+  /** purge removes cancelled tasks from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testPurge(): Unit = {
+    val threadStarted = new CountDownLatch(1)
+    val done = new CountDownLatch(1)
+    val q = new ArrayBlockingQueue[Runnable](10)
+    val p =
+      new ThreadPoolExecutor(1, 1, LONG_DELAY_MS, MILLISECONDS, q)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val tasks = new Array[FutureTask[_]](5)
+      for (i <- 0 until tasks.length) {
+        val task =
+          new CheckedCallable[java.lang.Boolean]() {
+            @throws[InterruptedException]
+            override def realCall(): java.lang.Boolean = {
+              threadStarted.countDown()
+              await(done)
+              java.lang.Boolean.TRUE
+            }
+          }
+        tasks(i) = new FutureTask[java.lang.Boolean](task)
+        p.execute(tasks(i))
+      }
+      await(threadStarted)
+      assertEquals(tasks.length, p.getTaskCount)
+      assertEquals(tasks.length - 1, q.size)
+      assertEquals(1L, p.getActiveCount)
+      assertEquals(0L, p.getCompletedTaskCount)
+      tasks(4).cancel(true)
+      tasks(3).cancel(false)
+      p.purge()
+      assertEquals(tasks.length - 3, q.size)
+      assertEquals(tasks.length - 2, p.getTaskCount)
+      p.purge() // Nothing to do
+
+      assertEquals(tasks.length - 3, q.size)
+      assertEquals(tasks.length - 2, p.getTaskCount)
+
+    }
+  }
+
+  /** shutdownNow returns a list containing tasks that were not run, and those
+   *  tasks are drained from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testShutdownNow(): Unit = {
+    val poolSize = 2
+    val count = 5
+    val ran = new AtomicInteger(0)
+    val p = new ThreadPoolExecutor(
+      poolSize,
+      poolSize,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    val threadsStarted = new CountDownLatch(poolSize)
+    val waiter = new CheckedRunnable() {
+      override def realRun(): Unit = {
+        threadsStarted.countDown()
+        try MILLISECONDS.sleep(LONGER_DELAY_MS)
+        catch {
+          case success: InterruptedException =>
+
+        }
+        ran.getAndIncrement
+      }
+    }
+    for (i <- 0 until count) { p.execute(waiter) }
+    await(threadsStarted)
+    assertEquals(poolSize, p.getActiveCount)
+    assertEquals(0, p.getCompletedTaskCount)
+    try {
+      val queuedTasks = p.shutdownNow
+      assertTrue(p.isShutdown)
+      assertTrue(p.getQueue.isEmpty)
+      assertEquals(count - poolSize, queuedTasks.size)
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated)
+      assertEquals(poolSize, ran.get)
+      assertEquals(poolSize, p.getCompletedTaskCount)
+    } catch {
+      // Allowed in case test doesn't have privs
+      case ok: SecurityException =>
+    }
+
+  }
+
+  /** Constructor throws if corePoolSize argument is less than zero
+   */
+  // Exception Tests
+  @Test def testConstructor1(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        -1,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is less than zero
+   */
+  @Test def testConstructor2(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        -1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if maximumPoolSize is equal to zero
+   */
+  @Test def testConstructor3(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        0,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if keepAliveTime is less than zero
+   */
+  @Test def testConstructor4(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        -1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if corePoolSize is greater than the maximumPoolSize
+   */
+  @Test def testConstructor5(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        2,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if workQueue is set to null
+   */
+  @Test def testConstructorNullPointerException(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        1L,
+        SECONDS,
+        null.asInstanceOf[BlockingQueue[Runnable]]
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+  @Test def testConstructor6(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        -1,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor7(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        -1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor8(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        0,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor9(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        -1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor10(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        2,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructorNullPointerException2(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        1L,
+        SECONDS,
+        null.asInstanceOf[BlockingQueue[Runnable]],
+        new SimpleThreadFactory
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if threadFactory is set to null
+   */
+  @Test def testConstructorNullPointerException3(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        null.asInstanceOf[ThreadFactory]
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+  @Test def testConstructor11(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        -1,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor12(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        -1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor13(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        0,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor14(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        -1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor15(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        2,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructorNullPointerException4(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        1L,
+        SECONDS,
+        null.asInstanceOf[BlockingQueue[Runnable]],
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if handler is set to null
+   */
+  @Test def testConstructorNullPointerException5(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        null.asInstanceOf[RejectedExecutionHandler]
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+  @Test def testConstructor16(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        -1,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor17(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        -1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor18(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        0,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor19(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        -1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+  @Test def testConstructor20(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        2,
+        1,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: IllegalArgumentException =>
+
+    }
+  }
+
+  /** Constructor throws if workQueue is null
+   */
+  @Test def testConstructorNullPointerException6(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        1L,
+        SECONDS,
+        null.asInstanceOf[BlockingQueue[Runnable]],
+        new SimpleThreadFactory,
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if handler is null
+   */
+  @Test def testConstructorNullPointerException7(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        new SimpleThreadFactory,
+        null.asInstanceOf[RejectedExecutionHandler]
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** Constructor throws if ThreadFactory is null
+   */
+  @Test def testConstructorNullPointerException8(): Unit = {
+    try {
+      new ThreadPoolExecutor(
+        1,
+        2,
+        1L,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](10),
+        null.asInstanceOf[ThreadFactory],
+        new NoOpREHandler
+      )
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
+
+    }
+  }
+
+  /** get of submitted callable throws InterruptedException if interrupted
+   */
+  @throws[InterruptedException]
+  @Test def testInterruptedSubmit(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      60,
+      SECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val t = newStartedThread(
+        new CheckedInterruptedRunnable() {
+          @throws[Exception]
+          override def realRun(): Unit = {
+            val task =
+              new CheckedCallable[Boolean]() {
+                @throws[InterruptedException]
+                override def realCall(): Boolean = {
+                  threadStarted.countDown()
+                  await(done)
+                  java.lang.Boolean.TRUE
+                }
+              }
+            p.submit(task).get
+          }
+        }
+      )
+      await(threadStarted) // ensure quiescence
+
+      t.interrupt()
+      awaitTermination(t)
+
+    }
+  }
+
+  /** Submitted tasks are rejected when saturated or shutdown
+   */
+  @throws[InterruptedException]
+  @Ignore("Flaky, even on the JVM")
+  @Test def testSubmittedTasksRejectedWhenSaturatedOrShutdown(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      1,
+      SECONDS,
+      new ArrayBlockingQueue[Runnable](1)
+    )
+    val saturatedSize = JSR166Test.saturatedSize(p)
+    val rnd = ThreadLocalRandom.current
+    val threadsStarted = new CountDownLatch(
+      p.getMaximumPoolSize
+    )
+    val done = new CountDownLatch(1)
+    val r: CheckedRunnable = () => {
+      def foo(): Unit = {
+        threadsStarted.countDown()
+        var break = true
+        while (!break) try {
+          done.await()
+          break = true
+        } catch {
+          case shutdownNowDeliberatelyIgnored: InterruptedException =>
+        }
+      }
+      foo()
+    }
+    val c: CheckedCallable[java.lang.Boolean] = () => {
+      def foo() = {
+        threadsStarted.countDown()
+        var break = false
+        while (!break) try {
+          done.await()
+          break = true
+        } catch {
+          case shutdownNowDeliberatelyIgnored: InterruptedException =>
+        }
+        java.lang.Boolean.TRUE
+      }
+      foo()
+    }
+    val shutdownNow = rnd.nextBoolean
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p => // saturate
+      for (i <- saturatedSize until 0 by -1) {
+        rnd.nextInt(4) match {
+          case 0 => p.execute(r)
+          case 1 => assertFalse(p.submit(r).isDone)
+          case 2 => assertFalse(p.submit(r, java.lang.Boolean.TRUE).isDone)
+          case 3 => assertFalse(p.submit(c).isDone)
+        }
+      }
+      await(threadsStarted)
+      assertTaskSubmissionsAreRejected(p)
+      if (shutdownNow) p.shutdownNow()
+      else p.shutdown()
+      // Pool is shutdown, but not yet terminated
+      assertTaskSubmissionsAreRejected(p)
+      assertFalse(p.isTerminated)
+      done.countDown() // release blocking tasks
+
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTaskSubmissionsAreRejected(p)
+    }
+    assertEquals(
+      JSR166Test.saturatedSize(p) -
+        (if (shutdownNow) p.getQueue.remainingCapacity else 0),
+      p.getCompletedTaskCount
+    )
+  }
+
+  /** executor using DiscardOldestPolicy drops oldest task if saturated.
+   */
+  @Test def testSaturatedExecute_DiscardOldestPolicy(): Unit = {
+    val done = new CountDownLatch(1)
+    val r1 = awaiter(done)
+    val r2 = awaiter(done)
+    val r3 = awaiter(done)
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](1),
+      new ThreadPoolExecutor.DiscardOldestPolicy
+    )
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      assertEquals(LatchAwaiter.NEW, r1.state)
+      assertEquals(LatchAwaiter.NEW, r2.state)
+      assertEquals(LatchAwaiter.NEW, r3.state)
+      p.execute(r1)
+      p.execute(r2)
+      assertTrue(p.getQueue.contains(r2))
+      p.execute(r3)
+      assertFalse(p.getQueue.contains(r2))
+      assertTrue(p.getQueue.contains(r3))
+
+    }
+    assertEquals(LatchAwaiter.DONE, r1.state)
+    assertEquals(LatchAwaiter.NEW, r2.state)
+    assertEquals(LatchAwaiter.DONE, r3.state)
+  }
+
+  /** execute using DiscardOldestPolicy drops task on shutdown
+   */
+  @Test def testDiscardOldestOnShutdown(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](1),
+      new ThreadPoolExecutor.DiscardOldestPolicy
+    )
+    try p.shutdown()
+    catch {
+      case ok: SecurityException =>
+        return
+    }
+    usingPoolCleaner(p) { p =>
+      val r =
+        new TrackedNoOpRunnable
+      p.execute(r)
+      assertFalse(r.done)
+
+    }
+  }
+
+  /** Submitting null tasks throws NullPointerException
+   */
+  @Test def testNullTaskSubmission(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      1L,
+      SECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      assertNullTaskSubmissionThrowsNullPointerException(p)
+    }
+  }
+
+  /** setCorePoolSize of negative value throws IllegalArgumentException
+   */
+  @Test def testCorePoolSizeIllegalArgumentException(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setCorePoolSize(-1)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** setMaximumPoolSize(int) throws IllegalArgumentException if given a value
+   *  less the core pool size
+   */
+  @Test def testMaximumPoolSizeIllegalArgumentException(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      3,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setMaximumPoolSize(1)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** setMaximumPoolSize throws IllegalArgumentException if given a negative
+   *  value
+   */
+  @Test def testMaximumPoolSizeIllegalArgumentException2(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      3,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setMaximumPoolSize(-1)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** Configuration changes that allow core pool size greater than max pool size
+   *  result in IllegalArgumentException.
+   */
+  @Test def testPoolSizeInvariants(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      for (s <- 1 until 5) {
+        p.setMaximumPoolSize(s)
+        p.setCorePoolSize(s)
+        try {
+          p.setMaximumPoolSize(s - 1)
+          shouldThrow()
+        } catch {
+          case success: IllegalArgumentException =>
+
+        }
+        assertEquals(s, p.getCorePoolSize)
+        assertEquals(s, p.getMaximumPoolSize)
+        try {
+          p.setCorePoolSize(s + 1)
+          shouldThrow()
+        } catch {
+          case success: IllegalArgumentException =>
+
+        }
+        assertEquals(s, p.getCorePoolSize)
+        assertEquals(s, p.getMaximumPoolSize)
+      }
+    }
+  }
+
+  /** setKeepAliveTime throws IllegalArgumentException when given a negative
+   *  value
+   */
+  @Test def testKeepAliveTimeIllegalArgumentException(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      3,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      try {
+        p.setKeepAliveTime(-1, MILLISECONDS)
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** terminated() is called on termination
+   */
+  @Test def testTerminated(): Unit = {
+    val p =
+      new ThreadPoolExecutorTest.ExtendedTPE
+    usingPoolCleaner(p) { p =>
+      try {
+        p.shutdown()
+        assertTrue(p.terminatedCalled)
+        assertTrue(p.isShutdown)
+      } catch { case ok: SecurityException => }
+    }
+  }
+
+  /** beforeExecute and afterExecute are called when executing task
+   */
+  @throws[InterruptedException]
+  @Test def testBeforeAfter(): Unit = {
+    val p = new ThreadPoolExecutorTest.ExtendedTPE
+    usingPoolCleaner(p) { p =>
+      val done = new CountDownLatch(1)
+      p.execute(new CheckedRunnable() {
+        override def realRun(): Unit = { done.countDown() }
+      })
+      await(p.afterCalledLatch)
+      assertEquals(0, done.getCount)
+      assertTrue(p.afterCalled)
+      assertTrue(p.beforeCalled)
+
+    }
+  }
+
+  /** completed submit of callable returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitCallable(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { p =>
+      val future = e.submit(new StringTask)
+      val result = future.get
+      assertSame(TEST_STRING, result)
+
+    }
+  }
+
+  /** completed submit of runnable returns successfully
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { p =>
+      val future = e.submit(new NoOpRunnable)
+      future.get
+      assertTrue(future.isDone)
+
+    }
+  }
+
+  /** completed submit of (runnable, result) returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable2(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { p =>
+      val future =
+        e.submit(new NoOpRunnable, TEST_STRING)
+      val result = future.get
+      assertSame(TEST_STRING, result)
+
+    }
+  }
+
+  /** invokeAny(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testInvokeAny1(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAny(null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+    }
+  }
+
+  /** invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testInvokeAny2(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAny(new ArrayList[Callable[String]])
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** invokeAny(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAny3(): Unit = {
+    val latch = new CountDownLatch(1)
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      try {
+        e.invokeAny(l)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+      latch.countDown()
+
+    }
+  }
+
+  /** invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testInvokeAny4(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new NPETask)
+      try {
+        e.invokeAny(l)
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+
+    }
+  }
+
+  /** invokeAny(c) returns result of some task
+   */
+  @throws[Exception]
+  @Test def testInvokeAny5(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val result = e.invokeAny(l)
+      assertSame(TEST_STRING, result)
+
+    }
+  }
+
+  /** invokeAll(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testInvokeAll1(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAll(null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+    }
+  }
+
+  /** invokeAll(empty collection) returns empty list
+   */
+  @throws[InterruptedException]
+  @Test def testInvokeAll2(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    val emptyCollection = Collections.emptyList
+    usingPoolCleaner(e) { e =>
+      val r = e.invokeAll(emptyCollection)
+      assertTrue(r.isEmpty)
+
+    }
+  }
+
+  /** invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAll3(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(null)
+      try {
+        e.invokeAll(l)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+
+    }
+  }
+
+  /** get of element of invokeAll(c) throws exception on failed task
+   */
+  @throws[Exception]
+  @Test def testInvokeAll4(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val futures = e.invokeAll(l)
+      assertEquals(1, futures.size)
+      try {
+        futures.get(0).get
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+
+    }
+  }
+
+  /** invokeAll(c) returns results of all completed tasks
+   */
+  @throws[Exception]
+  @Test def testInvokeAll5(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val futures = e.invokeAll(l)
+      assertEquals(2, futures.size)
+      futures.forEach { future => assertSame(TEST_STRING, future.get) }
+
+    }
+  }
+
+  /** timed invokeAny(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny1(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAny(null, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+
+    }
+  }
+
+  /** timed invokeAny(,,null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAnyNullTimeUnit(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { p =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      try {
+        e.invokeAny(l, randomTimeout(), null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+
+    }
+  }
+
+  /** timed invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny2(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAny(
+          new ArrayList[Callable[String]],
+          randomTimeout(),
+          randomTimeUnit()
+        )
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+
+      }
+    }
+  }
+
+  /** timed invokeAny(c) throws NullPointerException if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny3(): Unit = {
+    val latch = new CountDownLatch(1)
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      try {
+        e.invokeAny(l, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+      latch.countDown()
+
+    }
+  }
+
+  /** timed invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny4(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val startTime = System.nanoTime
+      val l = new ArrayList[Callable[String]]
+      l.add(new NPETask)
+      try {
+        e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    }
+  }
+
+  /** timed invokeAny(c) returns result of some task
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny5(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val startTime = System.nanoTime
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val result = e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+      assertSame(TEST_STRING, result)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    }
+  }
+
+  /** timed invokeAll(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll1(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      try {
+        e.invokeAll(null, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+  }
+
+  /** timed invokeAll(,,null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAllNullTimeUnit(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      try {
+        e.invokeAll(l, randomTimeout(), null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+
+    }
+  }
+
+  /** timed invokeAll(empty collection) returns empty list
+   */
+  @throws[InterruptedException]
+  @Test def testTimedInvokeAll2(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    val emptyCollection = Collections.emptyList
+    usingPoolCleaner(e) { e =>
+      val r =
+        e.invokeAll(emptyCollection, randomTimeout(), randomTimeUnit())
+      assertTrue(r.isEmpty)
+
+    }
+  }
+
+  /** timed invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll3(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(null)
+      try {
+        e.invokeAll(l, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+
+      }
+
+    }
+  }
+  @throws[Exception]
+  @Test def testTimedInvokeAll4(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val futures =
+        e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(1, futures.size)
+      try {
+        futures.get(0).get
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+
+    }
+  }
+
+  /** timed invokeAll(c) returns results of all completed tasks
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll5(): Unit = {
+    val e = new ThreadPoolExecutor(
+      2,
+      2,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(e) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val futures =
+        e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(2, futures.size)
+      futures.forEach { future => assertSame(TEST_STRING, future.get) }
+
+    }
+  }
+
+  /** timed invokeAll(c) cancels tasks not completed by timeout
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll6(): Unit = {
+    var timeout = timeoutMillis()
+    var break = false
+    while (!break) {
+      val done = new CountDownLatch(1)
+      val waiter =
+        new CheckedCallable[String]() {
+          override def realCall(): String = {
+            try done.await(LONG_DELAY_MS, MILLISECONDS)
+            catch {
+              case ok: InterruptedException =>
+
+            }
+            "1"
+          }
+        }
+      val p = new ThreadPoolExecutor(
+        2,
+        2,
+        LONG_DELAY_MS,
+        MILLISECONDS,
+        new ArrayBlockingQueue[Runnable](10)
+      )
+      usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+        val tasks = new ArrayList[Callable[String]]
+        tasks.add(new StringTask("0"))
+        tasks.add(waiter)
+        tasks.add(new StringTask("2"))
+        val startTime = System.nanoTime
+        val futures =
+          p.invokeAll(tasks, timeout, MILLISECONDS)
+        assertEquals(tasks.size, futures.size)
+        assertTrue(millisElapsedSince(startTime) >= timeout)
+        futures.forEach { future => assertTrue(future.isDone) }
+        assertTrue(futures.get(1).isCancelled)
+        try {
+          assertEquals("0", futures.get(0).get)
+          assertEquals("2", futures.get(2).get)
+          break = true
+        } catch {
+          case retryWithLongerTimeout: CancellationException =>
+            timeout *= 2
+            if (timeout >= LONG_DELAY_MS / 2)
+              fail("expected exactly one task to be cancelled")
+        }
+
+      }
+    }
+  }
+
+  /** Execution continues if there is at least one thread even if thread factory
+   *  fails to create more
+   */
+  @throws[InterruptedException]
+  @Test def testFailingThreadFactory(): Unit = {
+    val e = new ThreadPoolExecutor(
+      100,
+      100,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new LinkedBlockingQueue[Runnable],
+      new ThreadPoolExecutorTest.FailingThreadFactory
+    )
+    usingPoolCleaner(e) { p =>
+      val TASKS = 100
+      val done = new CountDownLatch(TASKS)
+      for (k <- 0 until TASKS) {
+        e.execute(new CheckedRunnable() {
+          override def realRun(): Unit = { done.countDown() }
+        })
+      }
+      await(done)
+
+    }
+  }
+
+  /** allowsCoreThreadTimeOut is by default false.
+   */
+  @Test def testAllowsCoreThreadTimeOut(): Unit = {
+    val p = new ThreadPoolExecutor(
+      2,
+      2,
+      1000,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p => assertFalse(p.allowsCoreThreadTimeOut) }
+  }
+
+  /** allowCoreThreadTimeOut(true) causes idle threads to time out
+   */
+  @throws[Exception]
+  @Test def testAllowCoreThreadTimeOut_true(): Unit = {
+    val keepAliveTime = timeoutMillis()
+    val p = new ThreadPoolExecutor(
+      2,
+      10,
+      keepAliveTime,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      p.allowCoreThreadTimeOut(true)
+      p.execute(new CheckedRunnable() {
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getPoolSize)
+        }
+      })
+      await(threadStarted)
+      delay(keepAliveTime)
+      val startTime = System.nanoTime
+      while ({
+        p.getPoolSize > 0 && millisElapsedSince(startTime) < LONG_DELAY_MS
+      }) Thread.`yield`()
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+      assertEquals(0, p.getPoolSize)
+
+    }
+  }
+
+  /** allowCoreThreadTimeOut(false) causes idle threads not to time out
+   */
+  @throws[Exception]
+  @Test def testAllowCoreThreadTimeOut_false(): Unit = {
+    val keepAliveTime = timeoutMillis()
+    val p = new ThreadPoolExecutor(
+      2,
+      10,
+      keepAliveTime,
+      MILLISECONDS,
+      new ArrayBlockingQueue[Runnable](10)
+    )
+    usingPoolCleaner(p) { p =>
+      val threadStarted = new CountDownLatch(1)
+      p.allowCoreThreadTimeOut(false)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertTrue(p.getPoolSize >= 1)
+        }
+      })
+      delay(2 * keepAliveTime)
+      assertTrue(p.getPoolSize >= 1)
+
+    }
+  }
+
+  /** execute allows the same task to be submitted multiple times, even if
+   *  rejected
+   */
+  @throws[InterruptedException]
+  @Test def testRejectedRecycledTask(): Unit = {
+    val nTasks = 1000
+    val done = new CountDownLatch(nTasks)
+    val recycledTask = new Runnable() {
+      override def run(): Unit = { done.countDown() }
+    }
+    val p =
+      new ThreadPoolExecutor(
+        1,
+        30,
+        60,
+        SECONDS,
+        new ArrayBlockingQueue[Runnable](30)
+      )
+    usingPoolCleaner(p) { p =>
+      for (i <- 0 until nTasks) {
+        breakable {
+          while (true) try {
+            p.execute(recycledTask)
+            break()
+          } catch { case ignore: RejectedExecutionException => }
+        }
+      }
+      // enough time to run all tasks
+      await(done, nTasks * SHORT_DELAY_MS)
+
+    }
+  }
+
+  /** get(cancelled task) throws CancellationException
+   */
+  @throws[Exception]
+  @Test def testGet_cancelled(): Unit = {
+    val done = new CountDownLatch(1)
+    val e = new ThreadPoolExecutor(
+      1,
+      1,
+      LONG_DELAY_MS,
+      MILLISECONDS,
+      new LinkedBlockingQueue[Runnable]
+    )
+    usingWrappedPoolCleaner(e)(cleaner(_, done)) { e =>
+      val blockerStarted = new CountDownLatch(1)
+      val futures = new ArrayList[Future[_]]
+      for (i <- 0 until 2) {
+        val r = new CheckedRunnable() {
+          @throws[Throwable]
+          override def realRun(): Unit = {
+            blockerStarted.countDown()
+            assertTrue(done.await(2 * LONG_DELAY_MS, MILLISECONDS))
+          }
+        }
+        futures.add(e.submit(r))
+      }
+      await(blockerStarted)
+      futures.forEach(_.cancel(false))
+      futures.forEach { future =>
+        try {
+          future.get
+          shouldThrow()
+        } catch { case success: CancellationException => }
+        try {
+          future.get(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch { case success: CancellationException => }
+        assertTrue(future.isCancelled)
+        assertTrue(future.isDone)
+      }
+
+    }
+  }
+
+  /** Directly test simple ThreadPoolExecutor RejectedExecutionHandlers. */
+  @Test def testStandardRejectedExecutionHandlers(): Unit = {
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      1,
+      SECONDS,
+      new ArrayBlockingQueue[Runnable](1)
+    )
+    val thread = new AtomicReference[Thread]
+    val r = new Runnable() {
+      override def run(): Unit = { thread.set(Thread.currentThread) }
+    }
+    try {
+      new ThreadPoolExecutor.AbortPolicy().rejectedExecution(r, p)
+      shouldThrow()
+    } catch {
+      case success: RejectedExecutionException =>
+
+    }
+    assertNull(thread.get)
+    new ThreadPoolExecutor.DiscardPolicy().rejectedExecution(r, p)
+    assertNull(thread.get)
+    new ThreadPoolExecutor.CallerRunsPolicy().rejectedExecution(r, p)
+    assertSame(Thread.currentThread, thread.get)
+    // check that pool was not perturbed by handlers
+    assertTrue(
+      p.getRejectedExecutionHandler.isInstanceOf[ThreadPoolExecutor.AbortPolicy]
+    )
+    assertEquals(0, p.getTaskCount)
+    assertTrue(p.getQueue.isEmpty)
+  }
+  @Test def testThreadFactoryReturnsTerminatedThread_shouldThrow(): Unit = {
+    if (!testImplementationDetails) return
+    val returnsTerminatedThread: ThreadFactory = (runnableIgnored: Runnable) =>
+      {
+        def foo(runnableIgnored: Runnable) = {
+          val thread = new Thread(() => {
+            def foo() = {}
+            foo()
+          })
+          thread.start()
+          try thread.join()
+          catch {
+            case ex: InterruptedException =>
+              throw new Error(ex)
+          }
+          thread
+        }
+        foo(runnableIgnored)
+      }
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      1,
+      SECONDS,
+      new ArrayBlockingQueue[Runnable](1),
+      returnsTerminatedThread
+    )
+    usingPoolCleaner(p) { p =>
+      assertThrows(
+        classOf[IllegalThreadStateException],
+        () =>
+          p.execute(() => {
+            def foo() = {}
+            foo()
+          })
+      )
+    }
+  }
+  @Test def testThreadFactoryReturnsStartedThread_shouldThrow(): Unit = {
+    if (!testImplementationDetails) return
+    val latch = new CountDownLatch(1)
+    val awaitLatch: Runnable = () => {
+      def foo() = {
+        try latch.await()
+        catch {
+          case ex: InterruptedException =>
+            throw new Error(ex)
+        }
+      }
+      foo()
+    }
+    val returnsStartedThread: ThreadFactory = (runnable: Runnable) => {
+      def foo(runnable: Runnable) = {
+        val thread = new Thread(awaitLatch)
+        thread.start()
+        thread
+      }
+      foo(runnable)
+    }
+    val p = new ThreadPoolExecutor(
+      1,
+      1,
+      1,
+      SECONDS,
+      new ArrayBlockingQueue[Runnable](1),
+      returnsStartedThread
+    )
+    usingPoolCleaner(p) { p =>
+      assertThrows(
+        classOf[IllegalThreadStateException],
+        () =>
+          p.execute(() => {
+            def foo() = {}
+            foo()
+          })
+      )
+      latch.countDown()
+
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
@@ -429,44 +429,43 @@ class ReentrantLockTest extends JSR166Test {
     }
   }
 
-  // TODO: CyclicBarrier
-  // /** isLocked is true when locked and false when not
-  //  */
-  // @Test def testIsLocked(): Unit = { testIsLocked(false) }
-  // @Test def testIsLocked_fair(): Unit = { testIsLocked(true) }
-  // def testIsLocked(fair: Boolean): Unit = {
-  //   val lock = new ReentrantLock(fair)
-  //   try {
-  //     assertFalse(lock.isLocked)
-  //     lock.lock()
-  //     assertTrue(lock.isLocked)
-  //     lock.lock()
-  //     assertTrue(lock.isLocked)
-  //     lock.unlock()
-  //     assertTrue(lock.isLocked)
-  //     lock.unlock()
-  //     assertFalse(lock.isLocked)
-  //     val barrier = new CyclicBarrier(2)
-  //     val t = newStartedThread(new CheckedRunnable() {
-  //       @throws[Exception]
-  //       override def realRun(): Unit = {
-  //         lock.lock()
-  //         assertTrue(lock.isLocked)
-  //         barrier.await
-  //         barrier.await
-  //         lock.unlock()
-  //       }
-  //     })
-  //     barrier.await
-  //     assertTrue(lock.isLocked)
-  //     barrier.await
-  //     awaitTermination(t)
-  //     assertFalse(lock.isLocked)
-  //   } catch {
-  //     case fail: Exception =>
-  //       threadUnexpectedException(fail)
-  //   }
-  // }
+  /** isLocked is true when locked and false when not
+   */
+  @Test def testIsLocked(): Unit = { testIsLocked(false) }
+  @Test def testIsLocked_fair(): Unit = { testIsLocked(true) }
+  def testIsLocked(fair: Boolean): Unit = {
+    val lock = new ReentrantLock(fair)
+    try {
+      assertFalse(lock.isLocked)
+      lock.lock()
+      assertTrue(lock.isLocked)
+      lock.lock()
+      assertTrue(lock.isLocked)
+      lock.unlock()
+      assertTrue(lock.isLocked)
+      lock.unlock()
+      assertFalse(lock.isLocked)
+      val barrier = new CyclicBarrier(2)
+      val t = newStartedThread(new CheckedRunnable() {
+        @throws[Exception]
+        override def realRun(): Unit = {
+          lock.lock()
+          assertTrue(lock.isLocked)
+          barrier.await
+          barrier.await
+          lock.unlock()
+        }
+      })
+      barrier.await
+      assertTrue(lock.isLocked)
+      barrier.await
+      awaitTermination(t)
+      assertFalse(lock.isLocked)
+    } catch {
+      case fail: Exception =>
+        threadUnexpectedException(fail)
+    }
+  }
 
   /** lockInterruptibly succeeds when unlocked, else is interruptible
    */


### PR DESCRIPTION
* Ports fixed thread pool executor, its tests and helper methods in `j,u.c.Executors`. 
* Resotres tests requiring `ThreadPoolExecutor`