### PR TITLE
Fix poisonous new lines escapes in `nir.Show` leading to linker failures

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -714,8 +714,9 @@ object Show {
       """([^\\]|^)\n""".r.replaceAllIn(
         s,
         _.matched.toSeq match {
-          case Seq(sngl)     => s"""\\\\n"""
-          case Seq(fst, snd) => s"""${fst}\\\\n"""
+          case Seq(sngl)     => raw"\\n"
+          case Seq('$', snd) => raw"\$$\\n"
+          case Seq(fst, snd) => raw"\${fst}\\n"
         }
       )
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -590,6 +590,10 @@ class IssuesTest {
     }
     assertEquals(Foo.fooLiteral, Foo.fooLazy)
   }
+  @Test def i3147(): Unit = {
+    // It's not a runtime, but linktime bug related to nir.Show new lines escapes for string literals
+    println("$\n")
+  }
 
   @Test def i3195(): Unit = {
     // Make sure that inlined calls are resetting the stack upon returning


### PR DESCRIPTION
Fixes #3147  
Our previous logic for escaping new lines in string literal for textual NIR and LLVM IR representation was crashing due to unescaped '$' character, which after inserting in the escaped string was leading to an invalid regex expression

