### PR TITLE
Fix #3352: javalib {Stream, DoubleStream}#sorted characteristics now match JVM

### DIFF
--- a/javalib/src/main/scala/java/util/stream/ObjectStreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/ObjectStreamImpl.scala
@@ -601,7 +601,7 @@ private[stream] class ObjectStreamImpl[T](
   }
 
   def sorted(): Stream[T] = {
-    // No commenceOperation() here. sorted(comparator) will make that happen.
+    // No commenceOperation() here. This is an intermediate operation.
 
     /* Be aware that this method will/should throw on first use if type
      * T is not Comparable[T]. This is described in the Java Stream doc.
@@ -623,13 +623,41 @@ private[stream] class ObjectStreamImpl[T](
   }
 
   def sorted(comparator: Comparator[_ >: T]): Stream[T] = {
-    commenceOperation()
+    // No commenceOperation() here. This is an intermediate operation.
 
-    val buffer = new ArrayList[T]()
-    _spliter.forEachRemaining((e) => buffer.add(e))
+    /* Someday figure out the types for the much cleaner 'toArray(generator)'
+     * There is a bit of type nastiness/abuse going on here.
+     * The hidden assumption is that type is a subclass of Object, or at
+     * least AnyRef (T <: Object). However the class declaration places
+     * no such restriction on T. It is T <: Any.
+     *
+     * The Ancients, in their wisdom, must have had a reason for declaring
+     * the type that way.
+     *
+     * I think the class declaration is _wrong_, or at leads one to
+     * type abuse, such as here. However, that declaration is pretty
+     * hardwired at this point.  Perhaps it will get corrected across
+     * the board for Scala Native 1.0.
+     *
+     * Until then make the shaky assumption that the class creator is always
+     * specifying T <: AnyRef so that the coercion will work at
+     * runtime.
+     */
+    val buffer = toArray()
 
-    buffer.sort(comparator)
-    buffer.stream()
+    /* Scala 3 and 2.13.11 both allow ""Arrays.sort(" here.
+     * Scala 2.12.18 requires "sort[Object](".
+     */
+    Arrays
+      .sort[Object](buffer, comparator.asInstanceOf[Comparator[_ >: Object]])
+
+    val spl = Spliterators.spliterator[T](
+      buffer,
+      Spliterator.SORTED | Spliterator.ORDERED |
+        Spliterator.SIZED | Spliterator.SUBSIZED
+    )
+
+    new ObjectStreamImpl[T](spl, _parallel, pipeline)
   }
 
   def toArray(): Array[Object] = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
@@ -1125,6 +1125,64 @@ class DoubleStreamTest {
     assertEquals(msg, nElements, count)
   }
 
+  @Test def doubleStreamSorted_Characteristics(): Unit = {
+    // See comments in StreamTest#streamSorted_Characteristics
+
+    val nElements = 8
+    val wild = new Array[Double](nElements)
+
+    // Ensure that the Elements are not inserted in sorted or reverse order.
+    wild(0) = 45.32
+    wild(1) = 21.4
+    wild(2) = 11.2
+    wild(3) = 31.5
+    wild(4) = 68.16
+    wild(5) = 3.77
+    wild(6) = 61.44
+    wild(7) = 9.60
+
+    val seqDoubleStream = DoubleStream.of(wild: _*)
+    assertFalse(
+      "Expected sequential stream",
+      seqDoubleStream.isParallel()
+    )
+
+    // same expected values for SN sequential, SN parallel, & JVM streams
+    /* The characteristics here differ from those of the corresponding
+     * StreamTest because of the way the streams are constructed.
+     * StreamTest reports 0x4050, while this adds IMMUTABLE yeilding 0x4450.
+     * This stream is constructed using "of()" which is indeed IMMUTABLE.
+     * Mix things up, for variety and  to keep people trying to follow along
+     * at home on their toes.
+     */
+    val expectedPreCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED |
+        Spliterator.ORDERED | Spliterator.IMMUTABLE
+
+    // Drop IMMUTABLE, add SORTED
+    val expectedPostCharacteristics =
+      (expectedPreCharacteristics & ~Spliterator.IMMUTABLE) +
+        Spliterator.SORTED
+
+    val seqDoubleSpliter = seqDoubleStream.spliterator()
+
+    assertEquals(
+      "sequential characteristics",
+      expectedPreCharacteristics,
+      seqDoubleSpliter.characteristics()
+    )
+
+    val sortedSeqDoubleStream = DoubleStream.of(wild: _*).sorted()
+    val sortedSeqSpliter = sortedSeqDoubleStream.spliterator()
+
+    assertEquals(
+      "sorted sequential characteristics",
+      expectedPostCharacteristics,
+      sortedSeqSpliter.characteristics()
+    )
+
+  }
+
   @Test def doubleStreamSum(): Unit = {
     val nElements = 9
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -1013,6 +1013,86 @@ class StreamTest {
     assertEquals(msg, nElements, count)
   }
 
+  @Test def streamSorted_Characteristics(): Unit = {
+    /* SN sequential, SN parallel, & JVM streams should all return the same
+     * characteristics both before (pre) and after (post) sorting.
+     *
+     * Test both sequential and parallel streams to verify this expectation.
+     * Testing 'sorted()' will call 'sorted(comparator)', so this one Test
+     * covers both methods.
+     */
+
+    val nElements = 8
+    val wild = new ArrayList[String](nElements)
+
+    // Ensure that the Elements are not inserted in sorted or reverse order.
+    wild.add("Dasher")
+    wild.add("Prancer")
+    wild.add("Vixen")
+    wild.add("Comet")
+    wild.add("Cupid")
+    wild.add("Donner")
+    wild.add("Blitzen")
+    wild.add("Rudolph")
+
+    val ordered = new ArrayList(wild)
+    ju.Collections.sort(ordered)
+
+    val seqStream = wild.stream()
+    assertFalse(
+      "Expected sequential stream",
+      seqStream.isParallel()
+    )
+
+    // same expected values for SN sequential, SN parallel, & JVM streams
+    val expectedPreCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED // 0x4050
+
+    val expectedPostCharacteristics =
+      expectedPreCharacteristics + Spliterator.SORTED
+
+    val seqSpliter = seqStream.spliterator()
+
+    assertEquals(
+      "sequential characteristics",
+      expectedPreCharacteristics,
+      seqSpliter.characteristics()
+    )
+
+    val sortedSeqStream = wild.stream().sorted()
+    val sortedSeqSpliter = sortedSeqStream.spliterator()
+
+    assertEquals(
+      "sorted sequential characteristics",
+      expectedPostCharacteristics,
+      sortedSeqSpliter.characteristics()
+    )
+
+    val parStream = wild.stream().parallel()
+    assertFalse(
+      "Expected  parallel stream",
+      seqStream.isParallel()
+    )
+
+    val parSpliter = parStream.spliterator()
+
+    assertEquals(
+      "parallel characteristics",
+      expectedPreCharacteristics,
+      parSpliter.characteristics()
+    )
+
+    val sortedParStream = wild.stream().parallel().sorted()
+    val sortedParSpliter = sortedParStream.spliterator()
+
+    assertEquals(
+      "sorted parallel characteristics",
+      expectedPostCharacteristics,
+      sortedParSpliter.characteristics()
+    )
+
+  }
+
   @Test def streamSorted_UsingComparator(): Unit = {
     val nElements = 8
     val wild = new ArrayList[String](nElements)


### PR DESCRIPTION
Fix #3352

1. The javalib `{Stream, DoubleStream}#sorted` methods now return the same characteristics
    as a JVM: `Spliterator.SORTED | Spliterator.ORDERED | Spliterator.SIZED | Spliterator.SUBSIZED`.

2. Due to internal restructuring, both methods should have improved performance, both in
    the sort and in downstream splitting.