### PR TITLE
Fix handling empty list of var args for extern method in Scala 2.13 

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2596,6 +2596,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                   }
                   res += promotedArg
                 }
+              // Scala 2.13 only
+              case Select(_, name) if name == definitions.NilModule.name => ()
               case _ =>
                 reporter.error(
                   argp.pos,

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
@@ -21,7 +21,8 @@ class CVarArgListTest {
       val got = fromCString(buff)
       assertTrue(s"$got != $output", got == output)
     }
-
+  @Test def empty(): Unit =
+    vatest(c"hello", Seq(), "hello")
   @Test def byteValue0(): Unit =
     vatest(c"%d", Seq(0.toByte), "0")
   @Test def byteValue1(): Unit =

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgTest.scala
@@ -21,6 +21,8 @@ class CVarArgTest {
     assertEquals(got, output)
   }
 
+  @Test def empty(): Unit =
+    vatest(c"hello", "hello")(stdio.sprintf(_, _))
   @Test def byteValue0(): Unit =
     vatest(c"%d", "0")(stdio.sprintf(_, _, 0.toByte))
   @Test def byteValue1(): Unit =


### PR DESCRIPTION
Fixes compilation error when trying to compiling calls to extern methods using variadic arguments lists when not providing any variadic arguments

Fixes #3239 