### PR TITLE
Fix #3309: javalib stream limit methods now match Java 8

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -828,6 +828,172 @@ class StreamTest {
     assertEquals(s"unexpected element count", expectedCount, s1.count())
   }
 
+  /*  Note Well: The Issue #3309 tests are written to match Java 8 behavior.
+   *  Scala Native javalib currently advertises itself as Java 8 (1.8)
+   *  compliant, so these tests match that.
+   *
+   *  Somewhere after Java 11  and before or at Java 17, the behavior changes
+   *  and these tests will begin to fail for parallel ORDERED streams.
+   *  See the issue for details.
+   */
+
+  // Issue #3309 - 1 of 5
+  @Test def streamLimit_Size(): Unit = {
+    StreamTestHelpers.requireJDK8CompatibleCharacteristics()
+
+    val srcSize = 10
+
+    val spliter = Stream
+      .iterate(0, n => n + 1)
+      .limit(srcSize)
+      .spliterator()
+
+    val expectedExactSize = -1
+    assertEquals(
+      "expected exact size",
+      expectedExactSize,
+      spliter.getExactSizeIfKnown()
+    )
+
+    val expectedEstimatedSize = Long.MaxValue
+    assertEquals(
+      "expected estimated size",
+      expectedEstimatedSize,
+      spliter.estimateSize()
+    )
+  }
+
+  // Issue #3309 - 2 of 5
+  @Test def streamLimit_Characteristics(): Unit = {
+    StreamTestHelpers.requireJDK8CompatibleCharacteristics()
+
+    val zeroCharacteristicsSpliter =
+      new Spliterators.AbstractSpliterator[Object](Long.MaxValue, 0x0) {
+        def tryAdvance(action: Consumer[_ >: Object]): Boolean = true
+      }
+
+    val sZero = StreamSupport.stream(zeroCharacteristicsSpliter, false)
+    val sZeroLimited = sZero.limit(9)
+
+    val sZeroLimitedSpliter = sZeroLimited.spliterator()
+
+    val expectedSZeroLimitedCharacteristics = 0x0
+
+    assertEquals(
+      "Unexpected characteristics for zero characteristics stream",
+      expectedSZeroLimitedCharacteristics,
+      sZeroLimitedSpliter.characteristics()
+    )
+
+    /* JVM fails the StreamSupport.stream() call with IllegalStateException
+     * when SORTED is specified. Top of stack traceback is:
+     *    at java.util.Spliterator.getComparator(Spliterator.java:471)
+     *
+     * Test the bits we can here and let Test
+     * streamLimit_SortedCharacteristics() handle SORTED.
+     */
+    val allCharacteristicsSpliter =
+      new Spliterators.AbstractSpliterator[Object](Long.MaxValue, 0x5551) {
+        def tryAdvance(action: Consumer[_ >: Object]): Boolean = true
+      }
+
+    val sAll = StreamSupport.stream(allCharacteristicsSpliter, false)
+
+    val sAllLimited = sAll.limit(9)
+    val sAllLimitedSpliter = sAllLimited.spliterator()
+
+    // JVM 8 expects 0x11 (decimal 17), JVM >= 17 expects 0x4051 (Dec 16465)
+    val expectedSAllLimitedCharacteristics =
+      Spliterator.ORDERED | Spliterator.DISTINCT // 0x11
+      // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
+      // SORTED was not there to drop.
+
+    assertEquals(
+      "Unexpected characteristics for all characteristics stream",
+      expectedSAllLimitedCharacteristics,
+      sAllLimitedSpliter.characteristics()
+    )
+  }
+
+  // Issue #3309 - 3 of 5
+  @Test def streamLimit_SortedCharacteristics(): Unit = {
+    StreamTestHelpers.requireJDK8CompatibleCharacteristics()
+
+    /* Address issues with SORTED described in Test
+     * streamLimit_sequentialAlwaysCharacteristics
+     */
+    val allCharacteristicsSpliter =
+      new Spliterators.AbstractSpliterator[Object](0, 0x5551) {
+        def tryAdvance(action: Consumer[_ >: Object]): Boolean = false
+      }
+
+    val sAll = StreamSupport.stream(allCharacteristicsSpliter, false)
+
+    val sAllLimited = sAll.sorted().limit(9)
+    val sAllLimitedSpliter = sAllLimited.spliterator()
+
+    // JVM 8 expects 0x15 (decimal 21), JVM >= 17 expects 0x4055 (Dec 16469)
+    val expectedSAllLimitedCharacteristics =
+      Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SORTED // 0x15        // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
+
+    assertEquals(
+      "Unexpected characteristics for all characteristics sorted stream",
+      expectedSAllLimitedCharacteristics,
+      sAllLimitedSpliter.characteristics()
+    )
+  }
+
+  // Issue #3309 - 4 of 5
+  @Test def streamLimit_UnsizedCharacteristics(): Unit = {
+    StreamTestHelpers.requireJDK8CompatibleCharacteristics()
+
+    val srcSize = 20
+
+    val unsizedSpliter = Stream
+      .iterate(0, n => n + 1)
+      .limit(srcSize)
+      .spliterator()
+
+    val expectedUnsizedCharacteristics = Spliterator.ORDERED // 0x10
+
+    assertEquals(
+      "Unexpected unsized characteristics",
+      expectedUnsizedCharacteristics,
+      unsizedSpliter.characteristics()
+    )
+  }
+
+  // Issue #3309 - 5 of 5
+  @Test def streamLimit_SizedCharacteristics(): Unit = {
+    StreamTestHelpers.requireJDK8CompatibleCharacteristics()
+
+    val proofSpliter = Stream.of("Air", "Earth", "Fire", "Water").spliterator()
+
+    val expectedProofCharacteristics =
+      Spliterator.SIZED | Spliterator.SUBSIZED
+        | Spliterator.ORDERED | Spliterator.IMMUTABLE // 0x4450
+
+    assertEquals(
+      "Unexpected origin stream characteristics",
+      expectedProofCharacteristics,
+      proofSpliter.characteristics()
+    )
+
+    val sizedSpliter = Stream
+      .of("Air", "Earth", "Fire", "Water")
+      .limit(3)
+      .spliterator()
+
+    // JVM 8 expects 0x10 (decimal 16), JVM >= 17 expects 0x4050 (Dec 16464)
+    val expectedSizedLimitCharacteristics = Spliterator.ORDERED
+
+    assertEquals(
+      "Unexpected characteristics for SIZED stream",
+      expectedSizedLimitCharacteristics,
+      sizedSpliter.characteristics()
+    )
+  }
+
   @Test def streamMap(): Unit = {
     val nElements = 4
     val prefix = "mapped_"

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTestHelpers.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTestHelpers.scala
@@ -1,5 +1,7 @@
 package org.scalanative.testsuite.javalib.util.stream
 
+import org.junit.Assume._
+
 import java.util.Spliterator
 
 object StreamTestHelpers {
@@ -55,4 +57,62 @@ object StreamTestHelpers {
       s"unexpected characteristics, unknown mask: ${unknownBitsMsg}"
     )
   }
+
+  def requireJDK8CompatibleCharacteristics(): Unit = {
+
+    val defaultVersion = 8
+    val defaultVersionString = "1.8" // a.k.a. Java 8
+
+    val jvmVersionString =
+      System.getProperty("java.version", s"${defaultVersion}")
+
+    /* This parse is lazy in the sense of developer lazy & easier to get right.
+     * It is reasonably robust but not fool-proof. Feel free to to better.
+     */
+
+    val parseFailMsg = s"Could not parse java.version: ${jvmVersionString}"
+
+    val elements = jvmVersionString.split('.')
+
+    assumeTrue(
+      parseFailMsg,
+      elements.size >= 1
+    )
+
+    val jvmVersion =
+      try {
+        val selected =
+          if (elements(0) == "1") 1 // e.g. "1.8" a.k.a. Java 8
+          else 0 // e.g. 17.0.7
+        elements(selected).toInt
+      } catch {
+        case _: NumberFormatException =>
+          assumeTrue(parseFailMsg, false)
+          defaultVersion // Should never reach here, keep compiler happy.
+      }
+
+    /* Java is _almost_ always backward compatible.  It appears that this
+     * is not the case for the characteristics returned by the stream
+     * limit() methods for parallel ORDERED streams. See Issue #Issue #3309
+     * and the code in the *StreamImpl.scala files.
+     *
+     * Somewhere after Java 8 and before or in Java 17.0.7 the
+     * characteristics of parallel ORDERED streams changed to add SIZED.
+     * The change is not in Java 11.
+     * A complication is that it may or not be in various patch version of a
+     * JVM. That is, Java 17.0.7 has it but 17.0.0 might not. Here the
+     * assumption is that 17.0.0 has it.
+     *
+     * A person with too much time on their hands and access to a wide
+     * range of JDKs could narrow the bounds.  As long as Scala Native
+     * JDK only describes itself as supporting Java 8, this is good enough.
+     */
+    val inbounds = (jvmVersion >= 8) && (jvmVersion < 17)
+
+    assumeTrue(
+      "Tests of stream limit methods require Java >= 8 and < 17",
+      inbounds
+    )
+  }
+
 }


### PR DESCRIPTION
Fix #3309

The `limit()` methods in javalib Stream and DoubleStream classes now match the size and characteristics
reported by Java 8.

Please note well that sometime at least by Java 17, the behavior of those methods changed for
parallel ORDERED streams.  The Java 17+ behavior is incompatible with Java 8.

Scala Native javalib describes itself as Java 8 (1.8).  The behavior implemented here matches
that description but is likely to annoy people porting Java 17+ code to Scala Native.

Please see the Issue for a longer discussion.

The fix in this PR required making the `sorted()` methods return characteristics
which better match a JVM.