### PR TITLE
Fix #3351: javalib LinkedList#spliterator now reports ORDERED characteristic.

### DIFF
--- a/javalib/src/main/scala/java/util/LinkedList.scala
+++ b/javalib/src/main/scala/java/util/LinkedList.scala
@@ -387,6 +387,15 @@ class LinkedList[E]()
 
   override def clone(): AnyRef =
     new LinkedList[E](this)
+
+  override def spliterator(): Spliterator[E] = {
+    // Report the ORDERED characteristic, same as the JVM.
+    Spliterators.spliterator[E](
+      this,
+      Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED
+    )
+  }
+
 }
 
 object LinkedList {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/LinkedListTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/LinkedListTest.scala
@@ -8,7 +8,6 @@ package org.scalanative.testsuite.javalib.util
 
 import org.junit.Test
 import org.junit.Assert._
-import org.junit.Ignore
 
 import java.util.LinkedList
 import java.util.Spliterator
@@ -174,7 +173,6 @@ class LinkedListTest extends AbstractListTest {
   }
 
   // Issue #3351
-  @Ignore // Issue #3351 not yet fixed
   @Test def spliteratorHasExpectedCharacteristics(): Unit = {
 
     val coll =


### PR DESCRIPTION
Fix #3351

javalib ` LinkedList#spliterator` now reports the ORDERED characteristic in addition to the
SIZED and SUBSIZED characteristics it had previously been reporting.  The behavior
of this PR now matches a JVM.