### PR TITLE
Implement `scala.scalanative.annotation.align` annotation, replacement for JVM `@Contended`

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/Striped64.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/Striped64.scala
@@ -19,10 +19,8 @@ import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
 
 @SuppressWarnings(Array("serial"))
 private[atomic] object Striped64 {
-
-  /** Currently, Contended annotation is not supported. */
-  // @jdk.internal.vm.annotation.Contended
-  final private[atomic] class Cell private[atomic] (
+  type Contended = scala.scalanative.annotation.align
+  @Contended final private[atomic] class Cell private[atomic] (
       @volatile private[atomic] var value: Long
   ) {
 

--- a/nativelib/src/main/scala/scala/scalanative/annotation/align.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/align.scala
@@ -1,0 +1,29 @@
+package scala.scalanative
+package annotation
+
+import scala.scalanative.meta.LinktimeInfo.contendedPaddingWidth
+
+/** Allows to align field or class layout to expected size reflected in number
+ *  of bytes. Can be aliased as `Contended` for cross-compiling with the JVM.
+ *  @param size
+ *    Size of the alignment represented in number of bytes
+ *  @param group
+ *    Optional tag allowing to put multiple fields in the same aligned memory
+ *    area
+ */
+final class align(size: Int, group: String)
+    extends scala.annotation.StaticAnnotation {
+  def this(size: Int) = this(size, "")
+
+  // JVM  Contended compat
+
+  /** Dynamic, platform specific alignment. Can be used as replecement JVM
+   *  \@Contended
+   */
+  def this(group: String) = this(contendedPaddingWidth, group)
+
+  /** Dynamic, platform specific alignment. Can be used as replecement JVM
+   *  \@Contended
+   */
+  def this() = this(contendedPaddingWidth, "")
+}

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -40,8 +40,10 @@ object LinktimeInfo {
   )
   def isMultithreadingEnabled: Boolean = resolved
 
-  // Referenced in nscplugin and codegen 
-  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.contendedPaddingWidth")
+  // Referenced in nscplugin and codegen
+  @resolvedAtLinktime(
+    "scala.scalanative.meta.linktimeinfo.contendedPaddingWidth"
+  )
   def contendedPaddingWidth: Int = resolved
 
   object target {

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -40,6 +40,10 @@ object LinktimeInfo {
   )
   def isMultithreadingEnabled: Boolean = resolved
 
+  // Referenced in nscplugin and codegen 
+  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.contendedPaddingWidth")
+  def contendedPaddingWidth: Int = resolved
+
   object target {
     @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.target.arch")
     def arch: String = resolved

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -32,12 +32,18 @@ object Attr {
   case object Volatile extends Attr
   case object Final extends Attr
   case object LinktimeResolved extends Attr
+  case class Alignment(size: Int, group: Option[String]) extends Attr
+  object Alignment{
+    // Alignment by defintion must be positive integer, magic value treated specially by compiler
+    final val linktimeResolved = -1
+  }
 }
 
 final case class Attrs(
     inlineHint: Inline = MayInline,
     specialize: Specialize = MaySpecialize,
     opt: Opt = UnOpt,
+    align: Option[Alignment] = Option.empty,
     isExtern: Boolean = false,
     isBlocking: Boolean = false,
     isDyn: Boolean = false,
@@ -54,6 +60,7 @@ final case class Attrs(
     if (inlineHint != MayInline) out += inlineHint
     if (specialize != MaySpecialize) out += specialize
     if (opt != UnOpt) out += opt
+    out ++= align
     if (isExtern) out += Extern(isBlocking)
     if (isDyn) out += Dyn
     if (isStub) out += Stub
@@ -73,6 +80,7 @@ object Attrs {
     var inline = None.inlineHint
     var specialize = None.specialize
     var opt = None.opt
+    var align = None.align
     var isExtern = false
     var isDyn = false
     var isStub = false
@@ -87,6 +95,8 @@ object Attrs {
       case attr: Inline     => inline = attr
       case attr: Specialize => specialize = attr
       case attr: Opt        => opt = attr
+      case attr: Alignment  => align = Some(attr)
+        println(attr)
       case Extern(blocking) =>
         isExtern = true
         isBlocking = blocking
@@ -104,6 +114,7 @@ object Attrs {
       inlineHint = inline,
       specialize = specialize,
       opt = opt,
+      align = align,
       isExtern = isExtern,
       isBlocking = isBlocking,
       isDyn = isDyn,

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -33,7 +33,7 @@ object Attr {
   case object Final extends Attr
   case object LinktimeResolved extends Attr
   case class Alignment(size: Int, group: Option[String]) extends Attr
-  object Alignment{
+  object Alignment {
     // Alignment by defintion must be positive integer, magic value treated specially by compiler
     final val linktimeResolved = -1
   }
@@ -95,8 +95,8 @@ object Attrs {
       case attr: Inline     => inline = attr
       case attr: Specialize => specialize = attr
       case attr: Opt        => opt = attr
-      case attr: Alignment  => align = Some(attr)
-        println(attr)
+      case attr: Alignment =>
+        align = Some(attr)
       case Extern(blocking) =>
         isExtern = true
         isBlocking = blocking

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -111,6 +111,13 @@ object Show {
         str("final")
       case Attr.LinktimeResolved =>
         str("linktime")
+      case Attr.Alignment(size, group) =>
+        str("align(")
+        str(size)
+        group.foreach { v =>
+          str(", "); str(escapeQuotes(v))
+        }
+        str(")")
     }
 
     def next_(next: Next): Unit = next match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -201,6 +201,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
     case T.FinalAttr    => Attr.Final
 
     case T.LinktimeResolvedAttr => Attr.LinktimeResolved
+    case T.AlignAttr            => Attr.Alignment(getLebSignedInt(), getOpt(getString()))
   }
 
   private def getBin(): Bin = (getTag(): @switch) match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -192,6 +192,10 @@ final class BinarySerializer(channel: WritableByteChannel) {
       case Attr.Final              => putTag(T.FinalAttr)
 
       case Attr.LinktimeResolved => putTag(T.LinktimeResolvedAttr)
+      case Attr.Alignment(size, group) =>
+        putTag(T.AlignAttr)
+        putLebSignedInt(size)
+        putOpt(group)(putString)
     }
 
     private def putInsts(insts: Seq[Inst]): Unit = {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -27,6 +27,7 @@ object Tags {
   final val VolatileAttr = 1 + AbstractAttr
   final val FinalAttr = 1 + VolatileAttr
   final val LinktimeResolvedAttr = 1 + FinalAttr
+  final val AlignAttr = 1 + LinktimeResolvedAttr
 
   // Binary ops
   final val IaddBin = 1

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -52,6 +52,7 @@ trait NirDefinitions {
     lazy val NoSpecializeClass = getRequiredClass(
       "scala.scalanative.annotation.nospecialize"
     )
+    lazy val AlignClass = getRequiredClass("scala.scalanative.annotation.align")
 
     lazy val NativeModule = getRequiredModule(
       "scala.scalanative.unsafe.package"

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -26,6 +26,7 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val NoSpecializeClass = requiredClass("scala.scalanative.annotation.nospecialize")
 
   @tu lazy val StubClass = requiredClass("scala.scalanative.annotation.stub")
+  @tu lazy val AlignClass = requiredClass("scala.scalanative.annotation.align")
   @tu lazy val NameClass = requiredClass("scala.scalanative.unsafe.name")
   @tu lazy val LinkClass = requiredClass("scala.scalanative.unsafe.link")
   @tu lazy val ExternClass = requiredClass("scala.scalanative.unsafe.extern")

--- a/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
@@ -13,17 +13,29 @@ class FieldLayout(cls: Class)(implicit meta: Metadata) {
   import meta.platform
 
   def index(fld: Field) = entries.indexOf(fld) + Object.ValuesOffset
-  val entries: Seq[Field] = {
-    val base = cls.parent.fold {
-      Seq.empty[Field]
-    } { parent => meta.layout(parent).entries }
-    base ++ cls.members.collect { case f: Field => f }
+  // Proxy fields due to cyclic dependency
+  def entries: Seq[Field] = entries0
+  def layout: MemoryLayout = layout0
+
+  private lazy val (entries0, layout0): (Seq[Field], MemoryLayout) = {
+    val entries: Seq[Field] = {
+      val base = cls.parent.fold {
+        Seq.empty[Field]
+      } { parent => meta.layout(parent).entries }
+      base ++ cls.members.collect { case f: Field => f }
+    }
+    val usesCustomAlignment = entries.exists(_.attrs.align.isDefined)
+    if (usesCustomAlignment) {
+      val fields = entries.sortBy(_.attrs.align.flatMap(_.group))
+      val layout = MemoryLayout.ofAlignedFields(fields)
+      (fields, layout)
+    } else {
+      val layout = MemoryLayout(ObjectHeader.layout +: entries.map(_.ty))
+      (entries, layout)
+    }
   }
-  val struct: Type.StructValue = {
-    val data = entries.map(_.ty)
-    Type.StructValue(ObjectHeader.layout +: data)
-  }
-  val layout = MemoryLayout(struct.tys)
+
+  val struct = Type.StructValue(layout.tys.map(_.ty))
   val size = layout.size
   val referenceOffsetsValue = Val.StructValue(
     Seq(Val.Const(Val.ArrayValue(Type.Long, layout.offsetArray)))

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -8,6 +8,10 @@ import scalanative.util.unsupported
 import scalanative.codegen.MemoryLayout.PositionedType
 import scala.scalanative.build.Config
 import scala.scalanative.linker.ClassRef
+import scala.scalanative.linker.Field
+import scala.scalanative.nir.Attr.Alignment
+import scala.scalanative.build.BuildException
+import scala.annotation.tailrec
 
 final case class MemoryLayout(
     size: Long,
@@ -65,17 +69,108 @@ object MemoryLayout {
     val pos = mutable.UnrolledBuffer.empty[PositionedType]
     var offset = 0L
 
-    tys.foreach { ty =>
-      offset = align(offset, alignmentOf(ty))
+    val maxAlign = tys.foldLeft(1L) {
+      case (maxAlign, ty) =>
+        val align = alignmentOf(ty)
+
+        offset = this.align(offset, align)
+        pos += PositionedType(ty, offset)
+        offset += sizeOf(ty)
+
+        align.max(maxAlign)
+    }
+
+    MemoryLayout(align(offset, maxAlign), pos.toSeq)
+  }
+
+  def ofAlignedFields(
+      fields: Seq[Field]
+  )(implicit platform: PlatformInfo, meta: Metadata): MemoryLayout = {
+    import meta.layouts.ObjectHeader
+
+    val pos = mutable.UnrolledBuffer.empty[PositionedType]
+    var offset = 0L
+    var maxAlign = 1L
+
+    def addPadding(alignment: Int): Unit = {
+      val remainingPadding = align(offset, alignment) - offset
+      if (remainingPadding > 0) {
+        val last = pos.last
+        // Update last postion to set correct padding by replaceing the type with struct{ty, array[byte]}
+        pos.update(
+          pos.indexOf(last),
+          last.copy(ty =
+            Type.StructValue(
+              Seq(last.ty, Type.ArrayValue(Type.Byte, remainingPadding.toInt))
+            )
+          )
+        )
+        offset += remainingPadding
+      }
+    }
+
+    def addField(ty: Type, fieldAlignment: Option[Int] = None): Unit = {
+      val alignment = fieldAlignment.map(_.toLong).getOrElse(alignmentOf(ty))
+      maxAlign = maxAlign.max(alignment)
+
+      offset = align(offset, alignment)
+      println(offset)
       pos += PositionedType(ty, offset)
       offset += sizeOf(ty)
     }
 
-    val alignment = {
-      if (tys.isEmpty) 1
-      else tys.map(alignmentOf(_)).max
+    lazy val dynamicAlignmentWidth = {
+      val propName =
+        "scala.scalanative.meta.linktimeinfo.contendedPaddingWidth"
+      meta.linked.resolvedVals
+        .get(propName)
+        .collectFirst { case Val.Int(value) => value }
+        .getOrElse(
+          throw new BuildException(
+            s"Unable to resolve size of dynamic field alignment, linktime property not found: $propName"
+          )
+        )
+    }
+    def resolveAlignWidth(align: Alignment): Int = align.size match {
+      case nir.Attr.Alignment.linktimeResolved => dynamicAlignmentWidth
+      case fixedWidth                          => fixedWidth
     }
 
-    MemoryLayout(align(offset, alignment), pos.toSeq)
+    def isGroupAligned(field: Field) =
+      field.attrs.align.flatMap(_.group).isDefined
+
+    // fields should be already ordered by group names
+    @tailrec def loop(fields: List[Field]): Unit = fields match {
+      case Nil => ()
+      case field :: tail =>
+        val alignInfo = field.attrs.align
+        val groupName = alignInfo.flatMap(_.group)
+        val groupTail =
+          if (isGroupAligned(field))
+            tail.takeWhile(_.attrs.align.flatMap(_.group) == groupName)
+          else Nil
+        val headAlignSize = alignInfo.map(resolveAlignWidth)
+        // Align size is equal to maximal alignment of all fields in the group
+        val alignSize = headAlignSize.map {
+          groupTail.foldLeft(_) {
+            case (maxSize, field) =>
+              field.attrs.align
+                .map(resolveAlignWidth)
+                .map(_.max(maxSize))
+                .getOrElse(maxSize)
+          }
+        }
+
+        alignSize.foreach(addPadding)
+        addField(field.ty, alignSize)
+        groupTail.foreach(field => addField(field.ty))
+        alignSize.foreach(addPadding)
+
+        loop(tail.drop(groupTail.size))
+    }
+
+    addField(ObjectHeader.layout)
+    loop(fields.toList)
+    MemoryLayout(align(offset, maxAlign), pos.toSeq)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -114,7 +114,6 @@ object MemoryLayout {
       maxAlign = maxAlign.max(alignment)
 
       offset = align(offset, alignment)
-      println(offset)
       pos += PositionedType(ty, offset)
       offset += sizeOf(ty)
     }

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -64,7 +64,8 @@ class LinktimeConditionsSpec extends OptimizerSpec with Matchers {
       s"$linktimeInfo.target.arch",
       s"$linktimeInfo.target.vendor",
       s"$linktimeInfo.target.os",
-      s"$linktimeInfo.target.env"
+      s"$linktimeInfo.target.env",
+      s"$linktimeInfo.contendedPaddingWidth"
     )
   }
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/annotation/AlignTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/annotation/AlignTest.scala
@@ -1,0 +1,172 @@
+package scala.scalanative
+package annotation
+
+import org.junit.{Test, Assume}
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalanative.unsafe.{sizeOf, Ptr}
+import scala.scalanative.runtime.MemoryLayout.Object.FieldsOffset
+import scala.scalanative.runtime.Intrinsics.{
+  castObjectToRawPtr,
+  classFieldRawPtr
+}
+import scala.scalanative.runtime.fromRawPtr
+import scala.scalanative.meta.LinktimeInfo
+
+package AlignTestCases {
+  class NoAlign {
+    var a: Int = 0
+    var b: Int = 1
+    var c: Int = 2
+    var d: Int = 3
+
+    assert((a, b, c, d) != null, "ensure linked")
+  }
+
+  @align(64) class AlignAllFixed {
+    var a: Int = 0
+    var b: Int = 1
+    var c: Int = 2
+    var d: Int = 3
+
+    assert((a, b, c, d) != null, "ensure linked")
+  }
+
+  @align() class AlignAllDynamic {
+    var a: Int = 0
+    var b: Int = 1
+    var c: Int = 2
+    var d: Int = 3
+
+    assert((a, b, c, d) != null, "ensure linked")
+  }
+
+  class AlignFields {
+    var a: Int = 0
+    var b: Int = 1
+    @align(64) var c: Int = 2
+    @align(64) var d: Int = 3
+
+    assert((a, b, c, d) != null, "ensure linked")
+  }
+
+  class AlignFieldsGrouped {
+    @align(64, "a") var a: Int = 0
+    @align(64, "b") var b: Int = 1
+    @align(64, "a") var c: Int = 2
+    @align(64, "b") var d: Int = 3
+
+    assert((a, b, c, d) != null, "ensure linked")
+  }
+}
+
+class AlignTest {
+  import AlignTestCases._
+  private def checkClassSize(expected: Int, classSize: Int) = assertEquals(
+    "class fields size size",
+    expected,
+    classSize
+  )
+
+  private def checkOffsets(
+      expected: Seq[Int],
+      basePointer: Ptr[Any],
+      fieldPointers: Seq[Ptr[Any]]
+  ) = {
+
+    assertEquals(
+      s"probes amount",
+      expected.size,
+      fieldPointers.size
+    )
+    assertEquals(
+      "offsets",
+      expected.toList,
+      fieldPointers
+        .map(_.toLong - basePointer.toLong)
+        .ensuring(_.forall(_ >= 0), "negative calucated offset")
+        .toList
+    )
+  }
+
+  @Test def noAlign(): Unit = {
+    val obj = new NoAlign()
+    checkClassSize(16 + FieldsOffset, sizeOf[NoAlign])
+    checkOffsets(
+      expected = Seq(0, 4, 8, 12).map(_ + FieldsOffset),
+      basePointer = fromRawPtr(castObjectToRawPtr(obj)),
+      fieldPointers = Seq(
+        fromRawPtr(classFieldRawPtr(obj, "a")),
+        fromRawPtr(classFieldRawPtr(obj, "b")),
+        fromRawPtr(classFieldRawPtr(obj, "c")),
+        fromRawPtr(classFieldRawPtr(obj, "d"))
+      )
+    )
+  }
+
+  @Test def allignAllFixed(): Unit = {
+    val obj = new AlignAllFixed()
+    checkClassSize(320, sizeOf[AlignAllFixed])
+    checkOffsets(
+      expected = Seq(64, 128, 192, 256),
+      basePointer = fromRawPtr(castObjectToRawPtr(obj)),
+      fieldPointers = Seq(
+        fromRawPtr(classFieldRawPtr(obj, "a")),
+        fromRawPtr(classFieldRawPtr(obj, "b")),
+        fromRawPtr(classFieldRawPtr(obj, "c")),
+        fromRawPtr(classFieldRawPtr(obj, "d"))
+      )
+    )
+  }
+
+  @Test def allignAllDynamic(): Unit = {
+    val obj = new AlignAllDynamic()
+    assumeTrue(
+      "non default contention padding width",
+      64 == LinktimeInfo.contendedPaddingWidth
+    )
+    checkClassSize(320, sizeOf[AlignAllDynamic])
+    checkOffsets(
+      expected = Seq(64, 128, 192, 256),
+      basePointer = fromRawPtr(castObjectToRawPtr(obj)),
+      fieldPointers = Seq(
+        fromRawPtr(classFieldRawPtr(obj, "a")),
+        fromRawPtr(classFieldRawPtr(obj, "b")),
+        fromRawPtr(classFieldRawPtr(obj, "c")),
+        fromRawPtr(classFieldRawPtr(obj, "d"))
+      )
+    )
+  }
+
+  @Test def allignFields(): Unit = {
+    val obj = new AlignFields()
+    checkClassSize(192, sizeOf[AlignFields])
+    checkOffsets(
+      expected = Seq(FieldsOffset, FieldsOffset + 4, 64, 128),
+      basePointer = fromRawPtr(castObjectToRawPtr(obj)),
+      fieldPointers = Seq(
+        fromRawPtr(classFieldRawPtr(obj, "a")),
+        fromRawPtr(classFieldRawPtr(obj, "b")),
+        fromRawPtr(classFieldRawPtr(obj, "c")),
+        fromRawPtr(classFieldRawPtr(obj, "d"))
+      )
+    )
+  }
+
+  @Test def allignFieldsGrouped(): Unit = {
+    val obj = new AlignFieldsGrouped()
+    checkClassSize(192, sizeOf[AlignFieldsGrouped])
+    checkOffsets(
+      // grouped by: a b a b
+      expected = Seq(64, 128, 68, 132),
+      basePointer = fromRawPtr(castObjectToRawPtr(obj)),
+      fieldPointers = Seq(
+        fromRawPtr(classFieldRawPtr(obj, "a")),
+        fromRawPtr(classFieldRawPtr(obj, "b")),
+        fromRawPtr(classFieldRawPtr(obj, "c")),
+        fromRawPtr(classFieldRawPtr(obj, "d"))
+      )
+    )
+  }
+}


### PR DESCRIPTION
Resolves #3359 

Implements new public annotation allowing to modify alignment of the fields. It is source-compatible with the JVM Contaned annotation, and have similar characteristics. `@align(size: Int, group: String)` takes the fixed size of alignment in bytes and group name allowing to coalate fields. When `size` is not passed or when pointing to `scalanative.meta.LinktimeInfo.contendedPaddingWidth` it would use linktime resolved value instead (default to 64 bytes, the most popular cache line size on modern architectures). This allows to use it as a direct replecment for Contended, which cannot be implemented in Scala Native directly.  