### PR TITLE
Port `java.util.concurrent.ScheduledThreadPoolExecutor` from JSR-166

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/Delayed.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Delayed.scala
@@ -1,0 +1,11 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+trait Delayed extends Comparable[Delayed] {
+  def getDelay(unit: TimeUnit): Long
+}

--- a/javalib/src/main/scala/java/util/concurrent/Executors.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Executors.scala
@@ -79,11 +79,43 @@ object Executors {
     )
   }
 
+  def newSingleThreadScheduledExecutor(): ScheduledExecutorService = {
+    new Executors.DelegatedScheduledExecutorService(
+      new ScheduledThreadPoolExecutor(1)
+    )
+  }
+
+  def newSingleThreadScheduledExecutor(
+      threadFactory: ThreadFactory
+  ): ScheduledExecutorService = {
+    new Executors.DelegatedScheduledExecutorService(
+      new ScheduledThreadPoolExecutor(1, threadFactory)
+    )
+  }
+
+  def newScheduledThreadPool(corePoolSize: Int): ScheduledExecutorService = {
+    new ScheduledThreadPoolExecutor(corePoolSize)
+  }
+
+  def newScheduledThreadPool(
+      corePoolSize: Int,
+      threadFactory: ThreadFactory
+  ): ScheduledExecutorService = {
+    new ScheduledThreadPoolExecutor(corePoolSize, threadFactory)
+  }
+
   def unconfigurableExecutorService(
       executor: ExecutorService
   ): ExecutorService = {
     if (executor == null) throw new NullPointerException
     new Executors.DelegatedExecutorService(executor)
+  }
+
+  def unconfigurableScheduledExecutorService(
+      executor: ScheduledExecutorService
+  ): ScheduledExecutorService = {
+    if (executor == null) throw new NullPointerException
+    new Executors.DelegatedScheduledExecutorService(executor)
   }
 
   def defaultThreadFactory(): ThreadFactory = {
@@ -306,6 +338,41 @@ object Executors {
     override protected def finalize(): Unit = { super.shutdown() }
   }
 
+  private class DelegatedScheduledExecutorService(
+      e: ScheduledExecutorService
+  ) extends Executors.DelegatedExecutorService(e)
+      with ScheduledExecutorService {
+    override def schedule(
+        command: Runnable,
+        delay: Long,
+        unit: TimeUnit
+    ): ScheduledFuture[AnyRef] = {
+      return e.schedule(command, delay, unit)
+    }
+    override def schedule[V <: AnyRef](
+        callable: Callable[V],
+        delay: Long,
+        unit: TimeUnit
+    ): ScheduledFuture[V] = {
+      e.schedule(callable, delay, unit)
+    }
+    override def scheduleAtFixedRate(
+        command: Runnable,
+        initialDelay: Long,
+        period: Long,
+        unit: TimeUnit
+    ): ScheduledFuture[AnyRef] = {
+      e.scheduleAtFixedRate(command, initialDelay, period, unit)
+    }
+    override def scheduleWithFixedDelay(
+        command: Runnable,
+        initialDelay: Long,
+        delay: Long,
+        unit: TimeUnit
+    ): ScheduledFuture[AnyRef] = {
+      e.scheduleWithFixedDelay(command, initialDelay, delay, unit)
+    }
+  }
 }
 
 // Cannot instantiate.

--- a/javalib/src/main/scala/java/util/concurrent/RunnableScheduledFuture.scala
+++ b/javalib/src/main/scala/java/util/concurrent/RunnableScheduledFuture.scala
@@ -1,0 +1,15 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+trait RunnableScheduledFuture[V]
+    extends RunnableFuture[V]
+    with ScheduledFuture[V] {
+
+  def isPeriodic(): Boolean
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/ScheduledExecutorService.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ScheduledExecutorService.scala
@@ -1,0 +1,37 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+trait ScheduledExecutorService extends ExecutorService {
+
+  def schedule(
+      command: Runnable,
+      delay: Long,
+      unit: TimeUnit
+  ): ScheduledFuture[AnyRef]
+
+  def schedule[V <: AnyRef](
+      command: Callable[V],
+      delay: Long,
+      unit: TimeUnit
+  ): ScheduledFuture[V]
+
+  def scheduleAtFixedRate(
+      command: Runnable,
+      initialDelay: Long,
+      period: Long,
+      unit: TimeUnit
+  ): ScheduledFuture[AnyRef]
+
+  def scheduleWithFixedDelay(
+      command: Runnable,
+      initialDelay: Long,
+      period: Long,
+      unit: TimeUnit
+  ): ScheduledFuture[AnyRef]
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/ScheduledFuture.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ScheduledFuture.scala
@@ -1,0 +1,9 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent;
+
+trait ScheduledFuture[V] extends Delayed with Future[V]

--- a/javalib/src/main/scala/java/util/concurrent/ScheduledThreadPoolExecutor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ScheduledThreadPoolExecutor.scala
@@ -1,0 +1,738 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+import java.util.concurrent.TimeUnit._
+import java.util
+import java.util._
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks._
+import scala.annotation.tailrec
+
+object ScheduledThreadPoolExecutor {
+
+  private val sequencer = new AtomicLong
+
+  private val DEFAULT_KEEPALIVE_MILLIS = 10L
+
+  private[concurrent] object DelayedWorkQueue {
+    private val INITIAL_CAPACITY = 16
+
+    private def setIndex(f: RunnableScheduledFuture[AnyRef], idx: Int): Unit =
+      f match {
+        case f: ScheduledThreadPoolExecutor#ScheduledFutureTask[_] =>
+          f.heapIndex = idx
+        case _ => ()
+      }
+  }
+  private[concurrent] class DelayedWorkQueue
+      extends util.AbstractQueue[Runnable]
+      with BlockingQueue[Runnable] {
+    private var queue =
+      new Array[RunnableScheduledFuture[AnyRef]](
+        DelayedWorkQueue.INITIAL_CAPACITY
+      )
+    final private val lock = new ReentrantLock
+    private var _size = 0
+
+    /** Thread designated to wait for the task at the head of the queue. This
+     *  variant of the Leader-Follower pattern
+     *  (http://www.cs.wustl.edu/~schmidt/POSA/POSA2/) serves to minimize
+     *  unnecessary timed waiting. When a thread becomes the leader, it waits
+     *  only for the next delay to elapse, but other threads await indefinitely.
+     *  The leader thread must signal some other thread before returning from
+     *  take() or poll(...), unless some other thread becomes leader in the
+     *  interim. Whenever the head of the queue is replaced with a task with an
+     *  earlier expiration time, the leader field is invalidated by being reset
+     *  to null, and some waiting thread, but not necessarily the current
+     *  leader, is signalled. So waiting threads must be prepared to acquire and
+     *  lose leadership while waiting.
+     */
+    private var leader: Thread = null
+
+    final private val available = lock.newCondition()
+
+    private def siftUp(_k: Int, key: RunnableScheduledFuture[AnyRef]): Unit = {
+      var k = _k
+      var break = false
+      while (!break && k > 0) {
+        val parent = (k - 1) >>> 1
+        val e = queue(parent)
+        if (key.compareTo(e) >= 0) break = true
+        else {
+          queue(k) = e
+          DelayedWorkQueue.setIndex(e, k)
+          k = parent
+        }
+      }
+      queue(k) = key
+      DelayedWorkQueue.setIndex(key, k)
+    }
+
+    private def siftDown(
+        _k: Int,
+        key: RunnableScheduledFuture[AnyRef]
+    ): Unit = {
+      var k = _k
+      val half = _size >>> 1
+      var break = false
+      while (!break && k < half) {
+        var child = (k << 1) + 1
+        var c = queue(child)
+        val right = child + 1
+        if (right < _size && c.compareTo(queue(right)) > 0) {
+          child = right
+          c = queue(child)
+        }
+        if (key.compareTo(c) <= 0) break = true
+        else {
+          queue(k) = c
+          DelayedWorkQueue.setIndex(c, k)
+          k = child
+        }
+      }
+      queue(k) = key
+      DelayedWorkQueue.setIndex(key, k)
+    }
+
+    private def grow(): Unit = {
+      val oldCapacity = queue.length
+      var newCapacity = oldCapacity + (oldCapacity >> 1) // grow 50%
+      if (newCapacity < 0) { // overflow
+        newCapacity = Integer.MAX_VALUE
+      }
+      queue = util.Arrays.copyOf(queue, newCapacity)
+    }
+
+    private def indexOf(x: Any): Int = x match {
+      case null => -1
+      case t: ScheduledThreadPoolExecutor#ScheduledFutureTask[_] =>
+        val i = t.heapIndex
+        // Sanity check; x could conceivably be a
+        // ScheduledFutureTask from some other pool.
+        if (i >= 0 && i < _size && (queue(i) == x)) i
+        else -1
+      case _ =>
+        var i = 0
+        while (i < _size) {
+          if (x == queue(i)) return i
+          i += 1
+        }
+        -1
+    }
+
+    override def contains(x: Any): Boolean = {
+      val lock = this.lock
+      lock.lock()
+      try indexOf(x) != -1
+      finally lock.unlock()
+    }
+
+    override def remove(x: Any): Boolean = {
+      val lock = this.lock
+      lock.lock()
+      try {
+        val i = indexOf(x)
+        if (i < 0) return false
+        DelayedWorkQueue.setIndex(queue(i), -1)
+        _size -= 1
+        val s = _size
+        val replacement = queue(s)
+        queue(s) = null
+        if (s != i) {
+          siftDown(i, replacement)
+          if (queue(i) eq replacement) siftUp(i, replacement)
+        }
+        true
+      } finally lock.unlock()
+    }
+
+    override def size(): Int = {
+      val lock = this.lock
+      lock.lock()
+      try this._size
+      finally lock.unlock()
+    }
+
+    override def isEmpty(): Boolean = _size == 0
+    override def remainingCapacity(): Int = Integer.MAX_VALUE
+    override def peek(): RunnableScheduledFuture[AnyRef] = {
+      val lock = this.lock
+      lock.lock()
+      try queue(0)
+      finally lock.unlock()
+    }
+
+    override def offer(x: Runnable): Boolean = {
+      if (x == null) throw new NullPointerException
+      val e = x.asInstanceOf[RunnableScheduledFuture[AnyRef]]
+      val lock = this.lock
+      lock.lock()
+      try {
+        val i = _size
+        if (i >= queue.length) grow()
+        _size = i + 1
+        if (i == 0) {
+          queue(0) = e
+          DelayedWorkQueue.setIndex(e, 0)
+        } else siftUp(i, e)
+        if (queue(0) eq e) {
+          leader = null
+          available.signal()
+        }
+      } finally lock.unlock()
+      true
+    }
+
+    override def put(e: Runnable): Unit = { offer(e) }
+    override def add(e: Runnable): Boolean = offer(e)
+    override def offer(e: Runnable, timeout: Long, unit: TimeUnit): Boolean =
+      offer(e)
+
+    private def finishPoll(f: RunnableScheduledFuture[AnyRef]) = {
+      val s = { _size -= 1; _size }
+      val x = queue(s)
+      queue(s) = null
+      if (s != 0) siftDown(0, x)
+      DelayedWorkQueue.setIndex(f, -1)
+      f
+    }
+
+    override def poll(): RunnableScheduledFuture[AnyRef] = {
+      val lock = this.lock
+      lock.lock()
+      try {
+        val first = queue(0)
+        if (first == null || first.getDelay(NANOSECONDS) > 0) null
+        else finishPoll(first)
+      } finally lock.unlock()
+    }
+
+    @throws[InterruptedException]
+    override def take(): RunnableScheduledFuture[AnyRef] = {
+      @tailrec def loop(): RunnableScheduledFuture[AnyRef] = {
+        var first = queue(0)
+        if (first == null) {
+          available.await()
+          loop()
+        } else {
+          val delay = first.getDelay(NANOSECONDS)
+          if (delay <= 0L) finishPoll(first)
+          else {
+            first = null // don't retain ref while waiting
+            if (leader != null) available.await()
+            else {
+              val thisThread = Thread.currentThread()
+              leader = thisThread
+              try available.awaitNanos(delay)
+              finally if (leader eq thisThread) leader = null
+            }
+            loop()
+          }
+        }
+      }
+
+      val lock = this.lock
+      lock.lockInterruptibly()
+      try loop()
+      finally {
+        if (leader == null && queue(0) != null) available.signal()
+        lock.unlock()
+      }
+    }
+
+    @throws[InterruptedException]
+    override def poll(
+        timeout: Long,
+        unit: TimeUnit
+    ): RunnableScheduledFuture[AnyRef] = {
+      @tailrec def loop(nanos: Long): RunnableScheduledFuture[AnyRef] = {
+        var first = queue(0)
+        if (first == null)
+          if (nanos <= 0L) null
+          else loop(available.awaitNanos(nanos))
+        else {
+          val delay = first.getDelay(NANOSECONDS)
+          if (delay <= 0L) finishPoll(first)
+          else if (nanos <= 0L) null
+          else {
+            first = null
+            if (nanos < delay || leader != null)
+              loop(available.awaitNanos(nanos))
+            else {
+              val thisThread = Thread.currentThread()
+              leader = thisThread
+              loop(try {
+                val timeLeft = available.awaitNanos(delay)
+                nanos - (delay - timeLeft)
+              } finally if (leader eq thisThread) leader = null)
+            }
+          }
+        }
+      }
+
+      val lock = this.lock
+      lock.lockInterruptibly()
+      try loop(unit.toNanos(timeout))
+      finally {
+        if (leader == null && queue(0) != null) available.signal()
+        lock.unlock()
+      }
+    }
+
+    override def clear(): Unit = {
+      val lock = this.lock
+      lock.lock()
+      try {
+        for (i <- 0 until _size) {
+          val t = queue(i)
+          if (t != null) {
+            queue(i) = null
+            DelayedWorkQueue.setIndex(t, -1)
+          }
+        }
+        _size = 0
+      } finally lock.unlock()
+    }
+
+    override def drainTo(c: util.Collection[_ >: Runnable]): Int =
+      drainTo(c, Integer.MAX_VALUE)
+
+    override def drainTo(
+        c: util.Collection[_ >: Runnable],
+        maxElements: Int
+    ): Int = {
+      Objects.requireNonNull(c)
+      if (c eq this) throw new IllegalArgumentException
+      if (maxElements <= 0) return 0
+      val lock = this.lock
+      lock.lock()
+      try {
+        var n = 0
+        var first: RunnableScheduledFuture[AnyRef] = null
+        while ({
+          n < maxElements && { first = queue(0); first != null } &&
+          first.getDelay(NANOSECONDS) <= 0
+        }) {
+          c.add(first) // In this order, in case add() throws.
+
+          finishPoll(first)
+          n += 1
+        }
+        n
+      } finally lock.unlock()
+    }
+
+    override def toArray(): Array[AnyRef] = {
+      val lock = this.lock
+      lock.lock()
+      try util.Arrays.copyOf(queue, _size, classOf[Array[AnyRef]])
+      finally lock.unlock()
+    }
+
+    @SuppressWarnings(Array("unchecked"))
+    override def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
+      val lock = this.lock
+      lock.lock()
+      try {
+        if (a.length < _size)
+          return util.Arrays
+            .copyOf(queue, _size)
+            .asInstanceOf[Array[T]]
+        System.arraycopy(queue, 0, a, 0, _size)
+        if (a.length > _size) a(_size) = null.asInstanceOf[T]
+        a
+      } finally lock.unlock()
+    }
+    override def iterator(): util.Iterator[Runnable] = {
+      val lock = this.lock
+      lock.lock()
+      try
+        new Itr(util.Arrays.copyOf(queue, _size))
+      finally lock.unlock()
+    }
+
+    private[concurrent] class Itr private[concurrent] (
+        val array: Array[RunnableScheduledFuture[AnyRef]]
+    ) extends util.Iterator[Runnable] {
+
+      // index of next element to return; initially 0
+      private[concurrent] var cursor = 0
+
+      // index of last element returned; -1 if no such
+      private[concurrent] var lastRet = -1
+
+      override def hasNext(): Boolean = cursor < array.length
+
+      override def next(): Runnable = {
+        if (cursor >= array.length) throw new NoSuchElementException
+        lastRet = cursor
+        cursor += 1
+        array(lastRet)
+      }
+
+      override def remove(): Unit = {
+        if (lastRet < 0) throw new IllegalStateException
+        DelayedWorkQueue.this.remove(array(lastRet))
+        lastRet = -1
+      }
+    }
+  }
+}
+
+class ScheduledThreadPoolExecutor(
+    corePoolSize: Int,
+    threadFactory: ThreadFactory,
+    handler: RejectedExecutionHandler
+) extends ThreadPoolExecutor(
+      corePoolSize,
+      Integer.MAX_VALUE,
+      ScheduledThreadPoolExecutor.DEFAULT_KEEPALIVE_MILLIS,
+      MILLISECONDS,
+      new ScheduledThreadPoolExecutor.DelayedWorkQueue,
+      threadFactory,
+      handler
+    )
+    with ScheduledExecutorService {
+
+  private var continueExistingPeriodicTasksAfterShutdown = false
+
+  private var executeExistingDelayedTasksAfterShutdown = true
+
+  private[concurrent] var removeOnCancel = false
+
+  private sealed trait ScheduledFutureTask[V <: AnyRef]
+      extends RunnableScheduledFuture[V] { self: FutureTask[V] =>
+
+    protected var time: Long
+
+    protected var period: Long
+
+    protected def sequenceNumber: Long
+
+    private[concurrent] var outerTask: RunnableScheduledFuture[V] = this
+
+    private[concurrent] var heapIndex: Int = 0
+
+    override def getDelay(unit: TimeUnit): Long =
+      unit.convert(time - System.nanoTime(), NANOSECONDS)
+    override def compareTo(other: Delayed): Int = {
+      if (other eq this) { // compare zero if same object
+        return 0
+      }
+      if (other
+            .isInstanceOf[ScheduledFutureTask[_]]) {
+        val x =
+          other.asInstanceOf[ScheduledFutureTask[_]]
+        val diff = time - x.time
+        if (diff < 0) return -1
+        else if (diff > 0) return 1
+        else if (sequenceNumber < x.sequenceNumber) return -1
+        else return 1
+      }
+      val diff = getDelay(NANOSECONDS) - other.getDelay(NANOSECONDS)
+      if (diff < 0) -1
+      else if (diff > 0) 1
+      else 0
+    }
+
+    override def isPeriodic(): Boolean = period != 0
+
+    protected def setNextRunTime(): Unit = {
+      val p = period
+      if (p > 0) time += p
+      else time = triggerTime(-p)
+    }
+
+  }
+
+  private class ScheduledFutureRunableTask[V <: AnyRef](
+      runnable: Runnable,
+      result: V,
+      protected var time: Long,
+      protected var period: Long,
+      protected val sequenceNumber: Long
+  ) extends FutureTask(runnable, result)
+      with ScheduledFutureTask[V] {
+    def this(
+        runnable: Runnable,
+        result: V,
+        time: Long,
+        sequenceNumber: Long
+    ) = this(
+      runnable,
+      result,
+      time = time,
+      period = 0,
+      sequenceNumber = sequenceNumber
+    )
+
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      // The racy read of heapIndex below is benign:
+      // if heapIndex < 0, then OOTA guarantees that we have surely
+      // been removed; else we recheck under lock in remove()
+      val cancelled = super.cancel(mayInterruptIfRunning)
+      if (cancelled && removeOnCancel && heapIndex >= 0) remove(this)
+      cancelled
+    }
+
+    override def run(): Unit = {
+      if (!canRunInCurrentRunState(this)) cancel(false)
+      else if (!isPeriodic()) super.run()
+      else if (runAndReset()) {
+        setNextRunTime()
+        reExecutePeriodic(outerTask)
+      }
+    }
+  }
+
+  private class ScheduledFutureCallableTask[V <: AnyRef](
+      callable: Callable[V],
+      protected var time: Long,
+      protected val sequenceNumber: Long
+  ) extends FutureTask(callable)
+      with ScheduledFutureTask[V] {
+    protected var period: Long = 0
+
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      // The racy read of heapIndex below is benign:
+      // if heapIndex < 0, then OOTA guarantees that we have surely
+      // been removed; else we recheck under lock in remove()
+      val cancelled = super.cancel(mayInterruptIfRunning)
+      if (cancelled && removeOnCancel && heapIndex >= 0) remove(this)
+      cancelled
+    }
+
+    override def run(): Unit = {
+      if (!canRunInCurrentRunState(this)) cancel(false)
+      else if (!isPeriodic()) super.run()
+      else if (runAndReset()) {
+        setNextRunTime()
+        reExecutePeriodic(outerTask)
+      }
+    }
+  }
+
+  private[concurrent] def canRunInCurrentRunState(
+      task: RunnableScheduledFuture[_]
+  ): Boolean = {
+    if (!isShutdown()) return true
+    if (isStopped()) return false
+    if (task.isPeriodic()) continueExistingPeriodicTasksAfterShutdown
+    else
+      executeExistingDelayedTasksAfterShutdown ||
+        task.getDelay(NANOSECONDS) <= 0
+  }
+
+  private def delayedExecute(task: RunnableScheduledFuture[_]): Unit = {
+    if (isShutdown()) reject(task)
+    else {
+      super.getQueue().add(task)
+      if (!canRunInCurrentRunState(task) && remove(task)) task.cancel(false)
+      else ensurePrestart()
+    }
+  }
+
+  private[concurrent] def reExecutePeriodic(
+      task: RunnableScheduledFuture[_]
+  ): Unit = {
+    if (canRunInCurrentRunState(task)) {
+      super.getQueue().add(task)
+      if (canRunInCurrentRunState(task) || !remove(task)) {
+        ensurePrestart()
+        return
+      }
+    }
+    task.cancel(false)
+  }
+
+  override private[concurrent] def onShutdown(): Unit = {
+    val q = super.getQueue()
+    val keepDelayed = getExecuteExistingDelayedTasksAfterShutdownPolicy()
+    val keepPeriodic = getContinueExistingPeriodicTasksAfterShutdownPolicy()
+    // Traverse snapshot to avoid iterator exceptions
+    // TODO: implement and use efficient removeIf
+    // super.getQueue().removeIf(...);
+    for (e <- q.toArray()) {
+      e match {
+        case t: RunnableScheduledFuture[_] =>
+          def check =
+            if (t.isPeriodic()) !keepPeriodic
+            else !keepDelayed && t.getDelay(NANOSECONDS) > 0
+          if (check || t.isCancelled()) { // also remove if already cancelled
+            if (q.remove(t)) t.cancel(false)
+          }
+
+        case _ => ()
+      }
+    }
+    tryTerminate()
+  }
+
+  protected def decorateTask[V](
+      runnable: Runnable,
+      task: RunnableScheduledFuture[V]
+  ): RunnableScheduledFuture[V] = task
+
+  protected def decorateTask[V](
+      callable: Callable[V],
+      task: RunnableScheduledFuture[V]
+  ): RunnableScheduledFuture[V] = task
+
+  def this(corePoolSize: Int, threadFactory: ThreadFactory) =
+    this(corePoolSize, threadFactory, new ThreadPoolExecutor.AbortPolicy())
+
+  def this(corePoolSize: Int) = this(
+    corePoolSize,
+    Executors.defaultThreadFactory()
+  )
+
+  def this(corePoolSize: Int, handler: RejectedExecutionHandler) =
+    this(corePoolSize, Executors.defaultThreadFactory(), handler)
+
+  private def triggerTime(delay: Long, unit: TimeUnit): Long = triggerTime(
+    unit.toNanos(
+      if (delay < 0) 0
+      else delay
+    )
+  )
+  private[concurrent] def triggerTime(delay: Long): Long =
+    System.nanoTime() + (if (delay < (java.lang.Long.MAX_VALUE >> 1)) delay
+                         else overflowFree(delay))
+
+  private def overflowFree(delay: Long): Long = {
+    val head = super.getQueue().peek().asInstanceOf[Delayed]
+    if (head != null) {
+      val headDelay = head.getDelay(NANOSECONDS)
+      if (headDelay < 0 && (delay - headDelay < 0))
+        return java.lang.Long.MAX_VALUE + headDelay
+    }
+    delay
+  }
+
+  override def schedule(
+      command: Runnable,
+      delay: Long,
+      unit: TimeUnit
+  ): ScheduledFuture[AnyRef] = {
+    if (command == null || unit == null) throw new NullPointerException
+    val t = decorateTask(
+      command,
+      new ScheduledFutureRunableTask(
+        command,
+        null: AnyRef,
+        triggerTime(delay, unit),
+        ScheduledThreadPoolExecutor.sequencer.getAndIncrement()
+      )
+    )
+    delayedExecute(t)
+    t
+  }
+
+  override def schedule[V <: AnyRef](
+      callable: Callable[V],
+      delay: Long,
+      unit: TimeUnit
+  ): ScheduledFuture[V] = {
+    if (callable == null || unit == null) throw new NullPointerException
+    val t = decorateTask(
+      callable,
+      new ScheduledFutureCallableTask[V](
+        callable,
+        triggerTime(delay, unit),
+        ScheduledThreadPoolExecutor.sequencer.getAndIncrement()
+      )
+    )
+    delayedExecute(t)
+    t
+  }
+
+  override def scheduleAtFixedRate(
+      command: Runnable,
+      initialDelay: Long,
+      period: Long,
+      unit: TimeUnit
+  ): ScheduledFuture[AnyRef] = {
+    if (command == null || unit == null) throw new NullPointerException
+    if (period <= 0L) throw new IllegalArgumentException
+    val sft = new ScheduledFutureRunableTask(
+      command,
+      null: AnyRef,
+      triggerTime(initialDelay, unit),
+      unit.toNanos(period),
+      ScheduledThreadPoolExecutor.sequencer.getAndIncrement()
+    )
+    val t = decorateTask(command, sft)
+    sft.outerTask = t
+    delayedExecute(t)
+    t
+  }
+
+  override def scheduleWithFixedDelay(
+      command: Runnable,
+      initialDelay: Long,
+      delay: Long,
+      unit: TimeUnit
+  ): ScheduledFuture[AnyRef] = {
+    if (command == null || unit == null) throw new NullPointerException
+    if (delay <= 0L) throw new IllegalArgumentException
+    val sft = new ScheduledFutureRunableTask(
+      command,
+      null: AnyRef,
+      triggerTime(initialDelay, unit),
+      -unit.toNanos(delay),
+      ScheduledThreadPoolExecutor.sequencer.getAndIncrement()
+    )
+    val t = decorateTask(command, sft)
+    sft.outerTask = t
+    delayedExecute(t)
+    t
+  }
+
+  override def execute(command: Runnable): Unit = {
+    schedule(command, 0, NANOSECONDS)
+  }
+
+  override def submit(task: Runnable): Future[_] =
+    schedule(task, 0, NANOSECONDS)
+
+  override def submit[T <: AnyRef](task: Runnable, result: T): Future[T] =
+    schedule(Executors.callable(task, result), 0L, NANOSECONDS)
+
+  override def submit[T <: AnyRef](task: Callable[T]): Future[T] =
+    schedule(task, 0, NANOSECONDS)
+
+  def setContinueExistingPeriodicTasksAfterShutdownPolicy(
+      value: Boolean
+  ): Unit = {
+    continueExistingPeriodicTasksAfterShutdown = value
+    if (!value && isShutdown()) onShutdown()
+  }
+
+  def getContinueExistingPeriodicTasksAfterShutdownPolicy(): Boolean =
+    continueExistingPeriodicTasksAfterShutdown
+
+  def setExecuteExistingDelayedTasksAfterShutdownPolicy(
+      value: Boolean
+  ): Unit = {
+    executeExistingDelayedTasksAfterShutdown = value
+    if (!value && isShutdown()) onShutdown()
+  }
+
+  def getExecuteExistingDelayedTasksAfterShutdownPolicy(): Boolean =
+    executeExistingDelayedTasksAfterShutdown
+
+  def setRemoveOnCancelPolicy(value: Boolean): Unit = removeOnCancel = value
+
+  def getRemoveOnCancelPolicy(): Boolean = removeOnCancel
+
+  override def shutdown(): Unit = super.shutdown()
+
+  override def shutdownNow(): List[Runnable] = super.shutdownNow()
+
+  override def getQueue(): BlockingQueue[Runnable] = super.getQueue()
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/ExecutorCompletionService9Test.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/ExecutorCompletionService9Test.scala
@@ -1,0 +1,101 @@
+/*
+ * Written by Doug Lea and Martin Buchholz with assistance from
+ * members of JCP JSR-166 Expert Group and released to the public
+ * domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.{Collection, ArrayList, Set, Comparator, List}
+import java.util.concurrent._
+
+class ExecutorCompletionService9Test extends JSR166Test {
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  def solveAll(e: Executor, solvers: Collection[Callable[Integer]]): Unit = {
+    val cs = new ExecutorCompletionService[Integer](e)
+    solvers.forEach(cs.submit(_))
+    for (i <- solvers.size until 0 by -1) {
+      val r = cs.take.get
+      if (r != null) use(r)
+    }
+  }
+  @throws[InterruptedException]
+  def solveAny(e: Executor, solvers: Collection[Callable[Integer]]): Unit = {
+    val cs =
+      new ExecutorCompletionService[Integer](e)
+    val n = solvers.size
+    val futures = new ArrayList[Future[Integer]](n)
+    var result: Integer = null
+    try {
+      solvers.forEach((solver: Callable[Integer]) =>
+        futures.add(cs.submit(solver))
+      )
+      import scala.util.control.Breaks._
+      breakable {
+        for (i <- n until 0 by -1) {
+          try {
+            val r = cs.take.get
+            if (r != null) {
+              result = r
+              break()
+            }
+          } catch { case ignore: ExecutionException => () }
+        }
+      }
+    } finally futures.forEach((future: Future[Integer]) => future.cancel(true))
+    if (result != null) use(result)
+  }
+  var results: ArrayList[Integer] = null
+  def use(x: Integer): Unit = {
+    if (results == null) results = new ArrayList[Integer]()
+    results.add(x)
+  }
+
+  /** The first "solvers" sample code in the class javadoc works.
+   */
+  @throws[InterruptedException]
+  @throws[ExecutionException]
+  @Test def testSolveAll(): Unit = {
+    results = null
+    val solvers = new java.util.HashSet[Callable[Integer]]
+    solvers.add(() => null)
+    solvers.add(() => 1: Integer)
+    solvers.add(() => 2: Integer)
+    solvers.add(() => 3: Integer)
+    solvers.add(() => null)
+    solveAll(cachedThreadPool, solvers)
+    // results.sort(Comparator.naturalOrder)
+    // assertEquals(List.of(1, 2, 3), results)
+    val resultsList = collection.mutable.ListBuffer.empty[Integer]
+    results.iterator().forEachRemaining(resultsList.append(_))
+    assertEquals(
+      resultsList.toList.sorted,
+      scala.List(1, 2, 3)
+    )
+  }
+
+  /** The second "solvers" sample code in the class javadoc works.
+   */
+  @throws[InterruptedException]
+  @Test def testSolveAny(): Unit = {
+    results = null
+    val solvers = new java.util.HashSet[Callable[Integer]]
+    solvers.add(() => {
+      def foo() = throw new ArithmeticException
+      foo()
+    })
+    solvers.add(() => null)
+    solvers.add(() => 1: Integer)
+    solvers.add(() => 2: Integer)
+
+    solveAny(cachedThreadPool, solvers)
+    assertEquals(1, results.size)
+    val elt = results.get(0)
+    assertTrue(elt == 1 || elt == 2)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorsTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorsTest.scala
@@ -162,95 +162,94 @@ class ExecutorsTest extends JSR166Test {
     }
   }
 
-  // TODO: ScheduledExecutor
-  // /** unconfigurableScheduledExecutorService(null) throws NPE
-  //  */
-  // @Test def testUnconfigurableScheduledExecutorServiceNPE(): Unit = {
-  //   try {
-  //     val unused =
-  //       Executors.unconfigurableScheduledExecutorService(null)
-  //     shouldThrow()
-  //   } catch {
-  //     case success: NullPointerException =>
+  /** unconfigurableScheduledExecutorService(null) throws NPE
+   */
+  @Test def testUnconfigurableScheduledExecutorServiceNPE(): Unit = {
+    try {
+      val unused =
+        Executors.unconfigurableScheduledExecutorService(null)
+      shouldThrow()
+    } catch {
+      case success: NullPointerException =>
 
-  //   }
-  // }
+    }
+  }
 
-  // /** a newSingleThreadScheduledExecutor successfully runs delayed task
-  //  */
-  // @throws[Exception]
-  // @Test def testNewSingleThreadScheduledExecutor(): Unit =
-  //   usingPoolCleaner(Executors.newSingleThreadScheduledExecutor) { p =>
-  //     val proceed = new CountDownLatch(1)
-  //     val task = new CheckedRunnable() {
-  //       override def realRun(): Unit = { await(proceed) }
-  //     }
-  //     val startTime = System.nanoTime
-  //     val f = p.schedule(
-  //       Executors.callable(task, java.lang.Boolean.TRUE),
-  //       timeoutMillis(),
-  //       MILLISECONDS
-  //     )
-  //     assertFalse(f.isDone)
-  //     proceed.countDown()
-  //     assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
-  //     assertSame(java.lang.Boolean.TRUE, f.get)
-  //     assertTrue(f.isDone)
-  //     assertFalse(f.isCancelled)
-  //     assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
-  //   }
+  /** a newSingleThreadScheduledExecutor successfully runs delayed task
+   */
+  @throws[Exception]
+  @Test def testNewSingleThreadScheduledExecutor(): Unit =
+    usingPoolCleaner(Executors.newSingleThreadScheduledExecutor) { p =>
+      val proceed = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = { await(proceed) }
+      }
+      val startTime = System.nanoTime
+      val f = p.schedule(
+        Executors.callable(task, java.lang.Boolean.TRUE),
+        timeoutMillis(),
+        MILLISECONDS
+      )
+      assertFalse(f.isDone)
+      proceed.countDown()
+      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+      assertSame(java.lang.Boolean.TRUE, f.get)
+      assertTrue(f.isDone)
+      assertFalse(f.isCancelled)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
 
-  // /** a newScheduledThreadPool successfully runs delayed task
-  //  */
-  // @throws[Exception]
-  // @Test def testNewScheduledThreadPool(): Unit =
-  //   usingPoolCleaner(Executors.newScheduledThreadPool(2)) { p =>
-  //     val proceed = new CountDownLatch(1)
-  //     val task = new CheckedRunnable() {
-  //       override def realRun(): Unit = { await(proceed) }
-  //     }
-  //     val startTime = System.nanoTime
-  //     val f = p.schedule(
-  //       Executors.callable(task, java.lang.Boolean.TRUE),
-  //       timeoutMillis(),
-  //       MILLISECONDS
-  //     )
-  //     assertFalse(f.isDone)
-  //     proceed.countDown()
-  //     assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
-  //     assertSame(java.lang.Boolean.TRUE, f.get)
-  //     assertTrue(f.isDone)
-  //     assertFalse(f.isCancelled)
-  //     assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
-  //   }
+  /** a newScheduledThreadPool successfully runs delayed task
+   */
+  @throws[Exception]
+  @Test def testNewScheduledThreadPool(): Unit =
+    usingPoolCleaner(Executors.newScheduledThreadPool(2)) { p =>
+      val proceed = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = { await(proceed) }
+      }
+      val startTime = System.nanoTime
+      val f = p.schedule(
+        Executors.callable(task, java.lang.Boolean.TRUE),
+        timeoutMillis(),
+        MILLISECONDS
+      )
+      assertFalse(f.isDone)
+      proceed.countDown()
+      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+      assertSame(java.lang.Boolean.TRUE, f.get)
+      assertTrue(f.isDone)
+      assertFalse(f.isCancelled)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
 
-  // /** an unconfigurable newScheduledThreadPool successfully runs delayed task
-  //  */
-  // @throws[Exception]
-  // @Test def testUnconfigurableScheduledExecutorService(): Unit =
-  //   usingPoolCleaner(
-  //     Executors.unconfigurableScheduledExecutorService(
-  //       Executors.newScheduledThreadPool(2)
-  //     )
-  //   ) { p =>
-  //     val proceed = new CountDownLatch(1)
-  //     val task = new CheckedRunnable() {
-  //       override def realRun(): Unit = { await(proceed) }
-  //     }
-  //     val startTime = System.nanoTime
-  //     val f = p.schedule(
-  //       Executors.callable(task, java.lang.Boolean.TRUE),
-  //       timeoutMillis(),
-  //       MILLISECONDS
-  //     )
-  //     assertFalse(f.isDone)
-  //     proceed.countDown()
-  //     assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
-  //     assertSame(java.lang.Boolean.TRUE, f.get)
-  //     assertTrue(f.isDone)
-  //     assertFalse(f.isCancelled)
-  //     assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
-  //   }
+  /** an unconfigurable newScheduledThreadPool successfully runs delayed task
+   */
+  @throws[Exception]
+  @Test def testUnconfigurableScheduledExecutorService(): Unit =
+    usingPoolCleaner(
+      Executors.unconfigurableScheduledExecutorService(
+        Executors.newScheduledThreadPool(2)
+      )
+    ) { p =>
+      val proceed = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = { await(proceed) }
+      }
+      val startTime = System.nanoTime
+      val f = p.schedule(
+        Executors.callable(task, java.lang.Boolean.TRUE),
+        timeoutMillis(),
+        MILLISECONDS
+      )
+      assertFalse(f.isDone)
+      proceed.countDown()
+      assertSame(java.lang.Boolean.TRUE, f.get(LONG_DELAY_MS, MILLISECONDS))
+      assertSame(java.lang.Boolean.TRUE, f.get)
+      assertTrue(f.isDone)
+      assertFalse(f.isCancelled)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
 
   /** Future.get on submitted tasks will time out if they compute too long.
    */

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
@@ -820,34 +820,33 @@ abstract class JSR166Test {
     }
 
     e match {
-      // TODO: ScheduledExecutor
-      // case ses: ScheduledExecutorService =>
-      //   try {
-      //     ses.schedule(nullRunnable, randomTimeout(), randomTimeUnit())
-      //     shouldThrow()
-      //   } catch { case sucess: NullPointerException => () }
-      //   try {
-      //     ses.schedule(nullCallable, randomTimeout(), randomTimeUnit())
-      //     shouldThrow()
-      //   } catch { case sucess: NullPointerException => () }
-      //   try {
-      //     ses.scheduleAtFixedRate(
-      //       nullRunnable,
-      //       randomTimeout(),
-      //       LONG_DELAY_MS,
-      //       MILLISECONDS
-      //     )
-      //     shouldThrow()
-      //   } catch { case sucess: NullPointerException => () }
-      //   try {
-      //     ses.scheduleWithFixedDelay(
-      //       nullRunnable,
-      //       randomTimeout(),
-      //       LONG_DELAY_MS,
-      //       MILLISECONDS
-      //     )
-      //     shouldThrow()
-      //   } catch { case sucess: NullPointerException => () }
+      case ses: ScheduledExecutorService =>
+        try {
+          ses.schedule(nullRunnable, randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch { case sucess: NullPointerException => () }
+        try {
+          ses.schedule(nullCallable, randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch { case sucess: NullPointerException => () }
+        try {
+          ses.scheduleAtFixedRate(
+            nullRunnable,
+            randomTimeout(),
+            LONG_DELAY_MS,
+            MILLISECONDS
+          )
+          shouldThrow()
+        } catch { case sucess: NullPointerException => () }
+        try {
+          ses.scheduleWithFixedDelay(
+            nullRunnable,
+            randomTimeout(),
+            LONG_DELAY_MS,
+            MILLISECONDS
+          )
+          shouldThrow()
+        } catch { case sucess: NullPointerException => () }
       case _ => ()
     }
 
@@ -909,47 +908,46 @@ abstract class JSR166Test {
       assertSame(p, recorder.p)
 
       p match {
-        // TODO: ScheduledExecutor
-        // case s: ScheduledExecutorService =>
-        //   var future: ScheduledFuture[_] = null
+        case s: ScheduledExecutorService =>
+          var future: ScheduledFuture[_] = null
 
-        //   recorder.reset()
-        //   future = s.schedule(r, randomTimeout(), randomTimeUnit())
-        //   assertFalse(future.isDone())
-        //   if (stock)
-        //     assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
-        //   assertSame(p, recorder.p)
+          recorder.reset()
+          future = s.schedule(r, randomTimeout(), randomTimeUnit())
+          assertFalse(future.isDone())
+          if (stock)
+            assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
+          assertSame(p, recorder.p)
 
-        //   recorder.reset()
-        //   future = s.schedule(c, randomTimeout(), randomTimeUnit())
-        //   assertFalse(future.isDone())
-        //   if (stock)
-        //     assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
-        //   assertSame(p, recorder.p)
+          recorder.reset()
+          future = s.schedule(c, randomTimeout(), randomTimeUnit())
+          assertFalse(future.isDone())
+          if (stock)
+            assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
+          assertSame(p, recorder.p)
 
-        //   recorder.reset()
-        //   future = s.scheduleAtFixedRate(
-        //     r,
-        //     randomTimeout(),
-        //     LONG_DELAY_MS,
-        //     MILLISECONDS
-        //   )
-        //   assertFalse(future.isDone())
-        //   if (stock)
-        //     assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
-        //   assertSame(p, recorder.p)
+          recorder.reset()
+          future = s.scheduleAtFixedRate(
+            r,
+            randomTimeout(),
+            LONG_DELAY_MS,
+            MILLISECONDS
+          )
+          assertFalse(future.isDone())
+          if (stock)
+            assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
+          assertSame(p, recorder.p)
 
-        //   recorder.reset()
-        //   future = s.scheduleWithFixedDelay(
-        //     r,
-        //     randomTimeout(),
-        //     LONG_DELAY_MS,
-        //     MILLISECONDS
-        //   )
-        //   assertFalse(future.isDone())
-        //   if (stock)
-        //     assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
-        //   assertSame(p, recorder.p)
+          recorder.reset()
+          future = s.scheduleWithFixedDelay(
+            r,
+            randomTimeout(),
+            LONG_DELAY_MS,
+            MILLISECONDS
+          )
+          assertFalse(future.isDone())
+          if (stock)
+            assertTrue(!(recorder.r.asInstanceOf[Future[_]]).isDone())
+          assertSame(p, recorder.p)
 
         case _ => ()
       }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ScheduledExectutorSubclassTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ScheduledExectutorSubclassTest.scala
@@ -1,0 +1,1281 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit._
+import java.util
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.atomic._
+
+import java.util.stream.Stream
+
+import org.junit._
+import org.junit.Assert._
+
+import scala.util.control.Breaks._
+
+import org.scalanative.testsuite.utils.Platform
+
+object ScheduledExecutorSubclassTest {
+  class CustomTask[V](private val task: RunnableScheduledFuture[V])
+      extends RunnableScheduledFuture[V] {
+    @volatile var ran = false
+    override def isPeriodic: Boolean = task.isPeriodic
+    override def run(): Unit = {
+      ran = true
+      task.run()
+    }
+    override def getDelay(unit: TimeUnit): Long = task.getDelay(unit)
+    override def compareTo(t: Delayed): Int = task.compareTo(
+      t.asInstanceOf[CustomTask[_]].task
+    )
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean =
+      task.cancel(mayInterruptIfRunning)
+    override def isCancelled: Boolean = task.isCancelled
+    override def isDone: Boolean = task.isDone
+    @throws[InterruptedException]
+    @throws[ExecutionException]
+    override def get: V = {
+      val v = task.get
+      assertTrue(ran)
+      v
+    }
+    @throws[InterruptedException]
+    @throws[ExecutionException]
+    @throws[TimeoutException]
+    override def get(time: Long, unit: TimeUnit): V = {
+      val v = task.get(time, unit)
+      assertTrue(ran)
+      v
+    }
+  }
+  class RunnableCounter extends Runnable {
+    val count = new AtomicInteger(0)
+    override def run(): Unit = { count.getAndIncrement }
+  }
+}
+class ScheduledExecutorSubclassTest extends JSR166Test {
+  import JSR166Test._
+  import ScheduledExecutorSubclassTest._
+
+  class CustomExecutor(
+      corePoolSize: Int,
+      threadFactory: ThreadFactory,
+      handler: RejectedExecutionHandler
+  ) extends ScheduledThreadPoolExecutor(corePoolSize, threadFactory, handler) {
+    def this(corePoolSize: Int, threadFactory: ThreadFactory) =
+      this(
+        corePoolSize,
+        threadFactory,
+        new ThreadPoolExecutor.AbortPolicy()
+      )
+    def this(corePoolSize: Int) = this(
+      corePoolSize,
+      Executors.defaultThreadFactory()
+    )
+    def this(corePoolSize: Int, handler: RejectedExecutionHandler) =
+      this(corePoolSize, Executors.defaultThreadFactory(), handler)
+
+    override protected def decorateTask[V](
+        r: Runnable,
+        task: RunnableScheduledFuture[V]
+    ) = new CustomTask[V](task)
+    override protected def decorateTask[V](
+        c: Callable[V],
+        task: RunnableScheduledFuture[V]
+    ) = new CustomTask[V](task)
+  }
+
+  /** execute successfully executes a runnable
+   */
+  @throws[InterruptedException]
+  @Test def testExecute(): Unit = usingPoolCleaner(new CustomExecutor(1)) { p =>
+    val done = new CountDownLatch(1)
+    val task = new CheckedRunnable() {
+      override def realRun(): Unit = { done.countDown() }
+    }
+    p.execute(task)
+    await(done)
+  }
+
+  /** delayed schedule of callable successfully executes after delay
+   */
+  @throws[Exception]
+  @Test def testSchedule1(): Unit = {
+    val done = new CountDownLatch(1)
+    usingWrappedPoolCleaner(new CustomExecutor(1))(cleaner(_, done)) { p =>
+      val p = new CustomExecutor(1)
+      val startTime = System.nanoTime
+      val task = new CheckedCallable[Boolean]() {
+        override def realCall(): Boolean = {
+          done.countDown()
+          assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+          java.lang.Boolean.TRUE
+        }
+      }
+      val f = p.schedule(task, timeoutMillis(), MILLISECONDS)
+      assertSame(java.lang.Boolean.TRUE, f.get)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
+  }
+
+  /** delayed schedule of runnable successfully executes after delay
+   */
+  @throws[Exception]
+  @Test def testSchedule3(): Unit = usingPoolCleaner(new CustomExecutor(1)) {
+    p =>
+      val startTime = System.nanoTime
+      val done = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = {
+          done.countDown()
+          assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+        }
+      }
+      val f = p.schedule(task, timeoutMillis(), MILLISECONDS)
+      await(done)
+      assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+  }
+
+  /** scheduleAtFixedRate executes runnable after given initial delay
+   */
+  @throws[InterruptedException]
+  @Test def testSchedule4(): Unit = usingPoolCleaner(new CustomExecutor(1)) {
+    p =>
+      val startTime = System.nanoTime
+      val done = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = {
+          done.countDown()
+          assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+        }
+      }
+      val f = p.scheduleAtFixedRate(
+        task,
+        timeoutMillis(),
+        LONG_DELAY_MS,
+        MILLISECONDS
+      )
+      await(done)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      f.cancel(true)
+  }
+
+  /** scheduleWithFixedDelay executes runnable after given initial delay
+   */
+  @throws[InterruptedException]
+  @Test def testSchedule5(): Unit = usingPoolCleaner(new CustomExecutor(1)) {
+    p =>
+      val startTime = System.nanoTime
+      val done = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = {
+          done.countDown()
+          assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+        }
+      }
+      val f = p.scheduleWithFixedDelay(
+        task,
+        timeoutMillis(),
+        LONG_DELAY_MS,
+        MILLISECONDS
+      )
+      await(done)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      f.cancel(true)
+  }
+
+  /** scheduleAtFixedRate executes series of tasks at given rate. Eventually, it
+   *  must hold that: cycles - 1 <= elapsedMillis/delay < cycles
+   */
+  @throws[InterruptedException]
+  @Test def testFixedRateSequence(): Unit =
+    usingPoolCleaner(new CustomExecutor(1)) { p =>
+      breakable {
+        var delay = 1
+        while (delay <= LONG_DELAY_MS) {
+          val startTime = System.nanoTime
+          val cycles = 8
+          val done = new CountDownLatch(cycles)
+          val task = new CheckedRunnable() {
+            override def realRun(): Unit = { done.countDown() }
+          }
+          val periodicTask = p.scheduleAtFixedRate(task, 0, delay, MILLISECONDS)
+          val totalDelayMillis = (cycles - 1) * delay
+          await(done, totalDelayMillis + LONG_DELAY_MS)
+          periodicTask.cancel(true)
+          val elapsedMillis = millisElapsedSince(startTime)
+          assertTrue(elapsedMillis >= totalDelayMillis)
+          if (elapsedMillis <= cycles * delay) break()
+
+          delay *= 3
+        }
+        fail("unexpected execution rate")
+      }
+    }
+
+  /** scheduleWithFixedDelay executes series of tasks with given period.
+   *  Eventually, it must hold that each task starts at least delay and at most
+   *  2 * delay after the termination of the previous task.
+   */
+  @throws[InterruptedException]
+  @Test def testFixedDelaySequence(): Unit =
+    usingPoolCleaner(new CustomExecutor(1)) { p =>
+      var delay = 1
+      breakable {
+        while (delay <= LONG_DELAY_MS) {
+          val startTime = System.nanoTime
+          val previous = new AtomicLong(startTime)
+          val tryLongerDelay = new AtomicBoolean(false)
+          val cycles = 8
+          val done = new CountDownLatch(cycles)
+          val d = delay
+          val task = new CheckedRunnable() {
+            override def realRun(): Unit = {
+              val now = System.nanoTime
+              val elapsedMillis = NANOSECONDS.toMillis(now - previous.get)
+              if (done.getCount == cycles) { // first execution
+                if (elapsedMillis >= d) tryLongerDelay.set(true)
+              } else {
+                assertTrue(elapsedMillis >= d)
+                if (elapsedMillis >= 2 * d) tryLongerDelay.set(true)
+              }
+              previous.set(now)
+              done.countDown()
+            }
+          }
+          val periodicTask =
+            p.scheduleWithFixedDelay(task, 0, delay, MILLISECONDS)
+          val totalDelayMillis = (cycles - 1) * delay
+          await(done, totalDelayMillis + cycles * LONG_DELAY_MS)
+          periodicTask.cancel(true)
+          val elapsedMillis = millisElapsedSince(startTime)
+          assertTrue(elapsedMillis >= totalDelayMillis)
+          if (!tryLongerDelay.get) break()
+
+          delay *= 3
+        }
+        fail("unexpected execution rate")
+      }
+    }
+
+  /** Submitting null tasks throws NullPointerException
+   */
+  @Test def testNullTaskSubmission(): Unit =
+    usingPoolCleaner(new CustomExecutor(1)) { p =>
+      assertNullTaskSubmissionThrowsNullPointerException(p)
+    }
+
+  /** Submitted tasks are rejected when shutdown
+   */
+  @throws[InterruptedException]
+  @Test def testSubmittedTasksRejectedWhenShutdown(): Unit = {
+    val p = new CustomExecutor(2)
+    val rnd = ThreadLocalRandom.current()
+    val threadsStarted = new CountDownLatch(p.getCorePoolSize)
+    val done = new CountDownLatch(1)
+    val r: CheckedRunnable = () => {
+      threadsStarted.countDown()
+      breakable {
+        while (true)
+          try {
+            done.await()
+            break()
+          } catch {
+            case shutdownNowDeliberatelyIgnored: InterruptedException =>
+          }
+      }
+    }
+    val c: CheckedCallable[java.lang.Boolean] = () => {
+      threadsStarted.countDown()
+      breakable {
+        while (true) try {
+          done.await()
+          break()
+        } catch {
+          case shutdownNowDeliberatelyIgnored: InterruptedException =>
+        }
+      }
+      java.lang.Boolean.TRUE
+    }
+
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      for (i <- p.getCorePoolSize() until 0 by -1) {
+        rnd.nextInt(4) match {
+          case 0 => p.execute(r)
+          case 1 => assertFalse(p.submit(r).isDone)
+          case 2 => assertFalse(p.submit(r, java.lang.Boolean.TRUE).isDone)
+          case 3 => assertFalse(p.submit(c).isDone)
+        }
+      }
+      // ScheduledThreadPoolExecutor has an unbounded queue, so never saturated.
+      await(threadsStarted)
+
+      if (rnd.nextBoolean()) p.shutdownNow()
+      else p.shutdown()
+      // Pool is shutdown, but not yet terminated
+      assertTaskSubmissionsAreRejected(p)
+      assertFalse(p.isTerminated)
+      done.countDown() // release blocking tasks
+
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTaskSubmissionsAreRejected(p)
+    }
+    assertEquals(p.getCorePoolSize, p.getCompletedTaskCount)
+  }
+
+  /** getActiveCount increases but doesn't overestimate, when a thread becomes
+   *  active
+   */
+  @throws[InterruptedException]
+  @Test def testGetActiveCount(): Unit = {
+    val done = new CountDownLatch(1)
+    usingWrappedPoolCleaner(new CustomExecutor(2))(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getActiveCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getActiveCount)
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getActiveCount)
+    }
+  }
+
+  /** getCompletedTaskCount increases, but doesn't overestimate, when tasks
+   *  complete
+   */
+  @throws[InterruptedException]
+  @Test def testGetCompletedTaskCount(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val threadProceed = new CountDownLatch(1)
+      val threadDone = new CountDownLatch(1)
+      assertEquals(0, p.getCompletedTaskCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(0, p.getCompletedTaskCount)
+          await(threadProceed)
+          threadDone.countDown()
+        }
+      })
+      await(threadStarted)
+      assertEquals(0, p.getCompletedTaskCount)
+      threadProceed.countDown()
+      await(threadDone)
+      val startTime = System.nanoTime
+      while (p.getCompletedTaskCount != 1) {
+        if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
+        Thread.`yield`()
+      }
+    }
+
+  /** getCorePoolSize returns size given in constructor if not otherwise set
+   */
+  @Test def testGetCorePoolSize(): Unit =
+    usingPoolCleaner(new CustomExecutor(1)) { p =>
+      assertEquals(1, p.getCorePoolSize)
+    }
+
+  /** getLargestPoolSize increases, but doesn't overestimate, when multiple
+   *  threads active
+   */
+  @throws[InterruptedException]
+  @Test def testGetLargestPoolSize(): Unit = {
+    val THREADS = 3
+    val done = new CountDownLatch(1)
+    val p = new CustomExecutor(THREADS)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadsStarted = new CountDownLatch(THREADS)
+      assertEquals(0, p.getLargestPoolSize)
+      for (i <- 0 until THREADS) {
+        p.execute(new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadsStarted.countDown()
+            await(done)
+            assertEquals(THREADS, p.getLargestPoolSize)
+          }
+        })
+      }
+      await(threadsStarted)
+      assertEquals(THREADS, p.getLargestPoolSize)
+    }
+    assertEquals(THREADS, p.getLargestPoolSize)
+  }
+
+  /** getPoolSize increases, but doesn't overestimate, when threads become
+   *  active
+   */
+  @throws[InterruptedException]
+  @Test def testGetPoolSize(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new CustomExecutor(1)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getPoolSize)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getPoolSize)
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getPoolSize)
+    }
+  }
+
+  /** getTaskCount increases, but doesn't overestimate, when tasks submitted
+   */
+  @throws[InterruptedException]
+  @Test def testGetTaskCount(): Unit = {
+    val TASKS = 3
+    val done = new CountDownLatch(1)
+    val p = new CustomExecutor(1)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+      for (i <- 0 until TASKS) {
+        assertEquals(1 + i, p.getTaskCount)
+        p.execute(new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            assertEquals(1 + TASKS, p.getTaskCount)
+            await(done)
+          }
+        })
+      }
+      assertEquals(1 + TASKS, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+    }
+    assertEquals(1 + TASKS, p.getTaskCount)
+    assertEquals(1 + TASKS, p.getCompletedTaskCount)
+  }
+
+  /** getThreadFactory returns factory in constructor if not set
+   */
+  @Test def testGetThreadFactory(): Unit = {
+    val threadFactory = new SimpleThreadFactory
+    usingPoolCleaner(new CustomExecutor(1, threadFactory)) { p =>
+      assertSame(threadFactory, p.getThreadFactory)
+    }
+  }
+
+  /** setThreadFactory sets the thread factory returned by getThreadFactory
+   */
+  @Test def testSetThreadFactory(): Unit = {
+    val threadFactory = new SimpleThreadFactory
+    usingPoolCleaner(new CustomExecutor(1)) { p =>
+      p.setThreadFactory(threadFactory)
+      assertSame(threadFactory, p.getThreadFactory)
+    }
+  }
+
+  /** setThreadFactory(null) throws NPE
+   */
+  @Test def testSetThreadFactoryNull(): Unit =
+    usingPoolCleaner(new CustomExecutor(1)) { p =>
+      assertThrows(
+        classOf[NullPointerException],
+        () => p.setThreadFactory(null)
+      )
+    }
+
+  /** isShutdown is false before shutdown, true after
+   */
+  @Test def testIsShutdown(): Unit = usingPoolCleaner(new CustomExecutor(1)) {
+    p =>
+      assertFalse(p.isShutdown)
+      try {
+        p.shutdown()
+        assertTrue(p.isShutdown)
+      } catch { case ok: SecurityException => }
+  }
+
+  /** isTerminated is false before termination, true after
+   */
+  @throws[InterruptedException]
+  @Test def testIsTerminated(): Unit = {
+    val done = new CountDownLatch(1)
+    usingPoolCleaner(new CustomExecutor(1)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(p.isTerminated)
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertFalse(p.isTerminated)
+      assertFalse(p.isTerminating)
+      done.countDown()
+      try p.shutdown()
+      catch { case ok: SecurityException => () }
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated)
+    }
+  }
+
+  /** isTerminating is not true when running or when terminated
+   */
+  @throws[InterruptedException]
+  @Test def testIsTerminating(): Unit = {
+    val done = new CountDownLatch(1)
+    usingPoolCleaner(new CustomExecutor(1)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertFalse(p.isTerminating)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(p.isTerminating)
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertFalse(p.isTerminating)
+      done.countDown()
+      try p.shutdown()
+      catch { case ok: SecurityException => }
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated)
+      assertFalse(p.isTerminating)
+    }
+  }
+
+  /** getQueue returns the work queue, which contains queued tasks
+   */
+  @throws[InterruptedException]
+  @Test def testGetQueue(): Unit = {
+    val done = new CountDownLatch(1)
+    usingWrappedPoolCleaner(new CustomExecutor(1))(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val tasks = new Array[ScheduledFuture[_]](5)
+      for (i <- 0 until tasks.length) {
+        val r = new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            await(done)
+          }
+        }
+        tasks(i) = p.schedule(r, 1, MILLISECONDS)
+      }
+      await(threadStarted)
+      val q = p.getQueue
+      assertTrue(q.contains(tasks(tasks.length - 1)))
+      assertFalse(q.contains(tasks(0)))
+    }
+  }
+
+  /** remove(task) removes queued task, and fails to remove active task
+   */
+  @throws[InterruptedException]
+  @Test def testRemove(): Unit = {
+    val done = new CountDownLatch(1)
+    usingWrappedPoolCleaner(new CustomExecutor(1))(cleaner(_, done)) { p =>
+      val tasks = new Array[ScheduledFuture[_]](5)
+      val threadStarted = new CountDownLatch(1)
+      for (i <- 0 until tasks.length) {
+        val r = new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            await(done)
+          }
+        }
+        tasks(i) = p.schedule(r, 1, MILLISECONDS)
+      }
+      await(threadStarted)
+      val q = p.getQueue
+      assertFalse(p.remove(tasks(0).asInstanceOf[Runnable]))
+      assertTrue(q.contains(tasks(4).asInstanceOf[Runnable]))
+      assertTrue(q.contains(tasks(3).asInstanceOf[Runnable]))
+      assertTrue(p.remove(tasks(4).asInstanceOf[Runnable]))
+      assertFalse(p.remove(tasks(4).asInstanceOf[Runnable]))
+      assertFalse(q.contains(tasks(4).asInstanceOf[Runnable]))
+      assertTrue(q.contains(tasks(3).asInstanceOf[Runnable]))
+      assertTrue(p.remove(tasks(3).asInstanceOf[Runnable]))
+      assertFalse(q.contains(tasks(3).asInstanceOf[Runnable]))
+    }
+  }
+
+  /** purge removes cancelled tasks from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testPurge(): Unit = {
+    val tasks = new Array[ScheduledFuture[_]](5)
+    val releaser = new Runnable() {
+      override def run(): Unit = {
+        for (task <- tasks) { if (task != null) task.cancel(true) }
+      }
+    }
+    val p = new CustomExecutor(1)
+    usingWrappedPoolCleaner(new CustomExecutor(1))(cleaner(_, releaser)) { p =>
+      for (i <- 0 until tasks.length) {
+        tasks(i) = p.schedule(
+          possiblyInterruptedRunnable(SMALL_DELAY_MS),
+          LONG_DELAY_MS,
+          MILLISECONDS
+        )
+      }
+      var max = tasks.length
+      if (tasks(4).cancel(true)) max -= 1
+      if (tasks(3).cancel(true)) max -= 1
+      // There must eventually be an interference-free point at
+      // which purge will not fail. (At worst, when queue is empty.)
+      breakable {
+        val startTime = System.nanoTime
+        while ({
+          p.purge()
+          val count = p.getTaskCount
+          if (count == max) break()
+          millisElapsedSince(startTime) < LONG_DELAY_MS
+        }) ()
+        fail("Purge failed to remove cancelled tasks")
+      }
+    }
+  }
+
+  /** shutdownNow returns a list containing tasks that were not run, and those
+   *  tasks are drained from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testShutdownNow(): Unit = {
+    val poolSize = 2
+    val count = 5
+    val ran = new AtomicInteger(0)
+    val p = new CustomExecutor(poolSize)
+    val threadsStarted = new CountDownLatch(poolSize)
+    val waiter = new CheckedRunnable() {
+      override def realRun(): Unit = {
+        threadsStarted.countDown()
+        try MILLISECONDS.sleep(LONGER_DELAY_MS)
+        catch {
+          case success: InterruptedException =>
+
+        }
+        ran.getAndIncrement
+      }
+    }
+    for (i <- 0 until count) { p.execute(waiter) }
+    await(threadsStarted)
+    assertEquals(poolSize, p.getActiveCount)
+    assertEquals(0, p.getCompletedTaskCount)
+    val queuedTasks: util.List[Runnable] = null
+    try {
+      val queuedTasks: util.List[Runnable] = p.shutdownNow()
+      assertTrue(p.isShutdown)
+      assertTrue(p.getQueue.isEmpty)
+      assertEquals(count - poolSize, queuedTasks.size)
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated)
+      assertEquals(poolSize, ran.get)
+      assertEquals(poolSize, p.getCompletedTaskCount)
+    } catch {
+      // Allowed in case test doesn't have privs
+      case ok: SecurityException => ()
+    }
+  }
+
+  /** shutdownNow returns a list containing tasks that were not run, and those
+   *  tasks are drained from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testShutdownNow_delayedTasks(): Unit = {
+    val p = new CustomExecutor(1)
+    val tasks = new util.ArrayList[ScheduledFuture[_]]
+    for (i <- 0 until 3) {
+      val r = new NoOpRunnable
+      tasks.add(p.schedule(r, 9, SECONDS))
+      tasks.add(p.scheduleAtFixedRate(r, 9, 9, SECONDS))
+      tasks.add(p.scheduleWithFixedDelay(r, 9, 9, SECONDS))
+    }
+    if (testImplementationDetails)
+      assertEquals(
+        new HashSet[AnyRef](tasks),
+        new HashSet[AnyRef](p.getQueue)
+      )
+    try {
+      val queuedTasks: util.List[Runnable] = p.shutdownNow
+      assertTrue(p.isShutdown)
+      assertTrue(p.getQueue.isEmpty)
+      if (testImplementationDetails)
+        assertEquals(
+          new HashSet[AnyRef](tasks),
+          new HashSet[AnyRef](queuedTasks)
+        )
+      assertEquals(tasks.size, queuedTasks.size)
+      tasks.forEach { task =>
+        assertFalse(
+          task.asInstanceOf[CustomTask[_]].ran
+        )
+        assertFalse(task.isDone)
+        assertFalse(task.isCancelled)
+      }
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(p.isTerminated)
+    } catch {
+      // Allowed in case test doesn't have privs
+      case ok: SecurityException =>
+    }
+
+  }
+
+  /** By default, periodic tasks are cancelled at shutdown. By default, delayed
+   *  tasks keep running after shutdown. Check that changing the default values
+   *  work:
+   *    - setExecuteExistingDelayedTasksAfterShutdownPolicy
+   *    - setContinueExistingPeriodicTasksAfterShutdownPolicy
+   */
+  @Test def testShutdown_cancellation(): Unit = {
+    Assume.assumeFalse(
+      "Fails in JDK8, fixed in JDK11",
+      Platform.executingInJVMOnLowerThenJDK11
+    )
+    val poolSize = 4
+    val p = new CustomExecutor(poolSize)
+    val q = p.getQueue
+    val rnd = ThreadLocalRandom.current
+    val delay = rnd.nextInt(2)
+    val rounds = rnd.nextInt(1, 3)
+    var effectiveDelayedPolicy = false
+    var effectivePeriodicPolicy = false
+    var effectiveRemovePolicy = false
+    if (rnd.nextBoolean)
+      p.setExecuteExistingDelayedTasksAfterShutdownPolicy(
+        { effectiveDelayedPolicy = rnd.nextBoolean; effectiveDelayedPolicy }
+      )
+    else effectiveDelayedPolicy = true
+    assertEquals(
+      effectiveDelayedPolicy,
+      p.getExecuteExistingDelayedTasksAfterShutdownPolicy
+    )
+    if (rnd.nextBoolean)
+      p.setContinueExistingPeriodicTasksAfterShutdownPolicy(
+        { effectivePeriodicPolicy = rnd.nextBoolean; effectivePeriodicPolicy }
+      )
+    else effectivePeriodicPolicy = false
+    assertEquals(
+      effectivePeriodicPolicy,
+      p.getContinueExistingPeriodicTasksAfterShutdownPolicy
+    )
+    if (rnd.nextBoolean)
+      p.setRemoveOnCancelPolicy({
+        effectiveRemovePolicy = rnd.nextBoolean; effectiveRemovePolicy
+      })
+    else effectiveRemovePolicy = false
+    assertEquals(effectiveRemovePolicy, p.getRemoveOnCancelPolicy)
+    val periodicTasksContinue = effectivePeriodicPolicy && rnd.nextBoolean
+    // Strategy: Wedge the pool with one wave of "blocker" tasks,
+    // then add a second wave that waits in the queue until unblocked.
+    val ran = new AtomicInteger(0)
+    val poolBlocked = new CountDownLatch(poolSize)
+    val unblock = new CountDownLatch(1)
+    val exception = new RuntimeException
+    class Task extends Runnable {
+      override def run(): Unit = {
+        try {
+          ran.getAndIncrement
+          poolBlocked.countDown()
+          await(unblock)
+        } catch {
+          case fail: Throwable =>
+            threadUnexpectedException(fail)
+        }
+      }
+    }
+    class PeriodicTask(var rounds: Int) extends Task {
+      override def run(): Unit = {
+        if ({ rounds -= 1; rounds } == 0) super.run()
+        // throw exception to surely terminate this periodic task,
+        // but in a separate execution and in a detectable way.
+        if (rounds == -1) throw exception
+      }
+    }
+    val task = new Task
+    val immediates = new util.ArrayList[Future[_]]
+    val delayeds = new util.ArrayList[Future[_]]
+    val periodics = new util.ArrayList[Future[_]]
+    immediates.add(p.submit(task))
+    delayeds.add(p.schedule(task, delay, MILLISECONDS))
+    periodics.add(
+      p.scheduleAtFixedRate(new PeriodicTask(rounds), delay, 1, MILLISECONDS)
+    )
+    periodics.add(
+      p.scheduleWithFixedDelay(new PeriodicTask(rounds), delay, 1, MILLISECONDS)
+    )
+    await(poolBlocked)
+    assertEquals(poolSize, ran.get)
+    assertEquals(poolSize, p.getActiveCount)
+    assertTrue(q.isEmpty)
+    // Add second wave of tasks.
+    immediates.add(p.submit(task))
+    delayeds.add(
+      p.schedule(
+        task,
+        if (effectiveDelayedPolicy) delay
+        else LONG_DELAY_MS.toInt,
+        MILLISECONDS
+      )
+    )
+    periodics.add(
+      p.scheduleAtFixedRate(new PeriodicTask(rounds), delay, 1, MILLISECONDS)
+    )
+    periodics.add(
+      p.scheduleWithFixedDelay(new PeriodicTask(rounds), delay, 1, MILLISECONDS)
+    )
+    assertEquals(poolSize, q.size)
+    assertEquals(poolSize, ran.get)
+    immediates.forEach((f: Future[_]) =>
+      assertTrue(f.asInstanceOf[ScheduledFuture[_]].getDelay(NANOSECONDS) <= 0L)
+    )
+    Seq(immediates, delayeds, periodics).foreach {
+      _.forEach((f: Future[_]) => assertFalse(f.isDone))
+    }
+    try p.shutdown()
+    catch {
+      case ok: SecurityException =>
+        return
+    }
+    assertTrue(p.isShutdown)
+    assertTrue(p.isTerminating)
+    assertFalse(p.isTerminated)
+    if (rnd.nextBoolean)
+      assertEachThrows(
+        classOf[RejectedExecutionException],
+        () => p.submit(task),
+        () => p.schedule(task, 1, SECONDS),
+        () => p.scheduleAtFixedRate(new PeriodicTask(1), 1, 1, SECONDS),
+        () => p.scheduleWithFixedDelay(new PeriodicTask(2), 1, 1, SECONDS)
+      )
+    assertTrue(q.contains(immediates.get(1)))
+    assertTrue(!effectiveDelayedPolicy ^ q.contains(delayeds.get(1)))
+    assertTrue(
+      !effectivePeriodicPolicy ^ q.containsAll(periodics.subList(2, 4))
+    )
+    immediates.forEach((f: Future[_]) => assertFalse(f.isDone))
+    assertFalse(delayeds.get(0).isDone)
+    if (effectiveDelayedPolicy) assertFalse(delayeds.get(1).isDone)
+    else assertTrue(delayeds.get(1).isCancelled)
+    if (effectivePeriodicPolicy) periodics.forEach((f: Future[_]) => {
+      assertFalse(f.isDone)
+      if (!periodicTasksContinue) {
+        assertTrue(f.cancel(false))
+        assertTrue(f.isCancelled)
+      }
+
+    })
+    else {
+      periodics.subList(0, 2).forEach((f: Future[_]) => assertFalse(f.isDone))
+      periodics
+        .subList(2, 4)
+        .forEach((f: Future[_]) => assertTrue(f.isCancelled))
+    }
+    unblock.countDown() // Release all pool threads
+
+    assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+    assertFalse(p.isTerminating)
+    assertTrue(p.isTerminated)
+    assertTrue(q.isEmpty)
+    Seq(immediates, delayeds, periodics).foreach {
+      _.forEach((f: Future[_]) => assertTrue(f.isDone))
+    }
+    immediates.forEach(f => assertNull(f.get()))
+    assertNull(delayeds.get(0).get)
+    if (effectiveDelayedPolicy) assertNull(delayeds.get(1).get)
+    else assertTrue(delayeds.get(1).isCancelled)
+    if (periodicTasksContinue) periodics.forEach((f: Future[_]) => {
+      try f.get
+      catch {
+        case success: ExecutionException =>
+          assertSame(exception, success.getCause)
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+
+    })
+    else periodics.forEach((f: Future[_]) => assertTrue(f.isCancelled))
+    assertEquals(
+      poolSize + 1 +
+        (if (effectiveDelayedPolicy) 1 else 0) +
+        (if (periodicTasksContinue) 2 else 0),
+      ran.get
+    )
+  }
+
+  /** completed submit of callable returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitCallable(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val future = e.submit(new StringTask)
+      val result = future.get
+      assertSame(TEST_STRING, result)
+    }
+
+  /** completed submit of runnable returns successfully
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val future = e.submit(new NoOpRunnable)
+      future.get
+      assertTrue(future.isDone)
+    }
+
+  /** completed submit of (runnable, result) returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable2(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val future = e.submit(new NoOpRunnable, TEST_STRING)
+      val result = future.get
+      assertSame(TEST_STRING, result)
+    }
+
+  /** invokeAny(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testInvokeAny1(): Unit = usingPoolCleaner(new CustomExecutor(2)) {
+    e =>
+      assertThrows(classOf[NullPointerException], () => e.invokeAll(null))
+  }
+
+  /** invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testInvokeAny2(): Unit = usingPoolCleaner(new CustomExecutor(2)) {
+    e =>
+      assertThrows(
+        classOf[IllegalArgumentException],
+        () => e.invokeAny(new util.ArrayList[Callable[String]])
+      )
+
+  }
+
+  /** invokeAny(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAny3(): Unit = {
+    val latch = new CountDownLatch(1)
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      assertThrows(classOf[NullPointerException], () => e.invokeAny(l))
+      latch.countDown()
+    }
+  }
+
+  /** invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testInvokeAny4(): Unit = usingPoolCleaner(new CustomExecutor(2)) {
+    e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val ex = assertThrows(classOf[ExecutionException], () => e.invokeAny(l))
+      assertTrue(ex.getCause.isInstanceOf[NullPointerException])
+  }
+
+  /** invokeAny(c) returns result of some task
+   */
+  @throws[Exception]
+  @Test def testInvokeAny5(): Unit = usingPoolCleaner(new CustomExecutor(2)) {
+    e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val result = e.invokeAny(l)
+      assertSame(TEST_STRING, result)
+  }
+
+  /** invokeAll(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testInvokeAll1(): Unit = usingPoolCleaner(new CustomExecutor(2)) {
+    e =>
+      assertThrows(classOf[NullPointerException], () => e.invokeAll(null))
+  }
+
+  /** invokeAll(empty collection) returns empty list
+   */
+  @throws[Exception]
+  @Test def testInvokeAll2(): Unit = usingPoolCleaner(new CustomExecutor(2)) {
+    e =>
+      val emptyCollection = Collections.emptyList
+      val r = e.invokeAll(emptyCollection)
+      assertTrue(r.isEmpty)
+  }
+
+  /** invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAll3(): Unit = usingPoolCleaner(new CustomExecutor(2)) {
+    e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(null)
+      assertThrows(classOf[NullPointerException], () => e.invokeAll(l))
+  }
+
+  /** get of invokeAll(c) throws exception on failed task
+   */
+  @throws[Exception]
+  @Test def testInvokeAll4(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val futures = e.invokeAll(l)
+      assertEquals(1, futures.size)
+      val ex =
+        assertThrows(classOf[ExecutionException], () => futures.get(0).get)
+      assertTrue(ex.getCause.isInstanceOf[NullPointerException])
+    }
+
+  /** invokeAll(c) returns results of all completed tasks
+   */
+  @throws[Exception]
+  @Test def testInvokeAll5(): Unit = usingPoolCleaner(new CustomExecutor(2)) {
+    e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val futures = e.invokeAll(l)
+      assertEquals(2, futures.size)
+      futures.forEach { future => assertSame(TEST_STRING, future.get) }
+  }
+
+  /** timed invokeAny(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny1(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      assertThrows(
+        classOf[NullPointerException],
+        () => e.invokeAny(null, randomTimeout(), randomTimeUnit())
+      )
+    }
+
+  /** timed invokeAny(,,null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAnyNullTimeUnit(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      assertThrows(
+        classOf[NullPointerException],
+        () => e.invokeAny(l, randomTimeout(), null)
+      )
+    }
+
+  /** timed invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny2(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val emptyCollection = Collections.emptyList
+      assertThrows(
+        classOf[IllegalArgumentException],
+        () => e.invokeAny(emptyCollection, randomTimeout(), randomTimeUnit())
+      )
+    }
+
+  /** timed invokeAny(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny3(): Unit = {
+    val latch = new CountDownLatch(1)
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      assertThrows(
+        classOf[NullPointerException],
+        () => e.invokeAny(l, randomTimeout(), randomTimeUnit())
+      )
+      latch.countDown()
+    }
+  }
+
+  /** timed invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny4(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val startTime = System.nanoTime
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val ex = assertThrows(
+        classOf[ExecutionException],
+        () => e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+      )
+      assertTrue(ex.getCause.isInstanceOf[NullPointerException])
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+
+  /** timed invokeAny(c) returns result of some task
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny5(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val startTime = System.nanoTime
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val result = e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+      assertSame(TEST_STRING, result)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+
+  /** timed invokeAll(null) throws NullPointerException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll1(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      assertThrows(
+        classOf[NullPointerException],
+        () => e.invokeAll(null, randomTimeout(), randomTimeUnit())
+      )
+    }
+
+  /** timed invokeAll(,,null) throws NullPointerException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAllNullTimeUnit(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      assertThrows(
+        classOf[NullPointerException],
+        () => e.invokeAll(l, randomTimeout(), null)
+      )
+    }
+
+  /** timed invokeAll(empty collection) returns empty list
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll2(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val emptyCollection = Collections.emptyList
+      val r = e.invokeAll(emptyCollection, randomTimeout(), randomTimeUnit())
+      assertTrue(r.isEmpty)
+    }
+
+  /** timed invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll3(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(null)
+      assertThrows(
+        classOf[NullPointerException],
+        () => e.invokeAll(l, randomTimeout(), randomTimeUnit())
+      )
+    }
+
+  /** get of element of invokeAll(c) throws exception on failed task
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll4(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val c = new util.ArrayList[Callable[String]]
+      c.add(new NPETask)
+      val futures = e.invokeAll(c, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(1, futures.size)
+      try {
+        futures.get(0).get
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+    }
+
+  /** timed invokeAll(c) returns results of all completed tasks
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll5(): Unit =
+    usingPoolCleaner(new CustomExecutor(2)) { e =>
+      val l = new util.ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val futures = e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(2, futures.size)
+      futures.forEach { future => assertSame(TEST_STRING, future.get) }
+    }
+
+  /** timed invokeAll(c) cancels tasks not completed by timeout
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll6(): Unit = {
+    var timeout = timeoutMillis()
+    var break = false
+    while (!break) {
+      val done = new CountDownLatch(1)
+      val waiter = new CheckedCallable[String]() {
+        override def realCall(): String = {
+          try done.await(LONG_DELAY_MS, MILLISECONDS)
+          catch {
+            case ok: InterruptedException =>
+          }
+          "1"
+        }
+      }
+      usingWrappedPoolCleaner(new CustomExecutor(2))(cleaner(_, done)) { p =>
+        val tasks = new util.ArrayList[Callable[String]]
+        tasks.add(new StringTask("0"))
+        tasks.add(waiter)
+        tasks.add(new StringTask("2"))
+        val startTime = System.nanoTime
+        val futures = p.invokeAll(tasks, timeout, MILLISECONDS)
+        assertEquals(tasks.size, futures.size)
+        assertTrue(millisElapsedSince(startTime) >= timeout)
+        futures.forEach { future => assertTrue(future.isDone) }
+        assertTrue(futures.get(1).isCancelled)
+        try {
+          assertEquals("0", futures.get(0).get)
+          assertEquals("2", futures.get(2).get)
+          break = true
+        } catch {
+          case retryWithLongerTimeout: CancellationException =>
+            timeout *= 2
+            if (timeout >= LONG_DELAY_MS / 2)
+              fail("expected exactly one task to be cancelled")
+        }
+      }
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ScheduledExecutorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ScheduledExecutorTest.scala
@@ -1,0 +1,1319 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit._
+import java.util
+import java.util._
+import java.util.Collections
+import java.util.concurrent._
+import java.util.concurrent.atomic._
+import java.util.stream.Stream
+
+import org.junit.{Test, Ignore}
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.function.ThrowingRunnable
+
+import org.scalanative.testsuite.utils.Platform
+
+object ScheduledExecutorTest {
+  class RunnableCounter extends Runnable {
+    val count = new AtomicInteger(0)
+    override def run(): Unit = { count.getAndIncrement }
+  }
+}
+
+class ScheduledExecutorTest extends JSR166Test {
+  import JSR166Test._
+
+  /** execute successfully executes a runnable
+   */
+  @throws[InterruptedException]
+  @Test def testExecute(): Unit = usingPoolCleaner(
+    new ScheduledThreadPoolExecutor(1)
+  ) { p =>
+    val done = new CountDownLatch(1)
+    val task = new CheckedRunnable() {
+      override def realRun(): Unit = { done.countDown() }
+    }
+    p.execute(task)
+    await(done)
+  }
+
+  /** delayed schedule of callable successfully executes after delay
+   */
+  @throws[Exception]
+  @Test def testSchedule1(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      val startTime = System.nanoTime
+      val done = new CountDownLatch(1)
+      val task = new CheckedCallable[Boolean]() {
+        override def realCall(): Boolean = {
+          done.countDown()
+          assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+          java.lang.Boolean.TRUE
+        }
+      }
+      val f = p.schedule(task, timeoutMillis(), MILLISECONDS)
+      assertSame(java.lang.Boolean.TRUE, f.get)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      assertEquals(0L, done.getCount)
+    }
+
+  /** delayed schedule of runnable successfully executes after delay
+   */
+  @throws[Exception]
+  @Test def testSchedule3(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      val startTime = System.nanoTime
+      val done = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = {
+          done.countDown()
+          assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+        }
+      }
+      val f = p.schedule(task, timeoutMillis(), MILLISECONDS)
+      await(done)
+      assertNull(f.get(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    }
+
+  /** scheduleAtFixedRate executes runnable after given initial delay
+   */
+  @throws[Exception]
+  @Test def testSchedule4(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      val startTime = System.nanoTime
+      val done = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = {
+          done.countDown()
+          assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+        }
+      }
+      val f = p.scheduleAtFixedRate(
+        task,
+        timeoutMillis(),
+        LONG_DELAY_MS,
+        MILLISECONDS
+      )
+      await(done)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      f.cancel(true)
+    }
+
+  /** scheduleWithFixedDelay executes runnable after given initial delay
+   */
+  @throws[Exception]
+  @Test def testSchedule5(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      val startTime = System.nanoTime
+      val done = new CountDownLatch(1)
+      val task = new CheckedRunnable() {
+        override def realRun(): Unit = {
+          done.countDown()
+          assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+        }
+      }
+      val f = p.scheduleWithFixedDelay(
+        task,
+        timeoutMillis(),
+        LONG_DELAY_MS,
+        MILLISECONDS
+      )
+      await(done)
+      assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      f.cancel(true)
+    }
+
+  /** scheduleAtFixedRate executes series of tasks at given rate. Eventually, it
+   *  must hold that: cycles - 1 <= elapsedMillis/delay < cycles
+   */
+  @throws[InterruptedException]
+  @Test def testFixedRateSequence(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      import scala.util.control.Breaks._
+      var delay = 1
+      breakable {
+        while ({ delay <= LONG_DELAY_MS }) {
+          val startTime = System.nanoTime
+          val cycles = 8
+          val done = new CountDownLatch(cycles)
+          val task = new CheckedRunnable() {
+            override def realRun(): Unit = { done.countDown() }
+          }
+          val periodicTask =
+            p.scheduleAtFixedRate(task, 0, delay, MILLISECONDS)
+          val totalDelayMillis = (cycles - 1) * delay
+          await(done, totalDelayMillis + LONG_DELAY_MS)
+          periodicTask.cancel(true)
+          val elapsedMillis = millisElapsedSince(startTime)
+          assertTrue(elapsedMillis >= totalDelayMillis)
+          if (elapsedMillis <= cycles * delay) break()
+          // else retry with longer delay
+
+          delay *= 3
+        }
+        fail("unexpected execution rate")
+      }
+    }
+
+  /** scheduleWithFixedDelay executes series of tasks with given period.
+   *  Eventually, it must hold that each task starts at least delay and at most
+   *  2 * delay after the termination of the previous task.
+   */
+  @throws[InterruptedException]
+  @Test def testFixedDelaySequence(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      var delay = 1
+      import scala.util.control.Breaks._
+      breakable {
+        while ({ delay <= LONG_DELAY_MS }) {
+          val startTime = System.nanoTime
+          val previous = new AtomicLong(startTime)
+          val tryLongerDelay = new AtomicBoolean(false)
+          val cycles = 8
+          val done = new CountDownLatch(cycles)
+          val d = delay
+          val task = new CheckedRunnable() {
+            override def realRun(): Unit = {
+              val now = System.nanoTime
+              val elapsedMillis = NANOSECONDS.toMillis(now - previous.get)
+              if (done.getCount == cycles) { // first execution
+                if (elapsedMillis >= d) tryLongerDelay.set(true)
+              } else {
+                assertTrue(elapsedMillis >= d)
+                if (elapsedMillis >= 2 * d) tryLongerDelay.set(true)
+              }
+              previous.set(now)
+              done.countDown()
+            }
+          }
+          val periodicTask =
+            p.scheduleWithFixedDelay(task, 0, delay, MILLISECONDS)
+          val totalDelayMillis = (cycles - 1) * delay
+          await(done, totalDelayMillis + cycles * LONG_DELAY_MS)
+          periodicTask.cancel(true)
+          val elapsedMillis = millisElapsedSince(startTime)
+          assertTrue(elapsedMillis >= totalDelayMillis)
+          if (!tryLongerDelay.get) break()
+
+          delay *= 3
+        }
+        fail("unexpected execution rate")
+      }
+    }
+
+  /** Submitting null tasks throws NullPointerException
+   */
+  @Test def testNullTaskSubmission(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) {
+      assertNullTaskSubmissionThrowsNullPointerException
+    }
+
+  /** Submitted tasks are rejected when shutdown
+   */
+  @throws[InterruptedException]
+  @Test def testSubmittedTasksRejectedWhenShutdown(): Unit = {
+    val p = new ScheduledThreadPoolExecutor(1)
+    val done = new CountDownLatch(1)
+    val rnd = ThreadLocalRandom.current
+    val threadsStarted = new CountDownLatch(p.getCorePoolSize)
+    val r: Runnable = () => {
+      def foo(): Unit = {
+        threadsStarted.countDown()
+        var break = false
+        while (true) try {
+          done.await()
+          return
+        } catch {
+          case shutdownNowDeliberatelyIgnored: InterruptedException =>
+        }
+      }
+      foo()
+    }
+    val c: Callable[Boolean] = () => {
+      def foo(): Boolean = {
+        threadsStarted.countDown()
+        while (true) try {
+          done.await()
+          return java.lang.Boolean.TRUE
+        } catch {
+          case shutdownNowDeliberatelyIgnored: InterruptedException => ()
+        }
+        false
+      }
+      foo()
+    }
+
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      var i = p.getCorePoolSize
+      while ({ { i -= 1; i + 1 } > 0 }) rnd.nextInt(4) match {
+        case 0 => p.execute(r)
+        case 1 => assertFalse(p.submit(r).isDone)
+        case 2 => assertFalse(p.submit(r, java.lang.Boolean.TRUE).isDone)
+        case 3 => assertFalse(p.submit(c).isDone)
+
+      }
+      // ScheduledThreadPoolExecutor has an unbounded queue, so never saturated.
+      await(threadsStarted)
+      if (rnd.nextBoolean) p.shutdownNow
+      else p.shutdown()
+      // Pool is shutdown, but not yet terminated
+      assertTaskSubmissionsAreRejected(p)
+      assertFalse(p.isTerminated)
+      done.countDown() // release blocking tasks
+
+      assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+      assertTaskSubmissionsAreRejected(p)
+    }
+    assertEquals(p.getCorePoolSize, p.getCompletedTaskCount)
+  }
+
+  /** getActiveCount increases but doesn't overestimate, when a thread becomes
+   *  active
+   */
+  @throws[InterruptedException]
+  @Test def testGetActiveCount(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new ScheduledThreadPoolExecutor(2)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getActiveCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getActiveCount)
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getActiveCount)
+    }
+  }
+
+  /** getCompletedTaskCount increases, but doesn't overestimate, when tasks
+   *  complete
+   */
+  @throws[InterruptedException]
+  @Test def testGetCompletedTaskCount(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val threadProceed = new CountDownLatch(1)
+      val threadDone = new CountDownLatch(1)
+      assertEquals(0, p.getCompletedTaskCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(0, p.getCompletedTaskCount)
+          await(threadProceed)
+          threadDone.countDown()
+        }
+      })
+      await(threadStarted)
+      assertEquals(0, p.getCompletedTaskCount)
+      threadProceed.countDown()
+      await(threadDone)
+      val startTime = System.nanoTime
+      while ({ p.getCompletedTaskCount != 1 }) {
+        if (millisElapsedSince(startTime) > LONG_DELAY_MS) fail("timed out")
+        Thread.`yield`()
+      }
+    }
+
+  /** getCorePoolSize returns size given in constructor if not otherwise set
+   */
+  @throws[InterruptedException]
+  @Test def testGetCorePoolSize(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      assertEquals(1, p.getCorePoolSize)
+    }
+
+  /** getLargestPoolSize increases, but doesn't overestimate, when multiple
+   *  threads active
+   */
+  @throws[InterruptedException]
+  @Test def testGetLargestPoolSize(): Unit = {
+    val THREADS = 3
+    val p = new ScheduledThreadPoolExecutor(THREADS)
+    val threadsStarted = new CountDownLatch(THREADS)
+    val done = new CountDownLatch(1)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      assertEquals(0, p.getLargestPoolSize)
+      for (i <- 0 until THREADS) {
+        p.execute(new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadsStarted.countDown()
+            await(done)
+            assertEquals(THREADS, p.getLargestPoolSize)
+          }
+        })
+      }
+      await(threadsStarted)
+      assertEquals(THREADS, p.getLargestPoolSize)
+    }
+    assertEquals(THREADS, p.getLargestPoolSize)
+  }
+
+  /** getPoolSize increases, but doesn't overestimate, when threads become
+   *  active
+   */
+  @throws[InterruptedException]
+  @Test def testGetPoolSize(): Unit = {
+    val p = new ScheduledThreadPoolExecutor(1)
+    val threadStarted = new CountDownLatch(1)
+    val done = new CountDownLatch(1)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      assertEquals(0, p.getPoolSize)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          assertEquals(1, p.getPoolSize)
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getPoolSize)
+    }
+  }
+
+  /** getTaskCount increases, but doesn't overestimate, when tasks submitted
+   */
+  @throws[InterruptedException]
+  @Test def testGetTaskCount(): Unit = {
+    val TASKS = 3
+    val done = new CountDownLatch(1)
+    val p = new ScheduledThreadPoolExecutor(1)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      assertEquals(0, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertEquals(1, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+      for (i <- 0 until TASKS) {
+        assertEquals(1 + i, p.getTaskCount)
+        p.execute(new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            assertEquals(1 + TASKS, p.getTaskCount)
+            await(done)
+          }
+        })
+      }
+      assertEquals(1 + TASKS, p.getTaskCount)
+      assertEquals(0, p.getCompletedTaskCount)
+    }
+    assertEquals(1 + TASKS, p.getTaskCount)
+    assertEquals(1 + TASKS, p.getCompletedTaskCount)
+  }
+
+  /** getThreadFactory returns factory in constructor if not set
+   */
+  @throws[InterruptedException]
+  @Test def testGetThreadFactory(): Unit = {
+    val threadFactory = new SimpleThreadFactory
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1, threadFactory)) { p =>
+      assertSame(threadFactory, p.getThreadFactory)
+    }
+  }
+
+  /** setThreadFactory sets the thread factory returned by getThreadFactory
+   */
+  @throws[InterruptedException]
+  @Test def testSetThreadFactory(): Unit = {
+    val threadFactory = new SimpleThreadFactory
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      p.setThreadFactory(threadFactory)
+      assertSame(threadFactory, p.getThreadFactory)
+    }
+  }
+
+  /** setThreadFactory(null) throws NPE
+   */
+  @throws[InterruptedException]
+  @Test def testSetThreadFactoryNull(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      try {
+        p.setThreadFactory(null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+
+  /** The default rejected execution handler is AbortPolicy.
+   */
+  @Test def testDefaultRejectedExecutionHandler(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      assertTrue(
+        p.getRejectedExecutionHandler
+          .isInstanceOf[ThreadPoolExecutor.AbortPolicy]
+      )
+    }
+
+  /** isShutdown is false before shutdown, true after
+   */
+  @Test def testIsShutdown(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      assertFalse(p.isShutdown)
+      try {
+        p.shutdown()
+        assertTrue(p.isShutdown)
+      } catch {
+        case ok: SecurityException =>
+      }
+    }
+
+  /** isTerminated is false before termination, true after
+   */
+  @throws[InterruptedException]
+  @Test def testIsTerminated(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val done = new CountDownLatch(1)
+      assertFalse(p.isTerminated)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(p.isTerminated)
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertFalse(p.isTerminating)
+      done.countDown()
+      try {
+        p.shutdown()
+        assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+        assertTrue(p.isTerminated)
+      } catch { case ok: SecurityException => () }
+    }
+
+  /** isTerminating is not true when running or when terminated
+   */
+  @throws[InterruptedException]
+  @Test def testIsTerminating(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val done = new CountDownLatch(1)
+      assertFalse(p.isTerminating)
+      p.execute(new CheckedRunnable() {
+        @throws[InterruptedException]
+        override def realRun(): Unit = {
+          assertFalse(p.isTerminating)
+          threadStarted.countDown()
+          await(done)
+        }
+      })
+      await(threadStarted)
+      assertFalse(p.isTerminating)
+      done.countDown()
+      try {
+        p.shutdown()
+        assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+        assertTrue(p.isTerminated)
+        assertFalse(p.isTerminating)
+      } catch { case ok: SecurityException => () }
+    }
+
+  /** getQueue returns the work queue, which contains queued tasks
+   */
+  @throws[InterruptedException]
+  @Test def testGetQueue(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new ScheduledThreadPoolExecutor(1)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val threadStarted = new CountDownLatch(1)
+      val tasks = new Array[ScheduledFuture[_]](5)
+      for (i <- 0 until tasks.length) {
+        val r = new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            await(done)
+          }
+        }
+        tasks(i) = p.schedule(r, 1, MILLISECONDS)
+      }
+      await(threadStarted)
+      val q = p.getQueue
+      assertTrue(q.contains(tasks(tasks.length - 1)))
+      assertFalse(q.contains(tasks(0)))
+    }
+  }
+
+  /** remove(task) removes queued task, and fails to remove active task
+   */
+  @throws[InterruptedException]
+  @Test def testRemove(): Unit = {
+    val done = new CountDownLatch(1)
+    val p = new ScheduledThreadPoolExecutor(1)
+    usingWrappedPoolCleaner(p)(cleaner(_, done)) { p =>
+      val tasks = new Array[ScheduledFuture[_]](5)
+      val threadStarted = new CountDownLatch(1)
+      for (i <- 0 until tasks.length) {
+        val r = new CheckedRunnable() {
+          @throws[InterruptedException]
+          override def realRun(): Unit = {
+            threadStarted.countDown()
+            await(done)
+          }
+        }
+        tasks(i) = p.schedule(r, 1, MILLISECONDS)
+      }
+      await(threadStarted)
+      val q = p.getQueue
+      assertFalse(p.remove(tasks(0).asInstanceOf[Runnable]))
+      assertTrue(q.contains(tasks(4).asInstanceOf[Runnable]))
+      assertTrue(q.contains(tasks(3).asInstanceOf[Runnable]))
+      assertTrue(p.remove(tasks(4).asInstanceOf[Runnable]))
+      assertFalse(p.remove(tasks(4).asInstanceOf[Runnable]))
+      assertFalse(q.contains(tasks(4).asInstanceOf[Runnable]))
+      assertTrue(q.contains(tasks(3).asInstanceOf[Runnable]))
+      assertTrue(p.remove(tasks(3).asInstanceOf[Runnable]))
+      assertFalse(q.contains(tasks(3).asInstanceOf[Runnable]))
+    }
+  }
+
+  /** purge eventually removes cancelled tasks from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testPurge(): Unit = {
+    val tasks = new Array[ScheduledFuture[_]](5)
+    val releaser = new Runnable() {
+      override def run(): Unit = {
+        for (task <- tasks) { if (task != null) task.cancel(true) }
+      }
+    }
+    usingWrappedPoolCleaner(new ScheduledThreadPoolExecutor(1))(
+      cleaner(_, releaser)
+    ) { p =>
+      for (i <- 0 until tasks.length) {
+        tasks(i) = p.schedule(
+          possiblyInterruptedRunnable(SMALL_DELAY_MS),
+          LONG_DELAY_MS,
+          MILLISECONDS
+        )
+      }
+      var max = tasks.length
+      if (tasks(4).cancel(true)) max -= 1
+      if (tasks(3).cancel(true)) max -= 1
+      // There must eventually be an interference-free point at
+      // which purge will not fail. (At worst, when queue is empty.)
+      val startTime = System.nanoTime
+      import scala.util.control.Breaks._
+      breakable {
+        while ({
+          p.purge()
+          val count = p.getTaskCount
+          if (count == max) break()
+          millisElapsedSince(startTime) < LONG_DELAY_MS
+        }) ()
+        fail("Purge failed to remove cancelled tasks")
+      }
+    }
+  }
+
+  /** shutdownNow returns a list containing tasks that were not run, and those
+   *  tasks are drained from the queue
+   */
+  @throws[InterruptedException]
+  @Test def testShutdownNow(): Unit = {
+    val poolSize = 2
+    val count = 5
+    val ran = new AtomicInteger(0)
+    val p = new ScheduledThreadPoolExecutor(poolSize)
+    val threadsStarted = new CountDownLatch(poolSize)
+    val waiter = new CheckedRunnable() {
+      override def realRun(): Unit = {
+        threadsStarted.countDown()
+        try MILLISECONDS.sleep(LONGER_DELAY_MS)
+        catch { case success: InterruptedException => }
+        ran.getAndIncrement()
+      }
+    }
+    for (i <- 0 until count) { p.execute(waiter) }
+    await(threadsStarted)
+    assertEquals("activeCount", poolSize, p.getActiveCount)
+    assertEquals(0, p.getCompletedTaskCount)
+    val queuedTasks =
+      try p.shutdownNow
+      catch {
+        case ok: SecurityException =>
+          return // Allowed in case test doesn't have privs
+      }
+    assertTrue(p.isShutdown)
+    assertTrue(p.getQueue.isEmpty)
+    assertEquals("queuedTasks", count - poolSize, queuedTasks.size)
+    assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+    assertTrue(p.isTerminated)
+    assertEquals(s"ran $ran - $threadsStarted", poolSize, ran.get)
+    assertEquals("completed", poolSize, p.getCompletedTaskCount)
+  }
+
+  @throws[InterruptedException]
+  @Test def testShutdownNow_delayedTasks(): Unit = {
+    val p = new ScheduledThreadPoolExecutor(1)
+    val tasks = new ArrayList[ScheduledFuture[_]]
+    for (i <- 0 until 3) {
+      val r = new NoOpRunnable
+      tasks.add(p.schedule(r, 9, SECONDS))
+      tasks.add(p.scheduleAtFixedRate(r, 9, 9, SECONDS))
+      tasks.add(p.scheduleWithFixedDelay(r, 9, 9, SECONDS))
+    }
+    if (testImplementationDetails)
+      assertEquals(new HashSet(tasks), new HashSet(p.getQueue))
+    val queuedTasks =
+      try p.shutdownNow
+      catch {
+        case ok: SecurityException =>
+          return
+      }
+    assertTrue(p.isShutdown)
+    assertTrue(p.getQueue.isEmpty)
+    if (testImplementationDetails)
+      assertEquals(new HashSet(tasks), new HashSet(queuedTasks))
+    assertEquals(tasks.size, queuedTasks.size)
+    tasks.forEach { task =>
+      assertFalse(task.isDone)
+      assertFalse(task.isCancelled)
+    }
+    assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+    assertTrue(p.isTerminated)
+  }
+
+  /** By default, periodic tasks are cancelled at shutdown. By default, delayed
+   *  tasks keep running after shutdown. Check that changing the default values
+   *  work:
+   *    - setExecuteExistingDelayedTasksAfterShutdownPolicy
+   *    - setContinueExistingPeriodicTasksAfterShutdownPolicy
+   */
+  @SuppressWarnings(Array("FutureReturnValueIgnored")) @throws[Exception]
+  @Test def testShutdown_cancellation(): Unit = {
+    assumeFalse(
+      "Fails due to bug in the JVM",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+    val poolSize = 4
+    val p = new ScheduledThreadPoolExecutor(poolSize)
+    val q = p.getQueue
+    val rnd = ThreadLocalRandom.current
+    val delay = rnd.nextInt(2)
+    val rounds = rnd.nextInt(1, 3)
+    var effectiveDelayedPolicy = false
+    var effectivePeriodicPolicy = false
+    var effectiveRemovePolicy = false
+    if (rnd.nextBoolean) {
+      effectiveDelayedPolicy = rnd.nextBoolean
+      p.setExecuteExistingDelayedTasksAfterShutdownPolicy(
+        effectiveDelayedPolicy
+      )
+    } else effectiveDelayedPolicy = true
+
+    assertEquals(
+      effectiveDelayedPolicy,
+      p.getExecuteExistingDelayedTasksAfterShutdownPolicy
+    )
+    if (rnd.nextBoolean) {
+      effectivePeriodicPolicy = rnd.nextBoolean
+      p.setContinueExistingPeriodicTasksAfterShutdownPolicy(
+        effectivePeriodicPolicy
+      )
+    } else effectivePeriodicPolicy = false
+    assertEquals(
+      effectivePeriodicPolicy,
+      p.getContinueExistingPeriodicTasksAfterShutdownPolicy()
+    )
+
+    if (rnd.nextBoolean) {
+      effectiveRemovePolicy = rnd.nextBoolean
+      p.setRemoveOnCancelPolicy(effectiveRemovePolicy)
+    } else effectiveRemovePolicy = false
+    assertEquals(effectiveRemovePolicy, p.getRemoveOnCancelPolicy)
+
+    val periodicTasksContinue =
+      effectivePeriodicPolicy && rnd.nextBoolean
+    // Strategy: Wedge the pool with one wave of "blocker" tasks,
+    // then add a second wave that waits in the queue until unblocked.
+    val ran = new AtomicInteger(0)
+    val poolBlocked = new CountDownLatch(poolSize)
+    val unblock = new CountDownLatch(1)
+    val exception = new RuntimeException
+    class Task extends Runnable {
+      override def run(): Unit = {
+        try {
+          ran.getAndIncrement
+          poolBlocked.countDown()
+          await(unblock)
+        } catch {
+          case fail: Throwable =>
+            threadUnexpectedException(fail)
+        }
+      }
+    }
+    class PeriodicTask(var rounds: Int) extends Task {
+      override def run(): Unit = {
+        if ({ rounds -= 1; rounds } == 0) super.run()
+        // throw exception to surely terminate this periodic task,
+        // but in a separate execution and in a detectable way.
+        if (rounds == -1) throw exception
+      }
+    }
+    val task = new Task
+    val immediates = new ArrayList[Future[_]]
+    val delayeds = new ArrayList[Future[_]]
+    val periodics = new ArrayList[Future[_]]
+    immediates.add(p.submit(task))
+    delayeds.add(p.schedule(task, delay, MILLISECONDS))
+    periodics.add(
+      p.scheduleAtFixedRate(new PeriodicTask(rounds), delay, 1, MILLISECONDS)
+    )
+    periodics.add(
+      p.scheduleWithFixedDelay(new PeriodicTask(rounds), delay, 1, MILLISECONDS)
+    )
+    await(poolBlocked)
+    assertEquals(poolSize, ran.get)
+    assertEquals(poolSize, p.getActiveCount)
+    assertTrue(q.isEmpty)
+    // Add second wave of tasks.
+    immediates.add(p.submit(task))
+    delayeds.add(
+      p.schedule(
+        task,
+        if (effectiveDelayedPolicy) delay.toLong else LONG_DELAY_MS,
+        MILLISECONDS
+      )
+    )
+    periodics.add(
+      p.scheduleAtFixedRate(new PeriodicTask(rounds), delay, 1, MILLISECONDS)
+    )
+    periodics.add(
+      p.scheduleWithFixedDelay(new PeriodicTask(rounds), delay, 1, MILLISECONDS)
+    )
+    assertEquals(poolSize, q.size)
+    assertEquals(poolSize, ran.get)
+    immediates.forEach((f: Future[_]) =>
+      assertTrue(
+        f.asInstanceOf[ScheduledFuture[_]].getDelay(NANOSECONDS) <= 0L
+      )
+    )
+    locally {
+      val stream = new ArrayList[Future[_]]
+      stream.addAll(immediates)
+      stream.addAll(delayeds)
+      stream.addAll(periodics)
+      stream.forEach { (f: Future[_]) => assertFalse(f.isDone) }
+    }
+    try p.shutdown()
+    catch {
+      case ok: SecurityException =>
+        return
+    }
+    assertTrue(p.isShutdown)
+    assertTrue(p.isTerminating)
+    assertFalse(p.isTerminated)
+    if (rnd.nextBoolean)
+      Seq(
+        { () => p.submit(task) }: ThrowingRunnable,
+        { () => p.schedule(task, 1, SECONDS) }: ThrowingRunnable,
+        { () =>
+          p.scheduleAtFixedRate(new PeriodicTask(1), 1, 1, SECONDS)
+        }: ThrowingRunnable,
+        { () =>
+          p.scheduleWithFixedDelay(new PeriodicTask(2), 1, 1, SECONDS)
+        }: ThrowingRunnable
+      ).foreach(
+        assertThrows(
+          classOf[RejectedExecutionException],
+          _
+        )
+      )
+    assertTrue(q.contains(immediates.get(1)))
+    assertTrue(!effectiveDelayedPolicy ^ q.contains(delayeds.get(1)))
+    assertTrue(
+      !effectivePeriodicPolicy ^ q.containsAll(periodics.subList(2, 4))
+    )
+    immediates.forEach((f: Future[_]) => assertFalse(f.isDone))
+    assertFalse(delayeds.get(0).isDone)
+    if (effectiveDelayedPolicy) assertFalse(delayeds.get(1).isDone)
+    else assertTrue(delayeds.get(1).isCancelled)
+    if (effectivePeriodicPolicy) periodics.forEach((f: Future[_]) => {
+      def foo(f: Future[_]) = {
+        assertFalse(f.isDone)
+        if (!periodicTasksContinue) {
+          assertTrue(f.cancel(false))
+          assertTrue(f.isCancelled)
+        }
+      }
+      foo(f)
+    })
+    else {
+      periodics.subList(0, 2).forEach((f: Future[_]) => assertFalse(f.isDone))
+      periodics
+        .subList(2, 4)
+        .forEach((f: Future[_]) => assertTrue(f.isCancelled))
+    }
+    unblock.countDown() // Release all pool threads
+
+    assertTrue(p.awaitTermination(LONG_DELAY_MS, MILLISECONDS))
+    assertFalse(p.isTerminating)
+    assertTrue(p.isTerminated)
+    assertTrue(q.isEmpty)
+
+    locally {
+      val stream = new ArrayList[Future[_]]
+      stream.addAll(immediates)
+      stream.addAll(delayeds)
+      stream.addAll(periodics)
+      stream.forEach { (f: Future[_]) => assertTrue(f.isDone) }
+    }
+    immediates.forEach { f => assertNull(f.get) }
+    assertNull(delayeds.get(0).get)
+    if (effectiveDelayedPolicy) assertNull(delayeds.get(1).get)
+    else assertTrue(delayeds.get(1).isCancelled)
+    if (periodicTasksContinue) periodics.forEach((f: Future[_]) => {
+      def foo(f: Future[_]) = try f.get
+      catch {
+        case success: ExecutionException =>
+          assertSame(exception, success.getCause)
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+      foo(f)
+    })
+    else periodics.forEach((f: Future[_]) => assertTrue(f.isCancelled))
+    assertEquals(
+      poolSize + 1 + (if (effectiveDelayedPolicy) 1
+                      else 0) + (if (periodicTasksContinue) 2
+                                 else 0),
+      ran.get
+    )
+  }
+
+  /** completed submit of callable returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitCallable(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val future = e.submit(new StringTask)
+      val result = future.get
+      assertEquals(TEST_STRING, result)
+    }
+
+  /** completed submit of runnable returns successfully
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val future = e.submit(new NoOpRunnable)
+      future.get
+      assertTrue(future.isDone)
+    }
+
+  /** completed submit of (runnable, result) returns result
+   */
+  @throws[Exception]
+  @Test def testSubmitRunnable2(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val future = e.submit(new NoOpRunnable, TEST_STRING)
+      val result = future.get
+      assertEquals(TEST_STRING, result)
+    }
+
+  /** invokeAny(null) throws NullPointerException
+   */
+  @throws[Exception]
+  @Test def testInvokeAny1(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      try {
+        e.invokeAny(null)
+        shouldThrow()
+      } catch { case success: NullPointerException => }
+    }
+
+  /** invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testInvokeAny2(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      try {
+        e.invokeAny(new ArrayList[Callable[String]])
+        shouldThrow()
+      } catch { case success: IllegalArgumentException => }
+    }
+
+  /** invokeAny(c) throws NullPointerException if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAny3(): Unit = {
+    val latch = new CountDownLatch(1)
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      try {
+        e.invokeAny(l)
+        shouldThrow()
+      } catch { case success: NullPointerException => }
+      latch.countDown()
+    }
+  }
+
+  /** invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testInvokeAny4(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new NPETask)
+      try {
+        e.invokeAny(l)
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+    }
+
+  /** invokeAny(c) returns result of some task
+   */
+  @throws[Exception]
+  @Test def testInvokeAny5(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val result = e.invokeAny(l)
+      assertEquals(TEST_STRING, result)
+    }
+
+  /** invokeAll(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testInvokeAll1(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      try {
+        e.invokeAll(null)
+        shouldThrow()
+      } catch { case success: NullPointerException => }
+    }
+
+  /** invokeAll(empty collection) returns empty list
+   */
+  @throws[Exception]
+  @Test def testInvokeAll2(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val emptyCollection = Collections.emptyList
+      val r = e.invokeAll(emptyCollection)
+      assertTrue(r.isEmpty)
+    }
+
+  /** invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testInvokeAll3(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(null)
+      try {
+        e.invokeAll(l)
+        shouldThrow()
+      } catch { case success: NullPointerException => }
+    }
+
+  /** get of invokeAll(c) throws exception on failed task
+   */
+  @throws[Exception]
+  @Test def testInvokeAll4(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val futures = e.invokeAll(l)
+      assertEquals(1, futures.size)
+      try {
+        futures.get(0).get
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+    }
+
+  /** invokeAll(c) returns results of all completed tasks
+   */
+  @throws[Exception]
+  @Test def testInvokeAll5(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val futures = e.invokeAll(l)
+      assertEquals(2, futures.size)
+      futures.forEach { future => assertEquals(TEST_STRING, future.get) }
+    }
+
+  /** timed invokeAny(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny1(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      try {
+        e.invokeAny(null, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch { case success: NullPointerException => }
+    }
+
+  /** timed invokeAny(,,null) throws NullPointerException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAnyNullTimeUnit(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      try {
+        e.invokeAny(l, randomTimeout(), null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+
+  /** timed invokeAny(empty collection) throws IllegalArgumentException
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny2(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val emptyCollection = Collections.emptyList
+      try {
+        e.invokeAny(emptyCollection, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: IllegalArgumentException =>
+      }
+    }
+
+  /** timed invokeAny(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny3(): Unit = {
+    val latch = new CountDownLatch(1)
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(latchAwaitingStringTask(latch))
+      l.add(null)
+      try {
+        e.invokeAny(l, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch { case success: NullPointerException => }
+      latch.countDown()
+    }
+  }
+
+  /** timed invokeAny(c) throws ExecutionException if no task completes
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny4(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val startTime = System.nanoTime
+      val l = new ArrayList[Callable[String]]
+      l.add(new NPETask)
+      try {
+        e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+
+  /** timed invokeAny(c) returns result of some task
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAny5(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val startTime = System.nanoTime
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val result = e.invokeAny(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(TEST_STRING, result)
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+
+  /** timed invokeAll(null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll1(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      try {
+        e.invokeAll(null, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+
+  /** timed invokeAll(,,null) throws NPE
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAllNullTimeUnit(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      try {
+        e.invokeAll(l, randomTimeout(), null)
+        shouldThrow()
+      } catch {
+        case success: NullPointerException =>
+      }
+    }
+
+  /** timed invokeAll(empty collection) returns empty list
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll2(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val emptyCollection = Collections.emptyList
+      val r = e.invokeAll(emptyCollection, randomTimeout(), randomTimeUnit())
+      assertTrue(r.isEmpty)
+    }
+
+  /** timed invokeAll(c) throws NPE if c has null elements
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll3(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(null)
+      try {
+        e.invokeAll(l, randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch { case success: NullPointerException => }
+    }
+
+  /** get of element of invokeAll(c) throws exception on failed task
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll4(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new NPETask)
+      val futures =
+        e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(1, futures.size)
+      try {
+        futures.get(0).get
+        shouldThrow()
+      } catch {
+        case success: ExecutionException =>
+          assertTrue(success.getCause.isInstanceOf[NullPointerException])
+      }
+    }
+
+  /** timed invokeAll(c) returns results of all completed tasks
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll5(): Unit =
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(2)) { e =>
+      val l = new ArrayList[Callable[String]]
+      l.add(new StringTask)
+      l.add(new StringTask)
+      val futures = e.invokeAll(l, LONG_DELAY_MS, MILLISECONDS)
+      assertEquals(2, futures.size)
+      futures.forEach { future => assertEquals(TEST_STRING, future.get) }
+    }
+
+  /** timed invokeAll(c) cancels tasks not completed by timeout
+   */
+  @throws[Exception]
+  @Test def testTimedInvokeAll6(): Unit = {
+    var timeout = timeoutMillis()
+    var break = false
+    while (!break) {
+      val done = new CountDownLatch(1)
+      val waiter = new CheckedCallable[String]() {
+        override def realCall(): String = {
+          try done.await(LONG_DELAY_MS, MILLISECONDS)
+          catch {
+            case ok: InterruptedException =>
+          }
+          "1"
+        }
+      }
+      usingWrappedPoolCleaner(new ScheduledThreadPoolExecutor(2))(
+        cleaner(_, done)
+      ) { p =>
+        val tasks = new ArrayList[Callable[String]]
+        tasks.add(new StringTask("0"))
+        tasks.add(waiter)
+        tasks.add(new StringTask("2"))
+        val startTime = System.nanoTime
+        val futures =
+          p.invokeAll(tasks, timeout, MILLISECONDS)
+        assertEquals(tasks.size, futures.size)
+        assertTrue(millisElapsedSince(startTime) >= timeout)
+        futures.forEach { future => assertTrue(future.isDone) }
+        assertTrue(futures.get(1).isCancelled)
+        try {
+          assertEquals("0", futures.get(0).get)
+          assertEquals("2", futures.get(2).get)
+          break = true
+        } catch {
+          case retryWithLongerTimeout: CancellationException =>
+            timeout *= 2
+            if (timeout >= LONG_DELAY_MS / 2)
+              fail("expected exactly one task to be cancelled")
+        }
+      }
+    }
+  }
+
+  /** A fixed delay task with overflowing period should not prevent a one-shot
+   *  task from executing. https://bugs.openjdk.java.net/browse/JDK-8051859
+   */
+  @SuppressWarnings(Array("FutureReturnValueIgnored")) @throws[Exception]
+  @Test def testScheduleWithFixedDelay_overflow(): Unit = {
+    assumeFalse(
+      "Fails due to bug in the JVM",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+    val delayedDone = new CountDownLatch(1)
+    val immediateDone = new CountDownLatch(1)
+    usingPoolCleaner(new ScheduledThreadPoolExecutor(1)) { p =>
+      val delayed: Runnable = () => {
+        def foo() = {
+          delayedDone.countDown()
+          p.submit({ () => immediateDone.countDown() }: Runnable)
+        }
+        foo()
+      }
+      p.scheduleWithFixedDelay(delayed, 0L, java.lang.Long.MAX_VALUE, SECONDS)
+      await(delayedDone)
+      await(immediateDone)
+    }
+  }
+}


### PR DESCRIPTION
Ports following `java.util.concurrent` types and their tests from JSR-166: 
* `Delayed`
* `Executors` (scheduled executor related methods)
* `RunnableScheduledFuture`
* `ScheduledExecutorService`
* `ScheduledFuture`
* `ScheduledThreadPoolExecutor`