### PR TITLE
Fix #3170: sandbox project no longer uses private nativeConfig values

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -441,11 +441,6 @@ object Build {
   lazy val sandbox =
     MultiScalaProject("sandbox", file("sandbox"))
       .enablePlugins(MyScalaNativePlugin)
-      .settings(nativeConfig ~= { c =>
-        c.withLTO(LTO.default)
-          .withMode(Mode.default)
-          .withGC(GC.default)
-      })
       .withNativeCompilerPlugin
       .withJUnitPlugin
       .dependsOn(scalalib, testInterface % "test")


### PR DESCRIPTION
Fix #3170 

The Scala Native build sandbox family of sub-projects no longer set idiocyncratic private values for  
`LTO, Mode, & GC`.  They now use the values passed to them in the enveloping nativeConfig
and behave like the javalib, clib, etc. projects.

In practical terms, this means that if, say, GC.commix  is set in, say, a project_root:local.sbt,
it will be used by a sandbox project.

If one needs, there are at least two ways to have sbt use sandbox local values. 





