### PR TITLE
Fix #3373: javalib {Stream, DoubleStream} sequential & parallel methods now match a JVM

### DIFF
--- a/javalib/src/main/scala/java/util/stream/DoubleStreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/DoubleStreamImpl.scala
@@ -121,7 +121,7 @@ private[stream] class DoubleStreamImpl(
     exceptionBuffer.reportExceptions()
   }
 
-  def isParallel(): Boolean = false
+  def isParallel(): Boolean = _parallel
 
   def iterator(): ju.PrimitiveIterator.OfDouble = {
     commenceOperation()
@@ -143,10 +143,17 @@ private[stream] class DoubleStreamImpl(
     this
   }
 
-  // parallel is not yet implemented.
-  def parallel(): DoubleStreamImpl = this
+  def parallel(): DoubleStream = {
+    if (!_parallel)
+      _parallel = true
+    this
+  }
 
-  def sequential(): DoubleStreamImpl = this
+  def sequential(): DoubleStream = {
+    if (_parallel)
+      _parallel = false
+    this
+  }
 
   def spliterator(): Spliterator.OfDouble = {
     commenceOperation()

--- a/javalib/src/main/scala/java/util/stream/ObjectStreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/ObjectStreamImpl.scala
@@ -117,7 +117,7 @@ private[stream] class ObjectStreamImpl[T](
     exceptionBuffer.reportExceptions()
   }
 
-  def isParallel(): Boolean = false
+  def isParallel(): Boolean = _parallel
 
   def iterator(): ju.Iterator[T] = {
     commenceOperation()
@@ -139,9 +139,17 @@ private[stream] class ObjectStreamImpl[T](
     this
   }
 
-  def parallel(): Stream[T] = this // parallel is not yet implemented.
+  def parallel(): Stream[T] = {
+    if (!_parallel)
+      _parallel = true
+    this
+  }
 
-  def sequential(): Stream[T] = this
+  def sequential(): Stream[T] = {
+    if (_parallel)
+      _parallel = false
+    this
+  }
 
   def spliterator(): Spliterator[_ <: T] = {
     commenceOperation()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -92,6 +92,126 @@ class StreamTest {
     )
   }
 
+  @Test def streamParallel(): Unit = {
+    val nElements = 7
+    val sisters = new ArrayList[String](nElements)
+    sisters.add("Maya")
+    sisters.add("Electra")
+    sisters.add("Taygete")
+    sisters.add("Alcyone")
+    sisters.add("Celaeno")
+    sisters.add("Sterope")
+    sisters.add("Merope")
+
+    val sPar = sisters.parallelStream()
+
+    assertTrue(
+      "Expected parallel stream",
+      sPar.isParallel()
+    )
+
+    val expectedCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED // 0x4050
+
+    val sParSpliterator = sPar.spliterator()
+    assertEquals(
+      "parallel characteristics",
+      expectedCharacteristics,
+      sParSpliterator.characteristics()
+    )
+
+    val sSeq = sisters.parallelStream().sequential()
+    assertFalse(
+      "Expected sequential stream",
+      sSeq.isParallel()
+    )
+
+    val sSeqSpliterator = sSeq.spliterator()
+
+    assertEquals(
+      "sequential characteristics",
+      expectedCharacteristics,
+      sSeqSpliterator.characteristics()
+    )
+
+    assertEquals(
+      "Unexpected sequential stream size",
+      nElements,
+      sSeqSpliterator.estimateSize()
+    )
+
+    // sequential stream has expected contents
+    var count = 0
+    sSeqSpliterator.forEachRemaining((e: String) => {
+      assertEquals(
+        s"sequential stream contents(${count})",
+        sisters.get(count),
+        e
+      )
+      count += 1
+    })
+  }
+
+  @Test def streamSequential(): Unit = {
+    val nElements = 7
+    val sisters = new ArrayList[String](nElements)
+    sisters.add("Maya")
+    sisters.add("Electra")
+    sisters.add("Taygete")
+    sisters.add("Alcyone")
+    sisters.add("Celaeno")
+    sisters.add("Sterope")
+    sisters.add("Merope")
+
+    val sSeq = sisters.stream()
+
+    assertFalse(
+      "Expected sequential stream",
+      sSeq.isParallel()
+    )
+
+    val expectedCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED // 0x4050
+
+    val sSeqSpliterator = sSeq.spliterator()
+    assertEquals(
+      "sequential characteristics",
+      expectedCharacteristics,
+      sSeqSpliterator.characteristics()
+    )
+
+    val sPar = sisters.stream().parallel()
+    assertTrue(
+      "Expected parallel stream",
+      sPar.isParallel()
+    )
+
+    val sParSpliterator = sPar.spliterator()
+
+    assertEquals(
+      "parallel characteristics",
+      expectedCharacteristics,
+      sParSpliterator.characteristics()
+    )
+
+    assertEquals(
+      "Unexpected parallel stream size",
+      nElements,
+      sParSpliterator.estimateSize()
+    )
+
+    // parallel stream has expected contents
+    var count = 0
+    sParSpliterator.forEachRemaining((e: String) => {
+      assertEquals(
+        s"parallel stream contents(${count})",
+        sisters.get(count),
+        e
+      )
+      count += 1
+    })
+  }
+
 // Methods specified in interface Stream --------------------------------
 
   @Test def streamBuilderCanBuildAnEmptyStream(): Unit = {


### PR DESCRIPTION
Fix #3373

1) javalib Stream and DoubleStream sequential() and parallel() methods now convert streams
    to and from sequential and parallel, matching a JVM.

2) Fixed two missing symbol link errors for DoubleStream.

At this point, converting a sequential stream to a parallel stream changes only a variable. 
No *Stream methods have yet been converted to implement parallel algorithms for parallel
streams.
