### PR TITLE
Fix #3173: Linux executable file .comment section shows build info

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -31,6 +31,7 @@ object Build {
    *        NativeConfig.empty
    *        .withGC(GC.default)
    *        .withMode(Mode.default)
+   *        .withMultithreadingSupport(enabled = false)
    *        .withClang(clang)
    *        .withClangPP(clangpp)
    *        .withLinkingOptions(linkopts)
@@ -71,7 +72,8 @@ object Build {
       // optimize and generate ll
       val generated = {
         val optimized = ScalaNative.optimize(config, linked)
-        ScalaNative.codegen(config, optimized)
+        ScalaNative.codegen(config, optimized) ++:
+          ScalaNative.identgen(fconfig) // ident list may be empty
       }
 
       val objectPaths = fconfig.logger.time("Compiling to native code") {

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -73,7 +73,7 @@ object Build {
       val generated = {
         val optimized = ScalaNative.optimize(config, linked)
         ScalaNative.codegen(config, optimized) ++:
-          ScalaNative.identgen(fconfig) // ident list may be empty
+          ScalaNative.genBuildInfo(fconfig) // ident list may be empty
       }
 
       val objectPaths = fconfig.logger.time("Compiling to native code") {

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -149,6 +149,11 @@ sealed trait Config {
     compilerConfig.targetTriple.exists { customTriple =>
       Seq("mac", "apple", "darwin").exists(customTriple.contains(_))
     }
+
+  private[scalanative] lazy val targetsLinux: Boolean = Platform.isLinux ||
+    compilerConfig.targetTriple.exists { customTriple =>
+      Seq("linux").exists(customTriple.contains(_))
+    }
 }
 
 /** Factory to create [[#empty]] [[Config]] objects */

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -184,4 +184,7 @@ private[scalanative] object ScalaNative {
       Global.Top(encoded)
     }
 
+  def identgen(config: Config): Seq[java.nio.file.Path] =
+    LLVM.generateLLVMIdent(config)
+
 }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -184,7 +184,7 @@ private[scalanative] object ScalaNative {
       Global.Top(encoded)
     }
 
-  def identgen(config: Config): Seq[java.nio.file.Path] =
+  def genBuildInfo(config: Config): Seq[java.nio.file.Path] =
     LLVM.generateLLVMIdent(config)
 
 }


### PR DESCRIPTION
Fix #3173, at least on Linux

Linux executable files now show some of the configuration with which they were built.
```
 $ readelf --string-dump .comment sandbox

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 12.2.0-3ubuntu1) 12.2.0
  [    25]  Ubuntu clang version 16.0.0 (++20230222053136+eb9440b3d8b4-1~exp1~20230222173148.38)
  [    7a]  Scala Native 0.5.0-SNAPSHOT (Multithread: true, Mode: debug, LTO: none, GC: immix)
```

This is an aid to development & maintenance. To wit, showing if an executable file was built with multithreadingSupport.
The Scala Native version info itself may be useful for problem isolation.

FreeBSD uses the ELF executable file format so it is a candidate. Support was not enabled for FreeBSD
because this feature has not been exercised.

macOS & Windows each use a non-ELF format, so they are left as an exercise for developers on those 
(cross) platforms.
