### PR TITLE
Commix GC - fix deadlocks due to missaligned pointers when marking range

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
@@ -389,11 +389,10 @@ void Marker_markProgramStack(Heap *heap, Stats *stats, GreyPacket **outHolder,
     word_t **stackBottom = __stack_bottom;
 
     while (current <= stackBottom) {
-
-        word_t *stackObject = *current;
-        if (Heap_IsWordInHeap(heap, stackObject)) {
+        word_t *obj = *current;
+        if (Heap_IsWordInHeap(heap, obj) && Bytemap_isPtrAligned(obj)) {
             Marker_markConservative(heap, stats, outHolder, outWeakRefHolder,
-                                    stackObject);
+                                    obj);
         }
         current += 1;
     }

--- a/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
@@ -143,7 +143,10 @@ int Marker_markRange(Heap *heap, Stats *stats, GreyPacket **outHolder,
     word_t **limit = fields + length;
     for (word_t **current = fields; current < limit; current++) {
         word_t *field = *current;
-        if (Heap_IsWordInHeap(heap, field)) {
+        // Memory allocated by GC is alligned, ignore unaligned pointers e.g.
+        // interim pointers, otherwise we risk undefined behaviour when assuming
+        // memory layout of underlying object.
+        if (Heap_IsWordInHeap(heap, field) && Bytemap_isPtrAligned(field)) {
             ObjectMeta *fieldMeta = Bytemap_Get(bytemap, field);
             if (ObjectMeta_IsAllocated(fieldMeta)) {
                 Marker_markObject(heap, stats, outHolder, outWeakRefHolder,

--- a/nativelib/src/main/resources/scala-native/gc/commix/datastructures/Bytemap.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/datastructures/Bytemap.h
@@ -18,23 +18,22 @@ typedef struct {
 
 void Bytemap_Init(Bytemap *bytemap, word_t *firstAddress, size_t size);
 
+static inline bool Bytemap_isPtrAligned(word_t *address) {
+    word_t aligned = ((word_t)address & ALLOCATION_ALIGNMENT_INVERSE_MASK);
+    return (word_t *)aligned == address;
+}
+
 static inline size_t Bytemap_index(Bytemap *bytemap, word_t *address) {
     size_t index =
         (address - bytemap->firstAddress) / ALLOCATION_ALIGNMENT_WORDS;
     assert(address >= bytemap->firstAddress);
     assert(index < bytemap->size);
-    assert(((word_t)address & ALLOCATION_ALIGNMENT_INVERSE_MASK) ==
-           (word_t)address);
+    assert(Bytemap_isPtrAligned(address));
     return index;
 }
 
 static inline ObjectMeta *Bytemap_Get(Bytemap *bytemap, word_t *address) {
-    size_t index =
-        (address - bytemap->firstAddress) / ALLOCATION_ALIGNMENT_WORDS;
-    assert(address >= bytemap->firstAddress);
-    assert(index < bytemap->size);
-    assert(((word_t)address & ALLOCATION_ALIGNMENT_INVERSE_MASK) ==
-           (word_t)address);
+    size_t index = Bytemap_index(bytemap, address);
     return &bytemap->data[index];
 }
 

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -109,7 +109,7 @@ NO_SANITIZE void Marker_markRange(Heap *heap, Stack *stack, word_t **from,
     assert(to != NULL);
     for (word_t **current = from; current <= to; current += 1) {
         word_t *addr = *current;
-        if (Heap_IsWordInHeap(heap, addr)) {
+        if (Heap_IsWordInHeap(heap, addr) && Bytemap_isPtrAligned(addr)) {
             Marker_markConservative(heap, stack, addr);
         }
     }

--- a/nativelib/src/main/resources/scala-native/gc/immix/datastructures/Bytemap.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/datastructures/Bytemap.h
@@ -5,8 +5,8 @@
 #include <stdbool.h>
 #include <string.h>
 #include "GCTypes.h"
-#include "Log.h"
 #include "../Constants.h"
+#include "Log.h"
 #include "../metadata/ObjectMeta.h"
 
 typedef struct {
@@ -18,23 +18,22 @@ typedef struct {
 
 void Bytemap_Init(Bytemap *bytemap, word_t *firstAddress, size_t size);
 
+static inline bool Bytemap_isPtrAligned(word_t *address) {
+    word_t aligned = ((word_t)address & ALLOCATION_ALIGNMENT_INVERSE_MASK);
+    return (word_t *)aligned == address;
+}
+
 static inline size_t Bytemap_index(Bytemap *bytemap, word_t *address) {
     size_t index =
         (address - bytemap->firstAddress) / ALLOCATION_ALIGNMENT_WORDS;
     assert(address >= bytemap->firstAddress);
     assert(index < bytemap->size);
-    assert(((word_t)address & ALLOCATION_ALIGNMENT_INVERSE_MASK) ==
-           (word_t)address);
+    assert(Bytemap_isPtrAligned(address));
     return index;
 }
 
 static inline ObjectMeta *Bytemap_Get(Bytemap *bytemap, word_t *address) {
-    size_t index =
-        (address - bytemap->firstAddress) / ALLOCATION_ALIGNMENT_WORDS;
-    assert(address >= bytemap->firstAddress);
-    assert(index < bytemap->size);
-    assert(((word_t)address & ALLOCATION_ALIGNMENT_INVERSE_MASK) ==
-           (word_t)address);
+    size_t index = Bytemap_index(bytemap, address);
     return &bytemap->data[index];
 }
 


### PR DESCRIPTION
Fixes #3058
When marking regions in Commix ignore misaligned pointers. These can be, eg. interim pointers. The offset of misaligned pointers was leading to undefined behavior when accessing class field offsets. The resulting SIGSEV would trigger signal handlers defined in SignalConfig, which would again try to allocate objects using GC leading to deadlock