### PR TITLE
Correctly memset all allocated memory for stackallocN in scala 2

### DIFF
--- a/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -139,7 +139,7 @@ private object MacroImpl {
           val $rawSize = $runtime.Intrinsics.sizeOf[$T]
           val $size    = $runtime.fromRawUSize($rawSize) * $n
           val $rawptr  = $runtime.Intrinsics.stackalloc($size)
-          $runtime.libc.memset($rawptr, 0, $rawSize)
+          $runtime.libc.memset($rawptr, 0, $runtime.toRawSize($size))
           $runtime.fromRawPtr[$T]($rawptr)
         }"""
   }


### PR DESCRIPTION
Previously we are only `memset`-ing the first element, leaving the rest uninitialized.
