### PR TITLE
Expose heap size information to the user

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -39,6 +39,16 @@ void *scalanative_alloc_atomic(void *info, size_t size) {
     return (void *)alloc;
 }
 
+size_t scalanative_get_max_heapsize() {
+    return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
+}
+
+size_t scalanative_get_min_heapsize() {
+    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", 0L);
+}
+
+size_t 
+
 void scalanative_collect() { GC_gcollect(); }
 
 void scalanative_register_weak_reference_handler(void *handler) {}

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -41,8 +41,7 @@ void *scalanative_alloc_atomic(void *info, size_t size) {
 }
 
 size_t scalanative_get_init_heapsize() {
-    return 0L;
-    // return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
+    return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
 }
 
 size_t scalanative_get_max_heapsize() {
@@ -51,8 +50,7 @@ size_t scalanative_get_max_heapsize() {
     GC_get_prof_stats(stats, sizeof(struct GC_prof_stats_s));
     size_t heap_sz = stats->heapsize_full;
     free(stats);
-    return heap_sz;
-    // return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", heap_sz);
+    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", heap_sz);
 }
 
 void scalanative_collect() { GC_gcollect(); }

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -3,11 +3,13 @@
 #define GC_THREADS
 #endif
 
+
 #include <gc/gc.h>
 #include "../shared/ScalaNativeGC.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include "../shared/Parsing.h"
 
 // At the moment we rely on the conservative
 // mode of Boehm GC as our garbage collector.
@@ -39,15 +41,21 @@ void *scalanative_alloc_atomic(void *info, size_t size) {
     return (void *)alloc;
 }
 
+size_t scalanative_get_init_heapsize() {
+    return 0L;
+    //return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
+}
+
 size_t scalanative_get_max_heapsize() {
-    return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
+    struct GC_prof_stats_s *stats = (struct GC_prof_stats_s*)malloc(sizeof(struct GC_prof_stats_s));
+    GC_get_prof_stats(stats, sizeof(struct GC_prof_stats_s));
+    size_t heap_sz = stats->heapsize_full;
+    free(stats);
+    return heap_sz;
+   // return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", heap_sz);
 }
 
-size_t scalanative_get_min_heapsize() {
-    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", 0L);
-}
 
-size_t 
 
 void scalanative_collect() { GC_gcollect(); }
 

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -3,7 +3,6 @@
 #define GC_THREADS
 #endif
 
-
 #include <gc/gc.h>
 #include "../shared/ScalaNativeGC.h"
 #include <stdlib.h>
@@ -43,19 +42,18 @@ void *scalanative_alloc_atomic(void *info, size_t size) {
 
 size_t scalanative_get_init_heapsize() {
     return 0L;
-    //return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
+    // return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
 }
 
 size_t scalanative_get_max_heapsize() {
-    struct GC_prof_stats_s *stats = (struct GC_prof_stats_s*)malloc(sizeof(struct GC_prof_stats_s));
+    struct GC_prof_stats_s *stats =
+        (struct GC_prof_stats_s *)malloc(sizeof(struct GC_prof_stats_s));
     GC_get_prof_stats(stats, sizeof(struct GC_prof_stats_s));
     size_t heap_sz = stats->heapsize_full;
     free(stats);
     return heap_sz;
-   // return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", heap_sz);
+    // return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", heap_sz);
 }
-
-
 
 void scalanative_collect() { GC_gcollect(); }
 

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -83,3 +83,11 @@ INLINE void scalanative_collect() {
 INLINE void scalanative_register_weak_reference_handler(void *handler) {
     WeakRefGreyList_SetHandler(handler);
 }
+
+unsigned long scalanative_get_min_heapsize() {
+    return Settings_MinHeapSize();
+}
+
+unsigned long scalanative_get_max_heapsize() {
+    return Settings_MaxHeapSize();
+}

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -16,6 +16,8 @@
 #include "WeakRefGreyList.h"
 #include "Sweeper.h"
 
+#include "Parsing.h"
+
 void scalanative_collect();
 
 void scalanative_afterexit() {
@@ -84,10 +86,20 @@ INLINE void scalanative_register_weak_reference_handler(void *handler) {
     WeakRefGreyList_SetHandler(handler);
 }
 
-unsigned long scalanative_get_min_heapsize() {
-    return Settings_MinHeapSize();
-}
+/**
+ * Get the minimum heap size
+ * If the user has set a minimum heap size using the GC_INITIAL_HEAP_SIZE environment variable,
+ * then this size will be returned.
+ * Otherwise, the default minimum heap size will be returned.
+ */
+size_t scalanative_get_init_heapsize() { return Settings_MinHeapSize(); }
 
-unsigned long scalanative_get_max_heapsize() {
-    return Settings_MaxHeapSize();
+/**
+ * Get the maximum heap size
+ * If the user has set a maximum heap size using the GC_MAXIMUM_HEAP_SIZE environment variable,
+ * then this size will be returned.
+ * Otherwise, the total size of the physical memory (guarded) will be returned
+*/
+size_t scalanative_get_max_heapsize() {
+    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
 }

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -86,20 +86,17 @@ INLINE void scalanative_register_weak_reference_handler(void *handler) {
     WeakRefGreyList_SetHandler(handler);
 }
 
-/**
- * Get the minimum heap size
- * If the user has set a minimum heap size using the GC_INITIAL_HEAP_SIZE environment variable,
- * then this size will be returned.
- * Otherwise, the default minimum heap size will be returned.
- */
+/* Get the minimum heap size */
+/* If the user has set a minimum heap size using the GC_INITIAL_HEAP_SIZE
+ * environment variable, */
+/* then this size will be returned. */
+/* Otherwise, the default minimum heap size will be returned.*/
 size_t scalanative_get_init_heapsize() { return Settings_MinHeapSize(); }
 
-/**
- * Get the maximum heap size
- * If the user has set a maximum heap size using the GC_MAXIMUM_HEAP_SIZE environment variable,
- * then this size will be returned.
- * Otherwise, the total size of the physical memory (guarded) will be returned
-*/
+/* Get the maximum heap size */
+/* If the user has set a maximum heap size using the GC_MAXIMUM_HEAP_SIZE */
+/* environment variable,*/
+/* then this size will be returned.*/
+/* Otherwise, the total size of the physical memory (guarded) will be returned*/
 size_t scalanative_get_max_heapsize() {
     return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
-}

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -100,3 +100,4 @@ size_t scalanative_get_init_heapsize() { return Settings_MinHeapSize(); }
 /* Otherwise, the total size of the physical memory (guarded) will be returned*/
 size_t scalanative_get_max_heapsize() {
     return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
+}

--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.h
@@ -88,5 +88,6 @@ void Heap_Init(Heap *heap, size_t minHeapSize, size_t maxHeapSize);
 void Heap_Collect(Heap *heap);
 void Heap_GrowIfNeeded(Heap *heap);
 void Heap_Grow(Heap *heap, uint32_t increment);
+size_t Heap_getMemoryLimit();
 
 #endif // IMMIX_HEAP_H

--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.h
@@ -52,5 +52,6 @@ void Heap_Collect(Heap *heap, Stack *stack);
 
 void Heap_Recycle(Heap *heap);
 void Heap_Grow(Heap *heap, uint32_t increment);
+size_t Heap_getMemoryLimit();
 
 #endif // IMMIX_HEAP_H

--- a/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
@@ -73,26 +73,21 @@ INLINE void scalanative_register_weak_reference_handler(void *handler) {
     WeakRefStack_SetHandler(handler);
 }
 
-/**
- * Get the minimum heap size
- * If the user has set a minimum heap size using the GC_INITIAL_HEAP_SIZE environment variable,
- * then this size will be returned.
- * Otherwise, the default minimum heap size will be returned.
- */
-size_t scalanative_get_init_heapsize() { 
-    return Settings_MinHeapSize(); 
-    }
+/* Get the minimum heap size */
+/* If the user has set a minimum heap size using the GC_INITIAL_HEAP_SIZE
+ * environment variable, */
+/* then this size will be returned. */
+/* Otherwise, the default minimum heap size will be returned.*/
+size_t scalanative_get_init_heapsize() { return Settings_MinHeapSize(); }
 
-/**
- * Get the maximum heap size
- * If the user has set a maximum heap size using the GC_MAXIMUM_HEAP_SIZE environment variable,
- * then this size will be returned.
- * Otherwise, the total size of the physical memory (guarded) will be returned
-*/
-
-size_t scalanative_get_max_heapsize() { 
-    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit()); 
-    }
+/* Get the maximum heap size */
+/* If the user has set a maximum heap size using the GC_MAXIMUM_HEAP_SIZE
+ * environment variable,*/
+/* then this size will be returned.*/
+/* Otherwise, the total size of the physical memory (guarded) will be returned*/
+size_t scalanative_get_max_heapsize() {
+    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
+}
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 typedef void *RoutineArgs;

--- a/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
@@ -13,7 +13,7 @@
 #include "Constants.h"
 #include "Settings.h"
 #include "WeakRefStack.h"
-
+#include "Parsing.h"
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #include "Synchronizer.h"
 #endif
@@ -73,13 +73,26 @@ INLINE void scalanative_register_weak_reference_handler(void *handler) {
     WeakRefStack_SetHandler(handler);
 }
 
-unsigned long scalanative_get_min_heapsize() {
-    return Settings_MinHeapSize();
-}
+/**
+ * Get the minimum heap size
+ * If the user has set a minimum heap size using the GC_INITIAL_HEAP_SIZE environment variable,
+ * then this size will be returned.
+ * Otherwise, the default minimum heap size will be returned.
+ */
+size_t scalanative_get_init_heapsize() { 
+    return Settings_MinHeapSize(); 
+    }
 
-unsigned long scalanative_get_max_heapsize() {
-    return Settings_MaxHeapSize();
-}
+/**
+ * Get the maximum heap size
+ * If the user has set a maximum heap size using the GC_MAXIMUM_HEAP_SIZE environment variable,
+ * then this size will be returned.
+ * Otherwise, the total size of the physical memory (guarded) will be returned
+*/
+
+size_t scalanative_get_max_heapsize() { 
+    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit()); 
+    }
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 typedef void *RoutineArgs;

--- a/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
@@ -73,6 +73,14 @@ INLINE void scalanative_register_weak_reference_handler(void *handler) {
     WeakRefStack_SetHandler(handler);
 }
 
+unsigned long scalanative_get_min_heapsize() {
+    return Settings_MinHeapSize();
+}
+
+unsigned long scalanative_get_max_heapsize() {
+    return Settings_MaxHeapSize();
+}
+
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 typedef void *RoutineArgs;
 typedef struct {

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -42,6 +42,14 @@ void exitWithOutOfMemory() {
     exit(1);
 }
 
+size_t scalanative_get_min_heapsize() {
+    return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
+}
+
+size_t scalanative_get_max_heapsize() {
+    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", getMemorySize());
+}
+
 void Prealloc_Or_Default() {
 
     if (TO_NORMAL_MMAP == 1L) { // Check if we have prealloc env varible

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -42,7 +42,7 @@ void exitWithOutOfMemory() {
     exit(1);
 }
 
-size_t scalanative_get_min_heapsize() {
+size_t scalanative_get_init_heapsize() {
     return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
 }
 

--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include "GCTypes.h"
 
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 // Boehm on Windows needs User32.lib linked
@@ -26,7 +27,7 @@ void *scalanative_alloc_large(void *info, size_t size);
 void *scalanative_alloc_atomic(void *info, size_t size);
 void scalanative_collect();
 void scalanative_register_weak_reference_handler(void *handler);
-size_t scalanative_get_min_heapsize();
+size_t scalanative_get_init_heapsize();
 size_t scalanative_get_max_heapsize();
 
 // Functions used to create a new thread supporting multithreading support in

--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -26,6 +26,8 @@ void *scalanative_alloc_large(void *info, size_t size);
 void *scalanative_alloc_atomic(void *info, size_t size);
 void scalanative_collect();
 void scalanative_register_weak_reference_handler(void *handler);
+size_t scalanative_get_min_heapsize();
+size_t scalanative_get_max_heapsize();
 
 // Functions used to create a new thread supporting multithreading support in
 // the garbage collector. Would execute a proxy startup routine to register

--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 #include "GCTypes.h"
 
-
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 // Boehm on Windows needs User32.lib linked

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -25,7 +25,7 @@ object GC {
   def init(): Unit = extern
   @name("scalanative_register_weak_reference_handler")
   def registerWeakReferenceHandler(handler: Ptr[Byte]): Unit = extern
-  @name("scalanative_get_min_heapsize")
+  @name("scalanative_get_init_heapsize")
   def getMinHeapSize(): CSize = extern
   @name("scalanative_get_max_heapsize")
   def getMaxHeapSize(): CSize = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -25,6 +25,10 @@ object GC {
   def init(): Unit = extern
   @name("scalanative_register_weak_reference_handler")
   def registerWeakReferenceHandler(handler: Ptr[Byte]): Unit = extern
+  @name("scalanative_get_min_heapsize")
+  def getMinHeapSize(): CSize = extern
+  @name("scalanative_get_max_heapsize")
+  def getMaxHeapSize(): CSize = extern
 
   /*  Multithreading awareness for GC Every implementation of GC supported in
    *  ScalaNative needs to register a given thread The main thread is

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -26,7 +26,7 @@ object GC {
   @name("scalanative_register_weak_reference_handler")
   def registerWeakReferenceHandler(handler: Ptr[Byte]): Unit = extern
   @name("scalanative_get_init_heapsize")
-  def getMinHeapSize(): CSize = extern
+  def getInitHeapSize(): CSize = extern
   @name("scalanative_get_max_heapsize")
   def getMaxHeapSize(): CSize = extern
 

--- a/tools/src/main/scala/scala/scalanative/build/GC.scala
+++ b/tools/src/main/scala/scala/scalanative/build/GC.scala
@@ -41,7 +41,7 @@ object GC {
   private[scalanative] case object None
       extends GC("none", Seq.empty, Seq("shared"))
   private[scalanative] case object Boehm
-      extends GC("boehm", Seq("gc"), Seq.empty)
+      extends GC("boehm", Seq("gc"), Seq("shared"))
   private[scalanative] case object Immix
       extends GC("immix", Seq.empty, Seq("shared", "immix_commix"))
   private[scalanative] case object Commix

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/HeapSizeTest.scala.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/HeapSizeTest.scala.scala
@@ -1,0 +1,28 @@
+package scala.scalanative.runtime
+import org.junit.Test
+import org.junit.Before
+import org.junit.Assert._
+import scala.scalanative.unsafe.CSize
+import scalanative.unsigned.{ULong, UnsignedRichInt}
+
+class HeapSizeTest {
+
+    @Before
+    val conversionFactor = (1024 * 1024 * 1024).toULong
+    val lowerBound : ULong = 0.toULong
+    val higherBound : ULong = 32.toULong * conversionFactor
+
+    @Test
+    def checkInitHeapSize(): Unit = {
+        val initHeapSz = GC.getInitHeapSize()
+        assertTrue(s"0 <= ${initHeapSz / conversionFactor}GB < 32GB", initHeapSz >= lowerBound && initHeapSz < higherBound)
+    }
+
+    @Test 
+    def checkMaxHeapSize(): Unit = {
+        val maxHeapSize = GC.getMaxHeapSize()
+        assertTrue(s"0 < ${maxHeapSize / conversionFactor}GB <= 32GB", maxHeapSize > lowerBound && maxHeapSize <= higherBound)
+    }
+    
+  
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/HeapSizeTest.scala.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/HeapSizeTest.scala.scala
@@ -7,22 +7,25 @@ import scalanative.unsigned.{ULong, UnsignedRichInt}
 
 class HeapSizeTest {
 
-    @Before
-    val conversionFactor = (1024 * 1024 * 1024).toULong
-    val lowerBound : ULong = 0.toULong
-    val higherBound : ULong = 32.toULong * conversionFactor
+  @Before
+  val conversionFactor = (1024 * 1024 * 1024).toULong
+  val lowerBound: ULong = 0.toULong
+  val higherBound: ULong = 32.toULong * conversionFactor
 
-    @Test
-    def checkInitHeapSize(): Unit = {
-        val initHeapSz = GC.getInitHeapSize()
-        assertTrue(s"0 <= ${initHeapSz / conversionFactor}GB < 32GB", initHeapSz >= lowerBound && initHeapSz < higherBound)
-    }
+  @Test def checkInitHeapSize(): Unit = {
+    val initHeapSz = GC.getInitHeapSize()
+    assertTrue(
+      s"0 <= ${initHeapSz / conversionFactor}GB < 32GB",
+      initHeapSz >= lowerBound && initHeapSz < higherBound
+    )
+  }
 
-    @Test 
-    def checkMaxHeapSize(): Unit = {
-        val maxHeapSize = GC.getMaxHeapSize()
-        assertTrue(s"0 < ${maxHeapSize / conversionFactor}GB <= 32GB", maxHeapSize > lowerBound && maxHeapSize <= higherBound)
-    }
-    
-  
+  @Test def checkMaxHeapSize(): Unit = {
+    val maxHeapSize = GC.getMaxHeapSize()
+    assertTrue(
+      s"0 < ${maxHeapSize / conversionFactor}GB <= 32GB",
+      maxHeapSize > lowerBound && maxHeapSize <= higherBound
+    )
+  }
+
 }


### PR DESCRIPTION
This PR aims at exposing heap size information to the end user of Scala Native. Concretely, the initial heap size and the maximum heap size should be accessed by the end user using `scalanative.runtime.GC.getInitHeapSize()` and `scalanative.runtime.GC.getMaxHeapSize()` which will both return the results in bytes. This is similar to `Runtime.getRuntime().maxMemory()` in the Java library.

## Motivation

In some cases, the user may be interested in knowing the initial and maximum heap size the garbage collector is using at runtime. For example, if the user sets the initial and maximum heap size using environment variables, the user may want to do a sanity check in their program to make sure that the variables are correctly set. This is useful in some (automated) benchmarking infrastructures, where the heap size is often limited, and it may come in handy to check that the heap size settings are correcly set and well understood by the Scala Native program. 

## Implementation

### Immix and Commix
For the immix and commix garbage collectors, accessing the initial heap size is achieved by using the `Settings_MinHeapSize()` function. As for the maximum heap size, if the user has set a maximum heap size using the corresponding environment variable, then this variable will be returned. Otherwise, the total amount of the available phyiscal memory on the machine will be returned.

### None
For the none gc, if the user did not change the heap size settings, the initial heap size will be 0, and the maximum heap size will be the total amount of physical memory.

### Boehm
Unfortuantely, I was not able to get the initial heap size using the public interface of the Boehm GC. I was able to locate it in the codebase of BDWGC [Line 928 bdwgc/misc.c](https://github.com/ivmai/bdwgc/blob/d654f40deaa60b9bcaa5177963aec76974745897/misc.c#L928), but I could not find directly any public interface to retrieve these results.
As for the maximum heap size, the `GC_get_prof_stats` function may be used. However when I was testing on my machine (Ubuntu 22.04) with a manually set maximum heap size, `GC_prof_stats_s.heapsize_full` did not seem to change, which makes me think that I probably misunderstood its usage, and  it is perhaps not the maximum heap size.