### PR TITLE
Build: Update sbt to 1.8.3

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.8.3


### PR DESCRIPTION
Build: Update sbt to 1.8.3

I believe this PR is correct, but since SN 4.13 is about to be released, it may make sense
to wait until after that before merging or considering for backport.