### PR TITLE
Skip nativeLink if the input hasn't changed from the previous build

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -147,7 +147,7 @@ object ScalaNativePluginInternal {
 
         interceptBuildException {
           // returns config.artifactPath
-          Build.build(config)(sharedScope).toFile()
+          Build.buildCached(config)(sharedScope).toFile()
         }
       }
       .tag(NativeTags.Link)

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -4,7 +4,6 @@ package build
 import java.nio.file.{Files, Path, Paths}
 import scala.scalanative.util.Scope
 import scala.util.Try
-import java.security.MessageDigest
 import java.nio.file.FileVisitOption
 import java.util.Optional
 import java.nio.file.attribute.FileTime

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -12,7 +12,7 @@ import java.nio.file.attribute.FileTime
 /** Utility methods for building code using Scala Native. */
 object Build {
 
-  private var previousBuildInputHash: Int = 0
+  private var prevBuildInputCheckSum: Int = 0
 
   /** Run the complete Scala Native pipeline, LLVM optimizer and system linker,
    *  producing a native binary in the end.
@@ -69,7 +69,7 @@ object Build {
       val inputHash = checkSum(fconfig)
 
       if (Files.exists(fconfig.artifactPath) &&
-          previousBuildInputHash == inputHash) {
+          prevBuildInputCheckSum == inputHash) {
         fconfig.logger.info(
           "Build skipped: No changes detected in build configuration and class path contents since last build."
         )
@@ -136,12 +136,11 @@ object Build {
     // - the output native binary ('s mtime)
     // Since the NIR code is shipped in jars, we should be able to detect the changes in NIRs.
     // One thing we miss is, we cannot detect changes in c libraries somewhere in `/usr/lib`.
-    val key = (
-      config.toString, // we use toString because `config` object contains Logger instance that changes for every invocation
+    (
+      config,
       config.classPath.map(getNewestMtime(_)),
       getLastModifiedTimeMillis(config.artifactPath)
-    )
-    key.hashCode()
+    ).hashCode()
   }
 
   /** Convenience method to combine finding and compiling native libaries.

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -191,9 +191,11 @@ object Build {
   /** Get the newest file's last modified time in millis under the given path.
    */
   private def getNewestMtime(path: Path): Optional[FileTime] =
-    Files
-      .walk(path, FileVisitOption.FOLLOW_LINKS)
-      .map[FileTime](Files.getLastModifiedTime(_))
-      .max(_.compareTo(_))
+    if (Files.exists(path))
+      Files
+        .walk(path, FileVisitOption.FOLLOW_LINKS)
+        .map[FileTime](Files.getLastModifiedTime(_))
+        .max(_.compareTo(_))
+    else Optional.empty()
 
 }

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -190,8 +190,8 @@ object Config {
       mainClass: Option[String],
       classPath: Seq[Path],
       compilerConfig: NativeConfig
-  )(
-      implicit val logger: Logger // Exclude logger from hashCode calculation https://stackoverflow.com/questions/10373715/scala-ignore-case-class-field-for-equals-hascode
+  )(implicit
+      val logger: Logger // Exclude logger from hashCode calculation https://stackoverflow.com/questions/10373715/scala-ignore-case-class-field-for-equals-hascode
   ) extends Config {
 
     def withBaseDir(value: Path): Config =

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -180,7 +180,6 @@ object Config {
       moduleName = "",
       mainClass = None,
       classPath = Seq.empty,
-      logger = Logger.default,
       compilerConfig = NativeConfig.empty
     )
 
@@ -190,7 +189,6 @@ object Config {
       moduleName: String,
       mainClass: Option[String],
       classPath: Seq[Path],
-      logger: Logger,
       compilerConfig: NativeConfig
   ) extends Config {
 
@@ -209,8 +207,15 @@ object Config {
     def withClassPath(value: Seq[Path]): Config =
       copy(classPath = value)
 
-    def withLogger(value: Logger): Config =
-      copy(logger = value)
+    def logger = _logger.getOrElse(defaultLogger)
+
+    private lazy val defaultLogger = Logger.default
+    private var _logger: Option[Logger] = None
+
+    def withLogger(value: Logger): Config = {
+      _logger = Some(value)
+      this
+    }
 
     override def withCompilerConfig(value: NativeConfig): Config =
       copy(compilerConfig = value)

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -191,29 +191,29 @@ object Config {
       classPath: Seq[Path],
       compilerConfig: NativeConfig
   )(
-      val logger: Logger // Exclude logger from hashCode calculation https://stackoverflow.com/questions/10373715/scala-ignore-case-class-field-for-equals-hascode
+      implicit val logger: Logger // Exclude logger from hashCode calculation https://stackoverflow.com/questions/10373715/scala-ignore-case-class-field-for-equals-hascode
   ) extends Config {
 
     def withBaseDir(value: Path): Config =
-      copy(baseDir = value)(logger)
+      copy(baseDir = value)
 
     def withTestConfig(value: Boolean): Config =
-      copy(testConfig = value)(logger)
+      copy(testConfig = value)
 
     def withModuleName(value: String): Config =
-      copy(moduleName = value)(logger)
+      copy(moduleName = value)
 
     def withMainClass(value: Option[String]): Config =
-      copy(mainClass = value)(logger)
+      copy(mainClass = value)
 
     def withClassPath(value: Seq[Path]): Config =
-      copy(classPath = value)(logger)
+      copy(classPath = value)
 
     override def withCompilerConfig(value: NativeConfig): Config =
-      copy(compilerConfig = value)(logger)
+      copy(compilerConfig = value)
 
     override def withCompilerConfig(fn: NativeConfig => NativeConfig): Config =
-      copy(compilerConfig = fn(compilerConfig))(logger)
+      copy(compilerConfig = fn(compilerConfig))
 
     override def withLogger(value: Logger): Config =
       copy()(value)

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -181,7 +181,7 @@ object Config {
       mainClass = None,
       classPath = Seq.empty,
       compilerConfig = NativeConfig.empty
-    )
+    )(Logger.default)
 
   private final case class Impl(
       baseDir: Path,
@@ -190,38 +190,33 @@ object Config {
       mainClass: Option[String],
       classPath: Seq[Path],
       compilerConfig: NativeConfig
+  )(
+      val logger: Logger // Exclude logger from hashCode calculation https://stackoverflow.com/questions/10373715/scala-ignore-case-class-field-for-equals-hascode
   ) extends Config {
 
     def withBaseDir(value: Path): Config =
-      copy(baseDir = value)
+      copy(baseDir = value)(logger)
 
     def withTestConfig(value: Boolean): Config =
-      copy(testConfig = value)
+      copy(testConfig = value)(logger)
 
     def withModuleName(value: String): Config =
-      copy(moduleName = value)
+      copy(moduleName = value)(logger)
 
     def withMainClass(value: Option[String]): Config =
-      copy(mainClass = value)
+      copy(mainClass = value)(logger)
 
     def withClassPath(value: Seq[Path]): Config =
-      copy(classPath = value)
-
-    def logger = _logger.getOrElse(defaultLogger)
-
-    private lazy val defaultLogger = Logger.default
-    private var _logger: Option[Logger] = None
-
-    def withLogger(value: Logger): Config = {
-      _logger = Some(value)
-      this
-    }
+      copy(classPath = value)(logger)
 
     override def withCompilerConfig(value: NativeConfig): Config =
-      copy(compilerConfig = value)
+      copy(compilerConfig = value)(logger)
 
     override def withCompilerConfig(fn: NativeConfig => NativeConfig): Config =
-      copy(compilerConfig = fn(compilerConfig))
+      copy(compilerConfig = fn(compilerConfig))(logger)
+
+    override def withLogger(value: Logger): Config =
+      copy()(value)
 
     override lazy val workDir: Path =
       baseDir.resolve(s"native$nameSuffix")


### PR DESCRIPTION
Based on the conversation in https://github.com/scala-native/scala-native/pull/3285

This PR

- Adds an new endpoint `buildCached` to `Build.scala`
- Makes sbt plugin to use `buildCached` instead of `build`.

`buildCached` will skip the whole build process of `nativeLink` if the followings are unchanged from previous build (only 1 previous build, so we don't use much memory to remember the cache).

- Build configuration
- The output native binary('s mtime)
- class path contents(' mtime)

One thing we cannot detect is the change in c library somewhere in `/usr/lib/...`, and if there's a change users may have to explicitly run `sbt clean` to re-run