### PR TITLE
Fix #3376: javalib {Stream#of, DoubleStream#of} characteristics now match a JVM

### DIFF
--- a/javalib/src/main/scala/java/util/stream/DoubleStream.scala
+++ b/javalib/src/main/scala/java/util/stream/DoubleStream.scala
@@ -329,9 +329,6 @@ object DoubleStream {
     new DoubleStreamImpl(spliter, parallel = false)
   }
 
-  def of(t: scala.Double): DoubleStream =
-    DoubleStream.builder().add(t).build()
-
   def of(values: Array[scala.Double]): DoubleStream = {
     /* One would expect variables arguments to be declared as
      * "values: Objects*" here.
@@ -339,11 +336,13 @@ object DoubleStream {
      * An implicit conversion must be missing in the javalib environment.
      */
 
-    val bldr = DoubleStream.builder()
-    for (j <- values)
-      bldr.add(j)
+    Arrays.stream(values)
+  }
 
-    bldr.build()
+  def of(t: scala.Double): DoubleStream = {
+    val values = new Array[Double](1)
+    values(0) = t
+    DoubleStream.of(values)
   }
 
 }

--- a/javalib/src/main/scala/java/util/stream/ObjectStreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/ObjectStreamImpl.scala
@@ -730,21 +730,6 @@ object ObjectStreamImpl {
     def add(e: Exception): Unit = buffer.addLast(e)
 
     def reportExceptions(): Unit = {
-      /*
-      val it = buffer.iterator()
-
-      if (it.hasNext()) {
-        val firstException = it.next()
-
-        while (it.hasNext()) {
-          val e = it.next()
-          if (e != firstException)
-            firstException.addSuppressed(e)
-        }
-
-        throw (firstException)
-      }
-       */
       if (!buffer.isEmpty()) {
         val firstException = buffer.removeFirst()
 

--- a/javalib/src/main/scala/java/util/stream/Stream.scala
+++ b/javalib/src/main/scala/java/util/stream/Stream.scala
@@ -406,14 +406,14 @@ object Stream {
      * An implicit conversion must be missing in the javalib environment.
      */
 
-    val bldr = Stream.builder[T]()
-    for (j <- values)
-      bldr.add(j.asInstanceOf[T])
-    bldr.build()
+    Arrays.stream(values).asInstanceOf[Stream[T]]
   }
 
-  def of[T](t: Object): Stream[T] =
-    Stream.builder[T]().add(t.asInstanceOf[T]).build()
+  def of[T](t: Object): Stream[T] = {
+    val values = new Array[Object](1)
+    values(0) = t
+    Stream.of(values)
+  }
 
   // Since: Java 9
   def ofNullable[T <: Object](t: T): Stream[T] = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
@@ -216,7 +216,7 @@ class DoubleStreamTest {
     })
   }
 
-// Methods specified in interface Stream --------------------------------
+// Methods specified in interface Double Stream -------------------------
 
   @Test def doubleStreamBuilderCanBuildAnEmptyStream(): Unit = {
     val s = DoubleStream.builder().build()
@@ -239,6 +239,23 @@ class DoubleStreamTest {
     assertFalse("DoubleStream should be empty and is not.", it.hasNext())
   }
 
+  @Test def streamOf_SingleElementCharacteristics(): Unit = {
+    val expected = 7.7
+
+    val s = DoubleStream.of(expected)
+    val spliter = s.spliterator()
+
+    val expectedCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED |
+        Spliterator.ORDERED | Spliterator.IMMUTABLE // 0x4450
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      spliter.characteristics()
+    )
+  }
+
   @Test def doubleStreamOf_MultipleElements(): Unit = {
     val s = DoubleStream.of(1.1, 2.2, 3.3)
     val it = s.iterator()
@@ -246,6 +263,21 @@ class DoubleStreamTest {
     assertEquals("element_2", 2.2, it.nextDouble(), epsilon)
     assertEquals("element_3", 3.3, it.nextDouble(), epsilon)
     assertFalse(it.hasNext())
+  }
+
+  @Test def streamOf_MultipleElementsCharacteristics(): Unit = {
+    val s = DoubleStream.of(1.1, 2.2, 3.3)
+    val spliter = s.spliterator()
+
+    val expectedCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED |
+        Spliterator.ORDERED | Spliterator.IMMUTABLE // 0x4450
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      spliter.characteristics()
+    )
   }
 
   @Test def doubleStreamFlatMapWorks(): Unit = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
@@ -224,6 +224,26 @@ class DoubleStreamTest {
     assertFalse(it.hasNext())
   }
 
+  @Test def doubleStreamBuilderCharacteristics(): Unit = {
+    val bldr = Stream.builder[Double]()
+    bldr
+      .add(1.1)
+      .add(-1.1)
+      .add(9.9)
+
+    val s = bldr.build()
+    val spliter = s.spliterator()
+
+    val expectedCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED // 0x4050
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      spliter.characteristics()
+    )
+  }
+
   @Test def doubleStreamEmptyIsEmpty(): Unit = {
     val s = DoubleStream.empty()
     val it = s.iterator()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -32,7 +32,7 @@ class StreamTest {
    *   streams.
    */
 
-  private def streamOfSingleton[T](single: T): Stream[T] = {
+  private def streamOfSingleton[T](single: Object): Stream[T] = {
     /* Scala Native Tests must support a range of Scala Versions, currently:
      * 2.12.13 to 3.2.2 (soon to be 3.3.0).
      * Scala 2.13.* and 3.* can distinguish between singleton and varargs
@@ -42,9 +42,10 @@ class StreamTest {
      * This tour of Robin Hood's barn allows Scala 2.12 Tests to run
      * without even more complication.
      */
-    val al = new ArrayList[T](1)
-    al.add(single)
-    al.stream()
+
+    val arr = new Array[Object](1)
+    arr(0) = single
+    Arrays.stream(arr).asInstanceOf[Stream[T]]
   }
 
 // Methods specified in interface BaseStream ----------------------------
@@ -227,13 +228,31 @@ class StreamTest {
   }
 
   @Test def streamOf_SingleElement(): Unit = {
-    val expected = 7
+    val expected = 7.toString()
 
-    val s = streamOfSingleton[Int](expected)
+    val s = streamOfSingleton[String](expected)
     val it = s.iterator()
     assertTrue("stream should not be empty", it.hasNext())
     assertEquals("unexpected element", it.next(), expected)
     assertFalse("stream should be empty and is not.", it.hasNext())
+    assertFalse("stream should be empty and is not.", it.hasNext())
+  }
+
+  @Test def streamOf_SingleElementCharacteristics(): Unit = {
+    val expected = 7.toString()
+
+    val s = streamOfSingleton[String](expected)
+    val spliter = s.spliterator()
+
+    val expectedCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED |
+        Spliterator.ORDERED | Spliterator.IMMUTABLE // 0x4450
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      spliter.characteristics()
+    )
   }
 
   @Test def streamOf_MultipleIntElements(): Unit = {
@@ -243,6 +262,21 @@ class StreamTest {
     assertEquals("element_2", 2, it.next())
     assertEquals("element_3", 3, it.next())
     assertFalse(it.hasNext())
+  }
+
+  @Test def streamOf_MultipleElementsCharacteristics(): Unit = {
+    val s = Stream.of(1, 2, 3)
+    val spliter = s.spliterator()
+
+    val expectedCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED |
+        Spliterator.ORDERED | Spliterator.IMMUTABLE // 0x4450
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      spliter.characteristics()
+    )
   }
 
   @Test def streamFlatMapWorks(): Unit = {
@@ -469,9 +503,9 @@ class StreamTest {
   @Test def streamAllMatch_True(): Unit = {
 
     /* stream.allMatch() will return "true" on an empty stream.
-     *  Try to distinguish that "true" from an actual all-elements-match "true"
-     *  Since streams can not be re-used, count s0. If it is non-empty, assume
-     *  its sibling s is also non-empty, distingishing the two "true"s.
+     * Try to distinguish that "true" from an actual all-elements-match "true"
+     * Since streams can not be re-used, count s0. If it is non-empty, assume
+     * its sibling s is also non-empty, distingishing the two "true"s.
      */
     val s0 = Stream.of("Air", "Earth", "Fire", "Water")
     assertTrue("unexpected empty stream", s0.count > 0)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -221,6 +221,26 @@ class StreamTest {
     assertFalse(it.hasNext())
   }
 
+  @Test def streamBuilderCharacteristics(): Unit = {
+    val bldr = Stream.builder[String]()
+    bldr
+      .add("A")
+      .add("B")
+      .add("C")
+
+    val s = bldr.build()
+    val spliter = s.spliterator()
+
+    val expectedCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED // 0x4050
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      spliter.characteristics()
+    )
+  }
+
   @Test def streamEmptyIsEmpty(): Unit = {
     val s = Stream.empty[Int]()
     val it = s.iterator()


### PR DESCRIPTION
Fix #3376

1) The characteristics of the spliterators used by javalib `Stream#of` and `DoubleStream#of` now match 
    those of a JVM.

2) The internals of those two methods were changed from using a Builder to using an Array. 
    This should improve the performance of both those methods and of the streams returned by them.