### PR TITLE
Fix #3308, #3350: better reporting of javalib stream & spliterator characteristics

### DIFF
--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -197,12 +197,14 @@ class ArrayList[E] private (
      * collections.
      */
 
+    // Flaw: This method makes no attempt to detect ConcurrentModification.
+
     new Spliterators.AbstractSpliterator[E](
       _size,
-      Spliterator.SIZED | Spliterator.SUBSIZED
+      Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED
     ) {
       private var cursor = 0
-      private val limit = _size
+      private lazy val limit = _size // late binding
 
       def tryAdvance(action: Consumer[_ >: E]): Boolean = {
         if (cursor >= limit) false

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
@@ -41,6 +41,54 @@ class DoubleStreamTest {
 
   final val epsilon = 0.00001 // tolerance for Floating point comparisons.
 
+// Methods specified in interface BaseStream ----------------------------
+
+  @Test def streamUnorderedOnUnorderedStream(): Unit = {
+    val dataSet = new ju.HashSet[Double]()
+    dataSet.add(0.1)
+    dataSet.add(1.1)
+    dataSet.add(-1.1)
+    dataSet.add(2.2)
+    dataSet.add(-2.2)
+
+    val s0 = dataSet.stream()
+    val s0Spliter = s0.spliterator()
+    assertFalse(
+      "Unexpected ORDERED stream from hashset",
+      s0Spliter.hasCharacteristics(Spliterator.ORDERED)
+    )
+
+    val su = dataSet.stream().unordered()
+    val suSpliter = su.spliterator()
+
+    assertFalse(
+      "Unexpected ORDERED stream",
+      suSpliter.hasCharacteristics(Spliterator.ORDERED)
+    )
+  }
+
+  @Test def streamUnorderedOnOrderedStream(): Unit = {
+    val s = DoubleStream.of(0.1, 1.1, -1.1, 2.2, -2.2)
+    val sSpliter = s.spliterator()
+
+    assertTrue(
+      "Expected ORDERED on stream from array",
+      sSpliter.hasCharacteristics(Spliterator.ORDERED)
+    )
+
+    // s was ordered, 'so' should be same same. Avoid "already used" exception
+    val so = DoubleStream.of(0.1, 1.1, -1.1, 2.2, -2.2)
+    val su = so.unordered()
+    val suSpliter = su.spliterator()
+
+    assertFalse(
+      "ORDERED stream after unordered()",
+      suSpliter.hasCharacteristics(Spliterator.ORDERED)
+    )
+  }
+
+// Methods specified in interface Stream --------------------------------
+
   @Test def doubleStreamBuilderCanBuildAnEmptyStream(): Unit = {
     val s = DoubleStream.builder().build()
     val it = s.iterator()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -47,6 +47,53 @@ class StreamTest {
     al.stream()
   }
 
+// Methods specified in interface BaseStream ----------------------------
+
+  @Test def streamUnorderedOnUnorderedStream(): Unit = {
+    val dataSet = new ju.HashSet[String]()
+    dataSet.add("T")
+    dataSet.add("S")
+    dataSet.add("X")
+    dataSet.add("Y")
+
+    val s0 = dataSet.stream()
+    val s0Spliter = s0.spliterator()
+    assertFalse(
+      "Unexpected ORDERED stream from hashset",
+      s0Spliter.hasCharacteristics(Spliterator.ORDERED)
+    )
+
+    val su = dataSet.stream().unordered()
+    val suSpliter = su.spliterator()
+
+    assertFalse(
+      "Unexpected ORDERED stream",
+      suSpliter.hasCharacteristics(Spliterator.ORDERED)
+    )
+  }
+
+  @Test def streamUnorderedOnOrderedStream(): Unit = {
+    val s = Stream.of("V", "W", "X", "Y", "Z")
+    val sSpliter = s.spliterator()
+
+    assertTrue(
+      "Expected ORDERED on stream from array",
+      sSpliter.hasCharacteristics(Spliterator.ORDERED)
+    )
+
+    // s was ordered, 'so' should be same same. Avoid "already used" exception
+    val so = Stream.of("V", "W", "X", "Y", "Z")
+    val su = so.unordered()
+    val suSpliter = su.spliterator()
+
+    assertFalse(
+      "ORDERED stream after unordered()",
+      suSpliter.hasCharacteristics(Spliterator.ORDERED)
+    )
+  }
+
+// Methods specified in interface Stream --------------------------------
+
   @Test def streamBuilderCanBuildAnEmptyStream(): Unit = {
     val s = Stream.builder().build()
     val it = s.iterator()


### PR DESCRIPTION
1. Fix #3350: spliterator returned by javalib `ArrayList#spliterator` now matches a JVM by reporting the
   ORDERED characteristic.

2. Fix #3308:  the javalib stream returned by the `unordered` method on  `Stream` or `DoubleStream`
   with an ORDERED stream argument now returns characteristics matching a JVM.  ORDERED
   is not present. Only the DISTINCT and SORTED characteristics, if present, are passed along to
   the new stream.

The first fix is used to test the second fix and *visa versa*.

Note:   The spliterator returned by `ArrayList#spliterator` now binds later, as part of the first
             `tryAdvance()`.  No attempt is made to detect `ConcurrentModification`, but the later
              binding should narrow the window of vulnerability. Here "Best Effort" is zero effort.