### PR TITLE
Fix #3333: javalib FileInputStream#available now matches JVM

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/FileInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/FileInputStreamTest.scala
@@ -1,11 +1,14 @@
 package org.scalanative.testsuite.javalib.io
 
 import java.io._
+import java.nio.file.{Files, Path}
 
 import scala.util.Try
 
 import org.junit.Test
 import org.junit.Assert._
+
+import org.scalanative.testsuite.javalib.io.IoTestHelpers.withTemporaryDirectory
 
 import org.scalanative.testsuite.utils.Platform.isWindows
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
@@ -68,4 +71,27 @@ class FileInputStreamTest {
       new FileInputStream("/the/path/does/not/exist/for/sure")
     )
   }
+
+  @Test def available(): Unit = {
+    withTemporaryDirectory { dir =>
+      val f = dir.toPath().resolve("FisTestDataForMethodAvailable.utf-8")
+      val str = "They were the best of us!"
+      Files.write(f, str.getBytes("UTF-8"))
+
+      val fis = new FileInputStream(f.toFile())
+      try {
+        // current position less than file size.
+        assertEquals("available pos < size", str.length(), fis.available())
+        // 2023-06-15 11:21 -0400 FIXME
+
+        // move current position to > than file size.
+        val channel = fis.getChannel()
+        channel.position(str.length * 2) // two is an arbitrary value > 1
+        assertEquals("available pos > size", 0, fis.available())
+      } finally {
+        fis.close()
+      }
+    }
+  }
+
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/IoTestHelpers.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/IoTestHelpers.scala
@@ -1,0 +1,71 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io.File
+import java.io.IOException
+
+/* Note on Technical Debt:
+ *
+ * The good news about Technical Debt is that it means that a project has
+ * endured long enough to accumulate it.  The bad news is that there
+ * is accumulated Technical Debt.
+ *
+ * Specifically, the "withTemporaryDirectory" concept and implementations of it
+ * and close kin, exist in a number of places) in javalib unit-tests.
+ * They tend to have slight variations, which make both development &
+ * maintenance both annoying and error prone.
+ * Someday they should be unified into a "Single Point of Truth".
+ *
+ * This file allows the FileInputStream#available test introduced in PR 3333
+ * to share the "withTemporaryDirectory" previously used in FileOutputStream.
+ * By doing so, it avoids introducing new Technical Debt. It makes no attempt
+ * to solve the whole "withTemporaryDirectory" problem.
+ *
+ * The impediment to solving the larger problem is probably determining a
+ * proper place in the directory tree for the common file and gaining
+ * consensus.
+ *
+ * Perhaps inspiration or enlightenment will strike the next time someone
+ * implements or maintains a unit-test requiring "withTemporaryDirectory".
+ */
+
+object IoTestHelpers {
+  def withTemporaryFile(f: File => Unit): Unit = {
+    val tmpfile = File.createTempFile("scala-native-test", null)
+    try {
+      f(tmpfile)
+    } finally {
+      tmpfile.delete()
+    }
+  }
+
+  // This variant takes "Temporary" to mean: clean up after yourself.
+  def withTemporaryDirectory(f: File => Unit): Unit = {
+    import java.nio.file._
+    import attribute._
+    val tmpdir = Files.createTempDirectory("scala-native-test")
+    try {
+      f(tmpdir.toFile())
+    } finally {
+      Files.walkFileTree(
+        tmpdir,
+        new SimpleFileVisitor[Path]() {
+          override def visitFile(
+              file: Path,
+              attrs: BasicFileAttributes
+          ): FileVisitResult = {
+            Files.delete(file)
+            FileVisitResult.CONTINUE
+          }
+          override def postVisitDirectory(
+              dir: Path,
+              exc: IOException
+          ): FileVisitResult = {
+            Files.delete(dir)
+            FileVisitResult.CONTINUE
+          }
+        }
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
Fix Issue #3333

Javalib `FileInputStream#available` now matches its JVM description and implementation.

Also, a few internal correctness, maintenance, and performance issues are fixed.