### PR TITLE
Don't emit `Inst.Jump`/`Inst.Label` in NIR taking single `Unit` argument

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -205,12 +205,12 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       locally {
         buf.label(thenn)(thenp.pos)
         val thenv = genExpr(thenp)
-        buf.jumpExcludeUnitValue(mergev.ty)(mergen, thenv)
+        buf.jumpExcludeUnitValue(retty)(mergen, thenv)
       }
       locally {
         buf.label(elsen)(elsep.pos)
         val elsev = genExpr(elsep)
-        buf.jumpExcludeUnitValue(mergev.ty)(mergen, elsev)
+        buf.jumpExcludeUnitValue(retty)(mergen, elsev)
       }
       buf.labelExcludeUnitValue(mergen, mergev)
     }
@@ -260,14 +260,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val scrut = genExpr(scrutp)
         buf.switch(scrut, defaultnext, casenexts)
         buf.label(defaultnext.name)(defaultp.pos)
-        buf.jumpExcludeUnitValue(mergev.ty)(merge, genExpr(defaultp))(
+        buf.jumpExcludeUnitValue(retty)(merge, genExpr(defaultp))(
           defaultp.pos
         )
         caseps.foreach {
           case (n, _, expr, pos) =>
             buf.label(n)(pos)
             val caseres = genExpr(expr)
-            buf.jumpExcludeUnitValue(mergev.ty)(merge, caseres)(pos)
+            buf.jumpExcludeUnitValue(retty)(merge, caseres)(pos)
         }
         buf.labelExcludeUnitValue(merge, mergev)
       }
@@ -378,13 +378,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         scoped(curUnwindHandler := Some(handler)) {
           nested.label(normaln)
           val res = nested.genExpr(expr)
-          nested.jumpExcludeUnitValue(mergev.ty)(mergen, res)
+          nested.jumpExcludeUnitValue(retty)(mergen, res)
         }
       }
       locally {
         nested.label(handler, Seq(excv))
         val res = nested.genTryCatch(retty, excv, mergen, catches)(expr.pos)
-        nested.jumpExcludeUnitValue(mergev.ty)(mergen, res)
+        nested.jumpExcludeUnitValue(retty)(mergen, res)
       }
 
       // Append finally to the try/catch instructions and merge them back.

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -154,6 +154,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
 
   class MethodLabelsEnv(val fresh: nir.Fresh) {
     private val entries, exits = mutable.Map.empty[Symbol, Local]
+    private val exitTypes = mutable.Map.empty[Local, nir.Type]
 
     def enterLabel(ld: Labeled): (nir.Local, nir.Local) = {
       val sym = ld.bind.symbol
@@ -168,6 +169,10 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
 
     def resolveExit(sym: Symbol): nir.Local = exits(sym)
     def resolveExit(label: Labeled): nir.Local = exits(label.bind.symbol)
+
+    def enterExitType(local: nir.Local, exitType: nir.Type): Unit =
+      exitTypes += local -> exitType
+    def resolveExitType(local: nir.Local): nir.Type = exitTypes(local)
   }
 
   class MethodEnv(val fresh: nir.Fresh) {


### PR DESCRIPTION
This change removed redundant jump/label arguments for control flow expecting `Type.Unit` as a result. This change allows to lower total number of `BoxedUnit` instance materialization in code and simplifies generated NIR