### PR TITLE
Adapt `scala.concurrent.ExecutionContext` to use concurrent executor in multithreading mode 

### DIFF
--- a/junit-async/native/src/main/scala/scala/scalanative/junit/async/package.scala
+++ b/junit-async/native/src/main/scala/scala/scalanative/junit/async/package.scala
@@ -1,11 +1,17 @@
 package scala.scalanative.junit
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 
 package object async {
   type AsyncResult = Unit
   def await(future: Future[_]): AsyncResult = {
-    scala.scalanative.runtime.loop()
-    future.value.get.get
+    if (isMultithreadingEnabled)
+      Await.result(future, Duration.Inf)
+    else {
+      scala.scalanative.runtime.loop()
+      future.value.get.get
+    }
   }
 }

--- a/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala.patch
+++ b/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala.patch
@@ -1,20 +1,28 @@
---- 2.12.15/scala/concurrent/ExecutionContext.scala
+--- 2.12.17/scala/concurrent/ExecutionContext.scala
 +++ overrides-2.12/scala/concurrent/ExecutionContext.scala
-@@ -138,7 +138,7 @@
-    *
-    * @return the global `ExecutionContext`
-    */
--  def global: ExecutionContextExecutor = Implicits.global.asInstanceOf[ExecutionContextExecutor]
-+  def global: ExecutionContextExecutor = scala.scalanative.runtime.ExecutionContext.global
+@@ -15,6 +15,7 @@
  
-   object Implicits {
-     /**
-@@ -149,7 +149,7 @@
+ import java.util.concurrent.{ ExecutorService, Executor }
+ import scala.annotation.implicitNotFound
++import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
+ 
+ /**
+  * An `ExecutionContext` can execute program logic asynchronously,
+@@ -149,7 +150,10 @@
       * the thread pool uses a target number of worker threads equal to the number of
       * [[https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors-- available processors]].
       */
 -    implicit lazy val global: ExecutionContext = impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+    implicit lazy val global: ExecutionContext = ExecutionContext.global
++    implicit lazy val global: ExecutionContext = {
++      if(isMultithreadingEnabled) impl.ExecutionContextImpl.fromExecutor(null: Executor)
++      else scala.scalanative.runtime.ExecutionContext.singleThreaded
++    }
    }
  
    /** Creates an `ExecutionContext` from the given `ExecutorService`.
+@@ -198,5 +202,3 @@
+    */
+   def defaultReporter: Throwable => Unit = _.printStackTrace()
+ }
+-
+-

--- a/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala.patch
+++ b/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala.patch
@@ -15,7 +15,7 @@
 -    implicit lazy val global: ExecutionContext = impl.ExecutionContextImpl.fromExecutor(null: Executor)
 +    implicit lazy val global: ExecutionContext = {
 +      if(isMultithreadingEnabled) impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+      else scala.scalanative.runtime.ExecutionContext.singleThreaded
++      else scala.scalanative.runtime.ExecutionContext.global
 +    }
    }
  

--- a/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala.patch
+++ b/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala.patch
@@ -1,31 +1,31 @@
---- 2.13.6/scala/concurrent/ExecutionContext.scala
+--- 2.13.10/scala/concurrent/ExecutionContext.scala
 +++ overrides-2.13/scala/concurrent/ExecutionContext.scala
-@@ -197,7 +197,7 @@
+@@ -15,6 +15,7 @@
+ 
+ import java.util.concurrent.{ ExecutorService, Executor }
+ import scala.annotation.implicitNotFound
++import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
+ 
+ /**
+  * An `ExecutionContext` can execute program logic asynchronously,
+@@ -197,7 +198,10 @@
     *
     * @return the global [[ExecutionContext]]
     */
 -  final lazy val global: ExecutionContextExecutor = impl.ExecutionContextImpl.fromExecutor(null: Executor)
-+  final lazy val global: ExecutionContextExecutor = scala.scalanative.runtime.ExecutionContext.global
++  final lazy val global: ExecutionContextExecutor = {
++    if(isMultithreadingEnabled) impl.ExecutionContextImpl.fromExecutor(null: Executor)
++    else scala.scalanative.runtime.ExecutionContext.global
++  }
  
    /**
     * WARNING: Only ever execute logic which will quickly return control to the caller.
-@@ -227,18 +227,8 @@
+@@ -227,7 +231,7 @@
    /**
     * See [[ExecutionContext.global]].
     */
 -  private[scala] lazy val opportunistic: ExecutionContextExecutor = new ExecutionContextExecutor with BatchingExecutor {
--    final override def submitForExecution(runnable: Runnable): Unit = global.execute(runnable)
-+  private[scala] lazy val opportunistic: ExecutionContextExecutor = ExecutionContext.global
++  private[scala] lazy val opportunistic: ExecutionContextExecutor = if(!isMultithreadingEnabled) ExecutionContext.global else new ExecutionContextExecutor with BatchingExecutor {
+     final override def submitForExecution(runnable: Runnable): Unit = global.execute(runnable)
  
--    final override def execute(runnable: Runnable): Unit =
--      if ((!runnable.isInstanceOf[impl.Promise.Transformation[_,_]] || runnable.asInstanceOf[impl.Promise.Transformation[_,_]].benefitsFromBatching) && runnable.isInstanceOf[Batchable])
--        submitAsyncBatched(runnable)
--      else
--        submitForExecution(runnable)
--
--    override final def reportFailure(t: Throwable): Unit = global.reportFailure(t)
--  }
--
-   object Implicits {
-     /**
-      * An accessor that can be used to import the global `ExecutionContext` into the implicit scope,
+     final override def execute(runnable: Runnable): Unit =

--- a/unit-tests/native/src/test/scala-2.13/scala/ExecutionContextExtTest.scala
+++ b/unit-tests/native/src/test/scala-2.13/scala/ExecutionContextExtTest.scala
@@ -21,7 +21,7 @@ class ExecutionContextExtTest {
     else {
       assertEquals(ExecutionContext.global, opportunistic)
       assertEquals(
-        scala.scalanative.runtime.NativeExecutionContext.queue,
+        scala.scalanative.runtime.ExecutionContext.global,
         opportunistic
       )
     }

--- a/unit-tests/native/src/test/scala-2.13/scala/ExecutionContextExtTest.scala
+++ b/unit-tests/native/src/test/scala-2.13/scala/ExecutionContextExtTest.scala
@@ -3,6 +3,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 
 /* Dummy test used determinate if scala.concurrent.ExecutionContext was correctly overridden
  * In case if it is not it would fail at linking or with UndefinedBehaviourException in runtime
@@ -15,16 +16,26 @@ class ExecutionContextExtTest {
       ExecutionContext.opportunistic
 
     assertNotNull(opportunistic)
-    assertEquals(ExecutionContext.global, opportunistic)
+    if (isMultithreadingEnabled)
+      assertNotEquals(ExecutionContext.global, opportunistic)
+    else {
+      assertEquals(ExecutionContext.global, opportunistic)
+      assertEquals(
+        scala.scalanative.runtime.NativeExecutionContext.queue,
+        opportunistic
+      )
+    }
 
     var x = 0
     Future {
       x = 90
     }
-    // always true, logic in Future would be executed after this Runnable ends
-    assertEquals(0, x)
-    x = 40
-    assertEquals(40, x)
+    if (!isMultithreadingEnabled) {
+      // always true, logic in Future would be executed after this Runnable ends
+      assertEquals(0, x)
+      x = 40
+      assertEquals(40, x)
+    }
   }
 
   @Test
@@ -38,9 +49,11 @@ class ExecutionContextExtTest {
     Future {
       x = 90
     }
-    // always true, logic in Future would be executed in this thread before continuing
-    assertEquals(90, x)
-    x = 40
-    assertEquals(40, x)
+    if (!isMultithreadingEnabled) {
+      // always true, logic in Future would be executed in this thread before continuing
+      assertEquals(90, x)
+      x = 40
+      assertEquals(40, x)
+    }
   }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ObjectMonitorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ObjectMonitorTest.scala
@@ -55,8 +55,8 @@ class ObjectMonitorTest {
     @volatile var counter = 0
     val lock = new {}
     def lockedOrderedExec(threadId: Int, threadsCount: Int) =
-      lock.synchronized {
-        while (counter <= maxIterations) {
+      while (counter <= maxIterations) {
+        lock.synchronized {
           if (counter % threadsCount != threadId) lock.wait()
           else counter += 1
           lock.notify()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ObjectMonitorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ObjectMonitorTest.scala
@@ -61,6 +61,8 @@ class ObjectMonitorTest {
           else counter += 1
           lock.notify()
         }
+        // To mitigate effects of rentering the same thread every time by the same thread on the JVM
+        Thread.`yield`
       }
 
     for (threadsCount <- testedThreads) {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool8Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool8Test.scala
@@ -12,6 +12,7 @@ import java.util.concurrent._
 
 import org.junit._
 import org.junit.Assert._
+import scala.scalanative.junit.utils.AssumesHelper
 
 import JSR166Test._
 
@@ -674,6 +675,7 @@ class ForkJoinPool8Test extends JSR166Test {
   /** inForkJoinPool of non-FJ task returns false
    */
   @Test def testInForkJoinPool2(): Unit = {
+    AssumesHelper.assumeNotExecutedInForkJoinPool()
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         assertFalse(ForkJoinTask.inForkJoinPool)
@@ -1263,6 +1265,7 @@ class ForkJoinPool8Test extends JSR166Test {
   /** getPool of non-FJ task returns null
    */
   @Test def testGetPool2CC(): Unit = {
+    AssumesHelper.assumeNotExecutedInForkJoinPool()
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = { assertNull(ForkJoinTask.getPool) }
     }
@@ -1272,6 +1275,7 @@ class ForkJoinPool8Test extends JSR166Test {
   /** inForkJoinPool of non-FJ task returns false
    */
   @Test def testInForkJoinPool2CC(): Unit = {
+    AssumesHelper.assumeNotExecutedInForkJoinPool()
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         assertFalse(ForkJoinTask.inForkJoinPool)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTask8Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTask8Test.scala
@@ -12,6 +12,7 @@ import java.util.concurrent._
 
 import org.junit._
 import org.junit.Assert._
+import scala.scalanative.junit.utils.AssumesHelper
 import JSR166Test._
 
 import scala.util.control.Breaks._
@@ -671,6 +672,7 @@ class ForkJoinTask8Test extends JSR166Test {
   /** getPool of non-FJ task returns null
    */
   @Test def testGetPool2(): Unit = {
+    AssumesHelper.assumeNotExecutedInForkJoinPool()
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = { assertNull(getPool) }
     }
@@ -695,6 +697,7 @@ class ForkJoinTask8Test extends JSR166Test {
   /** inForkJoinPool of non-FJ task returns false
    */
   @Test def testInForkJoinPool2(): Unit = {
+    AssumesHelper.assumeNotExecutedInForkJoinPool()
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = { assertFalse(inForkJoinPool) }
     }

--- a/unit-tests/shared/src/test/scala/scala/ExecutionContextTest.scala
+++ b/unit-tests/shared/src/test/scala/scala/ExecutionContextTest.scala
@@ -3,6 +3,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 import scala.concurrent.{ExecutionContext, Future}
+import org.scalanative.testsuite.utils.Platform
 
 /* Dummy test used determinate if scala.concurrent.ExecutionContext was correctly overridden
  * In case if it is not it would fail at linking or with UndefinedBehaviourException in runtime
@@ -22,12 +23,12 @@ class ExecutionContextTest {
     Future {
       x = 90
     }
-    assertEquals(
-      0,
-      x
-    ) // always true, logic in Future would be executed after this Runnable ends
-    x = 40
-    assertEquals(40, x)
+    if (!Platform.isMultithreadingEnabled) {
+      // always true, logic in Future would be executed after this Runnable ends
+      assertEquals(0, x)
+      x = 40
+      assertEquals(40, x)
+    }
   }
 
 }

--- a/unit-tests/shared/src/test/scala/utils/AssumesHelper.scala
+++ b/unit-tests/shared/src/test/scala/utils/AssumesHelper.scala
@@ -39,4 +39,11 @@ object AssumesHelper {
     // libunwind does not work with AddressSanitizer
     assumeNotASAN()
   }
+
+  def assumeNotExecutedInForkJoinPool() = {
+    Assume.assumeFalse(
+      "SN executes all tests using ForkJoinPool based executor in multithreading mode",
+      Platform.executingInScalaNative && Platform.isMultithreadingEnabled
+    )
+  }
 }


### PR DESCRIPTION
* Adapt scalalib patches to use real executor in mulithreading mode
* Adapts some of the tests to be aware of multithreading