### PR TITLE
Fix #3307, #3315: javalib *Stream.iterate characteristics now match JVM

### DIFF
--- a/javalib/src/main/scala/java/util/PrimitiveIterator.scala
+++ b/javalib/src/main/scala/java/util/PrimitiveIterator.scala
@@ -1,12 +1,14 @@
 package java.util
 
+import java.{lang => jl}
+
 import java.util.function._
 
 import Spliterator._
 
 object PrimitiveIterator {
-  trait OfDouble extends PrimitiveIterator[Double, DoubleConsumer] {
-    override def forEachRemaining(action: Consumer[_ >: Double]): Unit = {
+  trait OfDouble extends PrimitiveIterator[jl.Double, DoubleConsumer] {
+    override def forEachRemaining(action: Consumer[_ >: jl.Double]): Unit = {
       Objects.requireNonNull(action)
 
       if (action.isInstanceOf[DoubleConsumer]) {
@@ -38,8 +40,8 @@ object PrimitiveIterator {
     def nextDouble(): scala.Double // Abstract
   }
 
-  trait OfInt extends PrimitiveIterator[Int, IntConsumer] {
-    override def forEachRemaining(action: Consumer[_ >: Int]): Unit = {
+  trait OfInt extends PrimitiveIterator[jl.Integer, IntConsumer] {
+    override def forEachRemaining(action: Consumer[_ >: jl.Integer]): Unit = {
       Objects.requireNonNull(action)
 
       if (action.isInstanceOf[IntConsumer]) {
@@ -64,8 +66,8 @@ object PrimitiveIterator {
     def nextInt(): Int // Abstract
   }
 
-  trait OfLong extends PrimitiveIterator[Long, LongConsumer] {
-    override def forEachRemaining(action: Consumer[_ >: Long]): Unit = {
+  trait OfLong extends PrimitiveIterator[jl.Long, LongConsumer] {
+    override def forEachRemaining(action: Consumer[_ >: jl.Long]): Unit = {
       Objects.requireNonNull(action)
       if (action.isInstanceOf[LongConsumer]) {
         forEachRemaining(action.asInstanceOf[LongConsumer])

--- a/javalib/src/main/scala/java/util/stream/Stream.scala
+++ b/javalib/src/main/scala/java/util/stream/Stream.scala
@@ -245,8 +245,6 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
 
   def skip(n: Long): Stream[T]
 
-  def spliterator(): Spliterator[_ <: T]
-
   def sorted(): Stream[T]
 
   def sorted(comparator: Comparator[_ >: T]): Stream[T]
@@ -351,7 +349,10 @@ object Stream {
     var seedUsed = false
 
     val spliter =
-      new Spliterators.AbstractSpliterator[T](Long.MaxValue, 0) {
+      new Spliterators.AbstractSpliterator[T](
+        Long.MaxValue,
+        Spliterator.ORDERED | Spliterator.IMMUTABLE
+      ) {
         def tryAdvance(action: Consumer[_ >: T]): Boolean = {
           val current =
             if (seedUsed) next(previous)
@@ -377,7 +378,10 @@ object Stream {
     var seedUsed = false
 
     val spliter =
-      new Spliterators.AbstractSpliterator[T](Long.MaxValue, 0) {
+      new Spliterators.AbstractSpliterator[T](
+        Long.MaxValue,
+        Spliterator.ORDERED | Spliterator.IMMUTABLE
+      ) {
         def tryAdvance(action: Consumer[_ >: T]): Boolean = {
           val current =
             if (seedUsed) f(previous)

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTestOnJDK16.scala
@@ -12,7 +12,7 @@ import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 class DoubleStreamTestOnJDK16 {
 
   // Since: Java 16
-  @Test def streamMapMulti_Eliding(): Unit = {
+  @Test def doubleStreamMapMulti_Eliding(): Unit = {
     val initialCount = 6
     val expectedCount = 4
 
@@ -40,9 +40,7 @@ class DoubleStreamTestOnJDK16 {
   }
 
   // Since: Java 16
-  @Test def streamMapMulti_Expanding(): Unit = {
-
-    case class Item(name: String, info: Double)
+  @Test def doubleStreamMapMulti_Expanding(): Unit = {
 
     val initialCount = 6
     val expectedCount = 7

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/stream/StreamTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/stream/StreamTestOnJDK9.scala
@@ -100,9 +100,7 @@ class StreamTestOnJDK9 {
     )
 
     val spliter = s.spliterator()
-// 2023-06-03 19:48 -0400 FIXME
-    val hexMask = s"0X${spliter.characteristics().toHexString}"
-    printf(s"splitr.characteristics: ${hexMask}\n")
+
     // spliterator should have required characteristics and no others.
     val requiredPresent = Seq(Spliterator.ORDERED, Spliterator.IMMUTABLE)
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -1,5 +1,6 @@
 package org.scalanative.testsuite.javalib.util.stream
 
+import java.{lang => jl}
 import java.{util => ju}
 import java.util._
 
@@ -226,7 +227,7 @@ class StreamTest {
   }
 
   @Test def streamIterate_Unbounded_Characteristics(): Unit = {
-    val s = Stream.iterate(0, n => n + 1)
+    val s = Stream.iterate[jl.Double](0.0, n => n + 1)
     val spliter = s.spliterator()
 
     // spliterator should have required characteristics and no others.

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -225,6 +225,30 @@ class StreamTest {
     assertTrue("stream should not be empty", it.hasNext())
   }
 
+  @Test def streamIterate_Unbounded_Characteristics(): Unit = {
+    val s = Stream.iterate(0, n => n + 1)
+    val spliter = s.spliterator()
+
+    // spliterator should have required characteristics and no others.
+    val requiredPresent = Seq(Spliterator.ORDERED, Spliterator.IMMUTABLE)
+
+    val requiredAbsent = Seq(
+      Spliterator.SORTED,
+      Spliterator.SIZED,
+      Spliterator.SUBSIZED
+    )
+
+    StreamTestHelpers.verifyCharacteristics(
+      spliter,
+      requiredPresent,
+      requiredAbsent
+    )
+
+    // If SIZED is really missing, these conditions should hold.
+    assertEquals(s"getExactSizeIfKnown", -1L, spliter.getExactSizeIfKnown())
+    assertEquals(s"estimateSize", Long.MaxValue, spliter.estimateSize())
+  }
+
   @Test def streamOf_NoItems(): Unit = {
     val s = Stream.of()
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTestHelpers.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTestHelpers.scala
@@ -1,0 +1,58 @@
+package org.scalanative.testsuite.javalib.util.stream
+
+import java.util.Spliterator
+
+object StreamTestHelpers {
+
+  // spliterator and, presumably, stream characteristic names
+  private val maskNames = Map(
+    0x00000001 -> "DISTINCT",
+    0x00000004 -> "SORTED",
+    0x00000010 -> "ORDERED",
+    0x00000040 -> "SIZED",
+    0x00000100 -> "NONNULL",
+    0x00000400 -> "IMMUTABLE",
+    0x00001000 -> "CONCURRENT",
+    0x00004000 -> "SUBSIZED"
+  )
+
+  private def maskToName(mask: Int): String =
+    maskNames.getOrElse(mask, s"0x${mask.toHexString.toUpperCase}")
+
+  def verifyCharacteristics[T](
+      splItr: Spliterator[T],
+      requiredPresent: Seq[Int],
+      requiredAbsent: Seq[Int]
+  ): Unit = {
+    /* The splItr.hasCharacteristics() and splItr.characteristics()
+     * sections both seek the same information: Does the spliterator report
+     * the required characteristics and no other. They ask the question
+     * in slightly different ways to exercise each of the two Spliterator
+     * methods. The answers should match, belt & suspenders.
+     */
+
+    for (rp <- requiredPresent) {
+      assert(
+        splItr.hasCharacteristics(rp),
+        s"missing requiredPresent characteristic: ${maskToName(rp)}"
+      )
+    }
+
+    for (rp <- requiredAbsent) {
+      assert(
+        !splItr.hasCharacteristics(rp),
+        s"found requiredAbsent characteristic: ${maskToName(rp)}"
+      )
+    }
+
+    val sc = splItr.characteristics()
+    val requiredPresentMask = requiredPresent.fold(0)((x, y) => x | y)
+
+    val unknownBits = sc & ~requiredPresentMask
+    val unknownBitsMsg = s"0X${unknownBits.toHexString}"
+    assert(
+      0 == unknownBits,
+      s"unexpected characteristics, unknown mask: ${unknownBitsMsg}"
+    )
+  }
+}


### PR DESCRIPTION
Fix #3307, Fix #3315 

Four javalib {Stream, DoubleStream}.iterate() methods now report the same characteristics,
including ORDERED, as their JVM counterparts. This fixes #3307.

Issue #3315 needed to be fixed so that the fix above could be tested.  Programs which use
any of the four {Stream, DoubleStream} `iterate()` methods should now link and execute.

The primary fix for #3315 is in `PrimitiveIterator` but getting to that point required extensive
reorganization to change DoubleStream to extend `java.lang.Double` (and not the prior `Double` meaning
`scala.Double`) and to become stricter about specifying when  `java.lang.Double` Objects (AnyRef) and
`scala.Double` (Java primitive `double`)  (AnyVal) are expected. 

This PR should backport to the SN 0.4 series as it contains a number of corrections. I have not 
attempted that.  It is probably worth waiting a week or so before backporting it to let it settle and
prove itself.