### PR TITLE
Port `Item.java` from JSR-166

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/Item.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/Item.scala
@@ -1,0 +1,66 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.Comparator
+import java.io.Serializable
+
+/** A simple element class for collections etc
+ */
+final class Item extends Number with Comparable[Item] with Serializable {
+  final var value = 0
+
+  def this(v: Int) = {
+    this()
+    value = v
+  }
+
+  def this(i: Item) = {
+    this()
+    value = i.value
+  }
+
+  def this(i: Integer) = {
+    this()
+    value = i.intValue
+  }
+
+  override def intValue: Int = value
+
+  override def longValue: Long = value.toLong
+
+  override def floatValue: Float = value.toFloat
+
+  override def doubleValue: Double = value.toDouble
+
+  override def equals(x: Any): Boolean =
+    x.isInstanceOf[Item] && x.asInstanceOf[Item].value == value
+
+  def equals(b: Int): Boolean = value == b
+
+  override def compareTo(x: Item): Int = Integer.compare(this.value, x.value)
+
+  def compareTo(b: Int): Int = Integer.compare(this.value, b)
+
+  override def hashCode: Int = value
+
+  override def toString: String = Integer.toString(value)
+}
+
+object Item {
+  def valueOf(i: Int) = new Item(i)
+
+  def compare(x: Item, y: Item): Int = Integer.compare(x.value, y.value)
+
+  def compare(x: Item, b: Int): Int = Integer.compare(x.value, b)
+
+  def comparator = new Item.Cpr
+
+  class Cpr extends Comparator[Item] {
+    override def compare(x: Item, y: Item): Int =
+      Integer.compare(x.value, y.value)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
@@ -1134,6 +1134,30 @@ object JSR166Test {
    */
   final val SIZE = 20
 
+  def seqItems(size: Int) = {
+    val s = new Array[Item](size)
+    for (i <- 0 until size) {
+      s(i) = new Item(i)
+    }
+    s
+  }
+
+  def negativeSeqItems(size: Int) = {
+    val s = new Array[Item](size)
+    for (i <- 0 until size) {
+      s(i) = new Item(-i)
+    }
+    s
+  }
+
+  val defaultItems: Array[Item] = seqItems(SIZE);
+
+  def itemFor(i: Int) = { // check cache for defaultItems
+    val items = defaultItems
+    if (i >= 0 && i < items.length) items(i)
+    else new Item(i)
+  }
+
   // Some convenient Integer constants
   final val zero = Integer.valueOf(0)
   final val one = Integer.valueOf(1)
@@ -1152,6 +1176,75 @@ object JSR166Test {
   final val m5 = Integer.valueOf(-5)
   final val m6 = Integer.valueOf(-6)
   final val m10 = Integer.valueOf(-10)
+
+  def mustEqual(x: Item, y: Item): Unit = {
+    if (x ne y) assertEquals(x.value, y.value)
+  }
+  def mustEqual(x: Item, y: Int): Unit = {
+    assertEquals(x.value, y)
+  }
+  def mustEqual(x: Int, y: Item): Unit = {
+    assertEquals(x, y.value)
+  }
+  def mustEqual(x: Int, y: Int): Unit = {
+    assertEquals(x, y)
+  }
+  def mustEqual(x: Any, y: Any): Unit = {
+    if (x != y) assertEquals(x, y)
+  }
+  def mustEqual(x: Int, y: Any): Unit = {
+    if (y.isInstanceOf[Item]) assertEquals(x, y.asInstanceOf[Item].value)
+    else fail()
+  }
+  def mustEqual(x: Any, y: Int): Unit = {
+    if (x.isInstanceOf[Item]) assertEquals(x.asInstanceOf[Item].value, y)
+    else fail()
+  }
+  def mustEqual(x: Boolean, y: Boolean): Unit = {
+    assertEquals(x, y)
+  }
+  def mustEqual(x: Long, y: Long): Unit = {
+    assertEquals(x, y)
+  }
+  def mustEqual(x: Double, y: Double): Unit = {
+    assertEquals(x, y)
+  }
+  def mustContain(c: Collection[Item], i: Int): Unit = {
+    assertTrue(c.contains(itemFor(i)))
+  }
+  def mustContain(c: Collection[Item], i: Item): Unit = {
+    assertTrue(c.contains(i))
+  }
+  def mustNotContain(c: Collection[Item], i: Int): Unit = {
+    assertFalse(c.contains(itemFor(i)))
+  }
+  def mustNotContain(c: Collection[Item], i: Item): Unit = {
+    assertFalse(c.contains(i))
+  }
+  def mustRemove(c: Collection[Item], i: Int): Unit = {
+    assertTrue(c.remove(itemFor(i)))
+  }
+  def mustRemove(c: Collection[Item], i: Item): Unit = {
+    assertTrue(c.remove(i))
+  }
+  def mustNotRemove(c: Collection[Item], i: Int): Unit = {
+    assertFalse(c.remove(itemFor(i)))
+  }
+  def mustNotRemove(c: Collection[Item], i: Item): Unit = {
+    assertFalse(c.remove(i))
+  }
+  def mustAdd(c: Collection[Item], i: Int): Unit = {
+    assertTrue(c.add(itemFor(i)))
+  }
+  def mustAdd(c: Collection[Item], i: Item): Unit = {
+    assertTrue(c.add(i))
+  }
+  def mustOffer(c: Queue[Item], i: Int): Unit = {
+    assertTrue(c.offer(itemFor(i)))
+  }
+  def mustOffer(c: Queue[Item], i: Item): Unit = {
+    assertTrue(c.offer(i))
+  }
 
   /** Returns the number of milliseconds since time given by startNanoTime,
    *  which must have been previously returned from a call to {@link


### PR DESCRIPTION
From https://github.com/scala-native/scala-native/issues/3165

This PR ports `Item.java` and some related code from the jsr166.
This `Item.java` is not defined in [jsr166e](https://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166/src/test/tck-jsr166e/) (which is propably the base of current `JSR166Test.scala`) and seems to be introduced in the [latest jsr166](https://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166/src/test/tck/).
The current scala-native javalib has a mixture of both version, and I hope this PR will make the port of the latest jsr166 smoother.