### PR TITLE
Fix #3321: Remove warning by using checkout@v3, not v2

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,7 +8,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ammaraskar/sphinx-action@0.4
         with:
           pre-build-command: "pip install Sphinx==7.0.1 recommonmark==0.7.1"


### PR DESCRIPTION
Upgrade doc CI build to use  `checkout@v3`, as used in the rest of CI.