### PR TITLE
2-parameter (num/size) `stackalloc` intrinsic overload

### DIFF
--- a/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -57,4 +57,16 @@ private[scalanative] trait UnsafePackageCompat {
     libc.memset(ptr, 0, size)
     ptr
   }
+
+  /** Stack allocate and zero-initialize n values of given type, better static
+   *  version.
+   */
+  inline def stackalloc[T](n: Long): Ptr[T] = {
+    import scala.scalanative.unsigned.UnsignedRichLong
+    assert(n >= 0L)
+    val size = Intrinsics.sizeOf[T]
+    val ptr = fromRawPtr[T](Intrinsics.stackalloc(n, size))
+    libc.memset(ptr, 0, n.toUSize * sizeof[T])
+    ptr
+  }
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -11,6 +11,9 @@ object Intrinsics {
   /** Intrinsified stack allocation of n bytes. */
   def stackalloc(size: CSize): RawPtr = intrinsic
 
+  /** Intrinsified stack allocation of num * size bytes. */
+  def stackalloc(num: Long, size: RawSize): RawPtr = intrinsic
+
   /** Intrinsified unsigned devision on ints. */
   def divUInt(l: Int, r: Int): Int = intrinsic
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -163,7 +163,7 @@ final class NirDefinitions()(using ctx: Context) {
     .member(termName("stackalloc"))
     .alternatives
     .map(_.symbol)
-    .ensuring(_.size == 2)
+    .ensuring(_.size == 3)
   @tu lazy val Intrinsics_classFieldRawPtr = IntrinsicsModule.requiredMethod("classFieldRawPtr")
   @tu lazy val Intrinsics_sizeOfAlts = IntrinsicsModule.info
     .member(termName("sizeOf"))

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2148,7 +2148,6 @@ trait NirGenExpr(using Context) {
       else
         assert(Type.box.contains(sizeTy), s"Not a primitive type: ${sizeTy}")
         if sizeTy != nir.Type.Size then
-          // (nir.Type.Long, nir.Type.Size, Conv.SSizeCast)
           buf.conv(Conv.SSizeCast, nir.Type.Size, size, unwind)
         else size
     }


### PR DESCRIPTION
`stackalloc(num: Long, size: RawSize)` allocates `num` * `size` bytes as memory.
The `num` parameter is `Long` to maximize constant folding. 

