### PR TITLE
Fix #3174: SN build now echos multithreadSupport value used

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -28,7 +28,9 @@ private[scalanative] object ScalaNative {
   ): linker.Result =
     dump(config, "linked") {
       check(config) {
-        config.logger.time("Linking")(Link(config, entries))
+        val mtSupport = config.compilerConfig.multithreadingSupport.toString()
+        val linkingMsg = s"Linking (multithreading ${mtSupport})"
+        config.logger.time(linkingMsg)(Link(config, entries))
       }
     }
 


### PR DESCRIPTION
Fix #3174

The SN build now shows the value of multithreadSupport used in the SN link phase.
`[info] Linking (multithreading true) (1690 ms)` or
 `[info] Linking (multithreading false) (1690 ms)`.



