### PR TITLE
Fix #3318: Remove two recent JSR166 related deprecation warnings

### DIFF
--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ExecutorService19Test.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/concurrent/ExecutorService19Test.scala
@@ -61,7 +61,13 @@ class ExecutorService19Test extends JSR166Test {
     val future = executor.submit { () => null }
     awaitDone(future)
     assertEquals(SUCCESS, future.state())
-    assertEquals(null, future.resultNow())
+
+    /* Original Scala Native translation of Doug Lea Java code causes, for
+     * some unknown reason, a deprecation warning in testsJVM3. It is
+     * hard_to_evoke/not_seen using tests3.
+     * //  assertEquals(null, future.resultNow()) // Doug Lea original code.
+     */
+    assertNull("SN expected null result", future.resultNow()) // Scala Native
     assertThrows(classOf[IllegalStateException], () => future.exceptionNow())
   }
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/JSR166Test.scala
@@ -1035,6 +1035,9 @@ object JSR166Test {
     AssumesHelper.assumeMultithreadingIsEnabled()
   }
 
+  // Epsilon is added for Scala Native Test environment.
+  final val epsilon = 0.00001 // tolerance for Floating point comparisons.
+
   final val expensiveTests = true
 
   /** If true, also run tests that are not part of the official tck because they
@@ -1207,7 +1210,7 @@ object JSR166Test {
     assertEquals(x, y)
   }
   def mustEqual(x: Double, y: Double): Unit = {
-    assertEquals(x, y)
+    assertEquals(x, y, JSR166Test.epsilon) // epsilon added for Scala Native
   }
   def mustContain(c: Collection[Item], i: Int): Unit = {
     assertTrue(c.contains(itemFor(i)))


### PR DESCRIPTION
Fix the underlying cause of two recent javalib JSR166 `concurrent` deprecation warnings when
used with complicated mixtures of Java version (>= 19) and Scala Native versions.  The  deprecation
in  `ExecutorService19Test` was only seen when running JVM tests (JVM3).