### PR TITLE
Expose parsed target triple in `LinktimeInfo`

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1847,3 +1847,7 @@ The original license notice is included below:
 
 Additions by this project to the original `epollcat` implementation carry
 the Scala Native license.
+
+# License notice for LLVM
+
+Scala Native's `tools/` contains parts that are derived from the [LLVM Project](https://llvm.org/). Those parts are either marked with `// ported from LLVM` and/or include the full copyright preamble in the source code file. The original code was licensed under Apache License Version v2.0 with LLVM Exceptions.

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -24,9 +24,6 @@ object LinktimeInfo {
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isFreeBSD")
   def isFreeBSD: Boolean = resolved
 
-  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.arch")
-  def arch: String = resolved
-
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.is32BitPlatform")
   def is32BitPlatform: Boolean = resolved
 
@@ -42,4 +39,15 @@ object LinktimeInfo {
     "scala.scalanative.meta.linktimeinfo.isMultithreadingEnabled"
   )
   def isMultithreadingEnabled: Boolean = resolved
+
+  object target {
+    @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.target.arch")
+    def arch: String = resolved
+    @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.target.vendor")
+    def vendor: String = resolved
+    @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.target.os")
+    def os: String = resolved
+    @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.target.env")
+    def env: String = resolved
+  }
 }

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -12,17 +12,17 @@ object LinktimeInfo {
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.releaseMode")
   def releaseMode: Boolean = resolved
 
-  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isWindows")
-  def isWindows: Boolean = resolved
+  @resolvedAtLinktime
+  def isWindows: Boolean = target.os == "windows"
 
-  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isLinux")
-  def isLinux: Boolean = resolved
+  @resolvedAtLinktime
+  def isLinux: Boolean = target.os == "linux"
 
-  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isMac")
-  def isMac: Boolean = resolved
+  @resolvedAtLinktime
+  def isMac: Boolean = target.vendor == "apple" && target.os == "darwin"
 
-  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isFreeBSD")
-  def isFreeBSD: Boolean = resolved
+  @resolvedAtLinktime
+  def isFreeBSD: Boolean = target.os == "freebsd"
 
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.is32BitPlatform")
   def is32BitPlatform: Boolean = resolved

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -24,6 +24,9 @@ object LinktimeInfo {
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isFreeBSD")
   def isFreeBSD: Boolean = resolved
 
+  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.arch")
+  def arch: String = resolved
+
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.is32BitPlatform")
   def is32BitPlatform: Boolean = resolved
 

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -76,7 +76,7 @@ sealed trait NativeConfig {
   def optimizerConfig: OptimizerConfig
 
   private[scalanative] lazy val configuredOrDetectedTriple =
-    targetTriple.getOrElse(Discover.targetTriple(this))
+    TargetTriple.parse(targetTriple.getOrElse(Discover.targetTriple(this)))
 
   /** Are we targeting a 32-bit platform?
    *
@@ -85,10 +85,7 @@ sealed trait NativeConfig {
    *  architecture for a name that is not found seems excessive perhaps?
    */
   def is32BitPlatform = {
-    configuredOrDetectedTriple
-      .split('-')
-      .headOption
-      .getOrElse("") match {
+    configuredOrDetectedTriple.arch match {
       case "x86_64"  => false
       case "aarch64" => false
       case "arm64"   => false

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -75,7 +75,8 @@ sealed trait NativeConfig {
   /** Configuration when doing optimization */
   def optimizerConfig: OptimizerConfig
 
-  private lazy val detectedTriple = Discover.targetTriple(this)
+  private[scalanative] lazy val configuredOrDetectedTriple =
+    targetTriple.getOrElse(Discover.targetTriple(this))
 
   /** Are we targeting a 32-bit platform?
    *
@@ -84,8 +85,7 @@ sealed trait NativeConfig {
    *  architecture for a name that is not found seems excessive perhaps?
    */
   def is32BitPlatform = {
-    targetTriple
-      .getOrElse(detectedTriple)
+    configuredOrDetectedTriple
       .split('-')
       .headOption
       .getOrElse("") match {

--- a/tools/src/main/scala/scala/scalanative/build/TargetTriple.scala
+++ b/tools/src/main/scala/scala/scalanative/build/TargetTriple.scala
@@ -28,10 +28,10 @@ private[scalanative] object TargetTriple {
     val components = triple.split("-", 4).toList
     val unknown = "unknown"
     TargetTriple(
-      components.unapply(0).map(Arch.parse).getOrElse(unknown),
-      components.unapply(1).map(Vendor.parse).getOrElse(unknown),
-      components.unapply(2).map(OS.parse).getOrElse(unknown),
-      components.unapply(3).map(Env.parse).getOrElse(unknown)
+      components.lift(0).map(Arch.parse).getOrElse(unknown),
+      components.lift(1).map(Vendor.parse).getOrElse(unknown),
+      components.lift(2).map(OS.parse).getOrElse(unknown),
+      components.lift(3).map(Env.parse).getOrElse(unknown)
     )
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/TargetTriple.scala
+++ b/tools/src/main/scala/scala/scalanative/build/TargetTriple.scala
@@ -1,0 +1,453 @@
+// ported from LLVM 887d6ab dated 2023-04-16
+
+//===--- Triple.cpp - Target triple helper class --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+package scala.scalanative
+package build
+
+import java.nio.ByteOrder
+
+private[scalanative] final case class TargetTriple(
+    arch: String,
+    vendor: String,
+    os: String,
+    env: String
+) {
+  override def toString = s"$arch-$vendor-$os-$env"
+}
+
+private[scalanative] object TargetTriple {
+
+  def parse(triple: String): TargetTriple = {
+    val components = triple.split("-", 4).toList
+    val unknown = "unknown"
+    TargetTriple(
+      components.unapply(0).map(Arch.parse).getOrElse(unknown),
+      components.unapply(1).map(Vendor.parse).getOrElse(unknown),
+      components.unapply(2).map(OS.parse).getOrElse(unknown),
+      components.unapply(3).map(Env.parse).getOrElse(unknown)
+    )
+  }
+
+  object Arch {
+    def parse(str: String): String = str match {
+      case "i386" | "i486" | "i586" | "i686"          => x86
+      case "i786" | "i886" | "i986"                   => x86
+      case "amd64" | "x86_64" | "x86_64h"             => x86_64
+      case "powerpc" | "powerpcspe" | "ppc" | "ppc32" => ppc
+      case "powerpcle" | "ppcle" | "ppc32le"          => ppcle
+      case "powerpc64" | "ppu" | "ppc64"              => ppc64
+      case "powerpc64le" | "ppc64le"                  => ppc64le
+      case "xscale"                                   => arm
+      case "xscaleeb"                                 => armeb
+      case "aarch64"                                  => aarch64
+      case "aarch64_be"                               => aarch64_be
+      case "aarch64_32"                               => aarch64_32
+      case "arc"                                      => arc
+      case "arm64"                                    => aarch64
+      case "arm64_32"                                 => aarch64_32
+      case "arm64e"                                   => aarch64
+      case "arm64ec"                                  => aarch64
+      case "arm"                                      => arm
+      case "armeb"                                    => armeb
+      case "thumb"                                    => thumb
+      case "thumbeb"                                  => thumbeb
+      case "avr"                                      => avr
+      case "m68k"                                     => m68k
+      case "msp430"                                   => msp430
+      case "mips" | "mipseb" | "mipsallegrex" | "mipsisa32r6" | "mipsr6" => mips
+      case "mipsel" | "mipsallegrexel" | "mipsisa32r6el" | "mipsr6el" =>
+        mipsel
+      case "mips64" | "mips64eb" | "mipsn32" | "mipsisa64r6" | "mips64r6" |
+          "mipsn32r6" =>
+        mips64
+      case "mips64el" | "mipsn32el" | "mipsisa64r6el" | "mips64r6el" |
+          "mipsn32r6el" =>
+        mips64el
+      case "r600"                => r600
+      case "amdgcn"              => amdgcn
+      case "riscv32"             => riscv32
+      case "riscv64"             => riscv64
+      case "hexagon"             => hexagon
+      case "s390x" | "systemz"   => systemz
+      case "sparc"               => sparc
+      case "sparcel"             => sparcel
+      case "sparcv9" | "sparc64" => sparcv9
+      case "tce"                 => tce
+      case "tcele"               => tcele
+      case "xcore"               => xcore
+      case "nvptx"               => nvptx
+      case "nvptx64"             => nvptx64
+      case "le32"                => le32
+      case "le64"                => le64
+      case "amdil"               => amdil
+      case "amdil64"             => amdil64
+      case "hsail"               => hsail
+      case "hsail64"             => hsail64
+      case "spir"                => spir
+      case "spir64"              => spir64
+      case "spirv32" | "spirv32v1.0" | "spirv32v1.1" | "spirv32v1.2" |
+          "spirv32v1.3" | "spirv32v1.4" | "spirv32v1.5" =>
+        spirv32
+      case "spirv64" | "spirv64v1.0" | "spirv64v1.1" | "spirv64v1.2" |
+          "spirv64v1.3" | "spirv64v1.4" | "spirv64v1.5" =>
+        spirv64
+      case "lanai"          => lanai
+      case "renderscript32" => renderscript32
+      case "renderscript64" => renderscript64
+      case "shave"          => shave
+      case "ve"             => ve
+      case "wasm32"         => wasm32
+      case "wasm64"         => wasm64
+      case "csky"           => csky
+      case "loongarch32"    => loongarch32
+      case "loongarch64"    => loongarch64
+      case "dxil"           => dxil
+      case "xtensa"         => xtensa
+      case other            =>
+        // Some architectures require special parsing logic just to compute the
+        // ArchType result.
+
+        if (other.startsWith("kalimba"))
+          kalimba
+        else if (other.startsWith("arm") || other.startsWith("thumb") ||
+            other.startsWith("aarch64"))
+          parseArm(other)
+        else if (other.startsWith("bpf"))
+          parseBpf(other)
+        else
+          unknown
+    }
+
+    private def parseArm(str: String): String = {
+
+      val isa =
+        if (str.startsWith("aarch64") || str.startsWith("arm64")) aarch64
+        else if (str.startsWith("thumb")) thumb
+        else if (str.startsWith("arm")) arm
+        else unknown
+
+      val endian =
+        if (str.startsWith("armeb") || str.startsWith("thumbeb") ||
+            str.startsWith("aarch64_be"))
+          Some(ByteOrder.BIG_ENDIAN)
+        else if (str.startsWith("arm") || str.startsWith("thumb")) {
+          if (str.endsWith("eb"))
+            Some(ByteOrder.BIG_ENDIAN)
+          else
+            Some(ByteOrder.LITTLE_ENDIAN)
+        } else if (str.startsWith("aarch64") || str.startsWith("aarch64_32"))
+          Some(ByteOrder.LITTLE_ENDIAN)
+        else None
+
+      endian match {
+        case Some(ByteOrder.LITTLE_ENDIAN) =>
+          isa match {
+            case `arm`     => arm
+            case `thumb`   => thumb
+            case `aarch64` => aarch64
+            case _         => unknown
+          }
+        case Some(ByteOrder.BIG_ENDIAN) =>
+          isa match {
+            case `arm`     => armeb
+            case `thumb`   => thumbeb
+            case `aarch64` => aarch64_be
+            case _         => unknown
+          }
+        case _ => unknown
+      }
+    }
+
+    private def parseBpf(str: String): String = str match {
+      case "bpf" =>
+        if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN)
+          bpfel
+        else bpfeb
+      case "bpf_be" | "bpfeb" => bpfeb
+      case "bpf_le" | "bpfel" => bpfel
+      case _                  => unknown
+    }
+
+    final val unknown = "unknown"
+    final val aarch64 = "aarch64"
+    final val aarch64_32 = "aarch64_32"
+    final val aarch64_be = "aarch64_be"
+    final val amdgcn = "amdgcn"
+    final val amdil64 = "amdil64"
+    final val amdil = "amdil"
+    final val arc = "arc"
+    final val arm = "arm"
+    final val armeb = "armeb"
+    final val avr = "avr"
+    final val bpfeb = "bpfeb"
+    final val bpfel = "bpfel"
+    final val csky = "csky"
+    final val dxil = "dxil"
+    final val hexagon = "hexagon"
+    final val hsail64 = "hsail64"
+    final val hsail = "hsail"
+    final val kalimba = "kalimba"
+    final val lanai = "lanai"
+    final val le32 = "le32"
+    final val le64 = "le64"
+    final val loongarch32 = "loongarch32"
+    final val loongarch64 = "loongarch64"
+    final val m68k = "m68k"
+    final val mips64 = "mips64"
+    final val mips64el = "mips64el"
+    final val mips = "mips"
+    final val mipsel = "mipsel"
+    final val msp430 = "msp430"
+    final val nvptx64 = "nvptx64"
+    final val nvptx = "nvptx"
+    final val ppc64 = "powerpc64"
+    final val ppc64le = "powerpc64le"
+    final val ppc = "powerpc"
+    final val ppcle = "powerpcle"
+    final val r600 = "r600"
+    final val renderscript32 = "renderscript32"
+    final val renderscript64 = "renderscript64"
+    final val riscv32 = "riscv32"
+    final val riscv64 = "riscv64"
+    final val shave = "shave"
+    final val sparc = "sparc"
+    final val sparcel = "sparcel"
+    final val sparcv9 = "sparcv9"
+    final val spir64 = "spir64"
+    final val spir = "spir"
+    final val spirv32 = "spirv32"
+    final val spirv64 = "spirv64"
+    final val systemz = "s390x"
+    final val tce = "tce"
+    final val tcele = "tcele"
+    final val thumb = "thumb"
+    final val thumbeb = "thumbeb"
+    final val ve = "ve"
+    final val wasm32 = "wasm32"
+    final val wasm64 = "wasm64"
+    final val x86 = "i386"
+    final val x86_64 = "x86_64"
+    final val xcore = "xcore"
+    final val xtensa = "xtensa"
+  }
+
+  object Vendor {
+    def parse(str: String): String = str match {
+      case "apple"  => Apple
+      case "pc"     => PC
+      case "scei"   => SCEI
+      case "sie"    => SCEI
+      case "fsl"    => Freescale
+      case "ibm"    => IBM
+      case "img"    => ImaginationTechnologies
+      case "mti"    => MipsTechnologies
+      case "nvidia" => NVIDIA
+      case "csr"    => CSR
+      case "myriad" => Myriad
+      case "amd"    => AMD
+      case "mesa"   => Mesa
+      case "suse"   => SUSE
+      case "oe"     => OpenEmbedded
+      case _        => Unknown
+    }
+
+    final val Unknown = "unknown"
+    final val AMD = "amd"
+    final val Apple = "apple"
+    final val CSR = "csr"
+    final val Freescale = "fsl"
+    final val IBM = "ibm"
+    final val ImaginationTechnologies = "img"
+    final val Mesa = "mesa"
+    final val MipsTechnologies = "mti"
+    final val Myriad = "myriad"
+    final val NVIDIA = "nvidia"
+    final val OpenEmbedded = "oe"
+    final val PC = "pc"
+    final val SCEI = "scei"
+    final val SUSE = "suse"
+  }
+
+  object OS {
+    def parse(str: String): String = str match {
+      case os if os.startsWith("ananas")      => Ananas
+      case os if os.startsWith("cloudabi")    => CloudABI
+      case os if os.startsWith("darwin")      => Darwin
+      case os if os.startsWith("dragonfly")   => DragonFly
+      case os if os.startsWith("freebsd")     => FreeBSD
+      case os if os.startsWith("fuchsia")     => Fuchsia
+      case os if os.startsWith("ios")         => IOS
+      case os if os.startsWith("kfreebsd")    => KFreeBSD
+      case os if os.startsWith("linux")       => Linux
+      case os if os.startsWith("lv2")         => Lv2
+      case os if os.startsWith("macos")       => MacOSX
+      case os if os.startsWith("netbsd")      => NetBSD
+      case os if os.startsWith("openbsd")     => OpenBSD
+      case os if os.startsWith("solaris")     => Solaris
+      case os if os.startsWith("win32")       => Win32
+      case os if os.startsWith("windows")     => Win32
+      case os if os.startsWith("zos")         => ZOS
+      case os if os.startsWith("haiku")       => Haiku
+      case os if os.startsWith("minix")       => Minix
+      case os if os.startsWith("rtems")       => RTEMS
+      case os if os.startsWith("nacl")        => NaCl
+      case os if os.startsWith("aix")         => AIX
+      case os if os.startsWith("cuda")        => CUDA
+      case os if os.startsWith("nvcl")        => NVCL
+      case os if os.startsWith("amdhsa")      => AMDHSA
+      case os if os.startsWith("ps4")         => PS4
+      case os if os.startsWith("ps5")         => PS5
+      case os if os.startsWith("elfiamcu")    => ELFIAMCU
+      case os if os.startsWith("tvos")        => TvOS
+      case os if os.startsWith("watchos")     => WatchOS
+      case os if os.startsWith("driverkit")   => DriverKit
+      case os if os.startsWith("mesa3d")      => Mesa3D
+      case os if os.startsWith("contiki")     => Contiki
+      case os if os.startsWith("amdpal")      => AMDPAL
+      case os if os.startsWith("hermit")      => HermitCore
+      case os if os.startsWith("hurd")        => Hurd
+      case os if os.startsWith("wasi")        => WASI
+      case os if os.startsWith("emscripten")  => Emscripten
+      case os if os.startsWith("shadermodel") => ShaderModel
+      case os if os.startsWith("liteos")      => LiteOS
+      case _                                  => Unknown
+    }
+
+    final val Unknown = "unknown"
+    final val AIX = "aix"
+    final val AMDHSA = "amdhsa"
+    final val AMDPAL = "amdpal"
+    final val Ananas = "ananas"
+    final val CUDA = "cuda"
+    final val CloudABI = "cloudabi"
+    final val Contiki = "contiki"
+    final val Darwin = "darwin"
+    final val DragonFly = "dragonfly"
+    final val DriverKit = "driverkit"
+    final val ELFIAMCU = "elfiamcu"
+    final val Emscripten = "emscripten"
+    final val FreeBSD = "freebsd"
+    final val Fuchsia = "fuchsia"
+    final val Haiku = "haiku"
+    final val HermitCore = "hermit"
+    final val Hurd = "hurd"
+    final val IOS = "ios"
+    final val KFreeBSD = "kfreebsd"
+    final val Linux = "linux"
+    final val Lv2 = "lv2"
+    final val MacOSX = "macosx"
+    final val Mesa3D = "mesa3d"
+    final val Minix = "minix"
+    final val NVCL = "nvcl"
+    final val NaCl = "nacl"
+    final val NetBSD = "netbsd"
+    final val OpenBSD = "openbsd"
+    final val PS4 = "ps4"
+    final val PS5 = "ps5"
+    final val RTEMS = "rtems"
+    final val Solaris = "solaris"
+    final val TvOS = "tvos"
+    final val WASI = "wasi"
+    final val WatchOS = "watchos"
+    final val Win32 = "windows"
+    final val ZOS = "zos"
+    final val ShaderModel = "shadermodel"
+    final val LiteOS = "liteos"
+  }
+
+  object Env {
+    def parse(str: String): String = str match {
+      case env if env.startsWith("eabihf")        => EABIHF
+      case env if env.startsWith("eabi")          => EABI
+      case env if env.startsWith("gnuabin32")     => GNUABIN32
+      case env if env.startsWith("gnuabi64")      => GNUABI64
+      case env if env.startsWith("gnueabihf")     => GNUEABIHF
+      case env if env.startsWith("gnueabi")       => GNUEABI
+      case env if env.startsWith("gnuf32")        => GNUF32
+      case env if env.startsWith("gnuf64")        => GNUF64
+      case env if env.startsWith("gnusf")         => GNUSF
+      case env if env.startsWith("gnux32")        => GNUX32
+      case env if env.startsWith("gnu_ilp32")     => GNUILP32
+      case env if env.startsWith("code16")        => CODE16
+      case env if env.startsWith("gnu")           => GNU
+      case env if env.startsWith("android")       => Android
+      case env if env.startsWith("musleabihf")    => MuslEABIHF
+      case env if env.startsWith("musleabi")      => MuslEABI
+      case env if env.startsWith("muslx32")       => MuslX32
+      case env if env.startsWith("musl")          => Musl
+      case env if env.startsWith("msvc")          => MSVC
+      case env if env.startsWith("itanium")       => Itanium
+      case env if env.startsWith("cygnus")        => Cygnus
+      case env if env.startsWith("coreclr")       => CoreCLR
+      case env if env.startsWith("simulator")     => Simulator
+      case env if env.startsWith("macabi")        => MacABI
+      case env if env.startsWith("pixel")         => Pixel
+      case env if env.startsWith("vertex")        => Vertex
+      case env if env.startsWith("geometry")      => Geometry
+      case env if env.startsWith("hull")          => Hull
+      case env if env.startsWith("domain")        => Domain
+      case env if env.startsWith("compute")       => Compute
+      case env if env.startsWith("library")       => Library
+      case env if env.startsWith("raygeneration") => RayGeneration
+      case env if env.startsWith("intersection")  => Intersection
+      case env if env.startsWith("anyhit")        => AnyHit
+      case env if env.startsWith("closesthit")    => ClosestHit
+      case env if env.startsWith("miss")          => Miss
+      case env if env.startsWith("callable")      => Callable
+      case env if env.startsWith("mesh")          => Mesh
+      case env if env.startsWith("amplification") => Amplification
+      case env if env.startsWith("ohos")          => OpenHOS
+      case _                                      => Unknown
+    }
+
+    final val Unknown = "unknown"
+    final val Android = "android"
+    final val CODE16 = "code16"
+    final val CoreCLR = "coreclr"
+    final val Cygnus = "cygnus"
+    final val EABI = "eabi"
+    final val EABIHF = "eabihf"
+    final val GNU = "gnu"
+    final val GNUABI64 = "gnuabi64"
+    final val GNUABIN32 = "gnuabin32"
+    final val GNUEABI = "gnueabi"
+    final val GNUEABIHF = "gnueabihf"
+    final val GNUF32 = "gnuf32"
+    final val GNUF64 = "gnuf64"
+    final val GNUSF = "gnusf"
+    final val GNUX32 = "gnux32"
+    final val GNUILP32 = "gnu_ilp32"
+    final val Itanium = "itanium"
+    final val MSVC = "msvc"
+    final val MacABI = "macabi"
+    final val Musl = "musl"
+    final val MuslEABI = "musleabi"
+    final val MuslEABIHF = "musleabihf"
+    final val MuslX32 = "muslx32"
+    final val Simulator = "simulator"
+    final val Pixel = "pixel"
+    final val Vertex = "vertex"
+    final val Geometry = "geometry"
+    final val Hull = "hull"
+    final val Domain = "domain"
+    final val Compute = "compute"
+    final val Library = "library"
+    final val RayGeneration = "raygeneration"
+    final val Intersection = "intersection"
+    final val AnyHit = "anyhit"
+    final val ClosestHit = "closesthit"
+    final val Miss = "miss"
+    final val Callable = "callable"
+    final val Mesh = "mesh"
+    final val Amplification = "amplification"
+    final val OpenHOS = "ohos"
+  }
+
+}

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -9,20 +9,15 @@ trait LinktimeValueResolver { self: Reach =>
 
   private lazy val linktimeProperties = {
     val conf = config.compilerConfig
+    val triple = conf.configuredOrDetectedTriple
     val linktimeInfo = "scala.scalanative.meta.linktimeinfo"
     val predefined: NativeConfig.LinktimeProperites = Map(
       s"$linktimeInfo.debugMode" -> (conf.mode == Mode.debug),
       s"$linktimeInfo.releaseMode" -> (conf.mode == Mode.releaseFast || conf.mode == Mode.releaseFull || conf.mode == Mode.releaseSize),
-      s"$linktimeInfo.isWindows" -> Platform.isWindows,
-      s"$linktimeInfo.isLinux" -> Platform.isLinux,
-      s"$linktimeInfo.isMac" -> Platform.isMac,
-      s"$linktimeInfo.isFreeBSD" -> Platform.isFreeBSD,
-      s"$linktimeInfo.arch" -> {
-        config.compilerConfig.configuredOrDetectedTriple
-          .split('-')
-          .headOption
-          .getOrElse("unknown")
-      },
+      s"$linktimeInfo.isWindows" -> triple.os == "windows",
+      s"$linktimeInfo.isLinux" -> triple.os == "linux",
+      s"$linktimeInfo.isMac" -> triple.vendor == "apple" && triple.os == "darwin",
+      s"$linktimeInfo.isFreeBSD" -> triple.os == "freebsd",
       s"$linktimeInfo.isMultithreadingEnabled" -> conf.multithreadingSupport,
       s"$linktimeInfo.isWeakReferenceSupported" -> {
         conf.gc == GC.Immix ||
@@ -31,7 +26,11 @@ trait LinktimeValueResolver { self: Reach =>
       s"$linktimeInfo.is32BitPlatform" -> conf.is32BitPlatform,
       s"$linktimeInfo.asanEnabled" -> conf.asan,
       s"$linktimeInfo.isMsys" -> Platform.isMsys,
-      s"$linktimeInfo.isCygwin" -> Platform.isCygwin
+      s"$linktimeInfo.isCygwin" -> Platform.isCygwin,
+      s"$linktimeInfo.target.arch" -> triple.arch,
+      s"$linktimeInfo.target.vendor" -> triple.vendor,
+      s"$linktimeInfo.target.os" -> triple.os,
+      s"$linktimeInfo.target.env" -> triple.env
     )
     NativeConfig.checkLinktimeProperties(predefined)
     predefined ++ conf.linktimeProperties

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -17,6 +17,12 @@ trait LinktimeValueResolver { self: Reach =>
       s"$linktimeInfo.isLinux" -> Platform.isLinux,
       s"$linktimeInfo.isMac" -> Platform.isMac,
       s"$linktimeInfo.isFreeBSD" -> Platform.isFreeBSD,
+      s"$linktimeInfo.arch" -> {
+        config.compilerConfig.configuredOrDetectedTriple
+          .split('-')
+          .headOption
+          .getOrElse("unknown")
+      },
       s"$linktimeInfo.isMultithreadingEnabled" -> conf.multithreadingSupport,
       s"$linktimeInfo.isWeakReferenceSupported" -> {
         conf.gc == GC.Immix ||

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -15,10 +15,6 @@ trait LinktimeValueResolver { self: Reach =>
     val predefined: NativeConfig.LinktimeProperites = Map(
       s"$linktimeInfo.debugMode" -> (conf.mode == Mode.debug),
       s"$linktimeInfo.releaseMode" -> (conf.mode == Mode.releaseFast || conf.mode == Mode.releaseFull || conf.mode == Mode.releaseSize),
-      s"$linktimeInfo.isWindows" -> (triple.os == "windows"),
-      s"$linktimeInfo.isLinux" -> (triple.os == "linux"),
-      s"$linktimeInfo.isMac" -> (triple.vendor == "apple" && triple.os == "darwin"),
-      s"$linktimeInfo.isFreeBSD" -> (triple.os == "freebsd"),
       s"$linktimeInfo.isMultithreadingEnabled" -> conf.multithreadingSupport,
       s"$linktimeInfo.isWeakReferenceSupported" -> {
         conf.gc == GC.Immix ||

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -14,10 +14,10 @@ trait LinktimeValueResolver { self: Reach =>
     val predefined: NativeConfig.LinktimeProperites = Map(
       s"$linktimeInfo.debugMode" -> (conf.mode == Mode.debug),
       s"$linktimeInfo.releaseMode" -> (conf.mode == Mode.releaseFast || conf.mode == Mode.releaseFull || conf.mode == Mode.releaseSize),
-      s"$linktimeInfo.isWindows" -> triple.os == "windows",
-      s"$linktimeInfo.isLinux" -> triple.os == "linux",
-      s"$linktimeInfo.isMac" -> triple.vendor == "apple" && triple.os == "darwin",
-      s"$linktimeInfo.isFreeBSD" -> triple.os == "freebsd",
+      s"$linktimeInfo.isWindows" -> (triple.os == "windows"),
+      s"$linktimeInfo.isLinux" -> (triple.os == "linux"),
+      s"$linktimeInfo.isMac" -> (triple.vendor == "apple" && triple.os == "darwin"),
+      s"$linktimeInfo.isFreeBSD" -> (triple.os == "freebsd"),
       s"$linktimeInfo.isMultithreadingEnabled" -> conf.multithreadingSupport,
       s"$linktimeInfo.isWeakReferenceSupported" -> {
         conf.gc == GC.Immix ||

--- a/tools/src/test/scala/scala/scalanative/build/TargetTripleTest.scala
+++ b/tools/src/test/scala/scala/scalanative/build/TargetTripleTest.scala
@@ -1,0 +1,37 @@
+package scala.scalanative.build
+
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TargetTripleTest extends AnyFlatSpec with Matchers {
+
+  val cases = List(
+    "aarch64-unknown-linux-gnu" ->
+      TargetTriple("aarch64", "unknown", "linux", "gnu"),
+    "arm64-apple-darwin22.4.0" ->
+      TargetTriple("aarch64", "apple", "darwin", "unknown"),
+    "x86_64-apple-darwin13.4.0" ->
+      TargetTriple("x86_64", "apple", "darwin", "unknown"),
+    "x86_64-apple-darwin20.6.0" ->
+      TargetTriple("x86_64", "apple", "darwin", "unknown"),
+    "x86_64-apple-darwin21.6.0" ->
+      TargetTriple("x86_64", "apple", "darwin", "unknown"),
+    "x86_64-apple-darwin22.4.0" ->
+      TargetTriple("x86_64", "apple", "darwin", "unknown"),
+    "x86_64-pc-linux-gnu" ->
+      TargetTriple("x86_64", "pc", "linux", "gnu"),
+    "x86_64-pc-windows-msvc" ->
+      TargetTriple("x86_64", "pc", "windows", "msvc"),
+    "x86_64-portbld-freebsd13.1" ->
+      TargetTriple("x86_64", "unknown", "freebsd", "unknown")
+  )
+
+  "TargetTriple.parse" should "parse test cases" in {
+    cases.foreach {
+      case (triple, expected) =>
+        TargetTriple.parse(triple) should equal(expected)
+    }
+  }
+
+}

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -58,11 +58,15 @@ class LinktimeConditionsSpec extends OptimizerSpec with Matchers {
     Set(
       s"$linktimeInfo.asanEnabled",
       s"$linktimeInfo.is32BitPlatform",
-      s"$linktimeInfo.isFreeBSD",
-      s"$linktimeInfo.isMac",
-      s"$linktimeInfo.isWindows",
+      "M36scala.scalanative.meta.LinktimeInfo$D9isFreeBSDzEO",
+      "M36scala.scalanative.meta.LinktimeInfo$D5isMaczEO",
+      "M36scala.scalanative.meta.LinktimeInfo$D9isWindowszEO",
       s"$linktimeInfo.isMultithreadingEnabled",
-      s"$linktimeInfo.isWeakReferenceSupported"
+      s"$linktimeInfo.isWeakReferenceSupported",
+      s"$linktimeInfo.target.arch",
+      s"$linktimeInfo.target.vendor",
+      s"$linktimeInfo.target.os",
+      s"$linktimeInfo.target.env",
     )
   }
 

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -66,7 +66,7 @@ class LinktimeConditionsSpec extends OptimizerSpec with Matchers {
       s"$linktimeInfo.target.arch",
       s"$linktimeInfo.target.vendor",
       s"$linktimeInfo.target.os",
-      s"$linktimeInfo.target.env",
+      s"$linktimeInfo.target.env"
     )
   }
 


### PR DESCRIPTION
Closes https://github.com/scala-native/scala-native/issues/2802. Closes https://github.com/scala-native/scala-native/issues/2987.

1. Ports the target triple parser/normalizer from LLVM.
2. Extracts and normalizes the arch, vendor, os, and env components of a triple.
3. Exposes this under `LinktimeInfo.target` for link-time conditionals.

---

_Original description._

<details>

This is a first step towards https://github.com/scala-native/scala-native/issues/2802#issuecomment-1230342862, where we discussed exposing the parsed target triple in `LinktimeInfo`, so that the components can be compared with `==`.

I was not sure how to write a useful test for this. Since I think the architecture in the target triple may not match the architecture detected at runtime, in general 🤔 

**Motivation** in the Linux epoll API, the layout of `epoll_event` struct is different for `x86_64`. I'd like to be able to access this info at linking time (and not runtime).

https://github.com/torvalds/linux/blob/61d325dcbc05d8fef88110d35ef7776f3ac3f68b/include/uapi/linux/eventpoll.h#L71-L81

</details>