### PR TITLE
Fix #3071, #3135: Implement Java 11 writeString & readString methods and Java 10 transferTo

### DIFF
--- a/javalib/src/main/scala/java/io/Reader.scala
+++ b/javalib/src/main/scala/java/io/Reader.scala
@@ -1,6 +1,7 @@
 package java.io
 
 // Ported from Scala.js, commit: 7d7a621, dated 2022-03-07
+// 2023-02-01 implemented Java 10 transferTo() method
 
 import java.nio.CharBuffer
 
@@ -82,4 +83,21 @@ abstract class Reader() extends Readable with Closeable {
 
   def close(): Unit
 
+  // Since: Java 10
+  def transferTo(out: Writer): Long = {
+    val buffer = new Array[Char](4096)
+
+    @tailrec
+    def loop(nRead: Long): Long = {
+      val n = this.read(buffer)
+      if (n == -1) {
+        nRead
+      } else {
+        out.write(buffer, 0, n)
+        loop(nRead + n)
+      }
+    }
+
+    loop(0)
+  }
 }

--- a/javalib/src/main/scala/java/io/StringWriter.scala
+++ b/javalib/src/main/scala/java/io/StringWriter.scala
@@ -1,10 +1,13 @@
 package java.io
 
-class StringWriter extends Writer {
+class StringWriter(initialSize: Int) extends Writer {
 
-  private[this] val buf = new StringBuffer
+  def this() = this(128)
 
-  def this(initialSize: Int) = this()
+  if (initialSize < 0)
+    throw new IllegalArgumentException("Initial size < 0")
+
+  private val buf = new StringBuffer(initialSize)
 
   override def write(c: Int): Unit =
     buf.append(c.toChar)

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -11,8 +11,10 @@ import java.io.{
   InputStreamReader,
   OutputStream,
   OutputStreamWriter,
+  StringWriter,
   UncheckedIOException
 }
+
 import java.nio.file.attribute._
 import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.channels.{FileChannel, SeekableByteChannel}
@@ -28,12 +30,16 @@ import java.util.{
   Set
 }
 import java.util.stream.{Stream, WrappedScalaStream}
+
+import scala.annotation.tailrec
+
 import scalanative.unsigned._
 import scalanative.unsafe._
 import scalanative.libc._
-import scalanative.posix.{dirent, fcntl, limits, unistd}
-import dirent._
+
 import scalanative.posix.errno.{errno, EEXIST, ENOENT, ENOTEMPTY}
+import scalanative.posix.dirent, dirent._
+import scalanative.posix.{fcntl, limits, unistd}
 
 import java.nio.file.StandardCopyOption.{COPY_ATTRIBUTES, REPLACE_EXISTING}
 import scalanative.nio.fs.unix.UnixException
@@ -191,15 +197,14 @@ object Files {
       throw new IOException()
     }
 
-  def createFile(path: Path, attrs: Array[FileAttribute[_]]): Path =
+  def createFile(path: Path, attrs: Array[FileAttribute[_]]): Path = {
     if (exists(path, Array.empty))
       throw new FileAlreadyExistsException(path.toString)
-    else if (FileHelpers.createNewFile(path.toString)) {
+    else if (FileHelpers.createNewFile(path.toString, throwOnError = true)) {
       setAttributes(path, attrs)
-      path
-    } else {
-      throw new IOException()
     }
+    path
+  }
 
   def createLink(link: Path, existing: Path): Path = Zone { implicit z =>
     if (isWindows) {
@@ -772,6 +777,24 @@ object Files {
     }
   }
 
+  // Since: Java 11
+  def readString(path: Path): String = {
+    readString(path, StandardCharsets.UTF_8)
+  }
+
+  // Since: Java 11
+  def readString(path: Path, cs: Charset): String = {
+    val reader = newBufferedReader(path, cs)
+    try {
+      // Guess an cost-effective amortized size.
+      val writer = new StringWriter(2 * 1024)
+      reader.transferTo(writer)
+      writer.toString()
+      // No need to close() StringWriter, so no inner try/finally.
+    } finally
+      reader.close()
+  }
+
   def readSymbolicLink(link: Path): Path =
     if (!isSymbolicLink(link)) {
       throw new NotLinkException(link.toString)
@@ -1094,5 +1117,62 @@ object Files {
       "user" -> classOf[UserDefinedFileAttributeView],
       "posix" -> classOf[PosixFileAttributeView]
     )
+
+  // Since: Java 11
+  def writeString(
+      path: Path,
+      csq: java.lang.CharSequence,
+      cs: Charset,
+      options: Array[OpenOption]
+  ): Path = {
+    import java.io.Reader
+
+    // Java API has no CharSequenceReader, but the concept is useful here.
+    class CharSequenceReader(csq: CharSequence) extends Reader {
+      private var closed = false
+      private var pos = 0
+
+      override def close(): Unit = closed = true
+
+      override def read(cbuf: Array[Char], off: Int, len: Int): Int = {
+        if (closed)
+          throw new IOException("Operation on closed stream")
+
+        if (off < 0 || len < 0 || len > cbuf.length - off)
+          throw new IndexOutOfBoundsException
+
+        if (len == 0) 0
+        else {
+          val count = Math.min(len, csq.length() - pos)
+          var i = 0
+          while (i < count) {
+            cbuf(off + i) = csq.charAt(pos + i)
+            i += 1
+          }
+          pos += count
+          if (count == 0) -1 else count
+        }
+      }
+    }
+
+    val reader = new CharSequenceReader(csq)
+    val writer = newBufferedWriter(path, cs, options)
+    try {
+      reader.transferTo(writer)
+      // No need to close() CharSequenceReader, so no inner try/finally.
+    } finally
+      writer.close()
+
+    path
+  }
+
+  // Since: Java 11
+  def writeString(
+      path: Path,
+      csq: java.lang.CharSequence,
+      options: Array[OpenOption]
+  ): Path = {
+    writeString(path, csq, StandardCharsets.UTF_8, options)
+  }
 
 }

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/FilesTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/FilesTestOnJDK11.scala
@@ -61,17 +61,6 @@ class FilesTestOnJDK11 {
     assertEquals("data read back does not match data written", dataOut, dataIn)
   }
 
-  @Test def readStringUTF16LEUsingExplicitCharsetUTF8(): Unit = {
-    val ioPath = getCleanIoPath("utf16LE_forReadBack")
-    val dataOut = getDataOut()
-
-    Files.writeString(ioPath, dataOut, StandardCharsets.UTF_16LE)
-
-    val dataIn = Files.readString(ioPath, StandardCharsets.UTF_8)
-
-    assertNotEquals("data read back matchs data written", dataOut, dataIn)
-  }
-
   @Test def readStringUTF16LEUsingExplicitCharsetUTF16LE(): Unit = {
     val ioPath = getCleanIoPath("utf16LE_forReadBack")
     val dataOut = getDataOut()

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/FilesTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/FilesTestOnJDK11.scala
@@ -1,0 +1,439 @@
+package org.scalanative.testsuite
+package javalib.nio.file
+
+import java.{lang => jl}
+import java.{util => ju}
+
+import java.nio.charset.StandardCharsets
+import java.nio.CharBuffer
+import java.nio.file.Files
+import java.nio.file.{Path, Paths}
+import java.nio.file.{FileAlreadyExistsException, StandardOpenOption}
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.{BeforeClass, AfterClass}
+import org.junit.Ignore
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class FilesTestOnJDK11 {
+  import FilesTestOnJDK11._
+
+  /* Design Notes:
+   *
+   * 1) This set of Tests is designed to clean up after itself. That is
+   *    delete all directories and files created.  For debugging one
+   *    can comment-out the Files.delete() in the afterClass() static method.
+   *
+   * 2) To simplify implementation, The readString() Tests call writeString().
+   *    This leaves open the possibility of complementary and/or compensating
+   *    errors in the two methods.
+   *
+   *    In a better World, writeString() would be Test'ed before possibly
+   *    being used by readString(). Currently the order of execution of tests
+   *    is hard to determine and harder (not possible) to specify.
+   *    This Suite is forced to rely on writeString() eventually getting
+   *    strongly tested.
+   *
+   *    Normally one would expect to see the writeString() tests at the top
+   *    of the file, expecting them to be run before being used by
+   *    readString(). Here, the writeString() methods are later in the file
+   *    because there are hints, but not guarantees, that Tests later in the
+   *    file are run before those earlier.  No wonder why it is hard to
+   *    find Test developers.
+   *
+   * 3) The comment above the largeWriteStringThenReadString() Test explains
+   *    why it is @Ignore'd in normal Continuous Integration.
+   *
+   * 4) There are no tests for CharSequence javax.swing.text.Segment because
+   *    Segment is not implemented by Scala Native.
+   */
+
+  @Test def readStringUsingDefaultCharsetUTF8(): Unit = {
+    val ioPath = getCleanIoPath("utf8_forReadBack")
+    val dataOut = getDataOut()
+
+    Files.writeString(ioPath, dataOut)
+
+    val dataIn = Files.readString(ioPath)
+
+    assertEquals("data read back does not match data written", dataOut, dataIn)
+  }
+
+  @Test def readStringUTF16LEUsingExplicitCharsetUTF8(): Unit = {
+    val ioPath = getCleanIoPath("utf16LE_forReadBack")
+    val dataOut = getDataOut()
+
+    Files.writeString(ioPath, dataOut, StandardCharsets.UTF_16LE)
+
+    val dataIn = Files.readString(ioPath, StandardCharsets.UTF_8)
+
+    assertNotEquals("data read back matchs data written", dataOut, dataIn)
+  }
+
+  @Test def readStringUTF16LEUsingExplicitCharsetUTF16LE(): Unit = {
+    val ioPath = getCleanIoPath("utf16LE_forReadBack")
+    val dataOut = getDataOut()
+
+    Files.writeString(ioPath, dataOut, StandardCharsets.UTF_16LE)
+
+    val dataIn = Files.readString(ioPath, StandardCharsets.UTF_16LE)
+
+    assertEquals("data read back does not match data written", dataOut, dataIn)
+  }
+
+  @Test def readStringUTF16BEUsingExplicitCharsetUTF16BE(): Unit = {
+    val ioPath = getCleanIoPath("utf16BE_forReadBack")
+    val dataOut = getDataOut()
+
+    Files.writeString(ioPath, dataOut, StandardCharsets.UTF_16BE)
+
+    val dataIn = Files.readString(ioPath, StandardCharsets.UTF_16BE)
+
+    assertEquals("data read back does not match data written", dataOut, dataIn)
+  }
+
+  @Test def writeStringFromStringUsingDefaultCharsetUTF8(): Unit = {
+    val ioPath = getCleanIoPath("utf8_file")
+    val dataOut = getDataOut()
+
+    /* Test, at the same time, correctness of both writing the file and of
+     * using a variable number of arguments whilst doing so.
+     *
+     * Call without "OpenOption" third argument.
+     * Java documention says this will cause options "CREATE",
+     * "TRUNCATE_EXISTING", and "WRITE" to be used. CREATE and
+     * WRITE are exercised here.
+     */
+
+    Files.writeString(ioPath, dataOut)
+
+    verifySmallUtf8Payload(ioPath)
+  }
+
+  @Test def writeStringFromStringUsingExplicitCharsetUTF16LE(): Unit = {
+    val ioPath = getCleanIoPath("utf16LE_file")
+    val dataOut = getDataOut()
+
+   // format: off
+    val expectedValues = Array(
+	0xAC,
+	0x20,
+	0xA3,
+	0x00,
+	0x24,
+	0x00,
+    ).map (_.toByte)
+   // format: on
+
+    /* Euro, Pound, and Dollar characters are all 2 bytes in UTF-16.
+     * End-of-line newline will be 2 bytes. Windows carriage-return (CR),
+     * if present, will be another two bytes.
+     */
+    val expectedDataLength = expectedValues.size + (EOLlen * 2)
+
+    /* Write String out in "odd, non-standard 16LE" format instead of
+     * Java standard 16BE just to shake things up and invite faults.
+     */
+    Files.writeString(ioPath, dataOut, StandardCharsets.UTF_16LE)
+
+    val bytesRead = Files.readAllBytes(ioPath)
+
+    assertEquals("bytes read", expectedDataLength, bytesRead.length)
+
+    for (j <- 0 until (expectedValues.length)) {
+      assertEquals(
+        s"write/read mismatch at index ${j}",
+        expectedValues(j),
+        bytesRead(j)
+      )
+    }
+
+    verifyUtf16LeEOL(bytesRead)
+  }
+
+  @Test def writeStringFromStringUsingExplicitCharsetUTF16BE(): Unit = {
+    val ioPath = getCleanIoPath("utf16BE_file")
+    val dataOut = getDataOut()
+
+   // format: off
+    val expectedValues = Array(
+	0x20,
+	0xAC,
+	0x00,
+	0xA3,
+	0x00,
+	0x24,
+    ).map (_.toByte)
+   // format: on
+
+    /* Euro, Pound, and Dollar characters are all 2 bytes in UTF-16.
+     * End-of-line newline will be 2 bytes. Windows carriage-return (CR),
+     * if present, will be another two bytes.
+     */
+    val expectedDataLength = expectedValues.size + (EOLlen * 2)
+
+    // Write as represented in Java Characters, Big Endian or network order.
+    Files.writeString(ioPath, dataOut, StandardCharsets.UTF_16BE)
+
+    val bytesRead = Files.readAllBytes(ioPath)
+
+    assertEquals("bytes read", expectedDataLength, bytesRead.length)
+
+    for (j <- 0 until (expectedValues.length)) {
+      assertEquals(
+        s"write/read mismatch at index ${j}",
+        expectedValues(j),
+        bytesRead(j)
+      )
+    }
+
+    verifyUtf16BeEOL(bytesRead)
+  }
+
+  @Test def writeStringFromCharBufferWrapSmallArray(): Unit = {
+    val ioPath = getCleanIoPath("CharBufferWrapSmallArray")
+    val dataOut = getDataOut()
+
+    val output = CharBuffer.wrap(dataOut.toArray[Char])
+    Files.writeString(ioPath, output)
+
+    verifySmallUtf8Payload(ioPath)
+  }
+
+  @Test def writeStringFromCharBufferWrapSmallString(): Unit = {
+    val ioPath = getCleanIoPath("CharBufferWrapSmallString")
+    val dataOut = getDataOut()
+
+    val output = CharBuffer.wrap(dataOut)
+    Files.writeString(ioPath, output)
+
+    verifySmallUtf8Payload(ioPath)
+  }
+
+  @Test def writeStringFromStringBuilderSmall(): Unit = {
+    val ioPath = getCleanIoPath("StringBuilderSmall")
+    val dataOut = getDataOut()
+
+    val output = jl.StringBuilder(dataOut)
+    Files.writeString(ioPath, output)
+
+    verifySmallUtf8Payload(ioPath)
+  }
+
+  @Test def writeStringFromStringBufferSmall(): Unit = {
+    val ioPath = getCleanIoPath("StringBufferSmall")
+    val dataOut = getDataOut()
+
+    val output = jl.StringBuffer(dataOut)
+    Files.writeString(ioPath, output)
+
+    verifySmallUtf8Payload(ioPath)
+  }
+
+  @Test def writeStringFromStringUsingOptionArg(): Unit = {
+    /* Check that both writeString() variants properly pass an explicitly
+     * specified file open attributes varargs argument.
+     */
+    val ioPath = getCleanIoPath("utf8_forCreateNewOptionArg")
+    val dataOut = getDataOut()
+
+    Files.createFile(ioPath)
+
+    assertThrows(
+      classOf[FileAlreadyExistsException],
+      Files.writeString(
+        ioPath,
+        dataOut,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE_NEW
+      )
+    )
+
+    assertThrows(
+      classOf[FileAlreadyExistsException],
+      Files.writeString(
+        ioPath,
+        dataOut,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE_NEW
+      )
+    )
+  }
+
+  /* This Test is next to essential for both development & debugging.
+   * It is Ignore'd for normal Continuous Integration (CI) because, by
+   * its very purpose it creates and verifies a larger-than-a-breadbox
+   * file. In CI, this takes CPU & IO resources and has the possibility
+   * of leaving a large otherwise useless file lying around.
+   *
+   * The SN standard is to use "/* */" for multiline comments, as is done here.
+   * If someone if offended by the @Ignore, they could convert the contents
+   * below to "//" line comments then enclose the region in a "/* */" pair.
+   */
+  @Ignore
+  @Test def largeWriteStringThenReadString(): Unit = {
+    /* Same logic as small readString() tests but with enough data to
+     * exercise any internal buffering.
+     */
+
+    val ioPath = getCleanIoPath("LargeFile")
+
+    /* Use an unexpected string size to try to reveal defects in any
+     * underlying buffering.
+     *
+     * This test does not, and should not, know the sizes of any
+     * internal buffers used by writeString() and readString().
+     * If any such exist, they are likely to have a power-of-two size
+     * and more likely to have an even size. Developers like even sizes.
+     *
+     * Add an odd, and preferably prime, increment to a "reasonable" string
+     * size to almost certainly force any last buffer to be partial.
+     */
+
+    /* For a String filled with all but two 1-byte UTF-8 and two 2-byte
+     * UTF-8 characters, expect an actual file size of
+     * (40960 + 2 + 41) = 41003 bytes.
+     */
+    val maxStringSize = (40 * 1024) + 41
+
+    val startChar = '\u03B1' // Greek lowercase alpha; file bytes 0xCE 0xB1
+    val endChar = '\u03A9' // Greek uppercase omega; file bytes 0xCE 0xA9
+
+    val dataOut = getLargeDataOut(maxStringSize, startChar, endChar)
+
+    Files.writeString(ioPath, dataOut)
+
+    val dataIn = Files.readString(ioPath)
+
+    assertEquals("Unexpected dataIn size", maxStringSize, dataIn.size)
+    assertEquals(
+      "dataOut & dataIn sizes do not match",
+      dataOut.size,
+      dataIn.size
+    )
+
+    assertEquals("Unexpected first dataIn character", startChar, dataIn(0))
+    assertEquals(
+      "Unexpected last dataIn character",
+      endChar,
+      dataIn(maxStringSize - 1)
+    )
+
+    assertEquals("data read back does not match data written", dataOut, dataIn)
+  }
+}
+
+object FilesTestOnJDK11 {
+  private var orgPath: Path = _
+  private var workPath: Path = _
+
+  final val testsuitePackagePrefix = "org.scalanative."
+
+  val EOL = System.getProperty("line.separator") // end-of-line
+  val EOLlen = EOL.size
+
+  private def getCleanIoPath(fileName: String): Path = {
+    val ioPath = workPath.resolve(fileName)
+    Files.deleteIfExists(ioPath)
+    ioPath
+  }
+
+  def getDataOut(): String = {
+    /* Euro sign, Pound sign, dollarSign
+     *  Ref: https://www.compart.com/en/unicode
+     */
+
+    "\u20AC\u00A3\u0024" + EOL // ensure file ends with OS end-of-line.
+  }
+
+  def getLargeDataOut(maxSize: Int, startChar: Char, endChar: Char): String = {
+    val sb = new StringBuilder(maxSize)
+    sb.insert(0, startChar)
+    sb.setLength(maxSize - 1) // extend to size, filled with NUL characters
+    sb.append(endChar) // final size should be maxSize
+    // leave the string _without_ a terminal line.separator to trip things up.
+    sb.toString()
+  }
+
+  def verifyUtf8EOL(bytes: Array[Byte]): Unit = {
+    if (EOLlen == 2)
+      assertEquals("Expected Windows CR", '\r', bytes(bytes.length - EOLlen))
+
+    assertEquals("Expected newline", '\n', bytes(bytes.length - 1))
+  }
+
+  def verifyUtf16LeEOL(bytes: Array[Byte]): Unit = {
+    if (EOLlen == 2)
+      assertEquals("Expected Windows CR", '\r', bytes(bytes.length - 4))
+
+    assertEquals("Expected newline", '\n', bytes(bytes.length - 2))
+  }
+
+  def verifyUtf16BeEOL(bytes: Array[Byte]): Unit = {
+    if (EOLlen == 2)
+      assertEquals("Expected Windows CR", '\r', bytes(bytes.length - 3))
+
+    assertEquals("Expected newline", '\n', bytes(bytes.length - 1))
+  }
+
+  def verifySmallUtf8Payload(ioPath: Path): Unit = {
+   // format: off
+    val expectedValues = Array(
+	0xE2, 0x82, 0xAC, // EURO SIGN
+	0xC2, 0xA3,       // POUND (sterling) SIGN
+	0x24,             // DOLLAR SIGN
+    ).map (_.toByte)
+   // format: on
+
+    val expectedDataLength = expectedValues.size + EOLlen
+
+    val bytesRead = Files.readAllBytes(ioPath)
+    assertEquals("bytes read", expectedDataLength, bytesRead.length)
+
+    for (j <- 0 until (expectedValues.length)) {
+      assertEquals(
+        s"write/read mismatch at index ${j}",
+        expectedValues(j),
+        bytesRead(j)
+      )
+    }
+
+    verifyUtf8EOL(bytesRead)
+  }
+
+  @BeforeClass
+  def beforeClass(): Unit = {
+    /* Scala package statement does not allow "-", so the testsuite
+     * packages are all "scalanative", not the "scala-native" used
+     * in distribution artifacts or the name of the GitHub repository.
+     */
+    orgPath = Files.createTempDirectory(s"${testsuitePackagePrefix}testsuite")
+
+    val tmpPath =
+      orgPath.resolve(s"javalib/nio/file/${this.getClass().getSimpleName()}")
+    workPath = Files.createDirectories(tmpPath)
+  }
+
+  @AfterClass
+  def afterClass(): Unit = {
+    // Delete items created by this test.
+
+    // Avoid blind "rm -r /" and other oops! catastrophes.
+    if (!orgPath.toString().contains(s"${testsuitePackagePrefix}"))
+      fail(s"Refusing recursive delete of unknown path: ${orgPath}")
+
+    // Avoid resize overhead; 64 is a high guess. deque will grow if needed.
+    val stack = new ju.ArrayDeque[Path](64)
+    val stream = Files.walk(orgPath)
+
+    try {
+      // Delete Files; start with deepest & work upwards to beginning of walk.
+      stream.forEach(stack.addFirst(_)) // push() Path
+      stack.forEach(Files.delete(_)) // pop() a Path then delete it's File.
+    } finally {
+      stream.close()
+    }
+  }
+}


### PR DESCRIPTION
Fix #3071 implement two Java  11 `writeString()` methods & associated Test cases.

Fix #3135: implement two Java 11 `readString()` methods & associated Test cases.

Java 10 `transferTo()` method is implemented and used to implement the four methods above.