### PR TITLE
Update URLs of DRY and boy scout rule to working links

### DIFF
--- a/docs/contrib/contributing.rst
+++ b/docs/contrib/contributing.rst
@@ -226,8 +226,8 @@ followed by details of the commit, in the form of free text, or bulleted list.
 .. _Apache Harmony project: https://github.com/apache/harmony
 .. _Scala CLA: http://typesafe.com/contribute/cla/scala
 .. _Pull Request: https://help.github.com/articles/using-pull-requests
-.. _DRY: http://programmer.97things.oreilly.com/wiki/index.php/Don%27t_Repeat_Yourself
-.. _Boy Scout Rule: http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule
+.. _DRY: https://www.oreilly.com/library/view/97-things-every/9780596809515/ch30.html
+.. _Boy Scout Rule: https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html
 .. _Git Workflow: http://sandofsky.com/blog/git-workflow.html
 .. _GPL and Scala License are compatible: https://www.gnu.org/licenses/license-list.html#ModifiedBSD
 .. _GPL and Scala CLA are compatible: https://www.gnu.org/licenses/license-list.html#apache2


### PR DESCRIPTION
The URLs to O'Reilly Media did not seem to work anymore. Those URLs were linking to the explanation of the DRY rule and the Boy Scout rule from the book '97 things a programmer should know'. When opening the links now, you will be forwarded to the main page of O'Reilly Media. 

The new URLs seem to link to the correct place, though it seems to be only possible to read the first part of the explanation for free, then the user will have to get a subscription with O'Reilly Media to gain access to the full explanation.
Some alternative solutions for the URLs might be: 
- Using an explanation from a different source.
- Using the Wayback machine from archive.org. This might require some extra attention to copyright rules, though.