### PR TITLE
Use of `enablePlugins` syntax in user testing docs

### DIFF
--- a/docs/user/testing.rst
+++ b/docs/user/testing.rst
@@ -21,8 +21,7 @@ To enable JUnit support, add the following lines to your `build.sbt` file:
 
 .. parsed-literal::
 
-    libraryDependencies += "org.scala-native" %%% "junit-runtime" % |release|
-    addCompilerPlugin("org.scala-native" % "junit-plugin" % |release| cross CrossVersion.full)
+    enablePlugins(ScalaNativeJUnitPlugin)
 
 If you want to get more detailed output from the JUnit runtime, also include the following line:
 


### PR DESCRIPTION
Small change to use `enablePlugins` instead of `libraryDependencies/addCompilerPlugin` in the [documentation](https://scala-native.org/en/stable/user/testing.html).