### PR TITLE
fix cygwin and msys build problems

### DIFF
--- a/clib/src/main/resources/scala-native/math.c
+++ b/clib/src/main/resources/scala-native/math.c
@@ -8,8 +8,14 @@ float scalanative_infinity() { return INFINITY; }
 
 float scalanative_nan() { return NAN; }
 
+#if defined(math_errhandling)
 int scalanative_math_errhandling() { return math_errhandling; }
+#endif
 
+#if defined(MATH_ERRNO)
 int scalanative_math_errno() { return MATH_ERRNO; }
+#endif
 
+#if defined(MATH_ERREXCEPT)
 int scalanative_math_errexcept() { return MATH_ERREXCEPT; }
+#endif

--- a/nativelib/src/main/resources/scala-native/platform/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform/platform.c
@@ -85,6 +85,14 @@ int scalanative_platform_is_windows() {
 #endif
 }
 
+int scalanative_platform_is_msys() {
+#ifdef __MSYS__
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 // See http://stackoverflow.com/a/4181991
 int scalanative_little_endian() {
     int n = 1;

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -33,12 +33,4 @@ object Platform {
 
   @name("scalanative_platform_is_msys")
   def isMsys(): Boolean = extern
-
-  @deprecated("Use windows.WinNlsApi to retrieve locale info instead", "0.4.1")
-  @name("scalanative_windows_get_user_lang")
-  def windowsGetUserLang(): CString = extern
-
-  @deprecated("Use windows.WinNlsApi to retrieve locale info instead", "0.4.1")
-  @name("scalanative_windows_get_user_country")
-  def windowsGetUserCountry(): CString = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -30,4 +30,15 @@ object Platform {
 
   @name("scalanative_wide_char_size")
   final def SizeOfWChar: CSize = extern
+
+  @name("scalanative_platform_is_msys")
+  def isMsys(): Boolean = extern
+
+  @deprecated("Use windows.WinNlsApi to retrieve locale info instead", "0.4.1")
+  @name("scalanative_windows_get_user_lang")
+  def windowsGetUserLang(): CString = extern
+
+  @deprecated("Use windows.WinNlsApi to retrieve locale info instead", "0.4.1")
+  @name("scalanative_windows_get_user_country")
+  def windowsGetUserCountry(): CString = extern
 }

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -3,6 +3,10 @@
 #include <stdlib.h>
 #include <errno.h>
 
+#if defined(__MINGW64__)
+#include <mswsock.h>
+#include <ws2tcpip.h>
+#endif
 #ifdef _WIN32
 #include <WinSock2.h>
 #pragma comment(lib, "Ws2_32.lib")

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -149,6 +149,17 @@ sealed trait Config {
     compilerConfig.targetTriple.exists { customTriple =>
       Seq("mac", "apple", "darwin").exists(customTriple.contains(_))
     }
+
+  private[scalanative] lazy val targetsMsys: Boolean = {
+    compilerConfig.targetTriple.fold(Platform.isMsys) { customTriple =>
+      customTriple.contains("windows-msys")
+    }
+  }
+  private[scalanative] lazy val targetsCygwin: Boolean = {
+    compilerConfig.targetTriple.fold(Platform.isCygwin) { customTriple =>
+      customTriple.contains("windows-cygnus")
+    }
+  }
 }
 
 /** Factory to create [[#empty]] [[Config]] objects */

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -160,7 +160,7 @@ sealed trait Config {
       customTriple.contains("windows-cygnus")
     }
   }
-  
+
   private[scalanative] lazy val targetsLinux: Boolean = Platform.isLinux ||
     compilerConfig.targetTriple.exists { customTriple =>
       Seq("linux").exists(customTriple.contains(_))

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -195,7 +195,7 @@ object Discover {
    *  @return
    *    The detected target triple describing the target architecture.
    */
-  def targetTriple(clang: Path): String = {
+  def targetTriple(clang: Path = Discover.clang()): String = {
     val (_, _, target) = clangVersionMajorFullTarget(clang.abs)
     target
   }

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -195,7 +195,7 @@ object Discover {
    *  @return
    *    The detected target triple describing the target architecture.
    */
-  def targetTriple(clang: Path = Discover.clang()): String = {
+  def targetTriple(clang: Path): String = {
     val (_, _, target) = clangVersionMajorFullTarget(clang.abs)
     target
   }

--- a/tools/src/main/scala/scala/scalanative/build/IO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/IO.scala
@@ -21,7 +21,12 @@ import java.security.{DigestInputStream, MessageDigest}
 private[scalanative] object IO {
 
   implicit class RichPath(val path: Path) extends AnyVal {
-    def abs: String = path.toAbsolutePath.toString
+    def abs: String = path.toAbsolutePath.toString.norm
+  }
+  implicit class RichString(val s: String) extends AnyVal {
+    // commands issued in shell environments require forward slash
+    // clang and llvm command line tools accept forward slash
+    def norm: String = s.replace('\\', '/')
   }
 
   /** Write bytes to given file. */

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -36,7 +36,7 @@ private[scalanative] object LLVM {
     implicit val _config: Config = config
 
     // generate .o files for included source files
-    if (config.targetsMsys || config.targetsCygwin){
+    if (config.targetsMsys || config.targetsCygwin) {
       // TODO: should this be configurable in build.sbt?
       // sequentially; produces correct clang command lines in sbt -debug mode
       // clang command lines needed for quickly diagnosing failed compiles.
@@ -49,7 +49,7 @@ private[scalanative] object LLVM {
           compileFile(srcPath, objPath)
         } else objPath
       }
-    } else { 
+    } else {
       // generate .o files for all included source files in parallel
       paths.par.map { srcPath =>
         val inpath = srcPath.abs
@@ -355,7 +355,7 @@ private[scalanative] object LLVM {
     "-D_X86_64_ -D__X86_64__ -D__x86_64",
     "-D__USING_SJLJ_EXCEPTIONS__",
     "-DNO_OLDNAMES",
-    "-D_LIBUNWIND_BUILD_ZERO_COST_APIS",
+    "-D_LIBUNWIND_BUILD_ZERO_COST_APIS"
   )
 
 }

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -349,7 +349,6 @@ private[scalanative] object LLVM {
   }
 
   lazy val msysExtras = Seq(
-    "-g",
     "-D_WIN64",
     "-D__MINGW64__",
     "-D_X86_64_ -D__X86_64__ -D__x86_64",

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -83,10 +83,13 @@ private[scalanative] object LLVM {
       } else Seq("-std=gnu11")
     }
     val platformFlags = {
-      if (config.targetsMsys) msysExtras
-      if (config.targetsWindows) Seq("-g")
-      else Nil
+      if (config.targetsWindows) {
+        val common = Seq("-g") // needed for debug symbols in stack traces
+        val optional = if (config.targetsMsys) msysExtras else Nil
+        common ++ optional
+      } else Nil
     }
+
     val configFlags = {
       if (config.compilerConfig.multithreadingSupport)
         Seq("-DSCALANATIVE_MULTITHREADING_ENABLED")

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -252,7 +252,11 @@ object NativeConfig {
       copy(compileOptions = value)
 
     def withTargetTriple(value: Option[String]): NativeConfig = {
-      System.setProperty("target.triple", value.getOrElse(""))
+      val propertyName = "target.triple"
+      value match {
+        case Some(triple) => System.setProperty(propertyName, triple)
+        case None         => System.clearProperty(propertyName)
+      }
       copy(targetTriple = value)
     }
 

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -196,7 +196,7 @@ object NativeConfig {
       clangPP = Paths.get(""),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
-      targetTriple = Option(Discover.targetTriple(Discover.clang)),
+      targetTriple = None,
       gc = GC.default,
       lto = LTO.default,
       mode = Mode.default,

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -196,7 +196,7 @@ object NativeConfig {
       clangPP = Paths.get(""),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
-      targetTriple = None,
+      targetTriple = Option(Discover.targetTriple()),
       gc = GC.default,
       lto = LTO.default,
       mode = Mode.default,
@@ -251,8 +251,10 @@ object NativeConfig {
     def withCompileOptions(value: Seq[String]): NativeConfig =
       copy(compileOptions = value)
 
-    def withTargetTriple(value: Option[String]): NativeConfig =
+    def withTargetTriple(value: Option[String]): NativeConfig = {
+      System.setProperty("target.triple", value.getOrElse(""))
       copy(targetTriple = value)
+    }
 
     def withTargetTriple(value: String): NativeConfig = {
       withTargetTriple(Some(value))

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -196,7 +196,7 @@ object NativeConfig {
       clangPP = Paths.get(""),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
-      targetTriple = Option(Discover.targetTriple()),
+      targetTriple = Option(Discover.targetTriple(Discover.clang)),
       gc = GC.default,
       lto = LTO.default,
       mode = Mode.default,

--- a/tools/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Platform.scala
@@ -41,4 +41,21 @@ object Platform {
    *    true if `FreeBSD`, false otherwise
    */
   lazy val isFreeBSD: Boolean = osUsed.contains("freebsd")
+
+  /** Test for the target type
+   *
+   *  @return
+   *    true if `msys`, false otherwise
+   */
+  lazy val isMsys: Boolean = target.endsWith("msys")
+
+  /** Test for the target type
+   *
+   *  @return
+   *    true if `cygnus`, false otherwise
+   */
+  lazy val isCygwin: Boolean = target.endsWith("cygnus")
+
+  private lazy val target =
+    System.getProperty("target.triple", "unknown").toLowerCase(Locale.ROOT)
 }

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -23,7 +23,9 @@ trait LinktimeValueResolver { self: Reach =>
         conf.gc == GC.Commix
       },
       s"$linktimeInfo.is32BitPlatform" -> conf.is32BitPlatform,
-      s"$linktimeInfo.asanEnabled" -> conf.asan
+      s"$linktimeInfo.asanEnabled" -> conf.asan,
+      s"$linktimeInfo.isMsys" -> Platform.isMsys,
+      s"$linktimeInfo.isCygwin" -> Platform.isCygwin,
     )
     NativeConfig.checkLinktimeProperties(predefined)
     predefined ++ conf.linktimeProperties

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -25,7 +25,7 @@ trait LinktimeValueResolver { self: Reach =>
       s"$linktimeInfo.is32BitPlatform" -> conf.is32BitPlatform,
       s"$linktimeInfo.asanEnabled" -> conf.asan,
       s"$linktimeInfo.isMsys" -> Platform.isMsys,
-      s"$linktimeInfo.isCygwin" -> Platform.isCygwin,
+      s"$linktimeInfo.isCygwin" -> Platform.isCygwin
     )
     NativeConfig.checkLinktimeProperties(predefined)
     predefined ++ conf.linktimeProperties

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/securityObjectType.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/securityObjectType.c
@@ -1,4 +1,4 @@
-#if defined(_WIN32) || defined(WIN32)
+#if (defined(_WIN32) || defined(WIN32)) && !defined(__MINGW64__)
 #define WIN32_LEAN_AND_MEAN
 #include <AccCtrl.h>
 


### PR DESCRIPTION
These changes add support for building on Windows in `cygwin` or `msys`  environments.

the most significant changes include:

- convert backslashes to forward slashes in source file paths
- add methods to detect cygwin and msys targets
- for cygwin or msys targets, clang compiles are consecutive rather than parallel


The check in `LLVM.scala` for disabling parallel `clang` builds is a generally useful feature, so it should eventually be configurable for any environment.   It's helpful when diagnosing a failed `clang` command line, because avoid interleaving multiple `clang` compiles in the log output.


These changes don't affect other OS or targets.