### PR TITLE
Allow to use `scala.collection.concurrent.TrieMap`

### DIFF
--- a/auxlib/src/main/scala/scala/collection/concurrent/BasicNode.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/BasicNode.scala
@@ -1,0 +1,6 @@
+// Ported from Scala 2.13.10
+package scala.collection.concurrent
+
+abstract class BasicNode {
+  def string(lev: Int): String
+}

--- a/auxlib/src/main/scala/scala/collection/concurrent/CNodeBase.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/CNodeBase.scala
@@ -1,0 +1,27 @@
+package scala.collection.concurrent
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater
+
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+import scala.scalanative.runtime.fromRawPtr
+
+private[concurrent] abstract class CNodeBase[K <: AnyRef, V <: AnyRef]
+    extends MainNode[K, V] {
+  @volatile var csize: Int = -1
+
+  final val updater: AtomicIntegerFieldUpdater[CNodeBase[_, _]] =
+    new IntrinsicAtomicIntegerFieldUpdater(obj =>
+      fromRawPtr(classFieldRawPtr(obj, "csize"))
+    )
+
+  @alwaysinline
+  def CAS_SIZE(oldval: Int, nval: Int) =
+    updater.compareAndSet(this, oldval, nval)
+
+  @alwaysinline
+  def WRITE_SIZE(nval: Int): Unit = updater.set(this, nval)
+
+  @alwaysinline
+  def READ_SIZE: Int = updater.get(this)
+}

--- a/auxlib/src/main/scala/scala/collection/concurrent/Gen.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/Gen.scala
@@ -1,0 +1,5 @@
+// Ported from Scala 2.13.10
+
+package scala.collection.concurrent
+
+private[concurrent] final class Gen {}

--- a/auxlib/src/main/scala/scala/collection/concurrent/INodeBase.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/INodeBase.scala
@@ -1,0 +1,28 @@
+// Ported from Scala 2.13.10
+
+package scala.collection.concurrent
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+
+import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+import scala.scalanative.runtime.fromRawPtr
+
+object INodeBase {
+  final val updater
+      : AtomicReferenceFieldUpdater[INodeBase[_, _], MainNode[_, _]] =
+    new IntrinsicAtomicReferenceFieldUpdater(obj =>
+      fromRawPtr(classFieldRawPtr(obj, "mainnode"))
+    )
+
+  final val RESTART = new Object {}
+  final val NO_SUCH_ELEMENT_SENTINEL = new Object {}
+}
+
+private[concurrent] abstract class INodeBase[K <: AnyRef, V <: AnyRef](
+    generation: Gen
+) extends BasicNode {
+  @volatile var mainnode: MainNode[K, V] = _
+  final var gen: Gen = generation
+
+  def prev(): BasicNode = null
+}

--- a/auxlib/src/main/scala/scala/collection/concurrent/IntrinsicAtomicFieldUpdaters.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/IntrinsicAtomicFieldUpdaters.scala
@@ -1,0 +1,61 @@
+package scala.collection.concurrent
+
+import java.util.concurrent.atomic.{
+  AtomicIntegerFieldUpdater,
+  AtomicReferenceFieldUpdater
+}
+
+import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+import scala.scalanative.runtime.{RawPtr, fromRawPtr}
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.libc.atomic.{CAtomicRef, CAtomicInt, memory_order}
+import scala.scalanative.unsafe.Ptr
+
+private[concurrent] class IntrinsicAtomicReferenceFieldUpdater[
+    T <: AnyRef,
+    V <: AnyRef
+](@alwaysinline selector: T => Ptr[V])
+    extends AtomicReferenceFieldUpdater[T, V]() {
+  @alwaysinline private def atomicRef(insideObj: T) =
+    new CAtomicRef[V](selector(insideObj))
+
+  @alwaysinline def compareAndSet(obj: T, expect: V, update: V): Boolean =
+    atomicRef(obj).compareExchangeStrong(expect, update)
+
+  @alwaysinline def weakCompareAndSet(obj: T, expect: V, update: V): Boolean =
+    atomicRef(obj).compareExchangeWeak(expect, update)
+
+  @alwaysinline def set(obj: T, newIntalue: V): Unit =
+    atomicRef(obj).store(newIntalue)
+
+  @alwaysinline def lazySet(obj: T, newIntalue: V): Unit =
+    atomicRef(obj).store(newIntalue, memory_order.memory_order_release)
+
+  @alwaysinline def get(obj: T): V = atomicRef(obj).load()
+}
+
+class IntrinsicAtomicIntegerFieldUpdater[T <: AnyRef](
+    @alwaysinline selector: T => Ptr[Int]
+) extends AtomicIntegerFieldUpdater[T]() {
+  @alwaysinline private def atomicRef(insideObj: T) = new CAtomicInt(
+    selector(insideObj)
+  )
+
+  @alwaysinline def compareAndSet(obj: T, expect: Int, update: Int): Boolean =
+    atomicRef(obj).compareExchangeStrong(expect, update)
+
+  @alwaysinline def weakCompareAndSet(
+      obj: T,
+      expect: Int,
+      update: Int
+  ): Boolean =
+    atomicRef(obj).compareExchangeWeak(expect, update)
+
+  @alwaysinline def set(obj: T, newIntalue: Int): Unit =
+    atomicRef(obj).store(newIntalue)
+
+  @alwaysinline def lazySet(obj: T, newIntalue: Int): Unit =
+    atomicRef(obj).store(newIntalue, memory_order.memory_order_release)
+
+  @alwaysinline def get(obj: T): Int = atomicRef(obj).load()
+}

--- a/auxlib/src/main/scala/scala/collection/concurrent/MainNode.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/MainNode.scala
@@ -1,0 +1,38 @@
+package scala.collection.concurrent
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
+import scala.scalanative.runtime.fromRawPtr
+
+object MainNode {
+  final val updater
+      : AtomicReferenceFieldUpdater[MainNode[_, _], MainNode[_, _]] =
+    new IntrinsicAtomicReferenceFieldUpdater(obj =>
+      fromRawPtr(classFieldRawPtr(obj, "prev"))
+    )
+}
+
+private[concurrent] abstract class MainNode[K <: AnyRef, V <: AnyRef]
+    extends BasicNode {
+  import MainNode.updater
+
+  @volatile var prev: MainNode[K, V] = _
+
+  def cachedSize(ct: Object): Int
+
+  // standard contract
+  def knownSize(): Int
+
+  @alwaysinline
+  def CAS_PREV(oldval: MainNode[K, V], nval: MainNode[K, V]) =
+    updater.compareAndSet(this, oldval, nval)
+
+  @alwaysinline
+  def WRITE_PREV(nval: MainNode[K, V]): Unit = updater.set(this, nval)
+
+  @deprecated
+  @alwaysinline def READ_PREV(): MainNode[K, V] =
+    updater.get(this).asInstanceOf[MainNode[K, V]]
+}

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -5,12 +5,11 @@ import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.runtime.unwind
 import scala.scalanative.meta.LinktimeInfo
+// TODO: Replace with j.u.c.ConcurrentHashMap when implemented to remove scalalib dependency
+import scala.collection.concurrent.TrieMap
 
 private[lang] object StackTrace {
-  // TODO: Replace s.c.c.TrieMap/j.u.c.ConcurrentHashMap
-  private val cache = ThreadLocal.withInitial { () =>
-    collection.mutable.HashMap.empty[CUnsignedLong, StackTraceElement]
-  }
+  private val cache = TrieMap.empty[CUnsignedLong, StackTraceElement]
 
   private def makeStackTraceElement(
       cursor: Ptr[scala.Byte]
@@ -37,7 +36,7 @@ private[lang] object StackTrace {
       cursor: Ptr[scala.Byte],
       ip: CUnsignedLong
   ): StackTraceElement =
-    cache.get().getOrElseUpdate(ip, makeStackTraceElement(cursor))
+    cache.getOrElseUpdate(ip, makeStackTraceElement(cursor))
 
   @noinline private[lang] def currentStackTrace(): Array[StackTraceElement] = {
     var buffer = mutable.ArrayBuffer.empty[StackTraceElement]

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -7,7 +7,7 @@ import scala.scalanative.unsafe._
 import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 import scala.scalanative.runtime.libc.atomic_thread_fence
 import scala.scalanative.runtime.libc.memory_order._
-import java.util.concurrent.ConcurrentHashMap
+import scala.collection.concurrent.TrieMap
 
 trait NativeThread {
   import NativeThread._
@@ -94,7 +94,7 @@ object NativeThread {
     fromRawPtr[scala.Byte](castObjectToRawPtr(thread))
 
   object Registry {
-    private val _aliveThreads = new ConcurrentHashMap[Long, NativeThread]()
+    private val _aliveThreads = TrieMap.empty[Long, NativeThread]
 
     private[NativeThread] def add(thread: NativeThread): Unit =
       _aliveThreads.put(thread.thread.getId(), thread)
@@ -103,10 +103,7 @@ object NativeThread {
       _aliveThreads.remove(thread.thread.getId())
 
     def aliveThreads: scala.Array[NativeThread] =
-      _aliveThreads
-        .values()
-        .toArray()
-        .asInstanceOf[scala.Array[NativeThread]]
+      _aliveThreads.values.toArray
 
     def onMainThreadTermination() = {
       _aliveThreads.remove(MainThreadId)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -763,10 +763,20 @@ object Build {
         Test / unmanagedSources ++= {
           if (!shouldPartest.value) Nil
           else {
-            val blacklist: Set[String] =
-              blacklistedFromFile(
-                (Test / resourceDirectory).value / scalaVersion.value / "BlacklistedTests.txt"
-              )
+            val blacklist: Set[String] = {
+              val versionTestsDir =
+                (Test / resourceDirectory).value / scalaVersion.value
+              val base =
+                blacklistedFromFile(versionTestsDir / "BlacklistedTests.txt")
+              val requiringMultithreading =
+                if (nativeConfig.value.multithreadingSupport) Set.empty[String]
+                else
+                  blacklistedFromFile(
+                    versionTestsDir / "BlacklistedTests-require-threads.txt",
+                    ignoreMissing = true
+                  )
+              base ++ requiringMultithreading
+            }
 
             val jUnitTestsPath =
               (scalaPartest / fetchScalaSource).value / "test" / "junit"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -306,7 +306,7 @@ object Build {
   lazy val auxlib = MultiScalaProject("auxlib")
     .enablePlugins(MyScalaNativePlugin)
     .settings(mavenPublishSettings, commonJavalibSettings, disabledDocsSettings)
-    .dependsOn(nativelib)
+    .dependsOn(nativelib, clib)
     .withNativeCompilerPlugin
 
   lazy val scalalib: MultiScalaProject =

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -777,18 +777,13 @@ object Settings {
             }
           }
 
-          val useless =
-            path.contains("/scala/collection/parallel/") ||
-              path.contains("/scala/util/parsing/")
-          if (!useless) {
-            if (!patchGlob.matches(sourcePath))
-              addSource(path)(Some(sourcePath.toFile))
-            else {
-              val sourceName = path.stripSuffix(".patch")
-              addSource(sourceName)(
-                tryApplyPatch(sourceName)
-              )
-            }
+          if (!patchGlob.matches(sourcePath))
+            addSource(path)(Some(sourcePath.toFile))
+          else {
+            val sourceName = path.stripSuffix(".patch")
+            addSource(sourceName)(
+              tryApplyPatch(sourceName)
+            )
           }
         }
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -335,10 +335,19 @@ object Settings {
   }
 
   // Get all blacklisted tests from a file
-  def blacklistedFromFile(file: File) =
-    IO.readLines(file)
-      .filter(l => l.nonEmpty && !l.startsWith("#"))
-      .toSet
+  def blacklistedFromFile(
+      file: File,
+      ignoreMissing: Boolean = false
+  ): Set[String] =
+    if (file.exists())
+      IO.readLines(file)
+        .filter(l => l.nonEmpty && !l.startsWith("#"))
+        .toSet
+    else {
+      if (ignoreMissing) System.err.println(s"Ignore not existing file $file")
+      else throw new RuntimeException(s"Missing file: $file")
+      Set.empty
+    }
 
   // Get all scala sources from a directory
   def allScalaFromDir(dir: File): Seq[(String, java.io.File)] =

--- a/scala-partest-junit-tests/src/test/resources/2.12.17/BlacklistedTests.txt
+++ b/scala-partest-junit-tests/src/test/resources/2.12.17/BlacklistedTests.txt
@@ -8,6 +8,7 @@ scala/lang/primitives/BoxUnboxTest.scala
 scala/lang/stringinterpol/StringContextTest.scala
 scala/collection/SeqTest.scala
 scala/collection/Sizes.scala
+scala/collection/SetMapConsistencyTest.scala
 scala/collection/mutable/OpenHashMapTest.scala
 scala/collection/immutable/ListTest.scala
 scala/collection/immutable/ListMapTest.scala
@@ -142,13 +143,6 @@ scala/runtime/FloatBoxingTest.scala
 scala/collection/mutable/AnyRefMapTest.scala
 
 
-#scala.collection.parallel._
-scala/collection/NewBuilderTest.scala
-scala/collection/parallel/immutable/ParRangeTest.scala
-scala/collection/parallel/TaskTest.scala
-scala/collection/ParallelConsistencyTest.scala
-scala/runtime/ScalaRunTimeTest.scala
-
 #j.l.reflect.Modifier
 scala/reflect/macros/AttachmentsTest.scala
 scala/collection/IteratorTest.scala
@@ -161,11 +155,6 @@ scala/util/SpecVersionTest.scala
 scala/tools/testing/AssertUtil.scala
 scala/tools/testing/AssertUtilTest.scala
 scala/tools/testing/AssertThrowsTest.scala
-
-#s.c.c.TrieMap
-scala/collection/concurrent/TrieMapTest.scala
-scala/collection/SetMapConsistencyTest.scala
-scala/collection/SetMapRulesTest.scala
 
 #j.i.ObjectStream
 scala/PartialFunctionSerializationTest.scala
@@ -186,12 +175,16 @@ scala/collection/convert/NullSafetyToJavaTest.scala
 # Concurrency primitives
 scala/io/SourceTest.scala
 scala/sys/process/ProcessTest.scala
-scala/concurrent/impl/DefaultPromiseTest.scala
 
 #============
 ## Tests fail
 
 scala/collection/immutable/StreamTest.scala
+
+### Deadlocks maybe needs j.u.c.ConcurrentLinkedQueue
+scala/concurrent/impl/DefaultPromiseTest.scala
+scala/collection/parallel/TaskTest.scala
+scala/collection/NewBuilderTest.scala
 
 #=====
 ## Assumes JUnit 4.12

--- a/scala-partest-junit-tests/src/test/resources/2.13.10/BlacklistedTests-require-threads.txt
+++ b/scala-partest-junit-tests/src/test/resources/2.13.10/BlacklistedTests-require-threads.txt
@@ -1,0 +1,2 @@
+scala/collection/convert/MapWrapperTest.scala
+scala/collection/concurrent/TrieMapTest.scala

--- a/scala-partest-junit-tests/src/test/resources/2.13.10/BlacklistedTests.txt
+++ b/scala-partest-junit-tests/src/test/resources/2.13.10/BlacklistedTests.txt
@@ -152,9 +152,6 @@ scala/runtime/LongBoxingTest.scala
 scala/runtime/FloatBoxingTest.scala
 scala/runtime/DoubleBoxingTest.scala
 
-
-
-
 ## Do not link
 scala/jdk/DurationConvertersTest.scala
 scala/jdk/OptionConvertersTest.scala
@@ -168,10 +165,6 @@ scala/collection/immutable/ChampMapSmokeTest.scala
 scala/collection/immutable/ChampSetSmokeTest.scala
 scala/sys/process/ProcessBuilderTest.scala
 
-#scala.collection.parallel._
-scala/collection/NewBuilderTest.scala
-scala/runtime/ScalaRunTimeTest.scala
-
 #j.l.reflect.Modifier / testkit.AssertUtil
 scala/reflect/macros/AttachmentsTest.scala
 scala/collection/IteratorTest.scala
@@ -181,11 +174,7 @@ scala/util/SpecVersionTest.scala
 scala/tools/testkit/AssertUtilTest.scala
 scala/tools/testkit/ReflectUtilTest.scala
 
-#s.c.c.TrieMap
-scala/collection/IterableTest.scala
-scala/collection/SetMapConsistencyTest.scala
-scala/collection/SetMapRulesTest.scala
-scala/collection/concurrent/TrieMapTest.scala
+#j.u.stream.*
 scala/jdk/StepperConversionTest.scala
 scala/jdk/StepperTest.scala
 
@@ -212,9 +201,10 @@ scala/collection/convert/JConcurrentMapWrapperTest.scala
 #j.t.LocalDate
 scala/math/OrderingTest.scala
 
-# Concurrency primitives
-scala/collection/convert/MapWrapperTest.scala
-scala/concurrent/impl/DefaultPromiseTest.scala
+#j.l.Class.getDeclaredField
+scala/collection/immutable/VectorTest.scala
+
+#j.l.Thread contextClassloader
 scala/io/SourceTest.scala
 scala/lang/stringinterpol/StringContextTest.scala
 
@@ -231,7 +221,6 @@ scala/collection/StringOpsTest.scala
 scala/collection/convert/JSetWrapperTest.scala
 scala/collection/immutable/ArraySeqTest.scala
 scala/collection/immutable/LazyListGCTest.scala
-scala/collection/immutable/NumericRangeTest.scala
 scala/collection/immutable/StreamTest.scala
 scala/collection/immutable/VectorTest.scala
 scala/math/EquivTest.scala
@@ -239,3 +228,5 @@ scala/sys/process/ParserTest.scala
 scala/util/TryTest.scala
 # https://github.com/scala-native/scala-native/issues/2897
 scala/math/BigIntTest.scala
+### deadlocks maybe needs j.u.c.ConcurrentLinkedQueue
+scala/concurrent/impl/DefaultPromiseTest.scala

--- a/scalalib/overrides-2.12/scala/collection/concurrent/TrieMap.scala.patch
+++ b/scalalib/overrides-2.12/scala/collection/concurrent/TrieMap.scala.patch
@@ -1,0 +1,57 @@
+--- 2.12.17/scala/collection/concurrent/TrieMap.scala
++++ overrides-2.12/scala/collection/concurrent/TrieMap.scala
+@@ -20,6 +20,8 @@
+ import scala.util.control.ControlThrowable
+ import generic._
+ import scala.annotation.tailrec
++import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
++import scala.scalanative.runtime.fromRawPtr
+ 
+ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen) extends INodeBase[K, V](g) {
+   import INodeBase._
+@@ -636,7 +638,7 @@
+ 
+   def this(hashf: Hashing[K], ef: Equiv[K]) = this(
+     INode.newRootNode,
+-    AtomicReferenceFieldUpdater.newUpdater(classOf[TrieMap[K, V]], classOf[AnyRef], "root"),
++    new TrieMap.IntrinsicAtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef](obj => fromRawPtr(classFieldRawPtr(obj, "root"))),
+     hashf,
+     ef
+   )
+@@ -660,7 +662,7 @@
+ 
+   private def readObject(in: java.io.ObjectInputStream) {
+     root = INode.newRootNode
+-    rootupdater = AtomicReferenceFieldUpdater.newUpdater(classOf[TrieMap[K, V]], classOf[AnyRef], "root")
++    rootupdater = new TrieMap.IntrinsicAtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef]( obj => fromRawPtr(classFieldRawPtr(obj, "root")))
+ 
+     hashingobj = in.readObject().asInstanceOf[Hashing[K]]
+     equalityobj = in.readObject().asInstanceOf[Equiv[K]]
+@@ -966,8 +968,26 @@
+ 
+ 
+ object TrieMap extends MutableMapFactory[TrieMap] {
+-  val inodeupdater = AtomicReferenceFieldUpdater.newUpdater(classOf[INodeBase[_, _]], classOf[MainNode[_, _]], "mainnode")
++  // ScalaNative specific implementaiton of atomic reference field updater
++  import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
++  import scala.scalanative.runtime.RawPtr
++  import scala.scalanative.annotation.alwaysinline
++  import scala.scalanative.libc.atomic.{CAtomicRef, memory_order}
++  import scala.scalanative.unsafe.Ptr
+ 
++  private class IntrinsicAtomicReferenceFieldUpdater[
++      T <: AnyRef,
++      V <: AnyRef
++  ](@alwaysinline selector: T => Ptr[V]) extends AtomicReferenceFieldUpdater[T, V]() {
++    @alwaysinline private def atomicRef(obj: T) = new CAtomicRef(selector(obj))
++    @alwaysinline def compareAndSet(obj: T, expect: V, update: V): Boolean = atomicRef(obj).compareExchangeStrong(expect, update)
++    @alwaysinline def weakCompareAndSet(obj: T, expect: V, update: V): Boolean =  atomicRef(obj).compareExchangeWeak(expect, update)
++    @alwaysinline def set(obj: T, newIntalue: V): Unit = atomicRef(obj).store(newIntalue)
++    @alwaysinline def lazySet(obj: T, newIntalue: V): Unit = atomicRef(obj).store(newIntalue, memory_order.memory_order_release)
++    @alwaysinline def get(obj: T): V = atomicRef(obj).load()
++  }
++  val inodeupdater: AtomicReferenceFieldUpdater[INodeBase[_, _], MainNode[_, _]] = new IntrinsicAtomicReferenceFieldUpdater[INodeBase[_,_], MainNode[_,_]](obj => fromRawPtr(classFieldRawPtr(obj,  "mainnode")))
++
+   implicit def canBuildFrom[K, V]: CanBuildFrom[Coll, (K, V), TrieMap[K, V]] =
+     ReusableCBF.asInstanceOf[CanBuildFrom[Coll, (K, V), TrieMap[K, V]]]
+   private[this] val ReusableCBF = new MapCanBuildFrom[Nothing, Nothing]

--- a/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
@@ -1,9 +1,10 @@
 package scala.collection.immutable
 
-import java.lang.invoke.VarHandle
+import scala.scalanative.libc.atomic._
+import scala.scalanative.libc.atomic.memory_order._
 
 // Backport from scala.runtime moved into s.c.immutable and made package
 // private to avoid the need for MiMa whitelisting.
 /* private[immutable] */ object VM {
-  def releaseFence(): Unit = VarHandle.releaseFence()
+  def releaseFence(): Unit = atomic_thread_fence(memory_order_release)
 }

--- a/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
@@ -1,7 +1,9 @@
 package scala.collection.immutable
 
+import java.lang.invoke.VarHandle
+
 // Backport from scala.runtime moved into s.c.immutable and made package
 // private to avoid the need for MiMa whitelisting.
 /* private[immutable] */ object VM {
-  def releaseFence(): Unit = ()
+  def releaseFence(): Unit = VarHandle.releaseFence()
 }

--- a/scalalib/overrides-2.13/scala/collection/concurrent/TrieMap.scala.patch
+++ b/scalalib/overrides-2.13/scala/collection/concurrent/TrieMap.scala.patch
@@ -1,0 +1,67 @@
+--- 2.13.10/scala/collection/concurrent/TrieMap.scala
++++ overrides-2.13/scala/collection/concurrent/TrieMap.scala
+@@ -23,6 +23,8 @@
+ import scala.collection.mutable.GrowableBuilder
+ import scala.util.Try
+ import scala.util.hashing.Hashing
++import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
++import scala.scalanative.runtime.fromRawPtr
+ 
+ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen, equiv: Equiv[K]) extends INodeBase[K, V](g) {
+   import INodeBase._
+@@ -705,7 +707,7 @@
+ 
+   def this(hashf: Hashing[K], ef: Equiv[K]) = this(
+     INode.newRootNode(ef),
+-    AtomicReferenceFieldUpdater.newUpdater(classOf[TrieMap[K, V]], classOf[AnyRef], "root"),
++    new TrieMap.IntrinsicAtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef](obj => fromRawPtr(classFieldRawPtr(obj, "root"))),
+     hashf,
+     ef
+   )
+@@ -731,8 +733,7 @@
+ 
+   private def readObject(in: java.io.ObjectInputStream): Unit = {
+     root = INode.newRootNode(equality)
+-    rootupdater = AtomicReferenceFieldUpdater.newUpdater(classOf[TrieMap[K, V]], classOf[AnyRef], "root")
+-
++    rootupdater = new TrieMap.IntrinsicAtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef](obj => fromRawPtr(classFieldRawPtr(obj, "root")))
+     hashingobj = in.readObject().asInstanceOf[Hashing[K]]
+     equalityobj = in.readObject().asInstanceOf[Equiv[K]]
+ 
+@@ -1040,7 +1041,27 @@
+ 
+ @SerialVersionUID(3L)
+ object TrieMap extends MapFactory[TrieMap] {
++  // ScalaNative specific implementaiton of atomic reference field updater
++  import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
++  import scala.scalanative.runtime.RawPtr
++  import scala.scalanative.unsafe.Ptr
++  import scala.scalanative.annotation.alwaysinline
++  import scala.scalanative.libc.atomic.memory_order.memory_order_release
++  import scala.scalanative.libc.atomic.CAtomicRef
+ 
++  private class IntrinsicAtomicReferenceFieldUpdater[
++      T <: AnyRef,
++      V <: AnyRef
++  ](@alwaysinline selector: T => Ptr[V]) extends AtomicReferenceFieldUpdater[T, V]() {
++    @alwaysinline def atomicRef(obj: T) = new CAtomicRef(selector(obj))
++    @alwaysinline def compareAndSet(obj: T, expect: V, update: V): Boolean = atomicRef(obj).compareExchangeStrong(expect, update)
++    @alwaysinline def weakCompareAndSet(obj: T, expect: V, update: V): Boolean =  atomicRef(obj).compareExchangeWeak(expect, update)
++    @alwaysinline def set(obj: T, newIntalue: V): Unit = atomicRef(obj).store(newIntalue)
++    @alwaysinline def lazySet(obj: T, newIntalue: V): Unit = atomicRef(obj).store(newIntalue, memory_order_release)
++    @alwaysinline def get(obj: T): V = atomicRef(obj).load()
++  }
++
++
+   def empty[K, V]: TrieMap[K, V] = new TrieMap[K, V]
+ 
+   def from[K, V](it: IterableOnce[(K, V)]): TrieMap[K, V] = new TrieMap[K, V]() ++= it
+@@ -1048,7 +1069,7 @@
+   def newBuilder[K, V]: mutable.GrowableBuilder[(K, V), TrieMap[K, V]] = new GrowableBuilder(empty[K, V])
+ 
+   @transient
+-  val inodeupdater: AtomicReferenceFieldUpdater[INodeBase[_, _], MainNode[_, _]] = AtomicReferenceFieldUpdater.newUpdater(classOf[INodeBase[_, _]], classOf[MainNode[_, _]], "mainnode")
++  val inodeupdater: AtomicReferenceFieldUpdater[INodeBase[_, _], MainNode[_, _]] = new IntrinsicAtomicReferenceFieldUpdater[INodeBase[_,_], MainNode[_,_]](obj => fromRawPtr(classFieldRawPtr(obj, "mainnode")))
+ 
+   class MangledHashing[K] extends Hashing[K] {
+     def hash(k: K): Int = scala.util.hashing.byteswap32(k.##)


### PR DESCRIPTION
* Implements java dependencies and adapts TrieMap implementation to use Intrinsic based atomic field updaters
* Removed to longer required Scala 2 sources filtering for `scala.collection.parallel` 
* Updated ignored lists of Scala2 partest junit tests to test TrieMap and other concurrent types
* Use TrieMap instead of not concurrent aware implementation of `java.util.concurrent.CouncurrentHashMap`