### PR TITLE
Fix referential equality of scala.reflect.ClassTag by caching underlying Manifest instances

### DIFF
--- a/scalalib/overrides-2.12/scala/reflect/Manifest.scala.patch
+++ b/scalalib/overrides-2.12/scala/reflect/Manifest.scala.patch
@@ -1,6 +1,11 @@
---- 2.12.15/scala/reflect/Manifest.scala
+--- 2.12.17/scala/reflect/Manifest.scala
 +++ overrides-2.12/scala/reflect/Manifest.scala
-@@ -76,8 +76,8 @@
+@@ -1,3 +1,4 @@
++
+ /*
+  * Scala (https://www.scala-lang.org)
+  *
+@@ -76,8 +77,8 @@
      case _                    => false
    }
    override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
@@ -11,136 +16,20 @@
  }
  
  /** `ManifestFactory` defines factory methods for manifests.
-@@ -105,7 +105,7 @@
-     }
-     private def readResolve(): Any = Manifest.Byte
+@@ -241,9 +242,9 @@
    }
--  val Byte: AnyValManifest[Byte] = new ByteManifest
-+  @inline def Byte: AnyValManifest[Byte] = new ByteManifest
+   val Unit: AnyValManifest[Unit] = new UnitManifest
+ 
+-  private val ObjectTYPE = classOf[java.lang.Object]
+-  private val NothingTYPE = classOf[scala.runtime.Nothing$]
+-  private val NullTYPE = classOf[scala.runtime.Null$]
++  @inline private def ObjectTYPE = classOf[java.lang.Object]
++  @inline private def NothingTYPE = classOf[scala.runtime.Nothing$]
++  @inline private def NullTYPE = classOf[scala.runtime.Null$]
  
    @SerialVersionUID(1L)
-   private class ShortManifest extends AnyValManifest[scala.Short]("Short") {
-@@ -121,7 +121,7 @@
-     }
-     private def readResolve(): Any = Manifest.Short
-   }
--  val Short: AnyValManifest[Short] = new ShortManifest
-+  @inline def Short: AnyValManifest[Short] = new ShortManifest
- 
-   @SerialVersionUID(1L)
-   private class CharManifest extends AnyValManifest[scala.Char]("Char") {
-@@ -137,7 +137,7 @@
-     }
-     private def readResolve(): Any = Manifest.Char
-   }
--  val Char: AnyValManifest[Char] = new CharManifest
-+  @inline def Char: AnyValManifest[Char] = new CharManifest
- 
-   @SerialVersionUID(1L)
-   private class IntManifest extends AnyValManifest[scala.Int]("Int") {
-@@ -153,7 +153,7 @@
-     }
-     private def readResolve(): Any = Manifest.Int
-   }
--  val Int: AnyValManifest[Int] = new IntManifest
-+  @inline def Int: AnyValManifest[Int] = new IntManifest
- 
-   @SerialVersionUID(1L)
-   private class LongManifest extends AnyValManifest[scala.Long]("Long") {
-@@ -169,7 +169,7 @@
-     }
-     private def readResolve(): Any = Manifest.Long
-   }
--  val Long: AnyValManifest[Long] = new LongManifest
-+  @inline def Long: AnyValManifest[Long] = new LongManifest
- 
-   @SerialVersionUID(1L)
-   private class FloatManifest extends AnyValManifest[scala.Float]("Float") {
-@@ -185,7 +185,7 @@
-     }
-     private def readResolve(): Any = Manifest.Float
-   }
--  val Float: AnyValManifest[Float] = new FloatManifest
-+  @inline def Float: AnyValManifest[Float] = new FloatManifest
- 
-   @SerialVersionUID(1L)
-   private class DoubleManifest extends AnyValManifest[scala.Double]("Double") {
-@@ -204,7 +204,7 @@
-     }
-     private def readResolve(): Any = Manifest.Double
-   }
--  val Double: AnyValManifest[Double] = new DoubleManifest
-+  @inline def Double: AnyValManifest[Double] = new DoubleManifest
- 
-   @SerialVersionUID(1L)
-   private class BooleanManifest extends AnyValManifest[scala.Boolean]("Boolean") {
-@@ -220,7 +220,7 @@
-     }
-     private def readResolve(): Any = Manifest.Boolean
-   }
--  val Boolean: AnyValManifest[Boolean] = new BooleanManifest
-+  @inline def Boolean: AnyValManifest[Boolean] = new BooleanManifest
- 
-   @SerialVersionUID(1L)
-   private class UnitManifest extends AnyValManifest[scala.Unit]("Unit") {
-@@ -239,7 +239,7 @@
-     }
-     private def readResolve(): Any = Manifest.Unit
-   }
--  val Unit: AnyValManifest[Unit] = new UnitManifest
-+  @inline def Unit: AnyValManifest[Unit] = new UnitManifest
- 
-   private val ObjectTYPE = classOf[java.lang.Object]
-   private val NothingTYPE = classOf[scala.runtime.Nothing$]
-@@ -251,7 +251,7 @@
-     override def <:<(that: ClassManifest[_]): Boolean = (that eq this)
-     private def readResolve(): Any = Manifest.Any
-   }
--  val Any: Manifest[scala.Any] = new AnyManifest
-+  @inline def Any: Manifest[scala.Any] = new AnyManifest
- 
-   @SerialVersionUID(1L)
-   private class ObjectManifest extends PhantomManifest[java.lang.Object](ObjectTYPE, "Object") {
-@@ -259,9 +259,9 @@
-     override def <:<(that: ClassManifest[_]): Boolean = (that eq this) || (that eq Any)
-     private def readResolve(): Any = Manifest.Object
-   }
--  val Object: Manifest[java.lang.Object] = new ObjectManifest
-+  @inline def Object: Manifest[java.lang.Object] = new ObjectManifest
- 
--  val AnyRef: Manifest[scala.AnyRef] = Object.asInstanceOf[Manifest[scala.AnyRef]]
-+  @inline def AnyRef: Manifest[scala.AnyRef] = Object.asInstanceOf[Manifest[scala.AnyRef]]
- 
-   @SerialVersionUID(1L)
-   private class AnyValPhantomManifest extends PhantomManifest[scala.AnyVal](ObjectTYPE, "AnyVal") {
-@@ -269,7 +269,7 @@
-     override def <:<(that: ClassManifest[_]): Boolean = (that eq this) || (that eq Any)
-     private def readResolve(): Any = Manifest.AnyVal
-   }
--  val AnyVal: Manifest[scala.AnyVal] = new AnyValPhantomManifest
-+  @inline def AnyVal: Manifest[scala.AnyVal] = new AnyValPhantomManifest
- 
-   @SerialVersionUID(1L)
-   private class NullManifest extends PhantomManifest[scala.Null](NullTYPE, "Null") {
-@@ -278,7 +278,7 @@
-       (that ne null) && (that ne Nothing) && !(that <:< AnyVal)
-     private def readResolve(): Any = Manifest.Null
-   }
--  val Null: Manifest[scala.Null] = new NullManifest
-+  @inline def Null: Manifest[scala.Null] = new NullManifest
- 
-   @SerialVersionUID(1L)
-   private class NothingManifest extends PhantomManifest[scala.Nothing](NothingTYPE, "Nothing") {
-@@ -286,7 +286,7 @@
-     override def <:<(that: ClassManifest[_]): Boolean = (that ne null)
-     private def readResolve(): Any = Manifest.Nothing
-   }
--  val Nothing: Manifest[scala.Nothing] = new NothingManifest
-+  @inline def Nothing: Manifest[scala.Nothing] = new NothingManifest
- 
-   @SerialVersionUID(1L)
-   private class SingletonTypeManifest[T <: AnyRef](value: AnyRef) extends Manifest[T] {
-@@ -323,8 +323,8 @@
+   private class AnyManifest extends PhantomManifest[scala.Any](ObjectTYPE, "Any") {
+@@ -323,8 +324,8 @@
    private abstract class PhantomManifest[T](_runtimeClass: Predef.Class[_],
                                              override val toString: String) extends ClassTypeManifest[T](None, _runtimeClass, Nil) {
      override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/scalalib/reflect/ClassTagTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/scalalib/reflect/ClassTagTest.scala
@@ -17,14 +17,12 @@ class ClassTagTest {
         assertSame(ClassTag.Double, implicitly[ClassTag[Double]])
         assertSame(ClassTag.Boolean, implicitly[ClassTag[Boolean]])
         assertSame(ClassTag.Unit, implicitly[ClassTag[Unit]])
-        assertSame(ClassTag.Any, implicitly[ClassTag[Any]])
-        assertSame(ClassTag.Any, implicitly[ClassTag[Any]])
         assertSame(ClassTag.Object, implicitly[ClassTag[Object]])
         assertSame(ClassTag.AnyVal, implicitly[ClassTag[AnyVal]])
         assertSame(ClassTag.AnyRef, implicitly[ClassTag[AnyRef]])
-        assertSame(ClassTag.Nothing, implicitly[ClassTag[Nothing]])
-        assertSame(ClassTag.Null, implicitly[ClassTag[Null]])
         assertSame(ClassTag.Any, implicitly[ClassTag[Any]])
-        assertSame(ClassTag.Any, implicitly[ClassTag[Any]])
+        // No implicit ClassTag in Scala 3
+        assertSame(ClassTag.Nothing, ClassTag.Nothing)
+        assertSame(ClassTag.Null, ClassTag.Null)
     }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/scalalib/reflect/ClassTagTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/scalalib/reflect/ClassTagTest.scala
@@ -1,0 +1,30 @@
+package org.scalanative.testsuite.scalalib.reflect
+
+import scala.reflect.ClassTag
+
+import org.junit._
+import org.junit.Assert._
+
+class ClassTagTest {
+
+    @Test def referentialEquality(): Unit = {
+        assertSame(ClassTag.Byte, implicitly[ClassTag[Byte]])
+        assertSame(ClassTag.Short, implicitly[ClassTag[Short]])
+        assertSame(ClassTag.Char, implicitly[ClassTag[Char]])
+        assertSame(ClassTag.Int, implicitly[ClassTag[Int]])
+        assertSame(ClassTag.Long, implicitly[ClassTag[Long]])
+        assertSame(ClassTag.Float, implicitly[ClassTag[Float]])
+        assertSame(ClassTag.Double, implicitly[ClassTag[Double]])
+        assertSame(ClassTag.Boolean, implicitly[ClassTag[Boolean]])
+        assertSame(ClassTag.Unit, implicitly[ClassTag[Unit]])
+        assertSame(ClassTag.Any, implicitly[ClassTag[Any]])
+        assertSame(ClassTag.Any, implicitly[ClassTag[Any]])
+        assertSame(ClassTag.Object, implicitly[ClassTag[Object]])
+        assertSame(ClassTag.AnyVal, implicitly[ClassTag[AnyVal]])
+        assertSame(ClassTag.AnyRef, implicitly[ClassTag[AnyRef]])
+        assertSame(ClassTag.Nothing, implicitly[ClassTag[Nothing]])
+        assertSame(ClassTag.Null, implicitly[ClassTag[Null]])
+        assertSame(ClassTag.Any, implicitly[ClassTag[Any]])
+        assertSame(ClassTag.Any, implicitly[ClassTag[Any]])
+    }
+}


### PR DESCRIPTION
Fixes #3244