### PR TITLE
Use opaque pointers in generated LLVM IR when possible

### DIFF
--- a/.github/actions/linux-setup-env/action.yml
+++ b/.github/actions/linux-setup-env/action.yml
@@ -7,6 +7,8 @@ inputs:
   java-version:
     description: "Java version to use in tests"
     default: "8"
+  llvm-version:
+    description: "LLVM toolchain version"
 runs:
   using: "composite"
   steps:
@@ -38,6 +40,14 @@ runs:
           sudo apt-get update
           sudo apt-get install libgc-dev
 
+    - name: Install explicit LLVM toolchain
+      shell: bash
+      if: ${{ inputs.llvm-version != '' }}
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        yes "" | sudo ./llvm.sh ${{ inputs.llvm-version }}
+        
     # Loads cache with dependencies created in test-tools job
     - name: Cache dependencies
       uses: actions/cache@v3

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -204,6 +204,29 @@ jobs:
           export LLVM_BIN=$(dirname $(readlink -f /usr/bin/clang))
           sbt "test-scripted ${{matrix.scala}}"
 
+  test-llvm-versions:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        scala: [3.2.2]
+        llvm: [13, 14, 15, 16, 17] # Last 3 stable versions + available future versions
+    if: "(github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native'"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/linux-setup-env
+        with:
+          scala-version: ${{matrix.scala}}
+          llvm-version: ${{ matrix.llvm }}
+          java-version: 8
+
+      - name: Run tests
+        env:
+          SCALANATIVE_MODE: release-fast
+          SCALANATIVE_LTO: thin
+          LLVM_BIN: "/usr/lib/llvm-${{ matrix.llvm }}/bin"
+        run: sbt "test-runtime ${{ matrix.scala }}"
+
   test-multihreading:
     name: Test experimental multithreading support
     runs-on: ubuntu-20.04

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -135,6 +135,8 @@ object Type {
       .get(normalize(boxType))
       .contains(primitiveType)
   def isPtrBox(ty: Type): Boolean = isBoxOf(Type.Ptr)(ty)
+  def isPtrType(ty: Type): Boolean =
+    ty == Type.Ptr || ty.isInstanceOf[Type.RefKind]
   def isSizeBox(ty: Type): Boolean = isBoxOf(Type.Size)(ty)
 
   def normalize(ty: Type): Type = ty match {

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -221,8 +221,8 @@ object Discover {
       cache("opaque-pointers") { _ =>
         try {
           val version = clangInfo.majorVersion
-          if (version < 13) Unavilable
-          else if (version == 13) EnabledWithFlag("--force-opaque-pointers")
+          if (version <= 13) Unavilable
+          // if version == 13 EnabledWithFalg("--force-opaque-pointers"): works on Unix and probably on Homebew Clang; on Apple Clang missing or exists with different name
           else if (version < 15) EnabledWithFlag("--opaque-pointers")
           else Enabled
         } catch {

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -221,8 +221,8 @@ object Discover {
       cache("opaque-pointers") { _ =>
         try {
           val version = clangInfo.majorVersion
-          if (version <= 13) Unavilable
-          // if version == 13 EnabledWithFalg("--force-opaque-pointers"): works on Unix and probably on Homebew Clang; on Apple Clang missing or exists with different name
+          if (version <= 13) Unavailable
+          // if version == 13 EnabledWithFlag("--force-opaque-pointers"): works on Unix and probably on Homebrew Clang; on Apple Clang missing or exists with different name
           else if (version < 15) EnabledWithFlag("--opaque-pointers")
           else Enabled
         } catch {
@@ -230,14 +230,14 @@ object Discover {
             System.err.println(
               "Failed to detect version of clang, assuming opaque-pointers are not supported"
             )
-            Unavilable
+            Unavailable
         }
       }
 
     sealed trait FeatureSupport {
       def isAvailable: Boolean = this match {
-        case Unavilable => false
-        case _          => true
+        case Unavailable => false
+        case _           => true
       }
       def requiredFlag: Option[String] = this match {
         case EnabledWithFlag(flag) => Some(flag)
@@ -245,7 +245,7 @@ object Discover {
       }
     }
     object FeatureSupport {
-      case object Unavilable extends FeatureSupport
+      case object Unavailable extends FeatureSupport
       case object Enabled extends FeatureSupport
       case class EnabledWithFlag(compilationFlag: String) extends FeatureSupport
     }

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -221,9 +221,9 @@ object Discover {
       cache("opaque-pointers") { _ =>
         try {
           val version = clangInfo.majorVersion
-          if (version <= 13) Unavailable
           // if version == 13 EnabledWithFlag("--force-opaque-pointers"): works on Unix and probably on Homebrew Clang; on Apple Clang missing or exists with different name
-          else if (version < 15) EnabledWithFlag("--opaque-pointers")
+          // if version == 14 EnabledWithFlag("--opaque-pointers"): might require additional flag `--plugin-opt=opaque-pointers` to ld.lld linker on Unix, this opt is missing on ld64.lld in MacOS
+          if (version < 15) Unavailable
           else Enabled
         } catch {
           case ex: Exception =>

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -91,25 +91,29 @@ object Discover {
     libs
   }
 
-  private def clangVersionMajorFullTarget(
-      clang: String
-  ): (Int, String, String) = {
-    val versionCommand = Seq(clang, "--version")
+  private case class ClangInfo(
+      majorVersion: Int,
+      fullVersion: String,
+      targetTriple: String
+  )
+  private def clangInfo(implicit config: NativeConfig): ClangInfo =
+    cache("clang-info")(config => clangInfo(config.clang))
+
+  private def clangInfo(clang: Path): ClangInfo = {
+    val versionCommand = Seq(clang.abs, "--version")
+    val cmdString = versionCommand.mkString(" ")
     val processLines = Process(versionCommand)
       .lineStream_!(silentLogger())
-    val versionString = processLines.headOption
-      .getOrElse {
-        throw new BuildException(s"""Problem running '${versionCommand
-                                     .mkString(" ")}'. Please check clang setup.
-              |Refer to ($docSetup)""".stripMargin)
-      }
+      .toList
 
-    val targetString = processLines.tail.headOption
-      .getOrElse {
-        throw new BuildException(s"""Problem running '${versionCommand
-                                     .mkString(" ")}'. Please check clang setup.
-              |Refer to ($docSetup)""".stripMargin)
-      }
+    val (versionString, targetString) = processLines match {
+      case version :: target :: _ => (version, target)
+      case _ =>
+        throw new BuildException(
+          s"""Problem running '$cmdString'. Please check clang setup.
+              |Refer to ($docSetup)""".stripMargin
+        )
+    }
 
     // Apple macOS clang is different vs brew installed or Linux
     // Apple LLVM version 10.0.1 (clang-1001.0.46.4)
@@ -118,8 +122,11 @@ object Discover {
       val versionArray = versionString.split(" ")
       val versionIndex = versionArray.indexWhere(_.equals("version"))
       val version = versionArray(versionIndex + 1)
-      val majorVersion = version.split("\\.").head
-      (majorVersion.toInt, version, targetString.drop("Target: ".size))
+      ClangInfo(
+        majorVersion = version.takeWhile(_.isDigit).toInt,
+        fullVersion = version,
+        targetTriple = targetString.drop("Target: ".size)
+      )
     } catch {
       case t: Throwable =>
         throw new BuildException(s"""Output from '$versionCommand' unexpected.
@@ -133,9 +140,7 @@ object Discover {
    *  version required.
    */
   private[scalanative] def checkClangVersion(pathToClangBinary: Path): Unit = {
-    val (majorVersion, version, _) = clangVersionMajorFullTarget(
-      pathToClangBinary.abs
-    )
+    val ClangInfo(majorVersion, version, _) = clangInfo(pathToClangBinary)
 
     if (majorVersion < clangMinVersion) {
       throw new BuildException(
@@ -195,9 +200,10 @@ object Discover {
    *  @return
    *    The detected target triple describing the target architecture.
    */
-  def targetTriple(clang: Path): String = {
-    val (_, _, target) = clangVersionMajorFullTarget(clang.abs)
-    target
+  def targetTriple(clang: Path): String = clangInfo(clang).targetTriple
+
+  def targetTriple(implicit config: NativeConfig) = cache("target-triple") {
+    _ => clangInfo.targetTriple
   }
 
   private def silentLogger(): ProcessLogger =
@@ -205,4 +211,71 @@ object Discover {
 
   private def getenv(key: String): Option[String] =
     Option(System.getenv.get(key))
+
+  private object cache extends ContextBasedCache[NativeConfig, String, AnyRef]
+
+  private[scalanative] object features {
+    import FeatureSupport._
+
+    def opaquePointers(implicit config: NativeConfig): FeatureSupport =
+      cache("opaque-pointers") { _ =>
+        try {
+          val version = clangInfo.majorVersion
+          if (version < 13) Unavilable
+          else if (version == 13) EnabledWithFlag("--force-opaque-pointers")
+          else if (version < 15) EnabledWithFlag("--opaque-pointers")
+          else Enabled
+        } catch {
+          case ex: Exception =>
+            System.err.println(
+              "Failed to detect version of clang, assuming opaque-pointers are not supported"
+            )
+            Unavilable
+        }
+      }
+
+    sealed trait FeatureSupport {
+      def isAvailable: Boolean = this match {
+        case Unavilable => false
+        case _          => true
+      }
+      def requiredFlag: Option[String] = this match {
+        case EnabledWithFlag(flag) => Some(flag)
+        case _                     => None
+      }
+    }
+    object FeatureSupport {
+      case object Unavilable extends FeatureSupport
+      case object Enabled extends FeatureSupport
+      case class EnabledWithFlag(compilationFlag: String) extends FeatureSupport
+    }
+  }
+
+  class ContextBasedCache[Ctx, Key, Value <: AnyRef] {
+    private val cachedValues = scala.collection.mutable.Map.empty[Key, Value]
+    private var lastContext: Ctx = _
+
+    def apply[T <: Value: reflect.ClassTag](
+        key: Key
+    )(resolve: Ctx => T)(implicit context: Ctx): T = {
+      lastContext match {
+        case `context` =>
+          val result = cachedValues.getOrElseUpdate(key, resolve(context))
+          // Make sure stored value has correct type in case of duplicate keys
+          val expectedType = implicitly[reflect.ClassTag[T]].runtimeClass
+          assert(
+            expectedType.isAssignableFrom(result.getClass),
+            s"unexpected type of result for entry: `$key`, got ${result
+                .getClass()}, expected $expectedType"
+          )
+          result.asInstanceOf[T]
+
+        case _ =>
+          // Context have changed
+          cachedValues.clear()
+          lastContext = context
+          this(key)(resolve) // retry with cleaned cached
+      }
+    }
+  }
 }

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -71,7 +71,7 @@ private[scalanative] object LLVM {
 
     val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
     val stdflag = {
-      if (isLl) Seq.empty
+      if (isLl) llvmIrFeatures
       else if (isCpp) {
         // C++14 or newer standard is needed to compile code using Windows API
         // shipped with Windows 10 / Server 2016+ (we do not plan supporting older versions)
@@ -314,6 +314,14 @@ private[scalanative] object LLVM {
       case Mode.ReleaseSize => "-Oz"
       case Mode.ReleaseFull => "-O3"
     }
+
+  private def llvmIrFeatures(implicit config: Config): Seq[String] = {
+    implicit def nativeConfig: NativeConfig = config.compilerConfig
+    val opaquePointers = Discover.features.opaquePointers.requiredFlag.toList
+      .flatMap(Seq("-mllvm", _))
+
+    opaquePointers
+  }
 
   private def buildTargetCompileOpts(implicit config: Config): Seq[String] =
     config.compilerConfig.buildTarget match {

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -192,8 +192,8 @@ object NativeConfig {
   /** Default empty config object where all of the fields are left blank. */
   def empty: NativeConfig =
     Impl(
-      clang = Paths.get("clang"),
-      clangPP = Paths.get("clang++"),
+      clang = Paths.get(""),
+      clangPP = Paths.get(""),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
       targetTriple = None,

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -75,7 +75,7 @@ sealed trait NativeConfig {
   /** Configuration when doing optimization */
   def optimizerConfig: OptimizerConfig
 
-  private lazy val detectedTriple = Discover.targetTriple(clang)
+  private lazy val detectedTriple = Discover.targetTriple(this)
 
   /** Are we targeting a 32-bit platform?
    *
@@ -192,8 +192,8 @@ object NativeConfig {
   /** Default empty config object where all of the fields are left blank. */
   def empty: NativeConfig =
     Impl(
-      clang = Paths.get(""),
-      clangPP = Paths.get(""),
+      clang = Paths.get("clang"),
+      clangPP = Paths.get("clang++"),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
       targetTriple = None,

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -3,6 +3,7 @@ package scala.scalanative.codegen
 import java.nio.file.{Path, Paths}
 import java.{lang => jl}
 import scala.collection.mutable
+import scala.scalanative.build.Discover
 import scala.scalanative.codegen.compat.os.OsCompat
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir.ControlFlow.{Block, Graph => CFG}
@@ -14,11 +15,12 @@ import scala.scalanative.{build, linker, nir}
 private[codegen] abstract class AbstractCodeGen(
     env: Map[Global, Defn],
     defns: Seq[Defn]
-)(implicit meta: Metadata) {
+)(implicit val meta: Metadata) {
   import meta.platform
   import platform._
 
   val os: OsCompat
+  val pointerType = if (useOpaquePointers) "ptr" else "i8*"
 
   private var currentBlockName: Local = _
   private var currentBlockSplit: Int = _
@@ -364,9 +366,10 @@ private[codegen] abstract class AbstractCodeGen(
   private[codegen] def genType(ty: Type)(implicit sb: ShowBuilder): Unit = {
     import sb._
     ty match {
-      case Type.Vararg                                           => str("...")
-      case _: Type.RefKind | Type.Ptr | Type.Null | Type.Nothing => str("i8*")
-      case Type.Bool                                             => str("i1")
+      case Type.Vararg => str("...")
+      case _: Type.RefKind | Type.Ptr | Type.Null | Type.Nothing =>
+        str(pointerType)
+      case Type.Bool          => str("i1")
       case i: Type.FixedSizeI => str("i"); str(i.width)
       case Type.Size =>
         str("i")
@@ -452,11 +455,17 @@ private[codegen] abstract class AbstractCodeGen(
         str("%")
         genLocal(n)
       case Val.Global(n, ty) =>
-        str("bitcast (")
-        genType(lookup(n))
-        str("* @")
-        genGlobal(n)
-        str(" to i8*)")
+        if (useOpaquePointers) {
+          lookup(n)
+          str("@")
+          genGlobal(n)
+        } else {
+          str("bitcast (")
+          genType(lookup(n))
+          str("* @")
+          genGlobal(n)
+          str(" to i8*)")
+        }
       case _ =>
         unsupported(v)
     }
@@ -659,14 +668,16 @@ private[codegen] abstract class AbstractCodeGen(
         val isVolatile =
           isMultithreadingEnabled && syncAttrs.exists(_.isVolatile)
 
-        newline()
-        str("%")
-        genLocal(pointee)
-        str(" = bitcast ")
-        genVal(ptr)
-        str(" to ")
-        genType(ty)
-        str("*")
+        if (!useOpaquePointers) {
+          newline()
+          str("%")
+          genLocal(pointee)
+          str(" = bitcast ")
+          genVal(ptr)
+          str(" to ")
+          genType(ty)
+          str("*")
+        }
 
         newline()
         genBind()
@@ -675,9 +686,14 @@ private[codegen] abstract class AbstractCodeGen(
         if (isVolatile) str("volatile ")
         genType(ty)
         str(", ")
-        genType(ty)
-        str("* %")
-        genLocal(pointee)
+        if (useOpaquePointers) {
+          str("ptr ")
+          genJustVal(ptr)
+        } else {
+          genType(ty)
+          str("* %")
+          genLocal(pointee)
+        }
         if (isAtomic) {
           str(" ")
           syncAttrs.foreach(genSyncAttrs)
@@ -708,14 +724,16 @@ private[codegen] abstract class AbstractCodeGen(
         val isVolatile =
           isMultithreadingEnabled && syncAttrs.exists(_.isVolatile)
 
-        newline()
-        str("%")
-        genLocal(pointee)
-        str(" = bitcast ")
-        genVal(ptr)
-        str(" to ")
-        genType(ty)
-        str("*")
+        if (!useOpaquePointers) {
+          newline()
+          str("%")
+          genLocal(pointee)
+          str(" = bitcast ")
+          genVal(ptr)
+          str(" to ")
+          genType(ty)
+          str("*")
+        }
 
         newline()
         genBind()
@@ -723,10 +741,15 @@ private[codegen] abstract class AbstractCodeGen(
         if (isAtomic) str("atomic ")
         if (isVolatile) str("volatile ")
         genVal(value)
-        str(", ")
-        genType(ty)
-        str("* %")
-        genLocal(pointee)
+        if (useOpaquePointers) {
+          str(", ptr")
+          genJustVal(ptr)
+        } else {
+          str(", ")
+          genType(ty)
+          str("* %")
+          genLocal(pointee)
+        }
         if (isAtomic) syncAttrs.foreach {
           str(" ")
           genSyncAttrs(_)
@@ -738,54 +761,76 @@ private[codegen] abstract class AbstractCodeGen(
         val pointee = fresh()
         val derived = fresh()
 
-        newline()
-        str("%")
-        genLocal(pointee)
-        str(" = bitcast ")
-        genVal(ptr)
-        str(" to ")
-        genType(ty)
-        str("*")
+        if (!useOpaquePointers) {
+          newline()
+          str("%")
+          genLocal(pointee)
+          str(" = bitcast ")
+          genVal(ptr)
+          str(" to ")
+          genType(ty)
+          str("*")
+        }
 
         newline()
-        str("%")
-        genLocal(derived)
-        str(" = getelementptr ")
+        if (useOpaquePointers) genBind()
+        else {
+          str("%")
+          genLocal(derived)
+          str(" = ")
+        }
+        str("getelementptr ")
         genType(ty)
         str(", ")
-        genType(ty)
-        str("* %")
-        genLocal(pointee)
+        if (ty.isInstanceOf[Type.AggregateKind] || !useOpaquePointers) {
+          genType(ty)
+          str("*")
+        } else str("ptr")
+        str(" ")
+        if (useOpaquePointers) genJustVal(ptr)
+        else {
+          str("%")
+          genLocal(pointee)
+        }
         str(", ")
         rep(indexes, sep = ", ")(genVal)
 
-        newline()
-        genBind()
-        str("bitcast ")
-        genType(ty.elemty(indexes.tail))
-        str("* %")
-        genLocal(derived)
-        str(" to i8*")
+        if (!useOpaquePointers) {
+          newline()
+          genBind()
+          str("bitcast ")
+          genType(ty.elemty(indexes.tail))
+          str("* %")
+          genLocal(derived)
+          str(" to i8*")
+        }
 
       case Op.Stackalloc(ty, n) =>
         val pointee = fresh()
 
         newline()
-        str("%")
-        genLocal(pointee)
-        str(" = alloca ")
+        if (useOpaquePointers) genBind()
+        else {
+          str("%")
+          genLocal(pointee)
+          str(" = ")
+        }
+        str("alloca ")
         genType(ty)
         str(", ")
         genVal(n)
-        str(if (platform.is32Bit) ", align 4" else ", align 8")
+        str(", align ")
+        str(platform.sizeOfPtr)
 
-        newline()
-        genBind()
-        str("bitcast ")
-        genType(ty)
-        str("* %")
-        genLocal(pointee)
-        str(" to i8*")
+        if (!useOpaquePointers) {
+          newline()
+          genBind()
+          str("bitcast ")
+          genType(ty)
+          str("* %")
+          genLocal(pointee)
+          str(" to i8*")
+        }
 
       case _ =>
         newline()
@@ -832,21 +877,26 @@ private[codegen] abstract class AbstractCodeGen(
 
         val pointee = fresh()
 
-        newline()
-        str("%")
-        genLocal(pointee)
-        str(" = bitcast ")
-        genVal(ptr)
-        str(" to ")
-        genType(ty)
-        str("*")
+        if (!useOpaquePointers) {
+          newline()
+          str("%")
+          genLocal(pointee)
+          str(" = bitcast ")
+          genVal(ptr)
+          str(" to ")
+          genType(ty)
+          str("*")
+        }
 
         newline()
         genBind()
         str(if (unwind ne Next.None) "invoke " else "call ")
         genCallFunctionType(ty)
-        str(" %")
-        genLocal(pointee)
+        if (useOpaquePointers) genJustVal(ptr)
+        else {
+          str(" %")
+          genLocal(pointee)
+        }
         str("(")
         rep(args, sep = ", ")(genCallArgument)
         str(")")

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -686,10 +686,8 @@ private[codegen] abstract class AbstractCodeGen(
         if (isVolatile) str("volatile ")
         genType(ty)
         str(", ")
-        if (useOpaquePointers) {
-          str("ptr ")
-          genJustVal(ptr)
-        } else {
+        if (useOpaquePointers) genVal(ptr)
+        else {
           genType(ty)
           str("* %")
           genLocal(pointee)
@@ -785,7 +783,7 @@ private[codegen] abstract class AbstractCodeGen(
         if (ty.isInstanceOf[Type.AggregateKind] || !useOpaquePointers) {
           genType(ty)
           str("*")
-        } else str("ptr")
+        } else str(pointerType)
         str(" ")
         if (useOpaquePointers) genJustVal(ptr)
         else {
@@ -892,9 +890,10 @@ private[codegen] abstract class AbstractCodeGen(
         genBind()
         str(if (unwind ne Next.None) "invoke " else "call ")
         genCallFunctionType(ty)
+        str(" ")
         if (useOpaquePointers) genJustVal(ptr)
         else {
-          str(" %")
+          str("%")
           genLocal(pointee)
         }
         str("(")

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -140,7 +140,7 @@ object CodeGen {
     ): AbstractCodeGen = {
       new AbstractCodeGen(env, defns) {
         override val os: OsCompat = {
-          if (meta.platform.targetsWindows) new WindowsCompat(this)
+          if (this.meta.platform.targetsWindows) new WindowsCompat(this)
           else new UnixCompat(this)
         }
       }

--- a/tools/src/main/scala/scala/scalanative/codegen/PlatformInfo.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PlatformInfo.scala
@@ -1,12 +1,13 @@
 package scala.scalanative.codegen
 
-import scala.scalanative.build.Config
+import scala.scalanative.build.{Config, Discover}
 
 private[scalanative] case class PlatformInfo(
     targetTriple: Option[String],
     targetsWindows: Boolean,
     is32Bit: Boolean,
-    isMultithreadingEnabled: Boolean
+    isMultithreadingEnabled: Boolean,
+    useOpaquePointers: Boolean
 ) {
   val sizeOfPtr = if (is32Bit) 4 else 8
   val sizeOfPtrBits = sizeOfPtr * 8
@@ -16,6 +17,8 @@ object PlatformInfo {
     targetTriple = config.compilerConfig.targetTriple,
     targetsWindows = config.targetsWindows,
     is32Bit = config.compilerConfig.is32BitPlatform,
-    isMultithreadingEnabled = config.compilerConfig.multithreadingSupport
+    isMultithreadingEnabled = config.compilerConfig.multithreadingSupport,
+    useOpaquePointers =
+      Discover.features.opaquePointers(config.compilerConfig).isAvailable
   )
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/compat/os/OsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/compat/os/OsCompat.scala
@@ -1,12 +1,15 @@
-package scala.scalanative.codegen.compat.os
+package scala.scalanative.codegen
+package compat.os
 
 import scala.scalanative.nir.ControlFlow.Block
 import scala.scalanative.nir.{Fresh, Next, Position}
 import scala.scalanative.util.ShowBuilder
 
 private[codegen] trait OsCompat {
-
+  protected def codegen: AbstractCodeGen
   protected def osPersonalityType: String
+
+  def useOpaquePointers = codegen.meta.platform.useOpaquePointers
 
   def genPrelude()(implicit sb: ShowBuilder): Unit
   def genLandingPad(
@@ -15,6 +18,6 @@ private[codegen] trait OsCompat {
   def genBlockAlloca(block: Block)(implicit sb: ShowBuilder): Unit
 
   final lazy val gxxPersonality =
-    s"personality i8* bitcast (i32 (...)* $osPersonalityType to i8*)"
-
+    if (useOpaquePointers) s"personality ptr $osPersonalityType"
+    else s"personality i8* bitcast (i32 (...)* $osPersonalityType to i8*)"
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/compat/os/UnixCompat.scala
@@ -5,15 +5,20 @@ import scala.scalanative.nir.ControlFlow.Block
 import scala.scalanative.nir._
 import scala.scalanative.util.ShowBuilder
 
-private[codegen] class UnixCompat(codeGen: AbstractCodeGen) extends OsCompat {
+private[codegen] class UnixCompat(protected val codegen: AbstractCodeGen)
+    extends OsCompat {
+  import codegen.{pointerType => ptrT}
   val ehWrapperTy = "@_ZTIN11scalanative16ExceptionWrapperE"
-  val excRecTy = "{ i8*, i32 }"
+  val excRecTy = s"{ $ptrT, i32 }"
   val beginCatch = "@__cxa_begin_catch"
   val endCatch = "@__cxa_end_catch"
+  val catchSig =
+    if (useOpaquePointers) s"$ptrT $ehWrapperTy"
+    else s"i8* bitcast ({ i8*, i8*, i8* }* $ehWrapperTy to i8*)"
   val landingpad =
-    s"landingpad $excRecTy catch i8* bitcast ({ i8*, i8*, i8* }* $ehWrapperTy to i8*)"
+    s"landingpad $excRecTy catch $catchSig"
   val typeid =
-    s"call i32 @llvm.eh.typeid.for(i8* bitcast ({ i8*, i8*, i8* }* $ehWrapperTy to i8*))"
+    s"call i32 @llvm.eh.typeid.for($catchSig)"
 
   protected val osPersonalityType: String = "@__gxx_personality_v0"
 
@@ -48,12 +53,17 @@ private[codegen] class UnixCompat(codeGen: AbstractCodeGen) extends OsCompat {
 
     line(s"$excsucc:")
     indent()
-    line(s"$w0 = call i8* $beginCatch(i8* $r0)")
-    line(s"$w1 = bitcast i8* $w0 to i8**")
-    line(s"$w2 = getelementptr i8*, i8** $w1, i32 1")
-    line(s"$exc = load i8*, i8** $w2")
+    line(s"$w0 = call $ptrT $beginCatch($ptrT $r0)")
+    if (useOpaquePointers) {
+      line(s"$w2 = getelementptr ptr, ptr $w0, i32 1")
+      line(s"$exc = load ptr, ptr $w2")
+    } else {
+      line(s"$w1 = bitcast i8* $w0 to i8**")
+      line(s"$w2 = getelementptr i8*, i8** $w1, i32 1")
+      line(s"$exc = load i8*, i8** $w2")
+    }
     line(s"call void $endCatch()")
-    codeGen.genInst(Inst.Jump(next))
+    codegen.genInst(Inst.Jump(next))
     unindent()
 
     line(s"$excfail:")
@@ -64,10 +74,10 @@ private[codegen] class UnixCompat(codeGen: AbstractCodeGen) extends OsCompat {
 
   def genPrelude()(implicit builder: ShowBuilder): Unit = {
     import builder._
-    line("declare i32 @llvm.eh.typeid.for(i8*)")
+    line(s"declare i32 @llvm.eh.typeid.for($ptrT)")
     line(s"declare i32 $osPersonalityType(...)")
-    line(s"declare i8* $beginCatch(i8*)")
+    line(s"declare $ptrT $beginCatch($ptrT)")
     line(s"declare void $endCatch()")
-    line(s"$ehWrapperTy = external constant { i8*, i8*, i8* }")
+    line(s"$ehWrapperTy = external constant { $ptrT, $ptrT, $ptrT }")
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/compat/os/WindowsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/compat/os/WindowsCompat.scala
@@ -5,8 +5,9 @@ import scala.scalanative.nir.ControlFlow.Block
 import scala.scalanative.nir.{Fresh, Next, Position, Val}
 import scala.scalanative.util.ShowBuilder
 
-private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
+private[codegen] class WindowsCompat(protected val codegen: AbstractCodeGen)
     extends OsCompat {
+  import codegen.{pointerType => ptrT}
   val ehWrapperTy = "\"??_R0?AVExceptionWrapper@scalanative@@@8\""
   val ehWrapperName = "c\".?AVExceptionWrapper@scalanative@@\\00\""
   val ehClass = "%\"class.scalanative::ExceptionWrapper\""
@@ -28,16 +29,17 @@ private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
 
   override def genPrelude()(implicit sb: ShowBuilder): Unit = {
     import sb._
-    line("declare i32 @llvm.eh.typeid.for(i8*)")
+    def PtrRef = if (useOpaquePointers) ptrT else s"$ptrT*"
+    line(s"declare i32 @llvm.eh.typeid.for($ptrT*)")
     line(s"declare i32 $osPersonalityType(...)")
-    line(s"$typeDescriptor = type { i8**, i8*, [35 x i8] }")
-    line(s"%$stdExceptionData = type { i8*, i8 }")
+    line(s"$typeDescriptor = type { $PtrRef, $ptrT, [35 x i8] }")
+    line(s"%$stdExceptionData = type { $ptrT, i8 }")
     line(s"%$stdExceptionClass = type { i32 (...)**, %$stdExceptionData }")
-    line(s"$ehClass = type { %$stdExceptionClass, i8* }")
-    line(s"@$typeInfo = external constant i8*")
+    line(s"$ehClass = type { %$stdExceptionClass, $ptrT }")
+    line(s"@$typeInfo = external constant $ptrT")
     line(s"$$$ehWrapperTy = comdat any")
     line(
-      s"@$ehWrapperTy = linkonce_odr global $typeDescriptor { i8** @$typeInfo, i8* null, [35 x i8] $ehWrapperName }, comdat"
+      s"@$ehWrapperTy = linkonce_odr global $typeDescriptor { $PtrRef @$typeInfo, $ptrT null, [35 x i8] $ehWrapperName }, comdat"
     )
   }
 
@@ -63,13 +65,25 @@ private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
 
     line(s"$excsucc:")
     indent()
-    line(
-      s"$cpad = catchpad within $rec [$typeDescriptor* @$ehWrapperTy, i32 8, $ehClass** $ehVar]"
-    )
-    line(s"$w1 = load $ehClass*, $ehClass** $ehVar, align 8")
-    line(s"$w2 = getelementptr inbounds $ehClass, $ehClass* $w1, i32 0, i32 1")
-    line(s"$exc = load i8*, i8** $w2, align 8")
-    line(s"catchret from $cpad to ")
+    if (useOpaquePointers) {
+      line(
+        s"$cpad = catchpad within $rec [ptr @$ehWrapperTy, i32 8, ptr $ehVar]"
+      )
+      line(s"$w1 = load ptr, ptr $ehVar, align 8")
+      line(s"$w2 = getelementptr inbounds $ehClass, ptr $w1, i32 0, i32 1")
+      line(s"$exc = load ptr, ptr $w2, align 8")
+      line(s"catchret from $cpad to ")
+    } else {
+      line(
+        s"$cpad = catchpad within $rec [$typeDescriptor* @$ehWrapperTy, i32 8, $ehClass** $ehVar]"
+      )
+      line(s"$w1 = load $ehClass*, $ehClass** $ehVar, align 8")
+      line(
+        s"$w2 = getelementptr inbounds $ehClass, $ehClass* $w1, i32 0, i32 1"
+      )
+      line(s"$exc = load i8*, i8** $w2, align 8")
+      line(s"catchret from $cpad to ")
+    }
     genNext(next)
     unindent()
   }


### PR DESCRIPTION
Fixes #3161 

This PR adds changes to our code gen allowing for emitting opaque types. This should simplify our llvm it allowing for a bit faster compilation. Detection of the capability to use opaque pointers instead of their typed version is based on the detect version of clang. 

Removal of typed pointers and required for them bitcasts in `call`/`load`/`store`/`getelemptr` ops allows to reduce total number of bitcasts ops from 12k to ~250 when compiling sandbox project.