### PR TITLE
Enable to run scalalib-patch-tool.sc (with scala-cli)

### DIFF
--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -246,11 +246,13 @@ onto source defined for the current Scala version inside its standard library.
 In case `overrides*` directory contains both `*.scala` file and its corresponding patch file,
 only `*.scala` file would be added to the compilation sources.  
 
-To operate with patches it is recommended to use Ammonite script `scripts/scalalib-patch-tool.sc`. 
+To operate with patches it is recommended to use ScalaCLI script `scripts/scalalib-patch-tool.sc`. 
 It takes 2 mandatory arguments: command to use and Scala version. There are currently 3 supported commands defined:
 * recreate - creates `*.scala` files based on original sources with applied patches corresponding to their name;
 * create - creates `*.scala.patch` files from defined `*.scala` files in overrides directory with corresponding name;
 * prune - deletes all `*.scala` files which does not have corresponding `*.scala.patch` file;
+
+(e.g. `scala-cli scripts/scalalib-patch-tool.sc -- recreate 2.13.10`)
 
 Each of these commands is applied to all files defined in the overrides directory. 
 By default override directory is selected based on the used scala version, 


### PR DESCRIPTION
leftover from https://github.com/scala-native/scala-native/pull/3270

We don't need to merge this PR for a while until when we need to recreate the patch files, but I'll leave the change so we can smoothly run the script in future 😃 

---

Previously, scalalib-patch-tool.sc wasn't able to run with the new version of Ammonite because ammonite-ops is deprecated. This commit re-write the ammonite-ops related code into os-lib.

Also, migrated the script to use scala-cli, just for my preference.