### PR TITLE
0.4.x: Backport fix of javalib ServerSocket#accept

### DIFF
--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -234,7 +234,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
       val sa = storage.asInstanceOf[Ptr[in.sockaddr_in]]
       inet.inet_ntop(
         socket.AF_INET,
-        sa.sin_addr.asInstanceOf[Ptr[Byte]],
+        sa.sin_addr.at1.asInstanceOf[Ptr[Byte]],
         ipstr,
         in.INET6_ADDRSTRLEN.toUInt
       )
@@ -243,7 +243,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
       val sa = storage.asInstanceOf[Ptr[in.sockaddr_in6]]
       inet.inet_ntop(
         socket.AF_INET6,
-        sa.sin6_addr.asInstanceOf[Ptr[Byte]],
+        sa.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]],
         ipstr,
         in.INET6_ADDRSTRLEN.toUInt
       )


### PR DESCRIPTION
Backport PR #3140 to SN 0.4.x branch.  By intent, that PR fixed Issue #3131 on SN 0.5.0 only.

SN 0.5.x network code has diverged from 0.4.x, so only the essential & effective change was backported.
The other changes  in 0.5.x were for Software Engineering: consistency & proper, not C-style, type references.

This PR has been manually tested on IPv4 and passed.  There is no functioning IPv6 in SN 0.4.x.