### PR TITLE
Report error when extern definition is marked as inlined

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
@@ -1,0 +1,80 @@
+package scala.scalanative.nscplugin
+
+import dotty.tools.dotc.plugins.PluginPhase
+import dotty.tools._
+import dotc._
+import dotc.ast.tpd._
+import dotc.transform.SymUtils.setter
+import core.Contexts._
+import core.Definitions
+import core.Names._
+import core.Symbols._
+import core.Types._
+import core.StdNames._
+import core.Constants.Constant
+import NirGenUtil.ContextCached
+import dotty.tools.dotc.core.Flags
+
+/** This phase does:
+ *    - handle TypeApply -> Apply conversion for intrinsic methods
+ */
+object PostInlineNativeInterop {
+  val name = "scalanative-prepareInterop-postinline"
+}
+
+class PostInlineNativeInterop extends PluginPhase {
+  override val runsAfter = Set(transform.Inlining.name, PrepNativeInterop.name)
+  override val runsBefore = Set(transform.FirstTransform.name)
+  val phaseName = PostInlineNativeInterop.name
+  override def description: String = "prepare ASTs for Native interop"
+
+  def defn(using Context): Definitions = ctx.definitions
+  def defnNir(using Context): NirDefinitions = NirDefinitions.get
+
+  private def isTopLevelExtern(dd: ValOrDefDef)(using Context) = {
+    dd.rhs.symbol == defnNir.UnsafePackage_extern &&
+    dd.symbol.isWrappedToplevelDef
+  }
+
+  private class DealiasTypeMapper(using Context) extends TypeMap {
+    override def apply(tp: Type): Type =
+      val sym = tp.typeSymbol
+      val dealiased =
+        if sym.isOpaqueAlias then sym.opaqueAlias
+        else tp
+      dealiased.widenDealias match
+        case AppliedType(tycon, args) =>
+          AppliedType(this(tycon), args.map(this))
+        case ty => ty
+  }
+
+  override def transformTypeApply(tree: TypeApply)(using Context): Tree = {
+    val TypeApply(fun, tArgs) = tree
+    val defnNir = this.defnNir
+    def dealiasTypeMapper = DealiasTypeMapper()
+
+    // sizeOf[T] -> sizeOf(classOf[T])
+    fun.symbol match
+      case defnNir.Intrinsics_sizeOfType =>
+        val tpe = dealiasTypeMapper(tArgs.head.tpe)
+        cpy
+          .Apply(tree)(
+            ref(defnNir.Intrinsics_sizeOf),
+            List(Literal(Constant(tpe)))
+          )
+          .withAttachment(NirDefinitions.NonErasedType, tpe)
+
+      // alignmentOf[T] -> alignmentOf(classOf[T])
+      case defnNir.Intrinsics_alignmentOfType =>
+        val tpe = dealiasTypeMapper(tArgs.head.tpe)
+        cpy
+          .Apply(tree)(
+            ref(defnNir.Intrinsics_alignmentOf),
+            List(Literal(Constant(tpe)))
+          )
+          .withAttachment(NirDefinitions.NonErasedType, tpe)
+
+      case _ => tree
+  }
+
+}

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -51,5 +51,5 @@ class ScalaNativePlugin extends StandardPlugin:
           }
         case (config, _) => config
       }
-    List(PrepNativeInterop(), GenNIR(genNirSettings))
+    List(PrepNativeInterop(), PostInlineNativeInterop(), GenNIR(genNirSettings))
   }

--- a/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
+++ b/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
@@ -189,7 +189,7 @@ class NIRCompilerTest3 extends AnyFlatSpec with Matchers with Inspectors {
       NIRCompiler(_.compile("""
            |import scala.scalanative.unsafe.*
            |
-           |@exportedAccessors inline val foo: Int = 42
+           |@exportAccessors inline val foo: Int = 42
            |""".stripMargin))
     }.getMessage should include("Exported field cannot be inlined")
   }

--- a/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
+++ b/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
@@ -140,27 +140,37 @@ class NIRCompilerTest3 extends AnyFlatSpec with Matchers with Inspectors {
         |""".stripMargin
   )
 
-  it should "allow to report error if function passed to CFuncPtr.fromScalaFunction is not inlineable" in {
+  it should "report error when inlining extern function" in {
     intercept[CompilationFailedException] {
       NIRCompiler(_.compile("""
-        |import scala.scalanative.unsafe.*
-        |
-        |opaque type Visitor = CFuncPtr1[Int, Int]
-        |object Visitor:
-        |  def apply(f: Int => Int): Visitor = f
-        |
-        |@extern def useVisitor(x: Visitor): Unit = extern
-        |
-        |@main def test(n: Int): Unit = 
-        |  def callback(x: Int) = x*x + 2*n*n
-        |  val visitor: Visitor = (n: Int) => n * 10
-        |  useVisitor(Visitor(callback))
-        |  useVisitor(Visitor(_ * 10))
-        |  useVisitor(visitor)
-        | 
-        |""".stripMargin))
-    }.getMessage should include(
-      "Function passed to method fromScalaFunction needs to be inlined"
-    )
+           |import scala.scalanative.unsafe.*
+           |
+           |@extern object Foo{
+           |   inline def foo(): Int = extern
+           |}
+           |""".stripMargin))
+    }.getMessage should include("Extern method cannot be inlined")
+  }
+
+  it should "report error when inlining extern function in extern trait" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+           |import scala.scalanative.unsafe.*
+           |
+           |@extern trait Foo{
+           |   inline def foo(): Int = extern
+           |}
+           |""".stripMargin))
+    }.getMessage should include("Extern method cannot be inlined")
+  }
+
+  it should "report error when inlining extern function in top-level" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+           |import scala.scalanative.unsafe.*
+           |
+           |@extern inline def foo(): Int = extern
+           |""".stripMargin))
+    }.getMessage should include("Extern method cannot be inlined")
   }
 }

--- a/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
+++ b/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
@@ -173,4 +173,24 @@ class NIRCompilerTest3 extends AnyFlatSpec with Matchers with Inspectors {
            |""".stripMargin))
     }.getMessage should include("Extern method cannot be inlined")
   }
+
+  it should "report error when inlining exported function" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+           |import scala.scalanative.unsafe.*
+           |
+           |@exported inline def foo(): Int = 42
+           |""".stripMargin))
+    }.getMessage should include("Exported method cannot be inlined")
+  }
+
+  it should "report error when inlining exported field" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+           |import scala.scalanative.unsafe.*
+           |
+           |@exportedAccessors inline val foo: Int = 42
+           |""".stripMargin))
+    }.getMessage should include("Exported field cannot be inlined")
+  }
 }


### PR DESCRIPTION
* Fixes #3236 and extends it also for exported members validations
* `PrepNativeInterop` is now split into 2 compilation stages: one running after typer and other after inlines (this is required to support intrinsic based sizeOf / alignmentOf) 
