### PR TITLE
Fix #2937, 3163: improved j.nio.f.Files default directory idiom handling 

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -59,9 +59,9 @@ import java.io.FileNotFoundException
 
 object Files {
 
-  private val `1U` = 1.toUInt
+  private final val `1U` = 1.toUInt
 
-  private val emptyPath = Paths.get("", Array.empty)
+  private final val emptyPath = Paths.get("", Array.empty)
 
   // def getFileStore(path: Path): FileStore
   // def probeContentType(path: Path): String

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/PathMatcherGlobTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/PathMatcherGlobTest.scala
@@ -209,6 +209,6 @@ class PathMatcherGlobTest {
   @Test def correctMatchingOfInitialDotSlash(): Unit = {
     pass("*.sbt", "local.sbt") // establish baseline
     pass("./*.sbt", "./local.sbt")
-    fail("*.sbt", "./local.sbt")
+    fail("*.sbt", "./local.sbt") // glob "*" will not cross "/", so no match
   }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/PathMatcherGlobTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/PathMatcherGlobTest.scala
@@ -1,4 +1,5 @@
-package org.scalanative.testsuite.javalib.nio.file
+package org.scalanative.testsuite
+package javalib.nio.file
 
 import java.nio.file._
 
@@ -200,4 +201,14 @@ class PathMatcherGlobTest {
     pass("*", "")
   }
 
+  /* Issue #2937
+   * Glob itself should not match glob "*.sbt" with "./local.sbt".
+   * Files.getNewDirectoryStream() must normalize candidate path before
+   * handing it off to glob.
+   */
+  @Test def correctMatchingOfInitialDotSlash(): Unit = {
+    pass("*.sbt", "local.sbt") // establish baseline
+    pass("./*.sbt", "./local.sbt")
+    fail("*.sbt", "./local.sbt")
+  }
 }


### PR DESCRIPTION
Fix #2937, Fix #3163

The Java `Path` [documentation](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html)  describes:
```
Accessing a file using an empty path is equivalent to accessing 
the default directory of the file system.
```
In operation, this means that `Paths.get("")` and `Paths.get("./")` are _almost_ exactly equivalent. This 
PR addresses two cases where that is not true.

* Issue #3163 reports an "" being passed to `Files.list(dir)` would cause an Exception. JVM returns
   an empty list in this situation.   Now Scala Native does the same.

* Issue #2937 reports an "./" being passed as the dir to `Files.newDirectoryStream(dir, glob)` 
   would fail to find files matching the glob. JVM would properly find those file, so the problem
   was not the glob expression.  Scala Native now finds the expected files, and does not find
   unexpected files.

###### Backport

I have not run this on SN 0.4.x but I expect it to backport.  Please advise if you would
like me to do a private 0.4.x build or if there are problems with merging with 0.4.x.