### PR TITLE
[CI] Fix failing build due to missing Boehm GC

### DIFF
--- a/.github/actions/macos-setup-env/action.yml
+++ b/.github/actions/macos-setup-env/action.yml
@@ -31,7 +31,7 @@ runs:
     
     - name: Install dependencies
       shell: bash
-      if: ${{ inputs.gc == "boehm" }}
+      if: ${{ startsWith(inputs.gc, 'boehm') }}
       run: brew install bdw-gc
 
     # Loads cache with dependencies created in test-tools job

--- a/.github/actions/macos-setup-env/action.yml
+++ b/.github/actions/macos-setup-env/action.yml
@@ -7,6 +7,8 @@ inputs:
   java-version:
     description: "Java version to use in tests"
     default: "8"
+  gc: 
+    description: "Garbage collector used, might require installing dependencies"
 runs:
   using: "composite"
   steps:
@@ -26,6 +28,11 @@ runs:
           echo "binary-version=3" >> $GITHUB_ENV
           echo "project-version=3" >> $GITHUB_ENV
         fi
+    
+    - name: Install dependencies
+      shell: bash
+      if: ${{ inputs.gc == "boehm" }}
+      run: brew install bdw-gc
 
     # Loads cache with dependencies created in test-tools job
     - name: Cache dependencies

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -34,6 +34,7 @@ jobs:
         id: setup
         with:
           scala-version: ${{matrix.scala}}
+          gc: ${{ matrix.gc }}
 
       - name: Test runtime
         run: >
@@ -85,6 +86,8 @@ jobs:
       - uses: ./.github/actions/macos-setup-env
         with:
           scala-version: ${{matrix.scala}}
+          gc: ${{ matrix.gc }}
+
 
       - name: Run tests
         env:
@@ -134,6 +137,7 @@ jobs:
       - uses: ./.github/actions/macos-setup-env
         with:
           scala-version: ${{matrix.scala}}
+          gc: ${{ matrix.gc }}
 
       - name: Prepare native config command
         shell: bash


### PR DESCRIPTION
The latest versions of MacOS Github images are no longer containing BoehmGC. Now we need to install it manually when required.