### PR TITLE
Update sbt to 1.5.8 for scripted tests

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -6,7 +6,7 @@ Environment setup
 Scala Native has the following build dependencies:
 
 * Java 8 or newer
-* sbt 1.1.6 or newer
+* sbt 1.5.8 or newer
 * LLVM/Clang 6.0 or newer
 
 And following completely optional runtime library dependencies:

--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -81,19 +81,14 @@ object Commands {
             |   "-Dscala.version=$version" :+
             |   "-Dscala213.version=${ScalaVersions.scala213}"
             |}""".stripMargin
-      // Scala 3 is supported since sbt 1.5.0
+      // Scala 3 is supported since sbt 1.5.0. 1.5.8 is used.
       // Older versions set incorrect binary version
       val isScala3 = version.startsWith("3.")
-      val overrideSbtVersion =
-        if (isScala3)
-          """set sbtScalaNative/sbtVersion := "1.5.0" """ :: Nil
-        else Nil
       val scalaVersionTests =
         if (isScala3) "scala3/*"
         else ""
 
       setScriptedLaunchOpts ::
-        overrideSbtVersion :::
         s"sbtScalaNative/scripted ${scalaVersionTests} run/*" ::
         state
   }

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -18,7 +18,8 @@ object ScalaVersions {
   val scala213: String = crossScala213.last
   val scala3: String = "3.1.3"
 
-  val sbt10Version: String = "1.1.6" // minimum version
+  // minimum version - 1.5 is required for Scala 3 and 1.5.8 has log4j vulnerability fixed
+  val sbt10Version: String = "1.5.8"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/scripted-tests/run/hello-scala-app/build.sbt
+++ b/scripted-tests/run/hello-scala-app/build.sbt
@@ -10,12 +10,3 @@ scalaVersion := {
   else scalaVersion
 }
 
-// Old versions of sbt (like 1.1.6 which is being used) don't include
-// Scala version specific directiories and has problem with finding files in them
-Compile / sources ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, _)) =>
-      sourceDirectory.value / "main" / "scala-2" / "HelloScalaApp.scala" :: Nil
-    case _ => Nil
-  }
-}

--- a/scripted-tests/run/hello-scala-app/build.sbt
+++ b/scripted-tests/run/hello-scala-app/build.sbt
@@ -9,4 +9,3 @@ scalaVersion := {
     )
   else scalaVersion
 }
-


### PR DESCRIPTION
As discussed in #3110, update minimum `sbt` version. Version `1.5.0` is the first that supports Scala 3 and `1.5.8` is the last in the series and also has the log4f vulnerability fixed. `sbt` `1.5.8` was released on Dec 20, 2021.