### PR TITLE
Implement JDK-19 Thread API 

### DIFF
--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -21,7 +21,10 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-11]
         scala: [3.2.2]
-        java: [11, 17]
+        java: [11, 17, 20]
+        include:
+          - java: 20
+            java-options: "--enable-preview"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/macos-setup-env
@@ -36,7 +39,12 @@ jobs:
           java-version: ${{matrix.java}}
 
       - name: Test runtime
-        run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" "test-runtime ${{matrix.scala}}"
+        run: > 
+          _JAVA_OPTIONS='${{ matrix.java-options }}' 
+          sbt 
+          -Dscala.scalanative.multithreading.enable=true 
+          "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" 
+          "test-runtime ${{matrix.scala}}"
 
   tests-windows-jdk-compliance:
     name: Test Windows JDK compliance
@@ -45,7 +53,10 @@ jobs:
       fail-fast: false
       matrix:
         scala: [3.2.2]
-        java: [11, 17]
+        java: [11, 17, 20]
+        include:
+          - java: 20
+            java-options: "--enable-preview"
     steps:
       # Disable autocrlf setting, otherwise scalalib patches might not be possible to apply
       - name: Setup git config
@@ -63,5 +74,8 @@ jobs:
           set SCALANATIVE_INCLUDE_DIRS=${{steps.setup.outputs.vcpkg-dir}}\include&
           set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&
           set SCALANATIVE &
-          sbt ++${{matrix.scala}}
+          set _JAVA_OPTIONS=${{ matrix.java-options }} &
+          sbt 
+          -Dscala.scalanative.multithreading.enable=true 
+          ++${{matrix.scala}}
           "test-runtime ${{matrix.scala}}"

--- a/javalib/src/main/scala/java/lang/InheritableThreadLocal.scala
+++ b/javalib/src/main/scala/java/lang/InheritableThreadLocal.scala
@@ -20,4 +20,12 @@ class InheritableThreadLocal[T <: AnyRef] extends ThreadLocal[T] {
 
   override protected[lang] def values(current: Thread): ThreadLocal.Values =
     current.inheritableThreadLocals
+
+  override protected[lang] def initializeValues(
+      current: Thread
+  ): ThreadLocal.Values = {
+    val instance = new ThreadLocal.Values()
+    current.inheritableThreadLocals = instance
+    instance
+  }
 }

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -4,6 +4,8 @@ import java.lang.impl._
 import java.lang.Thread._
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.LockSupport
+import java.util.concurrent.ThreadFactory
+import java.time.Duration
 
 import scala.scalanative.meta.LinktimeInfo.{isWindows, isMultithreadingEnabled}
 
@@ -15,62 +17,107 @@ import scala.scalanative.runtime.NativeThread.State._
 import scala.scalanative.libc.atomic.{CAtomicLongLong, atomic_thread_fence}
 import scala.scalanative.libc.atomic.memory_order._
 
-import scala.scalanative.runtime.JoinNonDeamonThreads
+import scala.scalanative.runtime.JoinNonDaemonThreads
 
 class Thread private[lang] (
-    group: ThreadGroup,
-    target: Runnable,
-    stackSize: Long,
-    private[java] val inheritableThreadLocals: ThreadLocal.Values
+    @volatile private var name: String,
+    private[java] val platformCtx: PlatformThreadContext /* | Null */
 ) extends Runnable {
-  private[java] val threadId = getNextThreadId()
+  protected val tid = ThreadIdentifiers.next()
+
   @volatile private var interruptedState = false
-  private var name: String = s"Thread-$threadId"
-  private var priority: Int = Thread.NORM_PRIORITY
-  private var daemon = false
-  // Uncaught exception handler for this thread
-  private var exceptionHandler: Thread.UncaughtExceptionHandler = _
+  @volatile private[java] var parkBlocker: Object = _
+
+  private var unhandledExceptionHandler: Thread.UncaughtExceptionHandler = _
 
   // ThreadLocal values : local and inheritable
-  private[java] lazy val threadLocals: ThreadLocal.Values =
-    new ThreadLocal.Values()
-  private[java] var threadLocalRandomSeed: Long = 0
+  private[java] var threadLocals: ThreadLocal.Values = _
+  private[java] var inheritableThreadLocals: ThreadLocal.Values = _
+
+  private[java] var threadLocalRandomSeed: scala.Long = 0
   private[java] var threadLocalRandomProbe: Int = 0
   private[java] var threadLocalRandomSecondarySeed: Int = 0
 
-  private[java] val parkBlocker: AtomicReference[Object] =
-    new AtomicReference[Object]()
+  // Construct platform thread
+  private[java] def this(
+      group: ThreadGroup,
+      name: String,
+      characteristics: Int,
+      task: Runnable,
+      stackSize: scala.Long
+  ) = {
+    this(
+      name = name,
+      platformCtx = {
+        val parent = Thread.currentThread()
+        val threadGroup =
+          if (group != null) group
+          else parent.getThreadGroup()
+        PlatformThreadContext(
+          group = threadGroup,
+          task = task,
+          stackSize = stackSize,
+          daemon = parent.isDaemon(),
+          priority = parent.getPriority() min threadGroup.getMaxPriority()
+        )
+      }
+    )
+    if (name == null)
+      throw new IllegalArgumentException("Thread name cannot be null")
 
-  private[java] var nativeThread: NativeThread = _
+    def hasFlag(flag: Int) = (characteristics & flag) != 0
+
+    if (hasFlag(Characteristics.NoThreadLocal)) {
+      threadLocals = ThreadLocal.Values.Unsupported
+      inheritableThreadLocals = ThreadLocal.Values.Unsupported
+    } else if (!hasFlag(Characteristics.NoInheritThreadLocal)) {
+      val parent = Thread.currentThread()
+      val parentLocals = parent.inheritableThreadLocals
+      if (parentLocals != null && parentLocals != ThreadLocal.Values.Unsupported &&
+          parentLocals.size > 0) {
+        this.inheritableThreadLocals =
+          new ThreadLocal.Values(parent.inheritableThreadLocals)
+      }
+    }
+  }
+
+  // Construct virtual thread
+  private[java] def this(name: String, characteristics: Int) = {
+    this(
+      name = if (name != null) name else "",
+      platformCtx = null
+    )
+    def hasFlag(flag: Int) = (characteristics & flag) != 0
+    if (hasFlag(Characteristics.NoThreadLocal)) {
+      threadLocals = ThreadLocal.Values.Unsupported
+      inheritableThreadLocals = ThreadLocal.Values.Unsupported
+    } else if (!hasFlag(Characteristics.NoInheritThreadLocal)) {
+      val parent = Thread.currentThread()
+      val parentLocals = parent.inheritableThreadLocals
+      if (parentLocals != null && parentLocals != ThreadLocal.Values.Unsupported &&
+          parentLocals.size > 0) {
+        this.inheritableThreadLocals =
+          new ThreadLocal.Values(parent.inheritableThreadLocals)
+      }
+    }
+  }
 
   // constructors
   def this(
       group: ThreadGroup,
-      target: Runnable,
+      task: Runnable,
       name: String,
-      stacksize: scala.Long,
-      inheritThreadLocals: Boolean
-  ) = {
-    this(
-      group =
-        if (group != null) group
-        else Thread.currentThread().getThreadGroup(),
-      target = target,
-      stackSize = stacksize,
-      inheritableThreadLocals = {
-        val parent = Thread.currentThread()
-        if (inheritThreadLocals && parent != null)
-          new ThreadLocal.Values(parent.inheritableThreadLocals)
-        else new ThreadLocal.Values()
-      }
-    )
-    val parent = Thread.currentThread()
-    if (parent != null) {
-      this.daemon = parent.daemon
-      this.priority = parent.priority
-    }
-    if (name != null) this.name = name
-  }
+      stackSize: scala.Long,
+      inheritThreadLocals: scala.Boolean
+  ) = this(
+    group = group,
+    name = name,
+    characteristics =
+      if (inheritThreadLocals) 0
+      else Characteristics.NoInheritThreadLocal,
+    task = task,
+    stackSize = stackSize
+  )
 
   // since Java 9
   def this(
@@ -80,13 +127,13 @@ class Thread private[lang] (
       stacksize: scala.Long
   ) = this(group, target, name, stacksize, inheritThreadLocals = true)
 
-  def this() = this(null, null, null, 0)
+  def this() = this(null, null, nextThreadName(), 0)
 
   def this(target: Runnable) =
-    this(null, target, null, 0)
+    this(null, target, nextThreadName(), 0)
 
   def this(group: ThreadGroup, target: Runnable) =
-    this(group, target, null, 0)
+    this(group, target, nextThreadName(), 0)
 
   def this(name: String) =
     this(null, null, name, 0)
@@ -104,7 +151,11 @@ class Thread private[lang] (
   // def getContextClassLoader(): ClassLoader = null
   // def setContextClassLoader(classLoader: ClassLoader): Unit = ()
 
-  def getId(): scala.Long = threadId
+  @deprecated(
+    "This method is not final and may be overridden to return a value that is not the thread ID. Use threadId() instead.",
+    "JDK 19"
+  )
+  def getId(): scala.Long = threadId()
 
   final def getName(): String = name
   final def setName(name: String): Unit = {
@@ -112,20 +163,28 @@ class Thread private[lang] (
     this.name = name
   }
 
-  final def getPriority(): Int = priority
+  final def getPriority(): Int =
+    if (isVirtual()) Thread.NORM_PRIORITY
+    else platformCtx.priority
+
   final def setPriority(priority: Int): Unit = {
     if (priority > Thread.MAX_PRIORITY || priority < Thread.MIN_PRIORITY) {
       throw new IllegalArgumentException("Wrong Thread priority value")
     }
-    this.priority = priority
-    if (nativeThread != null) nativeThread.setPriority(priority)
+    if (!isVirtual()) {
+      platformCtx.priority = priority
+      if (platformCtx.nativeThread != null)
+        platformCtx.nativeThread.setPriority(priority)
+    }
   }
 
   def getStackTrace(): Array[StackTraceElement] =
     new Array[StackTraceElement](0)
 
   def getState(): State = {
+    assert(!isVirtual(), "should be overriden by virtual threads")
     import NativeThread.State._
+    val nativeThread = platformCtx.nativeThread
     if (nativeThread == null) State.NEW
     else
       nativeThread.state match {
@@ -138,54 +197,67 @@ class Thread private[lang] (
       }
   }
 
-  final def getThreadGroup(): ThreadGroup = group
+  final def getThreadGroup(): ThreadGroup = {
+    if (isVirtual()) ??? // special group for virtual threads
+    else
+      getState() match {
+        case State.TERMINATED => null
+        case _                => platformCtx.group
+      }
+  }
 
   def getUncaughtExceptionHandler(): Thread.UncaughtExceptionHandler = {
-    if (exceptionHandler != null) exceptionHandler
+    if (unhandledExceptionHandler != null) unhandledExceptionHandler
     else getThreadGroup()
   }
   def setUncaughtExceptionHandler(eh: Thread.UncaughtExceptionHandler): Unit =
-    exceptionHandler = eh
+    unhandledExceptionHandler = eh
 
-  final def isAlive(): scala.Boolean = nativeThread != null && {
-    nativeThread.state match {
-      case New | Terminated => false
-      case _                => true
-    }
+  final def isAlive(): scala.Boolean = getState() match {
+    case State.NEW | State.TERMINATED => false
+    case _                            => true
   }
 
-  final def isDaemon(): scala.Boolean = daemon
-  final def setDaemon(daemon: scala.Boolean): Unit = {
+  final def isDaemon(): scala.Boolean =
+    if (isVirtual()) true
+    else platformCtx.daemon
+
+  final def setDaemon(on: scala.Boolean): Unit = {
     if (isAlive()) throw new IllegalThreadStateException()
-    this.daemon = daemon
+    if (isVirtual() && !on)
+      throw new IllegalArgumentException(
+        "VirtualThread cannot be non-deamon thread"
+      )
+    else platformCtx.daemon = on
+
   }
 
   def isInterrupted(): scala.Boolean = interruptedState
-  def interrupt(): Unit = synchronized {
-    interruptedState = true
-    if (nativeThread != null) nativeThread.interrupt()
+  def interrupt(): Unit = if (isAlive()) {
+    synchronized {
+      interruptedState = true
+      if (isVirtual()) ??? // TODO
+      else platformCtx.nativeThread.interrupt()
+    }
   }
 
   def run(): Unit = {
-    if (target != null) target.run()
+    // Overriden in VirtualThread
+    val task = platformCtx.task
+    if (task != null) task.run()
   }
 
   def start(): Unit = synchronized {
-    if (nativeThread != null) {
-      throw new IllegalThreadStateException(
-        "This thread was already started!"
-      )
-    }
     if (!isMultithreadingEnabled)
       throw new IllegalStateException(
         "ScalaNative application linked with disabled multithreading support"
       )
-    atomic_thread_fence(memory_order_seq_cst)
-    nativeThread = Thread.nativeCompanion.create(this, stackSize)
-    atomic_thread_fence(memory_order_release)
-    while (nativeThread.state == New) Thread.onSpinWait()
-    atomic_thread_fence(memory_order_acquire)
-    nativeThread.setPriority(priority)
+    if (isVirtual())
+      throw new UnsupportedOperationException(
+        "VirtualThreads are not yet supported"
+      )
+    else
+      platformCtx.start(this)
   }
 
   final def join(): Unit = synchronized {
@@ -248,12 +320,42 @@ class Thread private[lang] (
     if (isAlive()) LockSupport.unpark(this)
 
   override def toString(): String = {
-    val groupName = if (group != null) group.getName() else ""
-    s"Thread[$threadId,$name,$priority,$groupName]"
+    val groupName = getThreadGroup() match {
+      case null  => ""
+      case group => group.getName()
+    }
+    s"Thread[${threadId()},${getName()},${getPriority()},$groupName]"
   }
 
   @deprecated("Deprecated for removal", "17")
   def checkAccess(): Unit = ()
+
+  // Since JDK 19
+  final def isVirtual(): scala.Boolean = isInstanceOf[VirtualThread]
+
+  @throws[InterruptedException](
+    "if the current thread is interrupted while waiting"
+  )
+  @throws[IllegalThreadStateException]("if this thread has not been started")
+  final def join(duration: Duration): scala.Boolean = {
+    getState() match {
+      case Thread.State.NEW =>
+        throw new IllegalThreadStateException("Cannot join unstarted thread")
+      case _ =>
+        if (duration.isNegative() || duration.isZero()) {
+          join(duration.getSeconds() * 1000, duration.getNano())
+        }
+        getState() == Thread.State.TERMINATED
+    }
+  }
+
+  final def threadId(): scala.Long = tid
+
+  private[lang] def clearReferences(): Unit = {
+    threadLocals = null
+    inheritableThreadLocals = null
+    if (unhandledExceptionHandler != null) unhandledExceptionHandler = null
+  }
 }
 
 object Thread {
@@ -284,23 +386,154 @@ object Thread {
     }
   }
 
+  // Since JDK 19
+  trait Builder {
+
+    /** Sets whether the thread is allowed to set values for its copy of
+     *  thread-local variables.
+     */
+    def allowSetThreadLocals(allow: scala.Boolean): Builder
+
+    /** Returns a ThreadFactory to create threads from the current state of the
+     *  builder.
+     */
+    def factory(): ThreadFactory
+
+    /** Sets whether the thread inherits the initial values of
+     *  inheritable-thread-local variables from the constructing thread.
+     */
+    def inheritInheritableThreadLocals(inherit: scala.Boolean): Builder
+
+    /** Sets the thread name. */
+    def name(name: String): Builder
+
+    /** Sets the thread name to be the concatenation of a string prefix and the
+     *  string representation of a counter value.
+     */
+    @throws[IllegalArgumentException]("if start is negative")
+    def name(prefix: String, start: scala.Long): Builder
+
+    /** Creates a new Thread from the current state of the builder and schedules
+     *  it to execute.
+     */
+    def start(task: Runnable): Thread
+
+    /** Sets the uncaught exception handler. */
+    def uncaughtExceptionHandler(
+        ueh: Thread.UncaughtExceptionHandler
+    ): Builder
+
+    /** Creates a new Thread from the current state of the builder to run the
+     *  given task.
+     */
+    def unstarted(task: Runnable): Thread
+  }
+
+  object Builder {
+    trait OfPlatform extends Builder {
+
+      /** Sets the daemon status to true. */
+      def daemon(): OfPlatform = daemon(true)
+
+      /** Sets the daemon status. */
+      def daemon(on: scala.Boolean): OfPlatform
+
+      /** Sets the thread group. */
+      def group(group: ThreadGroup): OfPlatform
+
+      /** Sets the thread priority. */
+      @throws[IllegalArgumentException](
+        "if the priority is less than Thread.MIN_PRIORITY or greater than Thread.MAX_PRIORITY"
+      )
+      def priority(priority: Int): OfPlatform
+
+      /** Sets the desired stack size. */
+      @throws[IllegalArgumentException]("if the stack size is negative")
+      def stackSize(stackSize: scala.Long): OfPlatform
+
+      /** Sets whether the thread is allowed to set values for its copy of
+       *  thread-local variables.
+       */
+      override def allowSetThreadLocals(allow: scala.Boolean): OfPlatform
+
+      /** Sets whether the thread inherits the initial values of
+       *  inheritable-thread-local variables from the constructing thread.
+       */
+      override def inheritInheritableThreadLocals(
+          inherit: scala.Boolean
+      ): OfPlatform
+
+      /** Sets the thread name. */
+      override def name(name: String): OfPlatform
+
+      /** Sets the thread name to be the concatenation of a string prefix and
+       *  the string representation of a counter value.
+       */
+      @throws[IllegalArgumentException]("if start is negative")
+      override def name(prefix: String, start: scala.Long): OfPlatform
+
+      /** Sets the uncaught exception handler. */
+      def uncaughtExceptionHandler(
+          ueh: Thread.UncaughtExceptionHandler
+      ): OfPlatform
+    }
+
+    trait OfVirtual extends Builder {
+
+      /** Sets whether the thread is allowed to set values for its copy of
+       *  thread-local variables.
+       */
+      override def allowSetThreadLocals(allow: scala.Boolean): OfVirtual
+
+      /** Sets whether the thread inherits the initial values of
+       *  inheritable-thread-local variables from the constructing thread.
+       */
+      override def inheritInheritableThreadLocals(
+          inherit: scala.Boolean
+      ): OfVirtual
+
+      /** Sets the thread name. */
+      override def name(name: String): OfVirtual
+
+      /** Sets the thread name to be the concatenation of a string prefix and
+       *  the string representation of a counter value.
+       */
+      @throws[IllegalArgumentException]("if start is negative")
+      override def name(prefix: String, start: scala.Long): OfVirtual
+
+      /** Sets the uncaught exception handler. */
+      def uncaughtExceptionHandler(
+          ueh: Thread.UncaughtExceptionHandler
+      ): OfVirtual
+    }
+  }
+
+  // Implementation detai
+  private[java] object Characteristics {
+    final val Default = 0
+    final val NoThreadLocal = 1 << 1
+    final val NoInheritThreadLocal = 1 << 2
+  }
+
   final val MAX_PRIORITY: Int = 10
   final val MIN_PRIORITY: Int = 1
   final val NORM_PRIORITY: Int = 5
 
   final val MainThread = new Thread(
-    group = new ThreadGroup(ThreadGroup.System, "main"),
-    target = null: Runnable,
-    stackSize = 0L,
-    inheritableThreadLocals = new ThreadLocal.Values()
+    name = "main",
+    platformCtx = PlatformThreadContext(
+      group = new ThreadGroup(ThreadGroup.System, "main"),
+      task = null: Runnable,
+      stackSize = 0L
+    )
   ) {
-    override private[java] val threadId: scala.Long = 0L
-    nativeThread = nativeCompanion.create(this, 0L)
-    setName("main")
-    JoinNonDeamonThreads.registerExitHook()
+    override protected val tid: scala.Long = 0L
+    inheritableThreadLocals = new ThreadLocal.Values()
+    platformCtx.nativeThread = nativeCompanion.create(this, 0L)
+    JoinNonDaemonThreads.registerExitHook()
   }
 
-  @alwaysinline private def nativeCompanion: NativeThread.Companion =
+  @alwaysinline private[lang] def nativeCompanion: NativeThread.Companion =
     if (isWindows) WindowsThread
     else PosixThread
 
@@ -344,7 +577,7 @@ object Thread {
 
   def sleep(millis: scala.Long): Unit = sleep(millis, 0)
 
-  def sleep(millis: scala.Long, nanos: scala.Int): Unit = {
+  def sleep(millis: scala.Long, nanos: Int): Unit = {
     if (millis < 0)
       throw new IllegalArgumentException("millis must be >= 0")
     if (nanos < 0 || nanos > 999999)
@@ -362,13 +595,67 @@ object Thread {
 
   @alwaysinline def `yield`(): Unit = nativeCompanion.yieldThread()
 
-  // Counter used to generate thread's ID, 0 resevered for main
-  final protected var threadId = 1L
-  private def getNextThreadId(): scala.Long = {
-    val threadIdRef = new CAtomicLongLong(
-      fromRawPtr(classFieldRawPtr(this, "threadId"))
+  // Since JDK 19
+  @throws[InterruptedException](
+    "if the current thread is interrupted while sleeping"
+  )
+  def sleep(duration: Duration): Unit =
+    sleep(millis = duration.getSeconds() * 1000, nanos = duration.getNano())
+
+  def ofPlatform(): Builder.OfPlatform =
+    new ThreadBuilders.PlatformThreadBuilder
+
+  def ofVirtual(): Builder.OfVirtual =
+    new ThreadBuilders.VirtualThreadBuilder
+
+  def startVirtualThread(task: Runnable): Thread = {
+    val thread = new VirtualThread(
+      name = null,
+      characteristics = Characteristics.Default,
+      task = task
     )
-    threadIdRef.fetchAdd(1L)
+    thread.start()
+    thread
   }
 
+  // Scala Native specific:
+  def nextThreadName(): String = s"Thread-${ThreadNamesNumbering.next()}"
+
+  // Counter used to generate thread's ID, 0 resevered for main
+  sealed abstract class Numbering {
+    final protected var cursor = 1L
+    final protected val cursorRef = new CAtomicLongLong(
+      fromRawPtr(classFieldRawPtr(this, "cursor"))
+    )
+    def next(): scala.Long = cursorRef.fetchAdd(1L)
+  }
+  object ThreadNamesNumbering extends Numbering
+  object ThreadIdentifiers extends Numbering
+}
+
+// ScalaNative specific
+private[java] case class PlatformThreadContext(
+    group: ThreadGroup,
+    task: Runnable,
+    stackSize: scala.Long,
+    @volatile var priority: Int = Thread.NORM_PRIORITY,
+    @volatile var daemon: scala.Boolean = false
+) {
+  var nativeThread: NativeThread = _
+
+  def unpark(): Unit = if (nativeThread != null) nativeThread.unpark()
+
+  def start(thread: Thread): Unit = {
+    assert(thread.platformCtx == this)
+    if (nativeThread != null) {
+      throw new IllegalThreadStateException("This thread was already started!")
+    }
+
+    atomic_thread_fence(memory_order_seq_cst)
+    nativeThread = Thread.nativeCompanion.create(thread, stackSize)
+    atomic_thread_fence(memory_order_release)
+    while (nativeThread.state == New) Thread.onSpinWait()
+    atomic_thread_fence(memory_order_acquire)
+    nativeThread.setPriority(priority)
+  }
 }

--- a/javalib/src/main/scala/java/lang/ThreadBuilders.scala
+++ b/javalib/src/main/scala/java/lang/ThreadBuilders.scala
@@ -1,0 +1,211 @@
+package java.lang
+
+import java.util.Objects
+import java.util.concurrent.ThreadFactory
+import java.lang.Thread.{Builder, Characteristics}
+import scala.scalanative.libc.atomic.CAtomicLongLong
+import scala.scalanative.runtime.{Intrinsics, fromRawPtr}
+
+// ScalaNative specific
+object ThreadBuilders {
+
+  sealed abstract class BaseThreadBuilder[Self <: Builder] extends Builder {
+    var name: String = _
+    var counter: scala.Long = -1
+    var characteristics: Int = Characteristics.Default
+    var ueh: Thread.UncaughtExceptionHandler = _
+
+    private def self: Self = this.asInstanceOf[Self]
+
+    protected def nextThreadName(): String = if (name != null && counter >= 0) {
+      val res = name + counter.toString
+      counter += 1
+      res
+    } else name
+
+    override def name(name: String): Self = {
+      this.name = Objects.requireNonNull(name)
+      this.counter = -1
+      self
+    }
+
+    override def name(prefix: String, start: scala.Long): Self = {
+      if (start < 0) throw new IllegalArgumentException("'start' is negative")
+      this.name = Objects.requireNonNull(prefix)
+      this.counter = start
+      self
+    }
+
+    override def allowSetThreadLocals(allow: scala.Boolean): Self = {
+      val flag = Characteristics.NoThreadLocal
+      if (allow) characteristics &= ~flag
+      else characteristics |= flag
+      self
+    }
+
+    override def inheritInheritableThreadLocals(inherit: scala.Boolean): Self = {
+      val flag = Characteristics.NoInheritThreadLocal
+      if (inherit) this.characteristics &= ~flag
+      else characteristics |= flag
+      self
+    }
+
+    override def uncaughtExceptionHandler(
+        ueh: Thread.UncaughtExceptionHandler
+    ): Self = {
+      this.ueh = Objects.requireNonNull(ueh)
+      self
+    }
+
+    // override def factory(): ThreadFactory
+
+    // def start(task: Runnable): Thread
+
+    // def unstarted(task: Runnable): Thread
+  }
+
+  final class PlatformThreadBuilder
+      extends BaseThreadBuilder[Builder.OfPlatform]
+      with Builder.OfPlatform {
+    private var group: ThreadGroup = _
+    private var daemonOpt: Option[Boolean] = None
+    private var priority: Int = 0
+    private var stackSize: scala.Long = 0L
+
+    override protected def nextThreadName(): String =
+      super.nextThreadName() match {
+        case null => Thread.nextThreadName()
+        case name => name
+      }
+
+    override def group(group: ThreadGroup): Builder.OfPlatform = {
+      this.group = Objects.requireNonNull(group)
+      this
+    }
+
+    override def daemon(on: scala.Boolean): Builder.OfPlatform = {
+      daemonOpt = Some(on)
+      this
+    }
+
+    override def priority(priority: Int): Builder.OfPlatform = {
+      if (priority < Thread.MIN_PRIORITY || priority > Thread.MAX_PRIORITY)
+        throw new IllegalArgumentException("Thread priority out of range")
+      this.priority = priority
+      this
+    }
+
+    override def stackSize(stackSize: scala.Long): Builder.OfPlatform = {
+      if (stackSize < 0L)
+        throw new IllegalArgumentException("Negative thread stack size")
+      this.stackSize = stackSize
+      this
+    }
+
+    override def unstarted(task: Runnable): Thread = {
+      Objects.requireNonNull(task)
+      val thread = new Thread(group, nextThreadName(), characteristics, task, stackSize)
+      daemonOpt.foreach(thread.setDaemon(_))
+      if (priority != 0) thread.setPriority(priority)
+      if (ueh != null) thread.setUncaughtExceptionHandler(ueh)
+      thread
+    }
+
+    override def start(task: Runnable): Thread = {
+      val thread = unstarted(task)
+      thread.start()
+      thread
+    }
+
+    override def factory(): ThreadFactory = new PlatformThreadFactory(
+      group = group,
+      name = name,
+      start = counter,
+      characteristics = characteristics,
+      daemon = daemonOpt,
+      priority = priority,
+      stackSize = stackSize,
+      ueh = ueh
+    )
+  }
+
+  final class VirtualThreadBuilder
+      extends BaseThreadBuilder[Builder.OfVirtual]
+      with Builder.OfVirtual {
+
+    override def unstarted(task: Runnable): Thread = {
+      Objects.requireNonNull(task)
+      val thread = new VirtualThread(nextThreadName(), characteristics, task)
+      if (ueh != null) thread.setUncaughtExceptionHandler(ueh)
+      thread
+    }
+
+    override def start(task: Runnable): Thread = {
+      val thread = unstarted(task)
+      thread.start()
+      thread
+    }
+
+    override def factory(): ThreadFactory =
+      new VirtualThreadFactory(name, counter, characteristics, ueh)
+  }
+
+  private abstract class BaseThreadFactory(
+      name: String,
+      start: scala.Long,
+      characteristics: Int,
+      ueh: Thread.UncaughtExceptionHandler
+  ) extends ThreadFactory {
+    @volatile var counter: scala.Long = start
+
+    private val counterRef = new CAtomicLongLong(
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "counter"))
+    )
+    private val hasCounter = name != null && start >= 0
+
+    def nextThreadName(): String = {
+      if (hasCounter) name + counterRef.fetchAdd(1L)
+      else name
+    }
+  }
+
+  private class PlatformThreadFactory(
+      group: ThreadGroup,
+      name: String,
+      start: scala.Long,
+      characteristics: Int,
+      daemon: Option[Boolean],
+      priority: Int,
+      stackSize: scala.Long,
+      ueh: Thread.UncaughtExceptionHandler
+  ) extends BaseThreadFactory(name, start, characteristics, ueh) {
+    override def nextThreadName(): String = super.nextThreadName() match {
+      case null => Thread.nextThreadName()
+      case name => name
+    }
+
+    override def newThread(task: Runnable): Thread = {
+      Objects.requireNonNull(task)
+      val thread = new Thread(group, nextThreadName(), characteristics, task, stackSize)
+      daemon.foreach(thread.setDaemon(_))
+      if (priority != 0) thread.setPriority(priority)
+      if (ueh != null) thread.setUncaughtExceptionHandler(ueh)
+      thread
+    }
+  }
+
+  private class VirtualThreadFactory(
+      name: String,
+      start: scala.Long,
+      characteristics: Int,
+      ueh: Thread.UncaughtExceptionHandler
+  ) extends BaseThreadFactory(name, start, characteristics, ueh) {
+    override def newThread(task: Runnable): Thread = {
+      Objects.requireNonNull(task)
+      val thread = new VirtualThread(nextThreadName(), characteristics, task)
+      if (ueh != null) thread.setUncaughtExceptionHandler(ueh)
+      thread
+    }
+  }
+
+}

--- a/javalib/src/main/scala/java/lang/ThreadBuilders.scala
+++ b/javalib/src/main/scala/java/lang/ThreadBuilders.scala
@@ -59,11 +59,6 @@ object ThreadBuilders {
       self
     }
 
-    // override def factory(): ThreadFactory
-
-    // def start(task: Runnable): Thread
-
-    // def unstarted(task: Runnable): Thread
   }
 
   final class PlatformThreadBuilder

--- a/javalib/src/main/scala/java/lang/ThreadBuilders.scala
+++ b/javalib/src/main/scala/java/lang/ThreadBuilders.scala
@@ -43,7 +43,9 @@ object ThreadBuilders {
       self
     }
 
-    override def inheritInheritableThreadLocals(inherit: scala.Boolean): Self = {
+    override def inheritInheritableThreadLocals(
+        inherit: scala.Boolean
+    ): Self = {
       val flag = Characteristics.NoInheritThreadLocal
       if (inherit) this.characteristics &= ~flag
       else characteristics |= flag
@@ -104,7 +106,8 @@ object ThreadBuilders {
 
     override def unstarted(task: Runnable): Thread = {
       Objects.requireNonNull(task)
-      val thread = new Thread(group, nextThreadName(), characteristics, task, stackSize)
+      val thread =
+        new Thread(group, nextThreadName(), characteristics, task, stackSize)
       daemonOpt.foreach(thread.setDaemon(_))
       if (priority != 0) thread.setPriority(priority)
       if (ueh != null) thread.setUncaughtExceptionHandler(ueh)
@@ -186,7 +189,8 @@ object ThreadBuilders {
 
     override def newThread(task: Runnable): Thread = {
       Objects.requireNonNull(task)
-      val thread = new Thread(group, nextThreadName(), characteristics, task, stackSize)
+      val thread =
+        new Thread(group, nextThreadName(), characteristics, task, stackSize)
       daemon.foreach(thread.setDaemon(_))
       if (priority != 0) thread.setPriority(priority)
       if (ueh != null) thread.setUncaughtExceptionHandler(ueh)

--- a/javalib/src/main/scala/java/lang/VirtualThread.scala
+++ b/javalib/src/main/scala/java/lang/VirtualThread.scala
@@ -1,0 +1,15 @@
+package java.lang
+
+final private[lang] class VirtualThread(
+    name: String,
+    characteristics: Int,
+    task: Runnable
+) extends Thread(name, characteristics) {
+
+  // TODO: continuations baed thread implementation
+  override def run(): Unit = throw new UnsupportedOperationException(
+    "Running VirtualThreads is not yet supported"
+  )
+
+  override def getState(): Thread.State = Thread.State.NEW
+}

--- a/javalib/src/main/scala/scala/scalanative/runtime/JoinNonDeamonThreads.scala
+++ b/javalib/src/main/scala/scala/scalanative/runtime/JoinNonDeamonThreads.scala
@@ -3,9 +3,9 @@ package scala.scalanative.runtime
 import NativeThread.Registry
 import Thread.MainThread
 
-object JoinNonDeamonThreads {
+object JoinNonDaemonThreads {
   def registerExitHook(): Unit = Shutdown.addHook { () =>
-    def pollDeamonThreads = Registry.aliveThreads.iterator
+    def pollDaemonThreads = Registry.aliveThreads.iterator
       .map(_.thread)
       .filter { thread =>
         !thread.isDaemon() && thread.isAlive()
@@ -13,7 +13,7 @@ object JoinNonDeamonThreads {
 
     Registry.onMainThreadTermination()
     Iterator
-      .continually(pollDeamonThreads)
+      .continually(pollDaemonThreads)
       .takeWhile(_.hasNext)
       .flatten
       .foreach(_.join())

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/ThreadBuilderTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/ThreadBuilderTestOnJDK19.scala
@@ -1,0 +1,625 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.LockSupport
+
+import org.junit._
+import org.junit.Assert._
+import org.junit.{Ignore, BeforeClass}
+
+import scala.scalanative.junit.utils.AssumesHelper
+
+object ThreadBuilderTestOnJDK19 {
+  @BeforeClass def checkRuntime(): Unit = {
+    AssumesHelper.assumeMultithreadingIsEnabled()
+  }
+
+  val Local = new ThreadLocal[AnyRef]
+  val InheritedLocal = new InheritableThreadLocal[AnyRef]
+}
+
+class ThreadBuilderTestOnJDK19 {
+  import ThreadBuilderTestOnJDK19._
+
+  @Test def testPlatformThread(): Unit = {
+    val parent = Thread.currentThread()
+    val builder = Thread.ofPlatform()
+    // unstarted
+    val done1 = new AtomicBoolean()
+    val thread1 = builder.unstarted(() => done1.set(true))
+    assertFalse(thread1.isVirtual)
+    assertTrue(thread1.getState() eq Thread.State.NEW)
+    assertFalse(thread1.getName().isEmpty)
+    assertTrue(thread1.getThreadGroup eq parent.getThreadGroup)
+    assertTrue(thread1.isDaemon() == parent.isDaemon())
+    assertTrue(thread1.getPriority() == parent.getPriority())
+    thread1.start()
+    thread1.join()
+    assertTrue(done1.get())
+    // start
+    val done2 = new AtomicBoolean()
+    val thread2 = builder.start(() => done2.set(true))
+    assertFalse(thread2.isVirtual)
+    assertTrue(thread2.getState() ne Thread.State.NEW)
+    assertFalse(thread2.getName().isEmpty)
+    val group2 = thread2.getThreadGroup
+    assertTrue((group2 eq parent.getThreadGroup) || group2 == null)
+    assertTrue(thread2.isDaemon() == parent.isDaemon())
+    assertTrue(thread2.getPriority() == parent.getPriority())
+    thread2.join()
+    assertTrue(done2.get())
+    // factory
+    val done3 = new AtomicBoolean()
+    val thread3 = builder.factory.newThread(() => done3.set(true))
+    assertFalse(thread3.isVirtual)
+    assertTrue(thread3.getState() eq Thread.State.NEW)
+    assertFalse(thread3.getName().isEmpty)
+    assertTrue(thread3.getThreadGroup eq parent.getThreadGroup)
+    assertTrue(thread3.isDaemon() == parent.isDaemon())
+    assertTrue(thread3.getPriority() == parent.getPriority())
+    thread3.start()
+    thread3.join()
+    assertTrue(done3.get())
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testVirtualThread(): Unit = {
+    val parent = Thread.currentThread()
+    val builder = Thread.ofVirtual()
+    // unstarted
+    val done1 = new AtomicBoolean()
+    val thread1 = builder.unstarted(() => done1.set(true))
+    assertTrue(thread1.isVirtual)
+    assertEquals(Thread.State.NEW, thread1.getState())
+    assertTrue(thread1.getName().isEmpty)
+    assertTrue(thread1.isDaemon())
+    assertEquals(Thread.NORM_PRIORITY, thread1.getPriority())
+    thread1.start()
+    thread1.join()
+    assertTrue(done1.get())
+
+    // start
+    val done2 = new AtomicBoolean()
+    val thread2 = builder.start(() => done2.set(true))
+    assertTrue(thread2.isVirtual)
+    assertNotEquals(Thread.State.NEW, thread2.getState())
+    assertTrue(thread2.getName().isEmpty)
+    assertTrue(thread2.isDaemon())
+    assertEquals(Thread.NORM_PRIORITY, thread2.getPriority())
+    thread2.join()
+    assertTrue(done2.get())
+
+    // factory
+    val done3 = new AtomicBoolean()
+    val thread3 = builder.factory.newThread(() => done3.set(true))
+    assertTrue(thread3.isVirtual)
+    assertEquals(Thread.State.NEW, thread3.getState())
+    assertTrue(thread3.getName().isEmpty)
+    assertTrue(thread3.isDaemon())
+    assertEquals(Thread.NORM_PRIORITY, thread3.getPriority())
+    thread3.start()
+    thread3.join()
+    assertTrue(done3.get())
+  }
+
+  @Test def testName1(): Unit = {
+    val builder = Thread.ofPlatform().name("foo")
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    assertTrue(thread1.getName() == "foo")
+    assertTrue(thread2.getName() == "foo")
+    assertTrue(thread3.getName() == "foo")
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testName2(): Unit = {
+    val builder = Thread.ofVirtual().name("foo")
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    assertTrue(thread1.getName() == "foo")
+    assertTrue(thread2.getName() == "foo")
+    assertTrue(thread3.getName() == "foo")
+  }
+
+  @Test def testName3(): Unit = {
+    val builder = Thread.ofPlatform().name("foo-", 100)
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.unstarted(() => {})
+    val thread3 = builder.unstarted(() => {})
+    assertTrue(thread1.getName() == "foo-100")
+    assertTrue(thread2.getName() == "foo-101")
+    assertTrue(thread3.getName() == "foo-102")
+    val factory = builder.factory
+    val thread4 = factory.newThread(() => {})
+    val thread5 = factory.newThread(() => {})
+    val thread6 = factory.newThread(() => {})
+    assertTrue(thread4.getName() == "foo-103")
+    assertTrue(thread5.getName() == "foo-104")
+    assertTrue(thread6.getName() == "foo-105")
+  }
+
+  @Test def testName4(): Unit = {
+    val builder = Thread.ofVirtual().name("foo-", 100)
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.unstarted(() => {})
+    val thread3 = builder.unstarted(() => {})
+    assertTrue(thread1.getName() == "foo-100")
+    assertTrue(thread2.getName() == "foo-101")
+    assertTrue(thread3.getName() == "foo-102")
+    val factory = builder.factory
+    val thread4 = factory.newThread(() => {})
+    val thread5 = factory.newThread(() => {})
+    val thread6 = factory.newThread(() => {})
+    assertTrue(thread4.getName() == "foo-103")
+    assertTrue(thread5.getName() == "foo-104")
+    assertTrue(thread6.getName() == "foo-105")
+  }
+
+  @Test def testThreadGroup1(): Unit = {
+    val group = new ThreadGroup("groupies")
+    val builder = Thread.ofPlatform().group(group)
+    val thread1 = builder.unstarted(() => {})
+    val done = new AtomicBoolean()
+    val thread2 = builder.start(() => {
+      while (!done.get()) LockSupport.park()
+
+    })
+    val thread3 = builder.factory.newThread(() => {})
+    try {
+      assertTrue(thread1.getThreadGroup eq group)
+      assertTrue(thread2.getThreadGroup eq group)
+      assertTrue(thread3.getThreadGroup eq group)
+    } finally {
+      done.set(true)
+      LockSupport.unpark(thread2)
+    }
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testThreadGroup2(): Unit = {
+    val vgroup =
+      Thread.ofVirtual().unstarted(() => {}).getThreadGroup
+    assertEquals(vgroup.getName(), "VirtualThreads")
+    val thread1 = Thread.ofVirtual().unstarted(() => {})
+    val thread2 = Thread.ofVirtual().start { () => LockSupport.park() }
+    val thread3 = Thread.ofVirtual().factory.newThread(() => {})
+    try {
+      assertTrue(thread1.getThreadGroup eq vgroup)
+      assertTrue(thread2.getThreadGroup eq vgroup)
+      assertTrue(thread3.getThreadGroup eq vgroup)
+    } finally LockSupport.unpark(thread2)
+  }
+
+  @Test def testPriority1(): Unit = {
+    val priority = Thread.currentThread().getPriority()
+    val builder = Thread.ofPlatform()
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    assertTrue(thread1.getPriority() == priority)
+    assertTrue(thread2.getPriority() == priority)
+    assertTrue(thread3.getPriority() == priority)
+  }
+  @Test def testPriority2(): Unit = {
+    val priority = Thread.MIN_PRIORITY
+    val builder = Thread.ofPlatform().priority(priority)
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    assertTrue(thread1.getPriority() == priority)
+    assertTrue(thread2.getPriority() == priority)
+    assertTrue(thread3.getPriority() == priority)
+  }
+  @Test def testPriority3(): Unit = {
+    val currentThread = Thread.currentThread()
+    Assume.assumeFalse(currentThread.isVirtual())
+
+    val maxPriority = currentThread.getThreadGroup.getMaxPriority
+    val priority = Math.min(maxPriority + 1, Thread.MAX_PRIORITY)
+    val builder = Thread.ofPlatform().priority(priority)
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    assertTrue(thread1.getPriority() == priority)
+    assertTrue(thread2.getPriority() == priority)
+    assertTrue(thread3.getPriority() == priority)
+  }
+  @Test def testPriority4(): Unit = {
+    val builder = Thread.ofPlatform()
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => builder.priority(Thread.MIN_PRIORITY - 1)
+    )
+  }
+  @Test def testPriority5(): Unit = {
+    val builder = Thread.ofPlatform()
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => builder.priority(Thread.MAX_PRIORITY + 1)
+    )
+  }
+
+  @Test def testDaemon1(): Unit = {
+    val builder = Thread.ofPlatform().daemon(false)
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    assertFalse(thread1.isDaemon())
+    assertFalse(thread2.isDaemon())
+    assertFalse(thread3.isDaemon())
+  }
+  @Test def testDaemon2(): Unit = {
+    val builder = Thread.ofPlatform().daemon(true)
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    assertTrue(thread1.isDaemon())
+    assertTrue(thread2.isDaemon())
+    assertTrue(thread3.isDaemon())
+  }
+  @Test def testDaemon3(): Unit = {
+    val builder = Thread.ofPlatform().daemon
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    assertTrue(thread1.isDaemon())
+    assertTrue(thread2.isDaemon())
+    assertTrue(thread3.isDaemon())
+  }
+  @Test def testDaemon4(): Unit = {
+    val builder = Thread.ofPlatform()
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    // daemon status should be inherited
+    val d = Thread.currentThread().isDaemon()
+    assertTrue(thread1.isDaemon() == d)
+    assertTrue(thread2.isDaemon() == d)
+    assertTrue(thread3.isDaemon() == d)
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testDaemon5(): Unit = {
+    val builder = Thread.ofVirtual()
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+    // daemon status should always be true
+    assertTrue(thread1.isDaemon())
+    assertTrue(thread2.isDaemon())
+    assertTrue(thread3.isDaemon())
+  }
+
+  @Test def testStackSize1(): Unit = {
+    val builder = Thread.ofPlatform().stackSize(1024 * 1024)
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+  }
+  @Test def testStackSize2(): Unit = {
+    val builder = Thread.ofPlatform().stackSize(0)
+    val thread1 = builder.unstarted(() => {})
+    val thread2 = builder.start(() => {})
+    val thread3 = builder.factory.newThread(() => {})
+  }
+  @Test def testStackSize3(): Unit = {
+    val builder = Thread.ofPlatform()
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => builder.stackSize(-1)
+    )
+  }
+
+  @Test def testUncaughtExceptionHandler1(): Unit = {
+    class FooException extends RuntimeException {}
+    val threadRef = new AtomicReference[Thread]
+    val exceptionRef =
+      new AtomicReference[Throwable]
+    val thread = Thread
+      .ofPlatform()
+      .uncaughtExceptionHandler((t, e) => {
+        assertTrue(t eq Thread.currentThread())
+        threadRef.set(t)
+        exceptionRef.set(e)
+
+      })
+      .start(() => {
+        throw new FooException
+
+      })
+    thread.join()
+    assertTrue(threadRef.get eq thread)
+    assertTrue(exceptionRef.get.isInstanceOf[FooException])
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testUncaughtExceptionHandler2(): Unit = {
+    class FooException extends RuntimeException {}
+    val threadRef = new AtomicReference[Thread]
+    val exceptionRef =
+      new AtomicReference[Throwable]
+    val thread = Thread
+      .ofVirtual()
+      .uncaughtExceptionHandler((t, e) => {
+        assertTrue(t eq Thread.currentThread())
+        threadRef.set(t)
+        exceptionRef.set(e)
+
+      })
+      .start(() => {
+        throw new FooException
+
+      })
+    thread.join()
+    assertTrue(threadRef.get eq thread)
+    assertTrue(exceptionRef.get.isInstanceOf[FooException])
+  }
+
+  @Test def testUncaughtExceptionHandler3(): Unit = {
+    class FooException extends RuntimeException {}
+    val threadRef = new AtomicReference[Thread]
+    val exceptionRef =
+      new AtomicReference[Throwable]
+    val thread = Thread
+      .ofPlatform()
+      .uncaughtExceptionHandler((t, e) => {
+        assertTrue(t eq Thread.currentThread())
+        threadRef.set(t)
+        exceptionRef.set(e)
+
+      })
+      .factory
+      .newThread(() => {
+        throw new FooException
+
+      })
+    thread.start()
+    thread.join()
+    assertTrue(threadRef.get eq thread)
+    assertTrue(exceptionRef.get.isInstanceOf[FooException])
+  }
+  @Test def testUncaughtExceptionHandler4(): Unit = {
+    class FooException extends RuntimeException {}
+    val threadRef = new AtomicReference[Thread]
+    val exceptionRef =
+      new AtomicReference[Throwable]
+    val thread = Thread
+      .ofPlatform()
+      .uncaughtExceptionHandler((t, e) => {
+        assertTrue(t eq Thread.currentThread())
+        threadRef.set(t)
+        exceptionRef.set(e)
+
+      })
+      .factory
+      .newThread(() => {
+        throw new FooException
+
+      })
+    thread.start()
+    thread.join()
+    assertTrue(threadRef.get eq thread)
+    assertTrue(exceptionRef.get.isInstanceOf[FooException])
+  }
+
+  private def testThreadLocals(builder: Thread.Builder): Unit = {
+    val done = new AtomicBoolean()
+    val task: Runnable = () => {
+      val value = new AnyRef
+      Local.set(value)
+      assertTrue(Local.get eq value)
+      done.set(true)
+
+    }
+    done.set(false)
+    val thread1 = builder.unstarted(task)
+    thread1.start()
+    thread1.join()
+    assertTrue(done.get())
+    done.set(false)
+    val thread2 = builder.start(task)
+    thread2.join()
+    assertTrue(done.get())
+    done.set(false)
+    val thread3 = builder.factory.newThread(task)
+    thread3.start()
+    thread3.join()
+    assertTrue(done.get())
+  }
+
+  private def testNoThreadLocals(builder: Thread.Builder): Unit = {
+    val done = new AtomicBoolean()
+    val task: Runnable = () => {
+      try Local.set(new AnyRef)
+      catch {
+        case expected: UnsupportedOperationException =>
+          done.set(true)
+      }
+
+    }
+    done.set(false)
+    val thread1 = builder.unstarted(task)
+    thread1.start()
+    thread1.join()
+    assertTrue(done.get())
+    done.set(false)
+    val thread2 = builder.start(task)
+    thread2.join()
+    assertTrue(done.get())
+    done.set(false)
+    val thread3 = builder.factory.newThread(task)
+    thread3.start()
+    thread3.join()
+    assertTrue(done.get())
+  }
+
+  @Test def testThreadLocals1(): Unit = {
+    val builder = Thread.ofPlatform()
+    testThreadLocals(builder)
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testThreadLocals2(): Unit = {
+    val builder = Thread.ofVirtual()
+    testThreadLocals(builder)
+  }
+
+  @Test def testThreadLocals3(): Unit = {
+    val builder = Thread.ofPlatform()
+    // disallow
+    builder.allowSetThreadLocals(false)
+    testNoThreadLocals(builder)
+    // allow
+    builder.allowSetThreadLocals(true)
+    testThreadLocals(builder)
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testThreadLocals4(): Unit = {
+    val builder = Thread.ofVirtual()
+    // disallow
+    builder.allowSetThreadLocals(false)
+    testNoThreadLocals(builder)
+    // allow
+    builder.allowSetThreadLocals(true)
+    testThreadLocals(builder)
+  }
+
+  private def testInheritedThreadLocals(builder: Thread.Builder): Unit = {
+    val value = new AnyRef
+    InheritedLocal.set(value)
+    val done = new AtomicBoolean()
+    val task: Runnable = () => {
+      assertTrue(InheritedLocal.get eq value)
+      done.set(true)
+
+    }
+    done.set(false)
+    val thread1 = builder.unstarted(task)
+    thread1.start()
+    thread1.join()
+    assertTrue(done.get())
+    done.set(false)
+    val thread2 = builder.start(task)
+    thread2.join()
+    assertTrue(done.get())
+    done.set(false)
+    val thread3 = builder.factory.newThread(task)
+    thread3.start()
+    thread3.join()
+    assertTrue(done.get())
+  }
+
+  private def testNoInheritedThreadLocals(builder: Thread.Builder): Unit = {
+    val value = new AnyRef
+    InheritedLocal.set(value)
+    val done = new AtomicBoolean()
+    val task: Runnable = () => {
+      assertTrue(InheritedLocal.get == null)
+      done.set(true)
+
+    }
+    done.set(false)
+    val thread1 = builder.unstarted(task)
+    thread1.start()
+    thread1.join()
+    assertTrue(done.get())
+    done.set(false)
+    val thread2 = builder.start(task)
+    thread2.join()
+    assertTrue(done.get())
+    done.set(false)
+    val thread3 = builder.factory.newThread(task)
+    thread3.start()
+    thread3.join()
+    assertTrue(done.get())
+  }
+
+  @Test def testInheritedThreadLocals1(): Unit = {
+    val builder = Thread.ofPlatform()
+    testInheritedThreadLocals(builder) // default
+
+    // do no inherit
+    builder.inheritInheritableThreadLocals(false)
+    testNoInheritedThreadLocals(builder)
+    // inherit
+    builder.inheritInheritableThreadLocals(true)
+    testInheritedThreadLocals(builder)
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testInheritedThreadLocals2(): Unit = {
+    val builder = Thread.ofVirtual()
+    testInheritedThreadLocals(builder) // default
+
+    // do no inherit
+    builder.inheritInheritableThreadLocals(false)
+    testNoInheritedThreadLocals(builder)
+    // inherit
+    builder.inheritInheritableThreadLocals(true)
+    testInheritedThreadLocals(builder)
+  }
+  @Test def testInheritedThreadLocals3(): Unit = {
+    val builder = Thread.ofPlatform()
+    // thread locals not allowed
+    builder.allowSetThreadLocals(false)
+    testNoInheritedThreadLocals(builder)
+    builder.inheritInheritableThreadLocals(false)
+    testNoInheritedThreadLocals(builder)
+    builder.inheritInheritableThreadLocals(true)
+    testNoInheritedThreadLocals(builder)
+    // thread locals allowed
+    builder.allowSetThreadLocals(true)
+    builder.inheritInheritableThreadLocals(false)
+    testNoInheritedThreadLocals(builder)
+    builder.inheritInheritableThreadLocals(true)
+    testInheritedThreadLocals(builder)
+  }
+
+  @Ignore("VirtualThreads unimplemented")
+  @Test def testInheritedThreadLocals4(): Unit = {
+    val builder = Thread.ofVirtual()
+    // thread locals not allowed
+    builder.allowSetThreadLocals(false)
+    testNoInheritedThreadLocals(builder)
+    builder.inheritInheritableThreadLocals(false)
+    testNoInheritedThreadLocals(builder)
+    builder.inheritInheritableThreadLocals(true)
+    testNoInheritedThreadLocals(builder)
+    // thread locals allowed
+    builder.allowSetThreadLocals(true)
+    builder.inheritInheritableThreadLocals(false)
+    testNoInheritedThreadLocals(builder)
+    builder.inheritInheritableThreadLocals(true)
+    testInheritedThreadLocals(builder)
+  }
+
+  @Test def testNulls1(): Unit = {
+    val builder = Thread.ofPlatform()
+    assertThrows(classOf[NullPointerException], () => builder.group(null))
+    assertThrows(classOf[NullPointerException], () => builder.name(null))
+    assertThrows(classOf[NullPointerException], () => builder.name(null, 0))
+    assertThrows(
+      classOf[NullPointerException],
+      () => builder.uncaughtExceptionHandler(null)
+    )
+    assertThrows(classOf[NullPointerException], () => builder.unstarted(null))
+    assertThrows(classOf[NullPointerException], () => builder.start(null))
+  }
+
+  @Test def testNulls2(): Unit = {
+    val builder = Thread.ofVirtual()
+    assertThrows(classOf[NullPointerException], () => builder.name(null))
+    assertThrows(classOf[NullPointerException], () => builder.name(null, 0))
+    assertThrows(
+      classOf[NullPointerException],
+      () => builder.uncaughtExceptionHandler(null)
+    )
+    assertThrows(classOf[NullPointerException], () => builder.unstarted(null))
+    assertThrows(classOf[NullPointerException], () => builder.start(null))
+  }
+}


### PR DESCRIPTION
This PR implements JDK-19 Thread API including thread builders `Thread.ofPlatform` and `Thread.ofVirtual` along with other new methods. 

* Added `join(Duration)` and `sleep(Duration)` methods - these require third-party implementation of `java.time.Duration`. 
* Added stub for `VirtualThread` 
* Added `Thread.ofPlatform` and `Thread.ofVirtual` builders along with extensive set of tests
* Fix multiple typos in `deamon` -> `daemon` 
* Fixed initialization of `ThreadLocals` allowing to support threads without ThreadLocal data in the future
* Refactored `Thread` for easier integration with VirtualThreads in the future - extracted platform thread context to separate container 
* Add JDK compliance tests running with JDK 20 + `--enable-preview` flag