### PR TITLE
Fix issues found in extended CI runs

### DIFF
--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -88,14 +88,16 @@ jobs:
           scala-version: ${{matrix.scala}}
           gc: ${{ matrix.gc }}
 
-
       - name: Run tests
         env:
           SCALANATIVE_MODE: ${{ matrix.build-mode }}
           SCALANATIVE_GC: ${{ matrix.gc }}
           SCALANATIVE_LTO: ${{ matrix.lto }}
           SCALANATIVE_OPTIMIZE: true
-        run: sbt "test-runtime ${{ matrix.scala }}"
+        run: |
+          export LLVM_BIN="$(brew --prefix llvm@15)/bin"
+          $LLVM_BIN/clang --version
+          sbt "test-runtime ${{ matrix.scala }}"
 
   run-scripted-tests:
     name: Scripted tests
@@ -185,10 +187,6 @@ jobs:
             junitTestOutputsNative${{env.project-version}}/test;
             scalaPartestJunitTests${{env.project-version}}/test
         run: |
-          # lld fails to link with BoehmGC when using shared library, force linking using static library
-          if [[ "${{matrix.gc}}" == "boehm" ]]; then 
-            unlink /usr/local/lib/libgc.dylib
-          fi
           export LLVM_BIN="$(brew --prefix llvm@15)/bin"
           $LLVM_BIN/clang --version
           sbt -J-Xmx5G "${TEST_COMMAND}"

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -122,11 +122,14 @@ jobs:
             lto: full
             gc: commix
     steps:
+      # Disable autocrlf setting, otherwise scalalib patches might not be possible to apply
+      - name: Setup git config
+        run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
       - uses: ./.github/actions/windows-setup-env
         with:
           scala-version: ${{matrix.scala}}
-  
+
       - name: Run tests
         run: >
           set SCALANATIVE_GC=${{matrix.gc}}&

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/StackTrace.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/StackTrace.c
@@ -10,7 +10,7 @@ void StackTrace_PrintStackTrace() {
     scalanative_unwind_init_local(cursor, context);
 
     while (scalanative_unwind_step(cursor) > 0) {
-        uint64_t offset, pc;
+        size_t offset, pc;
         scalanative_unwind_get_reg(cursor, scalanative_unw_reg_ip(), &pc);
         if (pc == 0) {
             break;

--- a/nativelib/src/main/scala/scala/scalanative/runtime/MemoryPool.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/MemoryPool.scala
@@ -78,7 +78,7 @@ object MemoryPool {
 final class MemoryPoolZone(private[this] val pool: MemoryPool) extends Zone {
   private[this] var tailPage = pool.claim()
   private[this] var headPage = tailPage
-  private[this] var largeAllocations: scala.Array[RawPtr] = null
+  private[this] var largeAllocations: scala.Array[Ptr[_]] = null
   private[this] var largeOffset = 0
 
   private def checkOpen(): Unit =
@@ -157,11 +157,11 @@ final class MemoryPoolZone(private[this] val pool: MemoryPool) extends Zone {
 
   private def allocLarge(size: CSize): Ptr[Byte] = {
     if (largeAllocations == null) {
-      largeAllocations = new scala.Array[RawPtr](16)
+      largeAllocations = new scala.Array[Ptr[_]](16)
     }
     if (largeOffset == largeAllocations.size) {
       val newLargeAllocations =
-        new scala.Array[RawPtr](largeAllocations.size * 2)
+        new scala.Array[Ptr[_]](largeAllocations.size * 2)
       Array.copy(
         largeAllocations,
         0,
@@ -171,11 +171,11 @@ final class MemoryPoolZone(private[this] val pool: MemoryPool) extends Zone {
       )
       largeAllocations = newLargeAllocations
     }
-    val result = libc.malloc(size)
+    val result = fromRawPtr[Byte](libc.malloc(size))
     largeAllocations(largeOffset) = result
     largeOffset += 1
 
-    fromRawPtr(result)
+    result
   }
 }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
@@ -11,6 +11,7 @@ object libc {
   def malloc(size: CSize): RawPtr = extern
   def realloc(ptr: RawPtr, size: CSize): RawPtr = extern
   def free(ptr: RawPtr): Unit = extern
+  def free(ptr: Ptr[_]): Unit = extern
   def strlen(str: CString): CSize = extern
   def wcslen(str: CWideString): CSize = extern
   def strcpy(dest: CString, src: CString): CString = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
@@ -23,6 +23,7 @@ object libc {
   def memset(dest: Ptr[_], ch: CInt, count: CSize): RawPtr = extern
   def memmove(dest: RawPtr, src: RawPtr, count: CSize): RawPtr = extern
   def remove(fname: CString): CInt = extern
+  def atexit(func: CFuncPtr0[Unit]): CInt = extern
 
   // Glue layer defined in libc
   @name("scalanative_atomic_compare_exchange_strong_byte")


### PR DESCRIPTION
* Don't use `scala.Array[RawPtr` in `MemoryPoolZone`, use boxed pointers instead
* When building with ASAN support free chunks allocated by `defaultMemoryPool` to prevent reporting them as memory leaks
* Set missing default newline character in git config for windows extended runtime run
* Use LLVM clang instead of Apple clang for running MaOS extended builds - it fails due to problems with atomics