### PR TITLE
Emit `Val.Unit`/`Type.Unit` as `void` in LLVM IR instead of ref to `BoxedUnit`

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -509,7 +509,7 @@ private[codegen] abstract class AbstractCodeGen(
 
   private[codegen] def genVal(value: Val)(implicit sb: ShowBuilder): Unit = {
     import sb._
-    if (value.ty != Type.Unit) {
+    if (value != Val.Unit) {
       genType(value.ty)
       str(" ")
     }
@@ -940,7 +940,9 @@ private[codegen] abstract class AbstractCodeGen(
     v match {
       case Val.Local(_, refty: Type.RefKind) =>
         val (nonnull, deref, size) = toDereferenceable(refty)
-        genType(refty)
+        // Primitive unit value cannot be passed as argument, probably BoxedUnit is expected
+        if (refty == Type.Unit) genType(Type.Ptr)
+        else genType(refty)
         if (nonnull) {
           str(" nonnull")
         }

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -429,6 +429,7 @@ private[codegen] abstract class AbstractCodeGen(
       case Val.True     => str("true")
       case Val.False    => str("false")
       case Val.Null     => str("null")
+      case Val.Unit     => str("void")
       case Val.Zero(ty) => str("zeroinitializer")
       case Val.Byte(v)  => str(v)
       case Val.Size(v) =>
@@ -508,8 +509,10 @@ private[codegen] abstract class AbstractCodeGen(
 
   private[codegen] def genVal(value: Val)(implicit sb: ShowBuilder): Unit = {
     import sb._
-    genType(value.ty)
-    str(" ")
+    if (value.ty != Type.Unit) {
+      genType(value.ty)
+      str(" ")
+    }
     genJustVal(value)
   }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -229,14 +229,12 @@ private[codegen] abstract class AbstractCodeGen(
 
   private[codegen] def genFunctionReturnType(
       retty: Type
-  )(implicit sb: ShowBuilder): Unit = {
-    retty match {
-      case refty: Type.RefKind =>
-        genReferenceTypeAttribute(refty)
-      case _ =>
-        ()
-    }
-    genType(retty)
+  )(implicit sb: ShowBuilder): Unit = retty match {
+    case refty: Type.RefKind if refty != Type.Unit =>
+      genReferenceTypeAttribute(refty)
+      genType(retty)
+    case _ =>
+      genType(retty)
   }
 
   private[codegen] def genReferenceTypeAttribute(
@@ -310,6 +308,7 @@ private[codegen] abstract class AbstractCodeGen(
     if (!block.isEntry) {
       val params = block.params
       params.zipWithIndex.foreach {
+        case (Val.Local(name, Type.Unit), n) => () // skip
         case (Val.Local(name, ty), n) =>
           newline()
           str("%")
@@ -367,6 +366,7 @@ private[codegen] abstract class AbstractCodeGen(
     import sb._
     ty match {
       case Type.Vararg => str("...")
+      case Type.Unit   => str("void")
       case _: Type.RefKind | Type.Ptr | Type.Null | Type.Nothing =>
         str(pointerType)
       case Type.Bool          => str("i1")

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -48,7 +48,7 @@ object Lower {
     private val unwindHandler = new util.ScopedVar[Option[Local]]
     private val currentDefn = new util.ScopedVar[Defn.Define]
     private def currentDefnRetType = {
-      val Type.Function(_, ret) = currentDefn.get.ty
+      val Type.Function(_, ret) = currentDefn.get.ty: @unchecked
       ret
     }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -98,11 +98,14 @@ trait Opt { self: Interflow =>
         case Inst.Ret(v) => v.ty
       }
 
-      val retty = rets match {
+      val retty0 = rets match {
         case Seq()   => Type.Nothing
         case Seq(ty) => ty
         case tys     => Sub.lub(tys, Some(origRetTy))
       }
+      // Make sure to not override expected BoxedUnit with primitive Unit
+      val retty = if(retty0 == Type.Unit && origRetTy.isInstanceOf[Type.Ref]) origRetTy
+      else retty0
 
       result(retty, insts)
     }

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -104,8 +104,9 @@ trait Opt { self: Interflow =>
         case tys     => Sub.lub(tys, Some(origRetTy))
       }
       // Make sure to not override expected BoxedUnit with primitive Unit
-      val retty = if(retty0 == Type.Unit && origRetTy.isInstanceOf[Type.Ref]) origRetTy
-      else retty0
+      val retty =
+        if (retty0 == Type.Unit && origRetTy.isInstanceOf[Type.Ref]) origRetTy
+        else retty0
 
       result(retty, insts)
     }


### PR DESCRIPTION
Fixes #3043 
Unblocks #3199 

This PR changes codegen logic in emitting Unit values. Currently we would emit large numbers of `BoxedUnit` instances anywhere function returned `Unit`. This also changes return type of functions returning unit to be `void` instead `ptr`. 
This allows us to use LLVM intrinsic returning `void` (otherwise compilation would fail due to incorrect signature) and allows to target WebAssembly - it requires strict matching of function signatures. 
