### PR TITLE
Character.isWhitespace(-1) returns false

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -544,7 +544,8 @@ object Character {
   def isWhitespace(codePoint: scala.Int): scala.Boolean = {
     def isSeparator(tpe: Int): scala.Boolean =
       tpe == SPACE_SEPARATOR || tpe == LINE_SEPARATOR || tpe == PARAGRAPH_SEPARATOR
-    if (codePoint < 256) {
+    if (codePoint < 0) false
+    else if (codePoint < 256) {
       codePoint == '\t' || codePoint == '\n' || codePoint == '\u000B' ||
       codePoint == '\f' || codePoint == '\r' ||
       ('\u001C' <= codePoint && codePoint <= '\u001F') ||
@@ -592,7 +593,8 @@ object Character {
     isLowerCase(c.toInt)
 
   def isLowerCase(c: Int): scala.Boolean = {
-    if (c < 256)
+    if (c < 0) false
+    else if (c < 256)
       c == '\u00AA' || c == '\u00BA' || getTypeLT256(c) == LOWERCASE_LETTER
     else
       isLowerCaseGE256(c)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/CharacterTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/CharacterTest.scala
@@ -487,6 +487,13 @@ class CharacterTest {
 
   }
 
+  @Test def isLowerCase(): Unit = {
+    assertTrue(Character.isLowerCase('a'))
+    assertTrue(Character.isLowerCase('z'))
+    assertFalse(Character.isLowerCase('A'))
+    assertFalse(Character.isLowerCase(-1))
+  }
+
   @Test def toLowerCaseLow(): Unit = {
     // low chars
     assertTrue(toLowerCase('\n') equals '\n')
@@ -606,4 +613,20 @@ class CharacterTest {
     // unspecified for non-supplementary code points
   }
 
+  @Test def isWhitespace(): Unit = {
+    assertTrue(Character.isWhitespace(' '))
+    assertTrue(Character.isWhitespace('\t'))
+    assertTrue(Character.isWhitespace('\n'))
+    assertTrue(Character.isWhitespace('\f'))
+    assertTrue(Character.isWhitespace('\r'))
+    assertTrue(Character.isWhitespace('\u001C')) // file separator
+    assertTrue(Character.isWhitespace('\u001D')) // group separator
+    assertTrue(Character.isWhitespace('\u001E')) // record separator
+    assertTrue(Character.isWhitespace('\u001F')) // unit separator
+
+    assertFalse(Character.isWhitespace('\b'))
+    assertFalse(Character.isWhitespace('a'))
+    // https://github.com/scala-native/scala-native/issues/3154
+    assertFalse(Character.isWhitespace(-1))
+  }
 }


### PR DESCRIPTION
Fix https://github.com/scala-native/scala-native/issues/3154

Previously, `Character.isWhitespace(-1)` and
`Character.isLowerCase(-1)` throw
`java.lang.ArrayIndexOutOfBoundsException: -1`.
However, they should return `false` as other java std libraries do.

We may want to fix `getTypeLT256`, but this commit guaranteed that the codepoint is gte 0 on call-site of `getTypeLT256` for not introducing the duplicated check of `codePoint < 0`.