### PR TITLE
Enable  experimental Scala3 projects only on demand

### DIFF
--- a/.github/workflows/run-tests-linux-multiarch.yml
+++ b/.github/workflows/run-tests-linux-multiarch.yml
@@ -77,6 +77,8 @@ jobs:
     name: Test runtime
     runs-on: ubuntu-22.04
     needs: build-image
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -19,6 +19,8 @@ jobs:
   tests-tools:
     name: Compile & test tools
     runs-on: ubuntu-20.04
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
       fail-fast: false
       matrix:
@@ -62,6 +64,8 @@ jobs:
 
   test-compiler-plugins:
     runs-on: ubuntu-20.04
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
       fail-fast: false
       matrix:
@@ -81,6 +85,8 @@ jobs:
     name: Test runtime
     runs-on: ubuntu-22.04
     needs: tests-tools
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -113,6 +113,8 @@ jobs:
     name: Test runtime extension
     runs-on: ubuntu-20.04
     needs: [tests-tools, test-runtime]
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     if: "(github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native'"
     strategy:
       fail-fast: false
@@ -162,6 +164,8 @@ jobs:
     name: Test runtime no-opt
     runs-on: ubuntu-20.04
     needs: tests-tools
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     if: "(github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native'"
     strategy:
       fail-fast: false
@@ -238,6 +242,8 @@ jobs:
     name: Test experimental multithreading support
     runs-on: ubuntu-20.04
     needs: tests-tools
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -16,6 +16,8 @@ jobs:
   test-runtime:
     name: Test runtime
     runs-on: macos-11
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -54,6 +54,8 @@ jobs:
     name: Test runtime extension
     runs-on: macos-11
     needs: [test-runtime]
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     if: "(github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native'"
     strategy:
       fail-fast: false
@@ -145,6 +147,8 @@ jobs:
   test-multihreading:
     name: Test experimental multithreading support
     runs-on: macos-11
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -16,6 +16,8 @@ jobs:
   test-runtime:
     name: Test runtime
     runs-on: windows-2019
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -93,6 +93,8 @@ jobs:
   test-runtime-ext:
     name: Test runtime extension
     runs-on: windows-2019
+    env:
+      ENABLE_EXPERIMENTAL_COMPILER: true
     needs: [test-runtime]
     if: "(github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native'"
     strategy:

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -52,6 +52,7 @@ RUN curl -s "https://get.sdkman.io" | bash  \
 ENV LC_ALL "C.UTF-8"
 ENV LANG "C.UTF-8"
 ENV PATH=/usr/lib/llvm-$LLVM_VERSION/bin:~/.sdkman/candidates/java/current/bin:~/.sdkman/candidates/sbt/current/bin:${PATH}
+ENV ENABLE_EXPERIMENTAL_COMPILER=true
 
 CMD sbt \
   "-Dscala.scalanative.testinterface.processrunner.emulator=$TARGET_EMULATOR" \

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -26,7 +26,9 @@ final case class MultiScalaProject private (
       Settings.noPublishSettings
     )
 
-  override def componentProjects: Seq[Project] = Seq(v2_12, v2_13, v3, v3Next)
+  override def componentProjects: Seq[Project] = Seq(v2_12, v2_13, v3) ++ {
+    if (enableExperimentalCompiler) Some(v3Next) else None
+  }
 
   def mapBinaryVersions(
       mapping: String => Project => Project
@@ -118,6 +120,18 @@ object ScopedMultiScalaProject {
 object MultiScalaProject {
   private def strictMapValues[K, U, V](v: Map[K, U])(f: U => V): Map[K, V] =
     v.map(v => (v._1, f(v._2)))
+
+  private final val ExperimentalCompilerEnv = "ENABLE_EXPERIMENTAL_COMPILER"
+  lazy val enableExperimentalCompiler = {
+    val enabled = scala.sys.env.contains(ExperimentalCompilerEnv)
+    val msg =
+      if (enabled)
+        s"Found `$ExperimentalCompilerEnv` env var: enabled sub-projects using Scala experimental version ${ScalaVersions.scala3Nightly}, using suffix `3_next`."
+      else
+        s"Not found `$ExperimentalCompilerEnv` env var: sub-projects using Scala experimental version would not be available."
+    println(msg)
+    enabled
+  }
 
   final val scalaCrossVersions = Map[String, Seq[String]](
     "2.12" -> ScalaVersions.crossScala212,


### PR DESCRIPTION
Enabling projects using nightly versions of the compiler requires set env var `ENABLE_EXPERIMENTAL_COMPILER`. This should allow for faster indexing times in IDEs and faster sbt startup