### PR TITLE
Allow to print stacktraces in GC on Windows

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
@@ -35,14 +35,16 @@ static long SafepointTrapHandler(EXCEPTION_POINTERS *ex) {
         if (SafepointInstance == (void *)addr) {
             Synchronizer_wait();
             return EXCEPTION_CONTINUE_EXECUTION;
-        } else if (defaultFilter != NULL) {
-            return defaultFilter(ex);
         }
-        break;
+        // pass-through
     default:
-        break;
+        fprintf(stderr, "Unhandled exception code %p\n",
+                (void *)(uintptr_t)ex->ExceptionRecord->ExceptionCode);
+        StackTrace_PrintStackTrace();
+        if (defaultFilter != NULL)
+            return defaultFilter(ex);
+        return EXCEPTION_EXECUTE_HANDLER;
     }
-    return EXCEPTION_EXECUTE_HANDLER;
 }
 #else
 #ifdef __APPLE__

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/StackTrace.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/StackTrace.c
@@ -1,26 +1,27 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
 #include "StackTrace.h"
 
 void StackTrace_PrintStackTrace() {
-#if defined(_WIN32)
-    printf("Stacktrace not implemented in Windows\n");
-#else
-    unw_cursor_t cursor;
-    unw_context_t context;
-    unw_getcontext(&context);
-    unw_init_local(&cursor, &context);
+    void *cursor = malloc(scalanative_unwind_sizeof_cursor());
+    void *context = malloc(scalanative_unwind_sizeof_context());
+    scalanative_unwind_get_context(context);
+    scalanative_unwind_init_local(cursor, context);
 
-    while (unw_step(&cursor) > 0) {
-        unw_word_t offset, pc;
-        unw_get_reg(&cursor, UNW_REG_IP, &pc);
+    while (scalanative_unwind_step(cursor) > 0) {
+        uint64_t offset, pc;
+        scalanative_unwind_get_reg(cursor, scalanative_unw_reg_ip(), &pc);
         if (pc == 0) {
             break;
         }
 
         char sym[256];
-        if (unw_get_proc_name(&cursor, sym, sizeof(sym), &offset) == 0) {
+        if (scalanative_unwind_get_proc_name(cursor, sym, sizeof(sym),
+                                             &offset) == 0) {
             printf("\tat %s\n", sym);
         }
     }
-#endif
+    free(cursor);
+    free(context);
 }

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/StackTrace.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/StackTrace.h
@@ -1,9 +1,7 @@
 #ifndef IMMIX_STACKTRACE_H
 #define IMMIX_STACKTRACE_H
 
-#ifndef _WIN32
-#include "../../platform/posix/libunwind/libunwind.h"
-#endif
+#include "../../platform/unwind.h"
 
 void StackTrace_PrintStackTrace();
 

--- a/nativelib/src/main/resources/scala-native/platform/posix/unwind.c
+++ b/nativelib/src/main/resources/scala-native/platform/posix/unwind.c
@@ -28,4 +28,11 @@ int scalanative_unwind_get_reg(void *cursor, int regnum, size_t *valp) {
 
 int scalanative_unw_reg_ip() { return UNW_REG_IP; }
 
+size_t scalanative_unwind_sizeof_context(){
+    return sizeof(unw_context_t);
+}
+size_t scalanative_unwind_sizeof_cursor(){
+    return sizeof(unw_cursor_t);
+}
+
 #endif // Unix or Mac OS

--- a/nativelib/src/main/resources/scala-native/platform/posix/unwind.c
+++ b/nativelib/src/main/resources/scala-native/platform/posix/unwind.c
@@ -28,11 +28,7 @@ int scalanative_unwind_get_reg(void *cursor, int regnum, size_t *valp) {
 
 int scalanative_unw_reg_ip() { return UNW_REG_IP; }
 
-size_t scalanative_unwind_sizeof_context(){
-    return sizeof(unw_context_t);
-}
-size_t scalanative_unwind_sizeof_cursor(){
-    return sizeof(unw_cursor_t);
-}
+size_t scalanative_unwind_sizeof_context() { return sizeof(unw_context_t); }
+size_t scalanative_unwind_sizeof_cursor() { return sizeof(unw_cursor_t); }
 
 #endif // Unix or Mac OS

--- a/nativelib/src/main/resources/scala-native/platform/unwind.h
+++ b/nativelib/src/main/resources/scala-native/platform/unwind.h
@@ -10,5 +10,7 @@ int scalanative_unwind_get_proc_name(void *cursor, char *buffer, size_t length,
                                      void *offset);
 int scalanative_unwind_get_reg(void *cursor, int regnum, size_t *valp);
 int scalanative_unw_reg_ip();
+size_t scalanative_unwind_sizeof_context();
+size_t scalanative_unwind_sizeof_cursor();
 
 #endif

--- a/nativelib/src/main/resources/scala-native/platform/windows/unwind.c
+++ b/nativelib/src/main/resources/scala-native/platform/windows/unwind.c
@@ -8,22 +8,27 @@
 #include "../unwind.h"
 
 #define MAX_LENGTH_OF_CALLSTACK 255
+#define MAX_LENGHT_OF_NAME 255
 
 typedef struct _UnwindContext {
-    void **stack;
+    void *stack[MAX_LENGTH_OF_CALLSTACK];
     unsigned short frames;
     HANDLE process;
     DWORD64 cursor;
-    SYMBOL_INFOW symbol;
+    struct {
+        SYMBOL_INFOW info;
+        wchar_t nameBuffer[MAX_LENGHT_OF_NAME + 1];
+    } symbol;
 } UnwindContext;
 
 int scalanative_unwind_get_context(void *context) { return 0; }
 
 int scalanative_unwind_init_local(void *cursor, void *context) {
     static int symInitialized = 0;
-    UnwindContext *ucontext = (UnwindContext *)cursor;
+    UnwindContext *ucontext = (UnwindContext *)context;
+    UnwindContext **ucontextRef = (UnwindContext **)cursor;
+    *ucontextRef = ucontext;
     memset(ucontext, 0, sizeof(UnwindContext));
-    ucontext->stack = (void **)context;
     ucontext->process = GetCurrentProcess();
     if (!symInitialized) {
         if (SymInitialize(ucontext->process, NULL, TRUE) == FALSE) {
@@ -34,13 +39,13 @@ int scalanative_unwind_init_local(void *cursor, void *context) {
     ucontext->frames = CaptureStackBackTrace(0, MAX_LENGTH_OF_CALLSTACK,
                                              ucontext->stack, NULL);
     ucontext->cursor = 0;
-    ucontext->symbol.MaxNameLen = 255;
-    ucontext->symbol.SizeOfStruct = sizeof(SYMBOL_INFOW);
+    ucontext->symbol.info.MaxNameLen = MAX_LENGHT_OF_NAME;
+    ucontext->symbol.info.SizeOfStruct = sizeof(ucontext->symbol.info);
     return 0;
 }
 
 int scalanative_unwind_step(void *cursor) {
-    UnwindContext *ucontext = (UnwindContext *)cursor;
+    UnwindContext *ucontext = *(UnwindContext **)cursor;
     return ucontext->frames - (++ucontext->cursor);
 }
 
@@ -49,10 +54,10 @@ int scalanative_unwind_get_proc_name(void *cursor, char *buffer, size_t length,
     DWORD displacement = 0;
     IMAGEHLP_LINE line;
     int fileNameLen = 0;
-    UnwindContext *ucontext = (UnwindContext *)cursor;
+    UnwindContext *ucontext = *(UnwindContext **)cursor;
     if (ucontext->cursor < ucontext->frames) {
         void *address = ucontext->stack[ucontext->cursor];
-        PSYMBOL_INFOW symbol = &ucontext->symbol;
+        PSYMBOL_INFOW symbol = &ucontext->symbol.info;
         SymFromAddrW(ucontext->process, (DWORD64)address, 0, symbol);
         snprintf(buffer, length, "%ws", symbol->Name);
         memcpy(offset, &(symbol->Address), sizeof(void *));
@@ -69,7 +74,7 @@ int scalanative_unwind_get_proc_name(void *cursor, char *buffer, size_t length,
 }
 
 int scalanative_unwind_get_reg(void *cursor, int regnum, size_t *valp) {
-    UnwindContext *ucontext = (UnwindContext *)cursor;
+    UnwindContext *ucontext = *(UnwindContext **)cursor;
     *valp = (size_t)(ucontext->stack[ucontext->cursor]);
     return 0;
 }
@@ -77,5 +82,8 @@ int scalanative_unwind_get_reg(void *cursor, int regnum, size_t *valp) {
 // Only usage results in passing to get_reg as `regnum`, where it's not actually
 // used
 int scalanative_unw_reg_ip() { return -1; }
+
+size_t scalanative_unwind_sizeof_context() { return sizeof(UnwindContext); }
+size_t scalanative_unwind_sizeof_cursor() { return sizeof(UnwindContext *); }
 
 #endif // _WIN32

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -16,7 +16,7 @@ object unwind {
       cursor: Ptr[Byte],
       buffer: CString,
       length: CSize,
-      offset: Ptr[Byte]
+      offset: Ptr[Long]
   ): CInt = extern
   @name("scalanative_unwind_get_reg")
   def get_reg(
@@ -27,4 +27,10 @@ object unwind {
 
   @name("scalanative_unw_reg_ip")
   def UNW_REG_IP: CInt = extern
+
+  @name("scalanative_unwind_sizeof_context")
+  def sizeOfContext: CSize = extern
+
+  @name("scalanative_unwind_sizeof_cursor")
+  def sizeOfCursor: CSize = extern
 }

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
@@ -69,22 +69,21 @@ private[testinterface] object SignalConfig {
         str
       }
 
-    val stackTraceHeader: Ptr[CChar] = stackalloc[CChar](2048.toUInt)
-    stackTraceHeader(0.toUInt) = 0.toByte
+    val stackTraceHeader: Ptr[CChar] = stackalloc[CChar](100.toUInt)
     strcat(stackTraceHeader, errorTag)
     strcat(stackTraceHeader, c" Fatal signal ")
     strcat(stackTraceHeader, signalNumberStr)
     strcat(stackTraceHeader, c" caught\n")
     printError(stackTraceHeader)
 
-    val cursor: Ptr[scala.Byte] = stackalloc[scala.Byte](2048.toUInt)
-    val context: Ptr[scala.Byte] = stackalloc[scala.Byte](2048.toUInt)
+    val cursor = stackalloc[Byte](unwind.sizeOfCursor)
+    val context = stackalloc[Byte](unwind.sizeOfContext)
     unwind.get_context(context)
     unwind.init_local(cursor, context)
 
     while (unwind.step(cursor) > 0) {
-      val offset: Ptr[scala.Byte] = stackalloc[scala.Byte](8.toUInt)
-      val pc = stackalloc[CUnsignedLong]()
+      val offset = stackalloc[Long]()
+      val pc = stackalloc[CSize]()
       unwind.get_reg(cursor, unwind.UNW_REG_IP, pc)
       if (!pc == 0.toUInt) return
       val symMax = 1024
@@ -96,11 +95,11 @@ private[testinterface] object SignalConfig {
             offset
           ) == 0) {
         sym(symMax - 1) = 0.toByte
-        val className: Ptr[CChar] = stackalloc[CChar](1024.toUInt)
-        val methodName: Ptr[CChar] = stackalloc[CChar](1024.toUInt)
+        val className: Ptr[CChar] = stackalloc[CChar](512.toUInt)
+        val methodName: Ptr[CChar] = stackalloc[CChar](512.toUInt)
         SymbolFormatter.asyncSafeFromSymbol(sym, className, methodName)
 
-        val formattedSymbol: Ptr[CChar] = stackalloc[CChar](2048.toUInt)
+        val formattedSymbol: Ptr[CChar] = stackalloc[CChar](1100.toUInt)
         formattedSymbol(0) = 0.toByte
         strcat(formattedSymbol, errorTag)
         strcat(formattedSymbol, c"   at ")


### PR DESCRIPTION
* Adds unwind bindings for size of context/cursor, these should be used instead of fixed size buffers
* Adapted StackTrace.h to be able to consume both Unix and Windows unwind implementation
* Fix Windows exception filter in ImmixGC synchronizer to print stack traces upon unhandled exception
* Fix buffer overflows when accessing symbol names in Windows
* Adapt SignalConfig signal handlers to unwinding changes and reduce stackallocated array sized