### PR TITLE
Fix JUnit class cast when comparing Float/Double arrays

### DIFF
--- a/junit-runtime/src/main/scala/org/junit/internal/InexactComparisonCriteria.scala
+++ b/junit-runtime/src/main/scala/org/junit/internal/InexactComparisonCriteria.scala
@@ -18,10 +18,19 @@ class InexactComparisonCriteria private (val fDelta: AnyRef)
       expected: AnyRef,
       actual: AnyRef
   ): Unit = {
-    Assert.assertEquals(
-      expected.asInstanceOf[Double],
-      actual.asInstanceOf[Double],
-      fDelta.asInstanceOf[Double]
-    )
+    fDelta match {
+      case delta: java.lang.Double =>
+        Assert.assertEquals(
+          expected.asInstanceOf[Double],
+          actual.asInstanceOf[Double],
+          delta
+        )
+      case delta: java.lang.Float =>
+        Assert.assertEquals(
+          expected.asInstanceOf[Float],
+          actual.asInstanceOf[Float],
+          delta
+        )
+    }
   }
 }

--- a/unit-tests/native/src/test/scala-3/scala/scala/scalnative/IssuesTestScala3.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalnative/IssuesTestScala3.scala
@@ -27,7 +27,7 @@ class IssuesTestScala3 {
   @Test def i3231(): Unit = {
     @extern object extern_functions:
       @name("sprintf")
-      def test(buffer: CString, format: CString, args: Any*): Unit = extern
+      def test(buffer: CString, format: CString, args: Any*): CInt = extern
 
     object functions:
       export extern_functions.test // should compile


### PR DESCRIPTION
* Fix JUnit class cast when comparing Float/Double arrays
* Fix invalid signature of sprintf in tests leading to extended build failures