### PR TITLE
Improve resolving repeated parameters in Scala3

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -311,27 +311,18 @@ trait NirGenType(using Context) {
     import core.Phases._
     val repeatedParams = if (sym.isExtern) {
       atPhase(typerPhase) {
-        sym.paramInfo match {
+        sym.paramInfo.stripPoly match {
           // @extern def foo(a: Int): Int
           case MethodTpe(paramNames, paramTypes, _) =>
             for (name, tpe) <- paramNames zip paramTypes
             yield name -> tpe.isRepeatedParam
-          // @extern def foo[T](ptr: Ptr[T]): Int
-          case PolyType(_, MethodTpe(paramNames, paramTypes, _)) =>
-            for (name, tpe) <- paramNames zip paramTypes
-            yield name -> tpe.isRepeatedParam
-          // @extern def foo: Int
-          case ExprType(_) => Nil
-          // @extern var foo: Int
-          case TypeRef(_, _) => Nil
-          // @extern def foo: Ptr[Int]
-          case AppliedType(_, _) => Nil
-          case _ =>
+          case t if t.isVarArgsMethod =>
             report.warning(
               "Unable to resolve method sig params for symbol, extern VarArgs would not work",
               sym.srcPos
             )
             Nil
+          case _ => Nil
         }
       }.toMap
     } else Map.empty

--- a/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -421,4 +421,15 @@ class NIRCompilerTest extends AnyFlatSpec with Matchers with Inspectors {
     }.getMessage should include(CannotExportField)
   }
 
+  // https://github.com/scala-native/scala-native/issues/3228
+  it should "allow to define fields in extern object" in NIRCompiler(_.compile {
+    """
+    |import scala.scalanative.unsafe._
+    |
+    |@extern
+    |object Foo {
+    |  final val bar = 42
+    |}""".stripMargin
+  })
+
 }


### PR DESCRIPTION
Fixes #3228 

Typically extern objects should not be allowed to contain any non-extern fields of methods. However, `final val` was accepted in the previous version for some reason.