### PR TITLE
Fix #3176: The setting multithreadingSupport from .sbt files is now respected

### DIFF
--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -9,6 +9,28 @@ import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 object MyScalaNativePlugin extends AutoPlugin {
   override def requires: Plugins = ScalaNativePlugin
 
+  private def multithreadingEnabledBySbtSysProps(): Option[Boolean] = {
+    /* Started as: sbt -Dscala.scalanative.multithreading.enable=true
+     * That idiom is used by Windows Continuous Integration (CI).
+     *
+     * BEWARE the root project Quirk!
+     * This feature is not meant for general use. Anybody using it
+     * should understand how it works.
+     *
+     * Setting multithreading on the command line __will_ override any
+     * such setting in a .sbt file in all projects __except_ the root
+     * project. "show nativeConfig" will show the value from .sbt files
+     * "show sandbox3/nativeConfig" will show the effective value for
+     * non-root projects.
+     *
+     * Someday this quirk will get fixed.
+     */
+    sys.props.get("scala.scalanative.multithreading.enable") match {
+      case Some(v) => Some(java.lang.Boolean.parseBoolean(v))
+      case None    => None
+    }
+  }
+
   override def projectSettings: Seq[Setting[_]] = Def.settings(
     /* Remove libraryDependencies on ourselves; we use .dependsOn() instead
      * inside this build.
@@ -16,12 +38,13 @@ object MyScalaNativePlugin extends AutoPlugin {
     libraryDependencies ~= { libDeps =>
       libDeps.filterNot(_.organization == "org.scala-native")
     },
-    nativeConfig ~= {
-      _.withCheck(true)
+    nativeConfig ~= { nc =>
+      nc.withCheck(true)
         .withCheckFatalWarnings(true)
         .withDump(true)
         .withMultithreadingSupport(
-          sys.props.contains("scala.scalanative.multithreading.enable")
+          multithreadingEnabledBySbtSysProps()
+            .getOrElse(nc.multithreadingSupport)
         )
     },
     scalacOptions ++= {


### PR DESCRIPTION
Fix #3176 

The setting `nativeConfig.multithredingSupport` from .sbt files is now used in the build,
unless overridden by a the sbt command invocation.

The mechanism of setting the value from the sbt command line is meant to be used by
Windows CI and not generally.  The value was implemented as  "presence of" but used
as a boolean in .yml files.  This PR makes it a boolean, where setting it "false" is also effective.

There is a quirk documented in the file that setting multithreadingSupport from the 
sbt invocation does not affect the root project.  Thus, one can enable the support in a .sbt
file, invoke sbt with the proper define,  do "show nativeConfig", expect to see "false", and
freak when one sees "true".   Relax, "show javalib/nativeConfig" and other sub-projects
should show the expected value.   

One can waste hours & days with this quirk. Someday it should get fixed, but the 
fix is too complicated for now.  The changes of this PR can provide value while
waiting for a proper fix. 
