### PR TITLE
Synchronise ForkJoinPool port with JSR-166 changes for JDK 19

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/CountedCompleter.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CountedCompleter.scala
@@ -3,6 +3,7 @@
  * Expert Group and released to the public domain, as explained at
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
+// revision 1.72
 package java.util.concurrent
 
 import scala.scalanative.runtime.{Intrinsics, fromRawPtr}

--- a/javalib/src/main/scala/java/util/concurrent/ExecutorService.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ExecutorService.scala
@@ -9,7 +9,7 @@ package concurrent
 
 import java.security.{PrivilegedAction, PrivilegedExceptionAction}
 
-trait ExecutorService extends Executor {
+trait ExecutorService extends Executor with AutoCloseable {
 
   def shutdown(): Unit
 
@@ -44,5 +44,27 @@ trait ExecutorService extends Executor {
       timeout: Long,
       unit: TimeUnit
   ): T
+
+  // Since JDK 19
+  override def close(): Unit = {
+    var terminated = isTerminated()
+    if (!terminated) {
+      shutdown()
+      var interrupted = false
+      while (!terminated) {
+        try terminated = awaitTermination(1L, TimeUnit.DAYS)
+        catch {
+          case e: InterruptedException =>
+            if (!interrupted) {
+              shutdownNow()
+              interrupted = true
+            }
+        }
+      }
+      if (interrupted) {
+        Thread.currentThread().interrupt()
+      }
+    }
+  }
 
 }

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -1,3 +1,5 @@
+// Ported from JSR-166, revision: 1.411
+
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
@@ -19,40 +21,50 @@ import scala.annotation._
 import scala.scalanative.annotation._
 import scala.scalanative.unsafe._
 import scala.scalanative.libc.atomic.{CAtomicInt, CAtomicLongLong, CAtomicRef}
+import scala.scalanative.libc.atomic.atomic_thread_fence
+import scala.scalanative.libc.atomic.memory_order._
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics, ObjectArray}
+
+import ForkJoinPool._
 
 class ForkJoinPool private (
     factory: ForkJoinPool.ForkJoinWorkerThreadFactory,
     val ueh: UncaughtExceptionHandler,
     saturate: Predicate[ForkJoinPool],
     keepAlive: Long,
-    workerNamePrefix: String
+    workerNamePrefix: String,
+    bounds: Long,
+    config: Int
 ) extends AbstractExecutorService {
-  import ForkJoinPool._
+  import WorkQueue._
 
-  @volatile private[concurrent] var stealCount: Long = 0
-  @volatile private[concurrent] var threadIds: Int = 0
-  @volatile private[concurrent] var mode: Int = 0
-  @volatile private[concurrent] var ctl: Long = 0L // main pool control
+  @volatile var runState: Int = 0 // SHUTDOWN, STOP, TERMINATED bits
+  @volatile var stealCount: Long = 0
+  @volatile var threadIds: Long = 0
+  @volatile var ctl: Long = _ // main pool control
 
-  final private[concurrent] var bounds: Int = 0
-  final private[concurrent] val registrationLock = new ReentrantLock()
+  final var parallelism: Int = _ // target number of workers
+  final val registrationLock = new ReentrantLock()
 
-  private[concurrent] var scanRover: Int = 0 // advances across pollScan calls
   private[concurrent] var queues: Array[WorkQueue] = _ // main registry
   private[concurrent] var termination: Condition = _
 
-  private val modeAtomic = new CAtomicInt(
-    fromRawPtr(Intrinsics.classFieldRawPtr(this, "mode"))
-  )
-  private val ctlAtomic = new CAtomicLongLong(
+  // Support for atomic operations
+
+  @alwaysinline private def ctlAtomic = new CAtomicLongLong(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "ctl"))
   )
-  private val stealCountAtomic = new CAtomicLongLong(
+  @alwaysinline private def runStateAtomic = new CAtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "runState"))
+  )
+  @alwaysinline private def stealCountAtomic = new CAtomicLongLong(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "stealCount"))
   )
-  private val threadIdsAtomic = new CAtomicInt(
+  @alwaysinline private def threadIdsAtomic = new CAtomicLongLong(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "threadIds"))
+  )
+  @alwaysinline private def parallelismAtomic = new CAtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "parallelism"))
   )
 
   @alwaysinline
@@ -68,48 +80,50 @@ class ForkJoinPool private (
   @alwaysinline
   private def getAndAddCtl(v: Long): Long = ctlAtomic.fetchAdd(v)
   @alwaysinline
-  private def getAndBitwiseOrMode(v: Int): Int = modeAtomic.fetchOr(v)
+  private def getAndBitwiseOrRunState(v: Int): Int = runStateAtomic.fetchOr(v)
   @alwaysinline
-  private def getAndAddThreadIds(v: Int): Int = threadIdsAtomic.fetchAdd(v)
+  private def incrementThreadIds(): Long = threadIdsAtomic.fetchAdd(1L)
+  @alwaysinline
+  private def getAndSetParallelism(v: Int): Int = parallelismAtomic.exchange(v)
+  @alwaysinline
+  private def getParallelismOpaque(): Int = parallelism
+
+  // Creating, registering, and deregistering workers
 
   private def createWorker(): Boolean = {
-    var ex: Throwable = null
+    val fac = factory
     var wt: ForkJoinWorkerThread = null
-
-    try {
-      if (factory != null) {
-        wt = factory.newThread(this)
-        if (wt != null) {
-          wt.start()
-          return true
-        }
+    var ex: Throwable = null
+    try
+      if (runState >= 0 && // avoid construction if terminating
+          fac != null && { wt = fac.newThread(this); wt != null }) {
+        wt.start()
+        return true
       }
-    } catch {
-      case rex: Throwable =>
-        ex = rex
-    }
+    catch { case rex: Throwable => ex = rex }
     deregisterWorker(wt, ex)
     false
   }
 
   final private[concurrent] def nextWorkerThreadName(): String = {
-    val tid = getAndAddThreadIds(1) + 1
-    val prefix = Option(workerNamePrefix)
-      .getOrElse("ForkJoinPool.commonPool-worker-") // commonPool has no prefix
-    prefix + tid
+    val tid = incrementThreadIds() + 1
+    val prefix = workerNamePrefix match {
+      case null   => "ForkJoinPool.commonPool-worker-"
+      case prefix => prefix
+    }
+    prefix.concat(java.lang.Long.toString(tid))
   }
 
   final private[concurrent] def registerWorker(w: WorkQueue): Unit = {
-    val lock = registrationLock
     ThreadLocalRandom.localInit()
     val seed = ThreadLocalRandom.getProbe()
+    val lock = registrationLock
+    var cfg = config & FIFO
     if (w != null && lock != null) {
-      val modebits: Int = (mode & FIFO) | w.config
       w.array = new Array[ForkJoinTask[_]](INITIAL_QUEUE_CAPACITY)
+      cfg |= w.config | SRC
       w.stackPred = seed // stash for runWorker
 
-      if ((modebits & INNOCUOUS) != 0)
-        w.initializeInnocuousWorker()
       var id: Int = (seed << 1) | 1 // initial index guess
       lock.lock()
       try {
@@ -124,7 +138,7 @@ class ForkJoinPool private (
             k -= 2
           }
           if (k == 0) id = n | 1 // resize below
-          w.config = id | modebits // now publishable
+          w.config = id | cfg // now publishable
           w.phase = w.config
 
           if (id < n) qs(id) = w
@@ -152,44 +166,46 @@ class ForkJoinPool private (
       wt: ForkJoinWorkerThread,
       ex: Throwable
   ): Unit = {
-    val lock: ReentrantLock = registrationLock
-    val w: WorkQueue = if (wt != null) wt.workQueue else null
-    var cfg: Int = 0
-    if (w != null && lock != null) {
-      cfg = w.config
-      val ns: Long = w.nsteals & 0xffffffffL
-      lock.lock() // remove index from array
-      val qs = queues
-      val n: Int = if (qs != null) qs.length else 0
-      val i: Int = cfg & (n - 1)
-      if (n > 0 && qs(i) == w)
-        qs(i) = null
-      stealCount += ns // accumulate steals
+    val w = if (wt == null) null else wt.workQueue
+    var cfg = if (w == null) 0 else w.config
+    var c = ctl
+    if ((cfg & TRIMMED) == 0) {
+      while ({
+        val newC = (RC_MASK & (c - RC_UNIT)) |
+          (TC_MASK & (c - TC_UNIT)) |
+          (SP_MASK & c)
+        c != { c = compareAndExchangeCtl(c, newC); c }
+      }) ()
+    } else if (c.toInt == 0) // was dropped on timeout
+      cfg &= ~SRC // suppress signal if last
 
-      lock.unlock()
-      var c: Long = ctl
-      if (w.phase != QUIET) { // decrement counts
-        while ({
-          val c0 = c
-          val newC = (RC_MASK & (c - RC_UNIT)) |
-            (TC_MASK & (c - TC_UNIT)) |
-            (SP_MASK & c)
-          c = compareAndExchangeCtl(c, newC)
-          c0 != c
-        }) ()
-      } else if (c.toInt == 0) { // was dropped on timeout
-        cfg = 0 // suppress signal if last
+    if (!tryTerminate(false, false) && w != null) {
+      val ns = w.nsteals & 0xffffffffL
+      val lock = registrationLock
+      if (lock != null) {
+        lock.lock() // remove index unless terminating
+        val qs = queues
+        val n = if (qs != null) qs.length else 0
+        val i = cfg & (n - 1)
+        if (n > 0 && (qs(i) eq w))
+          qs(i) == null
+        stealCount += ns // accumulate steals
+        lock.unlock()
       }
-      while (w.pop() match {
-            case null => false
-            case t =>
-              ForkJoinTask.cancelIgnoringExceptions(t)
-              true
-          }) ()
+      if ((cfg & SRC) != 0)
+        signalWork() // possibly replace worker
     }
-    if (!tryTerminate(false, false) && w != null && (cfg & SRC) != 0)
-      signalWork() // possibly replace worker
-    if (ex != null) ForkJoinTask.rethrow(ex)
+    if (ex != null) {
+      if (w != null) {
+        w.access = STOP
+        while ({
+          val t = w.nextLocalTask(0)
+          ForkJoinTask.cancelIgnoringExceptions(t)
+          t != null
+        }) ()
+      }
+      ForkJoinTask.rethrow(ex)
+    }
   }
 
   /*
@@ -197,51 +213,111 @@ class ForkJoinPool private (
    */
   final private[concurrent] def signalWork(): Unit = {
     var c: Long = ctl
-    while (c < 0L) {
-      ((c.toInt & ~UNSIGNALLED): @switch) match {
-        case 0 => // no idle workers
-          if ((c & ADD_WORKER) == 0L) return // enough total workers
+    val pc = parallelism
+    val qs = queues
+    val n = if (qs != null) qs.length else 0
+    if ((c >>> RC_SHIFT).toShort < pc && n > 0) {
+      var create = false
+      var break = false
+      while (!break) {
+        val sp = c.toInt & ~INACTIVE
+        val v = qs(sp & (n - 1))
+        val deficit = pc - (c >>> TC_SHIFT).toShort
+        val ac: Long = (c + RC_UNIT) & RC_MASK
+        var nc = 0L
+        if (sp != 0 && v != null)
+          nc = (v.stackPred & SP_MASK) | (c & TC_MASK)
+        else if (deficit <= 0)
+          break = true
+        else {
+          create = true
+          nc = ((c + TC_UNIT) & TC_MASK)
+        }
+        if (!break && {
+              val c0 = c
+              c = compareAndExchangeCtl(c0, nc | ac)
+              c0 == c
+            }) {
+          if (create)
+            createWorker()
           else {
-            val prevC = c
-            c = compareAndExchangeCtl(
-              c,
-              (RC_MASK & (c + RC_UNIT)) | (TC_MASK & (c + TC_UNIT))
-            )
-            if (c == prevC) {
-              createWorker()
-              return
-            }
+            val owner = v.owner
+            v.phase = sp
+            if (v.access == PARKED) LockSupport.unpark(owner)
           }
-
-        case sp =>
-          val i = sp & SMASK
-          val qs = queues
-          def unstartedOrTerminated = qs == null
-          def terminated = qs.length <= i
-          def terminating = qs(i) == null
-
-          if (unstartedOrTerminated || terminated || terminating)
-            return // break
-          else {
-            val v = qs(i)
-            val vt = v.owner
-            val nc = (v.stackPred & SP_MASK) | (UC_MASK & (c + RC_UNIT))
-            val prevC = c
-            c = compareAndExchangeCtl(c, nc)
-            if (c == prevC) {
-              // release idle worker
-              v.phase = sp
-              vt.foreach(LockSupport.unpark)
-              return
-            }
-          }
+          break = true
+        }
       }
     }
   }
 
+  private def reactivate(): WorkQueue = {
+    var c = ctl
+    val qs = queues
+    val n = if (qs != null) qs.length else 0
+    if (n > 0) {
+      while (true) {
+        val sp = c.toInt & ~INACTIVE
+        val v = qs(sp & (n - 1))
+        val ac = UC_MASK & (c + RC_UNIT)
+        if (sp == 0 || v == null)
+          return null
+        if (c == {
+              c = compareAndExchangeCtl(c, (v.stackPred & SP_MASK) | ac); c
+            }) {
+          val owner = v.owner
+          v.phase = sp
+          if (v.access == PARKED) LockSupport.unpark(owner)
+          return v
+        }
+      }
+    }
+    null
+  }
+
+  private def tryTrim(w: WorkQueue): Boolean = {
+    if (w != null) {
+      val pred = w.stackPred
+      val cfg = w.config | TRIMMED
+      val c = ctl
+      val sp = c.toInt & ~INACTIVE
+      if ((sp & SMASK) == (cfg & SMASK) &&
+          compareAndSetCtl(c, (pred & SP_MASK) | (UC_MASK & (c - TC_UNIT)))) {
+        w.config = cfg // add sentinel for deregisterWorker
+        w.phase = sp
+        return true
+      }
+    }
+    false
+  }
+
+  private def hasTasks(submissionsOnly: Boolean): Boolean = {
+    val step = if (submissionsOnly) 2 else 1
+    var checkSum = 0
+    while (true) { // repeat until stable (normally twice)
+      VarHandle.acquireFence()
+      val qs = queues
+      val n = if (qs == null) 0 else qs.length
+      var sum = 0
+      var i = 0
+      while (i < n) {
+        val q = qs(i)
+        if (q != null) {
+          val s = q.top
+          if (q.access > 0 || s != q.base)
+            return true
+          sum += (s << 16) + i + 1
+        }
+        i += step
+      }
+      if (checkSum == sum) return false
+      else checkSum = sum
+    }
+    false // unreachable
+  }
+
   final private[concurrent] def runWorker(w: WorkQueue): Unit = {
     if (w != null) { // skip on failed init
-      w.config |= SRC // mark as valid source
 
       var r: Int = w.stackPred
       var src: Int = 0 // use seed from registerWorker
@@ -262,6 +338,7 @@ class ForkJoinPool private (
         r ^= r << 5 // xorshift
         tryScan() || tryAwaitWork()
       }) ()
+      w.access = STOP; // record normal termination
     }
   }
 
@@ -273,220 +350,174 @@ class ForkJoinPool private (
     var i: Int = n
     while (i > 0) {
       val j = r & (n - 1)
-      val q = qs(j)
+      val q = qs(j) // poll at qs[j].array[k]
       val a = if (q != null) q.array else null
       val cap = if (a != null) a.length else 0
       if (cap > 0) {
-        val b = q.base
-        val k: Int = (cap - 1) & b
-        val nextBase: Int = b + 1
-        val nextIndex: Int = (cap - 1) & nextBase
         val src: Int = j | SRC
-        val t: ForkJoinTask[_] = WorkQueue.getSlot(a, k)
+        val b = q.base
+        val k = (cap - 1) & b
+        val nb = b + 1
+        val nk = (cap - 1) & nb
+        val t: ForkJoinTask[_] = a(k)
+        VarHandle.acquireFence()
         if (q.base != b) { // inconsistent
           return prevSrc
         } else if (t != null && WorkQueue.casSlotToNull(a, k, t)) {
-          q.base = nextBase
-          val next: ForkJoinTask[_] = a(nextIndex)
+          q.base = nb
           w.source = src
-          if (src != prevSrc && next != null)
+          if (prevSrc == 0 && q.base == nb && a(nk) != null)
             signalWork() // propagate
           w.topLevelExec(t, q)
           return src
-        } else if (a(nextIndex) != null) { // revisit
-          return prevSrc
+        } else if ((q.array ne a) || a(k) != null || a(nk) != null) {
+          return prevSrc // revisit
         }
       }
-
       i -= 1
       r += step
     }
-    if (queues != qs) prevSrc
-    else -1 // possibly resized
+    -1
   }
 
   private def awaitWork(w: WorkQueue): Int = {
-    if (w == null) return -1 // already terminated
-    val phase = (w.phase + SS_SEQ) & ~UNSIGNALLED
-    w.phase = phase | UNSIGNALLED // advance phase
-
-    var prevCtl: Long = ctl
-    var c: Long = 0L // enqueue
+    if (w == null)
+      return -1 // already terminated
+    var p = (w.phase + SS_SEQ) & ~INACTIVE
+    var idle = false // true if possibly quiescent
+    if (runState < 0)
+      return -1 // terminating
+    val sp: Long = p & SP_MASK
+    var pc: Long = ctl
+    var qc: Long = 0
+    w.phase = p | INACTIVE
     while ({
-      w.stackPred = prevCtl.toInt
-      c = ((prevCtl - RC_UNIT) & UC_MASK) | (phase & SP_MASK)
-      val prev = prevCtl
-      prevCtl = compareAndExchangeCtl(prevCtl, c)
-      prev != prevCtl
+      w.stackPred = pc.toInt
+      qc = ((pc - RC_UNIT) & UC_MASK) | sp
+      pc != { pc = compareAndExchangeCtl(pc, qc); pc }
     }) ()
 
-    Thread.interrupted() // clear status
-
-    LockSupport.setCurrentBlocker(this) // prepare to block (exit also OK)
-
-    var deadline = 0L // nonzero if possibly quiescent
-    def setDeadline(v: Long): Unit = {
-      deadline = v match {
-        case 0L => 1L
-        case _  => v
-      }
+    if ((qc & RC_MASK) <= 0L) {
+      if (hasTasks(true) && (w.phase >= 0 || (reactivate() eq w)))
+        return 0 // check for stragglers
+      if (runState != 0 && tryTerminate(false, false))
+        return -1 // quiescent termination
+      idle = true
     }
 
-    var ac = (c >> RC_SHIFT).toInt
-    val md = mode
-    if (md < 0) { // pool is terminating
-      return -1
-    } else if ((md & SMASK) + ac <= 0) {
-      var checkTermination = (md & SHUTDOWN) != 0
-      setDeadline(System.currentTimeMillis() + keepAlive)
-      val qs = queues // check for racing submission
-      val n = if (qs == null) 0 else qs.length
-      var i = 0
+    val qs = queues // spin for expected #accesses in scan+signal
+    var spins = if (qs == null) 0 else ((qs.length & SMASK) << 1) | 0xf
+    while ({ p = w.phase; p < 0 } && { spins -= 1; spins > 0 })
+      Thread.onSpinWait()
+
+    if (p < 0) {
+      var deadline = if (idle) keepAlive + System.currentTimeMillis() else 0L
+      LockSupport.setCurrentBlocker(this)
+
       var break = false
-      while (!break && i < n) {
-        if (ctl != c) { // already signalled
-          checkTermination = false
+      while (!break) { // await signal or termination
+        if (runState < 0)
+          return -1
+        w.access = PARKED
+        if (w.phase < 0) {
+          if (idle)
+            LockSupport.parkUntil(deadline)
+          else
+            LockSupport.park()
+        }
+        w.access = 0
+        if (w.phase >= 0) {
+          LockSupport.setCurrentBlocker(null)
           break = true
         } else {
-          val q = qs(i)
-          val a = if (q != null) q.array else null
-          val cap = if (a != null) a.length else 0
-          if (cap > 0) {
-            val b = q.base
-            if (b != q.top ||
-                a((cap - 1) & b) != null ||
-                q.source != 0) {
-              if (compareAndSetCtl(c, prevCtl)) w.phase = phase // self-signal
-              checkTermination = false
-              break = true
+          Thread.interrupted() // clear status for next park
+          if (idle) { // check for idle timeout
+            if (deadline - System.currentTimeMillis() < TIMEOUT_SLOP) {
+              if (tryTrim(w))
+                return -1
+              else
+                deadline += keepAlive
             }
           }
         }
-
-        i += 2
       }
-      if (checkTermination && tryTerminate(false, false))
-        return -1 // trigger quiescent termination
     }
-
-    var alt = false
-    var break = false
-    while (!break) {
-      val currentCtl = ctl
-      if (w.phase >= 0) break = true
-      else if (mode < 0) return -1
-      else if ((ctl >> RC_SHIFT).toInt > ac)
-        Thread.onSpinWait() // signal in progress
-      else if (deadline != 0L &&
-          deadline - System.currentTimeMillis() <= TIMEOUT_SLOP) {
-        val prevC = c
-        c = ctl
-        if (prevC != c) { // ensure consistent
-          ac = (c >> RC_SHIFT).toInt
-        } else if (compareAndSetCtl(
-              c,
-              ((UC_MASK & (c - TC_UNIT)) | (w.stackPred & SP_MASK))
-            )) {
-          w.phase = QUIET
-          return -1 // drop on timeout
-        }
-      } else if ({ alt = !alt; !alt }) { // check between parks
-        Thread.interrupted()
-      } else if (deadline != 0L) LockSupport.parkUntil(deadline)
-      else LockSupport.park()
-    }
-    LockSupport.setCurrentBlocker(null)
     0
   }
 
-  final private[concurrent] def isSaturated(): Boolean = {
-    val maxTotal: Int = bounds >>> SWIDTH
-    @tailrec
-    def loop(): Boolean = {
-      val c = ctl
-      if ((c.toInt & ~UNSIGNALLED) != 0) false
-      else if ((c >>> TC_SHIFT).toShort >= maxTotal) true
-      else {
-        val nc: Long = ((c + TC_UNIT) & TC_MASK) | (c & ~TC_MASK)
-        if (compareAndSetCtl(c, nc)) !createWorker()
-        else loop()
-      }
-    }
-    loop()
+  /** Non-overridable version of isQuiescent. Returns true if quiescent or
+   *  already terminating.
+   */
+  private def canStop(): Boolean = {
+    var c = ctl
+    while ({
+      if (runState < 0)
+        return true
+      if ((c & RC_MASK) > 0L || hasTasks(false))
+        return false
+
+      c != { c = ctl; c } // validate
+    }) ()
+    true
   }
 
-  final private[concurrent] def canStop(): Boolean = {
-    var oldSum: Long = 0L
-    var break = false
-    while (!break) { // repeat until stable
-      val qs = queues
-      var md = mode
-      if (qs == null || (md & STOP) != 0) return true
-      val c = ctl
-      if ((md & SMASK) + (ctl >> RC_SHIFT).toInt > 0) break = true
-      else {
-        var checkSum: Long = c
-        var i = 1
-        while (!break && i < qs.length) { // scan submitters
-          val q = qs(i)
-          val a = if (q != null) q.array else null
-          val cap = if (a != null) a.length else 0
-          if (cap > 0) {
-            val s = q.top
-            if (s != q.base ||
-                a((cap - 1) & s) != null ||
-                q.source != 0)
-              break = true
-            else checkSum += (i.toLong << 32) ^ s
-          }
-          i += 2
+  private def pollScan(submissionsOnly: Boolean): ForkJoinTask[_] = {
+    var r = ThreadLocalRandom.nextSecondarySeed()
+    if (submissionsOnly)
+      r &= ~1
+    val step = if (submissionsOnly) 2 else 1
+    val qs = queues
+    val n = if (qs != null) qs.length else 0
+    if (runState >= 0 && n > 0) {
+      var i = n
+      while (i > 0) {
+        val q = qs(r & (n - 1))
+        if (q != null) {
+          val t = q.poll(this)
+          if (t != null) return t
         }
-        if (oldSum == checkSum && (queues eq qs)) return true
-        else oldSum = checkSum
+        i -= step
+        r += step
       }
     }
-    (mode & STOP) != 0 // recheck mode on false return
+    null
   }
 
-  private def tryCompensate(c: Long): Int = {
-    val md = mode
-    val b = bounds
+  private def tryCompensate(c: Long, canSaturate: Boolean): Int = {
+    val b = bounds // unpack fields
+    val pc = parallelism
     // counts are signed centered at parallelism level == 0
     val minActive: Int = (b & SMASK).toShort
-    val maxTotal: Int = b >>> SWIDTH
-    val active: Int = (c >> RC_SHIFT).toInt
+    val maxTotal: Int = (b >>> SWIDTH).toShort + pc
+    val active: Int = (c >>> RC_SHIFT).toShort
     val total: Int = (c >>> TC_SHIFT).toShort
-    val sp: Int = c.toInt & ~UNSIGNALLED
+    val sp: Int = c.toInt & ~INACTIVE
 
-    if (total >= 0) {
-      if (sp != 0) { // activate idle worker
-        val qs = queues
-        val n = if (qs != null) qs.length else 0
-        val v: WorkQueue = if (n > 0) qs(sp & (n - 1)) else null
-        if (v != null) {
-          val nc: Long = (v.stackPred.toLong & SP_MASK) | (UC_MASK & c)
-          if (compareAndSetCtl(c, nc)) {
-            v.phase = sp
-            v.owner.foreach(LockSupport.unpark)
-            return UNCOMPENSATE
-          }
+    if (sp != 0 && active <= pc) {
+      val qs = queues
+      val i = sp & SMASK
+      val v = if (qs != null && qs.length > i) qs(i) else null
+      if (ctl == c && v != null) {
+        val nc = (v.stackPred & SP_MASK) | (UC_MASK & c)
+        if (compareAndSetCtl(c, nc)) {
+          v.phase = sp
+          LockSupport.unpark(v.owner)
+          return UNCOMPENSATE
         }
-        return -1 // retry
-      } else if (active > minActive) { // reduce parallelism
-        val nc: Long = (RC_MASK & (c - RC_UNIT)) | (~RC_MASK & c)
-        return if (compareAndSetCtl(c, nc)) UNCOMPENSATE
-        else -1
       }
-    }
-    if (total < maxTotal) { // expand pool
-      val nc: Long = ((c + TC_UNIT) & TC_MASK) | (c & ~TC_MASK)
-      return if (!compareAndSetCtl(c, nc)) -1
-      else {
-        if (!createWorker()) 0
-        else UNCOMPENSATE
-      }
-    } else if (!compareAndSetCtl(c, c)) return -1
-    else if (saturate != null && saturate.test(this)) return 0
+      -1 // retry
+    } else if (active > minActive && total >= pc) { // reduce active workers
+      val nc = ((RC_MASK & (c - RC_UNIT)) | (~RC_MASK & c))
+      if (compareAndSetCtl(c, nc)) UNCOMPENSATE else -1
+    } else if (total < maxTotal && total < MAX_CAP) { // expand pool
+      val nc = ((c + TC_UNIT) & TC_MASK) | (c & ~TC_MASK)
+      if (!compareAndSetCtl(c, nc)) -1
+      else if (!createWorker()) 0
+      else UNCOMPENSATE
+    } else if (!compareAndSetCtl(c, c)) // validate
+      -1
+    else if (canSaturate || (saturate != null && saturate.test(this)))
+      0
     else
       throw new RejectedExecutionException(
         "Thread limit exceeded replacing blocked worker"
@@ -499,308 +530,292 @@ class ForkJoinPool private (
 
   final private[concurrent] def helpJoin(
       task: ForkJoinTask[_],
-      w: WorkQueue
+      w: WorkQueue,
+      timed: Boolean
   ): Int = {
-    var s = 0
-    if (task != null && w != null) {
-      val wsrc: Int = w.source
-      val wid: Int = w.config & SMASK
-      var r: Int = wid + 2
-      var scan: Boolean = true
-      var c: Long = 0L // track ctl stability
+    if (w == null || task == null)
+      return 0
 
-      var counter = 0
-      while (true) {
-        counter += 1
-        s = task.status
-        if (s < 0) return s
-        else if ({ scan = !scan; scan }) { // previous scan was empty
-          if (mode < 0) ForkJoinTask.cancelIgnoringExceptions(task)
-          else if ({
-            val prevC = c; c = ctl;
-            c == prevC && { s = tryCompensate(c); s >= 0 }
-          }) return s // block
-        } else { // scan for subtasks
-          val qs: Array[WorkQueue] = queues
-          val n: Int =
-            if (qs == null) 0
-            else qs.length
-          val m: Int = n - 1
-          var i: Int = n
+    val wsrc: Int = w.source
+    val wid: Int = (w.config & SMASK) | SRC
+    var r: Int = wid + 2
+    var sctl = 0L // track stability
+    var rescan: Boolean = true
+    while (true) {
+      var s = task.status
+      if (s < 0)
+        return s
+      if (!rescan && sctl == { sctl = ctl; sctl }) {
+        if (runState < 0)
+          return 0
+        s = tryCompensate(sctl, timed)
+        if (s >= 0)
+          return s // block
+      }
+      rescan = false
+      val qs = queues
+      val n = if (qs != null) qs.length else 0
+      val m = n - 1
+      // scan
+      var breakScan = false
+      var i = n >>> 1
+      while (!breakScan && i > 0) {
+        val j = r & m
+        val q = qs(j)
+        val a = if (q != null) q.array else null
+        val cap = if (a != null) a.length else 0
+        if (cap > 0) {
+          var src = j | SRC
           var break = false
-          while (!break && i > 0) {
-            val j: Int = r & m
-            val q: WorkQueue = qs(j)
-            if (q != null) {
-              val a = q.array
-              val cap = if (a != null) a.length else 0
-              if (cap > 0) {
-                val b: Int = q.base
-                val k: Int = (cap - 1) & b
-                val nextBase: Int = b + 1
-                val src: Int = j | SRC
-                val t: ForkJoinTask[_] = WorkQueue.getSlot(a, k)
-                val sq: Int = q.source & SMASK
-                val eligible: Boolean =
-                  sq == wid || {
-                    val x = qs(sq & m)
-                    x != null && {
-                      val sx = x.source & SMASK
-                      sx == wid || { // indirect
-                        val y = qs(sx & m)
-                        (y != null && (y.source & SMASK) == wid) // 2-indirect
-                      }
-                    }
-                  }
-
-                if ({ s = task.status; s < 0 }) return s
-                else if ((q.source & SMASK) != sq || q.base != b) {
-                  scan = true
-                } else if (t == null) {
-                  scan |=
-                    a(nextBase & (cap - 1)) != null || q.top != b // lagging
-                } else if (eligible) {
-                  if (WorkQueue.casSlotToNull(a, k, t)) {
-                    q.base = nextBase
-                    w.source = src
-                    t.doExec()
-                    w.source = wsrc
-                  }
-                  scan = true
-                  break = true
-                }
+          while (!breakScan && !break) {
+            val sq = q.source
+            val b = q.base
+            val k = (cap - 1) & b
+            val nb = b + 1
+            val t = a(k)
+            VarHandle.acquireFence() // for re-reads
+            var eligible = true // check steal chain
+            var breakInner = false
+            var d = n
+            var v = sq
+            while (!breakInner) { // may be cyclic; bound
+              lazy val p = qs(v & m)
+              if (v == wid)
+                breakInner = true
+              else if (v == 0 || { d -= 1; d == 0 } || p == null) {
+                eligible = false
+                breakInner = true
+              } else {
+                v = p.source
               }
             }
-
-            i -= 2
-            r += 2
+            if (q.source != sq || q.base != b) () // stale
+            else if ({ s = task.status; s < 0 })
+              return s // recheck before taking
+            else if (t == null) {
+              if (a(k) == null) {
+                if (!rescan && eligible &&
+                    ((q.array ne a) || q.top != b))
+                  rescan = true // resized or stalled
+                break = true
+              }
+            } else if ((t eq task) && !eligible)
+              break = true
+            else if (WorkQueue.casSlotToNull(a, k, t)) {
+              q.base = nb
+              w.source = src
+              t.doExec()
+              w.source = wsrc
+              rescan = true
+              break = true
+              breakScan = true
+            }
           }
         }
+        i -= 1
+        r += 2
       }
     }
-    s
+    ??? // unreachable
   }
 
   final private[concurrent] def helpComplete(
       task: ForkJoinTask[_],
       w: WorkQueue,
-      owned: Boolean
+      owned: Boolean,
+      timed: Boolean
   ): Int = {
-    var s: Int = 0
-    if (task != null && w != null) {
-      var r: Int = w.config
-      var scan: Boolean = true
-      var locals: Boolean = true
-      var c: Long = 0L
-      var breakOuter = false
-      while (!breakOuter) {
-        if (locals) { // try locals before scanning
-          if ({ s = w.helpComplete(task, owned, 0); s < 0 }) breakOuter = true
-          locals = false
-        } else if ({ s = task.status; s < 0 }) breakOuter = true
-        else if ({ scan = !scan; scan })
-          if ({ val prevC = c; c = ctl; prevC == c }) breakOuter = true
-          else {
-            val qs: Array[WorkQueue] = queues
-            val n: Int =
-              if ((qs == null)) 0
-              else qs.length
-            var i: Int = n
-            var break = false
-            while (!break && !breakOuter && i > 0) {
-              var j: Int = r & (n - 1)
-              val q = qs(j)
-              val a = if (q != null) q.array else null
-              val b: Int = if (q != null) q.base else 0
-              val cap: Int = if (a != null) a.length else 0
-              var eligible: Boolean = false
-              if (cap > 0) {
-                val k: Int = (cap - 1) & b
-                val nextBase: Int = b + 1
-                val t: ForkJoinTask[_] = WorkQueue.getSlot(a, k)
-                t match {
-                  case cc: CountedCompleter[_] =>
-                    var f: CountedCompleter[_] = cc
-                    while ({
-                      eligible = (f eq task)
-                      !eligible && { f = f.completer; f != null }
-                    }) ()
-                  case _ => ()
-                }
-                if ({ s = task.status; s < 0 }) breakOuter = true
-                else if (q.base != b) scan = true
-                else if (t == null)
-                  scan |= (a(nextBase & (cap - 1)) != null || q.top != b)
-                else if (eligible) {
-                  if (WorkQueue.casSlotToNull(a, k, t)) {
-                    q.setBaseOpaque(nextBase)
-                    t.doExec()
-                    locals = true
-                  }
-                  scan = true
-                  break = true
-                }
-              }
-
-              i -= 1
-              r += 1
-            }
-          }
-      }
-    }
-    s
-  }
-
-  private def pollScan(submissionsOnly: Boolean): ForkJoinTask[_] = {
-    VarHandle.acquireFence()
-    scanRover += 0x61c88647 // Weyl increment raciness OK
-    val r =
-      if (submissionsOnly) scanRover & ~1 // even indices only
-      else scanRover
-    val step = if (submissionsOnly) 2 else 1
-    var qs = queues
-    var n = 0
-    var break = false
-    while (!break && { qs = queues; qs != null } && {
-          n = qs.length; n > 0
-        }) {
-      var scan = false
-      var i = 0
-      while (i < n) {
-        val j: Int = (n - 1) & (r + i)
-        val q: WorkQueue = qs(j)
-        val a = if (q != null) q.array else null
-        val cap = if (a != null) a.length else 0
-        if (cap > 0) {
-          val b = q.base
-          val k: Int = (cap - 1) & b
-          val nextBase: Int = b + 1
-          val t: ForkJoinTask[_] = WorkQueue.getSlot(a, k)
-          if (q.base != b) scan = true
-          else if (t == null)
-            scan |= (q.top != b || a(nextBase & (cap - 1)) != null)
-          else if (!WorkQueue.casSlotToNull(a, k, t)) scan = true
-          else {
-            q.setBaseOpaque(nextBase)
-            return t
-          }
-        }
-
-        i += step
-      }
-      if (!scan && (queues eq qs)) break = true
-    }
-    null
-  }
-
-  final private[concurrent] def helpQuiescePool(
-      w: WorkQueue,
-      nanos: Long,
-      interruptible: Boolean
-  ): Int = {
-    if (w == null) return 0
-    val startTime = System.nanoTime()
-    var parkTime = 0L
-    val prevSrc = w.source
-    var wsrc = prevSrc
-    val cfg = w.config
-    var r = cfg + 1
-    var active = true
-    var locals = true
+    if (w == null || task == null)
+      return 0
+    val wsrc = w.source
+    var r = w.config
+    var sctl = 0L
+    var rescan = true
     while (true) {
-      var busy = false
-      var scan = false
-      if (locals) { // run local tasks before (re)polling
-        locals = false
-        var u = null: ForkJoinTask[_]
-        while ({
-          u = w.nextLocalTask(cfg)
-          u != null
-        }) u.doExec()
+      var s = w.helpComplete(task, owned, 0)
+      if (s < 0)
+        return s
+      if (!rescan && sctl == { sctl = ctl; sctl }) {
+        if (!owned || runState < 0)
+          return 0
+        s = tryCompensate(sctl, timed)
+        if (s >= 0)
+          return s
       }
+      rescan = false
       val qs = queues
-      val n = if (qs == null) 0 else qs.length
-      var break = false
+      val n = if (qs != null) qs.length else 0
+      val m = n - 1
+      // scan:
+      var breakScan = false
       var i = n
-      while (!break && i > 0) {
-        val j = (n - 1) & r
+      while (!breakScan && i > 0) {
+        val j = r & m
         val q = qs(j)
         val a = if (q != null) q.array else null
         val cap = if (a != null) a.length else 0
-        if (q != w && cap > 0) {
-          val b = q.base
-          val k = (cap - 1) & b
-          val nextBase = b + 1
+        if (cap > 0) {
+          // poll:
+          var breakPoll = false
           val src = j | SRC
-          val t = WorkQueue.getSlot(a, k)
-          if (q.base != b) {
-            busy = true
-            scan = true
-          } else if (t != null) {
-            busy = true
-            scan = true
-            if (!active) { // increment before taking
-              active = true
-              getAndAddCtl(RC_UNIT)
-            }
-            if (WorkQueue.casSlotToNull(a, k, t)) {
-              q.base = nextBase
-              w.source = src
-              t.doExec()
-              wsrc = prevSrc
-              w.source = wsrc
-              locals = true
-            }
-            break = true
-          } else if (!busy) {
-            if (q.top != b || a(nextBase & (cap - 1)) != null) {
-              busy = true
-              scan = true
-            } else if (q.source != QUIET && q.phase >= 0)
-              busy = true
+          var b = q.base
+          while (!breakPoll) {
+            val k = (cap - 1) & b
+            val nb = b + 1
+            val t = a(k)
+            VarHandle.acquireFence() // for re-reads
+            if (b != { b = q.base; b }) () // stale
+            else if ({ s = task.status; s < 0 })
+              return s // recheck before taking
+            else if (t == null) {
+              if (a(k) == null) {
+                if (!rescan && // resized or stalled
+                    ((q.array ne a) || q.top != b))
+                  rescan = true
+                breakPoll = true
+              }
+            } else
+              t match {
+                case _f: CountedCompleter[_] =>
+                  var f: CountedCompleter[_] = _f
+                  var break = false
+                  while (!break) {
+                    if (f eq task) break = true
+                    else if ({ f = f.completer; f == null }) {
+                      break = true
+                      breakPoll = true
+                    }
+                  }
+                  if (!breakPoll && WorkQueue.casSlotToNull(a, k, t)) {
+                    q.base = nb
+                    w.source = src
+                    t.doExec()
+                    w.source = wsrc
+                    rescan = true
+                    breakPoll = true
+                    breakScan = true
+                  }
+                case _ => breakPoll = true
+              }
           }
         }
         i -= 1
         r += 1
       }
-      VarHandle.acquireFence()
-      if (!scan && (queues eq qs)) {
-        if (!busy) {
-          w.source = prevSrc
-          if (!active) getAndAddCtl(RC_UNIT)
-          return 1
-        }
-        if (wsrc != QUIET) {
-          wsrc = QUIET
-          w.source = wsrc
-        }
-        if (active) { // decrement
-          active = false
-          parkTime = 0L
-          getAndAddCtl(RC_MASK & -RC_UNIT)
-        } else if (parkTime == 0L) {
-          parkTime = 1L << 10 // initially about 1 usec
-          Thread.`yield`()
-        } else {
-          val interrupted = interruptible && Thread.interrupted()
-          if (interrupted || System.nanoTime() - startTime > nanos) {
-            getAndAddCtl(RC_UNIT)
-            return if (interrupted) -1 else 0
-          } else {
-            LockSupport.parkNanos(this, parkTime)
-            if (parkTime < (nanos >>> 8) && parkTime < (1L << 20))
-              parkTime <<= 1 // max sleep approx 1 sec or 1% nanos
+    }
+    ??? // unreachable
+  }
+
+  private def helpQuiesce(
+      w: WorkQueue,
+      _nanos: Long,
+      interruptible: Boolean
+  ): Int = {
+    val startTime = System.nanoTime()
+    var parkTime = 0L
+    var nanos = _nanos
+    var phase = if (w != null) w.phase else -1
+    if (phase < 0) // w.phase set negative when temporarily quiescent
+      return 0
+    val activePhase = phase
+    val inactivePhase = phase | INACTIVE
+    var wsrc = w.source
+    var r = 0
+    var locals = true
+    while (true) {
+      if (runState < 0) {
+        w.phase = activePhase
+        return 1
+      }
+      if (locals) {
+        var u = null: ForkJoinTask[_]
+        while ({
+          u = w.nextLocalTask()
+          u != null
+        }) u.doExec()
+      }
+
+      var rescan, busy = false
+      locals = false
+      val qs = queues
+      val n = if (qs == null) 0 else qs.length
+      val m = n - 1
+      // scan:
+      var breakScan = false
+      var i = n
+      while (!breakScan && i > 0) {
+        val j = m & r
+        val q = qs(j)
+        if (q != null && (q ne w)) {
+          val src = j | SRC
+          var break = false
+          while (!break) {
+            val a = q.array
+            val b = q.base
+            val cap = if (a != null) a.length else 0
+            if (cap <= 0)
+              break = true
+            else {
+              val k = (cap - 1) & b
+              val nb = b + 1
+              val nk = (cap - 1) & nb
+              val t = a(k)
+              VarHandle.acquireFence() // for re-reads
+              if (q.base != b || (q.array ne a) || (a(k) ne t)) ()
+              else if (t == null) {
+                if (!rescan) {
+                  if (a(nk) != null || q.top - b > 0)
+                    rescan = true
+                  else if (!busy && q.owner != null && q.phase >= 0)
+                    busy = true
+                }
+                break = true
+              } else if (phase < 0) { // reactivate before taking
+                phase = activePhase
+                w.phase = activePhase
+              } else if (WorkQueue.casSlotToNull(a, k, t)) {
+                q.base = nb
+                w.source = src
+                t.doExec()
+                w.source = wsrc
+                rescan = true
+                locals = true
+                break = true
+                breakScan = true
+              }
+            }
           }
+        }
+        i -= 1
+        r += 1
+      }
+      if (rescan) () // retry
+      else if (phase >= 0) {
+        parkTime = 0L
+        phase = inactivePhase
+        w.phase = inactivePhase
+      } else if (!busy) {
+        w.phase = activePhase
+        return 1
+      } else if (parkTime == 0L) {
+        parkTime = 1L << 10 // initially about 1 usec
+        Thread.`yield`()
+      } else {
+        val interrupted = interruptible && Thread.interrupted()
+        if (interrupted || System.nanoTime() - startTime > nanos) {
+          w.phase = activePhase
+          return if (interrupted) -1 else 0
+        } else {
+          LockSupport.parkNanos(this, parkTime)
+          if (parkTime < (nanos >>> 8) && parkTime < (1L << 20))
+            parkTime <<= 1 // max sleep approx 1sec or 1% nanos
         }
       }
     }
     -1 // unreachable
   }
 
-  final private[concurrent] def externalHelpQuiescePool(
-      nanos: Long,
-      interruptible: Boolean
-  ): Int = {
+  private def externalHelpQuiesce(nanos: Long, interruptible: Boolean): Int = {
     val startTime = System.nanoTime()
     var parkTime = 0L
     while (true) {
@@ -823,122 +838,143 @@ class ForkJoinPool private (
     -1 // unreachable
   }
 
-  final private[concurrent] def nextTaskFor(w: WorkQueue): ForkJoinTask[_] =
-    if (w == null) pollScan(false)
-    else
-      w.nextLocalTask(w.config) match {
-        case null => pollScan(false)
-        case t    => t
-      }
+  final private[concurrent] def nextTaskFor(w: WorkQueue): ForkJoinTask[_] = {
+    var t: ForkJoinTask[_] = null.asInstanceOf[ForkJoinTask[_]]
+    if (w == null || { t = w.nextLocalTask(); t == null })
+      t = pollScan(false)
+    t
+  }
 
   // External operations
 
-  final private[concurrent] def submissionQueue(): WorkQueue = {
-
-    @tailrec
-    def loop(r: Int): WorkQueue = {
-      val qs = queues
-      val n = if (qs != null) qs.length else 0
-      if ((mode & SHUTDOWN) != 0 || n <= 0) return null
-
-      val id = r << 1
-      val i = (n - 1) & id
-      qs(i) match {
-        case null =>
-          Option(registrationLock)
-            .foreach { lock =>
-              val w = new WorkQueue(id | SRC)
-              lock.lock() // install under lock
-              if (qs(i) == null)
-                qs(i) = w // else lost race discard
-              lock.unlock()
-            }
-          loop(r)
-        case q if !q.tryLock() => // move and restart
-          loop(ThreadLocalRandom.advanceProbe(r))
-        case q => q
+  final private[concurrent] def submissionQueue(
+      isSubmit: Boolean
+  ): WorkQueue = {
+    val lock = registrationLock
+    var r = ThreadLocalRandom.getProbe() match {
+      case 0 =>
+        ThreadLocalRandom.localInit() // initialize caller's probe
+        ThreadLocalRandom.getProbe()
+      case n => n
+    }
+    if (lock != null) { // else init error
+      var id = r << 1
+      var break = false
+      while (!break) {
+        val qs = queues
+        val n = if (qs != null) qs.length else 0
+        if (n <= 0)
+          break = true
+        else {
+          val i = (n - 1) & id
+          val q = qs(i)
+          if (q == null) {
+            val w = new WorkQueue(null, id | SRC)
+            w.array = new Array[ForkJoinTask[_]](INITIAL_QUEUE_CAPACITY)
+            lock.lock()
+            if ((queues eq qs) && qs(i) == null)
+              qs(i) = w // else lost race; discard
+            lock.unlock()
+          } else if (q.getAndSetAccess(1) != 0) { // move and restart
+            r = ThreadLocalRandom.advanceProbe(r)
+            id = r << 1
+          } else if (isSubmit && runState != 0) {
+            q.access = 0
+            break = true
+          } else
+            return q
+        }
       }
     }
-
-    val r = ThreadLocalRandom.getProbe() match {
-      case 0 => // initialize caller's probe
-        ThreadLocalRandom.localInit()
-        ThreadLocalRandom.getProbe()
-      case probe => probe
-    }
-    loop(r) // even indices only
+    throw new RejectedExecutionException()
   }
 
-  final private[concurrent] def externalPush(task: ForkJoinTask[_]): Unit = {
-    submissionQueue() match {
-      case null =>
-        throw new RejectedExecutionException // shutdown or disabled
-      case q =>
-        if (q.lockedPush(task)) signalWork()
-    }
-  }
-
-  private def externalSubmit[T](task: ForkJoinTask[T]): ForkJoinTask[T] = {
+  private def poolSubmit[T](
+      signalIfEmpty: Boolean,
+      task: ForkJoinTask[T]
+  ): ForkJoinTask[T] = {
+    VarHandle.storeStoreFence()
     if (task == null) throw new NullPointerException()
 
-    Thread.currentThread() match {
-      case worker: ForkJoinWorkerThread
-          if worker.workQueue != null && (worker.pool eq this) =>
-        worker.workQueue.push(task, this)
+    val q = Thread.currentThread() match {
+      case wt: ForkJoinWorkerThread if wt.pool eq this =>
+        wt.workQueue
       case _ =>
-        externalPush(task)
+        task.markPoolSubmission()
+        submissionQueue(true)
     }
+    q.push(task, this, signalIfEmpty)
     task
   }
+
+  final def externalQueue(): WorkQueue = ForkJoinPool.externalQueue(this)
 
   // Termination
 
   private def tryTerminate(now: Boolean, enable: Boolean): Boolean = {
-    // try to set SHUTDOWN, then STOP, then help terminate
-    var md: Int = mode
-    if ((md & SHUTDOWN) == 0) {
-      if (!enable) return false
-      md = getAndBitwiseOrMode(SHUTDOWN)
+    val rs = runState
+    if (rs >= 0) { // set SHUTDOWN and/or STOP
+      if ((config & ISCOMMON) != 0)
+        return false // cannot shutdown
+      if (!now) {
+        if ((rs & SHUTDOWN) == 0) {
+          if (!enable)
+            return false
+          getAndBitwiseOrRunState(SHUTDOWN)
+        }
+        if (!canStop())
+          return false
+      }
+      getAndBitwiseOrRunState(SHUTDOWN | STOP)
     }
-    if ((md & STOP) == 0) {
-      if (!now && !canStop()) return false
-      md = getAndBitwiseOrMode(STOP)
-    }
-    if ((md & TERMINATED) == 0) {
-      while (pollScan(false) match {
-            case null => false
-            case t    => ForkJoinTask.cancelIgnoringExceptions(t); true
-          }) ()
-
-      // unblock other workers
+    val released = reactivate() // try signalling waiter
+    val tc: Int = (ctl >>> TC_SHIFT).toShort
+    if (released == null && tc > 0) {
+      val current = Thread.currentThread()
+      val w = current match {
+        case wt: ForkJoinWorkerThread => wt.workQueue
+        case _                        => null
+      }
+      val r = if (w == null) 0 else w.config + 1 // stagger traversals
       val qs = queues
       val n = if (qs != null) qs.length else 0
-      if (n > 0) {
-        for {
-          j <- 1 until n by 2
-          q = qs(j) if q != null
-          thread <- q.owner if !thread.isInterrupted()
-        } {
-          try thread.interrupt()
-          catch {
-            case ignore: Throwable => ()
-          }
+      for (i <- 0 until n) {
+        qs((r + i) & (n - 1)) match {
+          case null => ()
+          case q =>
+            val thread = q.owner
+            if ((thread ne current) && q.access != STOP) {
+              while (q.poll(null) match {
+                    case null => false
+                    case t =>
+                      ForkJoinTask.cancelIgnoringExceptions(t)
+                      true
+                  }) ()
+              if (thread != null && !thread.isInterrupted()) {
+                q.forcePhaseActive() // for awaitWork
+                try thread.interrupt()
+                catch { case ignore: Throwable => () }
+              }
+            }
         }
       }
-
-      // signal when no workers
-      if ((md & SMASK) + (ctl >>> TC_SHIFT).toShort <= 0 &&
-          (getAndBitwiseOrMode(TERMINATED) & TERMINATED) == 0) {
-        val lock = registrationLock
-        lock.lock()
-        if (termination != null) {
-          termination.signalAll()
-        }
-        lock.unlock()
+    }
+    val lock = registrationLock
+    if ((tc <= 0 || (ctl >>> TC_SHIFT).toShort <= 0) &&
+        (getAndBitwiseOrRunState(TERMINATED) & TERMINATED) == 0 &&
+        lock != null) {
+      lock.lock()
+      termination match {
+        case null => ()
+        case cond => cond.signalAll()
       }
+      lock.unlock()
     }
     true
   }
+
+  // Exported methods
+  // Constructors
 
   def this(
       parallelism: Int,
@@ -956,26 +992,29 @@ class ForkJoinPool private (
       factory = factory,
       ueh = handler,
       saturate = saturate,
-      keepAlive =
-        Math.max(unit.toMillis(keepAliveTime), ForkJoinPool.TIMEOUT_SLOP),
+      keepAlive = unit.toMillis(keepAliveTime).max(TIMEOUT_SLOP),
       workerNamePrefix = {
-        val pid: String = Integer.toString(ForkJoinPool.getAndAddPoolIds(1) + 1)
-        s"$pid-worker-"
-      }
+        val pid: String = Integer.toString(getAndAddPoolIds(1) + 1)
+        s"ForkJoinPool-$pid-worker-"
+      },
+      bounds = {
+        val p = parallelism
+        if (p <= 0 || p > MAX_CAP || p > maximumPoolSize || keepAliveTime <= 0L)
+          throw new IllegalArgumentException
+        val maxSpares = maximumPoolSize.min(MAX_CAP) - p
+        val minAvail = minimumRunnable.max(0).min(MAX_CAP)
+        val corep = corePoolSize.max(p).min(MAX_CAP)
+        (minAvail & SMASK).toLong |
+          (maxSpares << SWIDTH).toLong |
+          (corep.toLong << 32)
+      },
+      config = if (asyncMode) FIFO else 0
     )
     if (factory == null || unit == null) throw new NullPointerException
-    val p: Int = parallelism
-    if (p <= 0 || p > MAX_CAP || p > maximumPoolSize || keepAliveTime <= 0L)
-      throw new IllegalArgumentException
+    val p = parallelism
     val size: Int = 1 << (33 - Integer.numberOfLeadingZeros(p - 1))
-    val corep: Int = Math.min(Math.max(corePoolSize, p), MAX_CAP)
-    val maxSpares: Int = Math.min(maximumPoolSize, MAX_CAP) - p
-    val minAvail: Int =
-      Math.min(Math.max(minimumRunnable, 0), MAX_CAP)
-    this.bounds = ((minAvail - p) & SMASK) | (maxSpares << SWIDTH)
-    this.mode = p | (if (asyncMode) FIFO else 0)
-    this.ctl = ((((-corep).toLong << TC_SHIFT) & TC_MASK) |
-      ((-p.toLong << RC_SHIFT) & RC_MASK))
+    val corep = corePoolSize.max(p).min(MAX_CAP)
+    this.parallelism = p
     this.queues = new Array[WorkQueue](size)
   }
 
@@ -1020,12 +1059,12 @@ class ForkJoinPool private (
   }
 
   def invoke[T](task: ForkJoinTask[T]): T = {
-    externalSubmit(task)
+    poolSubmit(true, task)
     task.join()
   }
 
   def execute(task: ForkJoinTask[_]): Unit = {
-    externalSubmit(task)
+    poolSubmit(true, task)
   }
 
   // AbstractExecutorService methods
@@ -1033,30 +1072,42 @@ class ForkJoinPool private (
   override def execute(task: Runnable): Unit = {
     // Scala3 compiler has problems with type intererenfe when passed to externalSubmit directlly
     val taskToUse: ForkJoinTask[_] = task match {
-      case task: ForkJoinTask[_] => task
+      case task: ForkJoinTask[_] => task // avoid re-wrap
       case _                     => new ForkJoinTask.RunnableExecuteAction(task)
     }
-    externalSubmit(taskToUse)
+    poolSubmit(true, taskToUse)
   }
 
   def submit[T](task: ForkJoinTask[T]): ForkJoinTask[T] = {
-    externalSubmit(task)
+    poolSubmit(true, task)
   }
 
   override def submit[T](task: Callable[T]): ForkJoinTask[T] = {
-    externalSubmit(new ForkJoinTask.AdaptedCallable[T](task))
+    poolSubmit(true, new ForkJoinTask.AdaptedCallable[T](task))
   }
 
   override def submit[T](task: Runnable, result: T): ForkJoinTask[T] = {
-    externalSubmit(new ForkJoinTask.AdaptedRunnable[T](task, result))
+    poolSubmit(true, new ForkJoinTask.AdaptedRunnable[T](task, result))
   }
 
   override def submit(task: Runnable): ForkJoinTask[_] = {
     val taskToUse = task match {
-      case task: ForkJoinTask[_] => task
+      case task: ForkJoinTask[_] => task // avoid re-wrap
       case _ => new ForkJoinTask.AdaptedRunnableAction(task): ForkJoinTask[_]
     }
-    externalSubmit(taskToUse)
+    poolSubmit(true, taskToUse)
+  }
+
+  // Since JDK 19
+  def lazySubmit[T](task: ForkJoinTask[T]): ForkJoinTask[T] =
+    poolSubmit(false, task)
+
+  // Since JDK 19
+  def setParallelism(size: Int): Int = {
+    require(size >= 1 && size <= MAX_CAP)
+    if ((config & PRESET_SIZE) != 0)
+      throw new UnsupportedOperationException("Cannot override System property")
+    getAndSetParallelism(size)
   }
 
   override def invokeAll[T](
@@ -1068,7 +1119,7 @@ class ForkJoinPool private (
       while (it.hasNext()) {
         val f = new ForkJoinTask.AdaptedInterruptibleCallable[T](it.next())
         futures.add(f)
-        externalSubmit(f)
+        poolSubmit(true, f)
       }
       for (i <- futures.size() - 1 to 0 by -1) {
         futures.get(i).asInstanceOf[ForkJoinTask[_]].quietlyJoin()
@@ -1095,32 +1146,26 @@ class ForkJoinPool private (
       while (it.hasNext()) {
         val f = new ForkJoinTask.AdaptedInterruptibleCallable[T](it.next())
         futures.add(f)
-        externalSubmit(f)
+        poolSubmit(true, f)
       }
       val startTime = System.nanoTime()
       var ns = nanos
-      def timedOut = ns < 0L
+      var timedOut = ns < 0L
       for (i <- futures.size() - 1 to 0 by -1) {
-        val f = futures.get(i)
+        val f = futures.get(i).asInstanceOf[ForkJoinTask[T]]
         if (!f.isDone()) {
+          if (!timedOut)
+            timedOut = !f.quietlyJoin(ns, TimeUnit.NANOSECONDS)
           if (timedOut)
             ForkJoinTask.cancelIgnoringExceptions(f)
-          else {
-            try f.get(ns, TimeUnit.NANOSECONDS)
-            catch {
-              case _: CancellationException | _: TimeoutException |
-                  _: ExecutionException =>
-                ()
-            }
+          else
             ns = nanos - (System.nanoTime() - startTime)
-          }
         }
       }
       futures
     } catch {
       case t: Throwable =>
-        val it = futures.iterator()
-        while (it.hasNext()) ForkJoinTask.cancelIgnoringExceptions(it.next())
+        futures.forEach(ForkJoinTask.cancelIgnoringExceptions(_))
         throw t
     }
   }
@@ -1130,7 +1175,7 @@ class ForkJoinPool private (
   override def invokeAny[T](tasks: Collection[_ <: Callable[T]]): T = {
     if (tasks.isEmpty()) throw new IllegalArgumentException()
     val n = tasks.size()
-    val root = new InvokeAnyRoot[T](n)
+    val root = new InvokeAnyRoot[T](n, this)
     val fs = new ArrayList[InvokeAnyTask[T]](n)
     var break = false
     val it = tasks.iterator()
@@ -1140,15 +1185,13 @@ class ForkJoinPool private (
         case c =>
           val f = new InvokeAnyTask[T](root, c)
           fs.add(f)
-          if (isSaturated()) f.doExec()
-          else externalSubmit(f)
+          poolSubmit(true, f)
           if (root.isDone()) break = true
       }
     }
     try root.get()
     finally {
-      val it = fs.iterator()
-      while (it.hasNext()) ForkJoinTask.cancelIgnoringExceptions(it.next())
+      fs.forEach(ForkJoinTask.cancelIgnoringExceptions(_))
     }
   }
 
@@ -1163,7 +1206,7 @@ class ForkJoinPool private (
     val nanos = unit.toNanos(timeout)
     val n = tasks.size()
     if (n <= 0) throw new IllegalArgumentException()
-    val root = new InvokeAnyRoot[T](n)
+    val root = new InvokeAnyRoot[T](n, this)
     val fs = new ArrayList[InvokeAnyTask[T]](n)
     var break = false
     val it = tasks.iterator()
@@ -1173,15 +1216,13 @@ class ForkJoinPool private (
         case c =>
           val f = new InvokeAnyTask(root, c)
           fs.add(f)
-          if (isSaturated()) f.doExec()
-          else externalSubmit(f)
+          poolSubmit(true, f)
           if (root.isDone()) break = true
       }
     }
     try root.get(nanos, TimeUnit.NANOSECONDS)
     finally {
-      val it = fs.iterator()
-      while (it.hasNext()) ForkJoinTask.cancelIgnoringExceptions(it.next())
+      fs.forEach(ForkJoinTask.cancelIgnoringExceptions(_))
     }
   }
 
@@ -1189,23 +1230,16 @@ class ForkJoinPool private (
 
   def getUncaughtExceptionHandler(): UncaughtExceptionHandler = ueh
 
-  def getParallelism(): Int = {
-    (mode & SMASK).max(1)
-  }
+  def getParallelism(): Int = getParallelismOpaque().max(1)
 
-  def getPoolSize(): Int = {
-    ((mode & SMASK) + (ctl >>> TC_SHIFT).toShort)
-  }
+  def getPoolSize(): Int = (ctl >>> TC_SHIFT).toShort
 
-  def getAsyncMode(): Boolean = {
-    (mode & FIFO) != 0
-  }
+  def getAsyncMode(): Boolean = (config & FIFO) != 0
 
   def getRunningThreadCount: Int = {
-    VarHandle.acquireFence()
     val qs = queues
     var rc = 0
-    if (queues != null) {
+    if ((runState & TERMINATED) == 0 && qs != null) {
       for (i <- 1 until qs.length by 2) {
         val q = qs(i)
         if (q != null && q.isApparentlyUnblocked()) rc += 1
@@ -1214,10 +1248,7 @@ class ForkJoinPool private (
     rc
   }
 
-  def getActiveThreadCount(): Int = {
-    val r = (mode & SMASK) + (ctl >> RC_SHIFT).toInt
-    r.max(0) // suppress momentarily negative values
-  }
+  def getActiveThreadCount(): Int = (ctl >>> RC_SHIFT).toShort.max(0)
 
   def isQuiescent(): Boolean = canStop()
 
@@ -1234,10 +1265,9 @@ class ForkJoinPool private (
   }
 
   def getQueuedTaskCount(): Long = {
-    VarHandle.acquireFence()
     var count = 0
     val qs = queues
-    if (qs != null) {
+    if ((runState & TERMINATED) == 0 && qs != null) {
       for {
         i <- 1 until qs.length by 2
         q = qs(i) if q != null
@@ -1247,10 +1277,9 @@ class ForkJoinPool private (
   }
 
   def getQueuedSubmissionCount(): Int = {
-    VarHandle.acquireFence()
     var count = 0
     val qs = queues
-    if (qs != null) {
+    if ((runState & TERMINATED) == 0 && qs != null) {
       for {
         i <- 0 until qs.length by 2
         q = qs(i) if q != null
@@ -1259,20 +1288,7 @@ class ForkJoinPool private (
     count
   }
 
-  def hasQueuedSubmissions(): Boolean = {
-
-    VarHandle.acquireFence()
-    val qs = queues
-    if (qs != null) {
-      var i = 0
-      while (i < qs.length) {
-        val q = qs(i)
-        if (q != null && !q.isEmpty()) return true
-        i += 2
-      }
-    }
-    false
-  }
+  def hasQueuedSubmissions(): Boolean = hasTasks(true)
 
   protected[concurrent] def pollSubmission(): ForkJoinTask[_] = pollScan(true)
 
@@ -1294,8 +1310,6 @@ class ForkJoinPool private (
 
   override def toString(): String = {
     // Use a single pass through queues to collect counts
-    val md: Int = mode // read volatile fields first
-    val c: Long = ctl
     var st: Long = stealCount
     var ss, qt: Long = 0L
     var rc = 0
@@ -1315,19 +1329,21 @@ class ForkJoinPool private (
       }
     }
 
-    val pc = md & SMASK
-    val tc = pc + (c >>> TC_SHIFT).toShort
-    val ac = (pc + (c >> RC_SHIFT).toInt) match {
+    val pc = parallelism
+    val c = ctl
+    val tc = (c >>> TC_SHIFT).toShort
+    val ac = (c >>> RC_SHIFT).toShort match {
       case n if n < 0 => 0 // ignore transient negative
       case n          => n
     }
+    val rs = runState
 
     @alwaysinline
-    def modeSetTo(mode: Int): Boolean = (md & mode) != 0
+    def stateIs(mode: Int): Boolean = (rs & mode) != 0
     val level =
-      if (modeSetTo(TERMINATED)) "Terminated"
-      else if (modeSetTo(STOP)) "Terminating"
-      else if (modeSetTo(SHUTDOWN)) "Shutting down"
+      if (stateIs(TERMINATED)) "Terminated"
+      else if (stateIs(STOP)) "Terminating"
+      else if (stateIs(SHUTDOWN)) "Shutting down"
       else "Running"
 
     return super.toString() +
@@ -1342,69 +1358,76 @@ class ForkJoinPool private (
       "]"
   }
 
-  override def shutdown(): Unit = {
-    if (this != common) tryTerminate(false, true)
-  }
+  override def shutdown(): Unit = tryTerminate(false, true)
 
   override def shutdownNow(): List[Runnable] = {
-    if (this ne common) tryTerminate(true, true)
+    tryTerminate(true, true)
     Collections.emptyList()
   }
 
-  def isTerminated(): Boolean = {
-    (mode & TERMINATED) != 0
-  }
-
-  def isTerminating(): Boolean = {
-    (mode & (STOP | TERMINATED)) == STOP
-  }
-
-  override def isShutdown(): Boolean = {
-    (mode & SHUTDOWN) != 0
-  }
+  def isTerminated(): Boolean = (runState & TERMINATED) != 0
+  def isTerminating(): Boolean = (runState & (STOP | TERMINATED)) == STOP
+  def isShutdown(): Boolean = runState != 0
 
   @throws[InterruptedException]
   override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
     var nanos = unit.toNanos(timeout)
     var terminated = false
-    if (this eq common) {
-      val q = Thread.currentThread() match {
-        case worker: ForkJoinWorkerThread if (worker.pool eq this) =>
-          helpQuiescePool(worker.workQueue, nanos, true)
-        case _ =>
-          externalHelpQuiescePool(nanos, true)
-      }
-      if (q < 0) throw new InterruptedException()
-    } else {
-      def isTerminated() = (mode & TERMINATED) != 0
-      terminated = isTerminated()
+    if ((config & ISCOMMON) != 0) {
+      if (helpQuiescePool(this, nanos, true) < 0)
+        throw new InterruptedException()
+    } else if ({ terminated = (runState & TERMINATED) != 0; !terminated }) {
+      tryTerminate(false, false) // reduce transient blocking
       val lock = registrationLock
-      if (!terminated && lock != null) {
-        lock.lock()
-        if (termination == null) {
-          termination = lock.newCondition()
-        }
-        try
-          while ({
-            terminated = isTerminated()
-            !terminated && nanos > 0L
+      if (lock != null && {
+            terminated = (runState & TERMINATED) != 0; !terminated
           }) {
-            nanos = termination.awaitNanos(nanos)
+        lock.lock()
+        try {
+          val cond = termination match {
+            case null =>
+              val cond = lock.newCondition()
+              termination = cond
+              cond
+            case cond => cond
           }
-        finally lock.unlock()
+          while ({
+            terminated = (runState & TERMINATED) != 0; !terminated
+          } && nanos > 0L) {
+            nanos = cond.awaitNanos(nanos)
+          }
+        } finally lock.unlock()
       }
     }
     terminated
   }
 
-  def awaitQuiescence(timeout: Long, unit: TimeUnit): Boolean = {
-    val nanos: Long = unit.toNanos(timeout)
-    val q = Thread.currentThread() match {
-      case wt: ForkJoinWorkerThread if (wt.pool eq this) =>
-        helpQuiescePool(wt.workQueue, nanos, false)
-      case _ => externalHelpQuiescePool(nanos, false)
+  def awaitQuiescence(timeout: Long, unit: TimeUnit): Boolean =
+    helpQuiescePool(this, unit.toNanos(timeout), false) > 0
+
+  // Since JDK 19
+  override def close(): Unit = {
+    if ((config & ISCOMMON) == 0) {
+      var terminated = tryTerminate(false, false)
+      if (!terminated) {
+        shutdown()
+        var interrupted = false
+        while (!terminated) {
+          try {
+            terminated = awaitTermination(1L, TimeUnit.DAYS)
+          } catch {
+            case _: InterruptedException =>
+              if (!interrupted) {
+                shutdownNow()
+                interrupted = true
+              }
+          }
+        }
+        if (interrupted) {
+          Thread.currentThread().interrupt()
+        }
+      }
     }
-    q > 0
   }
 
   @throws[InterruptedException]
@@ -1416,7 +1439,7 @@ class ForkJoinPool private (
       val c = ctl
       if (blocker.isReleasable()) return ()
 
-      val comp = tryCompensate(c)
+      val comp = tryCompensate(c, false)
       if (comp >= 0) {
         val post = if (comp == 0) 0L else RC_UNIT
         val done =
@@ -1469,544 +1492,33 @@ object ForkJoinPool {
       // new ForkJoinWorkerThread.InnocuousForkJoinWorkerThread(pool)
     }
   }
+
   // Constants shared across ForkJoinPool and WorkQueue
-
-// Bounds
-  private[concurrent] final val SWIDTH = 16 // width of short
-  private[concurrent] final val SMASK = 0xffff // short bits == max index
-  private[concurrent] final val MAX_CAP = 0x7fff // max #workers - 1
-// Masks and units for WorkQueue.phase and ctl sp subfield
-  final val UNSIGNALLED = 1 << 31 // must be negative
-  final val SS_SEQ = 1 << 16 // version count
-
-  // Mode bits and sentinels, some also used in WorkQueue fields
+  final val DEFAULT_KEEPALIVE = 60000L
+  final val TIMEOUT_SLOP = 20L
+  final val DEFAULT_COMMON_MAX_SPARES = 256
+  final val INITIAL_QUEUE_CAPACITY: Int = 1 << 6
+  // Bounds
+  final val SWIDTH = 16 // width of short
+  final val SMASK = 0xffff // short bits == max index
+  final val MAX_CAP = 0x7fff // max #workers - 1
+  // pool.runState and workQueue.access bits and sentinels
+  final val STOP = 1 << 31
+  final val SHUTDOWN = 1
+  final val TERMINATED = 2
+  final val PARKED = -1
+  // {pool, workQueue}.config bits
   final val FIFO = 1 << 16 // fifo queue or access mode
   final val SRC = 1 << 17 // set for valid queue ids
-  final val INNOCUOUS = 1 << 18 // set for Innocuous workers
-  final val QUIET = 1 << 19 // quiescing phase or source
-  final val SHUTDOWN = 1 << 24
-  final val TERMINATED = 1 << 25
-  final val STOP = 1 << 31 // must be negative
+  final val CLEAR_TLS = 1 << 18 // set for Innocuous workers
+  final val TRIMMED = 1 << 19 // timed out while idle
+  final val ISCOMMON = 1 << 20 // set for common pool
+  final val PRESET_SIZE = 1 << 21 // size was set by property
+
   final val UNCOMPENSATE = 1 << 16 // tryCompensate return
-
-  private[concurrent] final val INITIAL_QUEUE_CAPACITY: Int = 1 << 8
-
-  private[concurrent] object WorkQueue {
-    // Support for atomic operations
-    import scala.scalanative.libc.atomic.memory_order._
-    @alwaysinline
-    private def arraySlotAtomicAccess[T <: AnyRef](
-        a: Array[T],
-        idx: Int
-    ): CAtomicRef[T] = {
-      val nativeArray = a.asInstanceOf[ObjectArray]
-      val elemRef = nativeArray.at(idx).asInstanceOf[Ptr[T]]
-      new CAtomicRef[T](elemRef)
-    }
-
-    private[concurrent] def getSlot(
-        a: Array[ForkJoinTask[_]],
-        i: Int
-    ): ForkJoinTask[_] = {
-      arraySlotAtomicAccess(a, i).load(memory_order_acquire)
-    }
-
-    @alwaysinline
-    private[concurrent] def getAndClearSlot(
-        a: Array[ForkJoinTask[_]],
-        i: Int
-    ): ForkJoinTask[_] = {
-      arraySlotAtomicAccess(a, i).exchange(null: ForkJoinTask[_])
-    }
-
-    private[concurrent] def setSlotVolatile(
-        a: Array[ForkJoinTask[_]],
-        i: Int,
-        v: ForkJoinTask[_]
-    ): Unit = {
-      arraySlotAtomicAccess(a, i).store(v)
-    }
-
-    private[concurrent] def casSlotToNull(
-        a: Array[ForkJoinTask[_]],
-        i: Int,
-        c: ForkJoinTask[_]
-    ): Boolean = {
-      arraySlotAtomicAccess(a, i)
-        .compareExchangeWeak(c, null: ForkJoinTask[_])
-    }
-  }
-
-  final class WorkQueue private (
-      private[concurrent] val owner: Option[ForkJoinWorkerThread]
-  ) {
-    // versioned, negative if inactive
-    @volatile private[concurrent] var phase: Int = 0
-    // source queue id, lock, or sentinel
-    @volatile private[concurrent] var source: Int = 0
-    private val sourceAtomic = new CAtomicInt(
-      fromRawPtr(Intrinsics.classFieldRawPtr(this, "source"))
-    )
-
-    // index, mode, ORed with SRC after init
-    private[concurrent] var config: Int = 0
-
-    // the queued tasks power of 2 size
-    private[concurrent] var array: Array[ForkJoinTask[_]] = _
-
-    // pool stack (ctl) predecessor link
-    private[concurrent] var stackPred: Int = 0
-    // index of next slot for poll
-    @volatile private[concurrent] var base: Int = 0
-    private[ForkJoinPool] val baseAtomic = new CAtomicInt(
-      fromRawPtr[Int](Intrinsics.classFieldRawPtr(this, "base"))
-    )
-    private[concurrent] var top: Int = 0 // index of next slot for push
-    private[concurrent] var nsteals: Int = 0 // steals from other queues
-
-    def this(owner: ForkJoinWorkerThread, isInnocuous: Boolean) = {
-      this(Some(owner))
-      this.config = if (isInnocuous) INNOCUOUS else 0
-    }
-
-    def this(config: Int) = {
-      this(owner = None)
-      this.array = new Array[ForkJoinTask[_]](INITIAL_QUEUE_CAPACITY)
-      this.config = config
-      this.phase = -1
-    }
-
-    @alwaysinline
-    final def tryLock(): Boolean = sourceAtomic.compareExchangeStrong(0, 1)
-
-    @alwaysinline
-    final def setBaseOpaque(b: Int): Unit = {
-      import scala.scalanative.libc.atomic.memory_order.memory_order_relaxed
-      baseAtomic.store(b, memory_order_relaxed)
-    }
-
-    final def getPoolIndex(): Int =
-      (config & 0xffff) >>> 1 // ignore odd/even tag bit
-
-    final def queueSize(): Int = {
-      VarHandle.acquireFence() // ensure fresh reads by external callers
-      val n = top - base
-      n.max(0) // ignore transient negative
-    }
-
-    final def isEmpty(): Boolean =
-      !((source != 0 && owner.isEmpty) || top - base > 0)
-
-    final def push(task: ForkJoinTask[_], pool: ForkJoinPool): Unit = {
-      val a = array
-      val s = top
-      top += 1
-      val d = s - base
-      val cap = if (a != null) a.length else 0
-      // skip insert if disabled
-      if (pool != null && cap > 0) {
-        val m = cap - 1
-        WorkQueue.setSlotVolatile(a, m & s, task)
-        val shouldGrowArray = d == m
-        if (shouldGrowArray)
-          growArray()
-        if (shouldGrowArray || a(m & (s - 1)) == null)
-          pool.signalWork() // signal if was empty or resized
-      }
-    }
-
-    final def lockedPush(task: ForkJoinTask[_]): Boolean = {
-      val a = array
-      val s = top
-      top += 1
-      val d = s - base
-      val cap = if (a != null) a.length else 0
-      if (cap > 0) {
-        val m = cap - 1
-        a(m & s) = task
-        def shouldGrowArray = d == m
-        if (shouldGrowArray) growArray()
-        source = 0 // unlock
-        if (shouldGrowArray || a(m & (s - 1)) == null)
-          return true
-      }
-      false
-    }
-
-    final def growArray(): Unit = {
-      val oldArray = array
-      val oldCap = if (oldArray != null) oldArray.length else 0
-      val newCap = oldCap << 1
-      val s = top - 1
-      if (oldCap > 0 && newCap > 0) { // skip if disabled
-        val newArray: Array[ForkJoinTask[_]] =
-          try new Array[ForkJoinTask[_]](newCap)
-          catch {
-            case ex: Throwable =>
-              top = s
-              if (owner.isEmpty) {
-                source = 0 // unlock
-              }
-              throw new RejectedExecutionException("Queue capacity exceeded")
-          }
-
-        val newMask = newCap - 1
-        val oldMask = oldCap - 1
-
-        @tailrec
-        def loop(k: Int, s: Int): Unit = {
-          if (k > 0) {
-            // poll old, push to new
-            getAndClearSlot(oldArray, s & oldMask) match {
-              case null => () // break, others already taken
-              case task =>
-                newArray(s & newMask) = task
-                loop(k = k - 1, s = s - 1)
-            }
-          }
-        }
-
-        loop(oldCap, s)
-
-        VarHandle.releaseFence() // fill before publish
-        array = newArray
-      }
-    }
-
-    private[concurrent] def pop(): ForkJoinTask[_] = {
-      val a = array
-      val cap = if (a != null) a.length else 0
-      val curTop = top
-      val s = curTop - 1
-      val t =
-        if (cap > 0 && base != curTop)
-          WorkQueue.getAndClearSlot(a, (cap - 1) & s)
-        else null
-      if (t != null) top = s
-      t
-    }
-
-    final def tryUnpush(task: ForkJoinTask[_]): Boolean = {
-      val s = top
-      val newS = s - 1
-      val a = array
-      val cap = if (a != null) a.length else 0
-      if (cap > 0 &&
-          base != s &&
-          WorkQueue.casSlotToNull(a, (cap - 1) & newS, task)) {
-        top = newS
-        true
-      } else false
-    }
-
-    final def externalTryUnpush(task: ForkJoinTask[_]): Boolean = {
-      while (true) {
-        val s = top
-        val a = array
-        val cap = if (a != null) a.length else 0
-        val k = (cap - 1) & (s - 1)
-        if (cap <= 0 || a(k) != task) return false
-        else if (tryLock()) {
-          if (top == s && array == a) {
-            if (WorkQueue.casSlotToNull(a, k, task))
-              top = s - 1
-            source = 0
-            return true
-          }
-          source = 0 // release lock for retry
-        }
-        Thread.`yield`() // trylock failure
-      }
-      false
-    }
-
-    final def tryRemove(task: ForkJoinTask[_], owned: Boolean): Boolean = {
-      val p = top
-      val a = array
-      val cap = if (a != null) a.length else 0
-      var taken = false
-
-      if (task != null && cap > 0) {
-        val m = cap - 1
-        val s = p - 1
-        val d = p - base
-
-        @tailrec
-        def loop(i: Int, d: Int): Unit = {
-          val k = i & m
-          a(k) match {
-            case `task` =>
-              if (owned || tryLock()) {
-                if ((owned || (array == a && top == p)) &&
-                    WorkQueue.casSlotToNull(a, k, task)) {
-                  for (j <- i.until(s)) {
-                    a(j & m) = getAndClearSlot(a, (j + 1) & m)
-                  }
-                  top = s
-                  taken = true
-                }
-                if (!owned) source = 0
-              }
-
-            case _ =>
-              if (d > 0) loop(i - 1, d - 1)
-          }
-        }
-
-        loop(i = s, d = d)
-      }
-
-      taken
-    }
-
-    // variants of poll
-
-    final def tryPoll(): ForkJoinTask[_] = {
-      val a = array
-      val cap = if (a != null) a.length else 0
-
-      val b = base
-      val k = (cap - 1) & b
-      if (cap > 0) {
-        val task = WorkQueue.getSlot(a, k)
-        if (base == b &&
-            task != null &&
-            WorkQueue.casSlotToNull(a, k, task)) {
-          setBaseOpaque(b + 1)
-          return task
-        }
-      }
-      null
-    }
-
-    final def nextLocalTask(cfg: Int): ForkJoinTask[_] = {
-      val a = array
-      val cap = if (a != null) a.length else 0
-      val mask = cap - 1
-      var currentTop = top
-
-      @tailrec
-      def loop(): ForkJoinTask[_] = {
-        var currentBase = base
-
-        val d = currentTop - currentBase
-        if (d <= 0) null
-        else {
-          def tryTopSlot(): Option[ForkJoinTask[_]] = {
-            currentTop -= 1
-            Option(getAndClearSlot(a, currentTop & mask))
-              .map { task =>
-                top = currentTop
-                task
-              }
-          }
-
-          def tryBaseSlot(): Option[ForkJoinTask[_]] = {
-            val b = currentBase
-            currentBase += 1
-            Option(getAndClearSlot(a, b & mask))
-              .map { task =>
-                setBaseOpaque(currentBase)
-                task
-              }
-          }
-
-          if (d == 1 || (cfg & FIFO) == 0)
-            tryTopSlot().orNull
-          else
-            tryBaseSlot() match {
-              case Some(value) => value
-              case None        => loop()
-            }
-        }
-      }
-
-      if (cap > 0) loop()
-      else null
-    }
-
-    final def nextLocalTask(): ForkJoinTask[_] =
-      nextLocalTask(config)
-
-    final def peek(): ForkJoinTask[_] = {
-      VarHandle.acquireFence()
-      // int cap Array[ForkJoinTask[_]]()  a
-      val a = array
-      val cap = if (a != null) a.length else 0
-      if (cap > 0) {
-        val mask = if ((config & FIFO) != 0) base else top - 1
-        a((cap - 1) & mask)
-      } else null: ForkJoinTask[_]
-    }
-
-    // specialized execution methods
-
-    final def topLevelExec(task: ForkJoinTask[_], q: WorkQueue): Unit = {
-      val cfg = config
-      var currentTask = task
-      var nStolen = 1
-      while (currentTask != null) {
-        currentTask.doExec()
-        currentTask = nextLocalTask(cfg)
-        currentTask match {
-          case null if q != null =>
-            currentTask = q.tryPoll()
-            if (currentTask != null) {
-              nStolen += 1
-            }
-          case _ => ()
-        }
-      }
-      nsteals += nStolen
-      source = 0
-      if ((cfg & INNOCUOUS) != 0) {
-        ThreadLocalRandom.eraseThreadLocals(Thread.currentThread())
-      }
-    }
-
-    final private[concurrent] def helpComplete(
-        task: ForkJoinTask[_],
-        owned: Boolean,
-        limit: Int
-    ): Int = {
-      var taken = false
-
-      @tailrec def loop(limit: Int): Int = {
-        val status = task.status
-        val a = array
-        val cap = if (a != null) a.length else 0
-        val p = top
-        val s = p - 1
-        val k = (cap - 1) & s
-        val t = if (cap > 0) a(k) else null
-
-        @tailrec
-        def doTryComplete(current: CountedCompleter[_]): Unit =
-          current match {
-            case `task` =>
-              @alwaysinline def tryTakeTask() = {
-                taken = WorkQueue.casSlotToNull(a, k, t); taken
-              }
-              if (owned) {
-                if (tryTakeTask()) top = s
-              } else if (tryLock()) {
-                if (top == p && array == a && tryTakeTask()) top = s
-                source = 0
-              }
-
-            case _ =>
-              val next = current.completer
-              if (next != null) doTryComplete(next)
-          }
-
-        t match {
-          case completer: CountedCompleter[_] if status >= 0 =>
-            taken = false
-            doTryComplete(completer)
-            if (!taken) status
-            else {
-              t.doExec()
-              val nextLimit = limit - 1
-              if (limit != 0 && nextLimit == 0) status
-              else loop(nextLimit)
-            }
-
-          case _ => status
-        }
-      }
-
-      if (task == null) 0
-      else loop(limit)
-    }
-
-    final private[concurrent] def helpAsyncBlocker(
-        blocker: ManagedBlocker
-    ): Unit = {
-      var cap: Int = 0
-      var b: Int = 0
-      var d: Int = 0
-      var k: Int = 0
-      var a: Array[ForkJoinTask[_]] = null
-      var t: ForkJoinTask[_] = null
-      while ({
-        blocker != null && { b = base; d = top - b; d > 0 } && {
-          a = array; a != null
-        } && { cap = a.length; cap > 0 } && {
-          k = (cap - 1) & b; t = WorkQueue.getSlot(a, k);
-          t == null && d > 1 || t
-            .isInstanceOf[CompletableFuture.AsynchronousCompletionTask]
-        } && !blocker.isReleasable()
-      }) {
-        if (t != null &&
-            base == { val b2 = b; b += 1; b2 } &&
-            WorkQueue.casSlotToNull(a, k, t)) {
-          setBaseOpaque(b)
-          t.doExec()
-        }
-      }
-    }
-
-    // misc
-
-    final def initializeInnocuousWorker(): Unit = {
-      val t = Thread.currentThread()
-      ThreadLocalRandom.eraseThreadLocals(t)
-    }
-
-    final def isApparentlyUnblocked(): Boolean = {
-      owner
-        .map(_.getState())
-        .exists { s =>
-          s != Thread.State.BLOCKED &&
-          s != Thread.State.WAITING &&
-          s != Thread.State.TIMED_WAITING
-        }
-    }
-  }
-
-  // TODO should be final, but it leads to problems with static forwarders
-  final val defaultForkJoinWorkerThreadFactory: ForkJoinWorkerThreadFactory =
-    new DefaultForkJoinWorkerThreadFactory()
-
-  private[concurrent] object common
-      extends ForkJoinPool(
-        factory = new DefaultCommonPoolForkJoinWorkerThreadFactory(),
-        ueh = null,
-        saturate = null,
-        keepAlive = DEFAULT_KEEPALIVE,
-        workerNamePrefix = null
-      ) {
-    val parallelism = Runtime.getRuntime().availableProcessors() - 1
-    this.mode = Math.min(Math.max(parallelism, 0), MAX_CAP)
-    val p = this.mode
-    val size = 1 << (33 - Integer.numberOfLeadingZeros((p - 1)))
-    this.bounds = ((1 - p) & SMASK) | (COMMON_MAX_SPARES << SWIDTH)
-    this.ctl = ((((-p).toLong) << TC_SHIFT) & TC_MASK) |
-      ((((-p).toLong) << RC_SHIFT) & RC_MASK)
-    this.queues = new Array[WorkQueue](size)
-  }
-
-  private[concurrent] lazy val COMMON_PARALLELISM =
-    Math.max(common.mode & SMASK, 1)
-
-  private[concurrent] lazy val COMMON_MAX_SPARES = DEFAULT_COMMON_MAX_SPARES
-
-  private val poolIds: AtomicInteger = new AtomicInteger(0)
-
-  private final val DEFAULT_KEEPALIVE = 60000L
-
-  private final val TIMEOUT_SLOP = 20L
-
-  /** The default value for COMMON_MAX_SPARES. Overridable using the
-   *  "java.util.concurrent.common.maximumSpares" system property. The default
-   *  value is far in excess of normal requirements, but also far short of
-   *  MAX_CAP and typical OS thread limits, so allows JVMs to catch misuse/abuse
-   *  before running out of resources needed to do so.
-   */
-  private val DEFAULT_COMMON_MAX_SPARES: Int = 256
   // Lower and upper word masks
   private val SP_MASK: Long = 0xffffffffL
-  private val UC_MASK: Long = ~(SP_MASK)
+  private val UC_MASK: Long = ~SP_MASK
   // Release counts
   private val RC_SHIFT: Int = 48
   private val RC_UNIT: Long = 0x0001L << RC_SHIFT
@@ -2015,19 +1527,506 @@ object ForkJoinPool {
   private val TC_SHIFT: Int = 32
   private val TC_UNIT: Long = 0x0001L << TC_SHIFT
   private val TC_MASK: Long = 0xffffL << TC_SHIFT
-  private val ADD_WORKER: Long = 0x0001L << (TC_SHIFT + 15) // sign
+  // sp bits
+  private final val SS_SEQ = 1 << 16; // version count
+  private final val INACTIVE = 1 << 31; // phase bit when idle
 
-  private def getAndAddPoolIds(x: Int): Int =
+  private[concurrent] object WorkQueue {
+    // Support for atomic operations
+    import scala.scalanative.libc.atomic.memory_order._
+    @alwaysinline
+    private def arraySlotAtomicAccess[T <: AnyRef](
+        a: Array[T],
+        i: Int
+    ): CAtomicRef[T] = {
+      val nativeArray = a.asInstanceOf[ObjectArray]
+      val elemRef =
+        nativeArray
+          .at(i)
+          .asInstanceOf[Ptr[T]]
+      new CAtomicRef[T](elemRef)
+    }
+
+    @alwaysinline
+    private[concurrent] def getAndClearSlot(
+        a: Array[ForkJoinTask[_]],
+        i: Int
+    ): ForkJoinTask[_] =
+      arraySlotAtomicAccess(a, i)
+        .exchange(null: ForkJoinTask[_])
+
+    @alwaysinline
+    private[concurrent] def casSlotToNull(
+        a: Array[ForkJoinTask[_]],
+        i: Int,
+        c: ForkJoinTask[_]
+    ): Boolean =
+      arraySlotAtomicAccess(a, i)
+        .compareExchangeWeak(c, null: ForkJoinTask[_])
+  }
+
+  final class WorkQueue private (
+      val owner: ForkJoinWorkerThread
+  ) {
+    var base: Int = _ // index of next slot for poll
+    var config: Int = _ // index, mode, ORed with SRC after init
+    var top: Int = _ // index of next slot for push
+    var stackPred: Int = 0 // pool stack (ctl) predecessor link
+    var array: Array[ForkJoinTask[_]] = _ // the queued tasks power of 2 size
+    @volatile var access: Int = 0 // values 0, 1 (locked), PARKED, STOP
+    @volatile var phase: Int = 0 // versioned, negative if inactive
+    @volatile var source: Int = 0 // source queue id, lock, or sentinel
+    var nsteals: Int = 0 // steals from other queues
+
+    private[concurrent] def this(owner: ForkJoinWorkerThread, config: Int) = {
+      this(owner)
+      this.config = config
+      this.base = 1
+      this.top = 1
+    }
+
+    @alwaysinline def baseAtomic = new CAtomicInt(
+      fromRawPtr[Int](Intrinsics.classFieldRawPtr(this, "base"))
+    )
+    @alwaysinline def phaseAtomic = new CAtomicInt(
+      fromRawPtr[Int](Intrinsics.classFieldRawPtr(this, "phase"))
+    )
+    @alwaysinline def accessAtomic = new CAtomicInt(
+      fromRawPtr[Int](Intrinsics.classFieldRawPtr(this, "access"))
+    )
+
+    @alwaysinline final def forcePhaseActive(): Unit =
+      phaseAtomic.fetchAnd(0x7fffffff)
+    @alwaysinline final def getAndSetAccess(v: Int): Int =
+      accessAtomic.exchange(v)
+    @alwaysinline final def releaseAccess(): Unit =
+      accessAtomic.store(0)
+
+    final def getPoolIndex(): Int =
+      (config & 0xffff) >>> 1 // ignore odd/even tag bit
+
+    final def queueSize(): Int = {
+      val _ = access // for ordering effect
+      0.max(top - base) // ignore transient negative
+    }
+
+    final def push(
+        _task: ForkJoinTask[_],
+        pool: ForkJoinPool,
+        signalIfEmpty: Boolean
+    ): Unit = {
+      var task = _task
+      var resize = false
+      val s = top
+      top += 1
+      val b = base
+      val a = array
+      val cap = if (a != null) a.length else 0
+      if (cap > 0) {
+        val m = (cap - 1)
+        if (m == s - b) {
+          resize = true // rapidly grow until large
+          val newCap = if (cap < (1 << 24)) cap << 2 else cap << 1
+          val newArray =
+            try new Array[ForkJoinTask[_]](newCap)
+            catch {
+              case ex: Throwable =>
+                top = s
+                access = 0
+                throw new RejectedExecutionException("Queue capacity exceeded")
+            }
+          if (newCap > 0) {
+            val newMask = newCap - 1
+            var k = s
+            while ({
+              newArray(k & newMask) = task
+              k -= 1
+              task = getAndClearSlot(a, k & m)
+              task != null
+            }) ()
+          }
+        } else a(m & s) = task
+        getAndSetAccess(0)
+        if ((resize || (a(m & (s - 1)) == null && signalIfEmpty)) &&
+            pool != null)
+          pool.signalWork()
+      }
+    }
+
+    final def nextLocalTask(fifo: Int): ForkJoinTask[_] = {
+      var t: ForkJoinTask[_] = null.asInstanceOf[ForkJoinTask[_]]
+      val a = array
+      val p = top
+      val s = p - 1
+      var b = base
+      val cap = if (a != null) a.length else 0
+      if (p - b > 0 && cap > 0) {
+        while ({
+          val break = {
+            val nb = b + 1
+            if (fifo == 0 || nb == p) {
+              if ({ t = getAndClearSlot(a, (cap - 1) & s); t } != null) top = s
+              true // break
+            } else if ({ t = getAndClearSlot(a, (cap - 1) & b); t } != null) {
+              base = nb
+              true // break
+            } else {
+              while (b == { b = base; b }) {
+                VarHandle.acquireFence()
+                Thread.onSpinWait() // spin to reduce memory traffic
+              }
+              false // no-break
+            }
+          }
+          !break && (p - b > 0)
+        }) ()
+        VarHandle.releaseFence() // for timely index updates
+      }
+      t
+    }
+
+    final def nextLocalTask(): ForkJoinTask[_] = nextLocalTask(config & FIFO)
+
+    final def tryUnpush(task: ForkJoinTask[_], owned: Boolean): Boolean = {
+      val a = array
+      val p = top
+      val cap = if (a != null) a.length else 0
+      val s = p - 1
+      val k = (cap - 1) & s
+      if (task != null && base != p && cap > 0 && (a(k) eq task)) {
+        if (owned || getAndSetAccess(1) == 0) {
+          if (top != p || a(k) != task || getAndClearSlot(a, k) == null)
+            access = 0
+          else {
+            top = s
+            access = 0
+            return true
+          }
+        }
+      }
+      false
+    }
+
+    final def peek(): ForkJoinTask[_] = {
+      val a = array
+      val cfg = config
+      val p = top
+      var b = base
+      val cap = if (a != null) a.length else 0
+      if (p != b && cap > 0) {
+        if ((cfg & FIFO) == 0)
+          return a((cap - 1) & (p - 1))
+        else { // skip  over in-progress removal
+          while (p - b > 0) {
+            a((cap - 1) & b) match {
+              case null => b += 1
+              case t    => return t
+            }
+          }
+
+        }
+      }
+      null
+    }
+
+    final def poll(pool: ForkJoinPool): ForkJoinTask[_] = {
+      var b = base
+      var break = false
+      while (!break) {
+        val a = array
+        val cap = if (a != null) a.length else 0
+        if (cap <= 0) break = true // currently impossible
+        else {
+          val k = (cap - 1) & b
+          val nb = b + 1
+          val nk = (cap - 1) & nb
+          val t = a(k)
+          VarHandle.acquireFence() // for re-reads
+          if (b != { b = base; b }) () // incosistent
+          else if (t != null && WorkQueue.casSlotToNull(a, k, t)) {
+            base = nb
+            VarHandle.releaseFence()
+            if (pool != null && a(nk) != null)
+              pool.signalWork() // propagate
+            return t
+          } else if (array != a || a(k) != null) () // stale
+          else if (a(nk) == null && top - b <= 0)
+            break = true // empty
+        }
+      }
+      null
+    }
+
+    final def tryPool(): ForkJoinTask[_] = {
+      var b = base
+      val a = array
+      val cap = if (a != null) a.length else 0
+      if (cap > 0) {
+        var break = false
+        while (!break) {
+          val k = (cap - 1) & b
+          val nb = b + 1
+          val t = a(k)
+          VarHandle.acquireFence() // for re-reads
+          if (b != { b = base; b }) () // inconsistent
+          else if (t != null) {
+            if (WorkQueue.casSlotToNull(a, k, t)) {
+              base = nb
+              VarHandle.releaseFence()
+              return t
+            }
+            break = true // contended
+          } else if (a(k) == null)
+            break = true // empty or stalled
+        }
+      }
+      null
+    }
+
+    // specialized execution methods
+
+    final def topLevelExec(_task: ForkJoinTask[_], src: WorkQueue): Unit = {
+      var task = _task
+      val cfg = config
+      val fifo = cfg & FIFO
+      var nstolen = 1
+      while (task != null) {
+        task.doExec()
+        task = nextLocalTask(fifo)
+        if (task == null && src != null && {
+              task = src.tryPool(); task != null
+            })
+          nstolen += 1
+      }
+      nsteals += nstolen
+      source = 0
+      if ((cfg & CLEAR_TLS) != 0) {
+        ThreadLocalRandom.eraseThreadLocals(Thread.currentThread())
+      }
+    }
+
+    final def tryRemoveAndExec(task: ForkJoinTask[_], owned: Boolean): Int = {
+      val a = array
+      val p = top
+      val s = p - 1
+      var d = p - base
+      val cap = if (a != null) a.length else 0
+      if (task != null && d > 0 && cap > 0) {
+        val m = cap - 1
+        var i = s
+        var break = false
+        while (!break) {
+          val k = i & m
+          val t = a(k)
+          if (t eq task) {
+            if (!owned && getAndSetAccess(1) != 0)
+              break = true // fail if locked
+            else if (top != p || (a(k) ne task) ||
+                getAndClearSlot(a, k) == null) {
+              access = 0
+              break = true // missed
+            } else {
+              if (i != s && i == base)
+                base = i + 1 // avoid shift
+              else {
+                var j = i
+                while (j != s) // shift down
+                  a(j & m) = getAndClearSlot(a, { j += 1; j & m })
+                top = s
+              }
+              releaseAccess()
+              return task.doExec()
+            }
+          } else if (t == null || { d -= 1; d == 0 })
+            break = true
+          i -= 1
+        }
+      }
+      0
+    }
+
+    final private[concurrent] def helpComplete(
+        task: ForkJoinTask[_],
+        owned: Boolean,
+        _limit: Int
+    ): Int = {
+      var limit = _limit
+      var status = 0
+      if (task != null) {
+        var breakOuter = false
+        while (!breakOuter) {
+          status = task.status
+          if (status < 0)
+            return status
+          val a = array
+          val cap = if (a != null) a.length else 0
+          val p = top
+          val s = p - 1
+          val k = (cap - 1) & s
+          val t = if (cap > 0) a(k) else null
+          t match {
+            case _f: CountedCompleter[_] =>
+              var f: CountedCompleter[_] = _f
+              var break = false
+              while (!break) {
+                if (f eq task)
+                  break = true
+                else if ({ f = f.completer; f == null }) {
+                  break = true
+                  breakOuter = true // ineligible
+                }
+              }
+              if (!breakOuter) {
+                if (!owned && getAndSetAccess(1) != 0)
+                  breakOuter = true // fail if locked
+                else if (top != p || (a(k) ne t) ||
+                    getAndClearSlot(a, k) == null) {
+                  access = 0
+                  breakOuter = true // missed
+                }
+              }
+              if (!breakOuter) {
+                top = s
+                releaseAccess()
+                t.doExec()
+                if (limit != 0 && { limit -= 1; limit == 0 })
+                  breakOuter = true
+              }
+            case _ => breakOuter = true
+          }
+        }
+        status = task.status
+      }
+      status
+    }
+
+    final def helpAsyncBlocker(blocker: ManagedBlocker): Unit = {
+      if (blocker != null) {
+        var break = false
+        while (!break) {
+          val a = array
+          val b = base
+          val cap = if (a != null) a.length else 0
+          if (cap <= 0 || b == top)
+            break = true
+          else {
+            val k = (cap - 1) & b
+            val nb = b + 1
+            val nk = (cap - 1) & nb
+            val t = a(k)
+            VarHandle.acquireFence() // for re-reads
+            if (base != b) ()
+            else if (blocker.isReleasable())
+              break = true
+            else if (a(k) ne t) ()
+            else if (t != null) {
+              if (!t.isInstanceOf[CompletableFuture.AsynchronousCompletionTask])
+                break = true
+              else if (WorkQueue.casSlotToNull(a, k, t)) {
+                base = nb
+                VarHandle.releaseFence()
+                t.doExec()
+              }
+            } else if (a(nk) == null)
+              break = true
+          }
+        }
+      }
+    }
+
+    // misc
+
+    final def isApparentlyUnblocked(): Boolean = {
+      access != STOP && {
+        val wt = owner
+        owner != null && {
+          val s = wt.getState()
+          s != Thread.State.BLOCKED &&
+            s != Thread.State.WAITING &&
+            s != Thread.State.TIMED_WAITING
+        }
+      }
+    }
+
+    final def setClearThreadLocals(): Unit = config |= CLEAR_TLS
+  }
+
+  // TODO should be final, but it leads to problems with static forwarders
+  final val defaultForkJoinWorkerThreadFactory: ForkJoinWorkerThreadFactory =
+    new DefaultForkJoinWorkerThreadFactory()
+
+  private object commonPoolConfig {
+    def prop(sysProp: String) = scala.sys.Prop.IntProp(sysProp)
+
+    private val parallelismOpt = prop(
+      "java.util.concurrent.ForkJoinPool.common.parallelism"
+    )
+    val parallelism = parallelismOpt.option
+      .getOrElse(
+        1.max(Runtime.getRuntime().availableProcessors() - 1)
+      )
+      .min(MAX_CAP)
+    val presetParallelism = if (parallelismOpt.isSet) PRESET_SIZE else 0
+
+    val maximumSpares =
+      prop("java.util.concurrent.ForkJoinPool.common.maximumSpares").option
+        .map(_.min(MAX_CAP).max(0))
+        .getOrElse(DEFAULT_COMMON_MAX_SPARES)
+  }
+
+  private[concurrent] object common
+      extends ForkJoinPool(
+        factory = defaultForkJoinWorkerThreadFactory,
+        ueh = null,
+        saturate = null,
+        keepAlive = DEFAULT_KEEPALIVE,
+        workerNamePrefix = null,
+        bounds = (1 | (commonPoolConfig.maximumSpares << SWIDTH)).toLong,
+        config = ISCOMMON | commonPoolConfig.presetParallelism
+      ) {
+    val p = commonPoolConfig.parallelism
+    val size =
+      if (p == 0) 1
+      else 1 << (33 - Integer.numberOfLeadingZeros((p - 1)))
+    this.parallelism = p
+    this.queues = new Array[WorkQueue](size)
+  }
+
+  private val poolIds: AtomicInteger = new AtomicInteger(0)
+  @alwaysinline private def getAndAddPoolIds(x: Int): Int =
     poolIds.getAndAdd(x)
 
-  private[concurrent] def commonQueue(): WorkQueue = {
-    val p = common
-    val qs = if (p != null) p.queues else null
+  final private[concurrent] def helpQuiescePool(
+      pool: ForkJoinPool,
+      nanos: Long,
+      interruptible: Boolean
+  ): Int = {
+    @alwaysinline
+    def useWorkerthread(wt: ForkJoinWorkerThread): Boolean = {
+      val p = wt.pool
+      p != null && ((p eq pool) || pool == null)
+    }
+    Thread.currentThread() match {
+      case wt: ForkJoinWorkerThread if (useWorkerthread(wt)) =>
+        wt.pool.helpQuiesce(wt.workQueue, nanos, interruptible)
+      case _ =>
+        val p = if (pool != null) pool else common
+        if (p != null)
+          p.externalHelpQuiesce(nanos, interruptible)
+        else
+          0
+    }
+  }
+
+  private def externalQueue(p: ForkJoinPool): WorkQueue = {
     val r: Int = ThreadLocalRandom.getProbe()
-    var n: Int = if (qs != null) qs.length else 0
+    val qs = if (p != null) p.queues else null
+    val n = if (qs != null) qs.length else 0
     if (n > 0 && r != 0) qs((n - 1) & (r << 1))
     else null
   }
+
+  private[concurrent] def commonQueue(): WorkQueue = externalQueue(common)
 
   private[concurrent] def helpAsyncBlocker(
       e: Executor,
@@ -2049,9 +2048,9 @@ object ForkJoinPool {
           if wt.pool != null && wt.workQueue != null =>
         val pool = wt.pool
         val q = wt.workQueue
-        var p: Int = pool.mode & SMASK
-        val a: Int = p + (pool.ctl >> RC_SHIFT).toInt
         val n: Int = q.top - q.base
+        var p: Int = pool.parallelism
+        val a: Int = (pool.ctl >>> RC_SHIFT).toShort
         n - (if (a > { p >>>= 1; p }) 0
              else if (a > { p >>>= 1; p }) 1
              else if (a > { p >>>= 1; p }) 2
@@ -2066,27 +2065,32 @@ object ForkJoinPool {
 
   // Task to hold results from InvokeAnyTasks
   @SerialVersionUID(2838392045355241008L)
-  final private[concurrent] class InvokeAnyRoot[E](val n: Int)
-      extends ForkJoinTask[E] {
+  final private[concurrent] class InvokeAnyRoot[E](
+      n: Int,
+      val pool: ForkJoinPool
+  ) extends ForkJoinTask[E] {
     @volatile private[concurrent] var result: E = _
     final private[concurrent] val count: AtomicInteger = new AtomicInteger(n)
     final private[concurrent] def tryComplete(c: Callable[E]): Unit = { // called by InvokeAnyTasks
       var ex: Throwable = null
       var failed: Boolean = false
-      if (c != null) { // raciness OK
-        if (isCancelled()) failed = true
-        else if (!isDone())
-          try complete(c.call())
-          catch {
-            case tx: Throwable =>
-              ex = tx
-              failed = true
-          }
+      if (c == null || Thread.interrupted() ||
+          (pool != null && pool.runState < 0))
+        failed = true
+      else if (isDone()) ()
+      else {
+        try complete(c.call())
+        catch {
+          case tx: Throwable =>
+            ex = tx
+            failed = true
+        }
       }
-      if (failed && count.getAndDecrement() <= 1) {
+      if ((pool != null && pool.runState < 0) ||
+          (failed && count.getAndDecrement() <= 1)) {
         trySetThrown(
           if (ex != null) ex
-          else new CancellationException
+          else new CancellationException()
         )
       }
     }
@@ -2126,7 +2130,7 @@ object ForkJoinPool {
     override final def getRawResult(): E = null.asInstanceOf[E]
   }
 
-  def getCommonPoolParallelism(): Int = COMMON_PARALLELISM
+  def getCommonPoolParallelism(): Int = common.getParallelism()
 
   trait ManagedBlocker {
 

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
@@ -10,6 +10,7 @@ import java.io.Serializable
 import java.util._
 import java.util.RandomAccess
 import java.util.concurrent.locks.LockSupport
+import java.lang.invoke.VarHandle
 
 import scala.scalanative.libc.atomic._
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
@@ -37,6 +38,9 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   private def getAndBitwiseOrStatus(v: Int): Int = statusAtomic.fetchOr(v)
   private def casAux(c: Aux, v: Aux): Boolean =
     auxAtomic.compareExchangeStrong(c, v)
+
+  private[concurrent] final def markPoolSubmission(): Unit =
+    getAndBitwiseOrStatus(POOLSUBMIT)
 
   @tailrec
   private def signalWaiters(): Unit = {
@@ -122,122 +126,104 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
     s
   }
 
-  private def awaitJoin(
-      ran: Boolean,
-      _interruptible: Boolean,
-      timed: Boolean,
-      nanos: Long
-  ): Int = {
-    var interruptible = _interruptible
-    val (internal, p, q) = Thread.currentThread() match {
-      case wt: ForkJoinWorkerThread => (true, wt.pool, wt.workQueue)
-      case _ =>
-        if (interruptible && Thread.interrupted()) return ABNORMAL
-        (false, ForkJoinPool.common, ForkJoinPool.commonQueue())
-    }
-    var s = status
-    if (s < 0) return s
-    var deadline = 0L
-    if (timed) {
-      if (nanos <= 0L) return 0
-      else deadline = (nanos + System.nanoTime()).max(1L)
-    }
-
-    var uncompensate: ForkJoinPool = null
-    if (q != null && p != null) { // try helping
-      if ((!timed || p.isSaturated()) && {
-            this match {
-              case c: CountedCompleter[_] =>
-                s = p.helpComplete(this, q, internal)
-                s < 0
-              case _ =>
-                q.tryRemove(this, internal) && {
-                  s = doExec()
-                  s < 0
-                }
-            }
-          }) return s
-
-      if (internal) {
-        s = p.helpJoin(this, q)
-        if (s < 0) return s
-        if (s == UNCOMPENSATE) uncompensate = p
-        interruptible = false;
-      }
-    }
-    awaitDone(interruptible, deadline, uncompensate)
-  }
-
   private def awaitDone(
-      interruptible: Boolean,
-      deadline: Long,
-      pool: ForkJoinPool
+      how: Int,
+      deadline: Long
   ): Int = {
-    var s = 0
-    var interrupted = false
-    var queued = false
-    var parked = false
-    var node: Aux = null
-    var break = false
-    while (!break && { s = status; s >= 0 }) {
-      if (parked && Thread.interrupted()) {
-        if (interruptible) {
+    val timed = (how & TIMED) != 0
+    var owned, uncompensate = false
+    var s: Int = -1
+    var q: ForkJoinPool.WorkQueue = null
+    var p: ForkJoinPool = null
+    Thread.currentThread() match {
+      case wt: ForkJoinWorkerThread =>
+        owned = true
+        q = wt.workQueue
+        p = wt.pool
+      case t =>
+        p = ForkJoinPool.common
+        if (p != null && (how & POOLSUBMIT) == 0)
+          q = p.externalQueue()
+    }
+    if (q != null && p != null) { // try helping
+      if (isInstanceOf[CountedCompleter[_]])
+        s = p.helpComplete(this, q, owned, timed)
+      else if ((how & RAN) != 0 || {
+            s = q.tryRemoveAndExec(this, owned); s >= 0
+          })
+        s = if (owned) p.helpJoin(this, q, timed) else 0
+      if (s < 0)
+        return s
+      if (s == UNCOMPENSATE)
+        uncompensate = true
+    }
+    var node: Aux = null: Aux
+    var ns = 0L
+    var interrupted, queued, break = false
+    while (!break) {
+      var a: Aux = null: Aux
+      if ({ s = status; s < 0 })
+        break = true
+      else if (node == null)
+        node = new Aux(Thread.currentThread(), null)
+      else if (!queued) {
+        if (({ a = aux; a == null || a.ex == null }) && {
+              node.next = a; queued = casAux(node.next, node); queued
+            })
+          LockSupport.setCurrentBlocker(this)
+      } else if (timed && { ns = deadline - System.nanoTime(); ns <= 0 }) {
+        s = 0
+        break = true
+      } else if (Thread.interrupted()) {
+        interrupted = true
+        if ((how & POOLSUBMIT) != 0 && p != null && p.runState < 0)
+          cancelIgnoringExceptions(this) // cancel on shutdown
+        else if ((how & INTERRUPTIBLE) != 0) {
           s = ABNORMAL
           break = true
-        } else
-          interrupted = true
-      } else if (queued) {
-        if (deadline != 0L) {
-          val ns = deadline - System.nanoTime()
-          if (ns <= 0L) break = true
-          else LockSupport.parkNanos(ns)
-        } else LockSupport.park()
-        parked = true
-      } else if (node != null) {
-        val a = aux
-        if (a != null && a.ex != null)
-          Thread.onSpinWait() // exception in progress
-        else {
-          node.next = a
-          queued = casAux(a, node)
-          if (queued) LockSupport.setCurrentBlocker(this)
         }
-      } else {
-        try node = new Aux(Thread.currentThread(), null)
-        catch {
-          // try to cancel if cannot create
-          case ex: Throwable => casStatus(s, s | DONE | ABNORMAL)
-        }
-      }
+      } else if ({ s = status; s < 0 }) // recheck
+        break = true
+      else if (timed)
+        LockSupport.parkNanos(ns)
+      else
+        LockSupport.park()
     }
+    if (uncompensate) p.uncompensate()
 
-    if (pool != null) pool.uncompensate()
     if (queued) {
       LockSupport.setCurrentBlocker(null)
-      if (s >= 0) { // cancellation similar to AbstractQueuedSynchronizer
-        // outer // todo: labels are not supported
-        var a = aux
+      if (s >= 0) {
+        // outer:
         var breakOuter = false
-        while (!breakOuter && { a = aux; a != null && a.ex == null }) {
+        var a: Aux = aux
+        while (!breakOuter && { a = aux; a != null } && a.ex == null) {
           var trail: Aux = null
           var break = false
-          while (!break || !breakOuter) {
+          while (!break) {
             val next = a.next
-            if (a == node) {
-              if (trail != null) trail.casNext(trail, next)
-              else if (casAux(a, next)) breakOuter = true
-              break = true // restart
+            if (a eq node) {
+              if (trail != null)
+                trail.casNext(trail, next)
+              else if (casAux(a, next)) {
+                break = true
+                breakOuter = true
+              }
+              break = true
             } else {
-
               trail = a
               a = next
-              if (next == null) breakOuter = true
+              if (a == null) {
+                break = true
+                breakOuter = true
+              }
             }
           }
         }
       } else {
         signalWaiters() // help clean or signal
-        if (interrupted) Thread.currentThread().interrupt()
+        if (interrupted)
+          Thread.currentThread().interrupt()
       }
     }
     s
@@ -255,19 +241,14 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   private def getException(s: Int): Throwable = {
     var ex: Throwable = null
     if ((s & ABNORMAL) != 0 && {
-          (s & THROWN) == 0 || {
-            ex = getThrowableException()
-            ex == null
-          }
+          ex = getThrowableException()
+          ex == null
         }) ex = new CancellationException()
     ex
   }
 
-  private def reportException(s: Int): Unit = {
-    uncheckedThrow[RuntimeException](
-      if ((s & THROWN) != 0) getThrowableException()
-      else null
-    )
+  private def reportException(s: Int): Unit = uncheckedThrow[RuntimeException] {
+    getThrowableException()
   }
 
   private def reportExecutionException(s: Int): Unit = {
@@ -284,18 +265,23 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   }
 
   final def fork(): ForkJoinTask[V] = {
+    VarHandle.storeStoreFence()
     Thread.currentThread() match {
-      case worker: ForkJoinWorkerThread =>
-        worker.workQueue.push(this, worker.pool)
+      case wt: ForkJoinWorkerThread =>
+        val p = wt.pool
+        val q = wt.workQueue
+        q.push(this, p, true)
       case _ =>
-        ForkJoinPool.commonPool().externalPush(this)
+        val p = ForkJoinPool.common
+        val q = p.submissionQueue(false)
+        q.push(this, p, true)
     }
     this
   }
 
   final def join(): V = {
     var s = status
-    if (s >= 0) s = awaitJoin(false, false, false, 0L)
+    if (s >= 0) s = awaitDone(s & POOLSUBMIT, 0L)
     if ((s & ABNORMAL) != 0) reportException(s)
     getRawResult()
   }
@@ -303,7 +289,7 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   final def invoke(): V = {
     var s = doExec()
     if (s >= 0) {
-      s = awaitJoin(true, false, false, 0L)
+      s = awaitDone(RAN, 0L)
     }
     if ((s & ABNORMAL) != 0) reportException(s)
     getRawResult()
@@ -319,6 +305,27 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
 
   final def isCompletedNormally(): Boolean =
     (status & (DONE | ABNORMAL)) == DONE
+
+  override def state(): Future.State = {
+    val s = status
+    if (s >= 0) Future.State.RUNNING
+    else if ((s & (DONE | ABNORMAL)) == DONE) Future.State.SUCCESS
+    else if ((s & (ABNORMAL | THROWN)) == (ABNORMAL | THROWN))
+      Future.State.FAILED
+    else Future.State.CANCELLED
+  }
+
+  override def resultNow(): V = {
+    if (!isCompletedNormally())
+      throw new IllegalStateException()
+    getRawResult()
+  }
+
+  override def exceptionNow(): Throwable = {
+    if ((status & (ABNORMAL | THROWN)) != (ABNORMAL | THROWN))
+      throw new IllegalStateException()
+    getThrowableException()
+  }
 
   final def getException(): Throwable = getException(status)
 
@@ -343,7 +350,11 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   @throws[InterruptedException]
   @throws[ExecutionException]
   override final def get(): V = {
-    val s = awaitJoin(false, true, false, 0L)
+    var s = -1
+    if (Thread.interrupted())
+      s = ABNORMAL
+    else if ({ s = status; s >= 0 })
+      s = awaitDone((s & POOLSUBMIT) | INTERRUPTIBLE, 0L)
     if ((s & ABNORMAL) != 0) reportExecutionException(s)
     getRawResult()
   }
@@ -352,17 +363,54 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   @throws[ExecutionException]
   @throws[TimeoutException]
   override final def get(timeout: Long, unit: TimeUnit): V = {
-    val s = awaitJoin(false, true, true, unit.toNanos(timeout))
+    var s = -1
+    val nanos = unit.toNanos(timeout)
+    if (Thread.interrupted())
+      s = ABNORMAL
+    else if ({ s = status; s >= 0 } && nanos > 0L)
+      s = awaitDone(
+        (s & POOLSUBMIT) | INTERRUPTIBLE | TIMED,
+        nanos + System.nanoTime()
+      )
     if (s >= 0 || (s & ABNORMAL) != 0) reportExecutionException(s)
     getRawResult()
   }
 
   final def quietlyJoin(): Unit = {
-    if (status >= 0) awaitJoin(false, false, false, 0L)
+    val s = status
+    if (s >= 0) awaitDone(s & POOLSUBMIT, 0L)
   }
 
   final def quietlyInvoke(): Unit = {
-    if (doExec() >= 0) awaitJoin(true, false, false, 0L)
+    if (doExec() >= 0) awaitDone(RAN, 0L)
+  }
+
+  // since JDK 19
+  final def quietlyJoin(timeout: Long, unit: TimeUnit): Boolean = {
+    val nanos = unit.toNanos(timeout)
+    var s = -1
+    if (Thread.interrupted())
+      s = ABNORMAL
+    else if ({ s = status; s >= 0 } && nanos > 0L)
+      s = awaitDone(
+        (s & POOLSUBMIT) | INTERRUPTIBLE | TIMED,
+        nanos + System.nanoTime()
+      )
+    if (s == ABNORMAL)
+      throw new InterruptedException()
+    else
+      s < 0
+  }
+  // Since JDK 19
+  final def quietlyJoinUninterruptibly(
+      timeout: Long,
+      unit: TimeUnit
+  ): Boolean = {
+    val nanos = unit.toNanos(timeout)
+    var s = status
+    if (s >= 0 && nanos > 0L)
+      s = awaitDone((s & POOLSUBMIT) | TIMED, nanos + System.nanoTime())
+    s < 0
   }
 
   def reinitialize(): Unit = {
@@ -373,10 +421,10 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   def tryUnfork(): Boolean = Thread.currentThread() match {
     case worker: ForkJoinWorkerThread =>
       val q = worker.workQueue
-      q != null && q.tryUnpush(this)
+      q != null && q.tryUnpush(this, true)
     case _ =>
       val q = ForkJoinPool.commonQueue()
-      q != null && q.externalTryUnpush(this)
+      q != null && q.tryUnpush(this, false)
   }
 
   def getRawResult(): V
@@ -441,6 +489,12 @@ object ForkJoinTask {
   private final val THROWN = 1 << 17
   private final val SMASK = 0xffff // short bits for tags
   private final val UNCOMPENSATE = 1 << 16 // helpJoin return sentinel
+  private final val POOLSUBMIT = 1 << 18 // for pool.submit vs fork
+
+  // flags for awaitDone (in addition to above)
+  private final val RAN = 1;
+  private final val INTERRUPTIBLE = 2;
+  private final val TIMED = 4;
 
   private[concurrent] def isExceptionalStatus(s: Int) = (s & THROWN) != 0
 
@@ -469,12 +523,14 @@ object ForkJoinTask {
     if (t1 == null || t2 == null) throw new NullPointerException
     t2.fork()
     var s1 = t1.doExec()
-    if (s1 >= 0) s1 = t1.awaitJoin(true, false, false, 0L)
+    if (s1 >= 0) s1 = t1.awaitDone(RAN, 0L)
     if ((s1 & ABNORMAL) != 0) {
       cancelIgnoringExceptions(t2)
       t1.reportException(s1)
     } else {
-      var s2 = t2.awaitJoin(false, false, false, 0L)
+      var s2 = t2.status
+      if (s2 >= 0)
+        s2 = t2.awaitDone(0, 0L)
       if ((s2 & ABNORMAL) != 0)
         t2.reportException(s2)
     }
@@ -490,7 +546,7 @@ object ForkJoinTask {
         false
       } else if (i == 0) {
         var s = t.doExec()
-        if (s >= 0) s = t.awaitJoin(true, false, false, 0L)
+        if (s >= 0) s = t.awaitDone(RAN, 0L)
         if ((s & ABNORMAL) != 0) ex = t.getException(s)
         false
       } else {
@@ -503,7 +559,7 @@ object ForkJoinTask {
       val t = tasks(i)
       t == null || {
         var s = t.status
-        if (s >= 0) s = t.awaitJoin(false, false, false, 0L)
+        if (s >= 0) s = t.awaitDone(0, 0L)
         if ((s & ABNORMAL) != 0) ex = t.getException(s)
         ex == null
       }
@@ -526,7 +582,7 @@ object ForkJoinTask {
 
           case t if i == 0 =>
             var s = t.doExec()
-            if (s >= 0) s = t.awaitJoin(true, false, false, 0L)
+            if (s >= 0) s = t.awaitDone(RAN, 0L)
             if ((s & ABNORMAL) != 0) ex = t.getException(s)
             false
 
@@ -539,7 +595,7 @@ object ForkJoinTask {
         val t = ts.get(i)
         t == null || {
           var s = t.status
-          if (s >= 0) s = t.awaitJoin(false, false, false, 0L)
+          if (s >= 0) s = t.awaitDone(0, 0L)
           if ((s & ABNORMAL) != 0) {
             ex = t.getException(s)
           }
@@ -561,18 +617,8 @@ object ForkJoinTask {
     tasks
   }
 
-  def helpQuiesce(): Unit = {
-    Thread.currentThread() match {
-      case t: ForkJoinWorkerThread if t.pool != null =>
-        t.pool.helpQuiescePool(t.workQueue, java.lang.Long.MAX_VALUE, false)
-      case _ =>
-        ForkJoinPool.common
-          .externalHelpQuiescePool(
-            java.lang.Long.MAX_VALUE,
-            false
-          )
-    }
-  }
+  def helpQuiesce(): Unit =
+    ForkJoinPool.helpQuiescePool(null, java.lang.Long.MAX_VALUE, false);
 
   def getPool(): ForkJoinPool = {
     Thread.currentThread() match {
@@ -752,6 +798,7 @@ object ForkJoinTask {
   def adapt[T](callable: Callable[T]): ForkJoinTask[T] =
     new AdaptedCallable[T](callable)
 
+  // since JDK 19
   def adaptInterruptible[T](callable: Callable[T]): ForkJoinTask[T] =
     new AdaptedInterruptibleCallable[T](callable)
 }

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
@@ -15,6 +15,7 @@ import java.lang.invoke.VarHandle
 import scala.scalanative.libc.atomic._
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
 import scala.scalanative.unsafe.{Ptr, stackalloc}
+import scala.scalanative.annotation.alwaysinline
 
 import scala.annotation.tailrec
 
@@ -33,10 +34,10 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   private val auxAtomic = new CAtomicRef[Aux](
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "aux"))
   )
-  private def casStatus(expected: Int, value: Int): Boolean =
+  @alwaysinline private def casStatus(expected: Int, value: Int): Boolean =
     statusAtomic.compareExchangeWeak(expected, value)
-  private def getAndBitwiseOrStatus(v: Int): Int = statusAtomic.fetchOr(v)
-  private def casAux(c: Aux, v: Aux): Boolean =
+  @alwaysinline private def getAndBitwiseOrStatus(v: Int): Int = statusAtomic.fetchOr(v)
+  @alwaysinline private def casAux(c: Aux, v: Aux): Boolean =
     auxAtomic.compareExchangeStrong(c, v)
 
   private[concurrent] final def markPoolSubmission(): Unit =

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
@@ -36,7 +36,8 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
   )
   @alwaysinline private def casStatus(expected: Int, value: Int): Boolean =
     statusAtomic.compareExchangeWeak(expected, value)
-  @alwaysinline private def getAndBitwiseOrStatus(v: Int): Int = statusAtomic.fetchOr(v)
+  @alwaysinline private def getAndBitwiseOrStatus(v: Int): Int =
+    statusAtomic.fetchOr(v)
   @alwaysinline private def casAux(c: Aux, v: Aux): Boolean =
     auxAtomic.compareExchangeStrong(c, v)
 

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinWorkerThread.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinWorkerThread.scala
@@ -13,14 +13,23 @@ class ForkJoinWorkerThread private[concurrent] (
     group: ThreadGroup,
     private[concurrent] val pool: ForkJoinPool,
     useSystemClassLoader: Boolean,
-    isInnocuous: Boolean
-) extends Thread(group, null, pool.nextWorkerThreadName(), 0L) {
+    clearThreadLocals: Boolean
+) extends Thread(
+      group = group,
+      task = null,
+      name = pool.nextWorkerThreadName(),
+      stackSize = 0L,
+      inheritThreadLocals = !clearThreadLocals
+    ) {
+  private[concurrent] val workQueue =
+    new ForkJoinPool.WorkQueue(this, 0)
+
   super.setDaemon(true)
   if (pool.ueh != null) {
     super.setUncaughtExceptionHandler(pool.ueh)
   }
-  private[concurrent] val workQueue =
-    new ForkJoinPool.WorkQueue(this, isInnocuous);
+  if (clearThreadLocals)
+    workQueue.setClearThreadLocals()
 
   private[concurrent] def this(group: ThreadGroup, pool: ForkJoinPool) = {
     this(group, pool, false, false);
@@ -30,13 +39,16 @@ class ForkJoinWorkerThread private[concurrent] (
     this(null, pool, false, false);
   }
 
-  def getPool(): ForkJoinPool = {
-    pool;
-  }
+  // Since JDK 19
+  protected def this(
+      group: ThreadGroup,
+      pool: ForkJoinPool,
+      preserveThreadLocals: Boolean
+  ) = this(group, pool, false, !preserveThreadLocals)
 
-  def getPoolIndex(): Int = {
-    workQueue.getPoolIndex();
-  }
+  def getPool(): ForkJoinPool = pool
+
+  def getPoolIndex(): Int = workQueue.getPoolIndex()
 
   protected def onStart(): Unit = ()
 

--- a/javalib/src/main/scala/java/util/concurrent/Future.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Future.scala
@@ -1,3 +1,4 @@
+// revision 1.47
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
@@ -23,4 +24,100 @@ trait Future[V] {
   @throws[TimeoutException]
   def get(timeout: Long, unit: TimeUnit): V
 
+  // since JDK 19
+  def resultNow(): V = {
+    if (!isDone())
+      throw new IllegalStateException("Task has not completed")
+    var interrupted = false
+    try
+      while (true) {
+        try get()
+        catch {
+          case _: InterruptedException => interrupted = true
+          case _: ExecutionException =>
+            throw new IllegalStateException("Task completed with exception")
+          case _: CancellationException =>
+            throw new IllegalStateException("Task was cancelled")
+        }
+      }
+    finally {
+      if (interrupted)
+        Thread.currentThread().interrupt()
+    }
+    ??? // unreachable
+  }
+
+  // Since JDK 19
+  def exceptionNow(): Throwable = {
+    if (!isDone())
+      throw new IllegalStateException("Task has not completed")
+    if (isCancelled())
+      throw new IllegalStateException("Task was cancelled")
+    var interrupted = false
+    try
+      while (true) {
+        try {
+          get()
+          throw new IllegalStateException("Task completed with a result")
+        } catch {
+          case _: InterruptedException => interrupted = true
+          case e: ExecutionException   => e.getCause()
+        }
+      }
+    finally {
+      if (interrupted)
+        Thread.currentThread().interrupt()
+    }
+    ??? // unreachable
+  }
+
+  def state(): Future.State = {
+    if (!isDone())
+      return Future.State.RUNNING
+    if (isCancelled())
+      return Future.State.CANCELLED
+
+    var interrupted = false
+    try
+      while (true) {
+        try {
+          get() // may throw InterruptedException when done
+          return Future.State.SUCCESS
+        } catch {
+          case _: InterruptedException =>
+            interrupted = true
+          case _: ExecutionException =>
+            return Future.State.FAILED
+        }
+      }
+    finally {
+      if (interrupted) Thread.currentThread().interrupt()
+    }
+    ??? // unreachable
+  }
+}
+
+object Future {
+  // Since JDK 19
+  sealed class State(name: String, ordinal: Int)
+      extends java.lang._Enum[State](name, ordinal) {
+    override def toString() = this.name
+  }
+  object State {
+    final val RUNNING = new State("RUNNING", 0)
+    final val SUCCESS = new State("SUCCESS", 1)
+    final val FAILED = new State("FAILED", 2)
+    final val CANCELLED = new State("CANCELLED", 3)
+
+    private[this] val cachedValues =
+      Array(RUNNING, SUCCESS, FAILED, CANCELLED)
+    def values(): Array[State] = cachedValues.clone()
+    def valueOf(name: String): State = {
+      cachedValues.find(_.name() == name).getOrElse {
+        throw new IllegalArgumentException(
+          "No enum const java.util.concurrent.Future.State." + name
+        )
+      }
+    }
+  }
 }

--- a/javalib/src/main/scala/java/util/concurrent/Future.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Future.scala
@@ -31,7 +31,7 @@ trait Future[V] {
     var interrupted = false
     try
       while (true) {
-        try get()
+        try return get()
         catch {
           case _: InterruptedException => interrupted = true
           case _: ExecutionException =>
@@ -61,7 +61,7 @@ trait Future[V] {
           throw new IllegalStateException("Task completed with a result")
         } catch {
           case _: InterruptedException => interrupted = true
-          case e: ExecutionException   => e.getCause()
+          case e: ExecutionException   => return e.getCause()
         }
       }
     finally {

--- a/javalib/src/main/scala/java/util/concurrent/FutureTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/FutureTask.scala
@@ -33,7 +33,7 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
   if (callable == null) throw new NullPointerException()
   import FutureTask._
 
-  @volatile private var state = NEW
+  @volatile private var _state = NEW
 
   @volatile private var runner: Thread = _
 
@@ -42,7 +42,7 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
   private var outcome: AnyRef = _
 
   private val atomicState = new CAtomicInt(
-    fromRawPtr(Intrinsics.classFieldRawPtr(this, "state"))
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "_state"))
   )
   private val atomicRunner = new CAtomicRef[Thread](
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "runner"))
@@ -62,11 +62,11 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
   def this(runnable: Runnable, result: V) =
     this(Executors.callable(runnable, result))
 
-  override def isCancelled(): Boolean = state >= CANCELLED
-  override def isDone(): Boolean = state != NEW
+  override def isCancelled(): Boolean = _state >= CANCELLED
+  override def isDone(): Boolean = _state != NEW
   override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
     def newState = if (mayInterruptIfRunning) INTERRUPTING else CANCELLED
-    if (!(state == NEW &&
+    if (!(_state == NEW &&
           atomicState.compareExchangeStrong(NEW, newState))) return false
     try { // in case call to interrupt throws exception
       if (mayInterruptIfRunning) try {
@@ -80,7 +80,7 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
   @throws[InterruptedException]
   @throws[ExecutionException]
   override def get(): V = {
-    var s = state
+    var s = _state
     if (s <= COMPLETING) s = awaitDone(false, 0L)
     report(s)
   }
@@ -89,12 +89,45 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
   @throws[TimeoutException]
   override def get(timeout: Long, unit: TimeUnit): V = {
     if (unit == null) throw new NullPointerException
-    var s = state
+    var s = _state
     if (s <= COMPLETING && {
           s = awaitDone(true, unit.toNanos(timeout))
           s <= COMPLETING
         }) throw new TimeoutException
     report(s)
+  }
+
+  override def resultNow(): V = state() match {
+    case Future.State.SUCCESS => outcome.asInstanceOf[V]
+    case Future.State.FAILED =>
+      throw new IllegalStateException("Task completed with exception");
+    case Future.State.CANCELLED =>
+      throw new IllegalStateException("Task was cancelled");
+    case _ => throw new IllegalStateException("Task has not completed");
+  }
+
+  override def exceptionNow(): Throwable = state() match {
+    case Future.State.SUCCESS =>
+      throw new IllegalStateException("Task completed with a result")
+    case Future.State.FAILED => outcome.asInstanceOf[Throwable]
+    case Future.State.CANCELLED =>
+      throw new IllegalStateException("Task was cancelled");
+    case _ => throw new IllegalStateException("Task has not completed");
+  }
+
+  override def state(): Future.State = {
+    var s = _state
+    while (s == COMPLETING) {
+      // waiting for transition to NORMAL or EXCEPTIONAL
+      Thread.`yield`()
+      s = _state
+    }
+    s match {
+      case NORMAL                                 => Future.State.SUCCESS;
+      case EXCEPTIONAL                            => Future.State.FAILED;
+      case CANCELLED | INTERRUPTING | INTERRUPTED => Future.State.CANCELLED;
+      case _                                      => Future.State.RUNNING;
+    }
   }
 
   protected def done(): Unit = {}
@@ -115,13 +148,13 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
     }
   }
   override def run(): Unit = {
-    if (state != NEW || !atomicRunner.compareExchangeStrong(
+    if (_state != NEW || !atomicRunner.compareExchangeStrong(
           null: Thread,
           Thread.currentThread()
         )) return ()
     try {
       val c = callable
-      if (c != null && state == NEW) {
+      if (c != null && _state == NEW) {
         var result: V = null.asInstanceOf[V]
         var ran = false
         try {
@@ -135,23 +168,23 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
         if (ran) set(result)
       }
     } finally {
-      // runner must be non-null until state is settled to
+      // runner must be non-null until _state is settled to
       // prevent concurrent calls to run()
       runner = null
       // state must be re-read after nulling runner to prevent
       // leaked interrupts
-      val s = state
+      val s = _state
       if (s >= INTERRUPTING) handlePossibleCancellationInterrupt(s)
     }
   }
 
   protected def runAndReset(): Boolean = {
-    if (state != NEW || !atomicRunner.compareExchangeStrong(
+    if (_state != NEW || !atomicRunner.compareExchangeStrong(
           null: Thread,
           Thread.currentThread()
         )) return false
     var ran = false
-    var s = state
+    var s = _state
     try {
       val c = callable
       if (c != null && s == NEW) try {
@@ -161,7 +194,7 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
       } catch { case ex: Throwable => setException(ex) }
     } finally {
       runner = null
-      s = state
+      s = _state
       if (s >= INTERRUPTING) handlePossibleCancellationInterrupt(s)
     }
     ran && s == NEW
@@ -171,7 +204,7 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
     // It is possible for our interrupter to stall before getting a
     // chance to interrupt us.  Let's spin-wait patiently.
     if (s == INTERRUPTING)
-      while (state == INTERRUPTING)
+      while (_state == INTERRUPTING)
         Thread.`yield`() // wait out pending interrupt
     // assert state == INTERRUPTED;
     // We want to clear any interrupt we may have received from
@@ -221,7 +254,7 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
     var queued = false
 
     while (true) {
-      val s = state
+      val s = _state
       if (s > COMPLETING) {
         if (q != null) q.thread = null
         return s
@@ -247,12 +280,12 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
           val elapsed = System.nanoTime() - startTime
           if (elapsed >= nanos) {
             removeWaiter(q)
-            return state
+            return _state
           }
           parkNanos = nanos - elapsed
         }
         // nanoTime may be slow; recheck before parking
-        if (state < COMPLETING) LockSupport.parkNanos(this, parkNanos)
+        if (_state < COMPLETING) LockSupport.parkNanos(this, parkNanos)
       } else LockSupport.park(this)
     }
     -1 // unreachable
@@ -288,7 +321,7 @@ class FutureTask[V <: AnyRef](private var callable: Callable[V])
   }
 
   override def toString: String = {
-    val status = state match {
+    val status = _state match {
       case NORMAL      => "[Completed normally]"
       case EXCEPTIONAL => "[Completed exceptionally: " + outcome + "]"
       case CANCELLED | INTERRUPTED | INTERRUPTING => "[Cancelled]"

--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -230,7 +230,7 @@ object ThreadLocalRandom {
     probe
   }
 
-  private[concurrent] def nextSecondarySeed = {
+  private[concurrent] def nextSecondarySeed(): Int = {
     val t = Thread.currentThread()
     var r: Int = t.threadLocalRandomSecondarySeed
     if (r != 0) {
@@ -247,9 +247,8 @@ object ThreadLocalRandom {
   }
 
   private[concurrent] def eraseThreadLocals(thread: Thread): Unit = {
-    // TOOD: Adapt ThreadLocal implementation
-    // thread.localValues = null
-    // thread.inheritableValues = null
+    thread.threadLocals = null
+    thread.inheritableThreadLocals = null
   }
 
   private val GAMMA = 0x9e3779b97f4a7c15L

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
@@ -619,7 +619,10 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     private def canReacquire(
         node: AbstractQueuedLongSynchronizer.ConditionNode
     ) = { // check links, not status to avoid enqueue race
-      node != null && node.prev != null && isEnqueued(node)
+      var p: Node = null
+      node != null && {
+        p = node.prev; p != null
+      } && (p.next == node || isEnqueued(node))
     }
 
     private def unlinkCancelledWaiters(

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
@@ -26,22 +26,20 @@ object AbstractQueuedLongSynchronizer { // Node status bits, also used as argume
   private[locks] val COND = 2 // in a condition wait
 
   abstract private[locks] class Node {
-    @volatile var waiter: Thread = _ // visibly nonnull when enqueued
+    var waiter: Thread = _ // visibly nonnull when enqueued
     @volatile var prev: Node = _ // initially attached via casTail
     @volatile var next: Node = _ // visibly nonnull when signallable
     @volatile var status: Int = 0 // written by owner, atomic bit ops by others
 
-    private val prevPtr: Ptr[Node] = fromRawPtr(
-      Intrinsics.classFieldRawPtr(this, "prev")
+    private val prevAtomic = new CAtomicRef[Node](
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "prev"))
     )
-    private val prevAtomic = new CAtomicRef[Node](prevPtr)
     private val nextAtomic = new CAtomicRef[Node](
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "next"))
     )
-    private val statusPtr: Ptr[Int] = fromRawPtr(
-      Intrinsics.classFieldRawPtr(this, "status")
+    private val statusAtomic = new CAtomicInt(
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "status"))
     )
-    private val statusAtomic = new CAtomicInt(statusPtr)
 
     // methods for atomic operations
     def casPrev(c: Node, v: Node): Boolean = // for cleanQueue
@@ -54,24 +52,22 @@ object AbstractQueuedLongSynchronizer { // Node status bits, also used as argume
       statusAtomic.fetchAnd(~v)
 
     def setPrevRelaxed(p: Node): Unit = // for off-queue assignment
-      !prevPtr = p // U.putObject
+      prevAtomic.store(p) // U.putObject
 
     def setStatusRelaxed(s: Int) = // for off-queue assignment
-      !statusPtr = s // U.putInt
+      statusAtomic.store(s) // U.putInt
 
     def clearStatus(): Unit = // for reducing unneeded signals
       statusAtomic.store(0, memory_order_relaxed) // U.putIntOpaque
   }
 
   // Concrete classes tagged by type
-  final private[locks] class ExclusiveNode
-      extends AbstractQueuedLongSynchronizer.Node {}
+  final private[locks] class ExclusiveNode extends Node {}
 
-  final private[locks] class SharedNode
-      extends AbstractQueuedLongSynchronizer.Node {}
+  final private[locks] class SharedNode extends Node {}
 
   final private[locks] class ConditionNode
-      extends AbstractQueuedLongSynchronizer.Node
+      extends Node
       with ForkJoinPool.ManagedBlocker {
 
     // link to next waiting node
@@ -86,7 +82,7 @@ object AbstractQueuedLongSynchronizer { // Node status bits, also used as argume
     }
   }
 
-  private def signalNext(h: AbstractQueuedLongSynchronizer.Node): Unit =
+  private def signalNext(h: Node): Unit =
     if (h != null) h.next match {
       case s: Node if s.status != 0 =>
         s.getAndUnsetStatus(WAITING)
@@ -111,9 +107,7 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   import AbstractQueuedLongSynchronizer._
 
   @volatile private var head: Node = _
-
   @volatile private var tail: Node = _
-
   @volatile private var state: Long = 0
 
   // Support for atomic ops
@@ -134,17 +128,18 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   final protected def compareAndSetState(c: Long, v: Long): Boolean =
     stateAtomic.compareExchangeStrong(c, v)
 
-  private def casTail(c: Node, v: Node) = tailAtomic.compareExchangeStrong(c, v)
+  private def casTail(c: Node, v: Node) =
+    tailAtomic.compareExchangeStrong(c, v)
 
   private def tryInitializeHead(): Unit = {
-    val h = new AbstractQueuedLongSynchronizer.ExclusiveNode()
+    val h = new ExclusiveNode()
     val isInitialized = headAtomic.compareExchangeStrong(null: Node, h)
     if (isInitialized)
       tail = h
   }
 
   final private[locks] def enqueue(
-      node: AbstractQueuedLongSynchronizer.Node
+      node: Node
   ): Unit = {
     @tailrec
     def tryEnqueue(): Unit = {
@@ -158,9 +153,8 @@ abstract class AbstractQueuedLongSynchronizer protected ()
 
         case t if casTail(t, node) =>
           t.next = node
-          if (t.status < 0) { // wake up to clean link
+          if (t.status < 0) // wake up to clean link
             LockSupport.unpark(node.waiter)
-          }
         case _ => tryEnqueue()
       }
     }
@@ -168,10 +162,10 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   }
 
   final private[locks] def isEnqueued(
-      node: AbstractQueuedLongSynchronizer.Node
+      node: Node
   ): Boolean = {
     @tailrec
-    def checkLoop(t: AbstractQueuedLongSynchronizer.Node): Boolean = {
+    def checkLoop(t: Node): Boolean = {
       if (t == null) false
       else if (t eq node) true
       else checkLoop(t.prev)
@@ -180,7 +174,7 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   }
 
   final private[locks] def acquire(
-      _node: AbstractQueuedLongSynchronizer.Node,
+      _node: Node,
       arg: Long,
       shared: Boolean,
       interruptible: Boolean,
@@ -190,11 +184,10 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     val current = Thread.currentThread()
 
     var node: Node = _node
-    var spins = 0
-    var postSpins = 0 // retries upon unpark of first thread
-    var interrupted = false
-    var first = false
+    var spins, postSpins = 0 // retries upon unpark of first thread
+    var interrupted, first = false
     var pred: Node = null // predecessor of node when enqueued
+
     /*
      * Repeatedly:
      *  Check if node now first
@@ -216,20 +209,20 @@ abstract class AbstractQueuedLongSynchronizer protected ()
       first
     }
     while (true) {
-      var shouldReset = false
+      var continue = false
       if (!first &&
           getPred() != null &&
           !isFirst()) {
         if (pred.status < 0) {
           cleanQueue()
-          shouldReset = true
+          continue = true
         } else if (pred.prev == null) {
           Thread.onSpinWait()
-          shouldReset = true
+          continue = true
         }
       }
 
-      if (!shouldReset) {
+      if (!continue) {
         if (first || pred == null) {
           val acquired =
             try
@@ -289,13 +282,13 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   }
 
   private def cleanQueue(): Unit = {
-    var break = false
-    while (!break) {
-      // restart point
-      var q = tail
-      var s: Node = null
+    while (true) {
+      var break = false
       var n: Node = null
-      while (true) {
+      var s: Node = null
+      var q = tail
+      // restart point
+      while (!break) {
         val p = if (q != null) q.prev else null
         if (p == null) return () // end of list
 
@@ -309,7 +302,8 @@ abstract class AbstractQueuedLongSynchronizer protected ()
             else s.casPrev(q, p)
           if (casNode && (q.prev eq p)) {
             p.casNext(q, s) // OK if fails
-            if (p.prev == null) signalNext(p)
+            if (p.prev == null)
+              signalNext(p)
           }
           break = true
         } else {
@@ -317,7 +311,8 @@ abstract class AbstractQueuedLongSynchronizer protected ()
           if (n != q) { // help finish
             if (n != null && q.prev == p) {
               p.casNext(n, q)
-              if (p.prev == null) signalNext(p)
+              if (p.prev == null)
+                signalNext(p)
             }
             break = true
           }
@@ -330,14 +325,15 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   }
 
   private def cancelAcquire(
-      node: AbstractQueuedLongSynchronizer.Node,
+      node: Node,
       interrupted: Boolean,
       interruptible: Boolean
   ): Int = {
     if (node != null) {
       node.waiter = null
       node.status = CANCELLED
-      if (node.prev != null) cleanQueue()
+      if (node.prev != null)
+        cleanQueue()
     }
 
     if (interrupted) {
@@ -363,7 +359,8 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     throw new UnsupportedOperationException
 
   final def acquire(arg: Long): Unit = {
-    if (!tryAcquire(arg)) acquire(null, arg, false, false, false, 0L)
+    if (!tryAcquire(arg))
+      acquire(null, arg, false, false, false, 0L)
   }
 
   @throws[InterruptedException]
@@ -388,13 +385,14 @@ abstract class AbstractQueuedLongSynchronizer protected ()
 
   final def release(arg: Long): Boolean = {
     if (tryRelease(arg)) {
-      AbstractQueuedLongSynchronizer.signalNext(head)
+      signalNext(head)
       true
     } else false
   }
 
   final def acquireShared(arg: Long): Unit = {
-    if (tryAcquireShared(arg) < 0) acquire(null, arg, true, false, false, 0L)
+    if (tryAcquireShared(arg) < 0)
+      acquire(null, arg, true, false, false, 0L)
   }
 
   @throws[InterruptedException]
@@ -424,7 +422,7 @@ abstract class AbstractQueuedLongSynchronizer protected ()
 
   final def releaseShared(arg: Long): Boolean = {
     if (tryReleaseShared(arg)) {
-      AbstractQueuedLongSynchronizer.signalNext(head)
+      signalNext(head)
       true
     } else false
   }
@@ -468,7 +466,7 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   final def isQueued(thread: Thread): Boolean = {
     if (thread == null) throw new NullPointerException
     var p = tail
-    while ({ p != null }) {
+    while (p != null) {
       if (p.waiter eq thread) return true
       p = p.prev
     }
@@ -476,24 +474,25 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   }
 
   final private[locks] def apparentlyFirstQueuedIsExclusive() = {
-    val isNotShared = for {
-      h <- Option(head)
-      s <- Option(h.next)
-      _ <- Option(s.waiter)
-    } yield !s.isInstanceOf[AbstractQueuedLongSynchronizer.SharedNode]
+    val h = head
+    val s = if (h != null) h.next else null
 
-    isNotShared.getOrElse(false)
+    s != null &&
+      !s.isInstanceOf[SharedNode] &&
+      s.waiter != null
   }
 
   final def hasQueuedPredecessors(): Boolean = {
     val h = head
     val s = if (h != null) h.next else null
-    val first = if (s != null) s.waiter else null
+    var first = if (s != null) s.waiter else null
     val current =
-      if (h != null && (s == null || first == null || s.prev == null)) {
-        getFirstQueuedThread()
-      } else first
-    current != null && first != Thread.currentThread()
+      if (h != null && (s == null ||
+            first == null ||
+            s.prev == null)) {
+        first = getFirstQueuedThread()
+      }
+    first != null && (first ne Thread.currentThread())
   }
 
   final def getQueueLength(): Int = {
@@ -526,11 +525,11 @@ abstract class AbstractQueuedLongSynchronizer protected ()
   final def getQueuedThreads(): Collection[Thread] = getThreads(_ => true)
 
   final def getExclusiveQueuedThreads(): Collection[Thread] = getThreads { p =>
-    !p.isInstanceOf[AbstractQueuedLongSynchronizer.SharedNode]
+    !p.isInstanceOf[SharedNode]
   }
 
   final def getSharedQueuedThreads(): Collection[Thread] = getThreads {
-    _.isInstanceOf[AbstractQueuedLongSynchronizer.SharedNode]
+    _.isInstanceOf[SharedNode]
   }
 
   override def toString(): String =
@@ -571,7 +570,7 @@ abstract class AbstractQueuedLongSynchronizer protected ()
 
     @tailrec
     private def doSignal(
-        first: AbstractQueuedLongSynchronizer.ConditionNode,
+        first: ConditionNode,
         all: Boolean
     ): Unit = {
       if (first != null) {
@@ -597,44 +596,40 @@ abstract class AbstractQueuedLongSynchronizer protected ()
       if (first != null) doSignal(first, true)
     }
 
-    private def enableWait(
-        node: AbstractQueuedLongSynchronizer.ConditionNode
-    ): Long = {
+    private def enableWait(node: ConditionNode): Long = {
       if (isHeldExclusively()) {
         node.waiter = Thread.currentThread()
-        node.setStatusRelaxed(
-          AbstractQueuedLongSynchronizer.COND | AbstractQueuedLongSynchronizer.WAITING
-        )
+        node.setStatusRelaxed(COND | WAITING)
         val last = lastWaiter
         if (last == null) firstWaiter = node
         else last.nextWaiter = node
         lastWaiter = node
         val savedState = getState()
-        if (release(savedState)) return savedState
+        if (release(savedState))
+          return savedState
       }
       node.status = CANCELLED // lock not held or inconsistent
       throw new IllegalMonitorStateException()
     }
 
-    private def canReacquire(
-        node: AbstractQueuedLongSynchronizer.ConditionNode
-    ) = { // check links, not status to avoid enqueue race
+    private def canReacquire(node: ConditionNode) = {
+      // check links, not status to avoid enqueue race
       var p: Node = null
       node != null && {
         p = node.prev; p != null
-      } && (p.next == node || isEnqueued(node))
+      } && ((p.next eq node) || isEnqueued(node))
     }
 
     private def unlinkCancelledWaiters(
-        node: AbstractQueuedLongSynchronizer.ConditionNode
+        node: ConditionNode
     ): Unit = {
-      if (node == null || node.nextWaiter != null || (node == lastWaiter)) {
+      if (node == null || node.nextWaiter != null || (node eq lastWaiter)) {
         var w = firstWaiter
-        var trail: AbstractQueuedLongSynchronizer.ConditionNode = null
+        var trail: ConditionNode = null
 
         while (w != null) {
           val next = w.nextWaiter
-          if ((w.status & AbstractQueuedLongSynchronizer.COND) == 0) {
+          if ((w.status & COND) == 0) {
             w.nextWaiter = null
             if (trail == null) firstWaiter = next
             else trail.nextWaiter = next
@@ -646,16 +641,16 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     }
 
     override final def awaitUninterruptibly(): Unit = {
-      val node = new AbstractQueuedLongSynchronizer.ConditionNode
+      val node = new ConditionNode
       val savedState = enableWait(node)
-
-      var interrupted = false
-      var rejected = false
       LockSupport.setCurrentBlocker(this) // for back-compatibility
+      var interrupted, rejected = false
       while (!canReacquire(node)) {
         if (Thread.interrupted()) interrupted = true
         else if ((node.status & COND) != 0)
-          try ForkJoinPool.managedBlock(node)
+          try
+            if (rejected) node.block()
+            else ForkJoinPool.managedBlock(node)
           catch {
             case ex: RejectedExecutionException => rejected = true
             case ie: InterruptedException       => interrupted = true
@@ -674,20 +669,23 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     override final def await(): Unit = {
       if (Thread.interrupted()) throw new InterruptedException
 
-      val node = new AbstractQueuedLongSynchronizer.ConditionNode
+      val node = new ConditionNode
       val savedState = enableWait(node)
       LockSupport.setCurrentBlocker(this)
-      var interrupted = false
-      var cancelled = false
-      var break = false
+      var interrupted, cancelled, break, rejected = false
       while (!break && !canReacquire(node)) {
         interrupted |= Thread.interrupted()
         if (interrupted) {
           cancelled = (node.getAndUnsetStatus(COND) & COND) != 0
           if (cancelled) break = true
         } else if ((node.status & COND) != 0) { // else interrupted after signal
-          try ForkJoinPool.managedBlock(node)
-          catch { case ie: InterruptedException => interrupted = true }
+          try
+            if (rejected) node.block()
+            else ForkJoinPool.managedBlock(node)
+          catch {
+            case ex: RejectedExecutionException => rejected = true
+            case ie: InterruptedException       => interrupted = true
+          }
         } else Thread.onSpinWait() // awoke while enqueuing
       }
 
@@ -707,15 +705,13 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     override final def awaitNanos(nanosTimeout: Long): Long = {
       if (Thread.interrupted()) throw new InterruptedException
 
-      val node = new AbstractQueuedLongSynchronizer.ConditionNode()
+      val node = new ConditionNode()
       val savedState = enableWait(node)
 
       var nanos = nanosTimeout.max(0L)
       val deadline = System.nanoTime() + nanos
 
-      var cancelled = false
-      var interrupted = false
-      var break = false
+      var cancelled, interrupted, break = false
       while (!break && !canReacquire(node)) {
         interrupted |= Thread.interrupted()
         if (interrupted || {
@@ -745,12 +741,10 @@ abstract class AbstractQueuedLongSynchronizer protected ()
       val abstime = deadline.getTime()
       if (Thread.interrupted()) throw new InterruptedException
 
-      val node = new AbstractQueuedLongSynchronizer.ConditionNode
+      val node = new ConditionNode
       val savedState = enableWait(node)
 
-      var cancelled = false
-      var interrupted = false
-      var break = false
+      var cancelled, interrupted, break = false
       while (!break && !canReacquire(node)) {
         interrupted |= Thread.interrupted()
         if (interrupted || System.currentTimeMillis() >= abstime) {
@@ -773,14 +767,12 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     override final def await(time: Long, unit: TimeUnit): Boolean = {
       val nanosTimeout = unit.toNanos(time)
       if (Thread.interrupted()) throw new InterruptedException
-      val node = new AbstractQueuedLongSynchronizer.ConditionNode
+      val node = new ConditionNode
       val savedState = enableWait(node)
       var nanos = nanosTimeout.max(0L)
       val deadline = System.nanoTime() + nanos
 
-      var cancelled = false
-      var interrupted = false
-      var break = false
+      var cancelled, interrupted, break = false
       while (!break && !canReacquire(node)) {
         interrupted |= Thread.interrupted()
         if (interrupted || {
@@ -824,7 +816,6 @@ abstract class AbstractQueuedLongSynchronizer protected ()
       var w = firstWaiter
       while (w != null) {
         if ((w.status & COND) != 0) n += 1
-
         w = w.nextWaiter
       }
       n
@@ -835,7 +826,7 @@ abstract class AbstractQueuedLongSynchronizer protected ()
       val list = new ArrayList[Thread]
       var w = firstWaiter
       while (w != null) {
-        if ((w.status & AbstractQueuedLongSynchronizer.COND) != 0) {
+        if ((w.status & COND) != 0) {
           val t = w.waiter
           if (t != null) list.add(t)
         }

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
@@ -619,7 +619,10 @@ abstract class AbstractQueuedSynchronizer protected ()
 
     private def canReacquire(node: AbstractQueuedSynchronizer.ConditionNode) = {
       // check links, not status to avoid enqueue race
-      node != null && node.prev != null && isEnqueued(node)
+      var p: Node = null
+      node != null && {
+        p = node.prev; p != null
+      } && (p.next == node || isEnqueued(node))
     }
 
     private def unlinkCancelledWaiters(

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
@@ -26,22 +26,20 @@ object AbstractQueuedSynchronizer { // Node status bits, also used as argument a
   private[locks] val COND = 2 // in a condition wait
 
   abstract private[locks] class Node {
-    @volatile var waiter: Thread = _ // visibly nonnull when enqueued
+    var waiter: Thread = _ // visibly nonnull when enqueued
     @volatile var prev: Node = _ // initially attached via casTail
     @volatile var next: Node = _ // visibly nonnull when signallable
     @volatile var status: Int = 0 // written by owner, atomic bit ops by others
 
-    private val prevPtr: Ptr[Node] = fromRawPtr(
-      Intrinsics.classFieldRawPtr(this, "prev")
+    private val prevAtomic = new CAtomicRef[Node](
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "prev"))
     )
-    private val prevAtomic = new CAtomicRef[Node](prevPtr)
     private val nextAtomic = new CAtomicRef[Node](
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "next"))
     )
-    private val statusPtr: Ptr[Int] = fromRawPtr(
-      Intrinsics.classFieldRawPtr(this, "status")
+    private val statusAtomic = new CAtomicInt(
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "status"))
     )
-    private val statusAtomic = new CAtomicInt(statusPtr)
 
     // methods for atomic operations
     def casPrev(c: Node, v: Node): Boolean = // for cleanQueue
@@ -54,24 +52,22 @@ object AbstractQueuedSynchronizer { // Node status bits, also used as argument a
       statusAtomic.fetchAnd(~v)
 
     def setPrevRelaxed(p: Node): Unit = // for off-queue assignment
-      !prevPtr = p // U.putObject
+      prevAtomic.store(p) // U.putObject
 
     def setStatusRelaxed(s: Int) = // for off-queue assignment
-      !statusPtr = s // U.putInt
+      statusAtomic.store(s) // U.putInt
 
     def clearStatus(): Unit = // for reducing unneeded signals
       statusAtomic.store(0, memory_order_relaxed) // U.putIntOpaque
   }
 
   // Concrete classes tagged by type
-  final private[locks] class ExclusiveNode
-      extends AbstractQueuedSynchronizer.Node {}
+  final private[locks] class ExclusiveNode extends Node {}
 
-  final private[locks] class SharedNode
-      extends AbstractQueuedSynchronizer.Node {}
+  final private[locks] class SharedNode extends Node {}
 
   final private[locks] class ConditionNode
-      extends AbstractQueuedSynchronizer.Node
+      extends Node
       with ForkJoinPool.ManagedBlocker {
 
     // link to next waiting node
@@ -86,7 +82,7 @@ object AbstractQueuedSynchronizer { // Node status bits, also used as argument a
     }
   }
 
-  private def signalNext(h: AbstractQueuedSynchronizer.Node): Unit =
+  private def signalNext(h: Node): Unit =
     if (h != null) h.next match {
       case s: Node if s.status != 0 =>
         s.getAndUnsetStatus(WAITING)
@@ -111,9 +107,7 @@ abstract class AbstractQueuedSynchronizer protected ()
   import AbstractQueuedSynchronizer._
 
   @volatile private var head: Node = _
-
   @volatile private var tail: Node = _
-
   @volatile private var state: Int = 0
 
   // Support for atomic ops
@@ -134,18 +128,17 @@ abstract class AbstractQueuedSynchronizer protected ()
   final protected def compareAndSetState(c: Int, v: Int): Boolean =
     stateAtomic.compareExchangeStrong(c, v)
 
-  private def casTail(c: Node, v: Node) = tailAtomic.compareExchangeStrong(c, v)
+  private def casTail(c: Node, v: Node) =
+    tailAtomic.compareExchangeStrong(c, v)
 
   private def tryInitializeHead(): Unit = {
-    val h = new AbstractQueuedSynchronizer.ExclusiveNode()
+    val h = new ExclusiveNode()
     val isInitialized = headAtomic.compareExchangeStrong(null: Node, h)
     if (isInitialized)
       tail = h
   }
 
-  final private[locks] def enqueue(
-      node: AbstractQueuedSynchronizer.Node
-  ): Unit = {
+  final private[locks] def enqueue(node: Node): Unit = {
     @tailrec
     def tryEnqueue(): Unit = {
       val t = tail
@@ -158,9 +151,8 @@ abstract class AbstractQueuedSynchronizer protected ()
 
         case t if casTail(t, node) =>
           t.next = node
-          if (t.status < 0) { // wake up to clean link
+          if (t.status < 0) // wake up to clean link
             LockSupport.unpark(node.waiter)
-          }
         case _ => tryEnqueue()
       }
     }
@@ -168,10 +160,10 @@ abstract class AbstractQueuedSynchronizer protected ()
   }
 
   final private[locks] def isEnqueued(
-      node: AbstractQueuedSynchronizer.Node
+      node: Node
   ): Boolean = {
     @tailrec
-    def checkLoop(t: AbstractQueuedSynchronizer.Node): Boolean = {
+    def checkLoop(t: Node): Boolean = {
       if (t == null) false
       else if (t eq node) true
       else checkLoop(t.prev)
@@ -180,7 +172,7 @@ abstract class AbstractQueuedSynchronizer protected ()
   }
 
   final private[locks] def acquire(
-      _node: AbstractQueuedSynchronizer.Node,
+      _node: Node,
       arg: Int,
       shared: Boolean,
       interruptible: Boolean,
@@ -190,10 +182,8 @@ abstract class AbstractQueuedSynchronizer protected ()
     val current = Thread.currentThread()
 
     var node: Node = _node
-    var spins = 0
-    var postSpins = 0 // retries upon unpark of first thread
-    var interrupted = false
-    var first = false
+    var spins, postSpins = 0 // retries upon unpark of first thread
+    var interrupted, first = false
     var pred: Node = null // predecessor of node when enqueued
 
     /*
@@ -217,20 +207,20 @@ abstract class AbstractQueuedSynchronizer protected ()
       first
     }
     while (true) {
-      var shouldReset = false
+      var continue = false
       if (!first &&
           getPred() != null &&
           !isFirst()) {
         if (pred.status < 0) {
           cleanQueue()
-          shouldReset = true
+          continue = true
         } else if (pred.prev == null) {
           Thread.onSpinWait()
-          shouldReset = true
+          continue = true
         }
       }
 
-      if (!shouldReset) {
+      if (!continue) {
         if (first || pred == null) {
           val acquired =
             try
@@ -290,13 +280,13 @@ abstract class AbstractQueuedSynchronizer protected ()
   }
 
   private def cleanQueue(): Unit = {
-    var break = false
-    while (!break) {
-      // restart point
-      var q = tail
-      var s: Node = null
+    while (true) {
+      var break = false
       var n: Node = null
-      while (true) {
+      var s: Node = null
+      var q = tail
+      // restart point
+      while (!break) {
         val p = if (q != null) q.prev else null
         if (p == null) return () // end of list
 
@@ -310,7 +300,8 @@ abstract class AbstractQueuedSynchronizer protected ()
             else s.casPrev(q, p)
           if (casNode && (q.prev eq p)) {
             p.casNext(q, s) // OK if fails
-            if (p.prev == null) signalNext(p)
+            if (p.prev == null)
+              signalNext(p)
           }
           break = true
         } else {
@@ -318,7 +309,8 @@ abstract class AbstractQueuedSynchronizer protected ()
           if (n != q) { // help finish
             if (n != null && q.prev == p) {
               p.casNext(n, q)
-              if (p.prev == null) signalNext(p)
+              if (p.prev == null)
+                signalNext(p)
             }
             break = true
           }
@@ -331,14 +323,15 @@ abstract class AbstractQueuedSynchronizer protected ()
   }
 
   private def cancelAcquire(
-      node: AbstractQueuedSynchronizer.Node,
+      node: Node,
       interrupted: Boolean,
       interruptible: Boolean
   ): Int = {
     if (node != null) {
       node.waiter = null
       node.status = CANCELLED
-      if (node.prev != null) cleanQueue()
+      if (node.prev != null)
+        cleanQueue()
     }
 
     if (interrupted) {
@@ -364,7 +357,8 @@ abstract class AbstractQueuedSynchronizer protected ()
     throw new UnsupportedOperationException
 
   final def acquire(arg: Int): Unit = {
-    if (!tryAcquire(arg)) acquire(null, arg, false, false, false, 0L)
+    if (!tryAcquire(arg))
+      acquire(null, arg, false, false, false, 0L)
   }
 
   @throws[InterruptedException]
@@ -389,13 +383,14 @@ abstract class AbstractQueuedSynchronizer protected ()
 
   final def release(arg: Int): Boolean = {
     if (tryRelease(arg)) {
-      AbstractQueuedSynchronizer.signalNext(head)
+      signalNext(head)
       true
     } else false
   }
 
   final def acquireShared(arg: Int): Unit = {
-    if (tryAcquireShared(arg) < 0) acquire(null, arg, true, false, false, 0L)
+    if (tryAcquireShared(arg) < 0)
+      acquire(null, arg, true, false, false, 0L)
   }
 
   @throws[InterruptedException]
@@ -425,7 +420,7 @@ abstract class AbstractQueuedSynchronizer protected ()
 
   final def releaseShared(arg: Int): Boolean = {
     if (tryReleaseShared(arg)) {
-      AbstractQueuedSynchronizer.signalNext(head)
+      signalNext(head)
       true
     } else false
   }
@@ -469,7 +464,7 @@ abstract class AbstractQueuedSynchronizer protected ()
   final def isQueued(thread: Thread): Boolean = {
     if (thread == null) throw new NullPointerException
     var p = tail
-    while ({ p != null }) {
+    while (p != null) {
       if (p.waiter eq thread) return true
       p = p.prev
     }
@@ -477,24 +472,25 @@ abstract class AbstractQueuedSynchronizer protected ()
   }
 
   final private[locks] def apparentlyFirstQueuedIsExclusive() = {
-    val isNotShared = for {
-      h <- Option(head)
-      s <- Option(h.next)
-      _ <- Option(s.waiter)
-    } yield !s.isInstanceOf[AbstractQueuedSynchronizer.SharedNode]
+    val h = head
+    val s = if (h != null) h.next else null
 
-    isNotShared.getOrElse(false)
+    s != null &&
+      !s.isInstanceOf[SharedNode] &&
+      s.waiter != null
   }
 
   final def hasQueuedPredecessors(): Boolean = {
     val h = head
     val s = if (h != null) h.next else null
-    val first = if (s != null) s.waiter else null
+    var first = if (s != null) s.waiter else null
     val current =
-      if (h != null && (s == null || first == null || s.prev == null)) {
-        getFirstQueuedThread()
-      } else first
-    current != null && first != Thread.currentThread()
+      if (h != null && (s == null ||
+            first == null ||
+            s.prev == null)) {
+        first = getFirstQueuedThread()
+      }
+    first != null && (first ne Thread.currentThread())
   }
 
   final def getQueueLength(): Int = {
@@ -527,11 +523,11 @@ abstract class AbstractQueuedSynchronizer protected ()
   final def getQueuedThreads(): Collection[Thread] = getThreads(_ => true)
 
   final def getExclusiveQueuedThreads(): Collection[Thread] = getThreads { p =>
-    !p.isInstanceOf[AbstractQueuedSynchronizer.SharedNode]
+    !p.isInstanceOf[SharedNode]
   }
 
   final def getSharedQueuedThreads(): Collection[Thread] = getThreads {
-    _.isInstanceOf[AbstractQueuedSynchronizer.SharedNode]
+    _.isInstanceOf[SharedNode]
   }
 
   override def toString(): String =
@@ -572,7 +568,7 @@ abstract class AbstractQueuedSynchronizer protected ()
 
     @tailrec
     private def doSignal(
-        first: AbstractQueuedSynchronizer.ConditionNode,
+        first: ConditionNode,
         all: Boolean
     ): Unit = {
       if (first != null) {
@@ -599,42 +595,41 @@ abstract class AbstractQueuedSynchronizer protected ()
     }
 
     private def enableWait(
-        node: AbstractQueuedSynchronizer.ConditionNode
+        node: ConditionNode
     ): Int = {
       if (isHeldExclusively()) {
         node.waiter = Thread.currentThread()
-        node.setStatusRelaxed(
-          AbstractQueuedSynchronizer.COND | AbstractQueuedSynchronizer.WAITING
-        )
+        node.setStatusRelaxed(COND | WAITING)
         val last = lastWaiter
         if (last == null) firstWaiter = node
         else last.nextWaiter = node
         lastWaiter = node
         val savedState = getState()
-        if (release(savedState)) return savedState
+        if (release(savedState))
+          return savedState
       }
       node.status = CANCELLED // lock not held or inconsistent
       throw new IllegalMonitorStateException()
     }
 
-    private def canReacquire(node: AbstractQueuedSynchronizer.ConditionNode) = {
+    private def canReacquire(node: ConditionNode) = {
       // check links, not status to avoid enqueue race
       var p: Node = null
       node != null && {
         p = node.prev; p != null
-      } && (p.next == node || isEnqueued(node))
+      } && ((p.next eq node) || isEnqueued(node))
     }
 
     private def unlinkCancelledWaiters(
-        node: AbstractQueuedSynchronizer.ConditionNode
+        node: ConditionNode
     ): Unit = {
-      if (node == null || node.nextWaiter != null || (node == lastWaiter)) {
+      if (node == null || node.nextWaiter != null || (node eq lastWaiter)) {
         var w = firstWaiter
-        var trail: AbstractQueuedSynchronizer.ConditionNode = null
+        var trail: ConditionNode = null
 
         while (w != null) {
           val next = w.nextWaiter
-          if ((w.status & AbstractQueuedSynchronizer.COND) == 0) {
+          if ((w.status & COND) == 0) {
             w.nextWaiter = null
             if (trail == null) firstWaiter = next
             else trail.nextWaiter = next
@@ -646,16 +641,16 @@ abstract class AbstractQueuedSynchronizer protected ()
     }
 
     override final def awaitUninterruptibly(): Unit = {
-      val node = new AbstractQueuedSynchronizer.ConditionNode
+      val node = new ConditionNode
       val savedState = enableWait(node)
-
-      var interrupted = false
-      var rejected = false
       LockSupport.setCurrentBlocker(this) // for back-compatibility
+      var interrupted, rejected = false
       while (!canReacquire(node)) {
         if (Thread.interrupted()) interrupted = true
         else if ((node.status & COND) != 0)
-          try ForkJoinPool.managedBlock(node)
+          try
+            if (rejected) node.block()
+            else ForkJoinPool.managedBlock(node)
           catch {
             case ex: RejectedExecutionException => rejected = true
             case ie: InterruptedException       => interrupted = true
@@ -674,20 +669,23 @@ abstract class AbstractQueuedSynchronizer protected ()
     override final def await(): Unit = {
       if (Thread.interrupted()) throw new InterruptedException
 
-      val node = new AbstractQueuedSynchronizer.ConditionNode
+      val node = new ConditionNode
       val savedState = enableWait(node)
       LockSupport.setCurrentBlocker(this)
-      var interrupted = false
-      var cancelled = false
-      var break = false
+      var interrupted, cancelled, break, rejected = false
       while (!break && !canReacquire(node)) {
         interrupted |= Thread.interrupted()
         if (interrupted) {
           cancelled = (node.getAndUnsetStatus(COND) & COND) != 0
           if (cancelled) break = true
         } else if ((node.status & COND) != 0) { // else interrupted after signal
-          try ForkJoinPool.managedBlock(node)
-          catch { case ie: InterruptedException => interrupted = true }
+          try
+            if (rejected) node.block()
+            else ForkJoinPool.managedBlock(node)
+          catch {
+            case ex: RejectedExecutionException => rejected = true
+            case ie: InterruptedException       => interrupted = true
+          }
         } else Thread.onSpinWait() // awoke while enqueuing
       }
 
@@ -707,15 +705,13 @@ abstract class AbstractQueuedSynchronizer protected ()
     override final def awaitNanos(nanosTimeout: Long): Long = {
       if (Thread.interrupted()) throw new InterruptedException
 
-      val node = new AbstractQueuedSynchronizer.ConditionNode()
+      val node = new ConditionNode()
       val savedState = enableWait(node)
 
       var nanos = nanosTimeout.max(0L)
       val deadline = System.nanoTime() + nanos
 
-      var cancelled = false
-      var interrupted = false
-      var break = false
+      var cancelled, interrupted, break = false
       while (!break && !canReacquire(node)) {
         interrupted |= Thread.interrupted()
         if (interrupted || {
@@ -745,12 +741,10 @@ abstract class AbstractQueuedSynchronizer protected ()
       val abstime = deadline.getTime()
       if (Thread.interrupted()) throw new InterruptedException
 
-      val node = new AbstractQueuedSynchronizer.ConditionNode
+      val node = new ConditionNode
       val savedState = enableWait(node)
 
-      var cancelled = false
-      var interrupted = false
-      var break = false
+      var cancelled, interrupted, break = false
       while (!break && !canReacquire(node)) {
         interrupted |= Thread.interrupted()
         if (interrupted || System.currentTimeMillis() >= abstime) {
@@ -773,14 +767,12 @@ abstract class AbstractQueuedSynchronizer protected ()
     override final def await(time: Long, unit: TimeUnit): Boolean = {
       val nanosTimeout = unit.toNanos(time)
       if (Thread.interrupted()) throw new InterruptedException
-      val node = new AbstractQueuedSynchronizer.ConditionNode
+      val node = new ConditionNode
       val savedState = enableWait(node)
       var nanos = nanosTimeout.max(0L)
       val deadline = System.nanoTime() + nanos
 
-      var cancelled = false
-      var interrupted = false
-      var break = false
+      var cancelled, interrupted, break = false
       while (!break && !canReacquire(node)) {
         interrupted |= Thread.interrupted()
         if (interrupted || {
@@ -824,7 +816,6 @@ abstract class AbstractQueuedSynchronizer protected ()
       var w = firstWaiter
       while (w != null) {
         if ((w.status & COND) != 0) n += 1
-
         w = w.nextWaiter
       }
       n
@@ -835,7 +826,7 @@ abstract class AbstractQueuedSynchronizer protected ()
       val list = new ArrayList[Thread]
       var w = firstWaiter
       while (w != null) {
-        if ((w.status & AbstractQueuedSynchronizer.COND) != 0) {
+        if ((w.status & COND) != 0) {
           val t = w.waiter
           if (t != null) list.add(t)
         }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -8,6 +8,7 @@ import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 import scala.scalanative.runtime.libc.atomic_thread_fence
 import scala.scalanative.runtime.libc.memory_order._
 import scala.collection.concurrent.TrieMap
+import scala.annotation.nowarn
 
 trait NativeThread {
   import NativeThread._
@@ -49,6 +50,7 @@ trait NativeThread {
     park(deadlineEpoch, isAbsolute = true)
 
   @alwaysinline
+  @nowarn // Thread.getId is deprecated since JDK 19
   protected final def isMainThread = thread.getId() == MainThreadId
 
   protected def onTermination(): Unit = if (isMultithreadingEnabled) {
@@ -97,10 +99,10 @@ object NativeThread {
     private val _aliveThreads = TrieMap.empty[Long, NativeThread]
 
     private[NativeThread] def add(thread: NativeThread): Unit =
-      _aliveThreads.put(thread.thread.getId(), thread)
+      _aliveThreads.put(thread.thread.getId(): @nowarn, thread)
 
     private[NativeThread] def remove(thread: NativeThread): Unit =
-      _aliveThreads.remove(thread.thread.getId())
+      _aliveThreads.remove(thread.thread.getId(): @nowarn)
 
     def aliveThreads: scala.Array[NativeThread] =
       _aliveThreads.values.toArray

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -9,6 +9,8 @@ import scalanative.unsafe._
 import scala.annotation.nowarn
 import scala.scalanative.annotation.alwaysinline
 
+import scala.language.higherKinds
+
 class IssuesTest {
 
   def foo(arg: Int): Unit = ()

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
@@ -6,10 +6,8 @@ import org.junit.Assert._
 import scala.scalanative.meta.LinktimeInfo._
 import scala.language.implicitConversions
 import scala.scalanative.unsigned._
-import scala.scalanative.runtime.struct
 import scala.scalanative.unsafe.{Ptr, CArray, Size}
 import scala.scalanative.unsafe.{CStruct1, CStruct2, CStruct3, CStruct4}
-import scala.scalanative.runtime.sizeOfPtr
 
 private object IntrinsicsTest {
   object sizeOfClassTypes {

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/DelegatingExecutorService.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/DelegatingExecutorService.scala
@@ -1,0 +1,59 @@
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent._
+import java.util.{List, Collection, LinkedList}
+
+class DelegatingExecutorService(delegate: ExecutorService)
+    extends ExecutorService {
+
+  private def wrap[V](future: Future[V]): Future[V] = new Future[V] {
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean =
+      future.cancel(mayInterruptIfRunning)
+    override def isCancelled(): Boolean = future.isCancelled()
+    override def isDone(): Boolean = future.isDone()
+    override def get(): V = future.get()
+    override def get(timeout: Long, unit: TimeUnit) =
+      future.get(timeout, unit)
+  }
+
+  override def shutdown(): Unit = delegate.shutdown()
+  override def shutdownNow(): List[Runnable] = delegate.shutdownNow()
+  override def isShutdown(): Boolean = delegate.isShutdown()
+  override def isTerminated(): Boolean = delegate.isTerminated()
+  override def awaitTermination(timeout: Long, unit: TimeUnit) =
+    delegate.awaitTermination(timeout, unit)
+  override def submit[T](task: Callable[T]): Future[T] = wrap(
+    delegate.submit(task)
+  )
+  override def submit[T](task: Runnable, result: T): Future[T] = wrap(
+    delegate.submit(task, result)
+  )
+  override def submit(task: Runnable): Future[_] = wrap(delegate.submit(task))
+  override def invokeAll[T](
+      tasks: Collection[_ <: Callable[T]]
+  ): List[Future[T]] = {
+    val result = new LinkedList[Future[T]]()
+    delegate.invokeAll(tasks).forEach { f => result.add(wrap(f)) }
+    result
+  }
+  override def invokeAll[T](
+      tasks: Collection[_ <: Callable[T]],
+      timeout: Long,
+      unit: TimeUnit
+  ): List[Future[T]] = {
+    val result = new LinkedList[Future[T]]()
+    delegate.invokeAll(tasks, timeout, unit).forEach { f =>
+      result.add(wrap(f))
+    }
+    result
+  }
+
+  override def invokeAny[T](tasks: Collection[_ <: Callable[T]]): T =
+    delegate.invokeAny(tasks)
+  override def invokeAny[T](
+      tasks: Collection[_ <: Callable[T]],
+      timeout: Long,
+      unit: TimeUnit
+  ): T = delegate.invokeAny(tasks, timeout, unit)
+  override def execute(task: Runnable): Unit = delegate.execute(task)
+}

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/DelegatingExecutorService.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/DelegatingExecutorService.scala
@@ -28,7 +28,9 @@ class DelegatingExecutorService(delegate: ExecutorService)
   override def submit[T](task: Runnable, result: T): Future[T] = wrap(
     delegate.submit(task, result)
   )
-  override def submit(task: Runnable): Future[_] = wrap(delegate.submit(task))
+  override def submit(task: Runnable): Future[_] = wrap(
+    delegate.submit(task): Future[_]
+  )
   override def invokeAll[T](
       tasks: Collection[_ <: Callable[T]]
   ): List[Future[T]] = {

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ExecutorService19Test.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ExecutorService19Test.scala
@@ -1,0 +1,295 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{Test, Ignore}
+import JSR166Test._
+
+import java.util.concurrent._
+import Future.State._
+
+class ExecutorService19Test extends JSR166Test {
+
+  private def testExecutors(test: ExecutorService => Unit) = Seq(
+    new DelegatingExecutorService(Executors.newCachedThreadPool()),
+    new ForkJoinPool(),
+    Executors.newCachedThreadPool(),
+    Executors.newFixedThreadPool(1),
+    Executors.newCachedThreadPool()
+    // TODO: requires Executors.newThreadPerTaskExecutor
+    // Executors.newThreadPerTaskExecutor(Executors.defaultThreadFactory())
+    // TODO: requires VirtualThreads
+    // Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory()),
+  ).foreach(test)
+
+  // Future state/result
+
+  /** Test methods when the task has not completed.
+   */
+  @Test def testRunningTask(): Unit = testExecutors { executor =>
+    val latch = new CountDownLatch(1)
+    val future = executor.submit { () =>
+      latch.await()
+      null
+    }
+
+    try {
+      assertEquals(RUNNING, future.state());
+      assertThrows(classOf[IllegalStateException], () => future.resultNow())
+      assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+    } finally latch.countDown()
+  }
+
+  /** Test methods when the task has already completed with a result.
+   */
+  @Test def testCompletedTask1(): Unit = testExecutors { executor =>
+    val future = executor.submit { () => "foo" }
+    awaitDone(future)
+    assertEquals(SUCCESS, future.state())
+    assertEquals("foo", future.resultNow())
+    assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+  }
+
+  /** Test methods when the task has already completed with null.
+   */
+  @Test def testCompletedTask2(): Unit = testExecutors { executor =>
+    val future = executor.submit { () => null }
+    awaitDone(future)
+    assertEquals(SUCCESS, future.state())
+    assertEquals(null, future.resultNow())
+    assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+  }
+
+  /** Test methods when the task has completed with an exception.
+   */
+  @Test def testFailedTask(): Unit = testExecutors { executor =>
+    val future = executor.submit[String] { () =>
+      throw new ArithmeticException()
+    }
+    awaitDone(future)
+    assertEquals(FAILED, future.state());
+    assertThrows(classOf[IllegalStateException], () => future.resultNow())
+    val ex = future.exceptionNow();
+    assertTrue(ex.isInstanceOf[ArithmeticException])
+  }
+
+  /** Test methods when the task has been cancelled
+   *  (mayInterruptIfRunning=false)
+   */
+  @Test def testCancelledTask1(): Unit = testExecutors { executor =>
+    val latch = new CountDownLatch(1)
+    val future = executor.submit { () =>
+      latch.await()
+      null
+    }
+    future.cancel(false)
+    try {
+      assertEquals(CANCELLED, future.state())
+      assertThrows(classOf[IllegalStateException], () => future.resultNow())
+      assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+    } finally latch.countDown()
+  }
+
+  /** Test methods when the task has been cancelled (mayInterruptIfRunning=true)
+   */
+  @Test def testCancelledTask2(): Unit = testExecutors { executor =>
+    val latch = new CountDownLatch(1)
+    val future = executor.submit { () =>
+      latch.await()
+      null
+    }
+    future.cancel(true)
+    try {
+      assertEquals(CANCELLED, future.state())
+      assertThrows(classOf[IllegalStateException], () => future.resultNow())
+      assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+    } finally latch.countDown()
+  }
+
+  // TODO: requires CompletableFuture
+  // /** Test CompletableFuture with the task has not completed.
+  //  */
+  // @Test def testCompletableFuture1(): Unit = {
+  //   val future = new CompletableFuture[String]()
+  //   assertEquals(RUNNING, future.state())
+  //   assertThrows(classOf[IllegalStateException], () => future.resultNow())
+  //   assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+  // }
+
+  // /** Test CompletableFuture with the task has completed with result
+  //  */
+  // @Test def testCompletableFuture2(): Unit = {
+  //   val future = new CompletableFuture[String]()
+  //   future.complete("foo")
+  //   assertEquals(SUCCESS, future.state())
+  //   assertEquals("foo", future.resultNow())
+  //   assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+  // }
+
+  // /** Test CompletableFuture with the task has completed with null
+  //  */
+  // @Test def testCompletableFuture3(): Unit = {
+  //   val future = new CompletableFuture[String]()
+  //   future.complete(null)
+  //   assertEquals(SUCCESS, future.state())
+  //   assertEquals(null, future.resultNow())
+  //   assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+  // }
+
+  // /** Test CompletableFuture with the task has completed with exception
+  //  */
+  // @Test def testCompletableFuture4(): Unit = {
+  //   val future = new CompletableFuture[String]()
+  //   future.completeExceptionally(new ArithmeticException())
+  //   assertEquals(FAILED, future.state())
+  //   assertThrows(classOf[IllegalStateException], () => future.resultNow())
+  //   val ex = future.exceptionNow();
+  //   assertTrue(ex.isInstanceOf[ArithmeticException])
+  // }
+
+  // /** Test CompletableFuture with the task that was cancelled
+  //  */
+  // @Test def testCompletableFuture5(): Unit = {
+  //   val future = new CompletableFuture[String]()
+  //   future.cancel(false)
+  //   assertEquals(CANCELLED, future.state())
+  //   assertThrows(classOf[IllegalStateException], () => future.resultNow())
+  //   assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
+  // }
+
+  // Close
+  /** Test close with no tasks running.
+   */
+  @Test def testCloseWithNoTasks(): Unit = testExecutors { executor =>
+    executor.close()
+    assertTrue(executor.isShutdown)
+    assertTrue(executor.isTerminated)
+    assertTrue(executor.awaitTermination(10, TimeUnit.MILLISECONDS))
+  }
+
+  /** Test close with tasks running.
+   */
+  @Test def testCloseWithRunningTasks(): Unit = testExecutors { executor =>
+    val future: Future[_] = executor.submit(() => {
+      Thread.sleep(1000)
+      "foo"
+
+    })
+    executor.close() // waits for task to complete
+
+    assertTrue(executor.isShutdown)
+    assertTrue(executor.isTerminated)
+    assertTrue(executor.awaitTermination(10, TimeUnit.MILLISECONDS))
+    assertEquals("foo", future.get())
+  }
+
+  // TODO: requires Phaser
+  // /** Test close when executor is shutdown but not terminated.
+  //  */
+  // @Test def testShutdownBeforeClose(): Unit = testExecutors { executor =>
+  //   val phaser: Phaser = new Phaser(2)
+  //   val future: Future[_] = executor.submit(() => {
+  //     phaser.arriveAndAwaitAdvance
+  //     Thread.sleep(1000)
+  //     "foo"
+
+  //   })
+  //   phaser.arriveAndAwaitAdvance() // wait for task to start
+
+  //   executor.shutdown() // shutdown, will not immediately terminate
+
+  //   executor.close()
+  //   assertTrue(executor.isShutdown)
+  //   assertTrue(executor.isTerminated)
+  //   assertTrue(executor.awaitTermination(10, TimeUnit.MILLISECONDS))
+  //   assertEquals(future.get, "foo")
+  // }
+
+  // /** Test invoking close with interrupt status set.
+  //  */
+  // @Test def testInterruptBeforeClose(): Unit = testExecutors { executor =>
+  //   val phaser: Phaser = new Phaser(2)
+  //   val future: Future[_] = executor.submit(() => {
+  //     phaser.arriveAndAwaitAdvance
+  //     Thread.sleep(Int.MaxValue)
+  //     null
+
+  //   })
+  //   phaser.arriveAndAwaitAdvance // wait for task to start
+
+  //   Thread.currentThread.interrupt
+  //   try {
+  //     executor.close()
+  //     assertTrue(Thread.currentThread.isInterrupted)
+  //   } finally {
+  //     Thread.interrupted // clear interrupt status
+
+  //   }
+  //   assertTrue(executor.isShutdown)
+  //   assertTrue(executor.isTerminated)
+  //   assertTrue(executor.awaitTermination(10, TimeUnit.MILLISECONDS))
+  //   assertThrows(classOf[ExecutionException], () => future.get)
+  // }
+
+  /** Test close when terminated.
+   */
+  @Test def testTerminateBeforeClose(): Unit = testExecutors { executor =>
+    executor.shutdown()
+    assertTrue(executor.isTerminated)
+    executor.close()
+    assertTrue(executor.isShutdown)
+    assertTrue(executor.isTerminated)
+    assertTrue(executor.awaitTermination(10, TimeUnit.MILLISECONDS))
+  }
+
+  /** Test interrupting thread blocked in close.
+   */
+  @Test def testInterruptDuringClose(): Unit = testExecutors { executor =>
+    val future: Future[_] = executor.submit(() => {
+      Thread.sleep(Int.MaxValue)
+      null
+
+    })
+    val thread: Thread = Thread.currentThread
+    new Thread(() => {
+      try Thread.sleep(500)
+      catch {
+        case ignore: Exception =>
+      }
+      thread.interrupt()
+
+    }).start()
+    try {
+      executor.close()
+      assertTrue(Thread.currentThread.isInterrupted)
+    } finally {
+      Thread.interrupted // clear interrupt status
+
+    }
+    assertTrue(executor.isShutdown)
+    assertTrue(executor.isTerminated)
+    assertTrue(executor.awaitTermination(10, TimeUnit.MILLISECONDS))
+    assertThrows(classOf[ExecutionException], () => future.get)
+  }
+
+  // Utils
+
+  /** Waits for the future to be done.
+   */
+  private def awaitDone(future: Future[_]): Unit = {
+    var interrupted = false
+    while (!future.isDone()) {
+      try Thread.sleep(10)
+      catch { case _: InterruptedException => interrupted = true }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt()
+    }
+  }
+
+}

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool19Test.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool19Test.scala
@@ -459,28 +459,24 @@ class ForkJoinPool19Test extends JSR166Test {
     }
   }
 
-  import scala.util.Using // mock java try-with-resource
-
   /** Implicitly closing a new pool using try-with-resources terminates it
    */
   @Test def testClose(): Unit = {
     val f = new FibAction(8)
-    val pool = Using(new ForkJoinPool()) { p =>
-      p.execute(f)
-      p
-    }.get
+    val p = new ForkJoinPool()
+    try p.execute(f)
+    finally p.close()
     checkCompletedNormally(f)
-    assertTrue(pool != null && pool.isTerminated())
+    assertTrue(p != null && p.isTerminated())
   }
 
   @Test def testCloseCommonPool(): Unit = {
     val f = new FibAction(8)
-    val pool = Using(ForkJoinPool.commonPool()) { p =>
-      p.execute(f)
-      p
-    }.get
-    assertFalse(pool.isShutdown())
-    assertFalse(pool.isTerminating())
-    assertFalse(pool.isTerminated())
+    val p = ForkJoinPool.commonPool()
+    try p.execute(f)
+    finally p.close()
+    assertFalse(p.isShutdown())
+    assertFalse(p.isTerminating())
+    assertFalse(p.isTerminated())
   }
 }

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool19Test.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool19Test.scala
@@ -119,15 +119,15 @@ class ForkJoinPool19Test extends JSR166Test {
     assertNull(a.join)
     assertFalse(a.cancel(false))
     assertFalse(a.cancel(true))
-    val (v1, v2) =
-      try {
-        val v1 = a.get
-        val v2 = a.get(randomTimeout(), randomTimeUnit())
-        (v1, v2)
-      } catch {
-        case fail: Throwable =>
-          threadUnexpectedException(fail)
-      }
+    var v1, v2: Any = null.asInstanceOf[Any]
+    try {
+      v1 = a.get()
+      v2 = a.get(randomTimeout(), randomTimeUnit())
+      (v1, v2)
+    } catch {
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
     assertNull(v1)
     assertNull(v2)
   }

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool19Test.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinPool19Test.scala
@@ -1,0 +1,486 @@
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent._
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+import org.junit._
+import org.junit.Assert._
+
+object ForkJoinPool19Test {
+  final class FJException(cause: Throwable) extends RuntimeException(cause) {
+    def this() = this(null)
+  }
+
+  final class FailingFibAction(val number: Int) extends RecursiveAction {
+    var result = 0
+    override def compute(): Unit = {
+      val n = number
+      if (n <= 1) throw new FJException
+      else {
+        val f1 = new FailingFibAction(n - 1)
+        val f2 = new FailingFibAction(n - 2)
+        ForkJoinTask.invokeAll(f1, f2)
+        result = f1.result + f2.result
+      }
+    }
+  }
+}
+class ForkJoinPool19Test extends JSR166Test {
+  import ForkJoinPool19Test._
+  import JSR166Test._
+
+  /** SetParallelism sets reported parallellism and returns previous value
+   */
+  @Test def testSetParallelism(): Unit = {
+    val p = new ForkJoinPool(2)
+    assertEquals(2, p.getParallelism)
+    assertEquals(2, p.setParallelism(3))
+    assertEquals(3, p.setParallelism(2))
+    p.shutdown()
+  }
+
+  /** SetParallelism throws exception if argument out of bounds
+   */
+  @Test def testSetParallelismBadArgs(): Unit = {
+    val p = new ForkJoinPool(2)
+    try {
+      p.setParallelism(0)
+      shouldThrow()
+    } catch {
+      case success: Exception =>
+    }
+    try {
+      p.setParallelism(Integer.MAX_VALUE)
+      shouldThrow()
+    } catch {
+      case success: Exception =>
+
+    }
+    assertEquals(2, p.getParallelism)
+    p.shutdown()
+  }
+
+  private def testInvokeOnPool(pool: ForkJoinPool, a: RecursiveAction): Unit =
+    usingPoolCleaner(pool) { pool =>
+      checkNotDone(a)
+      assertNull(pool.invoke(a))
+      checkCompletedNormally(a)
+    }
+
+  private def checkInvoke(a: ForkJoinTask[_]): Unit = {
+    checkNotDone(a)
+    assertNull(a.invoke)
+    checkCompletedNormally(a)
+  }
+  def checkNotDone(a: ForkJoinTask[_]): Unit = {
+    assertFalse(a.isDone())
+    assertFalse(a.isCompletedNormally())
+    assertFalse(a.isCompletedAbnormally())
+    assertFalse(a.isCancelled())
+    assertNull(a.getException())
+    assertNull(a.getRawResult())
+    if (!ForkJoinTask.inForkJoinPool()) {
+      Thread.currentThread.interrupt()
+      try {
+        a.get()
+        shouldThrow()
+      } catch {
+        case success: InterruptedException =>
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+      Thread.currentThread.interrupt()
+      try {
+        a.get(randomTimeout(), randomTimeUnit())
+        shouldThrow()
+      } catch {
+        case success: InterruptedException =>
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+    }
+    try {
+      a.get(randomExpiredTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: TimeoutException =>
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  def checkCompletedNormally(a: ForkJoinTask[_]): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertTrue(a.isCompletedNormally)
+    assertFalse(a.isCompletedAbnormally)
+    assertNull(a.getException)
+    assertNull(a.getRawResult)
+    assertNull(a.join)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    val (v1, v2) =
+      try {
+        val v1 = a.get
+        val v2 = a.get(randomTimeout(), randomTimeUnit())
+        (v1, v2)
+      } catch {
+        case fail: Throwable =>
+          threadUnexpectedException(fail)
+      }
+    assertNull(v1)
+    assertNull(v2)
+  }
+
+  def checkCancelled(a: ForkJoinTask[_]): Unit = {
+    assertTrue(a.isDone)
+    assertTrue(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertTrue(a.getException.isInstanceOf[CancellationException])
+    assertNull(a.getRawResult)
+    try {
+      a.join
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: CancellationException =>
+
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+  def checkCompletedAbnormally(a: ForkJoinTask[_], t: Throwable): Unit = {
+    assertTrue(a.isDone)
+    assertFalse(a.isCancelled)
+    assertFalse(a.isCompletedNormally)
+    assertTrue(a.isCompletedAbnormally)
+    assertSame(t.getClass, a.getException.getClass)
+    assertNull(a.getRawResult)
+    assertFalse(a.cancel(false))
+    assertFalse(a.cancel(true))
+    try {
+      a.join
+      shouldThrow()
+    } catch {
+      case expected: Throwable =>
+        assertSame(expected.getClass, t.getClass)
+    }
+    try {
+      a.get
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+    try {
+      a.get(randomTimeout(), randomTimeUnit())
+      shouldThrow()
+    } catch {
+      case success: ExecutionException =>
+        assertSame(t.getClass, success.getCause.getClass)
+      case fail: Throwable =>
+        threadUnexpectedException(fail)
+    }
+  }
+
+  /** A simple recursive action for testing. */
+  final class FibAction(val number: Int) extends CheckedRecursiveAction {
+    var result = 0
+    protected def realCompute(): Unit = {
+      val n = number
+      if (n <= 1) result = n
+      else {
+        val f1 = new FibAction(n - 1)
+        val f2 = new FibAction(n - 2)
+        ForkJoinTask.invokeAll(f1, f2)
+        result = f1.result + f2.result
+      }
+    }
+  }
+
+  /** lazySubmit submits a task that is not executed until new workers are
+   *  created or it is explicitly joined by a worker.
+   */
+  @Test def testLazySubmit(): Unit = {
+    val p = new ForkJoinPool()
+    val f = new FibAction(8)
+    val j = new RecursiveAction() {
+      protected def compute(): Unit = f.join()
+    }
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        p.invoke(new FibAction(8))
+        p.lazySubmit(f)
+        p.invoke(new FibAction(8))
+        p.invoke(j)
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    testInvokeOnPool(p, a)
+  }
+
+  /** quietlyInvoke task returns when task completes normally.
+   *  isCompletedAbnormally and isCancelled return false for normally completed
+   *  tasks
+   */
+  @Test def testQuietlyInvoke(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        f.quietlyInvoke
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** join of a forked task returns when task completes
+   */
+  @Test def testForkJoin(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertNull(f.join)
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed quietlyJoinUninterruptibly of a forked task succeeds in the presence
+   *  of interrupts
+   */
+  @Test def testTimedQuietlyJoinUninterruptiblyInterrupts(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        var f: FibAction = null
+        val currentThread = Thread.currentThread
+        // test quietlyJoin()
+        f = new FibAction(8)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoinUninterruptibly(LONG_DELAY_MS, MILLISECONDS)
+        Thread.interrupted
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+        f = new FibAction(8)
+        f.cancel(true)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoinUninterruptibly(LONG_DELAY_MS, MILLISECONDS)
+        Thread.interrupted
+        checkCancelled(f)
+        f = new FibAction(8)
+        f.completeExceptionally(new FJException)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        f.quietlyJoinUninterruptibly(LONG_DELAY_MS, MILLISECONDS)
+        Thread.interrupted
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    checkInvoke(a)
+    a.reinitialize()
+    checkInvoke(a)
+  }
+
+  /** timed quietlyJoin throws IE in the presence of interrupts
+   */
+  @Test def testTimedQuietlyJoinInterrupts(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        var f: FibAction = null
+        val currentThread = Thread.currentThread
+        f = new FibAction(8)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        try f.quietlyJoin(LONG_DELAY_MS, MILLISECONDS)
+        catch {
+          case success: InterruptedException =>
+
+        }
+        Thread.interrupted
+        f.quietlyJoin
+        f = new FibAction(8)
+        f.cancel(true)
+        assertSame(f, f.fork)
+        currentThread.interrupt()
+        try f.quietlyJoin(LONG_DELAY_MS, MILLISECONDS)
+        catch {
+          case success: InterruptedException =>
+
+        }
+        f.quietlyJoin
+        checkCancelled(f)
+      }
+    }
+    checkInvoke(a)
+    a.reinitialize()
+    checkInvoke(a)
+  }
+
+  /** timed quietlyJoin of a forked task returns when task completes
+   */
+  @Test def testForkTimedQuietlyJoin(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertTrue(f.quietlyJoin(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed quietlyJoin with null time unit throws NPE
+   */
+  @Test def testForkTimedQuietlyJoinNPE(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.quietlyJoin(randomTimeout(), null)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  @Test def testAbnormalTimedQuietlyJoin(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FailingFibAction(8)
+        assertSame(f, f.fork)
+        assertTrue(f.quietlyJoin(LONG_DELAY_MS, MILLISECONDS))
+        assertTrue(f.getException.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed quietlyJoinUninterruptibly of a forked task returns when task
+   *  completes
+   */
+  @Test def testForkTimedQuietlyJoinUninterruptibly(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        assertTrue(f.quietlyJoinUninterruptibly(LONG_DELAY_MS, MILLISECONDS))
+        assertEquals(21, f.result)
+        checkCompletedNormally(f)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** timed quietlyJoinUninterruptibly with null time unit throws NPE
+   */
+  @Test def testForkTimedQuietlyJoinUninterruptiblyNPE(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      @throws[Exception]
+      protected def realCompute(): Unit = {
+        val f = new FibAction(8)
+        assertSame(f, f.fork)
+        try {
+          f.quietlyJoinUninterruptibly(randomTimeout(), null)
+          shouldThrow()
+        } catch {
+          case success: NullPointerException =>
+
+        }
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** quietlyInvoke task returns when task completes abnormally
+   */
+  @Test def testAbnormalTimedQuietlyJoinUninterruptibly(): Unit = {
+    val a: RecursiveAction = new CheckedRecursiveAction() {
+      protected def realCompute(): Unit = {
+        val f = new FailingFibAction(8)
+        assertSame(f, f.fork)
+        assertTrue(f.quietlyJoinUninterruptibly(LONG_DELAY_MS, MILLISECONDS))
+        assertTrue(f.getException.isInstanceOf[FJException])
+        checkCompletedAbnormally(f, f.getException)
+      }
+    }
+    checkInvoke(a)
+  }
+
+  /** adaptInterruptible(callable).toString() contains toString of wrapped task
+   */
+  @Test def testAdaptInterruptible_Callable_toString(): Unit = {
+    if (testImplementationDetails) {
+      val c: Callable[String] = () => ""
+      val task = ForkJoinTask.adaptInterruptible(c)
+      assertEquals(
+        identityString(task) + "[Wrapped task = " + c.toString + "]",
+        task.toString
+      )
+    }
+  }
+
+  import scala.util.Using // mock java try-with-resource
+
+  /** Implicitly closing a new pool using try-with-resources terminates it
+   */
+  @Test def testClose(): Unit = {
+    val f = new FibAction(8)
+    val pool = Using(new ForkJoinPool()) { p =>
+      p.execute(f)
+      p
+    }.get
+    checkCompletedNormally(f)
+    assertTrue(pool != null && pool.isTerminated())
+  }
+
+  @Test def testCloseCommonPool(): Unit = {
+    val f = new FibAction(8)
+    val pool = Using(ForkJoinPool.commonPool()) { p =>
+      p.execute(f)
+      p
+    }.get
+    assertFalse(pool.isShutdown())
+    assertFalse(pool.isTerminating())
+    assertFalse(pool.isTerminated())
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTask19Test.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ForkJoinTask19Test.scala
@@ -1,0 +1,29 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{Test, Ignore}
+import JSR166Test._
+
+import java.util.concurrent._
+
+class ForkJoinTask19Test extends JSR166Test {
+
+  /** adaptInterruptible(callable).toString() contains toString of wrapped task
+   */
+  @Test def testAdaptInterruptible_Callable_toString(): Unit = {
+    if (testImplementationDetails) {
+      val c: Callable[String] = () => ""
+      val task = ForkJoinTask.adaptInterruptible(c)
+      assertEquals(
+        identityString(task) + "[Wrapped task = " + c.toString() + "]",
+        task.toString()
+      )
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala-2.13+/scala/util/UsingTest.scala
+++ b/unit-tests/shared/src/test/scala-2.13+/scala/util/UsingTest.scala
@@ -19,6 +19,7 @@ import org.junit.Assert._
 import scala.reflect.ClassTag
 import scala.runtime.NonLocalReturnControl
 
+@deprecated("Uses type UsingInterruption=ThreadDeath which is deprecated", since = "JDK 19")
 class UsingTest {
   import UsingTest._
 
@@ -868,7 +869,7 @@ object UsingTest {
   final class ClosingLinkageError(message: String) extends LinkageError(message)
   final class UsingLinkageError(message: String) extends LinkageError(message)
   type ClosingInterruption = InterruptedException
-  type UsingInterruption = ThreadDeath
+  @deprecated type UsingInterruption = ThreadDeath
   // `NonLocalReturnControl` incorrectly suppresses exceptions, so this tests that
   //   `Using` special-cases it.
   final class ClosingControl(message: String)

--- a/unit-tests/shared/src/test/scala-2.13+/scala/util/UsingTest.scala
+++ b/unit-tests/shared/src/test/scala-2.13+/scala/util/UsingTest.scala
@@ -19,7 +19,10 @@ import org.junit.Assert._
 import scala.reflect.ClassTag
 import scala.runtime.NonLocalReturnControl
 
-@deprecated("Uses type UsingInterruption=ThreadDeath which is deprecated", since = "JDK 19")
+@deprecated(
+  "Uses type UsingInterruption=ThreadDeath which is deprecated",
+  since = "JDK 19"
+)
 class UsingTest {
   import UsingTest._
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThreadTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThreadTest.scala
@@ -37,6 +37,7 @@ class ThreadTest {
     }
   }
 
+  @deprecated
   @Test def getId(): Unit = {
     val id = Thread.currentThread().getId
     if (isMultithreadingEnabled) assertTrue(id >= 0)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorsTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExecutorsTest.scala
@@ -258,9 +258,8 @@ class ExecutorsTest extends JSR166Test {
     val executors = Array(
       Executors.newSingleThreadExecutor,
       Executors.newCachedThreadPool,
-      Executors.newFixedThreadPool(2)
-      // TODO
-      // Executors.newScheduledThreadPool(2)
+      Executors.newFixedThreadPool(2),
+      Executors.newScheduledThreadPool(2)
     )
     val done = new CountDownLatch(1)
     val sleeper = new CheckedRunnable() {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
@@ -245,7 +245,7 @@ abstract class JSR166Test {
   def joinPool(pool: ExecutorService): Unit =
     try {
       pool.shutdown()
-      if (!pool.awaitTermination(2 * LONG_DELAY_MS, MILLISECONDS)) {
+      if (!pool.awaitTermination(20 * LONG_DELAY_MS, MILLISECONDS)) {
         try {
           threadFail(
             s"ExecutorService $pool did not terminate in a timely manner"

--- a/util/src/main/scala/scala/scalanative/util/Stats.scala
+++ b/util/src/main/scala/scala/scalanative/util/Stats.scala
@@ -73,7 +73,7 @@ object Stats {
     times.clear()
     counts.clear()
   }
-  @nowarn //"Thread.getId() is deprecated")
+  @nowarn // "Thread.getId() is deprecated")
   private def threadKey(key: String): String =
     "" + java.lang.Thread.currentThread.getId + ":" + key
   def in[T](f: => T): T = {

--- a/util/src/main/scala/scala/scalanative/util/Stats.scala
+++ b/util/src/main/scala/scala/scalanative/util/Stats.scala
@@ -2,6 +2,7 @@ package scala.scalanative
 package util
 
 import scala.collection.mutable
+import scala.annotation.nowarn
 
 object Stats {
   private val times = mutable.Map.empty[String, Long]
@@ -72,6 +73,7 @@ object Stats {
     times.clear()
     counts.clear()
   }
+  @nowarn //"Thread.getId() is deprecated")
   private def threadKey(key: String): String =
     "" + java.lang.Thread.currentThread.getId + ":" + key
   def in[T](f: => T): T = {


### PR DESCRIPTION
JSR-166 had a recent update changing the implementation of ForkJoinPool with a goal of better support for VirtualThreads, it also adds new methods and interfaces, eg.: 

* `ExecutorService` now extends `AutoClosable`
* `java.util.concurrent.Future` now defines a new enum type `Future.State` and  methods `state(): State`, `resultNow(): V`, `exceptionNow(): Throwable`
* New protected constructor for `ForkJoinPool` 