### PR TITLE
POC - Implement unsigned integers in the compiler space

### DIFF
--- a/nativelib/src/main/scala-3/scala/scalanative/unsigned/conversions.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/unsigned/conversions.scala
@@ -1,0 +1,8 @@
+package scala.scalanative.unsigned
+
+extension (inline v: Int){
+  inline def u: NewUInt = NewUInt.unsigned(v)
+  inline def U: NewUInt = NewUInt.unsigned(v)
+  inline def ul: NewUInt = NewUInt.unsigned(v)
+  inline def UL: NewUInt = NewUInt.unsigned(v)
+}

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala
@@ -34,6 +34,11 @@ object Boxes {
   @inline def boxToSize(v: RawSize): Size   = new Size(v)
   @inline def boxToUSize(v: RawSize): USize = new USize(v)
 
+  @inline def boxToUnsignedInt(v: NewUInt): UnsignedInt = new UnsignedInt(v)
+  @inline def unboxToUnsignedInt(v: java.lang.Object): NewUInt = 
+    if(v == null) NewUInt.unsigned(0) 
+    else v.asInstanceOf[UnsignedInt].value  
+
   @inline def unboxToSize(o: java.lang.Object): RawSize =
     if (o == null) Intrinsics.castIntToRawSize(0)
     else o.asInstanceOf[Size].rawSize
@@ -41,6 +46,7 @@ object Boxes {
     if (o == null) Intrinsics.castIntToRawSize(0)
     else o.asInstanceOf[USize].rawSize
 
+    
   @inline def boxToUByte(v: Byte): UByte = new UByte(v)
   @inline def unboxToUByte(o: java.lang.Object): Byte =
     if (o == null) 0.toByte else o.asInstanceOf[UByte].underlying

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/NewUInt.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/NewUInt.scala
@@ -1,0 +1,119 @@
+package scala.scalanative
+package unsigned
+
+import scala.scalanative.runtime.intrinsic
+
+final abstract class NewUInt private {
+  def toByte: Byte
+  def toShort: Short
+  def toChar: Char
+  def toInt: Int
+  def toLong: Long
+  def toFloat: Float
+  def toDouble: Double
+
+  def toUByte: UByte
+  def toUShort: UShort
+  def toUInt: NewUInt
+  def toULong: ULong
+  def toUSize: USize
+
+  def unary_~ : NewUInt
+
+  def <<(x: Int): NewUInt
+  def <<(x: Long): NewUInt
+
+  def >>>(x: Int): NewUInt
+  def >>>(x: Long): NewUInt
+
+  def >>(x: Int): NewUInt
+  def >>(x: Long): NewUInt
+
+  def ==(x: UByte): Boolean
+  def ==(x: UShort): Boolean
+  def ==(x: NewUInt): Boolean
+  def ==(x: ULong): Boolean
+
+  def !=(x: UByte): Boolean
+  def !=(x: UShort): Boolean
+  def !=(x: NewUInt): Boolean
+  def !=(x: ULong): Boolean
+
+  def <(x: UByte): Boolean
+  def <(x: UShort): Boolean
+  def <(x: NewUInt): Boolean
+  def <(x: ULong): Boolean
+
+  def <=(x: UByte): Boolean
+  def <=(x: UShort): Boolean
+  def <=(x: NewUInt): Boolean
+  def <=(x: ULong): Boolean
+
+  def >(x: UByte): Boolean
+  def >(x: UShort): Boolean
+  def >(x: NewUInt): Boolean
+  def >(x: ULong): Boolean
+
+  def >=(x: UByte): Boolean
+  def >=(x: UShort): Boolean
+  def >=(x: NewUInt): Boolean
+  def >=(x: ULong): Boolean
+
+  def |(x: UByte): NewUInt
+  def |(x: UShort): NewUInt
+  def |(x: NewUInt): NewUInt
+  def |(x: ULong): ULong
+
+  def &(x: UByte): NewUInt
+  def &(x: UShort): NewUInt
+  def &(x: NewUInt): NewUInt
+  def &(x: ULong): ULong
+
+  def ^(x: UByte): NewUInt
+  def ^(x: UShort): NewUInt
+  def ^(x: NewUInt): NewUInt
+  def ^(x: ULong): ULong
+
+  def +(x: UByte): NewUInt
+  def +(x: UShort): NewUInt
+  def +(x: NewUInt): NewUInt
+  def +(x: ULong): ULong
+
+  def -(x: UByte): NewUInt
+  def -(x: UShort): NewUInt
+  def -(x: NewUInt): NewUInt
+  def -(x: ULong): ULong
+
+  def *(x: UByte): NewUInt
+  def *(x: UShort): NewUInt
+  def *(x: NewUInt): NewUInt
+  def *(x: ULong): ULong
+
+  def /(x: UByte): NewUInt
+  def /(x: UShort): NewUInt
+  def /(x: NewUInt): NewUInt
+  def /(x: ULong): ULong
+
+  def %(x: UByte): NewUInt
+  def %(x: UShort): NewUInt
+  def %(x: NewUInt): NewUInt
+  def %(x: ULong): ULong
+  //  override def toString(): String
+}
+
+object NewUInt {
+  def unsigned(v: Int): NewUInt = intrinsic
+
+  // /** The smallest value representable as a UInt. */
+  // final val MinValue
+
+  // /** The largest value representable as a UInt. */
+  // final val MaxValue
+
+  // /** The String representation of the scala.UInt companion object. */
+  // override def toString(): String
+
+  // /** Language mandated coercions from UInt to "wider" types. */
+  // import scala.language.implicitConversions
+  // implicit def uint2ulong(x: NewUInt): ULong
+}

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/UnsignedInt.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/UnsignedInt.scala
@@ -1,0 +1,33 @@
+package scala.scalanative
+package unsigned
+import scala.scalanative.unsigned.NewUInt
+
+final class UnsignedInt(private[scalanative] val value: NewUInt)
+    extends Number
+    with Comparable[UnsignedInt] {
+
+  override def intValue(): Int = value.toInt
+  override def longValue(): Long = value.toLong
+  override def floatValue(): Float = value.toFloat
+  override def doubleValue(): Double = value.toDouble
+  override def compareTo(o: UnsignedInt): Int =
+    Integer.compareUnsigned(this.intValue, o.intValue())
+
+   override def toString(): String = Integer.toUnsignedString(intValue())
+}
+
+// object UInt {
+
+//   /** The smallest value representable as a UInt. */
+//   final val MinValue
+
+//   /** The largest value representable as a UInt. */
+//   final val MaxValue
+
+//   /** The String representation of the scala.UInt companion object. */
+//   override def toString(): String
+
+//   /** Language mandated coercions from UInt to "wider" types. */
+//   import scala.language.implicitConversions
+//   implicit def uint2ulong(x: NewUInt): ULong
+// }

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -111,6 +111,8 @@ object Type {
     val Short = Type.Ref(Global.Top("scala.scalanative.unsigned.UShort"))
     val Int = Type.Ref(Global.Top("scala.scalanative.unsigned.UInt"))
     val Long = Type.Ref(Global.Top("scala.scalanative.unsigned.ULong"))
+    val NewInt = Type.Ref(Global.Top("scala.scalanative.unsigned.NewUInt"))
+    val NewIntBox = Type.Ref(Global.Top("scala.scalanative.unsigned.UnsignedInt"))
 
     val values: Set[nir.Type] = Set(Size, Byte, Short, Int, Long)
   }
@@ -119,6 +121,8 @@ object Type {
     unsigned.Byte -> Type.Byte,
     unsigned.Short -> Type.Short,
     unsigned.Int -> Type.Int,
+    unsigned.NewIntBox -> Type.Int,
+    // unsigned.NewIntBox -> Type.Int,
     unsigned.Long -> Type.Long
   )
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -83,6 +83,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
       .foreach(genClass)
 
     generatedDefns.toSeq
+      .tapEach(defn => println(nir.Show(defn)))
       .groupBy(defn => getFileFor(defn.name.top))
       .foreach(genIRFile(_, _))
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -4,6 +4,7 @@ import dotty.tools.dotc.core
 import core.Symbols._
 import core.Symbols.{toClassDenot, toDenot}
 import core.Contexts._
+import core.StdNames._
 import core.Names._
 import core.Types._
 import scala.annotation.{threadUnsafe => tu}
@@ -43,6 +44,9 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val SizeClass = requiredClass("scala.scalanative.unsafe.Size")
   @tu lazy val USizeClass = requiredClass("scala.scalanative.unsigned.USize")
   @tu lazy val RawSizeClass = requiredClass("scala.scalanative.runtime.RawSize")
+
+  @tu lazy val NewUIntClass = requiredClass("scala.scalanative.unsigned.NewUInt")
+  @tu lazy val UnsignedIntClass = requiredClass("scala.scalanative.unsigned.UnsignedInt")
 
   // Pointers
   @tu lazy val PtrClass = requiredClass("scala.scalanative.unsafe.Ptr")
@@ -157,6 +161,14 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val Intrinsics_alignmentOf = Intrinsics_alignmentOfAlts.find(_.info.paramInfoss.flatten.nonEmpty).get
   @tu lazy val Intrinsics_alignmentOfType = Intrinsics_alignmentOfAlts.find(_.info.paramInfoss.flatten.isEmpty).get
 
+  @tu lazy val UnsignedModule = requiredModule("scala.scalanative.unsigned.NewUInt")
+  @tu lazy val Intrinsics_unsignedAlts =
+    UnsignedModule.info
+      .member(termName("unsigned"))
+      .alternatives
+      .map(_.symbol)
+      .ensuring(_.size == 1)
+
   // Runtime types
   @tu lazy val RuntimePrimitive: Map[Char, Symbol] = Map(
     'B' -> requiredClass("scala.scalanative.runtime.PrimitiveBoolean"),
@@ -202,14 +214,17 @@ final class NirDefinitions()(using ctx: Context) {
     UShortClass -> RuntimeBoxesModule.requiredMethod("boxToUShort"),
     UIntClass -> RuntimeBoxesModule.requiredMethod("boxToUInt"),
     ULongClass -> RuntimeBoxesModule.requiredMethod("boxToULong"),
-    USizeClass -> RuntimeBoxesModule.requiredMethod("boxToUSize")
+    USizeClass -> RuntimeBoxesModule.requiredMethod("boxToUSize"),
+    NewUIntClass -> RuntimeBoxesModule.companionModule.requiredMethod("boxToUnsignedInt")
   )
   @tu lazy val UnboxUnsignedMethod = Map[Symbol, Symbol](
     UByteClass -> RuntimeBoxesModule.requiredMethod("unboxToUByte"),
     UShortClass -> RuntimeBoxesModule.requiredMethod("unboxToUShort"),
     UIntClass -> RuntimeBoxesModule.requiredMethod("unboxToUInt"),
     ULongClass -> RuntimeBoxesModule.requiredMethod("unboxToULong"),
-    USizeClass -> RuntimeBoxesModule.requiredMethod("unboxToUSize")
+    USizeClass -> RuntimeBoxesModule.requiredMethod("unboxToUSize"),
+    NewUIntClass -> RuntimeBoxesModule.companionModule.requiredMethod("unboxToUnsignedInt"),
+    UnsignedIntClass -> RuntimeBoxesModule.companionModule.requiredMethod("unboxToUnsignedInt")
   )
 
   // Scala boxes

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2036,9 +2036,16 @@ trait NirGenExpr(using Context) {
     private def genUnsignedOp(app: Tree, code: Int): Val = {
       given nir.Position = app.span
       import NirPrimitives._
+      def castToUnsigned = code == TO_UNSIGNED
       def castUnsignedInteger = code >= BYTE_TO_UINT && code <= INT_TO_ULONG
       def castUnsignedToFloat = code >= UINT_TO_FLOAT && code <= ULONG_TO_DOUBLE
       app match {
+        case Apply(_, Seq(argp)) if castToUnsigned =>
+          val arg = genExpr(argp)
+          println(argp -> arg)
+          arg
+          // buf.copy(arg, unwind)
+
         case Apply(_, Seq(argp)) if castUnsignedInteger =>
           val ty = genType(app.tpe)
           val arg = genExpr(argp)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -27,7 +27,8 @@ trait NirGenType(using Context) {
     defnNir.UShortClass,
     defnNir.UIntClass,
     defnNir.ULongClass,
-    defnNir.USizeClass
+    defnNir.USizeClass,
+    defnNir.NewUIntClass
   )
 
   extension (sym: Symbol)
@@ -175,7 +176,8 @@ trait NirGenType(using Context) {
     defn.NullClass -> nir.Type.Null,
     defn.NothingClass -> nir.Type.Nothing,
     defnNir.RawPtrClass -> nir.Type.Ptr,
-    defnNir.RawSizeClass -> nir.Type.Size
+    defnNir.RawSizeClass -> nir.Type.Size,
+    defnNir.NewUIntClass -> nir.Type.Int
   )
 
   def genRefType(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -51,5 +51,8 @@ class ScalaNativePlugin extends StandardPlugin:
           }
         case (config, _) => config
       }
-    List(PrepNativeInterop(), PostInlineNativeInterop(), GenNIR(genNirSettings))
+    PrepNativeInterop() ::
+      PostInlineNativeInterop() ::
+      UnsignedIntegersErasure() ::
+      GenNIR(genNirSettings) :: Nil
   }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/UnsignedIntegersErasure.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/UnsignedIntegersErasure.scala
@@ -1,0 +1,145 @@
+package scala.scalanative.nscplugin
+
+import dotty.tools.dotc.plugins.PluginPhase
+import dotty.tools._
+import dotc._
+import dotc.ast.tpd._
+import dotc.transform.SymUtils.setter
+import core.Contexts._
+import core.Definitions
+import core.Names._
+import core.Symbols._
+import core.Types._
+import core.StdNames._
+import core.Constants.Constant
+import NirGenUtil.ContextCached
+import dotty.tools.dotc.core.Flags
+import dotty.tools.dotc.transform.Erasure
+import dotty.tools.dotc.ast.tpd
+
+object UnsignedIntegersErasure:
+  val name = "scalanative-unsigned-erasure"
+
+class UnsignedIntegersErasure extends PluginPhase {
+  override val runsAfter = Set(transform.Erasure.name, PrepNativeInterop.name)
+  // override val runsAfter = Set(PostInlineNativeInterop.name)
+  // override val runsBefore = Set(transform.FirstTransform.name)
+  override val runsBefore = Set(GenNIR.name)
+  val phaseName = UnsignedIntegersErasure.name
+  override def description: String = "adapt unsigned integers to runtime model"
+
+  def defn(using Context): Definitions = ctx.definitions
+  def defnNir(using Context): NirDefinitions = NirDefinitions.get
+
+  override def transformApply(tree: Apply)(using Context): Tree = {
+    val params = tree.fun.symbol.paramInfo.stripPoly.paramInfoss.flatten
+    assert(params.size == tree.args.size)
+
+    if tree.args.exists(isUnsignedInteger)
+    then
+      cpy.Apply(tree)(
+        fun = tree.fun,
+        args = params.zip(tree.args).map { (paramTpe, arg) =>
+          if (shouldBox(paramTpe, arg)) box(arg)
+          else arg
+        }
+      )
+    else tree
+  }
+
+  override def transformTyped(tree: tpd.Typed)(using Context): tpd.Tree = {
+    val Typed(expr, tpt) = tree
+    if shouldBox(tpt.tpe.widenDealias, expr) then
+      cpy.Typed(tree)(expr = box(expr), tpt = tpt)
+    else tree
+  }
+
+  override def transformTypeApply(
+      tree: tpd.TypeApply
+  )(using Context): tpd.Tree = {
+    val defn = this.defn
+    val TypeApply(fun, args) = tree
+    def boxedUnsigedInteger = List(ref(defnNir.UnsignedIntClass))
+
+    val tpe = args.headOption.map(_.tpe)
+    if !tpe.exists(isUnsignedInteger) then tree
+    else
+      fun.symbol match {
+        case defn.Any_isInstanceOf =>
+          fun match
+            case Select(arg, _) =>
+              val argTpe = arg.tpe.widenDealias
+              // Evaulate expression at compile-time, simillary 1.asInstanceOf[Int] always evaluates to true
+              if isUnsignedInteger(argTpe)
+              then cpy.Literal(tree)(Constant(tpe.contains(argTpe)))
+              else cpy.TypeApply(tree)(fun, boxedUnsigedInteger)
+            case _ => tree
+
+        case defn.Any_asInstanceOf =>
+          cpy.TypeApply(tree)(fun, boxedUnsigedInteger)
+
+        case _ => tree
+      }
+  }
+
+  override def transformValDef(tree: tpd.ValDef)(using Context): tpd.Tree = {
+    val tpe = tree.tpt.tpe
+    val rhs = tree.forceIfLazy
+
+    if shouldBox(tpe, rhs) then
+      cpy.ValDef(tree)(tpt = ref(defnNir.UnsignedIntClass), rhs = box(rhs))
+    else if shouldUnbox(tpe, rhs) then
+      cpy.ValDef(tree)(tpt = ref(defnNir.NewUIntClass), rhs = unbox(rhs))
+    else if tpe != rhs.tpe &&
+        isUnsignedInteger(tpe) && !isUnsignedInteger(rhs) then
+      cpy.ValDef(tree)(rhs = unbox(rhs))
+    else tree
+  }
+
+  override def transformIf(tree: tpd.If)(using Context): tpd.Tree = {
+    val If(condt, thent, elset) = tree
+    condt match
+      case Apply(Select(ident, op), List(Literal(Constant(null))))
+          if isUnsignedInteger(ident) =>
+        if op == nme.ne then thent
+        else if op == nme.eq then elset
+        else tree
+      case _ => tree
+  }
+
+  override def transformAssign(tree: tpd.Assign)(using Context): tpd.Tree = {
+    val Assign(lhs, rhs) = tree
+    if shouldBox(lhs.tpe, rhs) then //
+      cpy.Assign(tree)(lhs = lhs, rhs = box(rhs))
+    else if shouldUnbox(lhs.tpe, rhs) then
+      cpy.Assign(tree)(lhs = lhs, rhs = unbox(rhs))
+    else tree
+  }
+
+  private def isUnsignedInteger(tree: Tree)(using Context): Boolean =
+    isUnsignedInteger(tree.tpe.widenDealias)
+
+  private def isUnsignedInteger(tpe: Type)(using Context): Boolean =
+    tpe.widenDealias.typeSymbol == defnNir.NewUIntClass
+
+  private def shouldBox(expectedTpe: Type, value: Tree)(using
+      Context
+  ): Boolean =
+    isUnsignedInteger(value) && defn.AnyRefType <:< expectedTpe.widenDealias
+
+  private def shouldUnbox(expectedTpe: Type, value: Tree)(using
+      Context
+  ): Boolean =
+    isUnsignedInteger(expectedTpe) && defn.AnyRefType <:< value.tpe.widenDealias
+
+  private def box(value: Tree)(using Context) = cpy.Apply(value)(
+    ref(defnNir.BoxUnsignedMethod(value.tpe.typeSymbol)),
+    List(value)
+  )
+
+  private def unbox(value: Tree)(using Context) = cpy.Apply(value)(
+    ref(defnNir.UnboxUnsignedMethod(value.tpe.typeSymbol)),
+    List(value)
+  )
+
+}

--- a/sandbox/src/main/scala/Test.scala
+++ b/sandbox/src/main/scala/Test.scala
@@ -1,5 +1,51 @@
+import scala.scalanative.unsigned._
+
+// given CanEqual[Int, NewUInt] = ???
 object Test {
+  def printn(v: Any): Unit = ()
   def main(args: Array[String]): Unit = {
-    println("Hello, World!")
+    // println("Hello, World!")
+    // println(classOf[NewUInt])
+    // val a0 = 42L.toInt
+    // println(a0)
+    // val a1 = 42
+    // println(a)
+    val a = 1.u
+    val b = a.toInt.U * 2.u
+    val c = a + b
+    val d = a + b + c
+    // val x: Any = 1.u
+
+    // println(1.isInstanceOf[Int])
+    // println(1.u.isInstanceOf[NewUInt])
+    // println(x.isInstanceOf[Int])
+    // println(x.isInstanceOf[NewUInt])
+
+    // println(1.asInstanceOf[Int])
+    // println(1.asInstanceOf[Integer])
+    // println(1.u.asInstanceOf[NewUInt])
+    // println(1.u.asInstanceOf[UnsignedInt])
+    // println(x.asInstanceOf[NewUInt])
+    // 42 match {
+    //   case v @ 21 => println(v)
+    //   case v: Int => println(v)
+    // }
+
+    // 42.u match {
+    //   case v: NewUInt => println(s"uint $v")
+    // }
+    // val v: Any = 1.u
+    // v match {
+    //   case v: Int => println("int: "+ v)
+    //   case v: NewUInt => println("uint: " + v)
+    //   case other => println("other: " + other)
+    // }
+
+    // var mutV: Any = 1
+    // mutV = 1.u
+    // mutV = (1.u: Any)
+    
+    // println(c)
+    // println(-1.U)
   }
 }


### PR DESCRIPTION
This is a proof of concept of how could we improve the implementation of unsigned types. 

Currently, the Scala compiler does not allow us to implement a first-class, efficient unsigned type in the user space:  
* Implementation based on value classes (AnyVal) would not allow defining other value classes using unsigned types
* Implementation based on opaque types would not allow us to implement a typesafe code in the erased context, and though would not allow for safe usage of unsigned types in pattern matching, besides matching on literal value
```scala
opaque type UInt = Int 
val x: UInt = ???
val y: Any = x
1.getClass // int
x.getClass() // class java.lang.Integer
y.getClass() // class java.lang.Integer
``` 

The ultimate solution for this problem would be defining first-class unsigned types in the stdlib, but [SIP-26](https://github.com/scala/improvement-proposals/pull/27) rejected this idea. However, at that time, unsigned types were implemented in the user space, mostly by the usage of the value classes, and were not incorporated in the main compiler and its type system. 

As a workaround, I present the POC for compiler-plugin-space implementation of unsigned types. 
`UInt` is now defined as `final abstract class NewUInt private()` and defines only the abstract method declarations, similarly to the `scala.Int` in the stdlib. All the actual implementation of these methods is handled by the compiler based on the registered set of primitive symbols. The `NewUInt` at the typer is treated as `AnyRef` class, however, in Scala Native backend it is treated as primitive type (AnyVal).  By moving the logic to the compiler-plugin we do risk a much higher complexity and maintenance cost, but it could be a coal stone of checking this experimental feature, and maybe eventually moving it to the compiler. 

We do not introduce a NIR primitive type for unsigned integers. At NIR level they're still represented as `Int`. Similary to LLVM IR representation signless of integers is only context-based - there is no dedicated `uint` type in LLVM.   

The following code: 
```scala
    val a = 1.u
    val b = a.toInt.U * 2.u
    val c = a + b
    val d: NewUInt = a + b + c
    val e: Any = d
```
would translate to following NIR 
```llvm
  %4 = imul[int] int 1, int 2     ; b = a * 2
  %5 = iadd[int] int 1, %4 : int  ; c = a + b
  %6 = iadd[int] int 1, %4 : int  ; a + b 
  %7 = iadd[int] %6 : int, %5 : int  
  %8 = module @"T32scala.scalanative.runtime.Boxes$"
  %9 = call[(@"T32scala.scalanative.runtime.Boxes$", int) => @"T38scala.scalanative.unsigned.UnsignedInt"] @"M32scala.scalanative.runtime.Boxes$D16boxToUnsignedIntiL38scala.scalanative.unsigned.UnsignedIntEO" : ptr(%8 : !?@"T32scala.scalanative.runtime.Boxes$", %7 : int)
```
What's important the literal types `1.u` and `a.toInt.U` are still literal constants at NIR level. It was not possible in the previous implementation, in which by default all unsigned types would be boxed, and might get rid of boxing in the optimizer

Problems of new implementation: 
* Even though at runtime `NewUInt` is a primtive type, we can define it as `AnyVal` it's impossible and limited by the compiler 
* All usages of new unsiged integers need to be rewritten in the compiler plugin. Becouse they're not recognized as primtive types by the compiler, we need to manually handle they're boxing/unboxing after the `Erasure` phase. Currently all operations used in the sanbox project (also commented out) are working correctly, but there is always a risk of bugs for each unhandled use case of new unsigned types