### PR TITLE
Fix #3329: javalib MappedByteBufferImpl no longer calls FileChannel truncate method

### DIFF
--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -327,25 +327,8 @@ private[nio] object MappedByteBufferImpl {
       mode: MapMode,
       position: Long,
       size: Int,
-      fd: FileDescriptor,
-      channel: FileChannel
+      fd: FileDescriptor
   ): MappedByteBufferImpl = {
-
-    // JVM resizes file to accomodate mapping
-    if (mode ne MapMode.READ_ONLY) {
-      val prevSize = channel.size()
-      val minSize = position + size
-      if (minSize > prevSize) {
-        val prevPosition = channel.position()
-        channel.truncate(minSize)
-        if (isWindows) {
-          channel.position(prevSize)
-          for (i <- prevSize until minSize)
-            channel.write(ByteBuffer.wrap(Array[Byte](0.toByte)))
-          channel.position(prevPosition)
-        }
-      }
-    }
 
     val mappedData =
       if (isWindows) mapWindows(position, size, fd, mode)

--- a/javalib/src/main/scala/java/nio/channels/FileChannel.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannel.scala
@@ -97,7 +97,7 @@ object FileChannel {
     }
 
     if (options.contains(APPEND) && options.contains(READ)) {
-      throw new IllegalArgumentException("APPEND + READ not allowed")
+      throw new IllegalArgumentException("READ + APPEND not allowed")
     }
 
     val writing = options.contains(WRITE) || options.contains(APPEND)


### PR DESCRIPTION
Fix #3329 

###### Credit: 
Aly on Scala Native Discourse gave invaluable information on how Windows extends files.
Any defects from misinterpretation of that information fall on this Author.

##### Changes

javalib `MappedByteBufferImpl` no longer calls `FileChannel#truncate` to extend files.
The latter method is defined as never extending a file, so the former method calling
the latter was a defect.

This is primarily an internal re-organization which prepares the ground for correcting the more
visible and impactful Issue #3330.

A keen user may detect three user visible changes.
- argument checking is more extensive and stricter.  
- Message of an `IllegalArgumentException` was changed to match (a, not every) JVM.
- Thanks to Aly, the performance of extending a file on Windows should be significantly improved.
