### PR TITLE
Implement posixlib dlfcn

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -16,7 +16,7 @@ C Header          Scala Native Module
 `cpio.h`_         scala.scalanative.posix.cpio_
 `ctype.h`_        scala.scalanative.posix.ctype_
 `dirent.h`_       scala.scalanative.posix.dirent_
-`dlfcn.h`_        N/A
+`dlfcn.h`_        scala.scalanative.posix.dlfcn_
 `errno.h`_        scala.scalanative.posix.errno_
 `fcntl.h`_        scala.scalanative.posix.fcntl_
 `fenv.h`_         scala.scalanative.posix.fenv_
@@ -181,6 +181,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.ctype: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/ctype.scala
 .. _scala.scalanative.posix.cpio: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/cpio.scala
 .. _scala.scalanative.posix.dirent: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
+.. _scala.scalanative.posix.dlfcn: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
 .. _scala.scalanative.posix.errno: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
 .. _scala.scalanative.posix.fcntl: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
 .. _scala.scalanative.posix.fenv: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/fenv.scala

--- a/posixlib/src/main/resources/scala-native/dlfcn.c
+++ b/posixlib/src/main/resources/scala-native/dlfcn.c
@@ -1,0 +1,14 @@
+#if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
+    (defined(__APPLE__) && defined(__MACH__))
+
+#include <dlfcn.h>
+
+int scalanative_rtld_lazy() { return RTLD_LAZY; };
+
+int scalanative_rtld_now() { return RTLD_NOW; };
+
+int scalanative_rtld_global() { return RTLD_GLOBAL; };
+
+int scalanative_rtld_local() { return RTLD_LOCAL; };
+
+#endif // Unix or Mac OS

--- a/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
@@ -1,0 +1,40 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+/** POSIX dlfcn.h for Scala
+ *
+ *  The Open Group Base Specifications
+ *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
+ */
+
+@link("dl")
+@extern object dlfcn {
+
+// Symbolic constants
+
+  @name("scalanative_rtld_lazy")
+  def RTLD_LAZY: CInt = extern
+
+  @name("scalanative_rtld_now")
+  def RTLD_NOW: CInt = extern
+
+  @name("scalanative_rtld_global")
+  def RTLD_GLOBAL: CInt = extern
+
+  @name("scalanative_rtld_local")
+  def RTLD_LOCAL: CInt = extern
+
+// Methods
+
+  // Convention: A C "void *" is represented in Scala Native as a "Ptr[Byte]".
+
+  def dlclose(handle: Ptr[Byte]): Int = extern
+
+  def dlerror(): CString = extern
+
+  def dlopen(filename: CString, flags: Int): Ptr[Byte] = extern
+
+  def dlsym(handle: Ptr[Byte], symbol: CString): Ptr[Byte] = extern
+}

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/DlfcnTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/DlfcnTest.scala
@@ -27,7 +27,7 @@ class DlfcnTest {
         if (is32BitPlatform)
           "/lib/i386-linux-gnu/"
         else if (PlatformExt.isArm64)
-          "/lib/aarch64-linux-gnu"
+          "/usr/lib/aarch64-linux-gnu"
         else
           "/lib/x86_64-linux-gnu"
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/DlfcnTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/DlfcnTest.scala
@@ -26,6 +26,8 @@ class DlfcnTest {
       val soFilePrefix =
         if (is32BitPlatform)
           "/lib/i386-linux-gnu/"
+        else if (PlatformExt.isArm64)
+          "/lib/aarch64-linux-gnu"
         else
           "/lib/x86_64-linux-gnu"
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/DlfcnTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/DlfcnTest.scala
@@ -1,0 +1,84 @@
+package org.scalanative.testsuite.posixlib
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalanative.meta.LinktimeInfo.isLinux
+import scala.scalanative.runtime.PlatformExt
+
+import java.io.File
+
+import scala.scalanative.unsafe._
+
+import scala.scalanative.posix.dlfcn._
+
+class DlfcnTest {
+
+  @Test def dlfcnOpensAndObtainsSymbolAddressLinux(): Unit = {
+
+    /* With some work, dlfcn could be tested on macOS.
+     * One would have to find a suitable "known" .so file.
+     * Same song, next verse for FreeBSD.
+     */
+    assumeTrue(
+      "dlfcn.scala is tested only on Linux platforms",
+      isLinux
+    )
+
+    if (isLinux) Zone { implicit z =>
+      val soFilePrefix =
+        if (is32BitPlatform)
+          "/lib/i386-linux-gnu/"
+        else
+          "/lib/x86_64-linux-gnu"
+
+      val soFile = s"${soFilePrefix}/libc.so.6"
+
+      /* Ensure the file exists before trying to "dlopen()" it.
+       * Someday the ".so.6" suffix is going to change to ".so.7" or such.
+       * When it does do a "soft failure", rather than failing the entire
+       * build.
+       */
+      assumeTrue(
+        s"shared library ${soFile} not found",
+        File(soFile).exists()
+      )
+
+      val handle = dlopen(toCString(soFile), RTLD_LAZY | RTLD_LOCAL)
+      assertNotNull(s"dlopen of ${soFile} failed", handle)
+
+      try {
+        val symbol = "strlen"
+        val symbolC = toCString(symbol)
+
+        val cFunc = dlsym(handle, symbolC)
+        assertNotNull(s"dlsym lookup of '${symbol}' failed", cFunc)
+
+        // Have symbol, does it function (sic)?
+        type StringLengthFn = CFuncPtr1[CString, Int]
+        val func: StringLengthFn = CFuncPtr.fromPtr[StringLengthFn](cFunc)
+
+        assertEquals(
+          s"executing symbol '${symbol}' failed",
+          symbol.length(),
+          func(symbolC)
+        )
+
+        val missingSymbol = "NOT_IN_LIBC"
+
+        val func2 = dlsym(handle, toCString(missingSymbol))
+        assertNull(s"dlsym lookup of ${symbol} should have failed", func2)
+
+        val msg = fromCString(dlerror())
+        // It is always chancy trying to match exact text. Go for suffix here.
+        assertTrue(
+          s"dlerror returned msg: |${msg}|",
+          msg.endsWith(s"undefined symbol: ${missingSymbol}")
+        )
+      } finally {
+        dlclose(handle)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Open Group  `dlfcn.h`  is now implemented in posixlib.  The key methods in this file are
`dlopen` and `dlsym`. These allow dynamically loading symbols from shareable 
libraries. Given the right kind of symbols,  the symbol can then be executed.

This is tested for Linux & macOS.  It probably works but is untested on FreeBSD.
It is not expected to work,as is,  on Windows.