### PR TITLE
Fix #3316: javalib FileChannel append behavior now matches a JVM

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/FileChannel.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannel.scala
@@ -90,17 +90,20 @@ object FileChannel {
   ): FileChannel = {
     import StandardOpenOption._
 
-    if (options.contains(APPEND) && options.contains(TRUNCATE_EXISTING)) {
-      throw new IllegalArgumentException(
-        "APPEND + TRUNCATE_EXISTING not allowed"
-      )
-    }
+    val appending = options.contains(APPEND)
+    val writing = options.contains(WRITE) || appending
 
-    if (options.contains(APPEND) && options.contains(READ)) {
-      throw new IllegalArgumentException("READ + APPEND not allowed")
-    }
+    if (appending) {
+      if (options.contains(TRUNCATE_EXISTING)) {
+        throw new IllegalArgumentException(
+          "APPEND + TRUNCATE_EXISTING not allowed"
+        )
+      }
 
-    val writing = options.contains(WRITE) || options.contains(APPEND)
+      if (options.contains(READ)) {
+        throw new IllegalArgumentException("READ + APPEND not allowed")
+      }
+    }
 
     val mode = new StringBuilder("r")
     if (writing) mode.append("w")
@@ -127,13 +130,8 @@ object FileChannel {
     val raf = tryRandomAccessFile(path.toString, mode.toString)
 
     try {
-      if (writing && options.contains(TRUNCATE_EXISTING)) {
+      if (writing && options.contains(TRUNCATE_EXISTING))
         raf.setLength(0L)
-      }
-
-      if (writing && options.contains(APPEND)) {
-        raf.seek(raf.length())
-      }
 
       new FileChannelImpl(
         raf.getFD(),
@@ -141,7 +139,8 @@ object FileChannel {
         deleteFileOnClose =
           options.contains(StandardOpenOption.DELETE_ON_CLOSE),
         openForReading = true,
-        openForWriting = writing
+        openForWriting = writing,
+        openForAppending = appending
       )
     } catch {
       case e: Throwable =>

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -42,12 +42,40 @@ private[java] final class FileChannelImpl(
     file: Option[File],
     deleteFileOnClose: Boolean,
     openForReading: Boolean,
-    openForWriting: Boolean
+    openForWriting: Boolean,
+    openForAppending: Boolean = false
 ) extends FileChannel {
+  /* Note:
+   *   Channels are described in the Java documentation as thread-safe.
+   *   This implementation is, most patently _not_ thread-safe.
+   *   Use with only one thread accessing the channel, even for READS.
+   */
+
+  if (openForAppending)
+    seekEOF() // so a position() before first APPEND write() matches JVM.
+
+  private def ensureOpen(): Unit =
+    if (!isOpen()) throw new ClosedChannelException()
+
+  private def seekEOF(): Unit = {
+    if (isWindows) {
+      SetFilePointerEx(
+        fd.handle,
+        distanceToMove = 0,
+        newFilePointer = null,
+        moveMethod = FILE_END
+      )
+    } else {
+      val pos = unistd.lseek(fd.fd, 0, stdio.SEEK_END);
+      if (pos < 0)
+        throwPosixException("lseek")
+    }
+  }
+
   private def throwPosixException(functionName: String): Unit = {
     if (!isWindows) {
       val errnoString = fromCString(string.strerror(errno))
-      throw new IOException(s"${functionName} failed: ${errnoString}")
+      throw new IOException("${functionName} failed: ${errnoString}")
     }
   }
 
@@ -176,7 +204,8 @@ private[java] final class FileChannelImpl(
     MappedByteBufferImpl(mode, position, size.toInt, fd)
   }
 
-  override def position(offset: Long): FileChannel = {
+  // change position, even in APPEND mode. Use _carefully_.
+  private def compelPosition(offset: Long): FileChannel = {
     if (isWindows)
       FileApi.SetFilePointerEx(
         fd.handle,
@@ -184,7 +213,19 @@ private[java] final class FileChannelImpl(
         null,
         FILE_BEGIN
       )
-    else unistd.lseek(fd.fd, offset.toSize, stdio.SEEK_SET)
+    else {
+      val pos = unistd.lseek(fd.fd, offset.toSize, stdio.SEEK_SET)
+      if (pos < 0)
+        throwPosixException("lseek")
+    }
+
+    this
+  }
+
+  override def position(offset: Long): FileChannel = {
+    if (!openForAppending)
+      compelPosition(offset)
+
     this
   }
 
@@ -199,7 +240,10 @@ private[java] final class FileChannelImpl(
       )
       !filePointer
     } else {
-      unistd.lseek(fd.fd, 0, stdio.SEEK_CUR).toLong
+      val pos = unistd.lseek(fd.fd, 0, stdio.SEEK_CUR).toLong
+      if (pos < 0)
+        throwPosixException("lseek")
+      pos
     }
 
   override def read(
@@ -434,51 +478,20 @@ private[java] final class FileChannelImpl(
 
     }
 
-    // Always check, to avoid moon-shot corner cases.
     if (currentPosition > newSize)
-      position(newSize)
+      compelPosition(newSize)
 
     this
   }
 
-  override def write(
-      buffers: Array[ByteBuffer],
-      offset: Int,
-      length: Int
-  ): Long = {
-    ensureOpen()
-    var i = 0
-    while (i < length) {
-      write(buffers(offset + i))
-      i += 1
-    }
-    i
-  }
-
-  override def write(buffer: ByteBuffer, pos: Long): Int = {
-    ensureOpen()
-    position(pos)
-    val srcPos: Int = buffer.position()
-    val srcLim: Int = buffer.limit()
-    val lim = math.abs(srcLim - srcPos)
-    val bytes = if (buffer.hasArray()) {
-      buffer.array()
-    } else {
-      val bytes = new Array[Byte](lim)
-      buffer.get(bytes)
-      bytes
-    }
-    write(bytes, 0, lim)
-    buffer.position(srcPos + lim)
-    lim
-  }
-
-  override def write(src: ByteBuffer): Int =
-    write(src, position())
-
-  private def ensureOpen(): Unit =
-    if (!isOpen()) throw new ClosedChannelException()
-
+  /* 2023-07-02 NOTE: This method is BROKEN!  It should be returning
+   *  an Int number of bytes written. It detects errors but not
+   *  partial writes.  Bad dog!
+   *
+   *  Fix 'writeByteBuffer()' after this methods gets fixed.
+   *  The former should return the actual number of bytes written
+   *  on partial writes.
+   */
   private[java] def write(
       buffer: Array[Byte],
       offset: Int,
@@ -513,6 +526,82 @@ private[java] final class FileChannelImpl(
         throw UnixException(file.fold("")(_.toString), errno)
       }
     }
+  }
+
+  private def writeByteBuffer(src: ByteBuffer): Int = {
+    val srcPos = src.position()
+    val srcLim = src.limit()
+    val nBytes = srcLim - srcPos // number of bytes in range.
+
+    val (arr, offset) = if (src.hasArray()) {
+      (src.array(), srcPos)
+    } else {
+      val ba = new Array[Byte](nBytes)
+      src.get(ba, srcPos, nBytes)
+      (ba, 0)
+    }
+
+    write(arr, offset, nBytes)
+
+    src.position(srcPos + nBytes)
+
+    /* 2023-07-02 NOTE: This return is BROKEN!  It does not handle
+     * partial OS writes. Fix after/when the 'write(arr, offset, nBytes)'
+     * method gets fixed to return a value.
+     */
+    nBytes // BUGGY
+  }
+
+  /* 2023-07-02 NOTE: This method is BROKEN!  It should be returning
+   *  an Long number of bytes written. Instead it is wrongly returning
+   * 'i' the number of buffers written. At least here the return type is
+   * correct.
+   */
+
+  override def write(
+      buffers: Array[ByteBuffer],
+      offset: Int,
+      length: Int
+  ): Long = {
+    // write(ByteBuffer) will call ensureOpen(), saveCPU cycles by no call here
+    var i = 0
+    while (i < length) {
+      write(buffers(offset + i))
+      i += 1
+    }
+    i
+  }
+
+  /* Write to absolute position, do not change current position.
+   *
+   * Understanding "does not change current position" when the channel
+   * has been opened requires some mind_bending/understanding.
+   *
+   * "Current position" when file has been opened for APPEND is
+   * a logical place, End of File (EOF), not an absolute number.
+   * When APPEND mode changes the position it reports as "current" to the
+   * new EOF rather than stashed position, according to JVM is is not
+   * really changing the "current position".
+   */
+  override def write(src: ByteBuffer, pos: Long): Int = {
+    ensureOpen()
+    val stashPosition = position()
+    compelPosition(pos)
+
+    val nBytesWritten = writeByteBuffer(src)
+
+    if (!openForAppending)
+      compelPosition(stashPosition)
+    else
+      seekEOF()
+
+    nBytesWritten
+  }
+
+  // Write relative to current position (SEEK_CUR) or, for APPEND, SEEK_END.
+  override def write(src: ByteBuffer): Int = {
+    ensureOpen()
+    writeByteBuffer(src)
   }
 
   /* The Scala Native implementation of FileInputStream#available delegates

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/channels/FileChannelTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/channels/FileChannelTest.scala
@@ -174,7 +174,7 @@ class FileChannelTest {
     }
   }
 
-  @Test def canWriteToChannelWithAppend(): Unit = {
+  @Test def canRelativeWriteToChannelWithAppend(): Unit = {
     withTemporaryDirectory { dir =>
       val f = dir.resolve("f")
       Files.write(f, "hello, ".getBytes("UTF-8"))
@@ -191,6 +191,161 @@ class FileChannelTest {
       val newLines = Files.readAllLines(f)
       assertTrue(newLines.size() == 1)
       assertTrue(newLines.get(0) == "hello, world")
+    }
+  }
+
+  // Issue #3316
+  @Test def canRepositionChannelThenRelativeWriteAppend(): Unit = {
+    withTemporaryDirectory { dir =>
+      val prefix = "Γειά "
+      val suffix = "σου Κόσμε"
+      val message = s"${prefix}${suffix}"
+
+      val prefixBytes = prefix.getBytes("UTF-8") // Greek uses 2 bytes per char
+      val suffixBytes = suffix.getBytes("UTF-8")
+
+      val f = dir.resolve("rePositionThenAppend.txt")
+      Files.write(f, prefixBytes)
+
+      val lines = Files.readAllLines(f)
+      assertEquals("lines size", 1, lines.size())
+      assertEquals("lines content", prefix, lines.get(0))
+
+      val channel = Files.newByteChannel(
+        f,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.APPEND
+      )
+
+      try {
+        // channel must start off positioned at EOF.
+        val positionAtOpen = channel.position()
+        assertEquals("position at open", channel.size(), positionAtOpen)
+
+        /* Java 8 SeekableByteChannel description says:
+         *   Setting the channel's position is not recommended when connected
+         *   to an entity, typically a file, that is opened with the APPEND
+         *   option.
+         *
+         * JVM re-inforces this caution by "position(pos)" on a channel
+         * opened for APPEND silently not actually move the position; it is
+         * a no-op.
+         */
+        channel.position(0L)
+
+        assertEquals("reposition", positionAtOpen, channel.position())
+
+        val src = ByteBuffer.wrap(suffixBytes)
+
+        while (src.remaining() > 0)
+          channel.write(src)
+
+        val newLines = Files.readAllLines(f)
+        assertEquals("Second lines size", 1, newLines.size())
+
+        // Verify append happened at expected place; end of line, not beginning
+        assertEquals("Second lines content", message, newLines.get(0))
+
+      } finally {
+        channel.close()
+      }
+    }
+  }
+
+  @Test def canAbsoluteWriteToChannel(): Unit = {
+    withTemporaryDirectory { dir =>
+      val f = dir.resolve("f")
+      Files.write(f, "hello, ".getBytes("UTF-8"))
+
+      val lines = Files.readAllLines(f)
+      assertTrue(lines.size() == 1)
+      assertTrue(lines.get(0) == "hello, ")
+
+      val bytes = "world".getBytes("UTF-8")
+      val src = ByteBuffer.wrap(bytes)
+      val channel = FileChannel.open(f, StandardOpenOption.WRITE)
+
+      try {
+        val preWritePos = channel.position()
+        assertEquals("pre-write position", 0, preWritePos)
+
+        channel.write(src, 3)
+
+        // Absolute write without APPEND should not move current position.
+        assertEquals("post-write position", preWritePos, channel.position())
+
+        val bytes2 = "%".getBytes("UTF-8")
+        val src2 = ByteBuffer.wrap(bytes2)
+
+        channel.write(src2)
+      } finally channel.close()
+
+      val newLines = Files.readAllLines(f)
+      assertEquals("size", 1, newLines.size())
+      assertEquals("content", "%elworld", newLines.get(0))
+    }
+  }
+
+  @Test def canAbsoluteWriteToChannelWithAppend(): Unit = {
+    withTemporaryDirectory { dir =>
+      val f = dir.resolve("f")
+      Files.write(f, "hello, ".getBytes("UTF-8"))
+
+      val lines = Files.readAllLines(f)
+      assertTrue(lines.size() == 1)
+      assertTrue(lines.get(0) == "hello, ")
+
+      val bytes = "world".getBytes("UTF-8")
+      val src = ByteBuffer.wrap(bytes)
+      val channel = FileChannel.open(f, StandardOpenOption.APPEND)
+
+      try {
+        val preWritePos = channel.position()
+        assertEquals("pre-write position", preWritePos, channel.size()) // EOF
+
+        val nWritten = channel.write(src, 2) // write at absolute position
+        assertEquals("bytes written", bytes.size, nWritten)
+
+        /* Absolute write with APPEND uses a logical "current position" of EOF
+         * not an absolute number qua position, such as 42.
+         *
+         * Using this understanding, the "current position" has not moved
+         * from EOF, even though the absolute position has been updated
+         * to the new EOF.
+         */
+
+        assertEquals("post-write position", channel.size(), channel.position())
+
+        val bytes2 = "!".getBytes("UTF-8")
+        val src2 = ByteBuffer.wrap(bytes2)
+
+        channel.write(src2) // APPEND relative write should be at EOF.
+      } finally channel.close()
+
+      val newLines = Files.readAllLines(f)
+      assertEquals("size", 1, newLines.size())
+
+      /* Welcome to the realm of Ὀϊζύς (Oizys), goddess of misery,
+       * anxiety, grief, depression, and misfortune.
+       *
+       * Skipping lightly over _lots_ of complexity, operating systems
+       * and their file systems differ in allowing the absolute write or not.
+       * Branching on all supported operating systems and each of _their_
+       * file systems is simply not feasible.
+       *
+       * The important part is that the relative write happened at EOF
+       * and the absolute write happened at a believable place, even
+       * if the re-position of that write was a no-op.
+       */
+
+      val content = newLines.get(0)
+
+      assertTrue(
+        s"unexpected content '${content}'",
+        (content == "heworld!") // write at absolute position happened
+          || (content == "hello, world!") // write happed at EOF.
+      )
     }
   }
 


### PR DESCRIPTION
Fix #3316

javalib FileChannel write & position methods now more closely match JVM behavior.