### PR TITLE
Don't emit logs when skipping embeding source files

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -54,21 +54,12 @@ private[scalanative] object ResourceEmbedder {
                   s"Did not embed: $pathName - file in the ignored \'scala-native\' folder."
                 )
                 None
-              } else if (isSourceFile((path))) {
-                config.logger.debug(
-                  s"Did not embed: $pathName - source file extension detected."
-                )
-                None
-              } else if (Files.isDirectory(correctedPath)) {
-                None
-              } else {
-                Some(ClasspathFile(path, pathName, virtualDir))
-              }
+              } else if (isSourceFile((path))) None
+              else if (Files.isDirectory(correctedPath)) None
+              else Some(ClasspathFile(path, pathName, virtualDir))
             }
         }
-      } else {
-        Seq.empty
-      }
+      } else Seq.empty
 
     def filterEqualPathNames(
         path: List[ClasspathFile]


### PR DESCRIPTION
When embedding resources is enabled the output log is trashed with debug messages, informing about not including `.class` / `.nir`, `.scala` sources, which are always ignored. This change disabled excessive logging about this process to cleanup the output logs.