### PR TITLE
Selective compilation of native sources using `@compile` annotation

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/atomic.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/atomic.scala
@@ -8,7 +8,9 @@ import scala.scalanative.annotation._
 import scala.language.implicitConversions
 
 
-@extern object atomic {
+@extern 
+@compile("atomic.c")
+object atomic {
   type memory_order = Int // enum
   @extern object memory_order{
     @name("scalanative_atomic_memory_order_relaxed")

--- a/clib/src/main/scala/scala/scalanative/libc/errno.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/errno.scala
@@ -5,7 +5,9 @@ import scalanative.unsafe._
 
 @extern object errno extends errno
 
-@extern private[scalanative] trait errno {
+@extern
+@compile("errno.c")
+ private[scalanative] trait errno {
   @name("scalanative_errno")
   def errno: CInt = extern
   @name("scalanative_set_errno")

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -94,6 +94,7 @@ object GC {
    *  execution of the thread.
    */
   @name("scalanative_gc_safepoint")
+  @compile("gc/shared/safepoint.c")
   private[scalanative] var safepoint: RawPtr = extern
 
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -144,6 +144,7 @@ object NativeThread {
   }
 
   @extern
+  @compile("nativeThreadTLS.c")
   private object TLS {
     @name("scalanative_assignCurrentThread")
     def assignCurrentThread(
@@ -160,6 +161,7 @@ object NativeThread {
 
   @extern object Platform {
     @blocking
+    @compile("yield_processor.c")
     @name("scalanative_yield_processor")
     def yieldProcessor(): Unit = extern
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -1,10 +1,10 @@
 package scala.scalanative
 package runtime
 
-import scala.scalanative.unsafe.{CSize, CString, CFuncPtr2, extern, name}
-import scala.scalanative.unsafe.CInt
+import scala.scalanative.unsafe._
 
 @extern
+@compile("platform/platform.c")
 object Platform {
   @name("scalanative_platform_is_freebsd")
   def isFreeBSD(): Boolean = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package runtime
 
-import scala.scalanative.unsafe.{CLongLong, extern}
+import scala.scalanative.unsafe.{CLongLong, extern, compile}
 
 @extern
 object time {
@@ -11,6 +11,7 @@ object time {
    *  @return
    *    increasing time hopefully at better than millisecond resolution
    */
+  @compile("time_nano.c")
   def scalanative_nano_time(): CLongLong = extern
 
   /** Milliseconds from the UNIX epoch to implement
@@ -19,6 +20,7 @@ object time {
    *  @return
    *    time in millis (UTC)
    */
+  @compile("time_millis.c")
   def scalanative_current_time_millis(): CLongLong = extern
 
   /** Time zone offset in seconds from UTC. Negative to the west and positive to
@@ -27,5 +29,6 @@ object time {
    *  @return
    *    offset in seconds from UTC
    */
+  @compile("time_zone_offset.c")
   def scalanative_time_zone_offset(): CLongLong = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -4,6 +4,9 @@ package runtime
 import scalanative.unsafe._
 
 @extern
+@compile("platform/posix/libunwind")
+@compile("platform/posix/unwind.c")
+@compile("platform/windows/unwind.c")
 object unwind {
   @name("scalanative_unwind_get_context")
   def get_context(context: Ptr[Byte]): CInt = extern

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/compile.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/compile.scala
@@ -1,0 +1,15 @@
+package scala.scalanative
+package unsafe
+
+/** An annotation that is used to automatically compile foreign code if
+ *  annotated symbol would be used in linked application
+ *  @param sourcePath
+ *    relative path the C, C++, Assembly or other support source file. The path
+ *    would be resolved from the `resources/scala-native` directory of current
+ *    project.
+ *  @param compileOptions
+ *    list of optional compiler options which would be applied when compiling
+ *    the source files
+ */
+final class compile(sourcePath: String, compileOptions: String*)
+    extends scala.annotation.StaticAnnotation

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -29,6 +29,7 @@ object Attr {
   case object Stub extends Attr
   case class Extern(blocking: Boolean) extends Attr
   final case class Link(name: String) extends Attr
+  final case class Compile(relPath: String, options: Seq[String]) extends Attr
   case object Abstract extends Attr
   case object Volatile extends Attr
   case object Final extends Attr
@@ -45,7 +46,8 @@ final case class Attrs(
     isAbstract: Boolean = false,
     isVolatile: Boolean = false,
     isFinal: Boolean = false,
-    links: Seq[Attr.Link] = Seq.empty
+    compiles: Seq[Attr.Compile] = Nil,
+    links: Seq[Attr.Link] = Nil
 ) {
   def toSeq: Seq[Attr] = {
     val out = Seq.newBuilder[Attr]
@@ -59,6 +61,7 @@ final case class Attrs(
     if (isAbstract) out += Abstract
     if (isVolatile) out += Volatile
     if (isFinal) out += Final
+    out ++= compiles
     out ++= links
 
     out.result()
@@ -78,6 +81,7 @@ object Attrs {
     var isBlocking = false
     var isVolatile = false
     var isFinal = false
+    val compiles = Seq.newBuilder[Attr.Compile]
     val links = Seq.newBuilder[Attr.Link]
 
     attrs.foreach {
@@ -87,12 +91,13 @@ object Attrs {
       case Extern(blocking) =>
         isExtern = true
         isBlocking = blocking
-      case Dyn             => isDyn = true
-      case Stub            => isStub = true
-      case link: Attr.Link => links += link
-      case Abstract        => isAbstract = true
-      case Volatile        => isVolatile = true
-      case Final           => isFinal = true
+      case Dyn                   => isDyn = true
+      case Stub                  => isStub = true
+      case compile: Attr.Compile => compiles += compile
+      case link: Attr.Link       => links += link
+      case Abstract              => isAbstract = true
+      case Volatile              => isVolatile = true
+      case Final                 => isFinal = true
     }
 
     new Attrs(
@@ -106,6 +111,7 @@ object Attrs {
       isAbstract = isAbstract,
       isVolatile = isVolatile,
       isFinal = isFinal,
+      compiles = compiles.result(),
       links = links.result()
     )
   }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -99,6 +99,12 @@ object Show {
       case Attr.Extern(isBlocking) =>
         str("extern")
         if (isBlocking) str(" blocking")
+      case Attr.Compile(path, options) => 
+        str("compile(")
+        str(escapeQuotes(path))
+        str(", opts=[")
+        str(options.map(escapeQuotes).mkString(", "))
+        str("])")
       case Attr.Link(name) =>
         str("link(\"")
         str(escapeQuotes(name))

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -77,6 +77,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     case T.DynAttr      => Attr.Dyn
     case T.StubAttr     => Attr.Stub
     case T.ExternAttr   => Attr.Extern(getBool())
+    case T.CompileAttr  => Attr.Compile(getUTF8String(), getSeq(getUTF8String()) )
     case T.LinkAttr     => Attr.Link(getUTF8String())
     case T.AbstractAttr => Attr.Abstract
     case T.VolatileAttr => Attr.Volatile

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -109,6 +109,10 @@ final class BinarySerializer {
     case Attr.Extern(isBlocking) =>
       putInt(T.ExternAttr)
       putBool(isBlocking)
+    case Attr.Compile(path, opts) =>
+      putInt(T.CompileAttr)
+      putUTF8String(path)
+      putSeq(opts)(putUTF8String)
     case Attr.Link(s)  => putInt(T.LinkAttr); putUTF8String(s)
     case Attr.Abstract => putInt(T.AbstractAttr)
     case Attr.Volatile => putInt(T.VolatileAttr)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -23,7 +23,8 @@ object Tags {
   final val DidOptAttr = 1 + NoOptAttr
   final val BailOptAttr = 1 + DidOptAttr
   final val ExternAttr = 1 + BailOptAttr
-  final val LinkAttr = 1 + ExternAttr
+  final val CompileAttr = 1 + ExternAttr
+  final val LinkAttr = 1 + CompileAttr
   final val DynAttr = 1 + LinkAttr
   final val StubAttr = 1 + DynAttr
   final val AbstractAttr = 1 + StubAttr

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -27,6 +27,7 @@ trait NirDefinitions {
     lazy val RawPtrClass = getRequiredClass("scala.scalanative.runtime.RawPtr")
 
     lazy val NameClass = getRequiredClass("scala.scalanative.unsafe.name")
+    lazy val CompileClass = getRequiredClass("scala.scalanative.unsafe.compile")
     lazy val LinkClass = getRequiredClass("scala.scalanative.unsafe.link")
     lazy val ExternClass = getRequiredClass(
       "scala.scalanative.unsafe.package$extern"

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -30,6 +30,7 @@ final class NirDefinitions()(using ctx: Context) {
 
   @tu lazy val StubClass = requiredClass("scala.scalanative.annotation.stub")
   @tu lazy val NameClass = requiredClass("scala.scalanative.unsafe.name")
+  @tu lazy val CompileClass = requiredClass("scala.scalanative.unsafe.compile")
   @tu lazy val LinkClass = requiredClass("scala.scalanative.unsafe.link")
   @tu lazy val ExternClass = requiredClass("scala.scalanative.unsafe.extern")
   @tu lazy val BlockingClass = requiredClass("scala.scalanative.unsafe.blocking")

--- a/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe.{CInt, extern, name}
+import scalanative.unsafe._
 
 @extern object errno extends errno
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -9,8 +9,9 @@ import scala.scalanative.posix.sys.types._
 // SUSv2 version is used for compatibility
 // see http://pubs.opengroup.org/onlinepubs/007908799/xsh/threads.html
 
-@link("pthread")
 @extern
+@link("pthread")
+@compile("pthread.c")
 object pthread {
 
   // simpify definitions - not in spec

--- a/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
@@ -1,10 +1,11 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe.{CInt, CString, CStruct5, extern, name, Ptr}
+import scalanative.unsafe._
 import scalanative.posix.sys.types.{uid_t, gid_t}
 
 @extern
+@compile("pwd.c")
 object pwd {
 
   type passwd = CStruct5[

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -10,7 +10,9 @@ import scala.scalanative.posix.signal.sigevent
 
 @extern object time extends time
 
-@extern trait time extends libc.time {
+@extern 
+@compile("time.c")
+trait time extends libc.time {
 
   type clock_t = types.clock_t
   type clockid_t = types.clockid_t

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -9,6 +9,7 @@ import scalanative.posix.sys.types
  *    [[https://scala-native.readthedocs.io/en/latest/lib/posixlib.html]]
  */
 @extern
+@compile("unistd.c")
 object unistd {
 
   type gid_t = types.gid_t

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -5,11 +5,12 @@ import java.nio.file.{Files, Path, Paths}
 
 import scalanative.build.IO.RichPath
 import scalanative.build.NativeLib._
+import scalanative.util.Scope
+import scalanative.io.VirtualDirectory
+import scalanative.linker.ClassPath
+import scalanative.linker.CompilationRequests
 
 private[scalanative] object Filter {
-
-  /** To find filter file */
-  private val nativeProjectProps = s"${nativeCodeDir}.properties"
 
   /** Filter the `nativelib` source files with special logic to select GC and
    *  optional components.
@@ -18,70 +19,42 @@ private[scalanative] object Filter {
    *    The configuration of the toolchain.
    *  @param linkerResult
    *    The results from the linker.
-   *  @param destPath
+   *  @param unpackedPath
    *    The unpacked location of the Scala Native nativelib.
-   *  @param allPaths
-   *    The native paths found for this library
    *  @return
    *    The paths filtered to be included in the compile.
    */
   def filterNativelib(
       config: Config,
       linkerResult: linker.Result,
-      destPath: Path,
-      allPaths: Seq[Path]
-  ): (Seq[Path], Config) = {
-    val nativeCodePath = destPath.resolve(nativeCodeDir)
-    // check if filtering is needed, o.w. return all paths
-    findFilterProperties(nativeCodePath).fold((allPaths, config)) { file =>
-      // predicate to check if given file path shall be compiled
-      // we only include sources of the current gc and exclude
-      // all optional dependencies if they are not necessary
-      val optPath = nativeCodePath.resolve("optional").abs
-      val (gcPath, gcIncludePaths, gcSelectedPaths) = {
-        val gcPath = nativeCodePath.resolve("gc")
-        val gcIncludePaths = config.gc.include.map(gcPath.resolve(_).abs)
-        val selectedGC = gcPath.resolve(config.gc.name).abs
-        val selectedGCPath = selectedGC +: gcIncludePaths
-        (gcPath.abs, gcIncludePaths, selectedGCPath)
+      nativeLib: NativeLib
+  ): Seq[nir.Attr.Compile] = {
+    val toCompile = linkerResult.compilations
+    if (toCompile.isEmpty) Nil
+    else
+      Scope { implicit scope: Scope =>
+        val cp = ClassPath(VirtualDirectory.real(nativeLib.src))
+        toCompile
+          .collect {
+            case CompilationRequests(ctx, name) if cp.contains(name) => ctx
+          }
+          .groupBy(_.relPath)
+          .toSeq
+          .map {
+            case (path, seq) =>
+              nir.Attr.Compile(
+                path,
+                seq.foldLeft(Seq.empty[String])(_ ++ _.options).distinct
+              )
+          }
       }
 
-      def include(path: String) = {
-        if (path.contains(optPath)) {
-          val name = Paths.get(path).toFile.getName.split("\\.").head
-          linkerResult.links.exists(_.name == name)
-        } else if (path.contains(gcPath)) {
-          gcSelectedPaths.exists(path.contains)
-        } else {
-          true
-        }
-      }
-
-      // All the .o files are kept but we pass on the
-      // included files to the link phase
-      val includePaths = allPaths.map(_.abs).filter(include)
-
-      val projectConfig = config.withCompilerConfig(
-        _.withCompileOptions(
-          config.compileOptions ++ gcIncludePaths.map("-I" + _)
-        )
-      )
-      val projectPaths = includePaths.map(Paths.get(_))
-      (projectPaths, projectConfig)
-    }
-  }
-
-  /** Check for a filtering properties file in destination native code
-   *  directory.
-   *
-   *  @param nativeCodePath
-   *    The native code directory
-   *  @return
-   *    The optional path to the file or none
-   */
-  private def findFilterProperties(nativeCodePath: Path): Option[Path] = {
-    val file = nativeCodePath.resolve(nativeProjectProps)
-    if (Files.exists(file)) Some(file)
-    else None
+    // val projectConfig = config.withCompilerConfig(
+    //   _.withCompileOptions(
+    //     config.compileOptions ++ gcIncludePaths.map("-I" + _)
+    //   )
+    // )
+    // val projectPaths = includePaths.map(Paths.get(_))
+    // Result(projectPaths, projectConfig)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -214,11 +214,12 @@ final class Field(
     owner.asInstanceOf[Class].fields.indexOf(this)
 }
 
-final class Result(
+final case class Result(
     val infos: mutable.Map[Global, Info],
     val entries: Seq[Global],
     val unavailable: Seq[Global],
     val referencedFrom: mutable.Map[Global, Global],
+    val compilations: Set[CompilationRequests],
     val links: Seq[Attr.Link],
     val defns: Seq[Defn],
     val dynsigs: Seq[Sig],
@@ -233,3 +234,5 @@ final class Result(
   lazy val StringCachedHashCodeField = infos(Rt.StringCachedHashCodeName)
     .asInstanceOf[Field]
 }
+
+case class CompilationRequests(attrs: nir.Attr.Compile, requestedBy: Global.Top)


### PR DESCRIPTION
POC for selective compilation of only used sources, similar to the usage of `@link` annotation. 
This should allow moving zlib bindings to javalib and resolve #2778 problems when defining glue code requiring external libraries