### PR TITLE
Fix Subclassed `WeakReference` to be GCed

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
@@ -11,7 +11,8 @@
 #include "GCTypes.h"
 
 extern int __object_array_id;
-extern int __weak_ref_id;
+extern int __weak_ref_ids_min;
+extern int __weak_ref_ids_max;
 extern int __weak_ref_field_offset;
 extern int __array_ids_min;
 extern int __array_ids_max;
@@ -86,7 +87,8 @@ static inline size_t Object_Size(Object *object) {
 }
 
 static inline bool Object_IsWeakReference(Object *object) {
-    return object->rtti->rt.id == __weak_ref_id;
+    int32_t id = object->rtti->rt.id;
+    return __weak_ref_ids_min <= id && id <= __weak_ref_ids_max;
 }
 
 static inline bool Object_IsReferantOfWeakReference(Object *object,

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -500,10 +500,10 @@ object Generate {
             Val.Int(value)
           )
 
-      val (weakRefId, modifiedFieldOffset) = linked.infos
+      val (weakRefIdsMin, weakRefIdsMax, modifiedFieldOffset) = linked.infos
         .get(Global.Top("java.lang.ref.WeakReference"))
         .collect { case cls: Class if cls.allocated => cls }
-        .fold((-1, -1)) { weakRef =>
+        .fold((-1, -1, -1)) { weakRef =>
           // if WeakReferences are being compiled and therefore supported
           val gcModifiedFieldIndexes: Seq[Int] =
             meta.layout(weakRef).entries.zipWithIndex.collect {
@@ -517,9 +517,14 @@ object Generate {
               "Exactly one field should have the \"_gc_modified_\" modifier in java.lang.ref.WeakReference"
             )
 
-          (meta.ids(weakRef), gcModifiedFieldIndexes.head)
+          (
+            meta.ranges(weakRef).start,
+            meta.ranges(weakRef).end,
+            gcModifiedFieldIndexes.head
+          )
         }
-      addToBuf(weakRefIdName, weakRefId)
+      addToBuf(weakRefIdsMaxName, weakRefIdsMax)
+      addToBuf(weakRefIdsMinName, weakRefIdsMin)
       addToBuf(weakRefFieldOffsetName, modifiedFieldOffset)
     }
 
@@ -621,7 +626,8 @@ object Generate {
     val moduleArrayName = extern("__modules")
     val moduleArraySizeName = extern("__modules_size")
     val objectArrayIdName = extern("__object_array_id")
-    val weakRefIdName = extern("__weak_ref_id")
+    val weakRefIdsMaxName = extern("__weak_ref_ids_max")
+    val weakRefIdsMinName = extern("__weak_ref_ids_min")
     val weakRefFieldOffsetName = extern("__weak_ref_field_offset")
     val registryOffsetName = extern("__weak_ref_registry_module_offset")
     val registryFieldOffsetName = extern("__weak_ref_registry_field_offset")

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/ref/WeakReferenceTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/ref/WeakReferenceTest.scala
@@ -18,10 +18,8 @@ import org.scalanative.testsuite.utils.Platform
 class WeakReferenceTest {
 
   case class A()
-  class SubclassedWeakRef1[A](a: A, referenceQueue: ReferenceQueue[A])
+  class SubclassedWeakRef[A](a: A, referenceQueue: ReferenceQueue[A])
       extends WeakReference[A](a, referenceQueue)
-  class SubclassedWeakRef2[A](a: A, referenceQueue: ReferenceQueue[A])
-      extends SubclassedWeakRef1[A](a, referenceQueue)
 
   def gcAssumption(): Unit = {
     assumeTrue(
@@ -30,12 +28,21 @@ class WeakReferenceTest {
     )
   }
 
-  @noinline def allocWeakRef[T <: WeakReference[A]](
-      referenceQueue: ReferenceQueue[A],
-      init: (A, ReferenceQueue[A]) => T
-  ): T = {
+  @noinline def allocWeakRef(
+      referenceQueue: ReferenceQueue[A]
+  ): WeakReference[A] = {
     var a = A()
-    val weakRef = init(a, referenceQueue)
+    val weakRef = new WeakReference(a, referenceQueue)
+    assertEquals("get() should return object reference", weakRef.get(), A())
+    a = null
+    weakRef
+  }
+
+  @noinline def allocSubclassedWeakRef(
+      referenceQueue: ReferenceQueue[A]
+  ): SubclassedWeakRef[A] = {
+    var a = A()
+    val weakRef = new SubclassedWeakRef(a, referenceQueue)
     assertEquals("get() should return object reference", weakRef.get(), A())
     a = null
     weakRef
@@ -75,41 +82,35 @@ class WeakReferenceTest {
 
     gcAssumption()
     val refQueue = new ReferenceQueue[A]()
-    val weakRef1 = allocWeakRef(refQueue, new WeakReference[A](_, _))
-    val weakRef2 = allocWeakRef(refQueue, new WeakReference[A](_, _))
-    val weakRef3 = allocWeakRef(refQueue, new SubclassedWeakRef1[A](_, _))
-    val weakRef4 = allocWeakRef(refQueue, new SubclassedWeakRef2[A](_, _))
-    val weakRefList = List(weakRef1, weakRef2, weakRef3, weakRef4)
+    val weakRef1 = allocWeakRef(refQueue)
+    val weakRef2 = allocWeakRef(refQueue)
+    val weakRef3 = allocSubclassedWeakRef(refQueue)
+    val weakRefList = List(weakRef1, weakRef2, weakRef3)
 
     GC.collect()
     def newDeadline() = System.currentTimeMillis() + 60 * 1000
     assertEventuallyIsCollected("weakRef1", weakRef1, deadline = newDeadline())
     assertEventuallyIsCollected("weakRef2", weakRef2, deadline = newDeadline())
     assertEventuallyIsCollected("weakRef3", weakRef3, deadline = newDeadline())
-    assertEventuallyIsCollected("weakRef4", weakRef4, deadline = newDeadline())
 
     assertEquals("weakRef1", null, weakRef1.get())
     assertEquals("weakRef2", null, weakRef2.get())
     assertEquals("weakRef3", null, weakRef3.get())
-    assertEquals("weakRef4", null, weakRef4.get())
     val a = refQueue.poll()
     assertNotNull("a was null", a)
     val b = refQueue.poll()
     assertNotNull("b was null", b)
     val c = refQueue.poll()
     assertNotNull("c was null", c)
-    val d = refQueue.poll()
-    assertNotNull("d was null", d)
     assertTrue("!contains a", weakRefList.contains(a))
     assertTrue("!contains b", weakRefList.contains(b))
     assertTrue("!contains c", weakRefList.contains(c))
-    assertTrue("!contains d", weakRefList.contains(d))
     def allDistinct(list: List[_]): Unit = list match {
       case head :: next =>
         next.foreach(assertNotEquals(_, head)); allDistinct(next)
       case Nil => ()
     }
-    allDistinct(List(a, b, c, d))
+    allDistinct(List(a, b, c))
     assertEquals("pool not null", null, refQueue.poll())
   }
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/ref/WeakReferenceTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/ref/WeakReferenceTest.scala
@@ -104,7 +104,6 @@ class WeakReferenceTest {
     assertTrue("!contains b", weakRefList.contains(b))
     assertTrue("!contains c", weakRefList.contains(c))
     assertTrue("!contains d", weakRefList.contains(d))
-    // assertNotEquals(a, b)
     def allDistinct(list: List[_]): Unit = list match {
       case head :: next =>
         next.foreach(assertNotEquals(_, head)); allDistinct(next)


### PR DESCRIPTION
Fix https://github.com/scala-native/scala-native/issues/3341

Instead of using `WeakReferenceId` directory to determine WeakReference, we use the `ranges` of WeakReference to make the determination, as `Class.is` does.