### PR TITLE
Improved linktime resolved definitions

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/resolvedAtLinktime.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/resolvedAtLinktime.scala
@@ -3,9 +3,16 @@ package scala.scalanative.unsafe
 import scala.annotation.StaticAnnotation
 import scala.annotation.meta.{field, getter}
 
-/** Used to annotate that given value should be resolved at link-time, based on
- *  provided `withName` parameter
+/** Used to annotate methods which should be evaluated in linktime, allowing to
+ *  remove unused paths and symbols, e.g. whe cross compiling for different OS
+ *  Annotated methods needs to operate only on literal values, other methods
+ *  with this annotation.
  */
 @field @getter
-private[scalanative] class resolvedAtLinktime(withName: String)
-    extends StaticAnnotation
+class resolvedAtLinktime() extends StaticAnnotation {
+
+  /** Used to annotate that given value should be resolved at link-time, based
+   *  on provided `withName` parameter provided by the build tool.
+   */
+  def this(withName: String) = this()
+}

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -31,6 +31,7 @@ object Attr {
   case object Abstract extends Attr
   case object Volatile extends Attr
   case object Final extends Attr
+  case object LinktimeResolved extends Attr
 }
 
 final case class Attrs(
@@ -44,6 +45,7 @@ final case class Attrs(
     isAbstract: Boolean = false,
     isVolatile: Boolean = false,
     isFinal: Boolean = false,
+    isLinktimeResolved: Boolean = false,
     links: Seq[Attr.Link] = Seq.empty
 ) {
   def toSeq: Seq[Attr] = {
@@ -58,6 +60,7 @@ final case class Attrs(
     if (isAbstract) out += Abstract
     if (isVolatile) out += Volatile
     if (isFinal) out += Final
+    if (isLinktimeResolved) out += LinktimeResolved
     out ++= links
 
     out.result()
@@ -77,6 +80,7 @@ object Attrs {
     var isBlocking = false
     var isVolatile = false
     var isFinal = false
+    var isLinktimeResolved = false
     val links = Seq.newBuilder[Attr.Link]
 
     attrs.foreach {
@@ -92,6 +96,8 @@ object Attrs {
       case Abstract        => isAbstract = true
       case Volatile        => isVolatile = true
       case Final           => isFinal = true
+
+      case LinktimeResolved => isLinktimeResolved = true
     }
 
     new Attrs(
@@ -105,6 +111,7 @@ object Attrs {
       isAbstract = isAbstract,
       isVolatile = isVolatile,
       isFinal = isFinal,
+      isLinktimeResolved = isLinktimeResolved,
       links = links.result()
     )
   }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -109,6 +109,8 @@ object Show {
         str("volatile")
       case Attr.Final =>
         str("final")
+      case Attr.LinktimeResolved =>
+        str("linktime")
     }
 
     def next_(next: Next): Unit = next match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -81,6 +81,8 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     case T.AbstractAttr => Attr.Abstract
     case T.VolatileAttr => Attr.Volatile
     case T.FinalAttr    => Attr.Final
+
+    case T.LinktimeResolvedAttr => Attr.LinktimeResolved
   }
 
   private def getBin(): Bin = getInt match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -112,6 +112,8 @@ final class BinarySerializer {
     case Attr.Abstract => putInt(T.AbstractAttr)
     case Attr.Volatile => putInt(T.VolatileAttr)
     case Attr.Final    => putInt(T.FinalAttr)
+
+    case Attr.LinktimeResolved => putInt(T.LinktimeResolvedAttr)
   }
 
   private def putBin(bin: Bin) = bin match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -29,6 +29,7 @@ object Tags {
   final val AbstractAttr = 1 + StubAttr
   final val VolatileAttr = 1 + AbstractAttr
   final val FinalAttr = 1 + VolatileAttr
+  final val LinktimeResolvedAttr = 1 + FinalAttr
 
   // Binary ops
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -209,6 +209,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val cond = genExpr(condp)
         buf.branch(cond, Next(thenn), Next(elsen))(condp.pos)
       } { cond =>
+        curMethodUsesLinktimeResolvedValues = true
         buf.branchLinktime(cond, Next(thenn), Next(elsen))(condp.pos)
       }
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -189,13 +189,23 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       genIf(retty, cond, thenp, elsep)(tree.pos)
     }
 
-    def genIf(retty: nir.Type, condp: Tree, thenp: Tree, elsep: Tree)(implicit
-        ifPos: nir.Position
-    ): Val = {
+    def genIf(
+        retty: nir.Type,
+        condp: Tree,
+        thenp: Tree,
+        elsep: Tree,
+        ensureLinktime: Boolean = false
+    )(implicit ifPos: nir.Position): Val = {
       val thenn, elsen, mergen = fresh()
       val mergev = Val.Local(fresh(), retty)
 
       getLinktimeCondition(condp).fold {
+        if (ensureLinktime) {
+          globalError(
+            condp.pos,
+            "Cannot resolve given condition in linktime, it might be depending on runtime value"
+          )
+        }
         val cond = genExpr(condp)
         buf.branch(cond, Next(thenn), Next(elsen))(condp.pos)
       } { cond =>
@@ -1209,7 +1219,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       condp match {
         // if(bool) (...)
-        case Apply(LinktimeProperty(name, position), Nil) =>
+        case Apply(LinktimeProperty(name, _, position), Nil) =>
           Some {
             SimpleCondition(
               propertyName = name,
@@ -1221,7 +1231,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         // if(!bool) (...)
         case Apply(
               Select(
-                Apply(LinktimeProperty(name, position), Nil),
+                Apply(LinktimeProperty(name, _, position), Nil),
                 nme.UNARY_!
               ),
               Nil
@@ -1236,7 +1246,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
         // if(property <comp> x) (...)
         case Apply(
-              Select(LinktimeProperty(name, position), comp),
+              Select(LinktimeProperty(name, _, position), comp),
               List(arg @ Literal(Constant(_)))
             ) =>
           Some {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -41,6 +41,7 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
   protected val curStatBuffer = new util.ScopedVar[StatBuffer]
   protected val cachedMethodSig =
     collection.mutable.Map.empty[(Symbol, Boolean), nir.Type.Function]
+  protected var curMethodUsesLinktimeResolvedValues = false
 
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get.fold[Next](Next.None) { handler =>

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -643,8 +643,13 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             scoped(
               curMethodSig := sig
             ) {
+              curMethodUsesLinktimeResolvedValues = false
               val body = genMethodBody(dd, rhs)
-              Some(Defn.Define(attrs, name, sig, body))
+              val methodAttrs =
+                if (curMethodUsesLinktimeResolvedValues)
+                  attrs.copy(isLinktimeResolved = true)
+                else attrs
+              Some(Defn.Define(methodAttrs, name, sig, body))
             }
         }
       }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -659,46 +659,89 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           "Link-time property cannot be constant value, it would be inlined by scalac compiler"
         )
       }
+      val retty = genType(dd.tpt.tpe)
 
-      dd.rhs.symbol match {
-        case ResolvedMethod =>
-          checkExplicitReturnTypeAnnotation(dd, "value resolved at link-time")
-          dd match {
-            case LinktimeProperty(propertyName, _) =>
-              val retty = genType(dd.tpt.tpe)
-              val defn = genLinktimeResolvedMethod(retty, propertyName, name)
-              Some(defn)
-            case _ => None
+      import LinktimeProperty.Type._
+      dd match {
+        case LinktimeProperty(propertyName, Provided, _) =>
+          if (dd.rhs.symbol == ResolvedMethod) Some {
+            checkExplicitReturnTypeAnnotation(dd, "value resolved at link-time")
+            genLinktimeResolvedMethod(dd, retty, name) {
+              _.call(
+                Linktime.PropertyResolveFunctionTy(retty),
+                Linktime.PropertyResolveFunction(retty),
+                Val.String(propertyName) :: Nil,
+                Next.None
+              )
+            }
           }
+          else {
+            globalError(
+              dd.pos,
+              s"Link-time resolved property must have ${ResolvedMethod.fullName} as body"
+            )
+            None
+          }
+
+        case LinktimeProperty(_, Calculated, _) =>
+          Some {
+            genLinktimeResolvedMethod(dd, retty, name) { buf =>
+              def resolve(tree: Tree): nir.Val = tree match {
+                case Literal(Constant(_)) =>
+                  buf.genExpr(tree)
+                case If(cond, thenp, elsep) =>
+                  buf.genIf(retty, cond, thenp, elsep, ensureLinktime = true)
+                case tree: Apply if retty == nir.Type.Bool =>
+                  val True = ValTree(nir.Val.True)
+                  val False = ValTree(nir.Val.False)
+                  buf.genIf(retty, tree, True, False, ensureLinktime = true)
+                case Block(stats, expr) =>
+                  stats.foreach { v =>
+                    globalError(
+                      v.pos,
+                      "Linktime resolved block can only contain other linktime resolved def defintions"
+                    )
+                    // unused, generated to prevent compiler plugin crash when referencing ident
+                    buf.genExpr(v)
+                  }
+                  resolve(expr)
+              }
+              resolve(dd.rhs)
+            }
+          }
+
         case _ =>
           globalError(
             dd.pos,
-            s"Link-time resolved property must have ${ResolvedMethod.fullName} as body"
+            "Cannot transform to linktime resolved expression"
           )
           None
       }
     }
 
-    /* Generate stub method that can be used to get value of link-time property at runtime */
     private def genLinktimeResolvedMethod(
+        dd: DefDef,
         retty: nir.Type,
-        propertyName: String,
         methodName: nir.Global
-    )(implicit pos: nir.Position): nir.Defn = {
+    )(genValue: ExprBuffer => nir.Val)(implicit pos: nir.Position): nir.Defn = {
       implicit val fresh: Fresh = Fresh()
       val buf = new ExprBuffer()
 
-      buf.label(fresh())
-      val value = buf.call(
-        Linktime.PropertyResolveFunctionTy(retty),
-        Linktime.PropertyResolveFunction(retty),
-        Val.String(propertyName) :: Nil,
-        Next.None
-      )
-      buf.ret(value)
+      scoped(
+        curFresh := fresh,
+        curMethodSym := dd.symbol,
+        curMethodThis := None,
+        curMethodEnv := new MethodEnv(fresh),
+        curMethodInfo := new CollectMethodInfo,
+        curUnwindHandler := None
+      ) {
+        buf.label(fresh())
+        val value = genValue(buf)
+        buf.ret(value)
+      }
 
       Defn.Define(
-        Attrs(inlineHint = Attr.AlwaysInline),
+        Attrs(inlineHint = Attr.AlwaysInline, isLinktimeResolved = true),
         methodName,
         Type.Function(Seq.empty, retty),
         buf.toSeq
@@ -1148,22 +1191,29 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
   }
 
   protected object LinktimeProperty {
-    def unapply(tree: Tree): Option[(String, nir.Position)] = {
+    sealed trait Type
+    object Type {
+      case object Provided extends Type
+      case object Calculated extends Type
+    }
+    def unapply(tree: Tree): Option[(String, Type, nir.Position)] = {
       if (tree.symbol == null) None
-      else {
+      else
         tree.symbol
           .getAnnotation(ResolvedAtLinktimeClass)
-          .flatMap(_.args.headOption)
-          .flatMap {
-            case Literal(Constant(name: String)) => Some((name, tree.pos))
-            case _ =>
+          .flatMap(_.args match {
+            case Literal(Constant(name: String)) :: Nil =>
+              Some(name, Type.Provided, tree.pos)
+            case _ :: Nil =>
               globalError(
                 tree.symbol.pos,
                 s"Name used to resolve link-time property needs to be non-null literal constant"
               )
               None
-          }
-      }
+            case Nil =>
+              val syntheticName = genName(tree.symbol).mangle
+              Some(syntheticName, Type.Calculated, tree.pos)
+          })
     }
   }
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -214,23 +214,4 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
     }
   }
 
-  protected object LinktimeProperty {
-    def unapply(tree: Tree): Option[(String, nir.Position)] = {
-      if (tree.symbol == null) None
-      else {
-        tree.symbol
-          .getAnnotation(defnNir.ResolvedAtLinktimeClass)
-          .flatMap(_.argumentConstantString(0))
-          .map(_ -> positionsConversions.fromSpan(tree.span))
-          .orElse {
-            report.error(
-              "Name used to resolve link-time property needs to be non-null literal constant",
-              tree.sourcePos
-            )
-            None
-          }
-      }
-    }
-  }
-
 end NirCodeGen

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -40,6 +40,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected val curMethodLabels = new util.ScopedVar[MethodLabelsEnv]
   protected val curMethodThis = new util.ScopedVar[Option[nir.Val]]
   protected val curMethodIsExtern = new util.ScopedVar[Boolean]
+  protected var curMethodUsesLinktimeResolvedValues = false
 
   protected val curFresh = new util.ScopedVar[nir.Fresh]
   protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -442,6 +442,7 @@ trait NirGenExpr(using Context) {
         given nir.Position = condp.span
         getLinktimeCondition(condp) match {
           case Some(cond) =>
+            curMethodUsesLinktimeResolvedValues = true
             buf.branchLinktime(cond, Next(thenn), Next(elsen))
           case None =>
             if ensureLinktime then

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -228,12 +228,13 @@ trait NirGenStat(using Context) {
           scoped(
             curMethodSig := sig
           ) {
-            val defn = Defn.Define(
-              attrs,
-              name,
-              sig,
-              genMethodBody(dd, rhs)
-            )
+            curMethodUsesLinktimeResolvedValues = false
+            val body = genMethodBody(dd, rhs)
+            val methodAttrs =
+              if (curMethodUsesLinktimeResolvedValues)
+                attrs.copy(isLinktimeResolved = true)
+              else attrs
+            val defn = Defn.Define(methodAttrs, name, sig, body)
             Some(defn)
           }
       }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -375,45 +375,98 @@ trait NirGenStat(using Context) {
         dd.sourcePos
       )
     }
+    val retty = genType(dd.tpt.tpe)
 
-    if (dd.rhs.symbol == defnNir.UnsafePackage_resolved) {
-      checkExplicitReturnTypeAnnotation(dd, "value resolved at link-time")
-      dd match {
-        case LinktimeProperty(propertyName, _) =>
-          val retty = genType(dd.tpt.tpe)
-          val defn = genLinktimeResolvedMethod(retty, propertyName, name)
-          Some(defn)
-        case _ => None
-      }
-    } else {
-      report.error(
-        s"Link-time resolved property must have ${defnNir.UnsafePackage_resolved.fullName} as body",
-        dd.sourcePos
-      )
-      None
+    import LinktimeProperty.Type._
+    dd match {
+      case LinktimeProperty(propertyName, Provided, _) =>
+        if (dd.rhs.symbol == defnNir.UnsafePackage_resolved) Some {
+          checkExplicitReturnTypeAnnotation(dd, "value resolved at link-time")
+          genLinktimeResolvedMethod(dd, retty, name) {
+            _.call(
+              Linktime.PropertyResolveFunctionTy(retty),
+              Linktime.PropertyResolveFunction(retty),
+              Val.String(propertyName) :: Nil,
+              Next.None
+            )
+          }
+        }
+        else {
+          report.error(
+            s"Link-time resolved property must have ${defnNir.UnsafePackage_resolved.fullName} as body",
+            dd.sourcePos
+          )
+          None
+        }
+
+      case LinktimeProperty(_, Calculated, _) =>
+        Some {
+          genLinktimeResolvedMethod(dd, retty, name) { buf =>
+            def resolve(tree: Tree): nir.Val = tree match {
+              case Literal(Constant(_)) =>
+                buf.genExpr(tree)
+              case If(cond, thenp, elsep) =>
+                buf.genIf(retty, cond, thenp, elsep, ensureLinktime = true)
+              case tree: Apply if retty == nir.Type.Bool =>
+                val True = ValTree(nir.Val.True)
+                val False = ValTree(nir.Val.False)
+                buf.genIf(retty, tree, True, False, ensureLinktime = true)
+              case Block(stats, expr) =>
+                stats.foreach { v =>
+                  report.error(
+                    "Linktime resolved block can only contain other linktime resolved def defintions",
+                    v.srcPos
+                  )
+                  // unused, generated to prevent compiler plugin crash when referencing ident
+                  buf.genExpr(v)
+                }
+                expr match {
+                  case Typed(Ident(_), _) | Ident(_) =>
+                    report.error(
+                      "Non-inlined terms are not allowed in linktime resolved methods",
+                      expr.srcPos
+                    )
+                    Val.Zero(retty)
+                  case Typed(tree, _) => resolve(tree)
+                  case tree           => resolve(tree)
+                }
+            }
+            resolve(dd.rhs)
+          }
+        }
+
+      case _ =>
+        report.error(
+          "Cannot transform to linktime resolved expression",
+          dd.srcPos
+        )
+        None
     }
   }
 
-  /* Generate stub method that can be used to get value of link-time property at runtime */
   private def genLinktimeResolvedMethod(
+      dd: DefDef,
       retty: nir.Type,
-      propertyName: String,
       methodName: nir.Global
-  )(using nir.Position): Defn = {
-    given fresh: Fresh = Fresh()
+  )(genValue: ExprBuffer => nir.Val)(using nir.Position): nir.Defn = {
+    implicit val fresh: Fresh = Fresh()
     val buf = new ExprBuffer()
 
-    buf.label(fresh())
-    val value = buf.call(
-      Linktime.PropertyResolveFunctionTy(retty),
-      Linktime.PropertyResolveFunction(retty),
-      Val.String(propertyName) :: Nil,
-      Next.None
-    )
-    buf.ret(value)
+    scoped(
+      curFresh := fresh,
+      curMethodSym := dd.symbol,
+      curMethodThis := None,
+      curMethodEnv := new MethodEnv(fresh),
+      curMethodInfo := new CollectMethodInfo,
+      curUnwindHandler := None
+    ) {
+      buf.label(fresh())
+      val value = genValue(buf)
+      buf.ret(value)
+    }
 
     Defn.Define(
-      Attrs(inlineHint = Attr.AlwaysInline),
+      Attrs(inlineHint = Attr.AlwaysInline, isLinktimeResolved = true),
       methodName,
       Type.Function(Seq.empty, retty),
       buf.toSeq
@@ -694,6 +747,36 @@ trait NirGenStat(using Context) {
         classDefn,
         genStaticForwardersFromModuleClass(Nil, sym)
       )
+    }
+  }
+
+  protected object LinktimeProperty {
+    enum Type:
+      case Provided, Calculated
+
+    def unapply(tree: Tree): Option[(String, Type, nir.Position)] = {
+      if (tree.symbol == null) None
+      else {
+        tree.symbol
+          .getAnnotation(defnNir.ResolvedAtLinktimeClass)
+          .flatMap { annot =>
+            val pos = positionsConversions.fromSpan(tree.span)
+            if annot.arguments.isEmpty then
+              val syntheticName = genName(tree.symbol).mangle
+              Some(syntheticName, Type.Calculated, pos)
+            else
+              annot
+                .argumentConstantString(0)
+                .map((_, Type.Provided, pos))
+                .orElse {
+                  report.error(
+                    "Name used to resolve link-time property needs to be non-null literal constant",
+                    tree.sourcePos
+                  )
+                  None
+                }
+          }
+      }
     }
   }
 }

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -3,6 +3,7 @@ package scala.scalanative.linker
 import scala.collection.mutable
 import scala.scalanative.nir._
 import scala.scalanative.build._
+import scala.scalanative.util.unsupported
 
 trait LinktimeValueResolver { self: Reach =>
   import LinktimeValueResolver._
@@ -40,8 +41,38 @@ trait LinktimeValueResolver { self: Reach =>
   protected def resolveLinktimeDefine(defn: Defn.Define): Defn.Define = {
     implicit def position: Position = defn.pos
 
-    if (!defn.insts.exists(shouldResolveInst)) defn
-    else {
+    def resolveInDefinition() = {
+      implicit val fresh = Fresh()
+      lazy val buf = {
+        val buf = new Buffer()
+        buf += defn.insts.head
+        buf
+      }
+
+      defn.insts match {
+        case Seq(_, Inst.Ret(_)) => defn
+
+        case Seq(
+              _,
+              Inst.Let(_, ReferencedPropertyOp(propertyName), _),
+              Inst.Ret(_)
+            ) =>
+          val value = resolveLinktimeProperty(propertyName)
+          resolvedValues.getOrElseUpdate(propertyName, value)
+          buf.ret(value.nirValue)
+          defn.copy(insts = buf.toSeq)
+
+        case _ =>
+          val mangledName = Mangle(defn.name)
+          val value = resolveLinktimeProperty(mangledName)
+          buf.ret(value.nirValue)
+          resolvedValues.getOrElseUpdate(mangledName, value)
+          defn.copy(insts = buf.toSeq)
+      }
+
+    }
+
+    def resolveInUsage() = {
       val resolvedInsts = ControlFlow.removeDeadBlocks {
         defn.insts.map {
           case inst: Inst.LinktimeIf => resolveLinktimeIf(inst)
@@ -54,6 +85,10 @@ trait LinktimeValueResolver { self: Reach =>
 
       defn.copy(insts = resolvedInsts)
     }
+
+    if (defn.attrs.isLinktimeResolved) resolveInDefinition()
+    else if (defn.insts.exists(shouldResolveInst)) resolveInUsage()
+    else defn
   }
 
   protected def shouldResolveInst(inst: Inst): Boolean = inst match {
@@ -70,9 +105,30 @@ trait LinktimeValueResolver { self: Reach =>
   private def lookupLinktimeProperty(
       propertyName: String
   )(implicit pos: Position): LinktimeValue = {
-    linktimeProperties
-      .get(propertyName)
-      .map(ComparableVal.fromAny(_).asAny)
+    def fromProvidedValue =
+      linktimeProperties
+        .get(propertyName)
+        .map(ComparableVal.fromAny(_).asAny)
+
+    def fromCalculatedValue =
+      util
+        .Try(Unmangle.unmangleGlobal(propertyName))
+        .toOption
+        .flatMap(lookup(_))
+        .collect {
+          case defn: Defn.Define if defn.attrs.isLinktimeResolved =>
+            try interpretLinktimeDefn(defn)
+            catch {
+              case ex: Exception =>
+                throw new LinkingException(
+                  s"Link-time method `$propertyName` cannot be interpreted at linktime"
+                )
+            }
+        }
+        .map(ComparableVal.fromNir)
+
+    fromProvidedValue
+      .orElse(fromCalculatedValue)
       .getOrElse {
         throw new LinkingException(
           s"Link-time property named `$propertyName` not defined in the config"
@@ -126,12 +182,63 @@ trait LinktimeValueResolver { self: Reach =>
 
   private def resolveLinktimeIf(
       inst: Inst.LinktimeIf
-  )(implicit pos: Position): Inst = {
+  )(implicit pos: Position): Inst.Jump = {
     val Inst.LinktimeIf(cond, thenp, elsep) = inst
 
     val matchesCondition = resolveCondition(cond)
     if (matchesCondition) Inst.Jump(thenp)
     else Inst.Jump(elsep)
+  }
+
+  private def interpretLinktimeDefn(defn: Defn.Define): Val = {
+    require(defn.attrs.isLinktimeResolved)
+    val cf = ControlFlow.Graph(defn.insts)
+    val locals = scala.collection.mutable.Map.empty[Val.Local, Val]
+
+    def resolveLocalVal(local: Val.Local): Val = locals(local) match {
+      case v: Val.Local => resolveLocalVal(v)
+      case value        => value
+    }
+
+    def interpretBlock(block: ControlFlow.Block): Val = {
+      def interpret(inst: Inst): Val = inst match {
+        case Inst.Ret(value) =>
+          value match {
+            case v: Val.Local => resolveLocalVal(v)
+            case _            => value
+          }
+
+        case Inst.Jump(next) =>
+          val nextBlock = cf.find(next.name)
+          next match {
+            case Next.Label(_, values) =>
+              locals ++= nextBlock.params.zip(values).toMap
+            case _ =>
+              unsupported(
+                "Only normal labels are expected in linktime resolved methods"
+              )
+          }
+          interpretBlock(nextBlock)
+
+        case Inst.Label(next, params) =>
+          val insts = cf.find(next).insts
+          assert(insts.size == 1)
+          interpret(insts.head)
+
+        case branch: Inst.LinktimeIf =>
+          interpret(resolveLinktimeIf(branch)(branch.pos))
+
+        case _: Inst.If | _: Inst.Let | _: Inst.Switch | _: Inst.Throw |
+            _: Inst.Unreachable =>
+          unsupported(
+            "Unexpected instruction found in linktime resolved method: " + inst
+          )
+      }
+
+      assert(block.insts.size == 1)
+      interpret(block.insts.head)
+    }
+    interpretBlock(cf.entry)
   }
 
 }

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -93,335 +93,415 @@ class LinktimeConditionsSpec extends OptimizerSpec with Matchers {
     }
   }
 
-  it should "resolve values from native config" in {
+  // it should "resolve values from native config" in {
+  //   linkWithProps(
+  //     "props.scala" -> props,
+  //     "main.scala" -> allPropsUsage
+  //   )(defaultProperties: _*) { (_, result) =>
+  //     def normalized(elems: Map[String, Val]): Map[String, Val] =
+  //       elems.filter { case (key, _) => !ignoredNames.contains(key) }
+  //     val expected =
+  //       defaultEntries.map { e => e.propertyName -> e.linktimeValue }
+  //     shouldContainAll(
+  //       normalized(expected.toMap),
+  //       normalized(result.resolvedVals.toMap)
+  //     )
+  //   }
+  // }
+
+  // it should "not allow to define property without `resolved` as rhs value" in {
+  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+  //     linkWithProps(
+  //       "props.scala" ->
+  //         """package scala.scalanative
+  //           |object props{
+  //           |   @scalanative.unsafe.resolvedAtLinktime("foo")
+  //           |   def linktimeProperty: Boolean = true
+  //           |}""".stripMargin,
+  //       "main.scala" ->
+  //         """import scala.scalanative.props._
+  //           |object Main {
+  //           |  def main(args: Array[String]): Unit = {
+  //           |    if(linktimeProperty) ???
+  //           |  }
+  //           |}""".stripMargin
+  //     )() { (_, _) => () }
+  //   }
+  //   assert(
+  //     caught.getMessage.matches(
+  //       "Link-time resolved property must have scala.scalanative.*resolved as body"
+  //     )
+  //   )
+  // }
+
+  // it should "not allow to define property with null rhs" in {
+  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+  //     linkWithProps(
+  //       "props.scala" -> """
+  //            |package scala.scalanative
+  //            |object props{
+  //            |   @scalanative.unsafe.resolvedAtLinktime("prop")
+  //            |   def linktimeProperty: Boolean = null.asInstanceOf[Boolean]
+  //            |}
+  //            |""".stripMargin,
+  //       "main.scala" -> """
+  //           |import scala.scalanative.props._
+  //           |object Main {
+  //           |  def main(args: Array[String]): Unit = {
+  //           |    if(linktimeProperty) ???
+  //           |  }
+  //           |}""".stripMargin
+  //     )() { (_, _) => () }
+  //   }
+  //   assert(
+  //     caught.getMessage.matches(
+  //       "Link-time resolved property must have scala.scalanative.*resolved as body"
+  //     )
+  //   )
+  // }
+
+  // it should "not allow to define property resolved from property with null name" in {
+  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+  //     linkWithProps(
+  //       "props.scala" ->
+  //         """package scala.scalanative
+  //           |object props{
+  //           |   @scalanative.unsafe.resolvedAtLinktime(withName = null.asInstanceOf[String])
+  //           |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+  //           |}""".stripMargin,
+  //       "main.scala" ->
+  //         """import scala.scalanative.props._
+  //           |object Main {
+  //           |  def main(args: Array[String]): Unit = {
+  //           |    if(linktimeProperty) ???
+  //           |  }
+  //           |}""".stripMargin
+  //     )() { (_, _) => () }
+  //   }
+  //   caught.getMessage shouldEqual "Name used to resolve link-time property needs to be non-null literal constant"
+  // }
+
+  // it should "not allow to define property without explicit return type" in {
+  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+  //     linkWithProps(
+  //       "props.scala" ->
+  //         """package scala.scalanative
+  //           |object props{
+  //           |   @scalanative.unsafe.resolvedAtLinktime("foo")
+  //           |   def linktimeProperty = scala.scalanative.unsafe.resolved
+  //           |}""".stripMargin,
+  //       "main.scala" ->
+  //         """import scala.scalanative.props._
+  //           |object Main {
+  //           |  def main(args: Array[String]): Unit = {
+  //           |    if(linktimeProperty) ???
+  //           |  }
+  //           |}""".stripMargin
+  //     )() { (_, _) => () }
+  //   }
+  //   caught.getMessage shouldEqual "value resolved at link-time linktimeProperty needs result type"
+  // }
+
+  // "Linktime conditions" should "resolve simple conditions" in {
+  //   val pathsRange = 1.to(3)
+  //   /* When using normal (runtime) conditions static reachability analysis
+  //    * would report missing stubs in each branch (in this case 3).
+  //    * When using linktime conditions only branch that fulfilled condition
+  //    * would be actually used, others would be discarded and never used/checked.
+  //    * Based on that only 1 unavailable symbol would be reported (from branch that was taken).
+  //    */
+  //   for (n <- pathsRange)
+  //     linkWithProps(
+  //       "props.scala" -> props,
+  //       "main.scala" -> s"""
+  //                         |import scala.scalanative.linktime
+  //                         |object Main {
+  //                         |  ${pathStrings(pathsRange)}
+  //                         |  
+  //                         |  def main(args: Array[String]): Unit = {
+  //                         |    if(linktime.int == 1) path1()
+  //                         |    else if (linktime.int == 2) path2()
+  //                         |    else path3()
+  //                         |  }
+  //                         |}""".stripMargin
+  //     )("int" -> n) { (_, result) =>
+  //       result.unavailable should contain only pathForNumber(n)
+  //     }
+  // }
+
+  // it should "allow to use inequality comparsion" in {
+  //   val property = "scala.scalanative.linktime.float"
+  //   val pathsRange = 0.until(6)
+
+  //   for (n <- pathsRange.init)
+  //     linkWithProps(
+  //       "props.scala" -> props,
+  //       "main.scala" ->
+  //         s"""
+  //         |import scala.scalanative.linktime
+  //         |object Main {
+  //         |  ${pathStrings(pathsRange)}
+  //         |  def main(args: Array[String]): Unit = {
+  //         |    if($property != 0.0f) {
+  //         |       if($property <= 1.0f) path1()
+  //         |       else if($property < 2.9f) path2()
+  //         |       else if($property > 3.9f) path4()
+  //         |       else if($property >= 3.0f) path3()
+  //         |       else () // should be unreachable
+  //         |    } else path0()
+  //         |  }
+  //         |}""".stripMargin
+  //     )("float" -> n.toFloat) { (_, result) =>
+  //       result.unavailable should contain only pathForNumber(n)
+  //     }
+  // }
+
+  // it should "allow to use complex conditions" in {
+  //   val doubleField = "linktime.inner.performanceMultiplier"
+  //   val longField = "linktime.inner.countFrom"
+  //   val stringField = "stringProp"
+  //   val pathsRange = 1.to(6)
+  //   val compilationUnit = Map(
+  //     "props.scala" -> props,
+  //     "props2.scala" -> """
+  //         |package scala.scalanative
+  //         |object props2{
+  //         |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.string")
+  //         |   def stringProp: String = scala.scalanative.unsafe.resolved
+  //         |}
+  //         |""".stripMargin,
+  //     "main.scala" ->
+  //       s"""import scala.scalanative.props2._
+  //          |import scala.scalanative.linktime
+  //          |
+  //          |object Main {
+  //          |  ${pathStrings(pathsRange)}
+  //          |  def main(args: Array[String]): Unit = {
+  //          |    if($doubleField == -1.0 || $stringField == "one" || $longField == 1) path1()
+  //          |     else if($doubleField >= 1 && $longField <= 2 && $stringField == "2") path2()
+  //          |     else if(($doubleField == 3.0 && $longField == 3) || $stringField == "tri") path3()
+  //          |     else if(($stringField != "three" || $longField > 3) && $doubleField <= 4.0) path4()
+  //          |     else if(($stringField != null && $longField < 1234567890) && ($doubleField >= -12345.789 && $doubleField <= 12345.789)) path5()
+  //          |     else path6()
+  //          |  }
+  //          |}""".stripMargin
+  //   )
+
+  //   val cases: List[((Double, String, Long), Int)] = List(
+  //     (-0.0, "none", 1L) -> 1,
+  //     (1.5, "2", 2L) -> 2,
+  //     (3.0, "tri", -1L) -> 3,
+  //     (3.0, "None", 3L) -> 3,
+  //     (4.0, "four", 4L) -> 4,
+  //     (4.0, "three", 4L) -> 4,
+  //     (5.0, "None", 1234567889L) -> 5,
+  //     (654321.0, "None", 1234567891L) -> 6
+  //   )
+
+  //   for (((doubleValue, stringValue, longValue), pathNumber) <- cases)
+  //     linkWithProps(compilationUnit.toSeq: _*)(
+  //       "secret.performance.multiplier" -> doubleValue,
+  //       "prop.string" -> stringValue,
+  //       "inner.countFrom" -> longValue
+  //     ) { (_, result) =>
+  //       result.unavailable should contain only pathForNumber(pathNumber)
+  //     }
+  // }
+
+  // it should "handle boolean properties in conditions" in {
+  //   val bool1 = "boolOne"
+  //   val bool2 = "bool2"
+  //   val pathsRange = 1.to(5)
+
+  //   val cases: List[((Boolean, Boolean), Int)] = List(
+  //     (true, true) -> 1,
+  //     (true, false) -> 2,
+  //     (false, true) -> 3
+  //   )
+
+  //   val compilationUnit = Map(
+  //     "props.scala" -> s"""
+  //          |package scala.scalanative
+  //          |object props{
+  //          |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.bool.1")
+  //          |   def $bool1: Boolean = scala.scalanative.unsafe.resolved
+  //          |
+  //          |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.bool.2")
+  //          |   def $bool2: Boolean = scala.scalanative.unsafe.resolved
+  //          |}""".stripMargin,
+  //     "main.scala" -> s"""
+  //       |import scala.scalanative.props._
+  //       |object Main {
+  //       |
+  //       |  ${pathStrings(pathsRange)}
+  //       |  def main(args: Array[String]): Unit = {
+  //       |    if($bool1 && $bool2 == true) path1()
+  //       |     else if($bool1 && !$bool2) path2()
+  //       |     else if($bool1 == false || $bool2) path3()
+  //       |     else path4()
+  //       |  }
+  //       |}""".stripMargin
+  //   )
+
+  //   for (((bool1, bool2), pathNumber) <- cases)
+  //     linkWithProps(compilationUnit.toSeq: _*)(
+  //       "prop.bool.1" -> bool1,
+  //       "prop.bool.2" -> bool2
+  //     ) { (_, result) =>
+  //       result.unavailable should contain only pathForNumber(pathNumber)
+  //     }
+  // }
+
+  // it should "not allow to mix link-time and runtime conditions" in {
+  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+  //     linkWithProps(
+  //       "props.scala" ->
+  //         """package scala.scalanative
+  //           |
+  //           |object props{
+  //           |   @scalanative.unsafe.resolvedAtLinktime("prop")
+  //           |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+  //           |
+  //           |   def runtimeProperty = true
+  //           |}
+  //           |""".stripMargin,
+  //       "main.scala" -> """
+  //          |import scala.scalanative.props._
+  //          |object Main {
+  //          |  def main(args: Array[String]): Unit = {
+  //          |    if(linktimeProperty || runtimeProperty) ??? 
+  //          |  }
+  //          |}""".stripMargin
+  //     )() { (_, _) => () }
+  //   }
+  //   caught.getMessage shouldEqual "Mixing link-time and runtime conditions is not allowed"
+  // }
+
+  // it should "allow to reference link-time condition at runtime" in {
+  //   linkWithProps(
+  //     "props.scala" ->
+  //       """package scala.scalanative
+  //           |
+  //           |object props{
+  //           |   @scalanative.unsafe.resolvedAtLinktime("prop")
+  //           |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+  //           |}
+  //           |""".stripMargin,
+  //     "main.scala" -> """
+  //                         |import scala.scalanative.props._
+  //                         |object Main {
+  //                         |  def main(args: Array[String]): Unit = {
+  //                         |    println(linktimeProperty)
+  //                         |  }
+  //                         |}""".stripMargin
+  //   )("prop" -> true) { (_, result) =>
+  //     result.resolvedVals("prop") shouldEqual Val.True
+  //   }
+  // }
+
+  // it should "allow to inline linktime property" in {
+  //   optimizeWithProps(
+  //     "props.scala" ->
+  //       """package scala.scalanative
+  //         |
+  //         |object props{
+  //         |   @scalanative.unsafe.resolvedAtLinktime("prop")
+  //         |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+  //         |}
+  //         |""".stripMargin,
+  //     "main.scala" -> """
+  //                       |import scala.scalanative.props._
+  //                       |object Main {
+  //                       |  @scalanative.annotation.alwaysinline
+  //                       |  def prop() = linktimeProperty
+  //                       |  def main(args: Array[String]): Unit = {
+  //                       |    println(prop())
+  //                       |  }
+  //                       |}""".stripMargin
+  //   )("prop" -> true) { (_, result) =>
+  //     // Check if compiles and does not fail to optimize
+  //     result.unavailable.isEmpty
+  //   }
+  // }
+
+  it should "allow to define linktime methods calculated based on linktime values" in {
     linkWithProps(
-      "props.scala" -> props,
-      "main.scala" -> allPropsUsage
-    )(defaultProperties: _*) { (_, result) =>
-      def normalized(elems: Map[String, Val]): Map[String, Val] =
-        elems.filter { case (key, _) => !ignoredNames.contains(key) }
-      val expected =
-        defaultEntries.map { e => e.propertyName -> e.linktimeValue }
-      shouldContainAll(
-        normalized(expected.toMap),
-        normalized(result.resolvedVals.toMap)
-      )
-    }
-  }
-
-  it should "not allow to define property without `resolved` as rhs value" in {
-    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-      linkWithProps(
-        "props.scala" ->
-          """package scala.scalanative
-            |object props{
-            |   @scalanative.unsafe.resolvedAtLinktime("foo")
-            |   def linktimeProperty: Boolean = true
-            |}""".stripMargin,
-        "main.scala" ->
-          """import scala.scalanative.props._
-            |object Main {
-            |  def main(args: Array[String]): Unit = {
-            |    if(linktimeProperty) ???
-            |  }
-            |}""".stripMargin
-      )() { (_, _) => () }
-    }
-    assert(
-      caught.getMessage.matches(
-        "Link-time resolved property must have scala.scalanative.*resolved as body"
-      )
-    )
-  }
-
-  it should "not allow to define property with null rhs" in {
-    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-      linkWithProps(
-        "props.scala" -> """
-             |package scala.scalanative
-             |object props{
-             |   @scalanative.unsafe.resolvedAtLinktime("prop")
-             |   def linktimeProperty: Boolean = null.asInstanceOf[Boolean]
-             |}
-             |""".stripMargin,
-        "main.scala" -> """
-            |import scala.scalanative.props._
-            |object Main {
-            |  def main(args: Array[String]): Unit = {
-            |    if(linktimeProperty) ???
-            |  }
-            |}""".stripMargin
-      )() { (_, _) => () }
-    }
-    assert(
-      caught.getMessage.matches(
-        "Link-time resolved property must have scala.scalanative.*resolved as body"
-      )
-    )
-  }
-
-  it should "not allow to define property resolved from property with null name" in {
-    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-      linkWithProps(
-        "props.scala" ->
-          """package scala.scalanative
-            |object props{
-            |   @scalanative.unsafe.resolvedAtLinktime(withName = null.asInstanceOf[String])
-            |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
-            |}""".stripMargin,
-        "main.scala" ->
-          """import scala.scalanative.props._
-            |object Main {
-            |  def main(args: Array[String]): Unit = {
-            |    if(linktimeProperty) ???
-            |  }
-            |}""".stripMargin
-      )() { (_, _) => () }
-    }
-    caught.getMessage shouldEqual "Name used to resolve link-time property needs to be non-null literal constant"
-  }
-
-  it should "not allow to define property without explicit return type" in {
-    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-      linkWithProps(
-        "props.scala" ->
-          """package scala.scalanative
-            |object props{
-            |   @scalanative.unsafe.resolvedAtLinktime("foo")
-            |   def linktimeProperty = scala.scalanative.unsafe.resolved
-            |}""".stripMargin,
-        "main.scala" ->
-          """import scala.scalanative.props._
-            |object Main {
-            |  def main(args: Array[String]): Unit = {
-            |    if(linktimeProperty) ???
-            |  }
-            |}""".stripMargin
-      )() { (_, _) => () }
-    }
-    caught.getMessage shouldEqual "value resolved at link-time linktimeProperty needs result type"
-  }
-
-  "Linktime conditions" should "resolve simple conditions" in {
-    val pathsRange = 1.to(3)
-    /* When using normal (runtime) conditions static reachability analysis
-     * would report missing stubs in each branch (in this case 3).
-     * When using linktime conditions only branch that fulfilled condition
-     * would be actually used, others would be discarded and never used/checked.
-     * Based on that only 1 unavailable symbol would be reported (from branch that was taken).
-     */
-    for (n <- pathsRange)
-      linkWithProps(
-        "props.scala" -> props,
-        "main.scala" -> s"""
-                          |import scala.scalanative.linktime
-                          |object Main {
-                          |  ${pathStrings(pathsRange)}
-                          |  
-                          |  def main(args: Array[String]): Unit = {
-                          |    if(linktime.int == 1) path1()
-                          |    else if (linktime.int == 2) path2()
-                          |    else path3()
-                          |  }
-                          |}""".stripMargin
-      )("int" -> n) { (_, result) =>
-        result.unavailable should contain only pathForNumber(n)
-      }
-  }
-
-  it should "allow to use inequality comparsion" in {
-    val property = "scala.scalanative.linktime.float"
-    val pathsRange = 0.until(6)
-
-    for (n <- pathsRange.init)
-      linkWithProps(
-        "props.scala" -> props,
-        "main.scala" ->
-          s"""
-          |import scala.scalanative.linktime
-          |object Main {
-          |  ${pathStrings(pathsRange)}
-          |  def main(args: Array[String]): Unit = {
-          |    if($property != 0.0f) {
-          |       if($property <= 1.0f) path1()
-          |       else if($property < 2.9f) path2()
-          |       else if($property > 3.9f) path4()
-          |       else if($property >= 3.0f) path3()
-          |       else () // should be unreachable
-          |    } else path0()
-          |  }
-          |}""".stripMargin
-      )("float" -> n.toFloat) { (_, result) =>
-        result.unavailable should contain only pathForNumber(n)
-      }
-  }
-
-  it should "allow to use complex conditions" in {
-    val doubleField = "linktime.inner.performanceMultiplier"
-    val longField = "linktime.inner.countFrom"
-    val stringField = "stringProp"
-    val pathsRange = 1.to(6)
-    val compilationUnit = Map(
-      "props.scala" -> props,
-      "props2.scala" -> """
-          |package scala.scalanative
-          |object props2{
-          |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.string")
-          |   def stringProp: String = scala.scalanative.unsafe.resolved
-          |}
-          |""".stripMargin,
-      "main.scala" ->
-        s"""import scala.scalanative.props2._
-           |import scala.scalanative.linktime
-           |
-           |object Main {
-           |  ${pathStrings(pathsRange)}
-           |  def main(args: Array[String]): Unit = {
-           |    if($doubleField == -1.0 || $stringField == "one" || $longField == 1) path1()
-           |     else if($doubleField >= 1 && $longField <= 2 && $stringField == "2") path2()
-           |     else if(($doubleField == 3.0 && $longField == 3) || $stringField == "tri") path3()
-           |     else if(($stringField != "three" || $longField > 3) && $doubleField <= 4.0) path4()
-           |     else if(($stringField != null && $longField < 1234567890) && ($doubleField >= -12345.789 && $doubleField <= 12345.789)) path5()
-           |     else path6()
-           |  }
-           |}""".stripMargin
-    )
-
-    val cases: List[((Double, String, Long), Int)] = List(
-      (-0.0, "none", 1L) -> 1,
-      (1.5, "2", 2L) -> 2,
-      (3.0, "tri", -1L) -> 3,
-      (3.0, "None", 3L) -> 3,
-      (4.0, "four", 4L) -> 4,
-      (4.0, "three", 4L) -> 4,
-      (5.0, "None", 1234567889L) -> 5,
-      (654321.0, "None", 1234567891L) -> 6
-    )
-
-    for (((doubleValue, stringValue, longValue), pathNumber) <- cases)
-      linkWithProps(compilationUnit.toSeq: _*)(
-        "secret.performance.multiplier" -> doubleValue,
-        "prop.string" -> stringValue,
-        "inner.countFrom" -> longValue
-      ) { (_, result) =>
-        result.unavailable should contain only pathForNumber(pathNumber)
-      }
-  }
-
-  it should "handle boolean properties in conditions" in {
-    val bool1 = "boolOne"
-    val bool2 = "bool2"
-    val pathsRange = 1.to(5)
-
-    val cases: List[((Boolean, Boolean), Int)] = List(
-      (true, true) -> 1,
-      (true, false) -> 2,
-      (false, true) -> 3
-    )
-
-    val compilationUnit = Map(
-      "props.scala" -> s"""
-           |package scala.scalanative
-           |object props{
-           |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.bool.1")
-           |   def $bool1: Boolean = scala.scalanative.unsafe.resolved
-           |
-           |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.bool.2")
-           |   def $bool2: Boolean = scala.scalanative.unsafe.resolved
-           |}""".stripMargin,
-      "main.scala" -> s"""
-        |import scala.scalanative.props._
-        |object Main {
-        |
-        |  ${pathStrings(pathsRange)}
-        |  def main(args: Array[String]): Unit = {
-        |    if($bool1 && $bool2 == true) path1()
-        |     else if($bool1 && !$bool2) path2()
-        |     else if($bool1 == false || $bool2) path3()
-        |     else path4()
-        |  }
-        |}""".stripMargin
-    )
-
-    for (((bool1, bool2), pathNumber) <- cases)
-      linkWithProps(compilationUnit.toSeq: _*)(
-        "prop.bool.1" -> bool1,
-        "prop.bool.2" -> bool2
-      ) { (_, result) =>
-        result.unavailable should contain only pathForNumber(pathNumber)
-      }
-  }
-
-  it should "not allow to mix link-time and runtime conditions" in {
-    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-      linkWithProps(
-        "props.scala" ->
-          """package scala.scalanative
-            |
-            |object props{
-            |   @scalanative.unsafe.resolvedAtLinktime("prop")
-            |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
-            |
-            |   def runtimeProperty = true
-            |}
-            |""".stripMargin,
-        "main.scala" -> """
-           |import scala.scalanative.props._
-           |object Main {
-           |  def main(args: Array[String]): Unit = {
-           |    if(linktimeProperty || runtimeProperty) ??? 
-           |  }
-           |}""".stripMargin
-      )() { (_, _) => () }
-    }
-    caught.getMessage shouldEqual "Mixing link-time and runtime conditions is not allowed"
-  }
-
-  it should "allow to reference link-time condition at runtime" in {
-    linkWithProps(
-      "props.scala" ->
-        """package scala.scalanative
-            |
-            |object props{
-            |   @scalanative.unsafe.resolvedAtLinktime("prop")
-            |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
-            |}
-            |""".stripMargin,
-      "main.scala" -> """
-                          |import scala.scalanative.props._
-                          |object Main {
-                          |  def main(args: Array[String]): Unit = {
-                          |    println(linktimeProperty)
-                          |  }
-                          |}""".stripMargin
-    )("prop" -> true) { (_, result) =>
-      result.resolvedVals("prop") shouldEqual Val.True
-    }
-  }
-
-  it should "allow to inline linktime property" in {
-    optimizeWithProps(
       "props.scala" ->
         """package scala.scalanative
           |
           |object props{
-          |   @scalanative.unsafe.resolvedAtLinktime("prop")
-          |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+          |   @scalanative.unsafe.resolvedAtLinktime("os")
+          |   def os: String = scala.scalanative.unsafe.resolved
+          | 
+          |   @scalanative.unsafe.resolvedAtLinktime
+          |   def isWindows: Boolean = os == "windows"
+          |    
+          |   @scalanative.unsafe.resolvedAtLinktime
+          |   def isMac: Boolean = {
+          |     @scalanative.unsafe.resolvedAtLinktime
+          |     def vendor = "apple"
+          |     
+          |     os == "darwin" && vendor == "apple"
+          |   }
+          |
+          |   @scalanative.unsafe.resolvedAtLinktime
+          |   def dynLibExt: String = 
+          |     if(isWindows) ".dll"
+          |     else if(isMac) ".dylib"
+          |     else ".so"
           |}
           |""".stripMargin,
       "main.scala" -> """
-                        |import scala.scalanative.props._
-                        |object Main {
-                        |  @scalanative.annotation.alwaysinline
-                        |  def prop() = linktimeProperty
-                        |  def main(args: Array[String]): Unit = {
-                        |    println(prop())
-                        |  }
-                        |}""".stripMargin
-    )("prop" -> true) { (_, result) =>
-      // Check if compiles and does not fail to optimize
-      result.unavailable.isEmpty
+          |import scala.scalanative.props._
+          |object Main {
+          |  def main(args: Array[String]): Unit = {
+          |    println(dynLibExt)
+          |  }
+          |}""".stripMargin
+    )("os" -> "darwin") { (_, result) =>
+      val Props = Global.Top("scala.scalanative.props$")
+      def calculatedVal(
+          name: String,
+          ty: Type,
+          scope: Sig.Scope = Sig.Scope.Public
+      ) = {
+        val global = Props.member(Sig.Method(name, Seq(ty), scope))
+        val mangled = scalanative.nir.Mangle(global)
+        result.resolvedVals.get(mangled)
+      }
+      result.resolvedVals("os") shouldEqual Val.String("darwin")
+      // nested method is defined as private
+      calculatedVal("vendor$1", Rt.String, Sig.Scope.Private(Props)) should
+        contain(Val.String("apple"))
+      calculatedVal("isWindows", Type.Bool) should contain(Val.False)
+      calculatedVal("isMac", Type.Bool) should contain(Val.True)
+      calculatedVal("dynLibExt", Rt.String) should contain(Val.String(".dylib"))
     }
+  }
+
+  it should "not allow to define linktime resolved vals in blocks" in {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+      linkWithProps(
+        "props.scala" ->
+          """package scala.scalanative
+            |object props{
+            |   @scalanative.unsafe.resolvedAtLinktime
+            |   def linktimeProperty = {
+            |     val foo = 42
+            |     foo
+            |  }
+            |}""".stripMargin,
+        "main.scala" ->
+          """import scala.scalanative.props._
+            |object Main {
+            |  def main(args: Array[String]): Unit = {
+            |    if(linktimeProperty != 42) ???
+            |  }
+            |}""".stripMargin
+      )() { (_, _) => () }
+    }
+    // Multiple errors
+    // caught.getMessage should contain("Linktime resolved block can only contain other linktime resolved def defintions")
   }
 
   private def shouldContainAll[T](

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -93,336 +93,336 @@ class LinktimeConditionsSpec extends OptimizerSpec with Matchers {
     }
   }
 
-  // it should "resolve values from native config" in {
-  //   linkWithProps(
-  //     "props.scala" -> props,
-  //     "main.scala" -> allPropsUsage
-  //   )(defaultProperties: _*) { (_, result) =>
-  //     def normalized(elems: Map[String, Val]): Map[String, Val] =
-  //       elems.filter { case (key, _) => !ignoredNames.contains(key) }
-  //     val expected =
-  //       defaultEntries.map { e => e.propertyName -> e.linktimeValue }
-  //     shouldContainAll(
-  //       normalized(expected.toMap),
-  //       normalized(result.resolvedVals.toMap)
-  //     )
-  //   }
-  // }
+  it should "resolve values from native config" in {
+    linkWithProps(
+      "props.scala" -> props,
+      "main.scala" -> allPropsUsage
+    )(defaultProperties: _*) { (_, result) =>
+      def normalized(elems: Map[String, Val]): Map[String, Val] =
+        elems.filter { case (key, _) => !ignoredNames.contains(key) }
+      val expected =
+        defaultEntries.map { e => e.propertyName -> e.linktimeValue }
+      shouldContainAll(
+        normalized(expected.toMap),
+        normalized(result.resolvedVals.toMap)
+      )
+    }
+  }
 
-  // it should "not allow to define property without `resolved` as rhs value" in {
-  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-  //     linkWithProps(
-  //       "props.scala" ->
-  //         """package scala.scalanative
-  //           |object props{
-  //           |   @scalanative.unsafe.resolvedAtLinktime("foo")
-  //           |   def linktimeProperty: Boolean = true
-  //           |}""".stripMargin,
-  //       "main.scala" ->
-  //         """import scala.scalanative.props._
-  //           |object Main {
-  //           |  def main(args: Array[String]): Unit = {
-  //           |    if(linktimeProperty) ???
-  //           |  }
-  //           |}""".stripMargin
-  //     )() { (_, _) => () }
-  //   }
-  //   assert(
-  //     caught.getMessage.matches(
-  //       "Link-time resolved property must have scala.scalanative.*resolved as body"
-  //     )
-  //   )
-  // }
+  it should "not allow to define property without `resolved` as rhs value" in {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+      linkWithProps(
+        "props.scala" ->
+          """package scala.scalanative
+            |object props{
+            |   @scalanative.unsafe.resolvedAtLinktime("foo")
+            |   def linktimeProperty: Boolean = true
+            |}""".stripMargin,
+        "main.scala" ->
+          """import scala.scalanative.props._
+            |object Main {
+            |  def main(args: Array[String]): Unit = {
+            |    if(linktimeProperty) ???
+            |  }
+            |}""".stripMargin
+      )() { (_, _) => () }
+    }
+    assert(
+      caught.getMessage.matches(
+        "Link-time resolved property must have scala.scalanative.*resolved as body"
+      )
+    )
+  }
 
-  // it should "not allow to define property with null rhs" in {
-  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-  //     linkWithProps(
-  //       "props.scala" -> """
-  //            |package scala.scalanative
-  //            |object props{
-  //            |   @scalanative.unsafe.resolvedAtLinktime("prop")
-  //            |   def linktimeProperty: Boolean = null.asInstanceOf[Boolean]
-  //            |}
-  //            |""".stripMargin,
-  //       "main.scala" -> """
-  //           |import scala.scalanative.props._
-  //           |object Main {
-  //           |  def main(args: Array[String]): Unit = {
-  //           |    if(linktimeProperty) ???
-  //           |  }
-  //           |}""".stripMargin
-  //     )() { (_, _) => () }
-  //   }
-  //   assert(
-  //     caught.getMessage.matches(
-  //       "Link-time resolved property must have scala.scalanative.*resolved as body"
-  //     )
-  //   )
-  // }
+  it should "not allow to define property with null rhs" in {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+      linkWithProps(
+        "props.scala" -> """
+             |package scala.scalanative
+             |object props{
+             |   @scalanative.unsafe.resolvedAtLinktime("prop")
+             |   def linktimeProperty: Boolean = null.asInstanceOf[Boolean]
+             |}
+             |""".stripMargin,
+        "main.scala" -> """
+            |import scala.scalanative.props._
+            |object Main {
+            |  def main(args: Array[String]): Unit = {
+            |    if(linktimeProperty) ???
+            |  }
+            |}""".stripMargin
+      )() { (_, _) => () }
+    }
+    assert(
+      caught.getMessage.matches(
+        "Link-time resolved property must have scala.scalanative.*resolved as body"
+      )
+    )
+  }
 
-  // it should "not allow to define property resolved from property with null name" in {
-  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-  //     linkWithProps(
-  //       "props.scala" ->
-  //         """package scala.scalanative
-  //           |object props{
-  //           |   @scalanative.unsafe.resolvedAtLinktime(withName = null.asInstanceOf[String])
-  //           |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
-  //           |}""".stripMargin,
-  //       "main.scala" ->
-  //         """import scala.scalanative.props._
-  //           |object Main {
-  //           |  def main(args: Array[String]): Unit = {
-  //           |    if(linktimeProperty) ???
-  //           |  }
-  //           |}""".stripMargin
-  //     )() { (_, _) => () }
-  //   }
-  //   caught.getMessage shouldEqual "Name used to resolve link-time property needs to be non-null literal constant"
-  // }
+  it should "not allow to define property resolved from property with null name" in {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+      linkWithProps(
+        "props.scala" ->
+          """package scala.scalanative
+            |object props{
+            |   @scalanative.unsafe.resolvedAtLinktime(withName = null.asInstanceOf[String])
+            |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+            |}""".stripMargin,
+        "main.scala" ->
+          """import scala.scalanative.props._
+            |object Main {
+            |  def main(args: Array[String]): Unit = {
+            |    if(linktimeProperty) ???
+            |  }
+            |}""".stripMargin
+      )() { (_, _) => () }
+    }
+    caught.getMessage shouldEqual "Name used to resolve link-time property needs to be non-null literal constant"
+  }
 
-  // it should "not allow to define property without explicit return type" in {
-  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-  //     linkWithProps(
-  //       "props.scala" ->
-  //         """package scala.scalanative
-  //           |object props{
-  //           |   @scalanative.unsafe.resolvedAtLinktime("foo")
-  //           |   def linktimeProperty = scala.scalanative.unsafe.resolved
-  //           |}""".stripMargin,
-  //       "main.scala" ->
-  //         """import scala.scalanative.props._
-  //           |object Main {
-  //           |  def main(args: Array[String]): Unit = {
-  //           |    if(linktimeProperty) ???
-  //           |  }
-  //           |}""".stripMargin
-  //     )() { (_, _) => () }
-  //   }
-  //   caught.getMessage shouldEqual "value resolved at link-time linktimeProperty needs result type"
-  // }
+  it should "not allow to define property without explicit return type" in {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+      linkWithProps(
+        "props.scala" ->
+          """package scala.scalanative
+            |object props{
+            |   @scalanative.unsafe.resolvedAtLinktime("foo")
+            |   def linktimeProperty = scala.scalanative.unsafe.resolved
+            |}""".stripMargin,
+        "main.scala" ->
+          """import scala.scalanative.props._
+            |object Main {
+            |  def main(args: Array[String]): Unit = {
+            |    if(linktimeProperty) ???
+            |  }
+            |}""".stripMargin
+      )() { (_, _) => () }
+    }
+    caught.getMessage shouldEqual "value resolved at link-time linktimeProperty needs result type"
+  }
 
-  // "Linktime conditions" should "resolve simple conditions" in {
-  //   val pathsRange = 1.to(3)
-  //   /* When using normal (runtime) conditions static reachability analysis
-  //    * would report missing stubs in each branch (in this case 3).
-  //    * When using linktime conditions only branch that fulfilled condition
-  //    * would be actually used, others would be discarded and never used/checked.
-  //    * Based on that only 1 unavailable symbol would be reported (from branch that was taken).
-  //    */
-  //   for (n <- pathsRange)
-  //     linkWithProps(
-  //       "props.scala" -> props,
-  //       "main.scala" -> s"""
-  //                         |import scala.scalanative.linktime
-  //                         |object Main {
-  //                         |  ${pathStrings(pathsRange)}
-  //                         |  
-  //                         |  def main(args: Array[String]): Unit = {
-  //                         |    if(linktime.int == 1) path1()
-  //                         |    else if (linktime.int == 2) path2()
-  //                         |    else path3()
-  //                         |  }
-  //                         |}""".stripMargin
-  //     )("int" -> n) { (_, result) =>
-  //       result.unavailable should contain only pathForNumber(n)
-  //     }
-  // }
+  "Linktime conditions" should "resolve simple conditions" in {
+    val pathsRange = 1.to(3)
+    /* When using normal (runtime) conditions static reachability analysis
+     * would report missing stubs in each branch (in this case 3).
+     * When using linktime conditions only branch that fulfilled condition
+     * would be actually used, others would be discarded and never used/checked.
+     * Based on that only 1 unavailable symbol would be reported (from branch that was taken).
+     */
+    for (n <- pathsRange)
+      linkWithProps(
+        "props.scala" -> props,
+        "main.scala" -> s"""
+                          |import scala.scalanative.linktime
+                          |object Main {
+                          |  ${pathStrings(pathsRange)}
+                          |  
+                          |  def main(args: Array[String]): Unit = {
+                          |    if(linktime.int == 1) path1()
+                          |    else if (linktime.int == 2) path2()
+                          |    else path3()
+                          |  }
+                          |}""".stripMargin
+      )("int" -> n) { (_, result) =>
+        result.unavailable should contain only pathForNumber(n)
+      }
+  }
 
-  // it should "allow to use inequality comparsion" in {
-  //   val property = "scala.scalanative.linktime.float"
-  //   val pathsRange = 0.until(6)
+  it should "allow to use inequality comparsion" in {
+    val property = "scala.scalanative.linktime.float"
+    val pathsRange = 0.until(6)
 
-  //   for (n <- pathsRange.init)
-  //     linkWithProps(
-  //       "props.scala" -> props,
-  //       "main.scala" ->
-  //         s"""
-  //         |import scala.scalanative.linktime
-  //         |object Main {
-  //         |  ${pathStrings(pathsRange)}
-  //         |  def main(args: Array[String]): Unit = {
-  //         |    if($property != 0.0f) {
-  //         |       if($property <= 1.0f) path1()
-  //         |       else if($property < 2.9f) path2()
-  //         |       else if($property > 3.9f) path4()
-  //         |       else if($property >= 3.0f) path3()
-  //         |       else () // should be unreachable
-  //         |    } else path0()
-  //         |  }
-  //         |}""".stripMargin
-  //     )("float" -> n.toFloat) { (_, result) =>
-  //       result.unavailable should contain only pathForNumber(n)
-  //     }
-  // }
+    for (n <- pathsRange.init)
+      linkWithProps(
+        "props.scala" -> props,
+        "main.scala" ->
+          s"""
+          |import scala.scalanative.linktime
+          |object Main {
+          |  ${pathStrings(pathsRange)}
+          |  def main(args: Array[String]): Unit = {
+          |    if($property != 0.0f) {
+          |       if($property <= 1.0f) path1()
+          |       else if($property < 2.9f) path2()
+          |       else if($property > 3.9f) path4()
+          |       else if($property >= 3.0f) path3()
+          |       else () // should be unreachable
+          |    } else path0()
+          |  }
+          |}""".stripMargin
+      )("float" -> n.toFloat) { (_, result) =>
+        result.unavailable should contain only pathForNumber(n)
+      }
+  }
 
-  // it should "allow to use complex conditions" in {
-  //   val doubleField = "linktime.inner.performanceMultiplier"
-  //   val longField = "linktime.inner.countFrom"
-  //   val stringField = "stringProp"
-  //   val pathsRange = 1.to(6)
-  //   val compilationUnit = Map(
-  //     "props.scala" -> props,
-  //     "props2.scala" -> """
-  //         |package scala.scalanative
-  //         |object props2{
-  //         |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.string")
-  //         |   def stringProp: String = scala.scalanative.unsafe.resolved
-  //         |}
-  //         |""".stripMargin,
-  //     "main.scala" ->
-  //       s"""import scala.scalanative.props2._
-  //          |import scala.scalanative.linktime
-  //          |
-  //          |object Main {
-  //          |  ${pathStrings(pathsRange)}
-  //          |  def main(args: Array[String]): Unit = {
-  //          |    if($doubleField == -1.0 || $stringField == "one" || $longField == 1) path1()
-  //          |     else if($doubleField >= 1 && $longField <= 2 && $stringField == "2") path2()
-  //          |     else if(($doubleField == 3.0 && $longField == 3) || $stringField == "tri") path3()
-  //          |     else if(($stringField != "three" || $longField > 3) && $doubleField <= 4.0) path4()
-  //          |     else if(($stringField != null && $longField < 1234567890) && ($doubleField >= -12345.789 && $doubleField <= 12345.789)) path5()
-  //          |     else path6()
-  //          |  }
-  //          |}""".stripMargin
-  //   )
+  it should "allow to use complex conditions" in {
+    val doubleField = "linktime.inner.performanceMultiplier"
+    val longField = "linktime.inner.countFrom"
+    val stringField = "stringProp"
+    val pathsRange = 1.to(6)
+    val compilationUnit = Map(
+      "props.scala" -> props,
+      "props2.scala" -> """
+          |package scala.scalanative
+          |object props2{
+          |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.string")
+          |   def stringProp: String = scala.scalanative.unsafe.resolved
+          |}
+          |""".stripMargin,
+      "main.scala" ->
+        s"""import scala.scalanative.props2._
+           |import scala.scalanative.linktime
+           |
+           |object Main {
+           |  ${pathStrings(pathsRange)}
+           |  def main(args: Array[String]): Unit = {
+           |    if($doubleField == -1.0 || $stringField == "one" || $longField == 1) path1()
+           |     else if($doubleField >= 1 && $longField <= 2 && $stringField == "2") path2()
+           |     else if(($doubleField == 3.0 && $longField == 3) || $stringField == "tri") path3()
+           |     else if(($stringField != "three" || $longField > 3) && $doubleField <= 4.0) path4()
+           |     else if(($stringField != null && $longField < 1234567890) && ($doubleField >= -12345.789 && $doubleField <= 12345.789)) path5()
+           |     else path6()
+           |  }
+           |}""".stripMargin
+    )
 
-  //   val cases: List[((Double, String, Long), Int)] = List(
-  //     (-0.0, "none", 1L) -> 1,
-  //     (1.5, "2", 2L) -> 2,
-  //     (3.0, "tri", -1L) -> 3,
-  //     (3.0, "None", 3L) -> 3,
-  //     (4.0, "four", 4L) -> 4,
-  //     (4.0, "three", 4L) -> 4,
-  //     (5.0, "None", 1234567889L) -> 5,
-  //     (654321.0, "None", 1234567891L) -> 6
-  //   )
+    val cases: List[((Double, String, Long), Int)] = List(
+      (-0.0, "none", 1L) -> 1,
+      (1.5, "2", 2L) -> 2,
+      (3.0, "tri", -1L) -> 3,
+      (3.0, "None", 3L) -> 3,
+      (4.0, "four", 4L) -> 4,
+      (4.0, "three", 4L) -> 4,
+      (5.0, "None", 1234567889L) -> 5,
+      (654321.0, "None", 1234567891L) -> 6
+    )
 
-  //   for (((doubleValue, stringValue, longValue), pathNumber) <- cases)
-  //     linkWithProps(compilationUnit.toSeq: _*)(
-  //       "secret.performance.multiplier" -> doubleValue,
-  //       "prop.string" -> stringValue,
-  //       "inner.countFrom" -> longValue
-  //     ) { (_, result) =>
-  //       result.unavailable should contain only pathForNumber(pathNumber)
-  //     }
-  // }
+    for (((doubleValue, stringValue, longValue), pathNumber) <- cases)
+      linkWithProps(compilationUnit.toSeq: _*)(
+        "secret.performance.multiplier" -> doubleValue,
+        "prop.string" -> stringValue,
+        "inner.countFrom" -> longValue
+      ) { (_, result) =>
+        result.unavailable should contain only pathForNumber(pathNumber)
+      }
+  }
 
-  // it should "handle boolean properties in conditions" in {
-  //   val bool1 = "boolOne"
-  //   val bool2 = "bool2"
-  //   val pathsRange = 1.to(5)
+  it should "handle boolean properties in conditions" in {
+    val bool1 = "boolOne"
+    val bool2 = "bool2"
+    val pathsRange = 1.to(5)
 
-  //   val cases: List[((Boolean, Boolean), Int)] = List(
-  //     (true, true) -> 1,
-  //     (true, false) -> 2,
-  //     (false, true) -> 3
-  //   )
+    val cases: List[((Boolean, Boolean), Int)] = List(
+      (true, true) -> 1,
+      (true, false) -> 2,
+      (false, true) -> 3
+    )
 
-  //   val compilationUnit = Map(
-  //     "props.scala" -> s"""
-  //          |package scala.scalanative
-  //          |object props{
-  //          |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.bool.1")
-  //          |   def $bool1: Boolean = scala.scalanative.unsafe.resolved
-  //          |
-  //          |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.bool.2")
-  //          |   def $bool2: Boolean = scala.scalanative.unsafe.resolved
-  //          |}""".stripMargin,
-  //     "main.scala" -> s"""
-  //       |import scala.scalanative.props._
-  //       |object Main {
-  //       |
-  //       |  ${pathStrings(pathsRange)}
-  //       |  def main(args: Array[String]): Unit = {
-  //       |    if($bool1 && $bool2 == true) path1()
-  //       |     else if($bool1 && !$bool2) path2()
-  //       |     else if($bool1 == false || $bool2) path3()
-  //       |     else path4()
-  //       |  }
-  //       |}""".stripMargin
-  //   )
+    val compilationUnit = Map(
+      "props.scala" -> s"""
+           |package scala.scalanative
+           |object props{
+           |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.bool.1")
+           |   def $bool1: Boolean = scala.scalanative.unsafe.resolved
+           |
+           |   @scalanative.unsafe.resolvedAtLinktime(withName = "prop.bool.2")
+           |   def $bool2: Boolean = scala.scalanative.unsafe.resolved
+           |}""".stripMargin,
+      "main.scala" -> s"""
+        |import scala.scalanative.props._
+        |object Main {
+        |
+        |  ${pathStrings(pathsRange)}
+        |  def main(args: Array[String]): Unit = {
+        |    if($bool1 && $bool2 == true) path1()
+        |     else if($bool1 && !$bool2) path2()
+        |     else if($bool1 == false || $bool2) path3()
+        |     else path4()
+        |  }
+        |}""".stripMargin
+    )
 
-  //   for (((bool1, bool2), pathNumber) <- cases)
-  //     linkWithProps(compilationUnit.toSeq: _*)(
-  //       "prop.bool.1" -> bool1,
-  //       "prop.bool.2" -> bool2
-  //     ) { (_, result) =>
-  //       result.unavailable should contain only pathForNumber(pathNumber)
-  //     }
-  // }
+    for (((bool1, bool2), pathNumber) <- cases)
+      linkWithProps(compilationUnit.toSeq: _*)(
+        "prop.bool.1" -> bool1,
+        "prop.bool.2" -> bool2
+      ) { (_, result) =>
+        result.unavailable should contain only pathForNumber(pathNumber)
+      }
+  }
 
-  // it should "not allow to mix link-time and runtime conditions" in {
-  //   val caught = intercept[scala.scalanative.api.CompilationFailedException] {
-  //     linkWithProps(
-  //       "props.scala" ->
-  //         """package scala.scalanative
-  //           |
-  //           |object props{
-  //           |   @scalanative.unsafe.resolvedAtLinktime("prop")
-  //           |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
-  //           |
-  //           |   def runtimeProperty = true
-  //           |}
-  //           |""".stripMargin,
-  //       "main.scala" -> """
-  //          |import scala.scalanative.props._
-  //          |object Main {
-  //          |  def main(args: Array[String]): Unit = {
-  //          |    if(linktimeProperty || runtimeProperty) ??? 
-  //          |  }
-  //          |}""".stripMargin
-  //     )() { (_, _) => () }
-  //   }
-  //   caught.getMessage shouldEqual "Mixing link-time and runtime conditions is not allowed"
-  // }
+  it should "not allow to mix link-time and runtime conditions" in {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
+      linkWithProps(
+        "props.scala" ->
+          """package scala.scalanative
+            |
+            |object props{
+            |   @scalanative.unsafe.resolvedAtLinktime("prop")
+            |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+            |
+            |   def runtimeProperty = true
+            |}
+            |""".stripMargin,
+        "main.scala" -> """
+           |import scala.scalanative.props._
+           |object Main {
+           |  def main(args: Array[String]): Unit = {
+           |    if(linktimeProperty || runtimeProperty) ??? 
+           |  }
+           |}""".stripMargin
+      )() { (_, _) => () }
+    }
+    caught.getMessage shouldEqual "Mixing link-time and runtime conditions is not allowed"
+  }
 
-  // it should "allow to reference link-time condition at runtime" in {
-  //   linkWithProps(
-  //     "props.scala" ->
-  //       """package scala.scalanative
-  //           |
-  //           |object props{
-  //           |   @scalanative.unsafe.resolvedAtLinktime("prop")
-  //           |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
-  //           |}
-  //           |""".stripMargin,
-  //     "main.scala" -> """
-  //                         |import scala.scalanative.props._
-  //                         |object Main {
-  //                         |  def main(args: Array[String]): Unit = {
-  //                         |    println(linktimeProperty)
-  //                         |  }
-  //                         |}""".stripMargin
-  //   )("prop" -> true) { (_, result) =>
-  //     result.resolvedVals("prop") shouldEqual Val.True
-  //   }
-  // }
+  it should "allow to reference link-time condition at runtime" in {
+    linkWithProps(
+      "props.scala" ->
+        """package scala.scalanative
+            |
+            |object props{
+            |   @scalanative.unsafe.resolvedAtLinktime("prop")
+            |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+            |}
+            |""".stripMargin,
+      "main.scala" -> """
+                          |import scala.scalanative.props._
+                          |object Main {
+                          |  def main(args: Array[String]): Unit = {
+                          |    println(linktimeProperty)
+                          |  }
+                          |}""".stripMargin
+    )("prop" -> true) { (_, result) =>
+      result.resolvedVals("prop") shouldEqual Val.True
+    }
+  }
 
-  // it should "allow to inline linktime property" in {
-  //   optimizeWithProps(
-  //     "props.scala" ->
-  //       """package scala.scalanative
-  //         |
-  //         |object props{
-  //         |   @scalanative.unsafe.resolvedAtLinktime("prop")
-  //         |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
-  //         |}
-  //         |""".stripMargin,
-  //     "main.scala" -> """
-  //                       |import scala.scalanative.props._
-  //                       |object Main {
-  //                       |  @scalanative.annotation.alwaysinline
-  //                       |  def prop() = linktimeProperty
-  //                       |  def main(args: Array[String]): Unit = {
-  //                       |    println(prop())
-  //                       |  }
-  //                       |}""".stripMargin
-  //   )("prop" -> true) { (_, result) =>
-  //     // Check if compiles and does not fail to optimize
-  //     result.unavailable.isEmpty
-  //   }
-  // }
+  it should "allow to inline linktime property" in {
+    optimizeWithProps(
+      "props.scala" ->
+        """package scala.scalanative
+          |
+          |object props{
+          |   @scalanative.unsafe.resolvedAtLinktime("prop")
+          |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
+          |}
+          |""".stripMargin,
+      "main.scala" -> """
+                        |import scala.scalanative.props._
+                        |object Main {
+                        |  @scalanative.annotation.alwaysinline
+                        |  def prop() = linktimeProperty
+                        |  def main(args: Array[String]): Unit = {
+                        |    println(prop())
+                        |  }
+                        |}""".stripMargin
+    )("prop" -> true) { (_, result) =>
+      // Check if compiles and does not fail to optimize
+      result.unavailable.isEmpty
+    }
+  }
 
   it should "allow to define linktime methods calculated based on linktime values" in {
     linkWithProps(


### PR DESCRIPTION
Allow sto define linktime resolved methods interpreted using other linktime resolved methods and literals constats.  

Example: 
```scala
  @resolvedAtLinktime("os")
  def os: String = scala.scalanative.unsafe.resolved

  @resolvedAtLinktime
  def isWindows: Boolean = os == "windows"
   
  @resolvedAtLinktime
  def isMac: Boolean = {
    @resolvedAtLinktime
    def vendor = "apple"
    
    os == "darwin" && vendor == "apple"
  }
  @resolvedAtLinktime
  def dynLibExt: String = 
    if(isWindows) ".dll"
    else if(isMac) ".dylib"
    else ".so"
```