### PR TITLE
Restore support for C VarArgs alongside current CVarArgLists

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stdio.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdio.scala
@@ -2,6 +2,7 @@ package scala.scalanative
 package libc
 
 import scalanative.unsafe._
+import stddef.size_t
 
 @extern object stdio extends stdio
 
@@ -415,6 +416,76 @@ import scalanative.unsafe._
 
   // Formatted input/output
 
+  /** Reads data from stdin and stores them according to the parameter format
+   *  into the locations pointed by the additional arguments.
+   *  @param format
+   *    C string that contains a sequence of characters that control how
+   *    characters extracted from the stream are treated
+   *
+   *  @param vargs
+   *    Depending on the format string, the function may expect a sequence of
+   *    additional arguments, each containing a pointer to allocated storage
+   *    where the interpretation of the extracted characters is stored with the
+   *    appropriate type. There should be at least as many of these arguments as
+   *    the number of values stored by the format specifiers. Additional
+   *    arguments are ignored by the function.
+   *  @return
+   *    the number of items of the argument listsuccessfully filled on success.
+   *    If a reading error happens or the end-of-file is reached while reading,
+   *    the proper indicator is set (feof or ferror). And, if either happens
+   *    before any data could be successfully read, EOF is returned.
+   */
+  @blocking def scanf(format: CString, vargs: Any*): CInt = extern
+
+  /** Reads data from the stream and stores them according to the parameter
+   *  format into the locations pointed by the additional arguments.
+   *  @param stream
+   *    Pointer to a FILE object that identifies the input stream to read data
+   *    from.
+   *  @param format
+   *    C string that contains a sequence of characters that control how
+   *    characters extracted from the stream are treated
+   *
+   *  @param vargs
+   *    Depending on the format string, the function may expect a sequence of
+   *    additional arguments, each containing a pointer to allocated storage
+   *    where the interpretation of the extracted characters is stored with the
+   *    appropriate type. There should be at least as many of these arguments as
+   *    the number of values stored by the format specifiers. Additional
+   *    arguments are ignored by the function.
+   *  @return
+   *    the number of items of the argument listsuccessfully filled on success.
+   *    If a reading error happens or the end-of-file is reached while reading,
+   *    the proper indicator is set (feof or ferror). And, if either happens
+   *    before any data could be successfully read, EOF is returned.
+   */
+  @blocking def fscanf(stream: Ptr[FILE], format: CString, vargs: Any*): CInt =
+    extern
+
+  /** Reads data from s and stores them according to parameter format into the
+   *  locations given by the additional arguments, as if scanf was used, but
+   *  reading from s instead of the standard input
+   *  @param s
+   *    C string that the function processes as its source to retrieve the data.
+   *  @param format
+   *    C string that contains a sequence of characters that control how
+   *    characters extracted from the stream are treated
+   *
+   *  @param vargs
+   *    Depending on the format string, the function may expect a sequence of
+   *    additional arguments, each containing a pointer to allocated storage
+   *    where the interpretation of the extracted characters is stored with the
+   *    appropriate type. There should be at least as many of these arguments as
+   *    the number of values stored by the format specifiers. Additional
+   *    arguments are ignored by the function.
+   *  @return
+   *    the number of items of the argument listsuccessfully filled on success.
+   *    If a reading error happens or the end-of-file is reached while reading,
+   *    the proper indicator is set (feof or ferror). And, if either happens
+   *    before any data could be successfully read, EOF is returned.
+   */
+  @blocking def sscanf(s: CString, format: CString, vargs: Any*): CInt = extern
+
   /** Read formatted data into variable argument list Reads data from the
    *  standard input (stdin) and stores them according to parameter format into
    *  the locations pointed by the elements in the variable argument list
@@ -482,6 +553,175 @@ import scalanative.unsafe._
       valist: CVarArgList
   ): CInt =
     extern
+
+  /** Writes the results to stdout.
+   *  @param format
+   *    pointer to a null-terminated character string specifying how to
+   *    interpret the data
+   *  @param vargs
+   *    variable argument list containing the data to print.
+   *
+   *  @return
+   *    The number of characters written if successful or negative value if an
+   *    error occurred.
+   *  @see
+   *    [[https://en.cppreference.com/w/c/io/printf]]
+   */
+  @blocking def printf(format: CString, vargs: Any*): CInt = extern
+
+  /** Writes the results to selected stream.
+   *  @param stream
+   *    output file stream to write to
+   *  @param format
+   *    pointer to a null-terminated character string specifying how to
+   *    interpret the data
+   *  @param vargs
+   *    variable argument list containing the data to print.
+   *
+   *  @return
+   *    The number of characters written if successful or negative value if an
+   *    error occurred.
+   *  @see
+   *    [[https://en.cppreference.com/w/c/io/fprintf]]
+   */
+  @blocking def fprintf(stream: Ptr[FILE], format: CString, vargs: Any*): CInt =
+    extern
+
+  /** Writes the results to a character string buffer.
+   *  @param buffer
+   *    pointer to a character string to write to
+   *  @param format
+   *    pointer to a null-terminated character string specifying how to
+   *    interpret the data
+   *  @param vargs
+   *    variable argument list containing the data to print.
+   *
+   *  @return
+   *    The number of characters written if successful or negative value if an
+   *    error occurred.
+   *  @see
+   *    [[https://en.cppreference.com/w/c/io/sprintf]]
+   */
+  def sprintf(
+      buffer: Ptr[CChar],
+      format: CString,
+      vargs: Any*
+  ): CInt = extern
+
+  /** Writes the results to a character string buffer. At most bufsz - 1
+   *  characters are written. The resulting character string will be terminated
+   *  with a null character, unless bufsz is zero. If bufsz is zero, nothing is
+   *  written and buffer may be a null pointer, however the return value (number
+   *  of bytes that would be written not including the null terminator) is still
+   *  calculated and returned.
+   *  @param buffer
+   *    pointer to a character string to write to
+   *  @param busz
+   *    number of character to write
+   *  @param format
+   *    pointer to a null-terminated character string specifying how to
+   *    interpret the data
+   *  @param vargs
+   *    variable argument list containing the data to print.
+   *
+   *  @return
+   *    The number of characters written if successful or negative value if an
+   *    error occurred.
+   *  @see
+   *    [[https://en.cppreference.com/w/c/io/snprintf]]
+   */
+  def snprintf(
+      buffer: Ptr[CChar],
+      bufsz: size_t,
+      format: CString,
+      vargs: Any*
+  ): CInt = extern
+
+  /** Writes the results to stdout.
+   *  @param format
+   *    pointer to a null-terminated character string specifying how to
+   *    interpret the data
+   *  @param vargs
+   *    variable argument list containing the data to print.
+   *
+   *  @return
+   *    The number of characters written if successful or negative value if an
+   *    error occurred.
+   *  @see
+   *    [[https://en.cppreference.com/w/c/io/printf_s]]
+   */
+  @blocking def printf_s(format: CString, vargs: Any*): CInt = extern
+
+  /** Writes the results to selected stream.
+   *  @param stream
+   *    output file stream to write to
+   *  @param format
+   *    pointer to a null-terminated character string specifying how to
+   *    interpret the data
+   *  @param vargs
+   *    variable argument list containing the data to print.
+   *
+   *  @return
+   *    The number of characters written if successful or negative value if an
+   *    error occurred.
+   *  @see
+   *    [[https://en.cppreference.com/w/c/io/fprintf_s]]
+   */
+  @blocking def fprintf_s(
+      stream: Ptr[FILE],
+      format: CString,
+      vargs: Any*
+  ): CInt = extern
+
+  /** Writes the results to a character string buffer.
+   *  @param buffer
+   *    pointer to a character string to write to
+   *  @param format
+   *    pointer to a null-terminated character string specifying how to
+   *    interpret the data
+   *  @param vargs
+   *    variable argument list containing the data to print.
+   *
+   *  @return
+   *    The number of characters written if successful or negative value if an
+   *    error occurred.
+   *  @see
+   *    [[https://en.cppreference.com/w/c/io/sprintf_s]]
+   */
+  def sprintf_s(
+      buffer: Ptr[CChar],
+      format: CString,
+      vargs: Any*
+  ): CInt = extern
+
+  /** Writes the results to a character string buffer. At most bufsz - 1
+   *  characters are written. The resulting character string will be terminated
+   *  with a null character, unless bufsz is zero. If bufsz is zero, nothing is
+   *  written and buffer may be a null pointer, however the return value (number
+   *  of bytes that would be written not including the null terminator) is still
+   *  calculated and returned.
+   *  @param buffer
+   *    pointer to a character string to write to
+   *  @param busz
+   *    number of character to write
+   *  @param format
+   *    pointer to a null-terminated character string specifying how to
+   *    interpret the data
+   *  @param vargs
+   *    variable argument list containing the data to print.
+   *
+   *  @return
+   *    The number of characters written if successful or negative value if an
+   *    error occurred.
+   *  @see
+   *    [[https://en.cppreference.com/w/c/io/snprintf_s]]
+   */
+  def snprintf_s(
+      buffer: Ptr[CChar],
+      bufsz: size_t,
+      format: CString,
+      vargs: Any*
+  ): CInt = extern
 
   /** Writes the results to stdout.
    *  @param format

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -105,12 +105,24 @@ object Type {
   final case class Var(ty: Type) extends SpecialKind
   final case class Function(args: Seq[Type], ret: Type) extends SpecialKind
 
-  val boxesTo = Seq[(Type, Type)](
-    Type.Ref(Global.Top("scala.scalanative.unsigned.USize")) -> Type.Size,
-    Type.Ref(Global.Top("scala.scalanative.unsigned.UByte")) -> Type.Byte,
-    Type.Ref(Global.Top("scala.scalanative.unsigned.UShort")) -> Type.Short,
-    Type.Ref(Global.Top("scala.scalanative.unsigned.UInt")) -> Type.Int,
-    Type.Ref(Global.Top("scala.scalanative.unsigned.ULong")) -> Type.Long,
+  object unsigned {
+    val Size = Type.Ref(Global.Top("scala.scalanative.unsigned.USize"))
+    val Byte = Type.Ref(Global.Top("scala.scalanative.unsigned.UByte"))
+    val Short = Type.Ref(Global.Top("scala.scalanative.unsigned.UShort"))
+    val Int = Type.Ref(Global.Top("scala.scalanative.unsigned.UInt"))
+    val Long = Type.Ref(Global.Top("scala.scalanative.unsigned.ULong"))
+
+    val values: Set[nir.Type] = Set(Size, Byte, Short, Int, Long)
+  }
+  private val unsignedBoxesTo = Seq[(Type, Type)](
+    unsigned.Size -> Type.Size,
+    unsigned.Byte -> Type.Byte,
+    unsigned.Short -> Type.Short,
+    unsigned.Int -> Type.Int,
+    unsigned.Long -> Type.Long
+  )
+
+  val boxesTo: Seq[(Type, Type)] = unsignedBoxesTo ++ Seq(
     Type.Ref(Global.Top("scala.scalanative.unsafe.CArray")) -> Type.Ptr,
     Type.Ref(Global.Top("scala.scalanative.unsafe.CVarArgList")) -> Type.Ptr,
     Type.Ref(Global.Top("scala.scalanative.unsafe.Ptr")) -> Type.Ptr,
@@ -146,6 +158,8 @@ object Type {
   def isPtrType(ty: Type): Boolean =
     ty == Type.Ptr || ty.isInstanceOf[Type.RefKind]
   def isSizeBox(ty: Type): Boolean = isBoxOf(Type.Size)(ty)
+  def isUnsignedType(ty: Type): Boolean =
+    unsigned.values.contains(normalize(ty))
 
   def normalize(ty: Type): Type = ty match {
     case ArrayValue(ty, n)          => ArrayValue(normalize(ty), n)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2575,15 +2575,23 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                       tree.symbol.tpe.finalResultType
                     else tree.tpe
                   val arg = genArg(tree, tpe)
+                  def isUnsigned = Type.isUnsignedType(genType(tpe))
                   // Decimal varargs needs to be promoted to at least Int, and float needs to be promoted to Double
                   val promotedArg = arg.ty match {
                     case Type.Float =>
                       this.genCastOp(Type.Float, Type.Double, arg)
                     case Type.FixedSizeI(width, _) if width < Type.Int.width =>
-                      val isUnsigned = Type.isUnsignedType(genType(tpe))
                       val conv =
-                        if (isUnsigned) nir.Conv.Zext else nir.Conv.Sext
+                        if (isUnsigned) nir.Conv.Zext 
+                        else nir.Conv.Sext
                       buf.conv(conv, Type.Int, arg, unwind)
+                    case Type.Long => 
+                      // On 32-bit systems Long needs to be truncated to Int
+                      // Cast it to size to make undependent from architecture
+                      val conv =
+                        if (isUnsigned) nir.Conv.ZSizeCast 
+                        else nir.Conv.SSizeCast
+                      buf.conv(conv, Type.Size, arg, unwind)
                     case _ => arg
                   }
                   res += promotedArg

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1877,7 +1877,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           Some(nir.Conv.Bitcast)
         case (Type.F(w1), Type.FixedSizeI(w2, _)) if w1 == w2 =>
           Some(nir.Conv.Bitcast)
-        case _ if fromty == toty => None
+        case _ if fromty == toty       => None
+        case (Type.Float, Type.Double) => Some(nir.Conv.Fpext)
+        case (Type.Double, Type.Float) => Some(nir.Conv.Fptrunc)
         case _ =>
           unsupported(s"cast from $fromty to $toty")
       }
@@ -2523,36 +2525,79 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def genMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[Val] =
-      if (!sym.owner.isExternType) {
-        genSimpleArgs(argsp)
-      } else {
-        val res = Seq.newBuilder[Val]
+      if (sym.owner.isExternType) genExternMethodArgs(sym, argsp)
+      else genSimpleArgs(argsp)
 
-        argsp.zip(sym.tpe.params).foreach {
-          case (argp, paramSym) =>
-            val externType = genExternType(paramSym.tpe)
-            val arg = (genExpr(argp), Type.box.get(externType)) match {
-              case (value @ Val.Null, Some(unboxedType)) =>
-                externType match {
-                  case Type.Ptr | _: Type.RefKind => value
-                  case _ =>
-                    reporter.warning(
-                      argp.pos,
-                      s"Passing null as argument of ${paramSym}: ${paramSym.tpe} to the extern method is unsafe. " +
-                        s"The argument would be unboxed to primitive value of type $externType."
-                    )
-                    Val.Zero(unboxedType)
-                }
-              case (value, _) => value
+    private def genSimpleArgs(argsp: Seq[Tree]): Seq[Val] = argsp.map(genExpr)
+
+    private def genExternMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[Val] = {
+      val res = Seq.newBuilder[Val]
+      val nir.Type.Function(argTypes, _) = genExternMethodSig(sym)
+      val paramSyms = sym.tpe.params
+      assert(
+        argTypes.size == argsp.size && argTypes.size == paramSyms.size,
+        "Different number of arguments passed to method signature and apply method"
+      )
+
+      def genArg(
+          argp: Tree,
+          paramTpe: global.Type
+      ): nir.Val = {
+        implicit def pos: nir.Position = argp.pos
+        val externType = genExternType(paramTpe)
+        val value = (genExpr(argp), Type.box.get(externType)) match {
+          case (value @ Val.Null, Some(unboxedType)) =>
+            externType match {
+              case Type.Ptr | _: Type.RefKind => value
+              case _ =>
+                reporter.warning(
+                  argp.pos,
+                  s"Passing null as argument of type ${paramTpe} to the extern method is unsafe. " +
+                    s"The argument would be unboxed to primitive value of type $externType."
+                )
+                Val.Zero(unboxedType)
             }
-            res += toExtern(externType, arg)(argp.pos)
+          case (value, _) => value
         }
-
-        res.result()
+        toExtern(externType, value)
       }
 
-    def genSimpleArgs(argsp: Seq[Tree]): Seq[Val] = {
-      argsp.map(genExpr)
+      for (((argp, sigType), paramSym) <- argsp zip argTypes zip paramSyms) {
+        sigType match {
+          case nir.Type.Vararg =>
+            argp match {
+              case Apply(_, List(ArrayValue(_, args))) =>
+                for (tree <- args) {
+                  implicit def pos: nir.Position = tree.pos
+                  val sym = tree.symbol
+                  val tpe =
+                    if (tree.symbol != null && tree.symbol.exists)
+                      tree.symbol.tpe.finalResultType
+                    else tree.tpe
+                  val arg = genArg(tree, tpe)
+                  // Decimal varargs needs to be promoted to at least Int, and float needs to be promoted to Double
+                  val promotedArg = arg.ty match {
+                    case Type.Float =>
+                      this.genCastOp(Type.Float, Type.Double, arg)
+                    case Type.FixedSizeI(width, _) if width < Type.Int.width =>
+                      val isUnsigned = Type.isUnsignedType(genType(tpe))
+                      val conv =
+                        if (isUnsigned) nir.Conv.Zext else nir.Conv.Sext
+                      buf.conv(conv, Type.Int, arg, unwind)
+                    case _ => arg
+                  }
+                  res += promotedArg
+                }
+              case _ =>
+                reporter.error(
+                  argp.pos,
+                  "Unable to extract vararg arguments, varargs to extern methods must be passed directly to the applied function"
+                )
+            }
+          case _ => res += genArg(argp, paramSym.tpe)
+        }
+      }
+      res.result()
     }
 
     private def labelExcludeUnitValue(label: Local, value: nir.Val.Local)(

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2582,14 +2582,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                       this.genCastOp(Type.Float, Type.Double, arg)
                     case Type.FixedSizeI(width, _) if width < Type.Int.width =>
                       val conv =
-                        if (isUnsigned) nir.Conv.Zext 
+                        if (isUnsigned) nir.Conv.Zext
                         else nir.Conv.Sext
                       buf.conv(conv, Type.Int, arg, unwind)
-                    case Type.Long => 
+                    case Type.Long =>
                       // On 32-bit systems Long needs to be truncated to Int
                       // Cast it to size to make undependent from architecture
                       val conv =
-                        if (isUnsigned) nir.Conv.ZSizeCast 
+                        if (isUnsigned) nir.Conv.ZSizeCast
                         else nir.Conv.SSizeCast
                       buf.conv(conv, Type.Size, arg, unwind)
                     case _ => arg

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -39,6 +39,8 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
   protected val curFresh = new util.ScopedVar[nir.Fresh]
   protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]
   protected val curStatBuffer = new util.ScopedVar[StatBuffer]
+  protected val cachedMethodSig =
+    collection.mutable.Map.empty[(Symbol, Boolean), nir.Type.Function]
 
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get.fold[Next](Next.None) { handler =>
@@ -158,6 +160,7 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
         .forEach { case (path, stats) => genIRFile(path, stats) }
     } finally {
       generatedMirrorClasses.clear()
+      cachedMethodSig.clear()
     }
   }
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -29,6 +29,8 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected val defnNir = NirDefinitions.get
   protected val nirPrimitives = new NirPrimitives()
   protected val positionsConversions = new NirPositions(settings.sourceURIMaps)
+  protected val cachedMethodSig =
+    collection.mutable.Map.empty[(Symbol, Boolean), nir.Type.Function]
 
   protected val curClassSym = new util.ScopedVar[ClassSymbol]
   protected val curClassFresh = new util.ScopedVar[nir.Fresh]
@@ -60,6 +62,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
       generatedDefns.clear()
       generatedMirrorClasses.clear()
       reflectiveInstantiationBuffers.clear()
+      cachedMethodSig.clear()
     }
   }
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1516,14 +1516,14 @@ trait NirGenExpr(using Context) {
                       this.genCastOp(Type.Float, Type.Double, arg)
                     case Type.FixedSizeI(width, _) if width < Type.Int.width =>
                       val conv =
-                        if (isUnsigned) nir.Conv.Zext 
+                        if (isUnsigned) nir.Conv.Zext
                         else nir.Conv.Sext
                       buf.conv(conv, Type.Int, arg, unwind)
-                    case Type.Long => 
+                    case Type.Long =>
                       // On 32-bit systems Long needs to be truncated to Int
                       // Cast it to size to make undependent from architecture
                       val conv =
-                        if (isUnsigned) nir.Conv.ZSizeCast 
+                        if (isUnsigned) nir.Conv.ZSizeCast
                         else nir.Conv.SSizeCast
                       buf.conv(conv, Type.Size, arg, unwind)
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgTest.scala
@@ -1,0 +1,835 @@
+package scala.scalanative
+package unsafe
+
+import org.junit.{Test, BeforeClass}
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scalanative.unsigned._
+import scalanative.unsafe._
+import scalanative.libc.{stdio, stdlib, string}
+
+import scala.scalanative.junit.utils.AssumesHelper._
+
+class CVarArgTest {
+  def vatest(cstr: CString, output: String)(
+      generator: (CString, Ptr[CChar]) => Unit
+  ): Unit = {
+    val buff: Ptr[CChar] = stackalloc[CChar](1024.toUSize)
+    generator(buff, cstr)
+    val got = fromCString(buff)
+    assertEquals(got, output)
+  }
+
+  @Test def byteValue0(): Unit =
+    vatest(c"%d", "0")(stdio.sprintf(_, _, 0.toByte))
+  @Test def byteValue1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toByte))
+  @Test def byteValueMinus1(): Unit =
+    vatest(c"%d", "-1")(stdio.sprintf(_, _, -1.toByte))
+  @Test def byteValueMin(): Unit =
+    vatest(c"%d", "-128")(stdio.sprintf(_, _, java.lang.Byte.MIN_VALUE))
+  @Test def byteValueMax(): Unit =
+    vatest(c"%d", "127")(stdio.sprintf(_, _, java.lang.Byte.MAX_VALUE))
+  @Test def byteArgs1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toByte))
+  @Test def byteArgs2(): Unit =
+    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1.toByte, 2.toByte))
+  @Test def byteArgs3(): Unit =
+    vatest(c"%d %d %d", "1 2 3")(
+      stdio.sprintf(_, _, 1.toByte, 2.toByte, 3.toByte)
+    )
+  @Test def byteArgs4(): Unit =
+    vatest(c"%d %d %d %d", "1 2 3 4")(
+      stdio.sprintf(_, _, 1.toByte, 2.toByte, 3.toByte, 4.toByte)
+    )
+  @Test def byteArgs5(): Unit =
+    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+      stdio.sprintf(_, _, 1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte)
+    )
+  @Test def byteArgs6(): Unit =
+    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+      stdio.sprintf(
+        _,
+        _,
+        1.toByte,
+        2.toByte,
+        3.toByte,
+        4.toByte,
+        5.toByte,
+        6.toByte
+      )
+    )
+  @Test def byteArgs7(): Unit =
+    vatest(c"%d %d %d %d %d %d %d", "1 2 3 4 5 6 7")(
+      stdio.sprintf(
+        _,
+        _,
+        1.toByte,
+        2.toByte,
+        3.toByte,
+        4.toByte,
+        5.toByte,
+        6.toByte,
+        7.toByte
+      )
+    )
+  @Test def byteArgs8(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toByte,
+        2.toByte,
+        3.toByte,
+        4.toByte,
+        5.toByte,
+        6.toByte,
+        7.toByte,
+        8.toByte
+      )
+    )
+  @Test def byteArgs9(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8 9"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toByte,
+        2.toByte,
+        3.toByte,
+        4.toByte,
+        5.toByte,
+        6.toByte,
+        7.toByte,
+        8.toByte,
+        9.toByte
+      )
+    )
+
+  @Test def shortValue0(): Unit =
+    vatest(c"%d", "0")(stdio.sprintf(_, _, 0.toShort))
+  @Test def shortValue1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toShort))
+  @Test def shortValueMinus1(): Unit =
+    vatest(c"%d", "-1")(stdio.sprintf(_, _, -1.toShort))
+  @Test def shortValueMin(): Unit =
+    vatest(c"%d", "-32768")(stdio.sprintf(_, _, java.lang.Short.MIN_VALUE))
+  @Test def shortValueMax(): Unit =
+    vatest(c"%d", "32767")(stdio.sprintf(_, _, java.lang.Short.MAX_VALUE))
+  @Test def shortArgs1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toShort))
+  @Test def shortArgs2(): Unit =
+    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1.toShort, 2.toShort))
+  @Test def shortArgs3(): Unit =
+    vatest(c"%d %d %d", "1 2 3")(
+      stdio.sprintf(_, _, 1.toShort, 2.toShort, 3.toShort)
+    )
+  @Test def shortArgs4(): Unit =
+    vatest(c"%d %d %d %d", "1 2 3 4")(
+      stdio.sprintf(_, _, 1.toShort, 2.toShort, 3.toShort, 4.toShort)
+    )
+  @Test def shortArgs5(): Unit =
+    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+      stdio.sprintf(_, _, 1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort)
+    )
+  @Test def shortArgs6(): Unit =
+    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+      stdio.sprintf(
+        _,
+        _,
+        1.toShort,
+        2.toShort,
+        3.toShort,
+        4.toShort,
+        5.toShort,
+        6.toShort
+      )
+    )
+  @Test def shortArgs7(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toShort,
+        2.toShort,
+        3.toShort,
+        4.toShort,
+        5.toShort,
+        6.toShort,
+        7.toShort
+      )
+    )
+  @Test def shortArgs8(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toShort,
+        2.toShort,
+        3.toShort,
+        4.toShort,
+        5.toShort,
+        6.toShort,
+        7.toShort,
+        8.toShort
+      )
+    )
+  @Test def shortArgs9(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8 9"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toShort,
+        2.toShort,
+        3.toShort,
+        4.toShort,
+        5.toShort,
+        6.toShort,
+        7.toShort,
+        8.toShort,
+        9.toShort
+      )
+    )
+
+  @Test def intValue0(): Unit =
+    vatest(c"%d", "0")(stdio.sprintf(_, _, 0))
+  @Test def intValue1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1))
+  @Test def intValueMinus1(): Unit =
+    vatest(c"%d", "-1")(stdio.sprintf(_, _, -1))
+  @Test def intValueMin(): Unit =
+    vatest(c"%d", "-2147483648")(
+      stdio.sprintf(_, _, java.lang.Integer.MIN_VALUE)
+    )
+  @Test def intValueMax(): Unit =
+    vatest(c"%d", "2147483647")(
+      stdio.sprintf(_, _, java.lang.Integer.MAX_VALUE)
+    )
+  @Test def intArgs1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1))
+  @Test def intArgs2(): Unit =
+    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1, 2))
+  @Test def intArgs3(): Unit =
+    vatest(c"%d %d %d", "1 2 3")(stdio.sprintf(_, _, 1, 2, 3))
+  @Test def intArgs4(): Unit =
+    vatest(c"%d %d %d %d", "1 2 3 4")(stdio.sprintf(_, _, 1, 2, 3, 4))
+  @Test def intArgs5(): Unit =
+    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(stdio.sprintf(_, _, 1, 2, 3, 4, 5))
+  @Test def intArgs6(): Unit =
+    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+      stdio.sprintf(_, _, 1, 2, 3, 4, 5, 6)
+    )
+  @Test def intArgs7(): Unit =
+    vatest(c"%d %d %d %d %d %d %d", "1 2 3 4 5 6 7")(
+      stdio.sprintf(_, _, 1, 2, 3, 4, 5, 6, 7)
+    )
+  @Test def intArgs8(): Unit =
+    vatest(c"%d %d %d %d %d %d %d %d", "1 2 3 4 5 6 7 8")(
+      stdio.sprintf(_, _, 1, 2, 3, 4, 5, 6, 7, 8)
+    )
+  @Test def intArgs9(): Unit =
+    vatest(c"%d %d %d %d %d %d %d %d %d", "1 2 3 4 5 6 7 8 9")(
+      stdio.sprintf(_, _, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    )
+
+  @Test def longValue0(): Unit =
+    vatest(c"%d", "0")(stdio.sprintf(_, _, 0L))
+  @Test def longValue1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1L))
+  @Test def longValueMinus1(): Unit =
+    vatest(c"%d", "-1")(stdio.sprintf(_, _, -1L))
+  @Test def longValueMin(): Unit = {
+    assumeNot32Bit()
+    vatest(c"%lld", "-9223372036854775808")(
+      stdio.sprintf(_, _, java.lang.Long.MIN_VALUE)
+    )
+  }
+  @Test def longValueMax(): Unit = {
+    assumeNot32Bit()
+    vatest(c"%lld", "9223372036854775807")(
+      stdio.sprintf(_, _, java.lang.Long.MAX_VALUE)
+    )
+  }
+  @Test def longArgs1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1L))
+  @Test def longArgs2(): Unit =
+    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1L, 2L))
+  @Test def longArgs3(): Unit =
+    vatest(c"%d %d %d", "1 2 3")(stdio.sprintf(_, _, 1L, 2L, 3L))
+  @Test def longArgs4(): Unit =
+    vatest(c"%d %d %d %d", "1 2 3 4")(stdio.sprintf(_, _, 1L, 2L, 3L, 4L))
+  @Test def longArgs5(): Unit =
+    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+      stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L)
+    )
+  @Test def longArgs6(): Unit =
+    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+      stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L, 6L)
+    )
+  @Test def longArgs7(): Unit =
+    vatest(c"%d %d %d %d %d %d %d", "1 2 3 4 5 6 7")(
+      stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L, 6L, 7L)
+    )
+  @Test def longArgs8(): Unit =
+    vatest(c"%d %d %d %d %d %d %d %d", "1 2 3 4 5 6 7 8")(
+      stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L)
+    )
+  @Test def longArgs9(): Unit =
+    vatest(c"%d %d %d %d %d %d %d %d %d", "1 2 3 4 5 6 7 8 9")(
+      stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
+    )
+
+  @Test def ubyteValueMin(): Unit =
+    vatest(c"%d", "0")(stdio.sprintf(_, _, UByte.MinValue))
+  @Test def ubyteValueMax(): Unit =
+    vatest(c"%d", "255")(stdio.sprintf(_, _, UByte.MaxValue))
+  @Test def ubyteArgs1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toUByte))
+  @Test def ubyteArgs2(): Unit =
+    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1.toUByte, 2.toUByte))
+  @Test def ubyteArgs3(): Unit =
+    vatest(c"%d %d %d", "1 2 3")(
+      stdio.sprintf(_, _, 1.toUByte, 2.toUByte, 3.toUByte)
+    )
+  @Test def ubyteArgs4(): Unit =
+    vatest(c"%d %d %d %d", "1 2 3 4")(
+      stdio.sprintf(_, _, 1.toUByte, 2.toUByte, 3.toUByte, 4.toUByte)
+    )
+  @Test def ubyteArgs5(): Unit =
+    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+      stdio.sprintf(_, _, 1.toUByte, 2.toUByte, 3.toUByte, 4.toUByte, 5.toUByte)
+    )
+  @Test def ubyteArgs6(): Unit =
+    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUByte,
+        2.toUByte,
+        3.toUByte,
+        4.toUByte,
+        5.toUByte,
+        6.toUByte
+      )
+    )
+  @Test def ubyteArgs7(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUByte,
+        2.toUByte,
+        3.toUByte,
+        4.toUByte,
+        5.toUByte,
+        6.toUByte,
+        7.toUByte
+      )
+    )
+  @Test def ubyteArgs8(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUByte,
+        2.toUByte,
+        3.toUByte,
+        4.toUByte,
+        5.toUByte,
+        6.toUByte,
+        7.toUByte,
+        8.toUByte
+      )
+    )
+  @Test def ubyteArgs9(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8 9"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUByte,
+        2.toUByte,
+        3.toUByte,
+        4.toUByte,
+        5.toUByte,
+        6.toUByte,
+        7.toUByte,
+        8.toUByte,
+        9.toUByte
+      )
+    )
+
+  @Test def ushortValueMin(): Unit =
+    vatest(c"%d", "0")(stdio.sprintf(_, _, UShort.MinValue))
+  @Test def ushortValueMax(): Unit =
+    vatest(c"%d", "65535")(stdio.sprintf(_, _, UShort.MaxValue))
+  @Test def ushortArgs1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toUShort))
+  @Test def ushortArgs2(): Unit =
+    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1.toUShort, 2.toUShort))
+  @Test def ushortArgs3(): Unit =
+    vatest(c"%d %d %d", "1 2 3")(
+      stdio.sprintf(_, _, 1.toUShort, 2.toUShort, 3.toUShort)
+    )
+  @Test def ushortArgs4(): Unit =
+    vatest(c"%d %d %d %d", "1 2 3 4")(
+      stdio.sprintf(_, _, 1.toUShort, 2.toUShort, 3.toUShort, 4.toUShort)
+    )
+  @Test def ushortArgs5(): Unit =
+    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUShort,
+        2.toUShort,
+        3.toUShort,
+        4.toUShort,
+        5.toUShort
+      )
+    )
+  @Test def ushortArgs6(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d",
+      "1 2 3 4 5 6"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUShort,
+        2.toUShort,
+        3.toUShort,
+        4.toUShort,
+        5.toUShort,
+        6.toUShort
+      )
+    )
+  @Test def ushortArgs7(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUShort,
+        2.toUShort,
+        3.toUShort,
+        4.toUShort,
+        5.toUShort,
+        6.toUShort,
+        7.toUShort
+      )
+    )
+  @Test def ushortArgs8(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUShort,
+        2.toUShort,
+        3.toUShort,
+        4.toUShort,
+        5.toUShort,
+        6.toUShort,
+        7.toUShort,
+        8.toUShort
+      )
+    )
+  @Test def ushortArgs9(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8 9"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUShort,
+        2.toUShort,
+        3.toUShort,
+        4.toUShort,
+        5.toUShort,
+        6.toUShort,
+        7.toUShort,
+        8.toUShort,
+        9.toUShort
+      )
+    )
+
+  @Test def uintValueMin(): Unit =
+    vatest(c"%u", "0")(stdio.sprintf(_, _, UInt.MinValue))
+  @Test def uintValueMax(): Unit =
+    vatest(c"%u", "4294967295")(stdio.sprintf(_, _, UInt.MaxValue))
+  @Test def uintArgs1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toUInt))
+  @Test def uintArgs2(): Unit =
+    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1.toUInt, 2.toUInt))
+  @Test def uintArgs3(): Unit =
+    vatest(c"%d %d %d", "1 2 3")(
+      stdio.sprintf(_, _, 1.toUInt, 2.toUInt, 3.toUInt)
+    )
+  @Test def uintArgs4(): Unit =
+    vatest(c"%d %d %d %d", "1 2 3 4")(
+      stdio.sprintf(_, _, 1.toUInt, 2.toUInt, 3.toUInt, 4.toUInt)
+    )
+  @Test def uintArgs5(): Unit =
+    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+      stdio.sprintf(_, _, 1.toUInt, 2.toUInt, 3.toUInt, 4.toUInt, 5.toUInt)
+    )
+  @Test def uintArgs6(): Unit =
+    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUInt,
+        2.toUInt,
+        3.toUInt,
+        4.toUInt,
+        5.toUInt,
+        6.toUInt
+      )
+    )
+  @Test def uintArgs7(): Unit =
+    vatest(c"%d %d %d %d %d %d %d", "1 2 3 4 5 6 7")(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUInt,
+        2.toUInt,
+        3.toUInt,
+        4.toUInt,
+        5.toUInt,
+        6.toUInt,
+        7.toUInt
+      )
+    )
+  @Test def uintArgs8(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUInt,
+        2.toUInt,
+        3.toUInt,
+        4.toUInt,
+        5.toUInt,
+        6.toUInt,
+        7.toUInt,
+        8.toUInt
+      )
+    )
+  @Test def uintArgs9(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8 9"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toUInt,
+        2.toUInt,
+        3.toUInt,
+        4.toUInt,
+        5.toUInt,
+        6.toUInt,
+        7.toUInt,
+        8.toUInt,
+        9.toUInt
+      )
+    )
+
+  @Test def ulongValueMin(): Unit = {
+    assumeNot32Bit()
+    vatest(c"%llu", "0")(stdio.sprintf(_, _, ULong.MinValue))
+  }
+  @Test def ulongValueMax(): Unit = {
+    assumeNot32Bit()
+    vatest(c"%llu", "18446744073709551615")(stdio.sprintf(_, _, ULong.MaxValue))
+  }
+  @Test def ulongArgs1(): Unit =
+    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toULong))
+  @Test def ulongArgs2(): Unit =
+    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1.toULong, 2.toULong))
+  @Test def ulongArgs3(): Unit =
+    vatest(c"%d %d %d", "1 2 3")(
+      stdio.sprintf(_, _, 1.toULong, 2.toULong, 3.toULong)
+    )
+  @Test def ulongArgs4(): Unit =
+    vatest(c"%d %d %d %d", "1 2 3 4")(
+      stdio.sprintf(_, _, 1.toULong, 2.toULong, 3.toULong, 4.toULong)
+    )
+  @Test def ulongArgs5(): Unit =
+    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+      stdio.sprintf(_, _, 1.toULong, 2.toULong, 3.toULong, 4.toULong, 5.toULong)
+    )
+  @Test def ulongArgs6(): Unit =
+    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+      stdio.sprintf(
+        _,
+        _,
+        1.toULong,
+        2.toULong,
+        3.toULong,
+        4.toULong,
+        5.toULong,
+        6.toULong
+      )
+    )
+  @Test def ulongArgs7(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toULong,
+        2.toULong,
+        3.toULong,
+        4.toULong,
+        5.toULong,
+        6.toULong,
+        7.toULong
+      )
+    )
+  @Test def ulongArgs8(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toULong,
+        2.toULong,
+        3.toULong,
+        4.toULong,
+        5.toULong,
+        6.toULong,
+        7.toULong,
+        8.toULong
+      )
+    )
+  @Test def ulongArgs9(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d %d",
+      "1 2 3 4 5 6 7 8 9"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1.toULong,
+        2.toULong,
+        3.toULong,
+        4.toULong,
+        5.toULong,
+        6.toULong,
+        7.toULong,
+        8.toULong,
+        9.toULong
+      )
+    )
+
+  @Test def floatArgs1(): Unit =
+    vatest(c"%1.1f", "1.1")(stdio.sprintf(_, _, 1.1f))
+  @Test def floatArgs2(): Unit =
+    vatest(c"%1.1f %1.1f", "1.1 2.2")(stdio.sprintf(_, _, 1.1f, 2.2f))
+  @Test def floatArgs3(): Unit =
+    vatest(c"%1.1f %1.1f %1.1f", "1.1 2.2 3.3")(
+      stdio.sprintf(_, _, 1.1f, 2.2f, 3.3f)
+    )
+  @Test def floatArgs4(): Unit =
+    vatest(c"%1.1f %1.1f %1.1f %1.1f", "1.1 2.2 3.3 4.4")(
+      stdio.sprintf(_, _, 1.1f, 2.2f, 3.3f, 4.4f)
+    )
+  @Test def floatArgs5(): Unit =
+    vatest(c"%1.1f %1.1f %1.1f %1.1f %1.1f", "1.1 2.2 3.3 4.4 5.5")(
+      stdio.sprintf(_, _, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f)
+    )
+  @Test def floatArgs6(): Unit =
+    vatest(c"%1.1f %1.1f %1.1f %1.1f %1.1f %1.1f", "1.1 2.2 3.3 4.4 5.5 6.6")(
+      stdio.sprintf(_, _, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f)
+    )
+  @Test def floatArgs7(): Unit =
+    vatest(
+      c"%1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1.1 2.2 3.3 4.4 5.5 6.6 7.7"
+    )(stdio.sprintf(_, _, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f))
+  @Test def floatArgs8(): Unit =
+    vatest(
+      c"%1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8"
+    )(stdio.sprintf(_, _, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 8.8f))
+  @Test def floatArgs9(): Unit =
+    vatest(
+      c"%1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9"
+    )(stdio.sprintf(_, _, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 8.8f, 9.9f))
+
+  @Test def doubleArgs1(): Unit =
+    vatest(c"%1.1f", "1.1")(stdio.sprintf(_, _, 1.1d))
+  @Test def doubleArgs2(): Unit =
+    vatest(c"%1.1f %1.1f", "1.1 2.2")(stdio.sprintf(_, _, 1.1d, 2.2d))
+  @Test def doubleArgs3(): Unit =
+    vatest(c"%1.1f %1.1f %1.1f", "1.1 2.2 3.3")(
+      stdio.sprintf(_, _, 1.1d, 2.2d, 3.3d)
+    )
+  @Test def doubleArgs4(): Unit =
+    vatest(c"%1.1f %1.1f %1.1f %1.1f", "1.1 2.2 3.3 4.4")(
+      stdio.sprintf(_, _, 1.1d, 2.2d, 3.3d, 4.4d)
+    )
+  @Test def doubleArgs5(): Unit =
+    vatest(c"%1.1f %1.1f %1.1f %1.1f %1.1f", "1.1 2.2 3.3 4.4 5.5")(
+      stdio.sprintf(_, _, 1.1d, 2.2d, 3.3d, 4.4d, 5.5d)
+    )
+  @Test def doubleArgs6(): Unit =
+    vatest(c"%1.1f %1.1f %1.1f %1.1f %1.1f %1.1f", "1.1 2.2 3.3 4.4 5.5 6.6")(
+      stdio.sprintf(_, _, 1.1d, 2.2d, 3.3d, 4.4d, 5.5d, 6.6d)
+    )
+  @Test def doubleArgs7(): Unit =
+    vatest(
+      c"%1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1.1 2.2 3.3 4.4 5.5 6.6 7.7"
+    )(stdio.sprintf(_, _, 1.1d, 2.2d, 3.3d, 4.4d, 5.5d, 6.6d, 7.7d))
+  @Test def doubleArgs8(): Unit =
+    vatest(
+      c"%1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8"
+    )(stdio.sprintf(_, _, 1.1d, 2.2d, 3.3d, 4.4d, 5.5d, 6.6d, 7.7d, 8.8d))
+  @Test def doubleArgs9(): Unit =
+    vatest(
+      c"%1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9"
+    )(stdio.sprintf(_, _, 1.1d, 2.2d, 3.3d, 4.4d, 5.5d, 6.6d, 7.7d, 8.8d, 9.9d))
+
+  @Test def mixArgs1(): Unit =
+    vatest(c"%d %1.1f", "1 1.1")(stdio.sprintf(_, _, 1, 1.1d))
+  @Test def mixArgs2(): Unit =
+    vatest(c"%d %d %1.1f %1.1f", "1 2 1.1 2.2")(
+      stdio.sprintf(_, _, 1, 2, 1.1d, 2.2d)
+    )
+  @Test def mixArgs3(): Unit =
+    vatest(c"%d %d %d %1.1f %1.1f %1.1f", "1 2 3 1.1 2.2 3.3")(
+      stdio.sprintf(_, _, 1, 2, 3, 1.1d, 2.2d, 3.3d)
+    )
+  @Test def mixArgs4(): Unit =
+    vatest(c"%d %d %d %d %1.1f %1.1f %1.1f %1.1f", "1 2 3 4 1.1 2.2 3.3 4.4")(
+      stdio.sprintf(_, _, 1, 2, 3, 4, 1.1d, 2.2d, 3.3d, 4.4d)
+    )
+  @Test def mixArgs5(): Unit =
+    vatest(
+      c"%d %d %d %d %d %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1 2 3 4 5 1.1 2.2 3.3 4.4 5.5"
+    )(stdio.sprintf(_, _, 1, 2, 3, 4, 5, 1.1d, 2.2d, 3.3d, 4.4d, 5.5d))
+  @Test def mixArgs6(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1 2 3 4 5 6 1.1 2.2 3.3 4.4 5.5 6.6"
+    )(stdio.sprintf(_, _, 1, 2, 3, 4, 5, 6, 1.1d, 2.2d, 3.3d, 4.4d, 5.5d, 6.6d))
+  @Test def mixArgs7(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1 2 3 4 5 6 7 1.1 2.2 3.3 4.4 5.5 6.6 7.7"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        1.1d,
+        2.2d,
+        3.3d,
+        4.4d,
+        5.5d,
+        6.6d,
+        7.7d
+      )
+    )
+  @Test def mixArgs8(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1 2 3 4 5 6 7 8 1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        1.1d,
+        2.2d,
+        3.3d,
+        4.4d,
+        5.5d,
+        6.6d,
+        7.7d,
+        8.8d
+      )
+    )
+  @Test def mixArgs9(): Unit =
+    vatest(
+      c"%d %d %d %d %d %d %d %d %d %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f %1.1f",
+      "1 2 3 4 5 6 7 8 9 1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9"
+    )(
+      stdio.sprintf(
+        _,
+        _,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        1.1d,
+        2.2d,
+        3.3d,
+        4.4d,
+        5.5d,
+        6.6d,
+        7.7d,
+        8.8d,
+        9.9d
+      )
+    )
+}


### PR DESCRIPTION
The NIR, it's code and partially compiler plugin were already prepared for supporting C VarArgs, `printf(format, ...)`. The only missing piece to allow for their usage was to update logic responsible for detecting usage of repeated params and adding additional rules when generating arguments taking varrargs as arguments. 

* Compiler plugins are now able to detect varargs in extern methods and generate correct arguments for their calls
* Resolved method signatures are now cached within a compilation unit (file) 
* Added bindings for C stdio methods taking var args, eg. `printf`, `sprintf`, `printf_s`, `scanf`
* Added tests for VarArgs based on the `CVarArgsListTest` 