### PR TITLE
Fix #1642: posixlib stdio.scala is now mostly Open Group 2018 compliant

### DIFF
--- a/posixlib/src/main/resources/scala-native/stdio.c
+++ b/posixlib/src/main/resources/scala-native/stdio.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+// This file contains functions that wrap posixlib
+// built-in macros. We need this because Scala Native
+// can not expand C macros, and that's the easiest way to
+// get the values out of those in a portable manner.
+
+// CX extension
+int scalanative_l_ctermid() { return L_ctermid; }

--- a/posixlib/src/main/resources/scala-native/stdio.c
+++ b/posixlib/src/main/resources/scala-native/stdio.c
@@ -1,5 +1,14 @@
 #include <stdio.h>
 
+#if !defined(L_ctermid)
+#if defined(_WIN32)
+// Windows MAX_PATH is 260, plus 1 for terminating NUL/NULL/"\u0000".
+#define L_ctermid 260 + 1
+#else
+#error "L_ctermid is not defined in stdio.h"
+#endif
+#endif
+
 // This file contains functions that wrap posixlib
 // built-in macros. We need this because Scala Native
 // can not expand C macros, and that's the easiest way to

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
@@ -50,7 +50,10 @@ import scalanative.posix.sys.types, types.{off_t, size_t}
     extern
 
   @blocking def ftello(stream: Ptr[FILE]): off_t = extern
-  @blocking def ftrylockfile(filehandle: Ptr[FILE]): Int = extern
+
+  // Can not block; see "try" part of "ftry*"
+  def ftrylockfile(filehandle: Ptr[FILE]): Int = extern
+
   @blocking def funlockfile(filehandle: Ptr[FILE]): Unit = extern
 
   @blocking def getc_unlocked(stream: Ptr[CString]): Int = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
@@ -1,10 +1,91 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe._
+import scalanative.unsafe, unsafe._
+import scalanative.posix.sys.types, types.{off_t, size_t}
 
 @extern object stdio extends stdio
 
 @extern trait stdio extends libc.stdio {
-  // no extensions
+  /* Open Group 2018 extensions to ISO/IEC C.
+   * Reference:
+   *   https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdio.h.html
+   *
+   * These definitions are annotated CX (ISO/IEC C extension)
+   * in the above specification.
+   */
+
+  type ssize_t = types.ssize_t
+
+  type va_list = unsafe.CVarArgList
+
+// Macros
+
+  /* Open Group POSIX defines this as a C macro.
+   * To provide the value in a portable manner, it is implemented here as
+   * an extenal method.  A slight but necessary deviation from the
+   * specification. The same idiom is used in an number of other posixlib
+   * files.
+   */
+  @name("scalanative_l_ctermid")
+  def L_ctermid: CUnsignedInt = extern
+
+// Methods
+
+  @blocking def ctermid(s: CString): CString = extern
+
+  @blocking def dprintf(fd: Int, format: CString, valist: va_list): Int = extern
+
+  @blocking def fdopen(fd: Int, mode: CString): Ptr[FILE] = extern
+  @blocking def fileno(stream: Ptr[FILE]): Int = extern
+  @blocking def flockfile(filehandle: Ptr[FILE]): Unit = extern
+
+  @blocking def fmemopen(
+      buf: Ptr[Byte],
+      size: size_t,
+      mode: CString
+  ): Ptr[FILE] = extern
+
+  @blocking def fseeko(stream: Ptr[FILE], offset: off_t, whence: Int): Int =
+    extern
+
+  @blocking def ftello(stream: Ptr[FILE]): off_t = extern
+  @blocking def ftrylockfile(filehandle: Ptr[FILE]): Int = extern
+  @blocking def funlockfile(filehandle: Ptr[FILE]): Unit = extern
+
+  @blocking def getc_unlocked(stream: Ptr[CString]): Int = extern
+  @blocking def getchar_unlocked(): Int = extern
+
+  @blocking def getdelim(
+      lineptr: Ptr[CString],
+      n: Ptr[size_t],
+      delim: Int,
+      stream: Ptr[FILE]
+  ): ssize_t = extern
+
+  @blocking def getline(
+      lineptr: Ptr[CString],
+      n: Ptr[size_t],
+      stream: Ptr[FILE]
+  ): ssize_t = extern
+
+  @blocking def open_memstream(
+      ptr: Ptr[CString],
+      sizeloc: Ptr[size_t]
+  ): Ptr[FILE] =
+    extern
+
+  @blocking def pclose(stream: Ptr[FILE]): Int = extern
+  @blocking def popen(command: CString, typ: CString): Ptr[FILE] = extern
+  @blocking def putc_unlocked(c: Int, stream: Ptr[FILE]): Int = extern
+  @blocking def putchar_unlocked(c: Int): Int = extern
+
+  @blocking def renameat(
+      olddirfd: Int,
+      oldpath: CString,
+      newdirdf: Int,
+      newpath: CString
+  ): Int = extern
+
+  @blocking def vdprintf(fd: Int, format: CString, ap: va_list): Int = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
@@ -23,7 +23,7 @@ import scalanative.posix.sys.types, types.{off_t, size_t}
 
   /* Open Group POSIX defines this as a C macro.
    * To provide the value in a portable manner, it is implemented here as
-   * an extenal method.  A slight but necessary deviation from the
+   * an external method.  A slight but necessary deviation from the
    * specification. The same idiom is used in an number of other posixlib
    * files.
    */


### PR DESCRIPTION
Fix #1642. 

##### SN versions

This PR is for 0.5.0 only, due to the use of `@blocking`.   

I have not built on 0.4.x but, it theory, it could be ported back
to 0.4.x by deleting about twenty of those.  Please advise if you or community member
would like me to create an 0.4.x PR.   

An alternate solution would be for me to create a dummy no-op `@blocking` annotation for 0.4.x.
and leave the code as is.  That might be more productive by  easing the backport of other code which might use `@blocking`.

##### Pull Request 
Aged PR #1642 listed a number of missing C related methods. Over the course of the last
3++ years, all but `fdopen()` have been implemented.  This PR implements that missing
method.  Progress happens, albeit slowly.

This PR also implements the parts of the Open Group 2018 (POSIX) specification described
as extensions to ISO/IEC C.  The Open Group uses the annotation CX in their document.

posixlib `stdio.scala` is now almost entirely compliant with the Open Group 2018 specification.

The one small area of non-compliance is the use of methods/functions to implement
definitions which are declared as C macros in the specification in a portable manner.
This idiom is commonly used across both posixlib & clib.  Noted here for completeness.

As always, actually using posixlib methods on Windows always incurs the possibility of
link errors because Windows does things differently. 