### PR TITLE
Use `Array[Int]` instead of `Array[Array[Boolean]]` for `[class,trait]_has_trait`

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/BitMatrix.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/BitMatrix.scala
@@ -8,8 +8,7 @@ private[scalanative] class BitMatrix private (
 
   def set(row: Int, col: Int): Unit = {
     val bitIndex = row * columns + col
-    val len = (bitIndex >> AddressBitsPerWord) + 1
-    bits(len - 1) |= 1L << (bitIndex & RightBits)
+    bits(bitIndex >> AddressBitsPerWord) |= 1L << (bitIndex & RightBits)
   }
 
   def toSeq = bits.toSeq

--- a/tools/src/main/scala/scala/scalanative/codegen/BitMatrix.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/BitMatrix.scala
@@ -1,26 +1,26 @@
 package scala.scalanative
 
 private[scalanative] class BitMatrix private (
-    bits: Array[Long],
+    bits: Array[Int],
     columns: Int
 ) {
   import BitMatrix.{AddressBitsPerWord, ElementSize, RightBits}
 
   def set(row: Int, col: Int): Unit = {
     val bitIndex = row * columns + col
-    bits(bitIndex >> AddressBitsPerWord) |= 1L << (bitIndex & RightBits)
+    bits(bitIndex >> AddressBitsPerWord) |= 1 << (bitIndex & RightBits)
   }
 
   def toSeq = bits.toSeq
 }
 private[scalanative] object BitMatrix {
-  private[scalanative] final val AddressBitsPerWord = 6 // Int Based 2^6 = 64
+  private[scalanative] final val AddressBitsPerWord = 5 // Int Based 2^5 = 32
   private[scalanative] final val ElementSize = 1 << AddressBitsPerWord
   private[scalanative] final val RightBits = ElementSize - 1
 
   def apply(rows: Int, columns: Int): BitMatrix = {
     val nbits = rows * columns
     val length = (nbits + RightBits) >> AddressBitsPerWord
-    new BitMatrix(new Array[Long](length), columns)
+    new BitMatrix(new Array[Int](length), columns)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/BitMatrix.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/BitMatrix.scala
@@ -1,0 +1,27 @@
+package scala.scalanative
+
+private[scalanative] class BitMatrix private (
+    bits: Array[Long],
+    columns: Int
+) {
+  import BitMatrix.{AddressBitsPerWord, ElementSize, RightBits}
+
+  def set(row: Int, col: Int): Unit = {
+    val bitIndex = row * columns + col
+    val len = (bitIndex >> AddressBitsPerWord) + 1
+    bits(len - 1) |= 1L << (bitIndex & RightBits)
+  }
+
+  def toSeq = bits.toSeq
+}
+private[scalanative] object BitMatrix {
+  private[scalanative] final val AddressBitsPerWord = 6 // Int Based 2^6 = 64
+  private[scalanative] final val ElementSize = 1 << AddressBitsPerWord
+  private[scalanative] final val RightBits = ElementSize - 1
+
+  def apply(rows: Int, columns: Int): BitMatrix = {
+    val nbits = rows * columns
+    val length = (nbits + RightBits) >> AddressBitsPerWord
+    new BitMatrix(new Array[Long](length), columns)
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -117,90 +117,77 @@ object Generate {
       val and = Val.Local(fresh(), Type.Long)
       val result = Val.Local(fresh(), Type.Bool)
 
+      def let(local: Val.Local, op: Op) = Inst.Let(local.name, op, Next.None)
+
       buf += Defn.Define(
         Attrs(inlineHint = Attr.AlwaysInline),
         name,
         sig,
         Seq(
           Inst.Label(fresh(), Seq(firstid, secondid)),
-          Inst.Let(
-            row.name,
-            Op.Bin(Bin.Imul, Type.Int, firstid, columns),
-            Next.None
-          ),
-          Inst.Let(
-            bitIndex.name,
-            Op.Bin(Bin.Iadd, Type.Int, row, secondid),
-            Next.None
-          ),
-          Inst.Let(
-            arrayPos.name,
+          let(row, Op.Bin(Bin.Imul, Type.Int, firstid, columns)),
+          let(bitIndex, Op.Bin(Bin.Iadd, Type.Int, row, secondid)),
+          let(
+            arrayPos,
             Op.Bin(
               Bin.Ashr,
               Type.Int,
               bitIndex,
               Val.Int(BitMatrix.AddressBitsPerWord)
-            ),
-            Next.None
+            )
           ),
-          Inst.Let(
-            longptr.name,
+          let(
+            longptr,
             Op.Elem(
               tableTy,
               tableVal,
               Seq(Val.Int(0), arrayPos)
-            ),
-            Next.None
+            )
           ),
-          Inst.Let(long.name, Op.Load(Type.Long, longptr), Next.None),
-          Inst.Let(
-            toShift.name,
+          let(long, Op.Load(Type.Long, longptr)),
+          let(
+            toShift,
             Op.Bin(
               Bin.And,
               Type.Int,
               bitIndex,
               Val.Int(BitMatrix.RightBits)
-            ),
-            Next.None
+            )
           ),
-          Inst.Let(
-            toShiftLong.name,
+          let(
+            toShiftLong,
             Op.Conv(
               Conv.Sext,
               Type.Long,
               toShift
-            ),
-            Next.None
+            )
           ),
-          Inst.Let(
-            mask.name,
+          let(
+            mask,
             Op.Bin(
               Bin.Shl,
               Type.Long,
               Val.Long(1),
               toShiftLong
-            ),
-            Next.None
+            )
           ),
-          Inst.Let(
-            and.name,
+          let(
+            and,
             Op.Bin(
               Bin.And,
               Type.Long,
               long,
               mask
-            ),
-            Next.None
+            )
           ),
-          Inst.Let(
-            result.name,
+          let(
+            result,
             Op.Comp(
               Comp.Ine,
               Type.Long,
               and,
               Val.Long(0)
-            ),
-            Next.None
+            )
           ),
           Inst.Ret(result)
         )

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -91,19 +91,11 @@ object Generate {
       )
     }
 
-    // def __get_[class,trait]_has_trait(firstid: Int, secondid: Int): Boolean = {
-    //   val columns = meta.traits.length
-    //   val row = firstid * columns
-    //   val bitIndex = row + secondid
-    //   val arrayPos = bitIndex >> AddressBitsPerWord
-    //   val long = bits(arrayPos)
-    //   val toShift = bitIndex & RightBits
-    //   val toShiftLong = toShift.toLong
-    //   val mask = 1L << toShiftLong
-    //   val and = long & mask
-    //   val result = and != 0L
-    //
-    //   result
+    // BitMatrix get adapted from the java.util.BitSet implementation.
+    // Equivalent to the following Scala code:
+    // def get_[class,trait]_has_trait(firstid: Int, secondid: Int): Boolean = {
+    //   val bitIndex = firstid * meta.traits.length + secondid
+    //   (table(bitIndex >> AddressBitsPerWord) & (1L << (bitIndex & RightBits))) != 0
     // }
     private def genHasTrait(
         name: Global.Member,

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -9,6 +9,14 @@ import scala.scalanative.build.Logger
 object Generate {
   import Impl._
 
+  val ClassHasTraitName =
+    Global.Member(rttiModule, Sig.Extern("__check_class_has_trait"))
+  val ClassHasTraitSig = Type.Function(Seq(Type.Int, Type.Int), Type.Bool)
+
+  val TraitHasTraitName =
+    Global.Member(rttiModule, Sig.Extern("__check_trait_has_trait"))
+  val TraitHasTraitSig = Type.Function(Seq(Type.Int, Type.Int), Type.Bool)
+
   def apply(entry: Option[Global.Top], defns: Seq[Defn])(implicit
       meta: Metadata
   ): Seq[Defn] =
@@ -592,16 +600,8 @@ object Generate {
     }
   }
 
-  object Impl {
+  private object Impl {
     val rttiModule = Global.Top("java.lang.rtti$")
-
-    val ClassHasTraitName =
-      Global.Member(rttiModule, Sig.Extern("__check_class_has_trait"))
-    val ClassHasTraitSig = Type.Function(Seq(Type.Int, Type.Int), Type.Bool)
-
-    val TraitHasTraitName =
-      Global.Member(rttiModule, Sig.Extern("__check_trait_has_trait"))
-    val TraitHasTraitSig = Type.Function(Seq(Type.Int, Type.Int), Type.Bool)
 
     val ObjectArray =
       Type.Ref(Global.Top("scala.scalanative.runtime.ObjectArray"))

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -95,7 +95,7 @@ object Generate {
     // Equivalent to the following Scala code:
     // def get_[class,trait]_has_trait(firstid: Int, secondid: Int): Boolean = {
     //   val bitIndex = firstid * meta.traits.length + secondid
-    //   (table(bitIndex >> AddressBitsPerWord) & (1L << (bitIndex & RightBits))) != 0
+    //   (table(bitIndex >> AddressBitsPerWord) & (1 << (bitIndex & RightBits))) != 0
     // }
     private def genHasTrait(
         name: Global.Member,
@@ -109,12 +109,11 @@ object Generate {
       val columns = Val.Int(meta.traits.length)
       val bitIndex = Val.Local(fresh(), Type.Int)
       val arrayPos = Val.Local(fresh(), Type.Int)
-      val longptr = Val.Local(fresh(), Type.Ptr)
-      val long = Val.Local(fresh(), Type.Long)
+      val intptr = Val.Local(fresh(), Type.Ptr)
+      val int = Val.Local(fresh(), Type.Int)
       val toShift = Val.Local(fresh(), Type.Int)
-      val toShiftLong = Val.Local(fresh(), Type.Long)
-      val mask = Val.Local(fresh(), Type.Long)
-      val and = Val.Local(fresh(), Type.Long)
+      val mask = Val.Local(fresh(), Type.Int)
+      val and = Val.Local(fresh(), Type.Int)
       val result = Val.Local(fresh(), Type.Bool)
 
       def let(local: Val.Local, op: Op) = Inst.Let(local.name, op, Next.None)
@@ -137,14 +136,14 @@ object Generate {
             )
           ),
           let(
-            longptr,
+            intptr,
             Op.Elem(
               tableTy,
               tableVal,
               Seq(Val.Int(0), arrayPos)
             )
           ),
-          let(long, Op.Load(Type.Long, longptr)),
+          let(int, Op.Load(Type.Int, intptr)),
           let(
             toShift,
             Op.Bin(
@@ -155,28 +154,20 @@ object Generate {
             )
           ),
           let(
-            toShiftLong,
-            Op.Conv(
-              Conv.Sext,
-              Type.Long,
-              toShift
-            )
-          ),
-          let(
             mask,
             Op.Bin(
               Bin.Shl,
-              Type.Long,
-              Val.Long(1),
-              toShiftLong
+              Type.Int,
+              Val.Int(1),
+              toShift
             )
           ),
           let(
             and,
             Op.Bin(
               Bin.And,
-              Type.Long,
-              long,
+              Type.Int,
+              int,
               mask
             )
           ),
@@ -184,9 +175,9 @@ object Generate {
             result,
             Op.Comp(
               Comp.Ine,
-              Type.Long,
+              Type.Int,
               and,
-              Val.Long(0)
+              Val.Int(0)
             )
           ),
           Inst.Ret(result)

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -66,14 +66,43 @@ object Generate {
     }
 
     def genClassHasTrait(): Unit = {
-      genHasTrait(ClassHasTraitName, ClassHasTraitSig)
+      genHasTrait(
+        ClassHasTraitName,
+        ClassHasTraitSig,
+        meta.hasTraitTables.classHasTraitTy,
+        meta.hasTraitTables.classHasTraitVal
+      )
     }
 
     def genTraitHasTrait(): Unit = {
-      genHasTrait(TraitHasTraitName, TraitHasTraitSig)
+      genHasTrait(
+        TraitHasTraitName,
+        TraitHasTraitSig,
+        meta.hasTraitTables.traitHasTraitTy,
+        meta.hasTraitTables.traitHasTraitVal
+      )
     }
 
-    private def genHasTrait(name: Global.Member, sig: Type.Function): Unit = {
+    // def __get_[class,trait]_has_trait(firstid: Int, secondid: Int): Boolean = {
+    //   val columns = meta.traits.length
+    //   val row = firstid * columns
+    //   val bitIndex = row + secondid
+    //   val arrayPos = bitIndex >> AddressBitsPerWord
+    //   val long = bits(arrayPos)
+    //   val toShift = bitIndex & RightBits
+    //   val toShiftLong = toShift.toLong
+    //   val mask = 1L << toShiftLong
+    //   val and = long & mask
+    //   val result = and != 0L
+    //
+    //   result
+    // }
+    private def genHasTrait(
+        name: Global.Member,
+        sig: Type.Function,
+        tableTy: Type,
+        tableVal: Val
+    ): Unit = {
       implicit val fresh = Fresh()
       val firstid, secondid = Val.Local(fresh(), Type.Int)
       val row = Val.Local(fresh(), Type.Int)
@@ -117,8 +146,8 @@ object Generate {
           Inst.Let(
             longptr.name,
             Op.Elem(
-              meta.hasTraitTables.traitHasTraitTy,
-              meta.hasTraitTables.traitHasTraitVal,
+              tableTy,
+              tableVal,
               Seq(Val.Int(0), arrayPos)
             ),
             Next.None

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -68,7 +68,14 @@ object Generate {
     def genClassHasTrait(): Unit = {
       implicit val fresh = Fresh()
       val classid, traitid = Val.Local(fresh(), Type.Int)
-      val boolptr = Val.Local(fresh(), Type.Ptr)
+      val row = Val.Local(fresh(), Type.Int)
+      val columns = Val.Local(fresh(), Type.Int)
+      val bitIndex = Val.Local(fresh(), Type.Int)
+      val arrayPos = Val.Local(fresh(), Type.Int)
+      val long = Val.Local(fresh(), Type.Long)
+      val toShift = Val.Local(fresh(), Type.Int)
+      val mask = Val.Local(fresh(), Type.Long)
+      val and = Val.Local(fresh(), Type.Long)
       val result = Val.Local(fresh(), Type.Bool)
 
       buf += Defn.Define(
@@ -78,15 +85,79 @@ object Generate {
         Seq(
           Inst.Label(fresh(), Seq(classid, traitid)),
           Inst.Let(
-            boolptr.name,
-            Op.Elem(
-              meta.hasTraitTables.classHasTraitTy,
-              meta.hasTraitTables.classHasTraitVal,
-              Seq(Val.Int(0), classid, traitid)
+            columns.name,
+            Op.Arraylength(meta.hasTraitTables.traitHasTraitVal),
+            Next.None
+          ),
+          Inst.Let(
+            row.name,
+            Op.Bin(Bin.Imul, Type.Long, classid, columns),
+            Next.None
+          ),
+          Inst.Let(
+            bitIndex.name,
+            Op.Bin(Bin.Iadd, Type.Long, row, traitid),
+            Next.None
+          ),
+          Inst.Let(
+            arrayPos.name,
+            Op.Bin(
+              Bin.Ashr,
+              Type.Long,
+              bitIndex,
+              Val.Const(Val.Int(BitMatrix.AddressBitsPerWord))
             ),
             Next.None
           ),
-          Inst.Let(result.name, Op.Load(Type.Bool, boolptr), Next.None),
+          Inst.Let(
+            long.name,
+            Op.Arrayload(
+              Type.Long,
+              meta.hasTraitTables.traitHasTraitVal,
+              Val.Const(Val.Int(BitMatrix.RightBits))
+            ),
+            Next.None
+          ),
+          Inst.Let(
+            toShift.name,
+            Op.Bin(
+              Bin.And,
+              Type.Int,
+              bitIndex,
+              arrayPos
+            ),
+            Next.None
+          ),
+          Inst.Let(
+            mask.name,
+            Op.Bin(
+              Bin.Shl,
+              Type.Int,
+              Val.Const(Val.Int(1)),
+              toShift
+            ),
+            Next.None
+          ),
+          Inst.Let(
+            and.name,
+            Op.Bin(
+              Bin.And,
+              Type.Long,
+              long,
+              mask
+            ),
+            Next.None
+          ),
+          Inst.Let(
+            result.name,
+            Op.Comp(
+              Comp.Ine,
+              Type.Long,
+              and,
+              Val.Const(Val.Long(0))
+            ),
+            Next.None
+          ),
           Inst.Ret(result)
         )
       )
@@ -103,7 +174,14 @@ object Generate {
     def genTraitHasTrait(): Unit = {
       implicit val fresh = Fresh()
       val leftid, rightid = Val.Local(fresh(), Type.Int)
-      val boolptr = Val.Local(fresh(), Type.Ptr)
+      val row = Val.Local(fresh(), Type.Int)
+      val columns = Val.Local(fresh(), Type.Int)
+      val bitIndex = Val.Local(fresh(), Type.Int)
+      val arrayPos = Val.Local(fresh(), Type.Int)
+      val long = Val.Local(fresh(), Type.Long)
+      val toShift = Val.Local(fresh(), Type.Int)
+      val mask = Val.Local(fresh(), Type.Long)
+      val and = Val.Local(fresh(), Type.Long)
       val result = Val.Local(fresh(), Type.Bool)
 
       buf += Defn.Define(
@@ -113,15 +191,79 @@ object Generate {
         Seq(
           Inst.Label(fresh(), Seq(leftid, rightid)),
           Inst.Let(
-            boolptr.name,
-            Op.Elem(
-              meta.hasTraitTables.traitHasTraitTy,
-              meta.hasTraitTables.traitHasTraitVal,
-              Seq(Val.Int(0), leftid, rightid)
+            columns.name,
+            Op.Arraylength(meta.hasTraitTables.traitHasTraitVal),
+            Next.None
+          ),
+          Inst.Let(
+            row.name,
+            Op.Bin(Bin.Imul, Type.Long, leftid, columns),
+            Next.None
+          ),
+          Inst.Let(
+            bitIndex.name,
+            Op.Bin(Bin.Iadd, Type.Long, row, rightid),
+            Next.None
+          ),
+          Inst.Let(
+            arrayPos.name,
+            Op.Bin(
+              Bin.Ashr,
+              Type.Long,
+              bitIndex,
+              Val.Const(Val.Int(BitMatrix.AddressBitsPerWord))
             ),
             Next.None
           ),
-          Inst.Let(result.name, Op.Load(Type.Bool, boolptr), Next.None),
+          Inst.Let(
+            long.name,
+            Op.Arrayload(
+              Type.Long,
+              meta.hasTraitTables.traitHasTraitVal,
+              Val.Const(Val.Int(BitMatrix.RightBits))
+            ),
+            Next.None
+          ),
+          Inst.Let(
+            toShift.name,
+            Op.Bin(
+              Bin.And,
+              Type.Int,
+              bitIndex,
+              arrayPos
+            ),
+            Next.None
+          ),
+          Inst.Let(
+            mask.name,
+            Op.Bin(
+              Bin.Shl,
+              Type.Int,
+              Val.Const(Val.Int(1)),
+              toShift
+            ),
+            Next.None
+          ),
+          Inst.Let(
+            and.name,
+            Op.Bin(
+              Bin.And,
+              Type.Long,
+              long,
+              mask
+            ),
+            Next.None
+          ),
+          Inst.Let(
+            result.name,
+            Op.Comp(
+              Comp.Ine,
+              Type.Long,
+              and,
+              Val.Const(Val.Long(0))
+            ),
+            Next.None
+          ),
           Inst.Ret(result)
         )
       )

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -9,6 +9,7 @@ class HasTraitTables(meta: Metadata) {
 
   private val classHasTraitName = Global.Top("__class_has_trait")
   val classHasTraitVal = Val.Global(classHasTraitName, Type.Ptr)
+  var classHasTraitTy: Type = _
   var classHasTraitDefn: Defn = _
 
   private val traitHasTraitName = Global.Top("__trait_has_trait")
@@ -41,6 +42,7 @@ class HasTraitTables(meta: Metadata) {
 
     classHasTraitDefn =
       Defn.Const(Attrs.None, classHasTraitName, tableVal.ty, tableVal)
+    classHasTraitTy = tableVal.ty
   }
 
   private def initTraitHasTrait(): Unit = {

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -7,12 +7,12 @@ import scalanative.linker.{Trait, Class}
 class HasTraitTables(meta: Metadata) {
   private implicit val pos: Position = Position.NoPosition
 
-  val classHasTraitName = Global.Top("__class_has_trait")
+  private val classHasTraitName = Global.Top("__class_has_trait")
   val classHasTraitVal = Val.Global(classHasTraitName, Type.Ptr)
   var classHasTraitTy: Type = _
   var classHasTraitDefn: Defn = _
 
-  val traitHasTraitName = Global.Top("__trait_has_trait")
+  private val traitHasTraitName = Global.Top("__trait_has_trait")
   val traitHasTraitVal = Val.Global(traitHasTraitName, Type.Ptr)
   var traitHasTraitTy: Type = _
   var traitHasTraitDefn: Defn = _
@@ -20,43 +20,44 @@ class HasTraitTables(meta: Metadata) {
   initClassHasTrait()
   initTraitHasTrait()
 
-  def markTraits(row: Array[Boolean], cls: Class): Unit = {
-    cls.traits.foreach(markTraits(row, _))
-    cls.parent.foreach(markTraits(row, _))
+  private def markTraits(matrix: BitMatrix, row: Int, cls: Class): Unit = {
+    cls.traits.foreach(markTraits(matrix, row, _))
+    cls.parent.foreach(markTraits(matrix, row, _))
   }
 
-  def markTraits(row: Array[Boolean], trt: Trait): Unit = {
-    row(meta.ids(trt)) = true
-    trt.traits.foreach { right => row(meta.ids(right)) = true }
-    trt.traits.foreach(markTraits(row, _))
+  private def markTraits(matrix: BitMatrix, row: Int, trt: Trait): Unit = {
+    matrix.set(row, meta.ids(trt))
+    trt.traits.foreach(markTraits(matrix, row, _))
   }
 
-  def initClassHasTrait(): Unit = {
-    val columns = meta.classes.map { cls =>
-      val row = new Array[Boolean](meta.traits.length)
-      markTraits(row, cls)
-      Val.ArrayValue(Type.Bool, row.toSeq.map(Val.Bool))
+  private def initClassHasTrait(): Unit = {
+    val matrix = BitMatrix(meta.classes.length, meta.traits.length)
+    var row = 0
+    meta.classes.foreach { cls =>
+      markTraits(matrix, row, cls)
+
+      row += 1
     }
-    val table =
-      Val.ArrayValue(Type.ArrayValue(Type.Bool, meta.traits.length), columns)
+    val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(Val.Long))
 
-    classHasTraitTy = table.ty
+    classHasTraitTy = tableVal.ty
     classHasTraitDefn =
-      Defn.Const(Attrs.None, classHasTraitName, table.ty, table)
+      Defn.Const(Attrs.None, classHasTraitName, tableVal.ty, tableVal)
   }
 
-  def initTraitHasTrait(): Unit = {
-    val columns = meta.traits.map { left =>
-      val row = new Array[Boolean](meta.traits.length)
-      markTraits(row, left)
-      row(meta.ids(left)) = true
-      Val.ArrayValue(Type.Bool, row.toSeq.map(Val.Bool))
-    }
-    val table =
-      Val.ArrayValue(Type.ArrayValue(Type.Bool, meta.traits.length), columns)
+  private def initTraitHasTrait(): Unit = {
+    val matrix = BitMatrix(meta.traits.length, meta.traits.length)
+    var row = 0
+    meta.traits.foreach { left =>
+      markTraits(matrix, row, left)
+      matrix.set(row, meta.ids(left))
 
-    traitHasTraitTy = table.ty
+      row += 1
+    }
+    val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(Val.Long))
+
+    traitHasTraitTy = tableVal.ty
     traitHasTraitDefn =
-      Defn.Const(Attrs.None, traitHasTraitName, table.ty, table)
+      Defn.Const(Attrs.None, traitHasTraitName, tableVal.ty, tableVal)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -38,7 +38,7 @@ class HasTraitTables(meta: Metadata) {
 
       row += 1
     }
-    val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(l => Val.Long(l)))
+    val tableVal = Val.ArrayValue(Type.Int, matrix.toSeq.map(i => Val.Int(i)))
 
     classHasTraitDefn =
       Defn.Const(Attrs.None, classHasTraitName, tableVal.ty, tableVal)
@@ -54,7 +54,7 @@ class HasTraitTables(meta: Metadata) {
 
       row += 1
     }
-    val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(l => Val.Long(l)))
+    val tableVal = Val.ArrayValue(Type.Int, matrix.toSeq.map(l => Val.Int(l)))
 
     traitHasTraitDefn =
       Defn.Const(Attrs.None, traitHasTraitName, tableVal.ty, tableVal)

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -9,12 +9,10 @@ class HasTraitTables(meta: Metadata) {
 
   private val classHasTraitName = Global.Top("__class_has_trait")
   val classHasTraitVal = Val.Global(classHasTraitName, Type.Ptr)
-  var classHasTraitTy: Type = _
   var classHasTraitDefn: Defn = _
 
   private val traitHasTraitName = Global.Top("__trait_has_trait")
   val traitHasTraitVal = Val.Global(traitHasTraitName, Type.Ptr)
-  var traitHasTraitTy: Type = _
   var traitHasTraitDefn: Defn = _
 
   initClassHasTrait()
@@ -31,6 +29,8 @@ class HasTraitTables(meta: Metadata) {
   }
 
   private def initClassHasTrait(): Unit = {
+    println(s"meta.classes.length = ${meta.classes.length}")
+    println(s"meta.traits.length = ${meta.traits.length}")
     val matrix = BitMatrix(meta.classes.length, meta.traits.length)
     var row = 0
     meta.classes.foreach { cls =>
@@ -40,7 +40,6 @@ class HasTraitTables(meta: Metadata) {
     }
     val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(Val.Long))
 
-    classHasTraitTy = tableVal.ty
     classHasTraitDefn =
       Defn.Const(Attrs.None, classHasTraitName, tableVal.ty, tableVal)
   }
@@ -56,7 +55,6 @@ class HasTraitTables(meta: Metadata) {
     }
     val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(Val.Long))
 
-    traitHasTraitTy = tableVal.ty
     traitHasTraitDefn =
       Defn.Const(Attrs.None, traitHasTraitName, tableVal.ty, tableVal)
   }

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -13,6 +13,7 @@ class HasTraitTables(meta: Metadata) {
 
   private val traitHasTraitName = Global.Top("__trait_has_trait")
   val traitHasTraitVal = Val.Global(traitHasTraitName, Type.Ptr)
+  var traitHasTraitTy: Type = _
   var traitHasTraitDefn: Defn = _
 
   initClassHasTrait()
@@ -29,8 +30,6 @@ class HasTraitTables(meta: Metadata) {
   }
 
   private def initClassHasTrait(): Unit = {
-    println(s"meta.classes.length = ${meta.classes.length}")
-    println(s"meta.traits.length = ${meta.traits.length}")
     val matrix = BitMatrix(meta.classes.length, meta.traits.length)
     var row = 0
     meta.classes.foreach { cls =>
@@ -57,5 +56,6 @@ class HasTraitTables(meta: Metadata) {
 
     traitHasTraitDefn =
       Defn.Const(Attrs.None, traitHasTraitName, tableVal.ty, tableVal)
+    traitHasTraitTy = tableVal.ty
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -38,7 +38,7 @@ class HasTraitTables(meta: Metadata) {
 
       row += 1
     }
-    val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(Val.Long))
+    val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(l => Val.Long(l)))
 
     classHasTraitDefn =
       Defn.Const(Attrs.None, classHasTraitName, tableVal.ty, tableVal)
@@ -54,7 +54,7 @@ class HasTraitTables(meta: Metadata) {
 
       row += 1
     }
-    val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(Val.Long))
+    val tableVal = Val.ArrayValue(Type.Long, matrix.toSeq.map(l => Val.Long(l)))
 
     traitHasTraitDefn =
       Defn.Const(Attrs.None, traitHasTraitName, tableVal.ty, tableVal)

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -950,16 +950,14 @@ object Lower {
               unwind
             )
           val id = let(Op.Load(Type.Int, idptr), unwind)
-          val boolptr = let(
-            Op.Elem(
-              hasTraitTables.classHasTraitTy,
-              hasTraitTables.classHasTraitVal,
-              Seq(zero, id, Val.Int(meta.ids(trt)))
+          let(
+            Op.Call(
+              Generate.Impl.ClassHasTraitSig,
+              Val.Global(Generate.Impl.ClassHasTraitName, Generate.Impl.ClassHasTraitSig),
+              Seq(id, Val.Int(meta.ids(trt)))
             ),
             unwind
           )
-          let(Op.Load(Type.Bool, boolptr), unwind)
-
         case _ =>
           util.unsupported(s"is[$ty] $obj")
       }

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -952,10 +952,10 @@ object Lower {
           val id = let(Op.Load(Type.Int, idptr), unwind)
           let(
             Op.Call(
-              Generate.Impl.ClassHasTraitSig,
+              Generate.ClassHasTraitSig,
               Val.Global(
-                Generate.Impl.ClassHasTraitName,
-                Generate.Impl.ClassHasTraitSig
+                Generate.ClassHasTraitName,
+                Generate.ClassHasTraitSig
               ),
               Seq(id, Val.Int(meta.ids(trt)))
             ),

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -953,7 +953,10 @@ object Lower {
           let(
             Op.Call(
               Generate.Impl.ClassHasTraitSig,
-              Val.Global(Generate.Impl.ClassHasTraitName, Generate.Impl.ClassHasTraitSig),
+              Val.Global(
+                Generate.Impl.ClassHasTraitName,
+                Generate.Impl.ClassHasTraitSig
+              ),
               Seq(id, Val.Int(meta.ids(trt)))
             ),
             unwind


### PR DESCRIPTION
## Results

Here the results with the Ember hello world.
```
 31056 -rwxr-xr-x@ 1 lorenzo  staff   15898802  8 Mag 14:31 after*
675624 -rw-r--r--@ 1 lorenzo  staff  345918875  8 Mag 15:07 after.ll
     0 drwxr-xr-x@ 4 lorenzo  staff        128  1 Mag 16:30 b/
 40632 -rwxr-xr-x@ 1 lorenzo  staff   20803106  8 Mag 14:52 before*
783056 -rw-r--r--@ 1 lorenzo  staff  400921751  8 Mag 14:40 before.ll
```

the binary size is reduced by ~`4.9 MB` and the generated `out.ll` file is reduced by `55 MB`
The runtime perfomance seems unchanged:

```
# Before
> hey -z 60s http://localhost:8081

Summary:
  Total:        60.0026 secs
  Slowest:      0.1061 secs
  Fastest:      0.0003 secs
  Average:      0.0034 secs
  Requests/sec: 14778.1655

# After
> hey -z 60s http://localhost:8080

Summary:
  Total:        60.0031 secs
  Slowest:      0.1002 secs
  Fastest:      0.0002 secs
  Average:      0.0034 secs
  Requests/sec: 14824.3753
```