### PR TITLE
Restore stack state after executing inlined function to prevent stack overflows

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/LLVMIntrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/LLVMIntrinsics.scala
@@ -82,4 +82,6 @@ object LLVMIntrinsics {
   def `llvm.cttz.i16`(source: Short, iszeroundef: Boolean): Short = extern
   def `llvm.cttz.i32`(source: Int, iszeroundef: Boolean): Int = extern
   def `llvm.cttz.i64`(source: Long, iszeroundef: Boolean): Long = extern
+  def `llvm.stacksave`(): RawPtr = extern
+  def `llvm.stackrestore`(state: RawPtr): Unit = extern
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -5,16 +5,13 @@ import scala.collection.mutable
 
 class Buffer(implicit fresh: Fresh) {
   private val buffer = mutable.UnrolledBuffer.empty[Inst]
-  def +=(inst: Inst): Unit =
-    buffer += inst
-  def ++=(insts: Seq[Inst]): Unit =
-    buffer ++= insts
-  def ++=(other: Buffer): Unit =
-    buffer ++= other.buffer
-  def toSeq: Seq[Inst] =
-    buffer.toSeq
-  def size: Int =
-    buffer.size
+  def +=(inst: Inst): Unit = buffer += inst
+  def ++=(insts: Seq[Inst]): Unit = buffer ++= insts
+  def ++=(other: Buffer): Unit = buffer ++= other.buffer
+
+  def toSeq: Seq[Inst] = buffer.toSeq
+  def size: Int = buffer.size
+  def exists(pred: Inst => Boolean) = buffer.exists(pred)
 
   // Control-flow ops
   def label(name: Local)(implicit pos: Position): Unit =

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Path, Files}
 import scala.collection.mutable
 import scala.scalanative.checker.Check
 import scala.scalanative.codegen.CodeGen
+import scala.scalanative.interflow.Interflow
 import scala.scalanative.linker.Link
 import scala.scalanative.nir._
 import scala.scalanative.util.Scope
@@ -17,7 +18,8 @@ private[scalanative] object ScalaNative {
    */
   def entries(config: Config): Seq[Global] = {
     val entry = encodedMainClass(config).map(_.member(Rt.ScalaMainSig))
-    entry ++: CodeGen.depends
+    val dependencies = CodeGen.depends ++ Interflow.depends
+    entry ++: dependencies
   }
 
   /** Given the classpath and main entry point, link under closed-world

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -154,10 +154,8 @@ trait Inline { self: Interflow =>
   ): Val =
     in(s"inlining ${name.show}") {
       val defn = mode match {
-        case build.Mode.Debug =>
-          getOriginal(name)
-        case _: build.Mode.Release =>
-          getDone(name)
+        case build.Mode.Debug      => getOriginal(name)
+        case _: build.Mode.Release => getDone(name)
       }
       val Type.Function(_, origRetTy) = defn.ty: @unchecked
 
@@ -223,7 +221,21 @@ trait Inline { self: Interflow =>
             }
       }
 
-      state.emit ++= emit
+      // Check if inlined function performed stack allocation, if so add
+      // insert stacksave/stackrestore LLVM Intrinsics to prevent affecting.
+      // By definition every stack allocation of inlined function is only needed within it's body
+      val allocatesOnStack = emit.exists {
+        case Inst.Let(_, _: Op.Stackalloc, _) => true
+        case _                                => false
+      }
+      if (allocatesOnStack) {
+        import Interflow.LLVMIntrinsics._
+        val stackState = state.emit
+          .call(StackSaveSig, StackSave, Nil, Next.None)
+        state.emit ++= emit
+        state.emit
+          .call(StackRestoreSig, StackRestore, Seq(stackState), Next.None)
+      } else state.emit ++= emit
       state.inherit(endState, res +: args)
 
       val Type.Function(_, retty) = defn.ty: @unchecked

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -160,4 +160,22 @@ object Interflow {
     interflow.visitLoop()
     interflow.result()
   }
+
+  object LLVMIntrinsics {
+    private val externAttrs = Attrs(isExtern = true)
+    private val LLVMI = Global.Top("scala.scalanative.runtime.LLVMIntrinsics$")
+    private def llvmIntrinsic(id: String) =
+      Val.Global(LLVMI.member(Sig.Extern(id)), Type.Ptr)
+
+    val StackSave = llvmIntrinsic("llvm.stacksave")
+    val StackSaveSig = Type.Function(Nil, Type.Ptr)
+
+    val StackRestore = llvmIntrinsic("llvm.stackrestore")
+    val StackRestoreSig = Type.Function(Seq(Type.Ptr), Type.Unit)
+  }
+
+  val depends: Seq[Global] = Seq(
+    LLVMIntrinsics.StackSave.name,
+    LLVMIntrinsics.StackRestore.name
+  )
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -592,7 +592,7 @@ class IssuesTest {
   }
 
   @Test def i3195(): Unit = {
-    // Make sure that inlined calls are reseting the stack upon returning
+    // Make sure that inlined calls are resetting the stack upon returning
     // Otherwise calls to functions allocating on stack in loop might lead to stack overflow
     @alwaysinline def allocatingFunction(): CSize = {
       import scala.scalanative.unsafe.{CArray, Nat}

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -7,6 +7,7 @@ import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import scalanative.unsigned._
 import scalanative.unsafe._
 import scala.annotation.nowarn
+import scala.scalanative.annotation.alwaysinline
 
 class IssuesTest {
 
@@ -588,6 +589,25 @@ class IssuesTest {
         else fooLiteral
     }
     assertEquals(Foo.fooLiteral, Foo.fooLazy)
+  }
+
+  @Test def i3195(): Unit = {
+    // Make sure that inlined calls are reseting the stack upon returning
+    // Otherwise calls to functions allocating on stack in loop might lead to stack overflow
+    @alwaysinline def allocatingFunction(): CSize = {
+      import scala.scalanative.unsafe.{CArray, Nat}
+      import Nat._
+      def `64KB` = (64 * 1024).toUSize
+      val chunk = stackalloc[Byte](`64KB`)
+      assertNotNull("stackalloc was null", chunk)
+      `64KB`
+    }
+    // 32MB, may more then available stack 1MB on Windows, < 8 MB on Unix
+    val toAllocate = (32 * 1024 * 1024).toUSize
+    var allocated = 0.toUSize
+    while (allocated < toAllocate) {
+      allocated += allocatingFunction()
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #3195 responsible for CI failures of Windwos build with enabled multithreaidng. 

Usage of `stackalloc` in inlined functions called inside a loop were not resetting the stack pointer after exiting the inlined function. This behavior, combined with calling the inlined function in loop could have lead to stack overflow. 

This change modifies interflow optimizer to check if inlined function uses `stackalloc`. If it does, a body of inlined function would be guarded with set of LLVM intrinsic calls `llvm.stacksave` and `llvm.stackrestore` ensuring the stack pointer would behave as the function would not be inlined. 