### PR TITLE
Port `definedTestNames` override from Scala.js

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -230,6 +230,16 @@ object ScalaNativePluginInternal {
               case (tf, Some(adapter)) => (tf, adapter)
             }
             .toMap
+        },
+
+        // Override default to avoid triggering a Test/nativeLink in a Test/compile
+        // without losing autocompletion.
+        definedTestNames := {
+          definedTests
+            .map(_.map(_.name).distinct)
+            .storeAs(definedTestNames)
+            .triggeredBy(loadedTestFrameworks)
+            .value
         }
       )
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -19,6 +19,7 @@ import scala.scalanative.testinterface.adapter.TestAdapter
 import scala.sys.process.Process
 import scala.util.Try
 import scala.scalanative.build.Platform
+import sjsonnew.BasicJsonProtocol._
 import java.nio.file.{Files, Path}
 
 /** ScalaNativePlugin delegates to this object


### PR DESCRIPTION
As seen in Scala.js
https://github.com/scala-js/scala-js/blob/6dc0f33b5b477971eb5859a2bc79f81524e35e36/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala#LL715-L720C9