### PR TITLE
Fix generation of CFuncPtr extern forwarders using opaque types

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -122,12 +122,16 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
         }
 
         def resolveGiven = Option.when(s.is(Given)) {
-          atPhase(Phases.postTyperPhase) {
+          val evidenceType = atPhase(Phases.postTyperPhase) {
             val givenTpe = s.denot.info.argInfos.head
-            // make sure to dealias the type here,
-            // information about underlying opaque type would not be available after erasue
-            fromType(givenTpe.widenDealias)
+            // In the backend (genBCode on JVM or this compiler plugin) opaque type should be dealiased
+            // to the underlying type otherwise non-existing types might be missing when classloading.
+            // Information about underlying opaque type would not be available after erasue
+            givenTpe.typeSymbol.opaqueAlias
+              .orElse(givenTpe)
+              .widenDealias
           }
+          fromType(evidenceType)
         }
 
         materializePrimitiveTypeMethodTypes


### PR DESCRIPTION
Fixes #3063 due to a bug in a NIR compiler plugin: in multi-stage/incremental compilation the opaque types where not correctly dealiased to the underlying type. This behavior leads to the usage of non-existing types in NIR and though failure in class-loading.
The fix makes sure to resolve opaque type alias if it is defined to fix the underlying issue. 

Changes were tested locally, but I was not able to create a regression test with the current testing infrastructure. Splitting the compilation into multiple stages was not enough to reproduce the failures. When compiling manually we need to go through the exact steps: 
1. Compile all sources for the first type - at this time opaque type is correctly dealiased (to Ptr[Byte])
2. Introduce change to the sources (can be adding whitespace)
3. Compile sources again and link: before fix the opaque type would use non existing type (eg. aliases$.mu_Font existing in early scalac phases), after fix it is dealiased to underlying type