### PR TITLE
Port `java.util.concurrent.atomic.Atomic*FieldUpdater`s from JSR-166

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.scala
@@ -12,7 +12,6 @@ import java.util.function.UnaryOperator
 object AtomicIntegerFieldUpdater {
   // Imposible to define currently in Scala Native, requires reflection
   // Don't define it, allow to fail at linktime instead of runtime
-  
   // def newUpdater[U <: AnyRef](
   //     tclass: Class[U],
   //     fieldName: String

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.scala
@@ -1,0 +1,146 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package java.util.concurrent.atomic
+
+import java.util.Objects
+import java.util.function.BinaryOperator
+import java.util.function.UnaryOperator
+
+object AtomicIntegerFieldUpdater {
+  // Imposible to define currently in Scala Native, requires reflection
+  // Don't define it, allow to fail at linktime instead of runtime
+  
+  // def newUpdater[U <: AnyRef](
+  //     tclass: Class[U],
+  //     fieldName: String
+  // ): AtomicIntegerFieldUpdater[U] = ???
+}
+
+abstract class AtomicIntegerFieldUpdater[T <: AnyRef] protected () {
+  def compareAndSet(obj: T, expect: Int, update: Int): Boolean
+  def weakCompareAndSet(obj: T, expect: Int, update: Int): Boolean
+  def set(obj: T, newIntalue: Int): Unit
+  def lazySet(obj: T, newIntalue: Int): Unit
+  def get(obj: T): Int
+
+  def getAndSet(obj: T, newIntalue: Int): Int = {
+    var prev: Int = null.asInstanceOf[Int]
+    while ({
+      prev = get(obj)
+      !compareAndSet(obj, prev, newIntalue)
+    }) ()
+    prev
+  }
+
+  final def getAndUpdate(obj: T, updateFunction: UnaryOperator[Int]): Int = {
+    var prev: Int = null.asInstanceOf[Int]
+    while ({
+      prev = get(obj)
+      val next = updateFunction(prev)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  final def updateAndGet(obj: T, updateFunction: UnaryOperator[Int]): Int = {
+    var next: Int = null.asInstanceOf[Int]
+    while ({
+      val prev = get(obj)
+      next = updateFunction(prev)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  final def getAndAccumulate(
+      obj: T,
+      x: Int,
+      accumulatorFunction: BinaryOperator[Int]
+  ): Int = {
+    var prev: Int = null.asInstanceOf[Int]
+    while ({
+      prev = get(obj)
+      val next = accumulatorFunction(prev, x)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  final def accumulateAndGet(
+      obj: T,
+      x: Int,
+      accumulatorFunction: BinaryOperator[Int]
+  ): Int = {
+    var next: Int = null.asInstanceOf[Int]
+    while ({
+      val prev = get(obj)
+      next = accumulatorFunction(prev, x)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  def getAndIncrement(obj: T): Int = {
+    var prev = 0
+    while ({
+      prev = get(obj)
+      val next = prev + 1
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  def getAndDecrement(obj: T): Int = {
+    var prev = 0
+    while ({
+      prev = get(obj)
+      val next = prev - 1
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  def getAndAdd(obj: T, delta: Int): Int = {
+    var prev = 0
+    while ({
+      prev = get(obj)
+      val next = prev + delta
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  def incrementAndGet(obj: T): Int = {
+    var next = 0
+    while ({
+      val prev = get(obj)
+      next = prev + 1
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  def decrementAndGet(obj: T): Int = {
+    var next = 0
+    while ({
+      val prev = get(obj)
+      next = prev - 1
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  def addAndGet(obj: T, delta: Int): Int = {
+    var next = 0
+    while ({
+      val prev = get(obj)
+      next = prev + delta
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongFieldUpdater.scala
@@ -1,0 +1,144 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package java.util.concurrent.atomic
+
+import java.util.Objects
+import java.util.function.BinaryOperator
+import java.util.function.UnaryOperator
+
+object AtomicLongFieldUpdater {
+  // Imposible to define currently in scala native, requires reflection
+  // Don't define it, instead of providing stub for feedback at linktime instead of runtime
+  // def newUpdater[U <: AnyRef](
+  //     tclass: Class[U],
+  //     fieldName: String
+  // ): AtomicLongFieldUpdater[U] = ???
+}
+
+abstract class AtomicLongFieldUpdater[T <: AnyRef] protected () {
+  def compareAndSet(obj: T, expect: Long, update: Long): Boolean
+  def weakCompareAndSet(obj: T, expect: Long, update: Long): Boolean
+  def set(obj: T, newLongalue: Long): Unit
+  def lazySet(obj: T, newLongalue: Long): Unit
+  def get(obj: T): Long
+
+  def getAndSet(obj: T, newLongalue: Long): Long = {
+    var prev: Long = null.asInstanceOf[Long]
+    while ({
+      prev = get(obj)
+      !compareAndSet(obj, prev, newLongalue)
+    }) ()
+    prev
+  }
+
+  final def getAndUpdate(obj: T, updateFunction: UnaryOperator[Long]): Long = {
+    var prev: Long = null.asInstanceOf[Long]
+    while ({
+      prev = get(obj)
+      val next = updateFunction(prev)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  final def updateAndGet(obj: T, updateFunction: UnaryOperator[Long]): Long = {
+    var next: Long = null.asInstanceOf[Long]
+    while ({
+      val prev = get(obj)
+      next = updateFunction(prev)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  final def getAndAccumulate(
+      obj: T,
+      x: Long,
+      accumulatorFunction: BinaryOperator[Long]
+  ): Long = {
+    var prev: Long = null.asInstanceOf[Long]
+    while ({
+      prev = get(obj)
+      val next = accumulatorFunction(prev, x)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  final def accumulateAndGet(
+      obj: T,
+      x: Long,
+      accumulatorFunction: BinaryOperator[Long]
+  ): Long = {
+    var next: Long = null.asInstanceOf[Long]
+    while ({
+      val prev = get(obj)
+      next = accumulatorFunction(prev, x)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  def getAndIncrement(obj: T): Long = {
+    var prev = 0L
+    while ({
+      prev = get(obj)
+      val next = prev + 1L
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  def getAndDecrement(obj: T): Long = {
+    var prev = 0L
+    while ({
+      prev = get(obj)
+      val next = prev - 1L
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  def getAndAdd(obj: T, delta: Long): Long = {
+    var prev = 0L
+    while ({
+      prev = get(obj)
+      val next = prev + delta
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  def incrementAndGet(obj: T): Long = {
+    var next = 0L
+    while ({
+      val prev = get(obj)
+      next = prev + 1L
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  def decrementAndGet(obj: T): Long = {
+    var next = 0L
+    while ({
+      val prev = get(obj)
+      next = prev - 1L
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  def addAndGet(obj: T, delta: Long): Long = {
+    var next = 0L
+    while ({
+      val prev = get(obj)
+      next = prev + delta
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+}

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongFieldUpdater.scala
@@ -10,8 +10,8 @@ import java.util.function.BinaryOperator
 import java.util.function.UnaryOperator
 
 object AtomicLongFieldUpdater {
-  // Imposible to define currently in scala native, requires reflection
-  // Don't define it, instead of providing stub for feedback at linktime instead of runtime
+  // Imposible to define currently in Scala Native, requires reflection
+  // Don't define it, allow to fail at linktime instead of runtime
   // def newUpdater[U <: AnyRef](
   //     tclass: Class[U],
   //     fieldName: String

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.scala
@@ -1,0 +1,88 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package java.util.concurrent.atomic
+
+import java.util.Objects
+import java.util.function.BinaryOperator
+import java.util.function.UnaryOperator
+
+object AtomicReferenceFieldUpdater {
+  // Imposible to define currently in scala native, requires reflection
+  // Don't define it, instead of providing stub for feedback at linktime instead of runtime
+  // def newUpdater[U <: AnyRef, W <: AnyRef](
+  //     tclass: Class[U],
+  //     vclass: Class[W],
+  //     fieldName: String
+  // ): AtomicReferenceFieldUpdater[U, W] = ???
+}
+
+abstract class AtomicReferenceFieldUpdater[
+    T <: AnyRef,
+    V <: AnyRef
+] protected () {
+  def compareAndSet(obj: T, expect: V, update: V): Boolean
+  def weakCompareAndSet(obj: T, expect: V, update: V): Boolean
+  def set(obj: T, newValue: V): Unit
+  def lazySet(obj: T, newValue: V): Unit
+  def get(obj: T): V
+
+  def getAndSet(obj: T, newValue: V): V = {
+    var prev: V = null.asInstanceOf[V]
+    while ({
+      prev = get(obj)
+      !compareAndSet(obj, prev, newValue)
+    }) ()
+    prev
+  }
+
+  final def getAndUpdate(obj: T, updateFunction: UnaryOperator[V]): V = {
+    var prev: V = null.asInstanceOf[V]
+    while ({
+      prev = get(obj)
+      val next = updateFunction(prev)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  final def updateAndGet(obj: T, updateFunction: UnaryOperator[V]): V = {
+    var next: V = null.asInstanceOf[V]
+    while ({
+      val prev = get(obj)
+      next = updateFunction(prev)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+
+  final def getAndAccumulate(
+      obj: T,
+      x: V,
+      accumulatorFunction: BinaryOperator[V]
+  ): V = {
+    var prev: V = null.asInstanceOf[V]
+    while ({
+      prev = get(obj)
+      val next = accumulatorFunction(prev, x)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    prev
+  }
+
+  final def accumulateAndGet(
+      obj: T,
+      x: V,
+      accumulatorFunction: BinaryOperator[V]
+  ): V = {
+    var next: V = null.asInstanceOf[V]
+    while ({
+      val prev = get(obj)
+      next = accumulatorFunction(prev, x)
+      !compareAndSet(obj, prev, next)
+    }) ()
+    next
+  }
+}

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.scala
@@ -10,8 +10,8 @@ import java.util.function.BinaryOperator
 import java.util.function.UnaryOperator
 
 object AtomicReferenceFieldUpdater {
-  // Imposible to define currently in scala native, requires reflection
-  // Don't define it, instead of providing stub for feedback at linktime instead of runtime
+  // Imposible to define currently in Scala Native, requires reflection
+  // Don't define it, allow to fail at linktime instead of runtime
   // def newUpdater[U <: AnyRef, W <: AnyRef](
   //     tclass: Class[U],
   //     vclass: Class[W],

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicIntegerFieldUpdaterTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicIntegerFieldUpdaterTest.scala
@@ -1,0 +1,256 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+// Uses custom Scala Native intrinsic based field updaters instead of reflection based used in JVM
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+
+import org.junit._
+import org.junit.Assert._
+
+import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+import scala.scalanative.runtime.{RawPtr, fromRawPtr}
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.libc.atomic.{CAtomicInt, memory_order}
+
+object AtomicIntegerFieldUpdaterTest {
+  class IntrinsicBasedImpl[T <: AnyRef](selector: T => RawPtr)
+      extends AtomicIntegerFieldUpdater[T]() {
+    private def atomicRef(insideObj: T) =
+      new CAtomicInt(fromRawPtr(selector(insideObj)))
+
+    def compareAndSet(obj: T, expect: Int, update: Int): Boolean =
+      atomicRef(obj).compareExchangeStrong(expect, update)
+
+    def weakCompareAndSet(obj: T, expect: Int, update: Int): Boolean =
+      atomicRef(obj).compareExchangeWeak(expect, update)
+
+    def set(obj: T, newIntalue: Int): Unit = atomicRef(obj).store(newIntalue)
+
+    def lazySet(obj: T, newIntalue: Int): Unit =
+      atomicRef(obj).store(newIntalue, memory_order.memory_order_release)
+    def get(obj: T): Int = atomicRef(obj).load()
+  }
+}
+
+class AtomicIntegerFieldUpdaterTest extends JSR166Test {
+  import JSR166Test._
+  import AtomicIntegerFieldUpdaterTest._
+
+  @volatile var x = 0
+  @volatile protected var protectedField = 0
+
+  def updaterForX = new IntrinsicBasedImpl(
+    classFieldRawPtr[AtomicIntegerFieldUpdaterTest](_, "x")
+  )
+  def updaterForProtectedField = new IntrinsicBasedImpl(
+    classFieldRawPtr[AtomicIntegerFieldUpdaterTest](_, "protectedField")
+  )
+
+  // Platform limitatios: following cases would not compile / would not be checked
+  /** Construction with non-existent field throws RuntimeException */
+  // def testConstructor(): Unit = ???
+
+  /** construction with field not of given type throws IllegalArgumentException
+   */
+  // def testConstructor2(): Unit = ???
+
+  /** construction with non-volatile field throws IllegalArgumentException
+   */
+  // def testConstructor3(): Unit = ???
+
+  /** construction using private field from subclass throws RuntimeException */
+  // def testPrivateFieldInSubclass(): Unit = ???
+
+  /** construction from unrelated class; package access is allowed, private
+   *  access is not
+   */
+  def testUnrelatedClassAccess(): Unit = {
+    new NonNestmates().checkPackageAccess(this)
+    // would not compile - cannot have intrinsic field ptr to private field
+    // new NonNestmates().checkPrivateAccess(this)
+  }
+
+  /** get returns the last value set or assigned
+   */
+  def testGetSet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.get(this))
+    a.set(this, 2)
+    assertEquals(2, a.get(this))
+    a.set(this, -3)
+    assertEquals(-3, a.get(this))
+  }
+
+  /** get returns the last value lazySet by same thread
+   */
+  def testGetLazySet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.get(this))
+    a.lazySet(this, 2)
+    assertEquals(2, a.get(this))
+    a.lazySet(this, -3)
+    assertEquals(-3, a.get(this))
+  }
+
+  /** compareAndSet succeeds in changing value if equal to expected else fails
+   */
+  def testCompareAndSet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertTrue(a.compareAndSet(this, 1, 2))
+    assertTrue(a.compareAndSet(this, 2, -4))
+    assertEquals(-4, a.get(this))
+    assertFalse(a.compareAndSet(this, -5, 7))
+    assertEquals(-4, a.get(this))
+    assertTrue(a.compareAndSet(this, -4, 7))
+    assertEquals(7, a.get(this))
+  }
+
+  /** compareAndSet succeeds in changing protected field value if equal to
+   *  expected else fails
+   */
+  def testCompareAndSetProtected(): Unit = {
+    val a = updaterForProtectedField
+    protectedField = 1
+    assertTrue(a.compareAndSet(this, 1, 2))
+    assertTrue(a.compareAndSet(this, 2, -4))
+    assertEquals(-4, a.get(this))
+    assertFalse(a.compareAndSet(this, -5, 7))
+    assertEquals(-4, a.get(this))
+    assertTrue(a.compareAndSet(this, -4, 7))
+    assertEquals(7, a.get(this))
+  }
+
+  /** compareAndSet succeeds in changing protected field value if equal to
+   *  expected else fails
+   */
+  def testCompareAndSetProtectedInSubclass(): Unit = {
+    new NonNestmates.AtomicIntegerFieldUpdaterTestSubclass()
+      .checkCompareAndSetProtectedSub()
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[Exception]
+  def testCompareAndSetInMultipleThreads(): Unit = {
+    def testSuite = this
+    x = 1
+    val a = updaterForX
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while (!a.compareAndSet(testSuite, 2, 3))
+          Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(a.compareAndSet(this, 1, 2))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertEquals(3, a.get(this))
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when equal to
+   *  expected
+   */
+  def testWeakCompareAndSet(): Unit = {
+    val a = updaterForX
+    x = 1
+    while (!a.weakCompareAndSet(this, 1, 2)) ()
+    while (!a.weakCompareAndSet(this, 2, -(4))) ()
+    assertEquals(-4, a.get(this))
+    while (!a.weakCompareAndSet(this, -(4), 7)) ()
+    assertEquals(7, a.get(this))
+  }
+
+  /** getAndSet returns previous value and sets to given value
+   */
+  def testGetAndSet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.getAndSet(this, 0))
+    assertEquals(0, a.getAndSet(this, -10))
+    assertEquals(-10, a.getAndSet(this, 1))
+  }
+
+  /** getAndAdd returns previous value and adds given value
+   */
+  def testGetAndAdd(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.getAndAdd(this, 2))
+    assertEquals(3, a.get(this))
+    assertEquals(3, a.getAndAdd(this, -4))
+    assertEquals(-1, a.get(this))
+  }
+
+  /** getAndDecrement returns previous value and decrements
+   */
+  def testGetAndDecrement(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.getAndDecrement(this))
+    assertEquals(0, a.getAndDecrement(this))
+    assertEquals(-1, a.getAndDecrement(this))
+  }
+
+  /** getAndIncrement returns previous value and increments
+   */
+  def testGetAndIncrement(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.getAndIncrement(this))
+    assertEquals(2, a.get(this))
+    a.set(this, -2)
+    assertEquals(-2, a.getAndIncrement(this))
+    assertEquals(-1, a.getAndIncrement(this))
+    assertEquals(0, a.getAndIncrement(this))
+    assertEquals(1, a.get(this))
+  }
+
+  /** addAndGet adds given value to current, and returns current value
+   */
+  def testAddAndGet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(3, a.addAndGet(this, 2))
+    assertEquals(3, a.get(this))
+    assertEquals(-1, a.addAndGet(this, -4))
+    assertEquals(-1, a.get(this))
+  }
+
+  /** decrementAndGet decrements and returns current value
+   */
+  def testDecrementAndGet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(0, a.decrementAndGet(this))
+    assertEquals(-1, a.decrementAndGet(this))
+    assertEquals(-2, a.decrementAndGet(this))
+    assertEquals(-2, a.get(this))
+  }
+
+  /** incrementAndGet increments and returns current value
+   */
+  def testIncrementAndGet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(2, a.incrementAndGet(this))
+    assertEquals(2, a.get(this))
+    a.set(this, -2)
+    assertEquals(-1, a.incrementAndGet(this))
+    assertEquals(0, a.incrementAndGet(this))
+    assertEquals(1, a.incrementAndGet(this))
+    assertEquals(1, a.get(this))
+  }
+}

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicLongFieldUpdaterTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicLongFieldUpdaterTest.scala
@@ -1,0 +1,257 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+// Uses custom Scala Native intrinsic based field updaters instead of reflection based used in JVM
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater
+
+import org.junit._
+import org.junit.Assert._
+
+import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+import scala.scalanative.runtime.{RawPtr, fromRawPtr}
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.libc.atomic.{CAtomicLongLong, memory_order}
+
+object AtomicLongFieldUpdaterTest {
+  class IntrinsicBasedImpl[T <: AnyRef](selector: T => RawPtr)
+      extends AtomicLongFieldUpdater[T]() {
+    private def atomicRef(insideObj: T) =
+      new CAtomicLongLong(fromRawPtr(selector(insideObj)))
+
+    def compareAndSet(obj: T, expect: Long, update: Long): Boolean =
+      atomicRef(obj).compareExchangeStrong(expect, update)
+
+    def weakCompareAndSet(obj: T, expect: Long, update: Long): Boolean =
+      atomicRef(obj).compareExchangeWeak(expect, update)
+
+    def set(obj: T, newIntalue: Long): Unit = atomicRef(obj).store(newIntalue)
+
+    def lazySet(obj: T, newIntalue: Long): Unit =
+      atomicRef(obj).store(newIntalue, memory_order.memory_order_release)
+    def get(obj: T): Long = atomicRef(obj).load()
+  }
+}
+
+class AtomicLongFieldUpdaterTest extends JSR166Test {
+  import AtomicLongFieldUpdaterTest._
+  import JSR166Test._
+
+  @volatile var x = 0L
+  @volatile protected var protectedField = 0L
+
+  def updaterForX = new IntrinsicBasedImpl[AtomicLongFieldUpdaterTest](
+    classFieldRawPtr(_, "x")
+  )
+  def updaterForProtectedField =
+    new IntrinsicBasedImpl[AtomicLongFieldUpdaterTest](
+      classFieldRawPtr(_, "protectedField")
+    )
+
+  // Platform limitatios: following cases would not compile / would not be checked
+  /** Construction with non-existent field throws RuntimeException */
+  // def testConstructor(): Unit = ???
+
+  /** construction with field not of given type throws IllegalArgumentException
+   */
+  // def testConstructor2(): Unit = ???
+
+  /** construction with non-volatile field throws IllegalArgumentException
+   */
+  // def testConstructor3(): Unit = ???
+
+  /** construction using private field from subclass throws RuntimeException */
+  // def testPrivateFieldInSubclass(): Unit = ???
+
+  /** construction from unrelated class; package access is allowed, private
+   *  access is not
+   */
+  def testUnrelatedClassAccess(): Unit = {
+    new NonNestmates().checkPackageAccess(this)
+    // Impossible to create field updater to private field
+    // new NonNestmates().checkPrivateAccess(this)
+  }
+
+  /** get returns the last value set or assigned
+   */
+  def testGetSet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.get(this))
+    a.set(this, 2)
+    assertEquals(2, a.get(this))
+    a.set(this, -3)
+    assertEquals(-3, a.get(this))
+  }
+
+  /** get returns the last value lazySet by same thread
+   */
+  def testGetLazySet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.get(this))
+    a.lazySet(this, 2)
+    assertEquals(2, a.get(this))
+    a.lazySet(this, -3)
+    assertEquals(-3, a.get(this))
+  }
+
+  /** compareAndSet succeeds in changing value if equal to expected else fails
+   */
+  def testCompareAndSet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertTrue(a.compareAndSet(this, 1, 2))
+    assertTrue(a.compareAndSet(this, 2, -4))
+    assertEquals(-4, a.get(this))
+    assertFalse(a.compareAndSet(this, -5, 7))
+    assertEquals(-4, a.get(this))
+    assertTrue(a.compareAndSet(this, -4, 7))
+    assertEquals(7, a.get(this))
+  }
+
+  /** compareAndSet succeeds in changing protected field value if equal to
+   *  expected else fails
+   */
+  def testCompareAndSetProtected(): Unit = {
+    val a = updaterForProtectedField
+    protectedField = 1
+    assertTrue(a.compareAndSet(this, 1, 2))
+    assertTrue(a.compareAndSet(this, 2, -4))
+    assertEquals(-4, a.get(this))
+    assertFalse(a.compareAndSet(this, -5, 7))
+    assertEquals(-4, a.get(this))
+    assertTrue(a.compareAndSet(this, -4, 7))
+    assertEquals(7, a.get(this))
+  }
+
+  /** compareAndSet succeeds in changing protected field value if equal to
+   *  expected else fails
+   */
+  def testCompareAndSetProtectedInSubclass(): Unit = {
+    new NonNestmates.AtomicLongFieldUpdaterTestSubclass()
+      .checkCompareAndSetProtectedSub()
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[Exception]
+  def testCompareAndSetInMultipleThreads(): Unit = {
+    val self = this
+    x = 1
+    val a = updaterForX
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while (!a.compareAndSet(self, 2, 3))
+          Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(a.compareAndSet(this, 1, 2))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertEquals(3, a.get(this))
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when equal to
+   *  expected
+   */
+  def testWeakCompareAndSet(): Unit = {
+    val a = updaterForX
+    x = 1
+    while (!a.weakCompareAndSet(this, 1, 2)) ()
+    while (!a.weakCompareAndSet(this, 2, -(4))) ()
+    assertEquals(-4, a.get(this))
+    while (!a.weakCompareAndSet(this, -(4), 7)) ()
+    assertEquals(7, a.get(this))
+  }
+
+  /** getAndSet returns previous value and sets to given value
+   */
+  def testGetAndSet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.getAndSet(this, 0))
+    assertEquals(0, a.getAndSet(this, -10))
+    assertEquals(-10, a.getAndSet(this, 1))
+  }
+
+  /** getAndAdd returns previous value and adds given value
+   */
+  def testGetAndAdd(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.getAndAdd(this, 2))
+    assertEquals(3, a.get(this))
+    assertEquals(3, a.getAndAdd(this, -4))
+    assertEquals(-1, a.get(this))
+  }
+
+  /** getAndDecrement returns previous value and decrements
+   */
+  def testGetAndDecrement(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.getAndDecrement(this))
+    assertEquals(0, a.getAndDecrement(this))
+    assertEquals(-1, a.getAndDecrement(this))
+  }
+
+  /** getAndIncrement returns previous value and increments
+   */
+  def testGetAndIncrement(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(1, a.getAndIncrement(this))
+    assertEquals(2, a.get(this))
+    a.set(this, -2)
+    assertEquals(-2, a.getAndIncrement(this))
+    assertEquals(-1, a.getAndIncrement(this))
+    assertEquals(0, a.getAndIncrement(this))
+    assertEquals(1, a.get(this))
+  }
+
+  /** addAndGet adds given value to current, and returns current value
+   */
+  def testAddAndGet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(3, a.addAndGet(this, 2))
+    assertEquals(3, a.get(this))
+    assertEquals(-1, a.addAndGet(this, -4))
+    assertEquals(-1, a.get(this))
+  }
+
+  /** decrementAndGet decrements and returns current value
+   */
+  def testDecrementAndGet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(0, a.decrementAndGet(this))
+    assertEquals(-1, a.decrementAndGet(this))
+    assertEquals(-2, a.decrementAndGet(this))
+    assertEquals(-2, a.get(this))
+  }
+
+  /** incrementAndGet increments and returns current value
+   */
+  def testIncrementAndGet(): Unit = {
+    val a = updaterForX
+    x = 1
+    assertEquals(2, a.incrementAndGet(this))
+    assertEquals(2, a.get(this))
+    a.set(this, -2)
+    assertEquals(-1, a.incrementAndGet(this))
+    assertEquals(0, a.incrementAndGet(this))
+    assertEquals(1, a.incrementAndGet(this))
+    assertEquals(1, a.get(this))
+  }
+}

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicReferenceFieldUpdaterTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicReferenceFieldUpdaterTest.scala
@@ -6,7 +6,7 @@
  * Pat Fisher, Mike Judd.
  */
 
- // Uses custom Scala Native intrinsic based field updaters instead of reflection based used in JVM
+// Uses custom Scala Native intrinsic based field updaters instead of reflection based used in JVM
 
 package org.scalanative.testsuite.javalib.util.concurrent
 package atomic

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicReferenceFieldUpdaterTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/AtomicReferenceFieldUpdaterTest.scala
@@ -1,0 +1,175 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+ // Uses custom Scala Native intrinsic based field updaters instead of reflection based used in JVM
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+
+import org.junit._
+import org.junit.Assert._
+
+import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+import scala.scalanative.runtime.{RawPtr, fromRawPtr}
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.libc.atomic.{CAtomicRef, memory_order}
+
+object AtomicReferenceFieldUpdaterTest {
+  class IntrinsicBasedImpl[T <: AnyRef, V <: AnyRef](selector: T => RawPtr)
+      extends AtomicReferenceFieldUpdater[T, V]() {
+    private def atomicRef(insideObj: T) =
+      new CAtomicRef[V](fromRawPtr(selector(insideObj)))
+
+    def compareAndSet(obj: T, expect: V, update: V): Boolean =
+      atomicRef(obj).compareExchangeStrong(expect, update)
+
+    def weakCompareAndSet(obj: T, expect: V, update: V): Boolean =
+      atomicRef(obj).compareExchangeWeak(expect, update)
+
+    def set(obj: T, newIntalue: V): Unit = atomicRef(obj).store(newIntalue)
+
+    def lazySet(obj: T, newIntalue: V): Unit =
+      atomicRef(obj).store(newIntalue, memory_order.memory_order_release)
+    def get(obj: T): V = atomicRef(obj).load()
+  }
+}
+
+class AtomicReferenceFieldUpdaterTest extends JSR166Test {
+  import AtomicReferenceFieldUpdaterTest._
+  import JSR166Test._
+
+  @volatile var x: Integer = null
+  @volatile protected var protectedField: Integer = null
+
+  def updaterForX =
+    new IntrinsicBasedImpl[AtomicReferenceFieldUpdaterTest, Integer](
+      classFieldRawPtr(_, "x")
+    )
+  def updaterForProtectedField =
+    new IntrinsicBasedImpl[AtomicReferenceFieldUpdaterTest, Integer](
+      classFieldRawPtr(_, "protectedField")
+    )
+
+  // Platform limitatios: following cases would not compile / would not be checked
+  // Construction with non-existent field throws RuntimeException
+  // def testConstructor(): Unit = ???
+
+  // construction with field not of given type throws IllegalArgumentException
+  // def testConstructor2(): Unit = ???
+
+  // construction with non-volatile field throws IllegalArgumentException
+  // def testConstructor3(): Unit = ???
+
+  // construction using private field from subclass throws RuntimeException
+  // def testPrivateFieldInSubclass(): Unit = ???
+
+  // Constructor with non-reference field throws ClassCastException
+  // def testConstructor4(): Unit = ???
+
+  // construction using private field from subclass throws RuntimeException
+  def testPrivateFieldInSubclass(): Unit = ???
+
+  /** construction from unrelated class; package access is allowed, private
+   *  access is not
+   */
+  def testUnrelatedClassAccess(): Unit = {
+    new NonNestmates().checkPackageAccess(this)
+    // Imposible to create
+    // new NonNestmates().checkPrivateAccess(this)
+  }
+
+  /** get returns the last value set or assigned
+   */
+  def testGetSet(): Unit = {
+    val a = updaterForX
+    x = one
+    assertSame(one, a.get(this))
+    a.set(this, two)
+    assertSame(two, a.get(this))
+    a.set(this, m3)
+    assertSame(m3, a.get(this))
+  }
+
+  /** get returns the last value lazySet by same thread
+   */
+  def testGetLazySet(): Unit = {
+    val a = updaterForX
+    x = one
+    assertSame(one, a.get(this))
+    a.lazySet(this, two)
+    assertSame(two, a.get(this))
+    a.lazySet(this, m3)
+    assertSame(m3, a.get(this))
+  }
+
+  /** compareAndSet succeeds in changing value if same as expected else fails
+   */
+  def testCompareAndSet(): Unit = {
+    val a = updaterForX
+    x = one
+    assertTrue(a.compareAndSet(this, one, two))
+    assertTrue(a.compareAndSet(this, two, m4))
+    assertSame(m4, a.get(this))
+    assertFalse(a.compareAndSet(this, m5, seven))
+    assertNotSame(seven, a.get(this))
+    assertTrue(a.compareAndSet(this, m4, seven))
+    assertSame(seven, a.get(this))
+  }
+
+  /** compareAndSet succeeds in changing protected field value if same as
+   *  expected else fails
+   */
+  def testCompareAndSetProtectedInSubclass(): Unit = {
+    new NonNestmates.AtomicReferenceFieldUpdaterTestSubclass()
+      .checkCompareAndSetProtectedSub()
+  }
+
+  /** compareAndSet in one thread enables another waiting for value to succeed
+   */
+  @throws[Exception]
+  def testCompareAndSetInMultipleThreads(): Unit = {
+    val self = this
+    x = one
+    val a = updaterForX
+    val t = new Thread(new CheckedRunnable() {
+      override def realRun(): Unit = {
+        while (!a.compareAndSet(self, two, three)) Thread.`yield`()
+      }
+    })
+    t.start()
+    assertTrue(a.compareAndSet(this, one, two))
+    t.join(LONG_DELAY_MS)
+    assertFalse(t.isAlive)
+    assertSame(three, a.get(this))
+  }
+
+  /** repeated weakCompareAndSet succeeds in changing value when same as
+   *  expected
+   */
+  def testWeakCompareAndSet(): Unit = {
+    val a = updaterForX
+    x = one
+    while (!a.weakCompareAndSet(this, one, two)) ()
+    while (!a.weakCompareAndSet(this, two, m4)) ()
+    assertSame(m4, a.get(this))
+    while (!a.weakCompareAndSet(this, m4, seven)) ()
+    assertSame(seven, a.get(this))
+  }
+
+  /** getAndSet returns previous value and sets to given value
+   */
+  def testGetAndSet(): Unit = {
+    val a = updaterForX
+    x = one
+    assertSame(one, a.getAndSet(this, zero))
+    assertSame(zero, a.getAndSet(this, m10))
+    assertSame(m10, a.getAndSet(this, 1))
+  }
+}

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/NonNestmates.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/NonNestmates.scala
@@ -1,0 +1,136 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+// Uses custom Scala Native intrinsic based field updaters instead of reflection based used in JVM
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package atomic
+
+import org.junit.Assert._
+import JSR166Test._
+
+import java.util.concurrent.atomic._
+import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+
+/** This source file contains test code deliberately not contained in the same
+ *  source file as the tests that use them, to avoid making them nestmates,
+ *  which affects accessibility rules (see JEP 181).
+ */
+object NonNestmates {
+  class AtomicIntegerFieldUpdaterTestSubclass
+      extends AtomicIntegerFieldUpdaterTest {
+    // Impossible to test
+    // Intrinsic based field updater does not allow to access private fields at compile time
+    // In JVM it fails at runtime
+    // def checkPrivateAccess(): Unit = ???
+
+    def checkCompareAndSetProtectedSub(): Unit = {
+      // AtomicIntegerFieldUpdater.newUpdater(
+      //   classOf[AtomicIntegerFieldUpdaterTest],
+      //   "protectedField"
+      // )
+      val a = new AtomicIntegerFieldUpdaterTest.IntrinsicBasedImpl[
+        AtomicIntegerFieldUpdaterTest
+      ](
+        classFieldRawPtr(_, "protectedField")
+      )
+      this.protectedField = 1
+      assertTrue(a.compareAndSet(this, 1, 2))
+      assertTrue(a.compareAndSet(this, 2, -4))
+      assertEquals(-4, a.get(this))
+      assertFalse(a.compareAndSet(this, -5, 7))
+      assertEquals(-4, a.get(this))
+      assertTrue(a.compareAndSet(this, -4, 7))
+      assertEquals(7, a.get(this))
+    }
+  }
+
+  class AtomicLongFieldUpdaterTestSubclass extends AtomicLongFieldUpdaterTest {
+    // Impossible, see AtomicIntFieldUpdaterTestSubclass
+    // def checkPrivateAccess(): Unit = ???
+    def checkCompareAndSetProtectedSub(): Unit = {
+      val a = new AtomicIntegerFieldUpdaterTest.IntrinsicBasedImpl[
+        AtomicLongFieldUpdaterTest
+      ](
+        classFieldRawPtr(_, "protectedField")
+      )
+      this.protectedField = 1
+      assertTrue(a.compareAndSet(this, 1, 2))
+      assertTrue(a.compareAndSet(this, 2, -4))
+      assertEquals(-4, a.get(this))
+      assertFalse(a.compareAndSet(this, -5, 7))
+      assertEquals(-4, a.get(this))
+      assertTrue(a.compareAndSet(this, -4, 7))
+      assertEquals(7, a.get(this))
+    }
+  }
+  class AtomicReferenceFieldUpdaterTestSubclass
+      extends AtomicReferenceFieldUpdaterTest {
+    // Impossible, see AtomicIntFieldUpdaterTestSubclass
+    // def checkPrivateAccess(): Unit = ???
+    def checkCompareAndSetProtectedSub(): Unit = {
+      // val a = AtomicReferenceFieldUpdater.newUpdater(
+      //   classOf[AtomicReferenceFieldUpdaterTest],
+      //   classOf[Integer],
+      //   "protectedField"
+      // )
+      val a = new AtomicReferenceFieldUpdaterTest.IntrinsicBasedImpl[
+        AtomicReferenceFieldUpdaterTest,
+        Integer
+      ](classFieldRawPtr(_, "protectedField"))
+      this.protectedField = one
+      assertTrue(a.compareAndSet(this, one, two))
+      assertTrue(a.compareAndSet(this, two, m4))
+      assertSame(m4, a.get(this))
+      assertFalse(a.compareAndSet(this, m5, seven))
+      assertNotSame(seven, a.get(this))
+      assertTrue(a.compareAndSet(this, m4, seven))
+      assertSame(seven, a.get(this))
+    }
+  }
+}
+
+class NonNestmates {
+  def checkPackageAccess(obj: AtomicIntegerFieldUpdaterTest): Unit = {
+    obj.x = 72
+    val a = new AtomicIntegerFieldUpdaterTest.IntrinsicBasedImpl(
+      classFieldRawPtr[AtomicIntegerFieldUpdaterTest](_, "x")
+    )
+    assertEquals(72, a.get(obj))
+    assertTrue(a.compareAndSet(obj, 72, 73))
+    assertEquals(73, a.get(obj))
+  }
+  def checkPackageAccess(obj: AtomicLongFieldUpdaterTest): Unit = {
+    obj.x = 72L
+    val a = new AtomicLongFieldUpdaterTest.IntrinsicBasedImpl(
+      classFieldRawPtr[AtomicLongFieldUpdaterTest](_, "x")
+    )
+    assertEquals(72L, a.get(obj))
+    assertTrue(a.compareAndSet(obj, 72L, 73L))
+    assertEquals(73L, a.get(obj))
+  }
+  def checkPackageAccess(obj: AtomicReferenceFieldUpdaterTest): Unit = {
+    val one = Integer.valueOf(1)
+    val two = Integer.valueOf(2)
+    obj.x = one
+    val a = new AtomicReferenceFieldUpdaterTest.IntrinsicBasedImpl[
+      AtomicReferenceFieldUpdaterTest,
+      Integer
+    ](
+      classFieldRawPtr(_, "x")
+    )
+    assertSame(one, a.get(obj))
+    assertTrue(a.compareAndSet(obj, one, two))
+    assertSame(two, a.get(obj))
+  }
+
+  // Impossible to test, would not compile
+  // def checkPrivateAccess(obj: AtomicIntegerFieldUpdaterTest): Unit = ???
+  // def checkPrivateAccess(obj: AtomicLongFieldUpdaterTest): Unit = ???
+  // def checkPrivateAccess(obj: AtomicReferenceFieldUpdaterTest): Unit = ???
+}

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/NonNestmates.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/NonNestmates.scala
@@ -16,6 +16,8 @@ import JSR166Test._
 
 import java.util.concurrent.atomic._
 import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+import scala.scalanative.runtime.fromRawPtr
+import scala.scalanative.libc.atomic.{CAtomicInt, CAtomicLongLong, CAtomicRef}
 
 /** This source file contains test code deliberately not contained in the same
  *  source file as the tests that use them, to avoid making them nestmates,
@@ -36,8 +38,12 @@ object NonNestmates {
       // )
       val a = new AtomicIntegerFieldUpdaterTest.IntrinsicBasedImpl[
         AtomicIntegerFieldUpdaterTest
-      ](
-        classFieldRawPtr(_, "protectedField")
+      ](obj =>
+        new CAtomicInt(
+          fromRawPtr(
+            classFieldRawPtr(obj, "protectedField")
+          )
+        )
       )
       this.protectedField = 1
       assertTrue(a.compareAndSet(this, 1, 2))
@@ -56,8 +62,12 @@ object NonNestmates {
     def checkCompareAndSetProtectedSub(): Unit = {
       val a = new AtomicIntegerFieldUpdaterTest.IntrinsicBasedImpl[
         AtomicLongFieldUpdaterTest
-      ](
-        classFieldRawPtr(_, "protectedField")
+      ](obj =>
+        new CAtomicInt(
+          fromRawPtr(
+            classFieldRawPtr(obj, "protectedField")
+          )
+        )
       )
       this.protectedField = 1
       assertTrue(a.compareAndSet(this, 1, 2))
@@ -82,7 +92,9 @@ object NonNestmates {
       val a = new AtomicReferenceFieldUpdaterTest.IntrinsicBasedImpl[
         AtomicReferenceFieldUpdaterTest,
         Integer
-      ](classFieldRawPtr(_, "protectedField"))
+      ](obj =>
+        new CAtomicRef(fromRawPtr(classFieldRawPtr(obj, "protectedField")))
+      )
       this.protectedField = one
       assertTrue(a.compareAndSet(this, one, two))
       assertTrue(a.compareAndSet(this, two, m4))
@@ -98,8 +110,14 @@ object NonNestmates {
 class NonNestmates {
   def checkPackageAccess(obj: AtomicIntegerFieldUpdaterTest): Unit = {
     obj.x = 72
-    val a = new AtomicIntegerFieldUpdaterTest.IntrinsicBasedImpl(
-      classFieldRawPtr[AtomicIntegerFieldUpdaterTest](_, "x")
+    val a = new AtomicIntegerFieldUpdaterTest.IntrinsicBasedImpl[
+      AtomicIntegerFieldUpdaterTest
+    ](obj =>
+      new CAtomicInt(
+        fromRawPtr(
+          classFieldRawPtr(obj, "x")
+        )
+      )
     )
     assertEquals(72, a.get(obj))
     assertTrue(a.compareAndSet(obj, 72, 73))
@@ -107,8 +125,12 @@ class NonNestmates {
   }
   def checkPackageAccess(obj: AtomicLongFieldUpdaterTest): Unit = {
     obj.x = 72L
-    val a = new AtomicLongFieldUpdaterTest.IntrinsicBasedImpl(
-      classFieldRawPtr[AtomicLongFieldUpdaterTest](_, "x")
+    val a = new AtomicLongFieldUpdaterTest.IntrinsicBasedImpl[
+      AtomicLongFieldUpdaterTest
+    ](obj =>
+      new CAtomicLongLong(
+        fromRawPtr(classFieldRawPtr(obj, "x"))
+      )
     )
     assertEquals(72L, a.get(obj))
     assertTrue(a.compareAndSet(obj, 72L, 73L))
@@ -121,8 +143,12 @@ class NonNestmates {
     val a = new AtomicReferenceFieldUpdaterTest.IntrinsicBasedImpl[
       AtomicReferenceFieldUpdaterTest,
       Integer
-    ](
-      classFieldRawPtr(_, "x")
+    ](obj =>
+      new CAtomicRef(
+        fromRawPtr(
+          classFieldRawPtr(obj, "x")
+        )
+      )
     )
     assertSame(one, a.get(obj))
     assertTrue(a.compareAndSet(obj, one, two))


### PR DESCRIPTION
* Port `Integer`, `Long`, `Reference` field updaters form JSR-166 without reflection-based implementation and its accessor (static `newUpdater` method)
* Ports tests and use SN intrinsic based updaters implemantions

Intrinsic-based implementation can be in the future moved to separate cross-platform library using macros/inlines to allow for generic usage field updaters. 
This change is required to support `scala.collection.concurrent.TrieMap`