### PR TITLE
Add debug logs for the build config

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -94,6 +94,8 @@ object Build {
       // validate Config
       val fconfig = Validator.validate(config)
 
+      config.logger.debug(config.toString())
+
       // find and link
       val linked = {
         val entries = ScalaNative.entries(fconfig)


### PR DESCRIPTION
Sometimes I manually print the config during local builds, but I thought it would be useful for others if it were included in the debug-logs.


<details>
<summary>Output example</summary>

```
[debug] Config(
[debug]  - baseDir:        /Users/s15255/work/scala-native/sandbox/.3/target/scala-3.1.3
[debug]  - testConfig:     false
[debug]  - workDir:        /Users/s15255/work/scala-native/sandbox/.3/target/scala-3.1.3/native
[debug]  - moduleName:     sandbox
[debug]  - baseName:       sandbox
[debug]  - artifactName:   sandbox
[debug]  - artifactPath:   /Users/s15255/work/scala-native/sandbox/.3/target/scala-3.1.3/sandbox
[debug]  - buildPath:      /Users/s15255/work/scala-native/sandbox/.3/target/scala-3.1.3/native/Main
[debug]  - mainClass:      Some(Main)
[debug]  - classPath:      List(/Users/s15255/work/scala-native/sandbox/.3/target/scala-3.1.3/sandbox_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT.jar
[debug]                      /Users/s15255/work/scala-native/scalalib/.3/target/scala-3.1.3/scala3lib_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT.jar
[debug]                      /Users/s15255/work/scala-native/auxlib/.3/target/scala-3.1.3/auxlib_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT.jar
[debug]                      /Users/s15255/work/scala-native/nativelib/.3/target/scala-3.1.3/nativelib_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT.jar
[debug]                      /Users/s15255/work/scala-native/clib/.3/target/scala-3.1.3/clib_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT.jar
[debug]                      /Users/s15255/work/scala-native/javalib/.3/target/scala-3.1.3/javalib_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT.jar
[debug]                      /Users/s15255/work/scala-native/posixlib/.3/target/scala-3.1.3/posixlib_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT.jar
[debug]                      /Users/s15255/work/scala-native/windowslib/.3/target/scala-3.1.3/windowslib_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT.jar
[debug]                      /Users/s15255/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.1.3/scala3-library_3-3.1.3.jar
[debug]                      /Users/s15255/.ivy2/local/org.scala-native/scalalib_native0.5.0-SNAPSHOT_2.13/0.5.0-SNAPSHOT/jars/scalalib_native0.5.0-SNAPSHOT_2.13.jar
[debug]                      /Users/s15255/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.10/scala-library-2.13.10.jar)
[debug]  - compilerConfig: NativeConfig(
[debug]  - clang:                  /usr/bin/clang
[debug]  - clangPP:                /usr/bin/clang++
[debug]  - linkingOptions:         List(-L/usr/local/lib)
[debug]  - compileOptions:         List(-I/usr/local/include, -Qunused-arguments)
[debug]  - targetTriple:           None
[debug]  - GC:                     immix
[debug]  - LTO:                    none
[debug]  - mode:                   debug
[debug]  - buildTarget             Application
[debug]  - check:                  true
[debug]  - checkFatalWarnings:     true
[debug]  - dump:                   true
[debug]  - asan:                   false
[debug]  - linkStubs:              false
[debug]  - optimize                true
[debug]  - incrementalCompilation: true
[debug]  - multithreading          false
[debug]  - linktimeProperties:     
[debug]  - embedResources:         false
[debug]  - baseName:               
[debug]  - optimizerConfig:        OptimizerConfig(
[debug]    - maxInlineDepth: None
[debug]    - maxInlineSize:  default
[debug]    - maxCallerSize:  default
[debug]    )
[debug] )
[debug] )
```

</details>