### PR TITLE
Add missing `@volatile` annotations to `java.util.concurrent` types implementations

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/PriorityBlockingQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/PriorityBlockingQueue.scala
@@ -162,7 +162,7 @@ class PriorityBlockingQueue[E <: AnyRef] private (
 
   final private val notEmpty: Condition = lock.newCondition()
 
-  private var allocationSpinLock = 0
+  @volatile private var allocationSpinLock = 0
 
   private val atomicAllocationSpinLock = new CAtomicInt(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "allocationSpinLock"))

--- a/javalib/src/main/scala/java/util/concurrent/ScheduledThreadPoolExecutor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ScheduledThreadPoolExecutor.scala
@@ -399,15 +399,19 @@ class ScheduledThreadPoolExecutor(
     )
     with ScheduledExecutorService {
 
+  @volatile
   private var continueExistingPeriodicTasksAfterShutdown = false
 
+  @volatile
   private var executeExistingDelayedTasksAfterShutdown = true
 
+  @volatile
   private[concurrent] var removeOnCancel = false
 
   private sealed trait ScheduledFutureTask[V <: AnyRef]
       extends RunnableScheduledFuture[V] { self: FutureTask[V] =>
 
+    @volatile
     protected var time: Long
 
     protected var period: Long

--- a/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
@@ -69,18 +69,18 @@ class ThreadPoolExecutor(
      *  Since the worker count is actually stored in COUNT_BITS bits, the
      *  effective limit is {@code corePoolSize & COUNT_MASK}.
      */
-    var corePoolSize: Int,
+    @volatile private var corePoolSize: Int,
     /** Maximum pool size.
      *
      *  Since the worker count is actually stored in COUNT_BITS bits, the
      *  effective limit is {@code maximumPoolSize & COUNT_MASK}.
      */
-    var maximumPoolSize: Int,
-    var keepAliveTime: Long,
-    val unit: TimeUnit,
-    val workQueue: BlockingQueue[Runnable],
-    var threadFactory: ThreadFactory,
-    var handler: RejectedExecutionHandler
+    @volatile private var maximumPoolSize: Int,
+    @volatile private var keepAliveTime: Long,
+    unit: TimeUnit,
+    workQueue: BlockingQueue[Runnable],
+    @volatile private var threadFactory: ThreadFactory,
+    @volatile private var handler: RejectedExecutionHandler
 ) extends AbstractExecutorService {
   import ThreadPoolExecutor._
 
@@ -155,6 +155,7 @@ class ThreadPoolExecutor(
 
   private var completedTaskCount: Long = 0L
 
+  @volatile
   private var allowCoreThreadTimeOut: Boolean = false
 
   @SerialVersionUID(6138294804551838833L)
@@ -167,7 +168,7 @@ class ThreadPoolExecutor(
     final private[concurrent] var thread: Thread =
       getThreadFactory().newThread(this)
 
-    private[concurrent] var completedTasks: Long = 0L
+    @volatile private[concurrent] var completedTasks: Long = 0L
 
     override def run(): Unit = runWorker(this)
     override protected def isHeldExclusively(): Boolean = getState() != 0


### PR DESCRIPTION
The crucial annotations were probably eliminated during converting Java sources to Scala with IntelliJ tools. 
This fix should add missing annotations to all already ported types. 
 `Atomic*` types - the underlying `value` fields are not marked as volatile to allow for the implementation of `set/getPlain` access which helps to atomic, unordered access - we achieve it by default thanks to the usage of unordered atomic access for shared variables. All the others methods use atomic ops on retrieved field pointers.