### PR TITLE
Fix compilation of 2 StreamTests when using JDK17 and Scala 2

### DIFF
--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/stream/StreamTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/stream/StreamTestOnJDK9.scala
@@ -2,6 +2,7 @@ package org.scalanative.testsuite.javalib.util.stream
 
 import java.util.stream._
 import java.util.Spliterator
+import java.util.function.{Predicate, UnaryOperator}
 
 import org.junit.Test
 import org.junit.Assert._
@@ -66,11 +67,11 @@ class StreamTestOnJDK9 {
     val expectedSeed = "Red bellied woodpecker"
     val s = Stream.iterate[String](
       expectedSeed,
-      str => count < limit,
-      e => {
+      (str => count < limit): Predicate[String],
+      (e => {
         count += 1
         count.toString()
-      }
+      }): UnaryOperator[String]
     )
 
     val it = s.iterator()
@@ -92,11 +93,11 @@ class StreamTestOnJDK9 {
     val expectedSeed = "Red bellied woodpecker"
     val s = Stream.iterate[String](
       expectedSeed,
-      str => count < limit,
-      e => {
+      (str => count < limit): Predicate[String],
+      (e => {
         count += 1
         count.toString()
-      }
+      }): UnaryOperator[String]
     )
 
     val spliter = s.spliterator()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -227,7 +227,8 @@ class StreamTest {
   }
 
   @Test def streamIterate_Unbounded_Characteristics(): Unit = {
-    val s = Stream.iterate[jl.Double](0.0, n => n + 1)
+    val s =
+      Stream.iterate[jl.Double](0.0, (n => n + 1): UnaryOperator[jl.Double])
     val spliter = s.spliterator()
 
     // spliterator should have required characteristics and no others.


### PR DESCRIPTION
2 tests were failing to compile when using JDK 17 and Scala 2.12/2.13