### PR TITLE
[doc] Mention `publish-local-dev` custom command in contributors' doc

### DIFF
--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -140,11 +140,11 @@ If you need to test your copy of Scala Native in the larger context of a
 separate build, you will need to locally publish all the artifacts of Scala
 Native.
 
-Use the special script that publishes all the cross versions:
+Use the custom sbt command to publish all projects for a specific Scala version (`x,y,z`):
 
 .. code-block:: text
 
-    $ scripts/publish-local
+    > publish-local-dev x.y.z
 
 Afterwards, set the version of `sbt-scala-native` in the target project's
 `project/plugins.sbt` to the current SNAPSHOT version of Scala Native, and use


### PR DESCRIPTION
There's no longer a special scripts like `scripts/publish-local`.
ScalaNative is required to depend on multiple Scala versions e.g. Scala 2.12 (sbtPlugin) or Scala 2.13 (scalalib for Scala 3) and just running `++x.y.z publishLocal` on root project is not recommended.
Instead, we can use `publish-local-dev` custom task in sbt.

see: https://github.com/scala-native/scala-native/pull/3270#pullrequestreview-1414996761