### PR TITLE
Add `atRawUnsafe` and `atUnsafe` to array classes

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -12,7 +12,7 @@
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
 //     --line-directive '' \
-//     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+//     -o nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
 //  personally or build-system specific identifiable information.
@@ -48,8 +48,14 @@ sealed abstract class Array[T]
   /** Pointer to the element. */
   @inline def at(i: Int): Ptr[T] = fromRawPtr[T](atRaw(i))
 
+  /** Pointer to the element without a bounds check. */
+  @inline def atUnsafe(i: Int): Ptr[T] = fromRawPtr[T](atRawUnsafe(i))
+
   /** Raw pointer to the element. */
   def atRaw(i: Int): RawPtr
+
+  /** Raw pointer to the element without a bounds check. */
+  def atRawUnsafe(i: Int): RawPtr
 
   /** Loads element at i, throws ArrayIndexOutOfBoundsException. */
   def apply(i: Int): T
@@ -162,9 +168,13 @@ final class BooleanArray private () extends Array[Boolean] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 1 * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 1 * i))
+  }
 
   @inline def apply(i: Int): Boolean = loadBoolean(atRaw(i))
 
@@ -214,9 +224,13 @@ final class CharArray private () extends Array[Char] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 2 * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 2 * i))
+  }
 
   @inline def apply(i: Int): Char = loadChar(atRaw(i))
 
@@ -266,9 +280,13 @@ final class ByteArray private () extends Array[Byte] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 1 * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 1 * i))
+  }
 
   @inline def apply(i: Int): Byte = loadByte(atRaw(i))
 
@@ -318,9 +336,13 @@ final class ShortArray private () extends Array[Short] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 2 * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 2 * i))
+  }
 
   @inline def apply(i: Int): Short = loadShort(atRaw(i))
 
@@ -370,9 +392,13 @@ final class IntArray private () extends Array[Int] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 4 * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 4 * i))
+  }
 
   @inline def apply(i: Int): Int = loadInt(atRaw(i))
 
@@ -422,9 +448,13 @@ final class LongArray private () extends Array[Long] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 8 * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 8 * i))
+  }
 
   @inline def apply(i: Int): Long = loadLong(atRaw(i))
 
@@ -474,9 +504,13 @@ final class FloatArray private () extends Array[Float] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 4 * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 4 * i))
+  }
 
   @inline def apply(i: Int): Float = loadFloat(atRaw(i))
 
@@ -526,9 +560,13 @@ final class DoubleArray private () extends Array[Double] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 8 * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + 8 * i))
+  }
 
   @inline def apply(i: Int): Double = loadDouble(atRaw(i))
 
@@ -578,9 +616,13 @@ final class ObjectArray private () extends Array[Object] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + castRawSizeToInt(sizeOfPtr) * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + castRawSizeToInt(sizeOfPtr) * i))
+  }
 
   @inline def apply(i: Int): Object = loadObject(atRaw(i))
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -12,7 +12,7 @@
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
 //     --line-directive '' \
-//     -o nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+//     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
 //  personally or build-system specific identifiable information.
@@ -159,7 +159,7 @@ final class BooleanArray private () extends Array[Boolean] {
     1.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -211,7 +211,7 @@ final class CharArray private () extends Array[Char] {
     2.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -263,7 +263,7 @@ final class ByteArray private () extends Array[Byte] {
     1.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -315,7 +315,7 @@ final class ShortArray private () extends Array[Short] {
     2.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -367,7 +367,7 @@ final class IntArray private () extends Array[Int] {
     4.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -419,7 +419,7 @@ final class LongArray private () extends Array[Long] {
     8.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -471,7 +471,7 @@ final class FloatArray private () extends Array[Float] {
     4.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -523,7 +523,7 @@ final class DoubleArray private () extends Array[Double] {
     8.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -575,7 +575,7 @@ final class ObjectArray private () extends Array[Object] {
     castRawSizeToInt(sizeOfPtr).toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -12,7 +12,7 @@
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
 //     --line-directive '' \
-//     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+//     -o nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
 //  personally or build-system specific identifiable information.
@@ -159,7 +159,7 @@ final class BooleanArray private () extends Array[Boolean] {
     1.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -211,7 +211,7 @@ final class CharArray private () extends Array[Char] {
     2.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -263,7 +263,7 @@ final class ByteArray private () extends Array[Byte] {
     1.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -315,7 +315,7 @@ final class ShortArray private () extends Array[Short] {
     2.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -367,7 +367,7 @@ final class IntArray private () extends Array[Int] {
     4.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -419,7 +419,7 @@ final class LongArray private () extends Array[Long] {
     8.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -471,7 +471,7 @@ final class FloatArray private () extends Array[Float] {
     4.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -523,7 +523,7 @@ final class DoubleArray private () extends Array[Double] {
     8.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
@@ -575,7 +575,7 @@ final class ObjectArray private () extends Array[Object] {
     castRawSizeToInt(sizeOfPtr).toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -12,7 +12,7 @@
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
 //     --line-directive '' \
-//     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+//     -o nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
 //  personally or build-system specific identifiable information.
@@ -175,7 +175,7 @@ final class ${T}Array private () extends Array[${T}] {
     ${sizeT}.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
+    if (i < 0 || i > length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -12,7 +12,7 @@
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
 //     --line-directive '' \
-//     -o nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+//     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
 //  personally or build-system specific identifiable information.
@@ -175,7 +175,7 @@ final class ${T}Array private () extends Array[${T}] {
     ${sizeT}.toUSize
 
   @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i > length) {
+    if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -12,7 +12,7 @@
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
 //     --line-directive '' \
-//     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+//     -o nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
 //  personally or build-system specific identifiable information.
@@ -48,8 +48,14 @@ sealed abstract class Array[T]
   /** Pointer to the element. */
   @inline def at(i: Int): Ptr[T] = fromRawPtr[T](atRaw(i))
 
+  /** Pointer to the element without a bounds check. */
+  @inline def atUnsafe(i: Int): Ptr[T] = fromRawPtr[T](atRawUnsafe(i))
+
   /** Raw pointer to the element. */
   def atRaw(i: Int): RawPtr
+
+  /** Raw pointer to the element without a bounds check. */
+  def atRawUnsafe(i: Int): RawPtr
 
   /** Loads element at i, throws ArrayIndexOutOfBoundsException. */
   def apply(i: Int): T
@@ -178,9 +184,13 @@ final class ${T}Array private () extends Array[${T}] {
     if (i < 0 || i >= length) {
       throwOutOfBounds(i)
     } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + ${sizeT} * i))
+      atRawUnsafe(i)
     }
+
+  @inline def atRawUnsafe(i: Int): RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, intToUSize(MemoryLayout.Array.ValuesOffset + ${sizeT} * i))
+  }
 
   @inline def apply(i: Int): ${T} = load${T}(atRaw(i))
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -144,6 +144,8 @@ package object unsafe extends unsafe.UnsafePackageCompat {
   /** Scala Native unsafe extensions to Arrays */
   implicit class UnsafeRichArray[T](val value: Array[T]) extends AnyVal {
     @inline def at(i: Int): Ptr[T] = value.asInstanceOf[runtime.Array[T]].at(i)
+    @inline def atUnsafe(i: Int): Ptr[T] =
+      value.asInstanceOf[runtime.Array[T]].atUnsafe(i)
   }
 
   /** Convert a CString to a String using given charset. */


### PR DESCRIPTION
Currently if you do:
```scala
// some native call
def foo(ptr: Ptr[Byte], len: Int): Unit = extern

val buf = new Array[Byte](0) // 0-length array
foo(buf.at(0), 0)
```

The `buf.at(0)` will throw an index-out-of-bounds exception, because the array is of zero length and there is no element at that position.

Does anyone else find this annoying? Whenever using `.at` I have to remember to to add a special case to handle 0-length arrays, even though the actual logic would not be broken. I keep forgetting and making bugs whenever I try to use this optimization 😅 

The fundamental conflict is that I'm not interested in the element at the 0th position, I'm interested in the pointer at which the array data starts (no matter what length it is).

If nobody thinks it is harmful, I'd like to change the semantic here.