### PR TITLE
Fix spurious multithreading build errors

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -412,9 +412,7 @@ class ForkJoinPool private (
       LockSupport.setCurrentBlocker(this)
 
       var break = false
-      var counter = 0
       while (!break) { // await signal or termination
-        counter += 1
         if (runState < 0)
           return -1
         w.access = PARKED

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -151,4 +151,10 @@ class Buffer(implicit fresh: Fresh) {
     let(Op.Arraystore(ty, arr, idx, value), unwind)
   def arraylength(arr: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Arraylength(arr), unwind)
+
+  def fence(memoryOrder: MemoryOrder)(implicit pos: Position): Val =
+    let(
+      Op.Fence(SyncAttrs(memoryOrder = memoryOrder, isVolatile = false)),
+      Next.None
+    )
 }

--- a/nir/src/main/scala/scala/scalanative/nir/MemoryOrder.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/MemoryOrder.scala
@@ -5,8 +5,7 @@ import scala.annotation.switch
 
 case class SyncAttrs(
     memoryOrder: MemoryOrder,
-    isVolatile: Boolean = true,
-    scope: Option[Global] = None
+    isVolatile: Boolean = true
 )
 
 sealed abstract class MemoryOrder(private[nir] val tag: Int) {

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -684,13 +684,6 @@ object Show {
     def syncAttrs_(attrs: SyncAttrs): Unit = {
       if (attrs.isVolatile) str("volatile ")
       memoryOrder_(attrs.memoryOrder)
-      str(" ")
-      attrs.scope.foreach { scope =>
-        str("syncscope(")
-        global_(scope)
-        str(")")
-        str(" ")
-      }
     }
 
     def linktimeCondition(cond: LinktimeCondition): Unit = {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -333,8 +333,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
   private def getSyncAttrs(): SyncAttrs =
     SyncAttrs(
       memoryOrder = getMemoryOrder(),
-      isVolatile = getBool(),
-      scope = getGlobalOpt()
+      isVolatile = getBool()
     )
 
   private def getMemoryOrder(): MemoryOrder = getInt() match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -560,7 +560,6 @@ final class BinarySerializer {
   def putSyncAttrs(value: SyncAttrs) = {
     putMemoryOrder(value.memoryOrder)
     putBool(value.isVolatile)
-    putGlobalOpt(value.scope)
   }
 
   def putMemoryOrder(value: MemoryOrder): Unit = {

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -1028,12 +1028,7 @@ private[codegen] abstract class AbstractCodeGen(
       attrs: SyncAttrs
   )(implicit sb: ShowBuilder): Unit = {
     import sb._
-    val SyncAttrs(memoryOrder, _, scope) = attrs
-    scope.foreach { scope =>
-      str("syncscope(")
-      genGlobal(scope)
-      str(") ")
-    }
+    val SyncAttrs(memoryOrder, _) = attrs
     str(memoryOrder match {
       case MemoryOrder.Unordered => "unordered"
       case MemoryOrder.Monotonic => "monotonic"

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -183,6 +183,13 @@ object Lower {
 
         case inst @ Inst.Ret(v) =>
           implicit val pos: Position = inst.pos
+          currentDefn.get.name match {
+            case Global.Member(ClassRef(cls), sig)
+                if sig.isCtor && cls.hasFinalFields =>
+              // Release memory fence after initialization of constructor with final fields
+              buf.fence(MemoryOrder.Release)
+            case _ => ()
+          }
           genGCSafepoint(buf)
           val retVal =
             if (v.ty == Type.Unit) optionallyBoxedUnit(v)
@@ -512,13 +519,13 @@ object Lower {
           throw new LinkingException(s"Metadata for field '$name' not found")
       }
 
-      val isSynchronized = field.attrs.isFinal || field.attrs.isVolatile
+      val isVolatile = field.attrs.isVolatile
       val syncAttrs = SyncAttrs(
         memoryOrder =
-          if (isSynchronized) MemoryOrder.Acquire
+          if (isVolatile) MemoryOrder.SeqCst
+          else if (field.attrs.isFinal) MemoryOrder.Monotonic
           else MemoryOrder.Unordered,
-        isVolatile = isSynchronized,
-        scope = Some(field.name)
+        isVolatile = isVolatile
       )
 
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
@@ -535,20 +542,16 @@ object Lower {
           throw new LinkingException(s"Metadata for field '$name' not found")
       }
 
-      val isFinal = field.attrs.isFinal
-      val isSynchronized = isFinal || field.attrs.isVolatile
+      val isVolatile = field.attrs.isVolatile
       val syncAttrs = SyncAttrs(
         memoryOrder =
-          if (isSynchronized) MemoryOrder.Release
+          if (isVolatile) MemoryOrder.SeqCst
+          else if (field.attrs.isFinal) MemoryOrder.Monotonic
           else MemoryOrder.Unordered,
-        isVolatile = isSynchronized,
-        scope = Some(field.name)
+        isVolatile = isVolatile
       )
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
       genStoreOp(buf, n, Op.Store(ty, elem, value, Some(syncAttrs)))
-      if (isFinal) {
-        buf.let(Op.Fence(syncAttrs), unwind)
-      }
     }
 
     def genFieldOp(buf: Buffer, n: Local, op: Op)(implicit
@@ -679,8 +682,7 @@ object Lower {
         }
         val syncAttrs = SyncAttrs(
           memoryOrder = MemoryOrder.Unordered,
-          isVolatile = true,
-          scope = None
+          isVolatile = true
         )
         val safepointAddr = buf.load(Type.Ptr, GCSafepoint, handler)
         buf.load(Type.Ptr, safepointAddr, handler, Some(syncAttrs))

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -120,6 +120,8 @@ final class Class(
     out.toSeq
   }
 
+  lazy val hasFinalFields: Boolean = fields.exists(_.attrs.isFinal)
+
   val ty: Type =
     Type.Ref(name)
   def isConstantModule(implicit top: Result): Boolean = {

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -782,12 +782,10 @@ class Reach(
     case Op.Load(ty, ptrv, syncAttrs) =>
       reachType(ty)
       reachVal(ptrv)
-      syncAttrs.foreach(reachSyncAttrs(_))
     case Op.Store(ty, ptrv, v, syncAttrs) =>
       reachType(ty)
       reachVal(ptrv)
       reachVal(v)
-      syncAttrs.foreach(reachSyncAttrs(_))
     case Op.Elem(ty, ptrv, indexvs) =>
       reachType(ty)
       reachVal(ptrv)
@@ -816,8 +814,7 @@ class Reach(
     case Op.Conv(conv, ty, v) =>
       reachType(ty)
       reachVal(v)
-    case Op.Fence(attrs) =>
-      reachSyncAttrs(attrs)
+    case Op.Fence(attrs) => ()
 
     case Op.Classalloc(n) =>
       classInfo(n).foreach(reachAllocation)
@@ -883,10 +880,6 @@ class Reach(
       reachVal(value)
     case Op.Arraylength(arr) =>
       reachVal(arr)
-  }
-
-  def reachSyncAttrs(attrs: SyncAttrs): Unit = {
-    attrs.scope.foreach(reachGlobal(_))
   }
 
   def reachNext(next: Next): Unit = next match {


### PR DESCRIPTION
* Fixes recent failures in multithreading builds: 
  - Use seq_cst memory order for volatile variables instead of acquire/release
  - Use monotonic memory order for final variables instead of acquire/release, also publish results using fence release once per constructor instead of after each assignment
* Removes missused sync_scope in LLVM atomic ops
* Makes sure null guards are applied only once per value