### PR TITLE
Improve IDE development experience

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -14,7 +14,7 @@ project.excludePaths = [
   "glob:**/src/**/scala-next/**"
 ]
 # Default runner.dialect is deprecated now, needs to be explicitly set
-runner.dialect = scala213
+runner.dialect = scala3
 # Added for CI error via --test option
 runner.fatalWarnings = true
 # This creates less of a diff but is not default
@@ -37,10 +37,7 @@ rewriteTokens = {
   "←": "<-"
 }
 fileOverride {
-  "glob:**/src/**/scala-3*/**" {
-     runner.dialect = scala3
-  }
-  "glob:**/scripts/**" {
-    runner.dialect = scala3
+  "glob:**/src/**/scala-2*/**" {
+     runner.dialect = scala213
   }
 }

--- a/docs/contrib/ides.rst
+++ b/docs/contrib/ides.rst
@@ -4,7 +4,7 @@ Metals
 ======
 Metals import should work out of the box for most of the modules, it's the recommended IDE.  
 To speed up indexing and prevent Bloop-related issues by default we export only 1 version of ``MultiScalaProject``, otherwise it would need to cross-compile sources for all binary Scala versions on each source-change.
-By default IDE would target Scala 3 projects, to change this behavior modify ``project/MyScalaNativeProject.scala`` and modify ``ideScalaVersion``. This change would be only required when developing Scala 2 compiler plugins, sbt plugins or Scala 2 specific sources.
+By default IDE would target Scala 3 projects, to change this behavior modify ``project/MyScalaNativePlugin.scala`` and modify ``ideScalaVersion``. This change would be only required when developing Scala 2 compiler plugins, sbt plugins or Scala 2 specific sources.
 
 
 IntelliJ IDEA

--- a/docs/contrib/ides.rst
+++ b/docs/contrib/ides.rst
@@ -1,5 +1,12 @@
 .. _ides:
 
+Metals
+======
+Metals import should work out of the box for most of the modules, it's the recommended IDE.  
+To speed up indexing and prevent Bloop-related issues by default we export only 1 version of ``MultiScalaProject``, otherwise it would need to cross-compile sources for all binary Scala versions on each source-change.
+By default IDE would target Scala 3 projects, to change this behavior modify ``project/MyScalaNativeProject.scala`` and modify ``ideScalaVersion``. This change would be only required when developing Scala 2 compiler plugins, sbt plugins or Scala 2 specific sources.
+
+
 IntelliJ IDEA
 =============
 
@@ -13,6 +20,3 @@ IntelliJ IDEA
 
 The above is not an exhaustive list, but it is the bare minimum to have the build working. Please keep in mind that you will have to repeat the above steps, in case you reload (re-import) the SBT build. This will need to happen if you change some SBT-related file (e.g. ``build.sbt``).
 
-Metals
-======
-Metals import should work out of the box for most of the modules.

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -330,8 +330,8 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
       end: scala.Int
   ): Unit = {
     val chars0 = if (chars != null) chars else "null"
-    if (index < 0 || index > count || start < 0 || end < 0 || start > end ||
-        end > chars0.length()) {
+    if (index < 0 || index > count || start < 0 || end < 0 ||
+        start > end || end > chars0.length()) {
       throw new IndexOutOfBoundsException()
     }
     insert0(index, chars0.subSequence(start, end).toString)

--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -512,7 +512,7 @@ object NetworkInterface {
   private def unixImplGetIndex(ifName: String): Int = Zone { implicit z =>
     // toInt truncation OK, since index will never be larger than MAX_INT
     if_nametoindex(toCString(ifName)).toInt
-    // Return 0 on error. Do not give errno error message.
+      // Return 0 on error. Do not give errno error message.
   }
 
   private def unixImplGetHardwareAddress(ifName: String): Array[Byte] = {

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -51,12 +51,12 @@ object Files {
 
     val out =
       if (!targetExists || (targetFile.isFile() && replaceExisting)) {
-        new FileOutputStream(targetFile, /* append = */ false)
+        new FileOutputStream(targetFile, append = false)
       } else if (targetFile.isDirectory() &&
           targetFile.list().isEmpty &&
           replaceExisting) {
         if (!targetFile.delete()) throw new IOException()
-        new FileOutputStream(targetFile, /* append = */ false)
+        new FileOutputStream(targetFile, append = false)
       } else if (targetFile.isDirectory() &&
           !targetFile.list().isEmpty &&
           replaceExisting) {
@@ -69,8 +69,8 @@ object Files {
       val copyResult = copy(in, out)
       // Make sure that created file has correct permissions
       if (!targetExists) {
-        targetFile.setReadable(true, /* ownerOnly = */ false)
-        targetFile.setWritable(true, /* ownerOnly = */ true)
+        targetFile.setReadable(true, ownerOnly = false)
+        targetFile.setWritable(true, ownerOnly = true)
       }
       copyResult
     } finally out.close()
@@ -411,10 +411,10 @@ object Files {
           attribute.substring(0, sepIndex),
           attribute.substring(sepIndex + 1, attribute.length)
         )
-    val viewClass: Class[FileAttributeView] = {
+    val viewClass = {
       if (!viewNamesToClasses.containsKey(viewName))
         throw new UnsupportedOperationException()
-      viewNamesToClasses.get(viewName).asInstanceOf[Class[FileAttributeView]]
+      viewNamesToClasses.get(viewName)
     }
     val view = getFileAttributeView(path, viewClass, options)
     view.getAttribute(attrName)
@@ -929,7 +929,7 @@ object Files {
           .asList(FileHelpers.list(start.toString, (n, t) => (n, t)))
           .stream()
           .flatMap[Path] {
-            case (name: String, FileHelpers.FileType.Link)
+            case (name, FileHelpers.FileType.Link)
                 if options.contains(FileVisitOption.FOLLOW_LINKS) =>
               val path = start.resolve(name)
 
@@ -946,14 +946,14 @@ object Files {
               else
                 walk(path, maxDepth, currentDepth + 1, options, visited)
 
-            case (name: String, FileHelpers.FileType.Directory)
+            case (name, FileHelpers.FileType.Directory)
                 if currentDepth < maxDepth =>
               val path = start.resolve(name)
               if (options.contains(FileVisitOption.FOLLOW_LINKS))
                 visited.add(path)
               walk(path, maxDepth, currentDepth + 1, options, visited)
 
-            case (name: String, _) =>
+            case (name, _) =>
               Stream.of(start.resolve(name))
           }
       )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -364,19 +364,14 @@ object Build {
 
   lazy val auxlib = MultiScalaProject("auxlib")
     .enablePlugins(MyScalaNativePlugin)
-    .settings(
-      mavenPublishSettings,
-      commonJavalibSettings,
-      disabledDocsSettings,
-      noIDEExportSettings
-    )
+    .settings(mavenPublishSettings, commonJavalibSettings, disabledDocsSettings)
     .dependsOn(nativelib, clib)
     .withNativeCompilerPlugin
 
   lazy val scalalib: MultiScalaProject =
     MultiScalaProject("scalalib")
       .enablePlugins(MyScalaNativePlugin)
-      .settings(mavenPublishSettings, disabledDocsSettings, noIDEExportSettings)
+      .settings(mavenPublishSettings, disabledDocsSettings)
       .withNativeCompilerPlugin
       .mapBinaryVersions {
         case version @ ("2.12" | "2.13") =>
@@ -457,7 +452,6 @@ object Build {
     .withJUnitPlugin
     .dependsOn(
       scalalib,
-      javalib,
       testInterface,
       junitRuntime
     )
@@ -512,7 +506,7 @@ object Build {
       .enablePlugins(MyScalaNativePlugin)
       .withNativeCompilerPlugin
       .withJUnitPlugin
-      .dependsOn(scalalib, javalib, testInterface % "test")
+      .dependsOn(scalalib, testInterface % "test")
 
 // Testing infrastructure ------------------------------------------------
   lazy val testingCompilerInterface =
@@ -564,7 +558,6 @@ object Build {
       .withJUnitPlugin
       .dependsOn(
         scalalib,
-        javalib,
         testInterfaceSbtDefs,
         junitRuntime,
         junitAsyncNative % "test"
@@ -576,7 +569,7 @@ object Build {
       .settings(mavenPublishSettings)
       .settings(docsSettings)
       .withNativeCompilerPlugin
-      .dependsOn(scalalib, javalib)
+      .dependsOn(scalalib)
 
   lazy val testRunner =
     MultiScalaProject("testRunner", file("test-runner"))
@@ -791,7 +784,7 @@ object Build {
           )
       }
       .withNativeCompilerPlugin
-      .dependsOn(scalalib, javalib)
+      .dependsOn(scalalib)
 
   lazy val scalaPartestJunitTests = MultiScalaProject(
     "scalaPartestJunitTests",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -638,7 +638,10 @@ object Build {
       .settings(
         scalacOptions --= Seq(
           "-Xfatal-warnings"
-        ),
+        ), {
+          if (ideScalaVersion.startsWith("2.")) Nil
+          else noIDEExportSettings
+        },
         noPublishSettings,
         shouldPartestSetting,
         resolvers += Resolver.typesafeIvyRepo("releases"),

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -5,9 +5,32 @@ import sbt.Keys._
 
 import scala.scalanative.sbtplugin.ScalaNativePlugin
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
+import scala.sys.env
 
 object MyScalaNativePlugin extends AutoPlugin {
   override def requires: Plugins = ScalaNativePlugin
+
+  final val isGeneratingForIDE =
+    env.getOrElse("METALS_ENABLED", "false").toBoolean
+
+  final val enableExperimentalCompiler = {
+    val ExperimentalCompilerEnv = "ENABLE_EXPERIMENTAL_COMPILER"
+    val enabled = env.contains(ExperimentalCompilerEnv)
+    println(
+      if (enabled)
+        s"Found `$ExperimentalCompilerEnv` env var: enabled sub-projects using Scala experimental version ${ScalaVersions.scala3Nightly}, using suffix `3_next`."
+      else
+        s"Not found `$ExperimentalCompilerEnv` env var: sub-projects using Scala experimental version would not be available."
+    )
+    enabled
+  }
+
+  // Allowed values: 3, 3-next, 2.13, 2.12
+  final val ideScalaVersion = if (enableExperimentalCompiler) "3-next" else "3"
+
+  // Would be visible in Metals logs
+  if (isGeneratingForIDE)
+    println(s"IDE support enabled using Scala $ideScalaVersion")
 
   private def multithreadingEnabledBySbtSysProps(): Option[Boolean] = {
     /* Started as: sbt -Dscala.scalanative.multithreading.enable=true

--- a/project/NoIDEExport.scala
+++ b/project/NoIDEExport.scala
@@ -1,0 +1,34 @@
+package build
+
+import sbt._
+import Keys._
+
+/** Settings to prevent projects from being exported to IDEs. */
+object NoIDEExport {
+  /* We detect whether bloop is on the classpath (which will be the case during
+   * import in Metals) and if yes, we deactivate the bloop export for
+   * irrelevant projects.
+   */
+  private lazy val bloopGenerateKey: Option[TaskKey[Option[File]]] = {
+    val optBloopKeysClass: Option[Class[_]] =
+      try Some(Class.forName("bloop.integrations.sbt.BloopKeys"))
+      catch { case _: ClassNotFoundException => None }
+
+    optBloopKeysClass.map { bloopKeysClass =>
+      val bloopGenerateGetter = bloopKeysClass.getMethod("bloopGenerate")
+      bloopGenerateGetter.invoke(null).asInstanceOf[TaskKey[Option[File]]]
+    }
+  }
+
+  /** Settings to prevent the project from being exported to IDEs. */
+  lazy val noIDEExportSettings: Seq[Setting[_]] = {
+    bloopGenerateKey match {
+      case None => Nil
+      case Some(key) =>
+        Seq(
+          Compile / key := None,
+          Test / key := None
+        )
+    }
+  }
+}

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -36,7 +36,7 @@ object ScalaVersions {
   val scala213: String = crossScala213.last
   val scala3: String = "3.1.3"
   // List of nightly version can be found here: https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/
-  lazy val scala3Nightly = "3.3.2-RC1-bin-20230608-0af8809-NIGHTLY"
+  lazy val scala3Nightly = "3.3.2-RC1-bin-20230601-8814760-NIGHTLY"
 
   // minimum version - 1.5 is required for Scala 3 and 1.5.8 has log4j vulnerability fixed
   val sbt10Version: String = "1.5.8"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -485,6 +485,14 @@ object Settings {
         }
         val newSources = experimentalSources.values.toList.diff(updatedSources)
         updatedSources ++ newSources
+      },
+      // Adjustment for bloopInstall which tries to add whole source directory leading to double definitions
+      scope / sourceDirectories --= {
+        val sourcesDir = (scope / sourceDirectory).value
+        lazy val experimentalSources = allScalaFromDir(sourcesDir / baseDir)
+        if (isGeneratingForIDE && experimentalSources.nonEmpty)
+          Seq((scope / scalaSource).value)
+        else Nil
       }
     )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -578,14 +578,6 @@ object Settings {
     // We put our classes on scalac's `javabootclasspath` so that it uses them
     // when compiling rather than the definitions from the JDK.
     recompileAllOrNothingSettings,
-    Compile / scalacOptions := {
-      val previous = (Compile / scalacOptions).value
-      val javaBootClasspath =
-        scala.tools.util.PathResolver.Environment.javaBootClassPath
-      val classDir = (Compile / classDirectory).value.getAbsolutePath
-      val separator = sys.props("path.separator")
-      "-javabootclasspath" +: s"$classDir$separator$javaBootClasspath" +: previous
-    },
     Compile / scalacOptions ++= scalaNativeCompilerOptions(
       "genStaticForwardersForNonTopLevelObjects"
     ),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -16,6 +16,7 @@ import com.jsuereth.sbtpgp.PgpKeys
 import scala.collection.mutable
 import scala.scalanative.build.Platform
 import Build.{crossPublish, crossPublishSigned}
+import MyScalaNativePlugin.isGeneratingForIDE
 
 import java.io.File
 
@@ -891,7 +892,8 @@ object Settings {
   }
 
   def scalaNativeCompilerOptions(options: String*): Seq[String] = {
-    options.map(opt => s"-P:scalanative:$opt")
+    if (isGeneratingForIDE) Nil
+    else options.map(opt => s"-P:scalanative:$opt")
   }
 
   def scalaNativeMapSourceURIOption(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -582,9 +582,6 @@ object Settings {
   )
 
   lazy val commonJavalibSettings = Def.settings(
-    // This is required to have incremental compilation to work in javalib.
-    // We put our classes on scalac's `javabootclasspath` so that it uses them
-    // when compiling rather than the definitions from the JDK.
     recompileAllOrNothingSettings,
     Compile / scalacOptions ++= scalaNativeCompilerOptions(
       "genStaticForwardersForNonTopLevelObjects"


### PR DESCRIPTION
* Limits the amount of created underlying bloop projects to only Scala 3 projects. This change should allow for faster imports, and more reliable IDE diagnostics (no-more classpath duplicate entries or compilation errors not allowing to finish indexing Metals)
* Disables usage of Scala Native compiler plugins when compiling for IDE to speedup compilaiton
* Sets scalafmt default dialect to scala3 (was scala213). Scala 3 is the main platform we're going to develop and maintaine. 
* Removes redundant javabootclasspath settings leading to indexing failures
* Don't create bloop projects for scalalib and auxlib - depend on Scala stdlib artifacts 

Most of these changes are ported from Scala.js, but modified to adjust our goals and allow to target Scala 3 by default and potentially Scala 3 unstable versions on demand.

Known issues: 
* Javalib might raise numerous `problems` (compilation errors), which are present due to incremental compilation. In normal compilation (in sbt) we force full compilation on any change to mitigate problem of double classpath definitions (javalib + JDK). This is however not possible to overcome in IDE/bloop