### PR TITLE
Fix FileChannelImp#throwPosixException error message

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -83,7 +83,7 @@ private[java] final class FileChannelImpl(
   private def throwPosixException(functionName: String): Unit = {
     if (!isWindows) {
       val errnoString = fromCString(string.strerror(errno))
-      throw new IOException("${functionName} failed: ${errnoString}")
+      throw new IOException(s"${functionName} failed: ${errnoString}")
     }
   }
 


### PR DESCRIPTION
Previously, `throwPosixException` throws an IOException with message "${functionName} failed: ${errnoString}" because it failed to do string interpolation.