### PR TITLE
Partial fix #3165: Port two JSR-166 concurrent interfaces/traits: BlockingDeque, TransferQueue

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/BlockingDeque.scala
+++ b/javalib/src/main/scala/java/util/concurrent/BlockingDeque.scala
@@ -1,0 +1,31 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util
+package concurrent
+
+trait BlockingDeque[E] extends BlockingQueue[E] with Deque[E] {
+
+  def addFirst(e: E): Unit
+
+  def addLast(e: E): Unit
+
+  def putFirst(e: E): Unit
+
+  def putLast(e: E): Unit
+
+  def offerFirst(e: E, timeout: Long, unit: TimeUnit): Boolean
+
+  def offerLast(e: E, timeout: Long, unit: TimeUnit): Boolean
+
+  def takeFirst(): E
+
+  def takeLast(): E
+
+  def pollFirst(timeout: Long, unit: TimeUnit): E
+
+  def pollLast(timeout: Long, unit: TimeUnit): E
+}

--- a/javalib/src/main/scala/java/util/concurrent/TransferQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/TransferQueue.scala
@@ -1,0 +1,21 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util
+package concurrent
+
+trait TransferQueue[E] extends BlockingQueue[E] {
+
+  def tryTransfer(e: E): Boolean
+
+  def transfer(e: E): Unit
+
+  def tryTransfer(e: E, timeout: Long, unit: TimeUnit): Boolean
+
+  def hasWaitingConsumer(): Boolean
+
+  def getWaitingConsumerCount(): Int
+}


### PR DESCRIPTION
Port JSR-166 concurrent BlockingDeque & TransferQueue interfaces/traits.

This completes the two known sub-interfaces of `BlockingQueue`. `BlockingQueue` itself
is already implemented in Scala Native.