### PR TITLE
Backport `Atomic{Integer,Long}.{getAndUpdate,updateAndGet}` to 0.4.x

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
@@ -1,5 +1,7 @@
 package java.util.concurrent.atomic
 
+import java.util.function.IntUnaryOperator
+
 class AtomicInteger(private[this] var value: Int)
     extends Number
     with Serializable {
@@ -53,6 +55,17 @@ class AtomicInteger(private[this] var value: Int)
     val newValue = value + delta
     value = newValue
     newValue
+  }
+
+  final def getAndUpdate(updateFunction: IntUnaryOperator): Int = {
+    val old = value
+    value = updateFunction.applyAsInt(old)
+    old
+  }
+
+  final def updateAndGet(updateFunction: IntUnaryOperator): Int = {
+    value = updateFunction.applyAsInt(value)
+    value
   }
 
   override def toString(): String =

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
@@ -1,5 +1,7 @@
 package java.util.concurrent.atomic
 
+import java.util.function.LongUnaryOperator
+
 class AtomicLong(private[this] var value: Long)
     extends Number
     with Serializable {
@@ -52,6 +54,17 @@ class AtomicLong(private[this] var value: Long)
     val newValue = value + delta
     value = newValue
     newValue
+  }
+
+  final def getAndUpdate(updateFunction: LongUnaryOperator): Long = {
+    val old = value
+    value = updateFunction.applyAsLong(old)
+    old
+  }
+
+  final def updateAndGet(updateFunction: LongUnaryOperator): Long = {
+    value = updateFunction.applyAsLong(value)
+    value
   }
 
   override def toString(): String =

--- a/javalib/src/main/scala/java/util/function/LongUnaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/LongUnaryOperator.scala
@@ -1,0 +1,19 @@
+// Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
+package java.util.function
+
+@FunctionalInterface
+trait LongUnaryOperator {
+  def applyAsLong(operand: Long): Long
+
+  def andThen(after: LongUnaryOperator): LongUnaryOperator = { (l: Long) =>
+    after.applyAsLong(applyAsLong(l))
+  }
+
+  def compose(before: LongUnaryOperator): LongUnaryOperator = { (l: Long) =>
+    applyAsLong(before.applyAsLong(l))
+  }
+}
+
+object LongUnaryOperator {
+  def identity(): LongUnaryOperator = (l: Long) => l
+}


### PR DESCRIPTION
This is a lazy backport PR. These atomic classes are already properly implemented in 0.5.x branch, just adding them to 0.4.x to unblock some downstream work.