### PR TITLE
Add libstdc++-12-dev to Ubuntu setup instructions

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -72,7 +72,7 @@ installation of macOS.
 
 .. code-block:: shell
 
-    $ sudo apt install clang
+    $ sudo apt install clang libstdc++-12-dev
     $ sudo apt install libgc-dev # optional
 
 **Arch Linux**


### PR DESCRIPTION
https://github.com/scala-native/scala-native/issues/3098