### PR TITLE
Remove most of the lint warnings in main sources when compiling with `-WwarnUnused:all`

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/atomic.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/atomic.scala
@@ -1,10 +1,9 @@
 // format: off
 package scala.scalanative.libc
 
-import scala.scalanative.runtime.{fromRawPtr, toRawPtr, Intrinsics}
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
-import scala.scalanative.annotation._
 import scala.language.implicitConversions
 
 
@@ -1398,9 +1397,6 @@ import scala.language.implicitConversions
   }
 
   final class CAtomicRef[T <: AnyRef](private val underlying: Ptr[T]) extends AnyVal {
-    implicit private def toAtomicPtr(v: T): Ptr[T] = fromRawPtr(Intrinsics.castObjectToRawPtr(v))
-    implicit private def fromAtomicPtr(v: Ptr[T]): T = Intrinsics.castRawPtrToObject(toRawPtr(v)).asInstanceOf[T]
-
     def init(value: T): Unit = atomic_init(underlying, value)
 
     def load(): T = atomic_load(underlying)

--- a/clib/src/main/scala/scala/scalanative/libc/atomic.scala.gyb
+++ b/clib/src/main/scala/scala/scalanative/libc/atomic.scala.gyb
@@ -1,10 +1,9 @@
 // format: off
 package scala.scalanative.libc
 
-import scala.scalanative.runtime.{fromRawPtr, toRawPtr, Intrinsics}
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
-import scala.scalanative.annotation._
 import scala.language.implicitConversions
 
 
@@ -278,9 +277,6 @@ import scala.language.implicitConversions
   }
 
   final class CAtomicRef[T <: AnyRef](private val underlying: Ptr[T]) extends AnyVal {
-    implicit private def toAtomicPtr(v: T): Ptr[T] = fromRawPtr(Intrinsics.castObjectToRawPtr(v))
-    implicit private def fromAtomicPtr(v: Ptr[T]): T = Intrinsics.castRawPtrToObject(toRawPtr(v)).asInstanceOf[T]
-
     def init(value: T): Unit = atomic_init(underlying, value)
 
     def load(): T = atomic_load(underlying)

--- a/clib/src/main/scala/scala/scalanative/libc/complex.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/complex.scala
@@ -24,7 +24,6 @@ import scalanative.unsafe._
 @extern object complex extends complex
 
 @extern private[scalanative] trait complex {
-  import Nat._2
   type CFloatComplex = CStruct2[CFloat, CFloat]
   type CDoubleComplex = CStruct2[CDouble, CDouble]
 

--- a/clib/src/main/scala/scala/scalanative/libc/package.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/package.scala
@@ -1,6 +1,5 @@
 package scala.scalanative
 import scalanative.unsafe._
-import scalanative.libc.stdio
 
 package object libc {
   implicit class StdioHelpers(val _stdio: libc.stdio.type) extends AnyVal {

--- a/clib/src/main/scala/scala/scalanative/libc/tgmath.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/tgmath.scala
@@ -9,7 +9,6 @@ object tgmath extends tgmath
 private[scalanative] trait tgmath {
   // real
 
-  import scala.scalanative.libc.math
   def fabs(x: CDouble): CDouble = math.fabs(x)
   def fabs(x: CFloat): CFloat = math.fabsf(x)
   def exp(x: CDouble): CDouble = math.exp(x)

--- a/javalib/src/main/scala-3/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala-3/java/lang/ProcessBuilder.scala
@@ -6,11 +6,9 @@
 
 package java.lang
 
-import java.util.{ArrayList, List}
-import java.util.Map
-import java.io.{File, IOException}
+import java.util.List
+import java.io.File
 import java.util.Arrays
-import ProcessBuilder.Redirect
 import java.lang.process.ProcessBuilderImpl
 
 final class ProcessBuilder(_command: List[String])

--- a/javalib/src/main/scala-3/java/math/RoundingMode.scala
+++ b/javalib/src/main/scala-3/java/math/RoundingMode.scala
@@ -25,8 +25,6 @@
 
 package java.math
 
-import scala.annotation.switch
-
 enum RoundingMode extends Enum[RoundingMode]():
   case UP extends RoundingMode
   case DOWN extends RoundingMode

--- a/javalib/src/main/scala-3/java/util/Formatter.scala
+++ b/javalib/src/main/scala-3/java/util/Formatter.scala
@@ -8,15 +8,8 @@ package java.util
 // Ported from Scala.js, commit: 0383e9f, dated: 2021-03-07
 
 import java.io._
-import java.lang.{
-  Double => JDouble,
-  Boolean => JBoolean,
-  StringBuilder => JStringBuilder
-}
-import java.math.{BigDecimal, BigInteger}
-import java.nio.CharBuffer
+import java.lang.{StringBuilder => JStringBuilder}
 import java.nio.charset.Charset
-import scala.annotation.{switch, tailrec}
 
 final class Formatter private (
     dest: Appendable,

--- a/javalib/src/main/scala-3/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala-3/java/util/concurrent/TimeUnit.scala
@@ -2,8 +2,6 @@
 
 package java.util.concurrent
 
-import java.sql.Time
-
 // Ported from Scala.js
 
 enum TimeUnit extends Enum[TimeUnit] {

--- a/javalib/src/main/scala/java/io/DataOutputStream.scala
+++ b/javalib/src/main/scala/java/io/DataOutputStream.scala
@@ -1,7 +1,5 @@
 package java.io
 
-import java.nio.charset.StandardCharsets
-
 class DataOutputStream(out: OutputStream)
     extends FilterOutputStream(out)
     with DataOutput {

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -22,7 +22,7 @@ import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.windows
 import windows._
-import windows.MinWinBaseApi.{FileTime => WinFileTime, _}
+import windows.MinWinBaseApi.{FileTime => WinFileTime}
 import windows.MinWinBaseApiOps.FileTimeOps._
 import windows.WinBaseApi._
 import windows.WinBaseApiExt._
@@ -707,10 +707,6 @@ class File(_path: String) extends Serializable with Comparable[File] {
 object File {
 
   private val `1U` = 1.toUInt
-  private val `4096U` = 4096.toUInt
-  private val `4095U` = 4095.toUInt
-
-  private val random = new java.util.Random()
 
   private def octal(v: String): UInt =
     Integer.parseInt(v, 8).toUInt
@@ -910,8 +906,6 @@ object File {
       else limits.PATH_MAX - `1U`
     val buffer: CString = alloc[Byte](bufferSize)
     if (isWindows) {
-      val filename = fromCString(link)
-
       withFileOpen(
         fromCString(link),
         access = FILE_GENERIC_READ,
@@ -946,8 +940,6 @@ object File {
   val pathSeparator: String = pathSeparatorChar.toString
   val separatorChar: Char = if (Platform.isWindows()) '\\' else '/'
   val separator: String = separatorChar.toString
-  private var counter: Int = 0
-  private var counterBase: Int = 0
   private val caseSensitive: Boolean = !Platform.isWindows()
 
   def listRoots(): Array[File] = {

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -1,7 +1,6 @@
 // Contains parts ported from Android Luni
 package java.lang
 
-import java.io.InvalidObjectException
 import java.util.Arrays
 import scala.util.control.Breaks._
 

--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -1,6 +1,5 @@
 package java.lang
 
-import scalanative.unsafe._
 import scalanative.libc
 
 import scalanative.runtime.ieee754tostring.ryu.{RyuRoundingMode, RyuDouble}

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -1,6 +1,5 @@
 package java.lang
 
-import scalanative.unsafe._
 import scalanative.libc
 import scalanative.runtime.Intrinsics
 

--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -2,7 +2,6 @@ package java.lang
 
 import scalanative.unsafe._
 import scalanative.unsigned._
-import scalanative.libc.string.memcpy
 import scalanative.libc.errno._
 
 private[java] object IEEE754Helpers {

--- a/javalib/src/main/scala/java/lang/Short.scala
+++ b/javalib/src/main/scala/java/lang/Short.scala
@@ -238,8 +238,6 @@ object Short {
 
   private val cache = new Array[java.lang.Short](256)
 
-  import ShortCache.cache
-
   @inline def valueOf(shortValue: scala.Short): Short = {
     if (shortValue.toByte.toShort != shortValue) {
       new Short(shortValue)

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -1,7 +1,6 @@
 package java.lang
 
 import scalanative.unsafe.{CString, fromCString}
-import scalanative.libc.string.strlen
 import scalanative.unsigned._
 import scala.scalanative.unsafe._
 import scala.scalanative.runtime.SymbolFormatter

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -3,7 +3,6 @@ package java.lang
 import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.libc.string.memcmp
-import scalanative.runtime.CharArray
 import java.io.Serializable
 import java.util._
 import java.util.regex._

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -2,7 +2,6 @@ package java.lang
 
 import java.lang.impl._
 import java.lang.Thread._
-import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.LockSupport
 import java.util.concurrent.ThreadFactory
 import java.time.Duration
@@ -280,7 +279,6 @@ class Thread private[lang] (
         if (interrupted()) throw new InterruptedException()
         val end = System.nanoTime() + 1000000 * millis + nanos.toLong
         var rest = 0L
-        var continue = true
         while (isAlive() && { rest = end - System.nanoTime(); rest > 0 }) {
           wait(millis, nanos)
           nanos = (rest % 1000000).toInt

--- a/javalib/src/main/scala/java/lang/ThreadBuilders.scala
+++ b/javalib/src/main/scala/java/lang/ThreadBuilders.scala
@@ -150,9 +150,7 @@ object ThreadBuilders {
 
   private abstract class BaseThreadFactory(
       name: String,
-      start: scala.Long,
-      characteristics: Int,
-      ueh: Thread.UncaughtExceptionHandler
+      start: scala.Long
   ) extends ThreadFactory {
     @volatile var counter: scala.Long = start
 
@@ -176,7 +174,7 @@ object ThreadBuilders {
       priority: Int,
       stackSize: scala.Long,
       ueh: Thread.UncaughtExceptionHandler
-  ) extends BaseThreadFactory(name, start, characteristics, ueh) {
+  ) extends BaseThreadFactory(name, start) {
     override def nextThreadName(): String = super.nextThreadName() match {
       case null => Thread.nextThreadName()
       case name => name
@@ -198,7 +196,7 @@ object ThreadBuilders {
       start: scala.Long,
       characteristics: Int,
       ueh: Thread.UncaughtExceptionHandler
-  ) extends BaseThreadFactory(name, start, characteristics, ueh) {
+  ) extends BaseThreadFactory(name, start) {
     override def newThread(task: Runnable): Thread = {
       Objects.requireNonNull(task)
       val thread = new VirtualThread(nextThreadName(), characteristics, task)

--- a/javalib/src/main/scala/java/lang/ThreadGroup.scala
+++ b/javalib/src/main/scala/java/lang/ThreadGroup.scala
@@ -76,7 +76,6 @@ class ThreadGroup(
   def isDestroyed(): scala.Boolean = false
 
   def activeCount(): Int = {
-    var n = 0
     NativeThread.Registry.aliveThreads
       .count { nativeThread =>
         val group = nativeThread.thread.getThreadGroup()

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -292,7 +292,7 @@ class AssertionError private (s: String, e: Throwable) extends Error(s, e) {
   def this(d: scala.Double) = this(d.toString, null)
 }
 
-class BootstrapMethodError(s: String, e: Throwable) extends LinkageError(s) {
+class BootstrapMethodError(s: String, e: Throwable) extends LinkageError(s, e) {
   def this(e: Throwable) = this(if (e == null) null else e.toString, e)
   def this(s: String) = this(s, null)
   def this() = this(null, null)
@@ -386,7 +386,8 @@ class VerifyError(s: String) extends LinkageError(s) {
   def this() = this(null)
 }
 
-abstract class VirtualMachineError(s: String, e: Throwable) extends Error(s) {
+abstract class VirtualMachineError(s: String, e: Throwable)
+    extends Error(s, e) {
   def this(s: String) = this(s, null)
   def this(e: Throwable) = this(null, e)
   def this() = this(null, null)

--- a/javalib/src/main/scala/java/lang/impl/PosixThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/PosixThread.scala
@@ -16,7 +16,6 @@ import scala.scalanative.posix.timeOps._
 import scala.scalanative.posix.sched._
 import scala.scalanative.posix.schedOps._
 import scala.scalanative.posix.pthread._
-import scala.scalanative.posix.signal._
 import scala.scalanative.posix.errno._
 import scala.scalanative.posix.poll._
 import scala.scalanative.posix.unistd._
@@ -201,7 +200,7 @@ private[java] class PosixThread(val thread: Thread, stackSize: Long)
       try
         while (millis > 0) {
           state = State.ParkedWaitingTimed
-          val status = poll(fds, 1.toUInt, (millis min Int.MaxValue).toInt)
+          poll(fds, 1.toUInt, (millis min Int.MaxValue).toInt)
           state = State.Running
           if (Thread.interrupted()) throw new InterruptedException()
 

--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -4,7 +4,6 @@ import java.io._
 import scala.annotation.tailrec
 import scala.scalanative.annotation.stub
 import scala.scalanative.unsafe._
-import scala.scalanative.libc._, signal._
 import scala.scalanative.posix.sys.ioctl._
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import scala.scalanative.windows.DWord

--- a/javalib/src/main/scala/java/lang/process/ProcessBuilderImpl.scala
+++ b/javalib/src/main/scala/java/lang/process/ProcessBuilderImpl.scala
@@ -5,14 +5,11 @@
 
 package java.lang.process
 
-import java.util.{ArrayList, List}
+import java.util.List
 import java.util.Map
-import java.io.{File, IOException}
+import java.io.File
 import java.util
 import java.util.Arrays
-import scala.scalanative.unsafe._
-import scala.scalanative.posix.unistd
-import scala.scalanative.runtime.Platform
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import ProcessBuilder.Redirect
 

--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -1,15 +1,8 @@
 package java.lang.process
 
-import scala.scalanative.unsafe._
 import scala.scalanative.meta.LinktimeInfo
 
-private[lang] abstract class UnixProcess protected (
-    pid: CInt,
-    builder: ProcessBuilder,
-    infds: Ptr[CInt],
-    outfds: Ptr[CInt],
-    errfds: Ptr[CInt]
-) extends GenericProcess {}
+private[lang] abstract class UnixProcess extends GenericProcess {}
 
 object UnixProcess {
   def apply(builder: ProcessBuilder): Process = {

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -16,15 +16,13 @@ import signal.{kill, SIGKILL}
 import time._
 import sys.time._
 
-import java.lang.ProcessBuilder.Redirect
-
 private[lang] class UnixProcessGen1 private (
     pid: CInt,
     builder: ProcessBuilder,
     infds: Ptr[CInt],
     outfds: Ptr[CInt],
     errfds: Ptr[CInt]
-) extends UnixProcess(pid, builder, infds, outfds, errfds) {
+) extends UnixProcess() {
 
   override def destroy(): Unit = kill(pid, sig.SIGTERM)
 
@@ -168,7 +166,7 @@ object UnixProcessGen1 {
     val argv = nullTerminate(cmd)
     val envp = nullTerminate {
       val list = new ArrayList[String]
-      val it = builder
+      builder
         .environment()
         .entrySet()
         .iterator()

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -44,7 +44,7 @@ private[lang] class UnixProcessGen2 private (
     infds: Ptr[CInt],
     outfds: Ptr[CInt],
     errfds: Ptr[CInt]
-) extends UnixProcess(pid, builder, infds, outfds, errfds) {
+) extends UnixProcess() {
 
   private[this] var _exitValue: Option[Int] = None
 
@@ -488,7 +488,6 @@ object UnixProcessGen2 {
       throwOnError(unistd.pipe(errfds), s"Couldn't create errfds pipe.")
 
     val exec = localCmd.get(0)
-    val dir = builder.directory()
     val argv = nullTerminate(localCmd)
     val envp = nullTerminate {
       val list = new ArrayList[String]

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -20,10 +20,8 @@ import FileApiExt._
 import NamedPipeApi._
 import SynchApi._
 import WinBaseApi._
-import WinBaseApiExt._
 import WinBaseApiOps._
 import winnt.AccessRights._
-import WindowsProcess._
 
 private[lang] class WindowsProcess private (
     val handle: Handle,
@@ -158,7 +156,7 @@ object WindowsProcess {
     val argv = toCWideStringUTF16LE(cmd.scalaOps.mkString("", " ", ""))
     val envp = nullTerminatedBlock {
       val list = new ArrayList[String]
-      val it = builder
+      builder
         .environment()
         .entrySet()
         .iterator()
@@ -218,7 +216,7 @@ object WindowsProcess {
       stdHandle: Handle,
       isStdIn: Boolean,
       msg: => String
-  )(implicit z: Zone): (Handle, Handle) = {
+  ): (Handle, Handle) = {
 
     val securityAttributes = stackalloc[SecurityAttributes]()
     securityAttributes.length = sizeof[SecurityAttributes].toUInt

--- a/javalib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Array.scala
@@ -34,7 +34,6 @@ object Array {
       dimensions: scala.Array[Int]
   ): AnyRef = {
     import scala.scalanative.runtime.{Array => NativeArray, ObjectArray}
-    val ty = componentType
     if (componentType eq null)
       throw new NullPointerException()
     if (dimensions.length == 0 || dimensions.length > 255)

--- a/javalib/src/main/scala/java/math/BigInteger.scala
+++ b/javalib/src/main/scala/java/math/BigInteger.scala
@@ -63,9 +63,6 @@ object BigInteger {
   /** The {@code BigInteger} constant -1 used for comparison. */
   private[math] final val MINUS_ONE = new BigInteger(-1, 1)
 
-  /** 2^32. */
-  private final val POW32 = 4294967296d
-
   /** All the {@code BigInteger} numbers in the range [0,10] are cached. */
   private final val SMALL_VALUES = Array(
     ZERO,

--- a/javalib/src/main/scala/java/math/Elementary.scala
+++ b/javalib/src/main/scala/java/math/Elementary.scala
@@ -62,8 +62,6 @@ private[math] object Elementary {
    */
   def add(op1: BigInteger, op2: BigInteger): BigInteger = {
     // scalastyle:off return
-    var resDigits: Array[Int] = null
-    var resSign: Int = 0
     val op1Sign = op1.sign
     val op2Sign = op2.sign
     val op1Len: Int = op1.numberLength
@@ -322,8 +320,6 @@ private[math] object Elementary {
    */
   def subtract(op1: BigInteger, op2: BigInteger): BigInteger = {
     // scalastyle:off return
-    var resSign = 0
-    var resDigits: Array[Int] = null
     val op1Sign = op1.sign
     val op2Sign = op2.sign
     val op1Len = op1.numberLength

--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -2,7 +2,6 @@ package java.net
 
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
-import scala.scalanative.runtime.ByteArray
 
 import scalanative.libc.string.memcpy
 

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -6,7 +6,6 @@ import scalanative.unsafe._
 import scalanative.unsigned._
 
 import scala.scalanative.posix.net.`if`._
-import scala.scalanative.posix.net.ifOps._
 import scala.scalanative.posix.stddef
 
 final class Inet6Address private (

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -12,7 +12,6 @@ import scala.scalanative.posix.string.memcpy
 
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
-import scala.scalanative.windows.WinSocketApi._
 import scala.scalanative.windows.WinSocketApiOps
 
 object SocketHelpers {

--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -32,8 +32,6 @@ final class URI private () extends Comparable[URI] with Serializable {
 
   import URI._
 
-  private val serialVersionUID = -6052424284110960213L
-
   private var string: String = _
 
   @transient private var scheme: String = _

--- a/javalib/src/main/scala/java/net/URIEncoderDecoder.scala
+++ b/javalib/src/main/scala/java/net/URIEncoderDecoder.scala
@@ -1,7 +1,6 @@
 package java.net
 
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 
 object URIEncoderDecoder {
 

--- a/javalib/src/main/scala/java/net/URLEncoder.scala
+++ b/javalib/src/main/scala/java/net/URLEncoder.scala
@@ -50,7 +50,6 @@ object URLEncoder {
       enc: String
   ): Unit = {
     val bytes = s.getBytes(enc)
-    var j = 0
     @tailrec
     def loop(j: Int): Unit = {
       if (j < bytes.length) {

--- a/javalib/src/main/scala/java/nio/GenMappedBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenMappedBuffer.scala
@@ -1,7 +1,5 @@
 package java.nio
 
-import java.nio.channels.FileChannel
-import scala.scalanative.windows.HandleApi._
 import scala.scalanative.runtime.ByteArray
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._

--- a/javalib/src/main/scala/java/nio/GenMappedBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenMappedBufferView.scala
@@ -1,7 +1,5 @@
 package java.nio
 
-import scala.scalanative.runtime.ByteArray
-
 // Based on the code ported from Scala.js,
 // see GenHeapBufferView.scala
 private[nio] object GenMappedBufferView {

--- a/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
@@ -1,8 +1,5 @@
 package java.nio
 
-import java.nio.channels.FileChannel
-import scala.scalanative.windows.HandleApi._
-
 abstract class MappedByteBuffer private[nio] (
     _capacity: Int,
     private[nio] override val _mappedData: MappedByteBufferData,

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -12,7 +12,6 @@ import scala.scalanative.unsigned._
 import scala.scalanative.windows.WinBaseApi.CreateFileMappingA
 import scala.scalanative.windows.WinBaseApiExt._
 import scala.scalanative.windows.MemoryApi._
-import scala.scalanative.windows.HandleApi._
 import scala.scalanative.windows._
 
 import java.io.IOException

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -14,12 +14,11 @@ import java.io.IOException
 
 import scala.scalanative.posix.fcntl._
 import scala.scalanative.posix.fcntlOps._
-import scala.scalanative.libc.stdio
 import scala.scalanative.unsafe._
 
 import scala.scalanative.posix.unistd
 import scala.scalanative.unsigned._
-import scala.scalanative.{runtime, windows}
+import scala.scalanative.windows
 import scalanative.libc.stdio
 import scala.scalanative.libc.errno.errno
 

--- a/javalib/src/main/scala/java/nio/file/DirectoryStreamImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/DirectoryStreamImpl.scala
@@ -1,6 +1,5 @@
 package java.nio.file
 
-import scala.collection.{Iterator => SIterator}
 import java.util.Iterator
 import java.util.function.Predicate
 import java.util.stream.Stream

--- a/javalib/src/main/scala/java/nio/file/FileSystems.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystems.scala
@@ -5,11 +5,8 @@ import java.nio.file.spi.FileSystemProvider
 import java.net.URI
 import java.util.{HashMap, Map}
 
-import scala.scalanative.nio.fs.unix.{UnixFileSystem, UnixFileSystemProvider}
-import scala.scalanative.nio.fs.windows.{
-  WindowsFileSystem,
-  WindowsFileSystemProvider
-}
+import scala.scalanative.nio.fs.unix.UnixFileSystemProvider
+import scala.scalanative.nio.fs.windows.WindowsFileSystemProvider
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
 object FileSystems {

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -17,28 +17,16 @@ import java.io.{
 
 import java.nio.file.attribute._
 import java.nio.charset.{Charset, StandardCharsets}
-import java.nio.channels.{FileChannel, SeekableByteChannel}
+import java.nio.channels.SeekableByteChannel
 import java.util.function.BiPredicate
-import java.util.{
-  EnumSet,
-  HashMap,
-  HashSet,
-  Iterator,
-  LinkedList,
-  List,
-  Map,
-  Set
-}
+import java.util.{EnumSet, HashMap, HashSet, LinkedList, List, Map, Set}
 import java.util.stream.{Stream, WrappedScalaStream}
-
-import scala.annotation.tailrec
 
 import scalanative.unsigned._
 import scalanative.unsafe._
 import scalanative.libc._
 
 import scalanative.posix.errno.{errno, EEXIST, ENOENT, ENOTEMPTY}
-import scalanative.posix.dirent, dirent._
 import scalanative.posix.{fcntl, limits, unistd}
 
 import java.nio.file.StandardCopyOption.{COPY_ATTRIBUTES, REPLACE_EXISTING}
@@ -55,7 +43,6 @@ import scalanative.nio.fs.FileHelpers
 import scalanative.compat.StreamsCompat._
 import scalanative.meta.LinktimeInfo.isWindows
 import scala.collection.immutable.{Map => SMap, Set => SSet}
-import java.io.FileNotFoundException
 
 object Files {
 
@@ -451,7 +438,6 @@ object Files {
     path.getFileSystem().provider().getFileAttributeView(path, tpe, options)
 
   def getLastModifiedTime(path: Path, options: Array[LinkOption]): FileTime = {
-    val realPath = path.toRealPath(options)
     val attributes =
       getFileAttributeView(path, classOf[BasicFileAttributeView], options)
         .readAttributes()

--- a/javalib/src/main/scala/java/nio/file/WindowsException.scala
+++ b/javalib/src/main/scala/java/nio/file/WindowsException.scala
@@ -1,16 +1,11 @@
 package java.nio.file
 
-import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.posix.errno._
 import scala.scalanative.windows._
 import java.io.IOException
-import java.nio.charset.StandardCharsets
 import scala.scalanative.windows.ErrorHandlingApi._
 import scala.scalanative.windows.ErrorHandlingApiOps.errorMessage
-import scala.scalanative.windows.WinBaseApi._
-import java.nio.file._
-import scalanative.libc.string
 
 trait WindowsException extends Exception
 object WindowsException {

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -5,7 +5,6 @@ import java.util.{HashMap, HashSet, Set}
 import java.util.concurrent.TimeUnit
 import java.nio.file.{LinkOption, Path, PosixException}
 import java.nio.file.attribute._
-import java.io.IOException
 
 import scalanative.unsigned._
 import scalanative.unsafe._

--- a/javalib/src/main/scala/java/nio/file/glob/GlobMatcher.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobMatcher.scala
@@ -1,7 +1,5 @@
 package java.nio.file.glob
 
-import java.nio.file.{PathMatcher, Path}
-import scala.util.matching.Regex
 import scala.annotation.tailrec
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
@@ -85,9 +83,6 @@ class GlobMatcher(glob: GlobNode, inputPath: String) {
               true
           }.isDefined
         } else {
-          val filteredStates = newStates.filter(node =>
-            node.minSepsLeft <= newSepsLeft && node.minCharsLeft <= newCharsLeft
-          )
           matchesInternal(inputIdx + 1, newStates, newCharsLeft, newSepsLeft)
         }
       } else {

--- a/javalib/src/main/scala/java/nio/file/glob/GlobPattern.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobPattern.scala
@@ -3,7 +3,6 @@ package java.nio.file.glob
 import java.util.regex.PatternSyntaxException
 
 import scala.collection.mutable
-import scala.annotation.tailrec
 import scala.scalanative.annotation.alwaysinline
 
 class GlobPattern(pattern: String) {

--- a/javalib/src/main/scala/java/security/MessageDigest.scala
+++ b/javalib/src/main/scala/java/security/MessageDigest.scala
@@ -10,7 +10,6 @@ abstract class MessageDigest(private var algorithm: String)
 }
 
 object MessageDigest {
-  private final val SERVICE = "MessageDigest"
   def isEqual(digestA: Array[Byte], digestB: Array[Byte]): Boolean =
     true
 

--- a/javalib/src/main/scala/java/security/cert/CertificateEncodingException.scala
+++ b/javalib/src/main/scala/java/security/cert/CertificateEncodingException.scala
@@ -2,8 +2,6 @@ package java.security.cert
 
 // Ported from Harmony
 
-import java.security.GeneralSecurityException
-
 @SerialVersionUID(6219492851589449162L)
 class CertificateEncodingException(
     private[this] val message: String,

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -133,7 +133,6 @@ class ArrayDeque[E](
         i += 1
       }
     }
-    // checkInvariants();
   }
 
   /** Capacity calculation for edge conditions, especially overflow. */
@@ -164,7 +163,6 @@ class ArrayDeque[E](
     val needed = minCapacity + 1 - elements.length
     if (needed > 0)
       grow(needed)
-    // checkInvariants();
   }
 
   /** Minimizes the internal storage of this collection.
@@ -179,7 +177,6 @@ class ArrayDeque[E](
       head = 0
       tail = size
     }
-    // checkInvariants();
   }
 
   /** Constructs an empty array deque with an initial capacity sufficient to
@@ -299,7 +296,6 @@ class ArrayDeque[E](
     es(head) = e.asInstanceOf[Object]
     if (head == tail)
       grow(1)
-    // checkInvariants();
   }
 
   /** Inserts the specified element at the end of this deque.
@@ -319,7 +315,6 @@ class ArrayDeque[E](
     tail = inc(tail, es.length)
     if (head == tail)
       grow(1)
-    // checkInvariants();
   }
 
   /** Adds all of the elements in the specified collection at the end of this
@@ -339,7 +334,6 @@ class ArrayDeque[E](
     if (needed > 0)
       grow(needed)
     copyElements(c)
-    // checkInvariants();
     return size() > s
   }
 
@@ -380,7 +374,6 @@ class ArrayDeque[E](
     val e = pollFirst()
     if (e == null)
       throw new NoSuchElementException()
-    // checkInvariants();
     return e
   }
 
@@ -389,7 +382,6 @@ class ArrayDeque[E](
     val e = pollLast()
     if (e == null)
       throw new NoSuchElementException()
-    // checkInvariants();
     return e
   }
 
@@ -401,7 +393,6 @@ class ArrayDeque[E](
       es(h) = null
       head = inc(h, es.length)
     }
-    // checkInvariants();
     return e
   }
 
@@ -413,7 +404,6 @@ class ArrayDeque[E](
       tail = t
       es(t) = null
     }
-    // checkInvariants();
     return e
   }
 
@@ -422,7 +412,6 @@ class ArrayDeque[E](
     val e = elementAt(elements, head)
     if (e == null)
       throw new NoSuchElementException()
-    // checkInvariants();
     return e
   }
 
@@ -432,17 +421,14 @@ class ArrayDeque[E](
     val e = elementAt(es, dec(tail, es.length))
     if (e == null)
       throw new NoSuchElementException()
-    // checkInvariants();
     return e
   }
 
   def peekFirst(): E = {
-    // checkInvariants();
     return elementAt(elements, head)
   }
 
   def peekLast(): E = {
-    // checkInvariants();
     val es = elements
     return elementAt(es, dec(tail, es.length))
   }
@@ -648,7 +634,6 @@ class ArrayDeque[E](
    *    true if elements near tail moved backwards
    */
   private def delete(i: Int): Boolean = {
-    // checkInvariants();
     val es = elements
     val capacity = es.length
     val h = head
@@ -668,7 +653,6 @@ class ArrayDeque[E](
       }
       es(h) = null
       head = inc(h, capacity)
-      // checkInvariants();
       return false
     } else {
       // move back elements backwards
@@ -681,7 +665,6 @@ class ArrayDeque[E](
         System.arraycopy(es, 1, es, 0, t - 1)
       }
       es(tail) = null
-      // checkInvariants();
       return true
     }
   }
@@ -959,7 +942,6 @@ class ArrayDeque[E](
       i = 0
       to = end
     }
-    // checkInvariants();
   }
 
   /** Replaces each element of this deque with the result of applying the
@@ -987,7 +969,6 @@ class ArrayDeque[E](
       i = 0
       to = end
     }
-    // checkInvariants();
   }
 
   /** @throws java.lang.NullPointerException */
@@ -1010,7 +991,6 @@ class ArrayDeque[E](
 
   /** Implementation of bulk remove methods. */
   def bulkRemove(filter: Predicate[_ >: E]): Boolean = {
-    // checkInvariants();
     val es = elements
     // Optimize for initial run of survivors
     var i = head
@@ -1118,7 +1098,6 @@ class ArrayDeque[E](
     if (end != tail) throw new ConcurrentModificationException()
     tail = w
     circularClear(es, tail, end)
-    // checkInvariants();
     return true;
   }
 
@@ -1176,7 +1155,6 @@ class ArrayDeque[E](
     circularClear(elements, head, tail)
     head = 0
     tail = 0
-    // checkInvariants();
   }
 
   /** Nulls out slots starting at array index i, upto index end. Condition i ==
@@ -1305,37 +1283,6 @@ class ArrayDeque[E](
     result.head = this.head
     result.tail = this.tail
     result
-  }
-
-  /** debugging */
-  private def checkInvariants(): Unit = {
-    // Use head and tail fields with empty slot at tail strategy.
-    // head == tail disambiguates to "empty".
-    try {
-      val capacity = elements.length
-      // assert 0 <= head && head < capacity;
-      // assert 0 <= tail && tail < capacity;
-      // assert capacity > 0;
-      // assert size() < capacity;
-      // assert head == tail || elements[head] != null;
-      // assert elements[tail] == null;
-      // assert head == tail || elements[dec(tail, capacity)] != null;
-    } catch {
-      case t: Throwable =>
-        System.err.printf(
-          "head=%d tail=%d capacity=%d%n",
-          Array[Object](
-            Integer.valueOf(head),
-            Integer.valueOf(tail),
-            Integer.valueOf(elements.length)
-          )
-        )
-        System.err.printf(
-          "elements=%s%n",
-          Array[Object](Arrays.toString(elements))
-        )
-        throw t
-    }
   }
 
 }

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -1000,8 +1000,6 @@ object Arrays {
   }
 
 // Scala Native additions --------------------------------------------------
-  import java.util.{Spliterator, Spliterators}
-
   private final val standardArraySpliteratorCharacteristics =
     Spliterator.SIZED |
       Spliterator.SUBSIZED |

--- a/javalib/src/main/scala/java/util/BitSet.scala
+++ b/javalib/src/main/scala/java/util/BitSet.scala
@@ -4,7 +4,6 @@ package java.util
 
 import java.io.Serializable
 import java.lang.Long.bitCount
-import java.lang.Integer.toUnsignedLong
 import java.nio.{ByteBuffer, LongBuffer}
 import java.util
 

--- a/javalib/src/main/scala/java/util/Collection.scala
+++ b/javalib/src/main/scala/java/util/Collection.scala
@@ -2,7 +2,6 @@
 // Additional Spliterator code implemented for Scala Native
 package java.util
 
-import java.util.function.Consumer
 import java.util.function.Predicate
 
 trait Collection[E] extends java.lang.Iterable[E] {

--- a/javalib/src/main/scala/java/util/FormatterImpl.scala
+++ b/javalib/src/main/scala/java/util/FormatterImpl.scala
@@ -16,7 +16,6 @@ import java.lang.{
 }
 import java.math.{BigDecimal, BigInteger}
 import java.nio.CharBuffer
-import java.nio.charset.Charset
 import scala.annotation.{switch, tailrec}
 
 private[util] abstract class FormatterImpl protected (
@@ -551,7 +550,6 @@ private[util] abstract class FormatterImpl protected (
     if (rounded.negative)
       builder.append('-')
 
-    val minDigits = 1 + scale // 1 before the '.' plus `scale` after it
     if (intStrLen > scale) {
       // There is at least one digit of intStr before the '.'
       // (we always take this branch when scale == 0)
@@ -978,9 +976,6 @@ private[util] abstract class FormatterImpl protected (
    * are here for consistency.
    */
 
-  private def throwDuplicateFormatFlagsException(flag: Char): Nothing =
-    throw new DuplicateFormatFlagsException(flag.toString())
-
   private def throwUnknownFormatConversionException(conversion: Char): Nothing =
     throw new UnknownFormatConversionException(conversion.toString())
 
@@ -1358,7 +1353,6 @@ object FormatterImpl extends FormatterCompanionImpl {
       @tailrec
       def loop(state: Int): FormatToken = {
         // FINITE STATE MACHINE
-        val prevChar = currentChar
         if (ParserStateMachine.Exit != state) {
           // exit state does not need to get next char
           currentChar = getNextFormatChar()

--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -8,8 +8,6 @@ package java.util
 
 import java.util.function.Supplier
 
-import scala.reflect.ClassTag
-
 object Objects {
 
   @inline

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -266,6 +266,7 @@ class Properties(protected val defaults: Properties)
         } else if (prevValueContinue && valueContinues()) {
           val value = parseValue()
           prevValueContinue = valueContinues()
+          setProperty(key, value)
         } else {
           val value = parseValue()
           setProperty(key, value)

--- a/javalib/src/main/scala/java/util/RedBlackTree.scala
+++ b/javalib/src/main/scala/java/util/RedBlackTree.scala
@@ -192,10 +192,6 @@ private[util] object RedBlackTree {
 
   // ---- size ----
 
-  private def size(node: Node[_, _]): Int =
-    if (node eq null) 0
-    else 1 + size(node.left) + size(node.right)
-
   def size(tree: Tree[_, _]): Int = tree.size
 
   def projectionSize[A, B](

--- a/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
+++ b/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
@@ -2,7 +2,6 @@ package java.util
 
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
-import java.io.IOException
 import scala.scalanative.windows.ProcessThreadsApi._
 import scala.scalanative.windows.HandleApi._
 import scala.scalanative.windows.HandleApiExt._

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
@@ -3,7 +3,6 @@
 package java.util.concurrent
 
 import java.util._
-import java.util.ScalaOps._
 
 class ConcurrentLinkedQueue[E]()
     extends AbstractQueue[E]
@@ -67,13 +66,6 @@ class ConcurrentLinkedQueue[E]()
 
   override def size(): Int =
     if (_size > Int.MaxValue) Int.MaxValue else _size.toInt
-
-  private def getNodeAt(index: Int): Node[E] = {
-    var current: Node[E] = head
-    for (_ <- 0 until index)
-      current = current.next
-    current
-  }
 
   private def removeNode(node: Node[E]): Unit = {
     if (node eq head) {

--- a/javalib/src/main/scala/java/util/concurrent/CyclicBarrier.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CyclicBarrier.scala
@@ -6,7 +6,6 @@
 
 package java.util.concurrent
 
-import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
 
 object CyclicBarrier {

--- a/javalib/src/main/scala/java/util/concurrent/ExecutorService.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ExecutorService.scala
@@ -7,8 +7,6 @@
 package java.util
 package concurrent
 
-import java.security.{PrivilegedAction, PrivilegedExceptionAction}
-
 trait ExecutorService extends Executor with AutoCloseable {
 
   def shutdown(): Unit

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -8,16 +8,14 @@
 package java.util.concurrent
 
 import java.lang.Thread.UncaughtExceptionHandler
-import java.lang.invoke.MethodHandles
 import java.lang.invoke.VarHandle
 import java.util.concurrent.ForkJoinPool.WorkQueue.getAndClearSlot
 import java.util.{ArrayList, Collection, Collections, List, concurrent}
 import java.util.function.Predicate
-import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.LockSupport
 import java.util.concurrent.locks.ReentrantLock
 import java.util.concurrent.locks.Condition
-import scala.annotation._
 import scala.scalanative.annotation._
 import scala.scalanative.unsafe._
 import scala.scalanative.libc.atomic.{CAtomicInt, CAtomicLongLong, CAtomicRef}
@@ -54,9 +52,6 @@ class ForkJoinPool private (
   )
   @alwaysinline private def runStateAtomic = new CAtomicInt(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "runState"))
-  )
-  @alwaysinline private def stealCountAtomic = new CAtomicLongLong(
-    fromRawPtr(Intrinsics.classFieldRawPtr(this, "stealCount"))
   )
   @alwaysinline private def threadIdsAtomic = new CAtomicLongLong(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "threadIds"))
@@ -1009,7 +1004,6 @@ class ForkJoinPool private (
     if (factory == null || unit == null) throw new NullPointerException
     val p = parallelism
     val size: Int = 1 << (33 - Integer.numberOfLeadingZeros(p - 1))
-    val corep = corePoolSize.max(p).min(MAX_CAP)
     this.parallelism = p
     this.queues = new Array[WorkQueue](size)
   }

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
@@ -14,7 +14,6 @@ import java.lang.invoke.VarHandle
 
 import scala.scalanative.libc.atomic._
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
-import scala.scalanative.unsafe.{Ptr, stackalloc}
 import scala.scalanative.annotation.alwaysinline
 
 import scala.annotation.tailrec
@@ -457,24 +456,6 @@ abstract class ForkJoinTask[V]() extends Future[V] with Serializable {
     if (s.toShort != expect) false
     else if (casStatus(s, (s & ~SMASK) | (update & SMASK))) true
     else compareAndSetForkJoinTaskTag(expect, update)
-  }
-
-  @throws[java.io.IOException]
-  private def writeObject(s: java.io.ObjectOutputStream): Unit = {
-    val a = aux
-    s.defaultWriteObject()
-    s.writeObject(
-      if (a == null) null
-      else a.ex
-    )
-  }
-
-  @throws[java.io.IOException]
-  @throws[ClassNotFoundException]
-  private def readObject(s: java.io.ObjectInputStream): Unit = {
-    s.defaultReadObject()
-    val ex = s.readObject
-    if (ex != null) trySetThrown(ex.asInstanceOf[Throwable])
   }
 }
 

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinWorkerThread.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinWorkerThread.scala
@@ -6,13 +6,10 @@
 
 package java.util.concurrent;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 class ForkJoinWorkerThread private[concurrent] (
     group: ThreadGroup,
     private[concurrent] val pool: ForkJoinPool,
-    useSystemClassLoader: Boolean,
+    useSystemClassLoader: Boolean, // unused
     clearThreadLocals: Boolean
 ) extends Thread(
       group = group,

--- a/javalib/src/main/scala/java/util/concurrent/FutureTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/FutureTask.scala
@@ -5,8 +5,6 @@
  */
 
 package java.util.concurrent
-import java.lang.invoke.MethodHandles
-import java.lang.invoke.VarHandle
 import java.util.concurrent.locks.LockSupport
 import scalanative.libc.atomic.{CAtomicInt, CAtomicRef}
 import scalanative.libc.atomic.memory_order._

--- a/javalib/src/main/scala/java/util/concurrent/PriorityBlockingQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/PriorityBlockingQueue.scala
@@ -5,8 +5,6 @@
  */
 
 package java.util.concurrent
-import java.lang.invoke.MethodHandles
-import java.lang.invoke.VarHandle
 import java.util
 import java.util._
 import java.util.concurrent.locks._
@@ -167,8 +165,6 @@ class PriorityBlockingQueue[E <: AnyRef] private (
   private val atomicAllocationSpinLock = new CAtomicInt(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "allocationSpinLock"))
   )
-
-  private var q = null
 
   def this(initialCapacity: Int, comparator: Comparator[_ >: E]) = {
     this(

--- a/javalib/src/main/scala/java/util/concurrent/SynchronousQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/SynchronousQueue.scala
@@ -12,7 +12,6 @@ import java.util.concurrent.locks._
 import scala.scalanative.libc.atomic.CAtomicRef
 import scala.scalanative.libc.atomic.memory_order._
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
-import scala.collection.concurrent.SNode
 
 /** A {@linkplain BlockingQueue blocking queue} in which each insert operation
  *  must wait for a corresponding remove operation by another thread, and vice

--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -204,7 +204,6 @@ object ThreadLocalRandom {
       if (consumer == null)
         throw new NullPointerException
 
-      var i = index
       if (index < fence) {
         val rng = ThreadLocalRandom.current()
         var i = index

--- a/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
@@ -21,7 +21,6 @@ object ThreadPoolExecutor {
   private val TIDYING: Int = 2 << COUNT_BITS
   private val TERMINATED: Int = 3 << COUNT_BITS
 // Packing and unpacking ctl
-  private def runStateOf(c: Int): Int = c & ~(COUNT_MASK)
   private def workerCountOf(c: Int): Int = c & COUNT_MASK
   private def ctlOf(rs: Int, wc: Int): Int = rs | wc
   private def runStateLessThan(c: Int, s: Int): Boolean = c < s
@@ -647,7 +646,6 @@ class ThreadPoolExecutor(
         // queue, but stop if queue becomes empty while doing so.
         var k: Int = delta min workQueue.size()
         while ({
-          var idx = k
           k -= 1
           k > 0 && addWorker(null, true) && !workQueue.isEmpty()
         }) ()

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
@@ -6,14 +6,12 @@
 
 package java.util.concurrent.atomic
 
-import scala.annotation.tailrec
 import scala.language.implicitConversions
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.unsafe._
 import scala.scalanative.libc.atomic.memory_order._
 import scala.scalanative.libc.atomic.CAtomicByte
-import scala.scalanative.runtime.{fromRawPtr, MemoryLayout}
-import scala.scalanative.runtime.Intrinsics
+import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
 
 @SerialVersionUID(4654671469794556979L)
 class AtomicBoolean private (private var value: Byte) extends Serializable {

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.scala
@@ -5,7 +5,6 @@
  */
 package java.util.concurrent.atomic
 
-import java.util.Objects
 import java.util.function.BinaryOperator
 import java.util.function.UnaryOperator
 

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
@@ -12,7 +12,6 @@ import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.unsafe._
 import scala.scalanative.libc.atomic.CAtomicLongLong
 import scala.scalanative.libc.atomic.memory_order._
-import scala.scalanative.runtime.MemoryLayout
 
 import java.util.function.{LongBinaryOperator, LongUnaryOperator}
 import java.util.Arrays

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongFieldUpdater.scala
@@ -5,7 +5,6 @@
  */
 package java.util.concurrent.atomic
 
-import java.util.Objects
 import java.util.function.BinaryOperator
 import java.util.function.UnaryOperator
 

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicMarkableReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicMarkableReference.scala
@@ -6,13 +6,10 @@
 
 package java.util.concurrent.atomic
 
-import scala.annotation.tailrec
 import scala.scalanative.annotation.alwaysinline
-import scala.scalanative.unsafe._
 import scala.scalanative.libc.atomic.CAtomicRef
 import scala.scalanative.libc.atomic.memory_order._
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
-import scala.scalanative.runtime.Intrinsics
 
 object AtomicMarkableReference {
   private[concurrent] case class MarkableReference[T <: AnyRef](

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.scala
@@ -5,7 +5,6 @@
  */
 package java.util.concurrent.atomic
 
-import java.util.Objects
 import java.util.function.BinaryOperator
 import java.util.function.UnaryOperator
 

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicStampedReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicStampedReference.scala
@@ -6,9 +6,7 @@
 
 package java.util.concurrent.atomic
 
-import scala.annotation.tailrec
 import scala.scalanative.annotation.alwaysinline
-import scala.scalanative.unsafe._
 import scala.scalanative.libc.atomic.CAtomicRef
 import scala.scalanative.libc.atomic.memory_order._
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractOwnableSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractOwnableSynchronizer.scala
@@ -7,8 +7,6 @@
 package java.util.concurrent
 package locks
 
-import java.util.concurrent.atomic.AtomicReference
-
 abstract class AbstractOwnableSynchronizer protected ()
     extends java.io.Serializable {
 

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
@@ -13,9 +13,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.RejectedExecutionException
 import scala.annotation.tailrec
-import java.util.concurrent.atomic.{AtomicReference, AtomicInteger}
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
-import scala.scalanative.unsafe._
 import scala.scalanative.libc.atomic.{CAtomicInt, CAtomicLongLong, CAtomicRef}
 import scala.scalanative.libc.atomic.memory_order._
 
@@ -486,12 +484,11 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     val h = head
     val s = if (h != null) h.next else null
     var first = if (s != null) s.waiter else null
-    val current =
-      if (h != null && (s == null ||
-            first == null ||
-            s.prev == null)) {
-        first = getFirstQueuedThread()
-      }
+    if (h != null && (s == null ||
+          first == null ||
+          s.prev == null)) {
+      first = getFirstQueuedThread()
+    }
     first != null && (first ne Thread.currentThread())
   }
 

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
@@ -13,9 +13,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.RejectedExecutionException
 import scala.annotation.tailrec
-import java.util.concurrent.atomic.{AtomicReference, AtomicInteger}
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
-import scala.scalanative.unsafe._
 import scala.scalanative.libc.atomic.{CAtomicInt, CAtomicRef}
 import scala.scalanative.libc.atomic.memory_order._
 
@@ -484,12 +482,11 @@ abstract class AbstractQueuedSynchronizer protected ()
     val h = head
     val s = if (h != null) h.next else null
     var first = if (s != null) s.waiter else null
-    val current =
-      if (h != null && (s == null ||
-            first == null ||
-            s.prev == null)) {
-        first = getFirstQueuedThread()
-      }
+    if (h != null && (s == null ||
+          first == null ||
+          s.prev == null)) {
+      first = getFirstQueuedThread()
+    }
     first != null && (first ne Thread.currentThread())
   }
 

--- a/javalib/src/main/scala/java/util/concurrent/locks/LockSupport.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/LockSupport.scala
@@ -6,8 +6,6 @@
 
 package java.util.concurrent.locks
 
-import java.util.Objects
-
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.runtime.{NativeThread, fromRawPtr}
 import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
@@ -54,7 +52,7 @@ object LockSupport {
   }
 
   @alwaysinline private def parkBlockerRef(thread: Thread): Ptr[Object] =
-    fromRawPtr(classFieldRawPtr(Thread.currentThread(), "parkBlocker"))
+    fromRawPtr(classFieldRawPtr(thread, "parkBlocker"))
 
   @alwaysinline private def setBlocker(
       thread: Thread,

--- a/javalib/src/main/scala/java/util/jar/JarEntry.scala
+++ b/javalib/src/main/scala/java/util/jar/JarEntry.scala
@@ -2,17 +2,15 @@ package java.util.jar
 
 // Ported from Apache Harmony
 
-import java.io.IOException
 import java.security.CodeSigner
 import java.security.cert.{
-  CertPath,
   Certificate,
   CertificateException,
   CertificateFactory,
   X509Certificate
 }
 import java.util.zip.{ZipConstants, ZipEntry}
-import java.util.{ArrayList, List}
+import java.util.ArrayList
 
 import javax.security.auth.x500.X500Principal
 

--- a/javalib/src/main/scala/java/util/jar/JarFile.scala
+++ b/javalib/src/main/scala/java/util/jar/JarFile.scala
@@ -2,14 +2,8 @@ package java.util.jar
 
 // Ported from Apache Harmony
 
-import java.io.{
-  ByteArrayOutputStream,
-  File,
-  FilterInputStream,
-  IOException,
-  InputStream
-}
-import java.util.{Enumeration, List}
+import java.io.{ByteArrayOutputStream, File, FilterInputStream, InputStream}
+import java.util.{Enumeration}
 import java.util.zip.{ZipConstants, ZipEntry, ZipFile}
 
 class JarFile(file: File, verify: Boolean, mode: Int)

--- a/javalib/src/main/scala/java/util/jar/JarVerifier.scala
+++ b/javalib/src/main/scala/java/util/jar/JarVerifier.scala
@@ -2,20 +2,14 @@ package java.util.jar
 
 // Ported from Apache Harmony
 
-import java.io.{
-  ByteArrayInputStream,
-  InputStream,
-  IOException,
-  OutputStream,
-  UnsupportedEncodingException
-}
+import java.io.{IOException, OutputStream}
 import java.security.{
   GeneralSecurityException,
   MessageDigest,
   NoSuchAlgorithmException
 }
 import java.security.cert.Certificate
-import java.util.{Map, HashMap, Iterator, StringTokenizer}
+import java.util.{Map, HashMap, StringTokenizer}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -138,7 +132,6 @@ private[jar] class JarVerifier(jarName: String) {
       case (null, _) | (_, null) =>
         ()
       case (sfBytes, manifest) =>
-        val sBlockBytes = metaEntries.get(certFile)
         try {
           // TODO: Port JarUtils from Apache Harmony, see #956.
           // val signerCertChain = JarUtils.verifySignature(

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -1,7 +1,6 @@
 package java.util
 package regex
 
-import scalanative.regex.RE2
 import scalanative.regex.{Matcher => rMatcher}
 
 // Inspired & informed by:
@@ -18,8 +17,6 @@ final class Matcher private[regex] (
 ) extends MatchResult {
 
   private val underlying = new rMatcher(_pattern.compiled, _inputSequence)
-
-  private var _groupCount = _pattern.compiled.groupCount()
 
   private var anchoringBoundsInUse = true
 

--- a/javalib/src/main/scala/java/util/zip/Adler32.scala
+++ b/javalib/src/main/scala/java/util/zip/Adler32.scala
@@ -2,7 +2,7 @@ package java.util.zip
 
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
-import scala.scalanative.runtime.{ByteArray, zlib}
+import scala.scalanative.runtime.zlib
 
 // Ported from Apache Harmony
 

--- a/javalib/src/main/scala/java/util/zip/CRC32.scala
+++ b/javalib/src/main/scala/java/util/zip/CRC32.scala
@@ -2,7 +2,7 @@ package java.util.zip
 
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
-import scala.scalanative.runtime.{ByteArray, zlib}
+import scala.scalanative.runtime.zlib
 
 // Ported from Apache Harmony
 

--- a/javalib/src/main/scala/java/util/zip/CheckedInputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/CheckedInputStream.scala
@@ -1,6 +1,6 @@
 package java.util.zip
 
-import java.io.{FilterInputStream, IOException, InputStream}
+import java.io.{FilterInputStream, InputStream}
 
 // Ported from Apache Harmony
 

--- a/javalib/src/main/scala/java/util/zip/CheckedOutputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/CheckedOutputStream.scala
@@ -2,7 +2,7 @@ package java.util.zip
 
 // Ported from Apache Harmony
 
-import java.io.{FilterOutputStream, IOException, OutputStream}
+import java.io.{FilterOutputStream, OutputStream}
 
 class CheckedOutputStream(out: OutputStream, cksum: Checksum)
     extends FilterOutputStream(out) {

--- a/javalib/src/main/scala/java/util/zip/Deflater.scala
+++ b/javalib/src/main/scala/java/util/zip/Deflater.scala
@@ -3,7 +3,7 @@ package java.util.zip
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
 import scala.scalanative.libc._
-import scala.scalanative.runtime.{ByteArray, zlib}
+import scala.scalanative.runtime.zlib
 import scala.scalanative.runtime.zlibExt.z_stream
 import scala.scalanative.runtime.zlibOps._
 import zlib._

--- a/javalib/src/main/scala/java/util/zip/Inflater.scala
+++ b/javalib/src/main/scala/java/util/zip/Inflater.scala
@@ -3,7 +3,7 @@ package java.util.zip
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
 import scala.scalanative.libc._
-import scala.scalanative.runtime.{ByteArray, zlib}
+import scala.scalanative.runtime.zlib
 import scala.scalanative.runtime.zlibExt.z_stream
 import scala.scalanative.runtime.zlibOps._
 import zlib._

--- a/javalib/src/main/scala/java/util/zip/InflaterOutputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/InflaterOutputStream.scala
@@ -5,7 +5,6 @@ package java.util.zip
 import java.io.FilterOutputStream
 import java.io.IOException
 import java.io.OutputStream
-import java.util.Arrays
 
 class InflaterOutputStream private (
     out: OutputStream,

--- a/javalib/src/main/scala/java/util/zip/ZipEntry.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipEntry.scala
@@ -4,13 +4,10 @@ package java.util.zip
 
 import java.io.{
   EOFException,
-  IOException,
   InputStream,
   RandomAccessFile,
   UnsupportedEncodingException
 }
-import java.util.{Calendar, Date, GregorianCalendar}
-
 class ZipEntry private (
     private[zip] var name: String,
     private[zip] var comment: String,

--- a/javalib/src/main/scala/java/util/zip/ZipFile.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipFile.scala
@@ -7,7 +7,6 @@ import java.io.{
   BufferedInputStream,
   Closeable,
   File,
-  FileInputStream,
   InputStream,
   RandomAccessFile
 }

--- a/javalib/src/main/scala/java/util/zip/ZipInputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipInputStream.scala
@@ -8,7 +8,7 @@ import java.io.{
   PushbackInputStream,
   UTFDataFormatException
 }
-import java.util.jar.{Attributes, JarEntry}
+import java.util.jar.JarEntry
 
 // Ported from Apache Harmony
 

--- a/javalib/src/main/scala/niocharset/ISO_8859_1.scala
+++ b/javalib/src/main/scala/niocharset/ISO_8859_1.scala
@@ -8,8 +8,6 @@
 
 package niocharset
 
-import java.nio.charset._
-
 private[niocharset] object ISO_8859_1
     extends ISO_8859_1_And_US_ASCII_Common( // format: off
       "ISO-8859-1",

--- a/javalib/src/main/scala/niocharset/ISO_8859_1_And_US_ASCII_Common.scala
+++ b/javalib/src/main/scala/niocharset/ISO_8859_1_And_US_ASCII_Common.scala
@@ -102,8 +102,6 @@ private[niocharset] abstract class ISO_8859_1_And_US_ASCII_Common protected (
   private class Encoder
       extends CharsetEncoder(ISO_8859_1_And_US_ASCII_Common.this, 1.0f, 1.0f) {
     def encodeLoop(in: CharBuffer, out: ByteBuffer): CoderResult = {
-      import java.lang.Character.{MIN_SURROGATE, MAX_SURROGATE}
-
       val maxValue = ISO_8859_1_And_US_ASCII_Common.this.maxValue
       val inRemaining = in.remaining()
       if (inRemaining == 0) {

--- a/javalib/src/main/scala/niocharset/US_ASCII.scala
+++ b/javalib/src/main/scala/niocharset/US_ASCII.scala
@@ -8,8 +8,6 @@
 
 package niocharset
 
-import java.nio.charset._
-
 private[niocharset] object US_ASCII
     extends ISO_8859_1_And_US_ASCII_Common( // format: off
       "US-ASCII",

--- a/javalib/src/main/scala/niocharset/UTF_16.scala
+++ b/javalib/src/main/scala/niocharset/UTF_16.scala
@@ -8,8 +8,6 @@
 
 package niocharset
 
-import java.nio.charset._
-
 private[niocharset] object UTF_16
     extends UTF_16_Common(
       "UTF-16",

--- a/javalib/src/main/scala/niocharset/UTF_16BE.scala
+++ b/javalib/src/main/scala/niocharset/UTF_16BE.scala
@@ -8,8 +8,6 @@
 
 package niocharset
 
-import java.nio.charset._
-
 private[niocharset] object UTF_16BE
     extends UTF_16_Common(
       "UTF-16BE",

--- a/javalib/src/main/scala/niocharset/UTF_16LE.scala
+++ b/javalib/src/main/scala/niocharset/UTF_16LE.scala
@@ -8,8 +8,6 @@
 
 package niocharset
 
-import java.nio.charset._
-
 private[niocharset] object UTF_16LE
     extends UTF_16_Common(
       // scalastyle:ignore

--- a/javalib/src/main/scala/niocharset/UTF_8.scala
+++ b/javalib/src/main/scala/niocharset/UTF_8.scala
@@ -8,7 +8,7 @@
 
 package niocharset
 
-import scala.annotation.{switch, tailrec}
+import scala.annotation.tailrec
 
 import java.nio._
 import java.nio.charset._

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -1,15 +1,14 @@
 package scala.scalanative.nio.fs
 
-import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.libc._
 import scalanative.posix.dirent._
 
 // Import posix name errno as variable, not class or type.
 import scalanative.posix.{errno => posixErrno}, posixErrno._
-import scalanative.posix.{fcntl, unistd}, unistd.access
+import scalanative.posix.unistd, unistd.access
 
-import scalanative.unsafe._, stdlib._, stdio._, string._
+import scalanative.unsafe._, stdio._
 import scalanative.meta.LinktimeInfo.isWindows
 import scala.collection.mutable.UnrolledBuffer
 import scala.reflect.ClassTag
@@ -28,7 +27,6 @@ import scala.scalanative.windows.winnt.AccessRights._
 
 import java.nio.file.WindowsException
 import scala.scalanative.nio.fs.unix.UnixException
-import java.nio.file.attribute.FileAttribute
 
 object FileHelpers {
   sealed trait FileType

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/GenericFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/GenericFileSystemProvider.scala
@@ -1,21 +1,13 @@
 package scala.scalanative.nio.fs
 
-import scala.scalanative.unsafe.{CChar, fromCString, stackalloc}
 import scala.scalanative.unsigned._
-import scala.scalanative.posix.unistd
 import scala.collection.immutable.{Map => SMap}
-import scala.scalanative.nio.fs.unix._
 
-import java.nio.channels.{
-  AsynchronousFileChannel,
-  FileChannel,
-  SeekableByteChannel
-}
+import java.nio.channels.FileChannel
 import java.nio.file._
 import java.nio.file.attribute._
 import java.nio.file.spi.FileSystemProvider
 import java.net.URI
-import java.util.concurrent.ExecutorService
 import java.util.{Map, Set}
 
 abstract class GenericFileSystemProvider extends FileSystemProvider {

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
@@ -16,14 +16,7 @@ import java.nio.file.attribute.UserPrincipalLookupService
 import java.nio.file.attribute.PosixUserPrincipalLookupService
 import java.{util => ju}
 
-import scala.scalanative.unsafe.{
-  CUnsignedLong,
-  Ptr,
-  sizeof,
-  toCString,
-  Zone,
-  alloc
-}
+import scala.scalanative.unsafe._
 
 import scala.scalanative.posix.sys.statvfs
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
@@ -50,10 +50,6 @@ class UnixPath(private val fs: UnixFileSystem, rawPath: String) extends Path {
     else subpath(0, nameCount - 1)
   }
 
-  private lazy val nameCount =
-    if (rawPath.isEmpty()) 1
-    else path.split("/").filter(_.nonEmpty).length
-
   private lazy val normalizedPath = new UnixPath(fs, normalized(this))
 
   private lazy val absPath =

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsAclFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsAclFileAttributeView.scala
@@ -1,24 +1,18 @@
 package scala.scalanative.nio.fs.windows
 
-import java.util.{HashMap, HashSet, Set}
-import java.util.concurrent.TimeUnit
 import java.nio.file.{LinkOption, Path}
 import java.nio.file.attribute._
 
 import scalanative.unsigned._
 import scalanative.unsafe._
-import scalanative.libc._
 import scalanative.annotation.stub
 import scala.scalanative.windows._
 import java.nio.file.WindowsException
-import java.util.WindowsHelperMethods._
 import java.{util => ju}
 
 class WindowsAclFileAttributeView(path: Path, options: Array[LinkOption])
     extends AclFileAttributeView {
   import SecurityBaseApi._
-  import MinWinBaseApi._
-  import WinBaseApi._
   import WinBaseApiExt._
   import AclApi._
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
@@ -5,10 +5,8 @@ import java.util.concurrent.TimeUnit
 import java.nio.file.{LinkOption, Path}
 import java.nio.file.attribute._
 import java.lang.{Boolean => JBoolean}
-import niocharset.StandardCharsets
 import scalanative.unsigned._
 import scalanative.unsafe._
-import scalanative.libc._
 import scala.scalanative.windows._
 import scala.scalanative.windows.MinWinBaseApi.{FileTime => WinFileTime, _}
 import scala.scalanative.windows.MinWinBaseApiOps.FileTimeOps._
@@ -17,7 +15,6 @@ import scala.scalanative.windows.FileApiExt._
 import scala.scalanative.windows.FileApiOps._
 import scala.scalanative.windows.winnt.AccessRights._
 import java.nio.file.WindowsException
-import scala.scalanative.annotation.alwaysinline
 import java.util.WindowsHelperMethods._
 
 final class WindowsDosFileAttributeView(path: Path, options: Array[LinkOption])

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
@@ -12,7 +12,6 @@ import java.nio.file.{
   PathMatcherImpl,
   WatchService
 }
-import java.nio.file.spi.FileSystemProvider
 import java.nio.file.attribute.UserPrincipalLookupService
 import java.util.{LinkedList, Set}
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystemProvider.scala
@@ -1,7 +1,5 @@
 package scala.scalanative.nio.fs.windows
 
-import scala.scalanative.unsafe.{CChar, fromCString, stackalloc}
-import scala.scalanative.unsigned._
 import scala.collection.immutable.{Map => SMap}
 import scala.scalanative.nio.fs.GenericFileSystemProvider
 import java.nio.file.attribute._

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
@@ -14,10 +14,7 @@ import java.nio.file.{
   WatchService
 }
 import java.util.Iterator
-import scala.scalanative.nio.fs.unix._
-import scala.collection.mutable.UnrolledBuffer
 import scalanative.annotation.alwaysinline
-import java.awt.Window
 
 class WindowsPath private[windows] (
     val pathType: WindowsPath.PathType,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPathParser.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPathParser.scala
@@ -1,20 +1,6 @@
 package scala.scalanative.nio.fs.windows
 
-import java.io.File
-import java.net.URI
-import java.nio.file.{
-  FileSystem,
-  Files,
-  LinkOption,
-  NoSuchFileException,
-  Path,
-  WatchEvent,
-  WatchKey
-}
-import java.util.Iterator
-import scala.collection.mutable.UnrolledBuffer
 import scalanative.annotation.alwaysinline
-import java.awt.Window
 import java.nio.file.InvalidPathException
 import scala.annotation.tailrec
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipal.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipal.scala
@@ -5,16 +5,13 @@ import java.nio.file.attribute._
 import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.windows._
-import java.util.WindowsHelperMethods._
 import java.nio.file.WindowsException
 
 sealed trait WindowsUserPrincipal extends UserPrincipal
 
 object WindowsUserPrincipal {
   import SecurityBaseApi._
-  import MinWinBaseApi._
   import WinBaseApi._
-  import AclApi._
   import winnt.SidNameUse
 
   case class User(sidString: String, accountName: String, sidType: SidNameUse)

--- a/javalib/src/main/scala/scala/scalanative/runtime/JoinNonDeamonThreads.scala
+++ b/javalib/src/main/scala/scala/scalanative/runtime/JoinNonDeamonThreads.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.runtime
 
 import NativeThread.Registry
-import Thread.MainThread
 
 object JoinNonDaemonThreads {
   def registerExitHook(): Unit = Shutdown.addHook { () =>

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
@@ -6,7 +6,6 @@ import scala.scalanative.runtime.libc._
 import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 import scala.scalanative.runtime.Intrinsics._
 import scala.scalanative.runtime.libc.memory_order._
-import scala.scalanative.unsigned._
 
 // Factored out LazyVals immutable state, allowing to treat LazyVals as constant module,
 // alowing to skip loading of the module on each call to its methods

--- a/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.unsafe
 
 import scala.scalanative.runtime._
-import scala.scalanative.unsigned._
 import scala.scalanative.runtime.Intrinsics.{castRawSizeToInt as toInt}
 
 private[scalanative] trait UnsafePackageCompat {

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -1,6 +1,5 @@
 package java.lang
 
-import scala.scalanative.unsafe._
 import scala.scalanative.runtime._
 import scala.scalanative.runtime.Intrinsics._
 import scala.scalanative.unsigned._

--- a/nativelib/src/main/scala/java/lang/resource/EmbeddedResourceInputStream.scala
+++ b/nativelib/src/main/scala/java/lang/resource/EmbeddedResourceInputStream.scala
@@ -1,7 +1,6 @@
 package java.lang.resource
 
 import java.io.InputStream
-import scala.scalanative.runtime._
 
 private[lang] class EmbeddedResourceInputStream(resourceId: Int)
     extends InputStream {
@@ -38,12 +37,6 @@ private[lang] class EmbeddedResourceInputStream(resourceId: Int)
   override def reset(): Unit = {
     position = markPosition
     leftSeq = markSeq
-    markReadLimit = 0
-  }
-
-  private def invalidateMark(): Unit = {
-    markPosition = 0
-    markSeq = Seq.empty
     markReadLimit = 0
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/regex/CharClass.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/CharClass.scala
@@ -14,22 +14,16 @@ package regex
 //
 // All methods mutate the internal state and return {@code this}, allowing
 // operations to be chained.
-class CharClass private (unit: Unit) {
+// Constructs a CharClass with initial ranges |r|.
+// The right to mutate |r| is passed to the callee.
+class CharClass(
+    // inclusive ranges, pairs of [lo,hi].  r.length is even.
+    private var r: Array[Int]
+) {
   import CharClass._
 
-  // inclusive ranges, pairs of [lo,hi].  r.length is even.
-  private var r: Array[Int] = _
-
   // prefix of |r| that is defined.  Even.
-  private var len: Int = _
-
-  // Constructs a CharClass with initial ranges |r|.
-  // The right to mutate |r| is passed to the callee.
-  def this(r: Array[Int]) = {
-    this(())
-    this.r = r
-    this.len = r.length
-  }
+  private var len: Int = r.length
 
   // Size the initial allocaton to reduce the number of doublings & copies
   // yet still be provident with memory.
@@ -37,9 +31,7 @@ class CharClass private (unit: Unit) {
 
   // Constructs an empty CharClass.
   def this() = {
-    this(())
-    val initialCapacity = 16
-    this.r = new Array[Int](initialCapacity)
+    this(new Array[Int](16))
     this.len = 0
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/regex/CharGroup.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/CharGroup.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package regex
 
-import java.util.HashMap
-
 class CharGroup(val sign: Int, val cls: Array[Int])
 
 object CharGroup {

--- a/nativelib/src/main/scala/scala/scalanative/regex/Machine.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Machine.scala
@@ -68,10 +68,6 @@ class Machine(re2: RE2) {
     t
   }
 
-  // free() returns t to the free pool.
-  private def free(t: Thread): Unit =
-    pool.add(t)
-
   // match() runs the machine over the input |in| starting at |pos| with the
   // RE2 Anchor |anchor|.
   // It reports whether a match was found.

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package runtime
 
 import scalanative.unsafe._
-import scalanative.unsigned.USize
 
 object Intrinsics {
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
@@ -2,10 +2,9 @@ package scala.scalanative.runtime
 package monitor
 
 import LockWord._
-import scala.annotation.{tailrec, switch}
+import scala.annotation.tailrec
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.unsafe.{stackalloc => _, _}
-import scala.scalanative.runtime.NativeThread
 import scala.scalanative.runtime.Intrinsics._
 import scala.scalanative.runtime.libc._
 import scala.scalanative.runtime.libc.memory_order._

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
@@ -236,13 +236,11 @@ private[monitor] class ObjectMonitor() {
     // assert(ownerThread != currentThread)
 
     // Current thread is no longer the owner, wait for the notification
-    val deadline = if (nanos > 0) System.nanoTime() + nanos else -1
     val interruped = currentThread.isInterrupted()
     if (!interruped && !node.isNotified) {
       if (nanos == 0) LockSupport.park(this)
       else LockSupport.parkNanos(this, nanos)
     }
-    val isTimedout = nanos > 0 && System.nanoTime() >= deadline
     if (node.state == WaiterNode.Waiting) {
       acquireWaitList()
       // Skip unlinking node if was moved from waitQueue to enterQueue by notify call
@@ -318,8 +316,6 @@ private[monitor] class ObjectMonitor() {
     classFieldRawPtr(this, "ownerThread")
   @alwaysinline private def arriveQueuePtr =
     classFieldRawPtr(this, "arriveQueue")
-  @alwaysinline private def enterQueuePtr =
-    classFieldRawPtr(this, "enterQueue")
 
   @alwaysinline private def waitListModificationLockPtr =
     classFieldRawPtr(this, "waitListModifcationLock")

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/package.scala
@@ -1,6 +1,5 @@
 package scala.scalanative.runtime
 
-import scala.scalanative.unsafe._
 import scala.scalanative.runtime.Intrinsics._
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.meta.LinktimeInfo.{is32BitPlatform => is32bit}

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -5,10 +5,7 @@ import scalanative.unsafe._
 import scalanative.unsigned.USize
 import scalanative.runtime.Intrinsics._
 import scalanative.runtime.monitor._
-import scala.scalanative.meta.LinktimeInfo.{
-  isMultithreadingEnabled,
-  is32BitPlatform
-}
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 
 package object runtime {
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CArray.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CArray.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package unsafe
 
 import scalanative.annotation.alwaysinline
-import scalanative.unsigned._
 import scalanative.runtime.RawPtr
 import scalanative.runtime.Intrinsics._
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CVarArg.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CVarArg.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package unsafe
 
 import scala.language.implicitConversions
-import runtime.intrinsic
 
 /** Type of a C-style vararg in an extern method. */
 final class CVarArg(val value: Any, val tag: Tag[Any])

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Ptr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Ptr.scala
@@ -5,7 +5,7 @@ import scala.language.implicitConversions
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.runtime.Intrinsics._
 import scala.scalanative.runtime._
-import scala.scalanative.unsigned.{USize, UnsignedRichLong}
+import scala.scalanative.unsigned.USize
 
 final class Ptr[T] private[scalanative] (
     private[scalanative] val rawptr: RawPtr

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala
@@ -13,12 +13,8 @@ package unsafe
 
 import scala.language.implicitConversions
 
-import scala.runtime.BoxesRunTime._
-import scala.reflect.ClassTag
-
 import scalanative.runtime._
 import scalanative.runtime.Intrinsics._
-import scalanative.runtime.Boxes._
 
 import scalanative.unsigned._
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala.gyb
@@ -13,12 +13,8 @@ package unsafe
 
 import scala.language.implicitConversions
 
-import scala.runtime.BoxesRunTime._
-import scala.reflect.ClassTag
-
 import scalanative.runtime._
 import scalanative.runtime.Intrinsics._
-import scalanative.runtime.Boxes._
 
 import scalanative.unsigned._
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
@@ -2,9 +2,7 @@ package scala.scalanative
 package unsafe
 
 import scala.annotation.implicitNotFound
-import scalanative.runtime.{libc, RawPtr, fromRawPtr}
 import scalanative.runtime.{MemoryPool, MemoryPoolZone}
-import scalanative.unsigned._
 
 /** Zone allocator which manages memory allocations. */
 @implicitNotFound("Given method requires an implicit zone.")

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/resolvedAtLinktime.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/resolvedAtLinktime.scala
@@ -2,7 +2,6 @@ package scala.scalanative.unsafe
 
 import scala.annotation.StaticAnnotation
 import scala.annotation.meta.{field, getter}
-import scala.scalanative.runtime.intrinsic
 
 /** Used to annotate that given value should be resolved at link-time, based on
  *  provided `withName` parameter

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala
@@ -13,12 +13,8 @@ package unsigned
 
 import scala.language.implicitConversions
 
-import scala.runtime.BoxesRunTime._
-import scala.reflect.ClassTag
-
 import scalanative.runtime._
 import scalanative.runtime.Intrinsics._
-import scalanative.runtime.Boxes._
 import unsafe._
 
 import java.lang.{Long => JLong}

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala.gyb
@@ -13,12 +13,8 @@ package unsigned
 
 import scala.language.implicitConversions
 
-import scala.runtime.BoxesRunTime._
-import scala.reflect.ClassTag
-
 import scalanative.runtime._
 import scalanative.runtime.Intrinsics._
-import scalanative.runtime.Boxes._
 import unsafe._
 
 import java.lang.{Long => JLong}

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/package.scala
@@ -1,9 +1,6 @@
 package scala.scalanative
 
-import java.nio.charset.Charset
 import scala.language.experimental.macros
-import scalanative.runtime.{libc, intrinsic, fromRawPtr}
-import scalanative.runtime.Intrinsics.castLongToRawSize
 
 package object unsigned {
 

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -1,7 +1,6 @@
 package scala.scalanative
 package nir
 
-import scala.collection.mutable
 import nir.Attr._
 
 sealed abstract class Attr {

--- a/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package nir
 
-import java.util.concurrent.atomic.AtomicInteger
-
 final class Fresh private (private var start: Long) {
   def apply(): Local = {
     start += 1

--- a/nir/src/main/scala/scala/scalanative/nir/MemoryOrder.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/MemoryOrder.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package nir
 
-import scala.annotation.switch
-
 case class SyncAttrs(
     memoryOrder: MemoryOrder,
     isVolatile: Boolean = true

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -1,7 +1,6 @@
 package scala.scalanative
 package nir
 
-import scala.annotation.tailrec
 import scala.language.implicitConversions
 
 final class Sig(val mangle: String) {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -159,7 +159,6 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     case T.ZSizeCastConv => Conv.ZSizeCast
   }
 
-  private def getDefns(): Seq[Defn] = getSeq(getDefn())
   private def getDefn(): Defn = {
     implicit val pos: nir.Position = getPosition()
     getInt() match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -5,7 +5,6 @@ package serialization
 import java.net.URI
 import java.io.{DataOutputStream, OutputStream}
 import java.nio.charset.StandardCharsets
-import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.scalanative.nir.serialization.{Tags => T}
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -2,10 +2,7 @@ package scala.scalanative.nscplugin
 
 import dotty.tools._
 import dotc._
-import dotc.transform.{LazyVals, MoveStatics}
 import dotc.ast.tpd._
-import plugins._
-import core.Flags._
 import core.Contexts._
 import core.Names._
 import core.Symbols._
@@ -45,7 +42,7 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
       val template @ Template(_, _, _, _) = td.rhs: @unchecked
       bitmapFieldNames ++= template.body.collect {
         case vd: ValDef if isLazyFieldOffset(vd.name) =>
-          import LazyValsNames.{LazyVals, *}
+          import LazyValsNames.*
           val fieldname = vd.rhs match {
             // Scala 3.1.x
             case Apply(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNativeExports.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNativeExports.scala
@@ -13,7 +13,7 @@ import dotty.tools.dotc.transform.SymUtils.*
 
 import scala.scalanative.nir
 import nir._
-import scala.scalanative.util.ScopedVar.{scoped, toValue}
+import scala.scalanative.util.ScopedVar.scoped
 
 trait GenNativeExports(using Context):
   self: NirCodeGen =>

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -6,7 +6,6 @@ import dotty.tools.dotc.ast.tpd._
 import dotty.tools.dotc.core
 import core.Contexts._
 import core.Symbols._
-import core.Constants._
 import core.StdNames._
 import core.Flags._
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -6,11 +6,7 @@ import core.Symbols.{toClassDenot, toDenot}
 import core.Contexts._
 import core.Names._
 import core.Types._
-import core.Decorators._
-import dotty.tools.backend.jvm.DottyPrimitives
 import scala.annotation.{threadUnsafe => tu}
-import dotty.tools.dotc.parsing.Scanners.IndentWidth.Run
-import dotty.tools.dotc.core.Definitions
 import dotty.tools.dotc.util.Property.StickyKey
 import NirGenUtil.ContextCached
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/fnmatch.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fnmatch.scala
@@ -3,8 +3,6 @@ package posix
 
 import scalanative.unsafe._
 
-import scalanative.posix.sys.types
-
 /** POSIX fnmatch.h for Scala
  *
  *  The Open Group Base Specifications

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -3,7 +3,6 @@ package scala.scalanative.posix
 import scalanative.unsafe._
 
 import scalanative.posix.sys.socket
-import scalanative.posix.netinet.in
 
 import scalanative.runtime.Platform
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe, unsafe._
+import scalanative.unsafe._
 import scalanative.posix.sys.types, types.{off_t, size_t}
 
 @extern object stdio extends stdio

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -6,8 +6,6 @@ import scalanative.unsafe._
 import scalanative.posix.time._
 import scalanative.posix.sys.types._
 
-import scalanative.meta.LinktimeInfo.is32BitPlatform
-
 @extern
 object stat {
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package posix
 package sys
 
-import scalanative.unsafe.{CInt, CLong, CLongInt, CStruct2, Ptr, extern}
+import scalanative.unsafe._
 import scalanative.posix.sys.types.{suseconds_t, time_t}
 
 @extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
@@ -4,8 +4,6 @@ package sys
 
 import scalanative.unsafe._
 
-import scalanative.posix.signal
-
 /** POSIX wait.h for Scala
  *
  *  The Open Group Base Specifications

--- a/posixlib/src/main/scala/scala/scalanative/posix/tgmath.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/tgmath.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package posix
 
-import scala.scalanative.unsafe._
-
 object tgmath extends tgmath
 
 trait tgmath extends libc.tgmath {

--- a/windowslib/src/main/scala/scala/scalanative/windows/HandleApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/HandleApi.scala
@@ -1,7 +1,7 @@
 package scala.scalanative.windows
 
 import scala.scalanative.runtime.fromRawPtr
-import scala.scalanative.runtime.Intrinsics.{castIntToRawPtr, castLongToRawPtr}
+import scala.scalanative.runtime.Intrinsics.{castLongToRawPtr}
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.windows.HandleApi.Handle

--- a/windowslib/src/main/scala/scala/scalanative/windows/NamedPipeApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/NamedPipeApi.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.windows
 
 import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
 import HandleApi.Handle
 import WinBaseApi.SecurityAttributes
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/SddlApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SddlApi.scala
@@ -1,13 +1,10 @@
 package scala.scalanative.windows
 
 import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
-import scala.scalanative.windows.HandleApi.Handle
 
 @link("Advapi32")
 @extern()
 object SddlApi {
-  import MinWinBaseApi._
   import SecurityBaseApi._
   def ConvertSidToStringSidW(sid: SIDPtr, stringSid: Ptr[CWString]): Boolean =
     extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.windows
 
 import scala.scalanative.unsafe.{Word => _, _}
-import scala.scalanative.unsigned._
 import scala.scalanative.windows.HandleApi.Handle
 
 @link("Advapi32")

--- a/windowslib/src/main/scala/scala/scalanative/windows/UserEnvApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/UserEnvApi.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.windows
 
 import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
 import scala.scalanative.windows.HandleApi.Handle
 
 @link("Userenv")

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/ops.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/ops.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.windows.accctrl
 
 import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
 import scala.scalanative.windows._
 
 import AclApi._

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/package.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/package.scala
@@ -6,7 +6,6 @@ import scala.scalanative.windows._
 
 import AclApi._
 import SecurityBaseApi._
-import WinBaseApi._
 
 package object accctrl {
   type AccessMode = CInt

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.windows.winnt
 
 import scalanative.unsafe._
-import scalanative.windows.DWord
 
 @link("Advapi32")
 @extern


### PR DESCRIPTION
Removes most of the warnings in the main sources detected in Scala 3.3.0-RC4 -WwarnUnused, there are still ~250 warnings in tests, and ~50 warnings in main sources, due to either false positives (2), unusused parameters in constructors (for compliance with JDK API), parameters in annotations, and a few cases witch should be annotated with `@nowarn`

Notes: 
At this moment it's too early to enable `-WwarnUnused` settings in default scalacOptions if we continue to compile with `-Xfatal-warnings`.