### PR TITLE
Fix #3206: posixlib unistd and monetary use new CVarArgs support

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/monetary.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/monetary.scala
@@ -3,107 +3,30 @@ package posix
 
 import scalanative.unsafe._
 
-import scalanative.posix.sys.types._
+import scalanative.posix.sys.types.{ssize_t, size_t}
 
 /** POSIX monetary.h for Scala
  *
  *  The Open Group Base Specifications
  *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
- *
- *  POSIX defines strfmon() and strfmon_l() using the "..." form of C variable
- *  arguments. Scala Native "supports native interoperability with C’s variadic
- *  argument list type (i.e. va_list), but not ... varargs".
- *
- *  This implementation supports up to 10 items in the variable arguments to
- *  strfmon() and strfmon_1().
  */
 
+@extern
 object monetary {
   type locale_t = locale.locale_t
-  private final val maxOutArgs = 10
 
   def strfmon(
       str: CString,
       max: size_t,
       format: CString,
-      argsIn: Double*
-  ): ssize_t = Zone { implicit z =>
-    val argsOut = new Array[Double](maxOutArgs)
-    val limit = Math.min(argsIn.size, maxOutArgs)
-
-    for (j <- 0 until limit)
-      argsOut(j) = argsIn(j)
-
-    // format: off
-    val nFormatted = monetaryExtern.strfmon_10(str, max, format,
-                                                 argsOut(0), argsOut(1),
-                                                 argsOut(2), argsOut(3),
-                                                 argsOut(4), argsOut(5),
-                                                 argsOut(6), argsOut(7),
-                                                 argsOut(8), argsOut(9)
-                                                 )
-    // format: on
-
-    nFormatted
-  }
+      vargs: Any*
+  ): ssize_t = extern
 
   def strfmon_l(
       str: CString,
       max: size_t,
       locale: locale_t,
       format: CString,
-      argsIn: Double*
-  ): ssize_t = Zone { implicit z =>
-    val argsOut = new Array[Double](maxOutArgs)
-    val limit = Math.min(argsIn.size, maxOutArgs)
-
-    for (j <- 0 until limit)
-      argsOut(j) = argsIn(j)
-
-    // format: off
-    val nFormatted = monetaryExtern.strfmon_l_10(str, max, locale, format, 
-                                                 argsOut(0), argsOut(1),
-                                                 argsOut(2), argsOut(3),
-                                                 argsOut(4), argsOut(5),
-                                                 argsOut(6), argsOut(7),
-                                                 argsOut(8), argsOut(9)
-                                                 )
-    // format: on
-
-    nFormatted
-  }
-
-}
-
-@extern
-object monetaryExtern {
-
-  // format: off
-  @name("scalanative_strfmon_10")
-  def strfmon_10(
-      str: CString,
-      max: size_t,
-      format: CString,
-      arg0: Double, arg1: Double,
-      arg2: Double, arg3: Double,
-      arg4: Double, arg5: Double,
-      arg6: Double, arg7: Double,
-      arg8: Double, arg9: Double
+      vargs: Any*
   ): ssize_t = extern
-  // format: on
-
-  // format: off
-  @name("scalanative_strfmon_l_10")
-  def strfmon_l_10(
-      str: CString,
-      max: size_t,
-      locale: monetary.locale_t,
-      format: CString,
-      arg0: Double, arg1: Double,
-      arg2: Double, arg3: Double,
-      arg4: Double, arg5: Double,
-      arg6: Double, arg7: Double,
-      arg8: Double, arg9: Double
-  ): ssize_t = extern
-  // format: on
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -65,12 +65,9 @@ object unistd {
   // XSI
   def encrypt(block: Ptr[Byte], edflag: Int): Unit = extern
 
-// Check _very_ carefully, may be issues with ... (and not varargs?)
-// Read & re-read that section in ReadTheDocs.
-// int		execl(const char *, const char *, ...);
-// int		execle(const char *, const char *, ...);
-// int		execlp(const char *, const char *, ...);
-
+  def execl(pathname: CString, arg: CString, vargs: Any*): CInt = extern
+  def execlp(file: CString, arg: CString, vargs: Any*): CInt = extern
+  def execle(pathname: CString, arg: CString, vargs: Any*): CInt = extern
   def execv(pathname: CString, argv: Ptr[CString]): CInt = extern
   def execve(pathname: CString, argv: Ptr[CString], envp: Ptr[CString]): CInt =
     extern


### PR DESCRIPTION
Fix #3206 

Two posixlib files now use the new CVarArgs (...) support. `unistd.scala` now defines three
previously missing `execl*()` methods. Workaround code was removed from `monetary.scala`.

Backport:  This PR depends upon, and owes a debt of gratitude to, PR #3204.  If that PR
                   gets backported, then this PR becomes eligible for backport.

Testing:  
1) `MonetaryTest` passes.

2) All of the posixlib `exec*()` methods are difficult to test in the SN `unit-tests` environment.
    I wrote a small private program to exercise `execl` before I submitted this PR.  It passes. 

    Later: To quell my anxieties, I extended this private program to additionally exercise both `execlp` 
                and `execle`.  Now all three pass locally.