### PR TITLE
nativeLinkReleaseFast and nativeLinkReleaseFull SBT tasks

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -38,6 +38,16 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeLink =
       taskKey[File]("Generates native binary without running it.")
 
+    val nativeLinkReleaseFast =
+      taskKey[File](
+        "Generates native binary in release-fast configuration without running it."
+      )
+
+    val nativeLinkReleaseFull =
+      taskKey[File](
+        "Generates native binary in release-full configuration without running it."
+      )
+
   }
 
   override def globalSettings: Seq[Setting[_]] =


### PR DESCRIPTION
Currently the way to build release fast/full is to either use the environment variables (either built-in or roll your own, which couples the correctness to the global settings you need to get right), or use `set nativeMode := ...` as part of the SBT call - but that necessarily reloads the session and isn't great for interactive use.

I think the experience can be improved - the tasks output stable locations of linked binaries, they can be immediately run, it works great with shell history (because of `-release-fast` suffix).

In the target folder you immediately see all the binaries with different names, which makes it clear and less error prone when running benchmarks against different configurations. You can also use these tasks to feed into other SBT tasks (running automatic benchmarks for example)

<img width="634" alt="image" src="https://github.com/scala-native/scala-native/assets/1052965/9111ca99-2d16-4240-a73e-354a2bac0383">
