### PR TITLE
In-memory cache for NIR linking

### DIFF
--- a/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
@@ -14,6 +14,10 @@ sealed abstract class ClassLoader {
 
 object ClassLoader {
 
+  def fromClasspath(classPath: Seq[ClassPath]): ClassLoader = {
+    new FromDisk(classPath)
+  }
+
   def fromDisk(config: build.Config)(implicit in: Scope): ClassLoader = {
     val classpath = config.classPath.map { path =>
       ClassPath(VirtualDirectory.real(path))

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -7,8 +7,10 @@ import scala.collection.mutable
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir.serialization.deserializeBinary
 import scala.scalanative.nir.{Defn, Global, Prelude => NirPrelude}
+import java.nio.file.attribute.FileTime
 
 sealed trait ClassPath {
+  private[scalanative] def lastModifiedMillis: Long
 
   /** Check if given global is present in this classpath. */
   private[scalanative] def contains(name: Global): Boolean
@@ -30,6 +32,8 @@ object ClassPath {
     new Impl(directory)
 
   private final class Impl(directory: VirtualDirectory) extends ClassPath {
+    override def lastModifiedMillis = directory.lastModified.toMillis()
+
     private val files =
       directory.files
         .filter(_.toString.endsWith(".nir"))

--- a/tools/src/main/scala/scala/scalanative/linker/Link.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Link.scala
@@ -4,11 +4,12 @@ package linker
 import scalanative.nir._
 import scalanative.util.Scope
 import scala.scalanative.io.VirtualDirectory
+import java.nio.file.Path
 
 object Link {
 
   private val cache =
-    collection.mutable.HashMap[(String, Seq[Global], Seq[Long]), Result]()
+    collection.mutable.HashMap[(Path, Seq[Global], Seq[Long]), Result]()
 
   /** Load all clases and methods reachable from the entry points. */
   def apply(config: build.Config, entries: Seq[Global])(implicit
@@ -18,7 +19,7 @@ object Link {
       ClassPath(VirtualDirectory.real(path))
     }
     val classPathMtime = classpath.map(_.lastModifiedMillis)
-    val key = (config.artifactName, entries, classPathMtime)
+    val key = (config.buildPath, entries, classPathMtime)
     cache.get(key) match {
       case None =>
         val res = Reach(config, entries, ClassLoader.fromClasspath(classpath))

--- a/tools/src/main/scala/scala/scalanative/linker/Link.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Link.scala
@@ -3,14 +3,32 @@ package linker
 
 import scalanative.nir._
 import scalanative.util.Scope
+import scala.scalanative.io.VirtualDirectory
 
 object Link {
+
+  private val cache =
+    collection.mutable.HashMap[(String, Seq[Global], Seq[Long]), Result]()
 
   /** Load all clases and methods reachable from the entry points. */
   def apply(config: build.Config, entries: Seq[Global])(implicit
       scope: Scope
-  ): Result =
-    Reach(config, entries, ClassLoader.fromDisk(config))
+  ): Result = {
+    val classpath = config.classPath.map { path =>
+      ClassPath(VirtualDirectory.real(path))
+    }
+    val classPathMtime = classpath.map(_.lastModifiedMillis)
+    val key = (config.artifactName, entries, classPathMtime)
+    cache.get(key) match {
+      case None =>
+        val res = Reach(config, entries, ClassLoader.fromClasspath(classpath))
+        cache.update(key, res)
+        res
+      case Some(res) =>
+        config.logger.info(s"NIR linking skipped due to cache hit.")
+        res
+    }
+  }
 
   /** Run reachability analysis on already loaded methods. */
   def apply(


### PR DESCRIPTION
This commit enables scala-native to cache the NIR link results
based on input: the hash of

- `config.artifactName`
- `entires: Seq[Global]`
- timestamps of the classPath

Since we use `config.artifactName`, we have the same problem as
https://github.com/scala-native/scala-native/pull/3283#issuecomment-1546274083

Related https://github.com/scala-native/scala-native/issues/3282

Before

```
[info] Linking (multithreading false) (596 ms)
[info] Checking intermediate code (74 ms)
[info] Dumping intermediate code (linked) (230 ms)
[info] Discovered 778 classes and 4879 methods
[info] Optimizing (debug mode) (546 ms)
[info] Checking intermediate code (33 ms)
[info] Dumping intermediate code (optimized) (125 ms)
[info] Dumping intermediate code (lowered) (173 ms)
[info] Generating intermediate code (512 ms)
[info] Produced 39 files
[info] Compiling to native code (209 ms)
[info] Linking native code (immix gc, none lto) (3 ms)
[info] Total (2370 ms)
[success] Total time: 4 s, completed May 15, 2023, 9:43:49 PM
sbt:scala-native> sandbox2_13/nativeLink
[info] Linking (multithreading false) (323 ms)
[info] Checking intermediate code (49 ms)
[info] Dumping intermediate code (linked) (120 ms)
[info] Discovered 778 classes and 4879 methods
[info] Optimizing (debug mode) (357 ms)
[info] Checking intermediate code (15 ms)
[info] Dumping intermediate code (optimized) (96 ms)
[info] Dumping intermediate code (lowered) (182 ms)
[info] Generating intermediate code (363 ms)
[info] Produced 39 files
[info] Compiling to native code (166 ms)
[info] Linking native code (immix gc, none lto) (4 ms)
[info] Total (1507 ms)
[success] Total time: 2 s, completed May 15, 2023, 9:43:54 PM
```

After

```
sbt:scala-native> sandbox2_13/nativeLink
[info] Linking (multithreading false) (717 ms)
[info] Checking intermediate code (105 ms)
[info] Dumping intermediate code (linked) (223 ms)
[info] Discovered 778 classes and 4879 methods
[info] Optimizing (debug mode) (549 ms)
[info] Checking intermediate code (36 ms)
[info] Dumping intermediate code (optimized) (129 ms)
[info] Dumping intermediate code (lowered) (207 ms)
[info] Generating intermediate code (510 ms)
[info] Produced 39 files
[info] Compiling to native code (172 ms)
[info] Linking native code (immix gc, none lto) (3 ms)
[info] Total (2486 ms)
[success] Total time: 4 s, completed May 15, 2023, 9:41:43 PM
sbt:scala-native> sandbox2_13/nativeLink
[info] NIR linking skipped due to cache hit.
[info] Linking (multithreading false) (12 ms)
[info] Checking intermediate code (22 ms)
[info] Dumping intermediate code (linked) (134 ms)
[info] Discovered 778 classes and 4879 methods
[info] Optimizing (debug mode) (275 ms)
[info] Checking intermediate code (15 ms)
[info] Dumping intermediate code (optimized) (110 ms)
[info] Dumping intermediate code (lowered) (160 ms)
[info] Generating intermediate code (301 ms)
[info] Produced 39 files
[info] Compiling to native code (165 ms)
[info] Linking native code (immix gc, none lto) (1 ms)
[info] Total (1045 ms)
```