### PR TITLE
A small re-organization of javalib internals

### DIFF
--- a/javalib/src/main/scala/java/util/stream/DoubleStreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/DoubleStreamImpl.scala
@@ -80,7 +80,7 @@ private[stream] class DoubleStreamImpl(
 
   protected def commenceOperation(): Unit = {
     if (_operatedUpon || _closed)
-      ObjectStreamImpl.throwIllegalStateException()
+      StreamImpl.throwIllegalStateException()
 
     _operatedUpon = true
   }
@@ -132,7 +132,7 @@ private[stream] class DoubleStreamImpl(
     // JVM appears to not set "operated upon" here.
 
     if (_closed)
-      ObjectStreamImpl.throwIllegalStateException()
+      StreamImpl.throwIllegalStateException()
 
     // detects & throws on closeHandler == null
     onCloseQueue.addLast(closeHandler)
@@ -375,7 +375,7 @@ private[stream] class DoubleStreamImpl(
   def limit(maxSize: Long): DoubleStream = {
 
     /* Important:
-     * See Issue #3309 & ObjectStreamImpl#limit for discussion of size
+     * See Issue #3309 & StreamImpl#limit for discussion of size
      * & characteristics in JVM 17 (and possibly as early as JVM 12)
      * for parallel ORDERED streams.
      * The behavior implemented here is Java 8 and at least Java 11.
@@ -450,11 +450,11 @@ private[stream] class DoubleStreamImpl(
         _spliter.tryAdvance((e: scala.Double) => action.accept(mapper(e)))
     }
 
-    new ObjectStreamImpl[U](
+    new StreamImpl[U](
       spl,
       _parallel,
       pipeline
-        .asInstanceOf[ArrayDeque[ObjectStreamImpl[U]]]
+        .asInstanceOf[ArrayDeque[StreamImpl[U]]]
     )
   }
 
@@ -671,7 +671,7 @@ object DoubleStreamImpl {
     private var built = false
 
     override def accept(t: scala.Double): Unit =
-      if (built) ObjectStreamImpl.throwIllegalStateException()
+      if (built) StreamImpl.throwIllegalStateException()
       else buffer.add(t)
 
     override def build(): DoubleStream = {
@@ -843,7 +843,7 @@ object DoubleStreamImpl {
   }
 
   def concat(a: DoubleStream, b: DoubleStream): DoubleStream = {
-    /* See ""Design Note" at corresponding place in ObjectStreamImpl.
+    /* See ""Design Note" at corresponding place in StreamImpl.
      * This implementaton shares the same noted "features".
      */
     val aImpl = a.asInstanceOf[DoubleStreamImpl]

--- a/javalib/src/main/scala/java/util/stream/Stream.scala
+++ b/javalib/src/main/scala/java/util/stream/Stream.scala
@@ -65,7 +65,7 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
       }
     }
 
-    new ObjectStreamImpl[T](spl, parallel = false, parent = this)
+    new StreamImpl[T](spl, parallel = false, parent = this)
   }
 
   def filter(pred: Predicate[_ >: T]): Stream[T]
@@ -146,7 +146,7 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
       }
     }
 
-    (new ObjectStreamImpl[R](
+    (new StreamImpl[R](
       spl,
       parallel = false,
       parent = this.asInstanceOf[Stream[R]]
@@ -193,7 +193,7 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
       }
 
     val coercedPriorStages = this
-      .asInstanceOf[ObjectStreamImpl[T]]
+      .asInstanceOf[StreamImpl[T]]
       .pipeline
       .asInstanceOf[ArrayDeque[DoubleStreamImpl]]
 
@@ -279,7 +279,7 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
       }
     }
 
-    new ObjectStreamImpl[T](spl, parallel = false, parent = this)
+    new StreamImpl[T](spl, parallel = false, parent = this)
   }
 
   def toArray(): Array[Object]
@@ -318,13 +318,13 @@ object Stream {
     def build(): Stream[T]
   }
 
-  def builder[T](): Builder[T] = new ObjectStreamImpl.Builder[T]
+  def builder[T](): Builder[T] = new StreamImpl.Builder[T]
 
   def concat[T](a: Stream[_ <: T], b: Stream[_ <: T]): Stream[T] =
-    ObjectStreamImpl.concat(a, b)
+    StreamImpl.concat(a, b)
 
   def empty[T](): Stream[T] =
-    new ObjectStreamImpl(Spliterators.emptySpliterator[T](), parallel = false)
+    new StreamImpl(Spliterators.emptySpliterator[T](), parallel = false)
 
   def generate[T](s: Supplier[T]): Stream[T] = {
     val spliter =
@@ -335,7 +335,7 @@ object Stream {
         }
       }
 
-    new ObjectStreamImpl(spliter, parallel = false)
+    new StreamImpl(spliter, parallel = false)
   }
 
   // Since: Java 9
@@ -370,7 +370,7 @@ object Stream {
         }
       }
 
-    new ObjectStreamImpl(spliter, parallel = false)
+    new StreamImpl(spliter, parallel = false)
   }
 
   def iterate[T](seed: T, f: UnaryOperator[T]): Stream[T] = {
@@ -396,7 +396,7 @@ object Stream {
         }
       }
 
-    new ObjectStreamImpl(spliter, parallel = false)
+    new StreamImpl(spliter, parallel = false)
   }
 
   def of[T](values: Array[Object]): Stream[T] = {

--- a/javalib/src/main/scala/java/util/stream/StreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamImpl.scala
@@ -5,8 +5,8 @@ import java.util._
 import java.util.function._
 import java.util.stream.Collector._
 
-private[stream] class ObjectStreamImpl[T](
-    val pipeline: ArrayDeque[ObjectStreamImpl[T]]
+private[stream] class StreamImpl[T](
+    val pipeline: ArrayDeque[StreamImpl[T]]
 ) extends Stream[T] {
   var _spliterArg: Spliterator[T] = _
   var _supplier: Supplier[Spliterator[T]] = _
@@ -30,7 +30,7 @@ private[stream] class ObjectStreamImpl[T](
       spliterator: Spliterator[T],
       parallel: Boolean
   ) = {
-    this(new ArrayDeque[ObjectStreamImpl[T]])
+    this(new ArrayDeque[StreamImpl[T]])
     _spliterArg = spliterator
     _parallel = parallel
   }
@@ -40,7 +40,7 @@ private[stream] class ObjectStreamImpl[T](
       parallel: Boolean,
       parent: Stream[_ <: T]
   ) = {
-    this(parent.asInstanceOf[ObjectStreamImpl[T]].pipeline)
+    this(parent.asInstanceOf[StreamImpl[T]].pipeline)
     _spliterArg = spliterator
     _parallel = parallel
   }
@@ -48,7 +48,7 @@ private[stream] class ObjectStreamImpl[T](
   def this(
       spliterator: Spliterator[T],
       parallel: Boolean,
-      pipeline: ArrayDeque[ObjectStreamImpl[T]]
+      pipeline: ArrayDeque[StreamImpl[T]]
   ) = {
     this(pipeline)
     _spliterArg = spliterator
@@ -60,7 +60,7 @@ private[stream] class ObjectStreamImpl[T](
       characteristics: Int,
       parallel: Boolean
   ) = {
-    this(new ArrayDeque[ObjectStreamImpl[T]])
+    this(new ArrayDeque[StreamImpl[T]])
     _supplier = supplier
     _parallel = parallel
     _characteristics = characteristics
@@ -76,14 +76,14 @@ private[stream] class ObjectStreamImpl[T](
 
   protected def commenceOperation(): Unit = {
     if (_operatedUpon || _closed)
-      ObjectStreamImpl.throwIllegalStateException()
+      StreamImpl.throwIllegalStateException()
 
     _operatedUpon = true
   }
 
   def close(): Unit = {
     if (!_closed) {
-      val exceptionBuffer = new ObjectStreamImpl.CloseExceptionBuffer()
+      val exceptionBuffer = new StreamImpl.CloseExceptionBuffer()
       val it = pipeline.iterator()
 
       while (it.hasNext()) {
@@ -101,7 +101,7 @@ private[stream] class ObjectStreamImpl[T](
   private def closeStage(): Unit = {
     _closed = true
 
-    val exceptionBuffer = new ObjectStreamImpl.CloseExceptionBuffer()
+    val exceptionBuffer = new StreamImpl.CloseExceptionBuffer()
 
     if (onCloseQueueActive) {
       val it = onCloseQueue.iterator()
@@ -128,7 +128,7 @@ private[stream] class ObjectStreamImpl[T](
     // JVM appears to not set "operated upon" here.
 
     if (_closed)
-      ObjectStreamImpl.throwIllegalStateException()
+      StreamImpl.throwIllegalStateException()
 
     // detects & throws on closeHandler == null
     onCloseQueue.addLast(closeHandler)
@@ -181,7 +181,7 @@ private[stream] class ObjectStreamImpl[T](
           _spliter.tryAdvance((e) => action.accept(e))
       }
 
-      new ObjectStreamImpl[T](spl, _parallel, pipeline)
+      new StreamImpl[T](spl, _parallel, pipeline)
     }
   }
 
@@ -294,7 +294,7 @@ private[stream] class ObjectStreamImpl[T](
         }
       }
 
-    new ObjectStreamImpl[T](spl, _parallel, pipeline)
+    new StreamImpl[T](spl, _parallel, pipeline)
   }
 
   def filter(pred: Predicate[_ >: T]): Stream[T] = {
@@ -326,7 +326,7 @@ private[stream] class ObjectStreamImpl[T](
         success
       }
     }
-    new ObjectStreamImpl[T](spl, _parallel, pipeline)
+    new StreamImpl[T](spl, _parallel, pipeline)
   }
 
   /* delegating to findFirst() is an implementation ~~hack~~ expediency.
@@ -350,16 +350,16 @@ private[stream] class ObjectStreamImpl[T](
   ): Stream[R] = {
     commenceOperation()
 
-    val csf = new ObjectStreamImpl.CompoundSpliteratorFactory[T, R](
+    val csf = new StreamImpl.CompoundSpliteratorFactory[T, R](
       _spliter,
       mapper,
       closeOnFirstTouch = true
     )
 
     val coercedPriorStages = pipeline
-      .asInstanceOf[ArrayDeque[ObjectStreamImpl[R]]]
+      .asInstanceOf[ArrayDeque[StreamImpl[R]]]
 
-    new ObjectStreamImpl[R](csf.get(), _parallel, coercedPriorStages)
+    new StreamImpl[R](csf.get(), _parallel, coercedPriorStages)
   }
 
   def flatMapToDouble(
@@ -368,7 +368,7 @@ private[stream] class ObjectStreamImpl[T](
     commenceOperation()
 
     val supplier =
-      new ObjectStreamImpl.DoublePrimitiveCompoundSpliteratorFactory[T](
+      new StreamImpl.DoublePrimitiveCompoundSpliteratorFactory[T](
         _spliter,
         mapper,
         closeOnFirstTouch = true
@@ -448,7 +448,7 @@ private[stream] class ObjectStreamImpl[T](
         }
     }
 
-    new ObjectStreamImpl[T](spl, _parallel, pipeline)
+    new StreamImpl[T](spl, _parallel, pipeline)
   }
 
   def map[R](
@@ -468,7 +468,7 @@ private[stream] class ObjectStreamImpl[T](
      * Type erasure is what makes this work, once one lies to the compiler
      * about the types involved.
      */
-    new ObjectStreamImpl[T](
+    new StreamImpl[T](
       spl.asInstanceOf[Spliterator[T]],
       _parallel,
       pipeline
@@ -565,7 +565,7 @@ private[stream] class ObjectStreamImpl[T](
         })
     }
 
-    new ObjectStreamImpl[T](spl, _parallel, pipeline)
+    new StreamImpl[T](spl, _parallel, pipeline)
   }
 
   def reduce(accumulator: BinaryOperator[T]): Optional[T] = {
@@ -623,7 +623,7 @@ private[stream] class ObjectStreamImpl[T](
         && (_spliter.tryAdvance((e) => nSkipped += 1L))) { /* skip */ }
 
     // Follow JVM practice; return new stream, not remainder of "this" stream.
-    new ObjectStreamImpl[T](_spliter, _parallel, pipeline)
+    new StreamImpl[T](_spliter, _parallel, pipeline)
   }
 
   def sorted(): Stream[T] = {
@@ -696,7 +696,7 @@ private[stream] class ObjectStreamImpl[T](
 
     val spl = Spliterators.spliterator[T](buffer, newCharacteristics)
 
-    new ObjectStreamImpl[T](spl, _parallel, pipeline)
+    new StreamImpl[T](spl, _parallel, pipeline)
   }
 
   def toArray(): Array[Object] = {
@@ -738,20 +738,20 @@ private[stream] class ObjectStreamImpl[T](
 
 }
 
-object ObjectStreamImpl {
+object StreamImpl {
 
   class Builder[T] extends Stream.Builder[T] {
     private var built = false
     private val buffer = new ArrayList[T]()
 
     override def accept(t: T): Unit =
-      if (built) ObjectStreamImpl.throwIllegalStateException()
+      if (built) StreamImpl.throwIllegalStateException()
       else buffer.add(t)
 
     override def build(): Stream[T] = {
       built = true
       val spliter = buffer.spliterator()
-      new ObjectStreamImpl(spliter, parallel = false)
+      new StreamImpl(spliter, parallel = false)
     }
   }
 
@@ -812,7 +812,7 @@ object ObjectStreamImpl {
         private var currentSpliter: ju.Spliterator[_ <: R] =
           Spliterators.emptySpliterator[R]()
 
-        var currentStream = Optional.empty[ObjectStreamImpl[R]]()
+        var currentStream = Optional.empty[StreamImpl[R]]()
 
         def tryAdvance(action: Consumer[_ >: R]): Boolean = {
           var advanced = false
@@ -833,7 +833,7 @@ object ObjectStreamImpl {
               done = !substreams
                 .tryAdvance((e) =>
                   currentSpliter = {
-                    val eOfR = e.asInstanceOf[ObjectStreamImpl[R]]
+                    val eOfR = e.asInstanceOf[StreamImpl[R]]
                     currentStream = Optional.of(eOfR)
 
                     /* Tricky bit here!
@@ -957,8 +957,8 @@ object ObjectStreamImpl {
      *   until the bug reports start pouring in.
      */
 
-    val aImpl = a.asInstanceOf[ObjectStreamImpl[T]]
-    val bImpl = b.asInstanceOf[ObjectStreamImpl[T]]
+    val aImpl = a.asInstanceOf[StreamImpl[T]]
+    val bImpl = b.asInstanceOf[StreamImpl[T]]
 
     aImpl.commenceOperation()
     bImpl.commenceOperation()
@@ -975,10 +975,10 @@ object ObjectStreamImpl {
 
     val pipelineA = aImpl.pipeline
     val pipelineB = bImpl.pipeline
-    val pipelines = new ArrayDeque[ObjectStreamImpl[T]](pipelineA)
+    val pipelines = new ArrayDeque[StreamImpl[T]](pipelineA)
     pipelines.addAll(pipelineB)
 
-    new ObjectStreamImpl[T](csf.get(), parallel = false, pipelines)
+    new StreamImpl[T](csf.get(), parallel = false, pipelines)
   }
 
   def throwIllegalStateException(): Unit = {

--- a/javalib/src/main/scala/java/util/stream/StreamSupport.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamSupport.scala
@@ -61,7 +61,7 @@ object StreamSupport {
       spliterator: Spliterator[T],
       parallel: Boolean
   ): Stream[T] = {
-    new ObjectStreamImpl[T](spliterator, parallel)
+    new StreamImpl[T](spliterator, parallel)
   }
 
   def stream[T](
@@ -69,6 +69,6 @@ object StreamSupport {
       characteristics: Int,
       parallel: Boolean
   ): Stream[T] = {
-    new ObjectStreamImpl[T](supplier, characteristics, parallel)
+    new StreamImpl[T](supplier, characteristics, parallel)
   }
 }


### PR DESCRIPTION
javalib Streams can have elements of type Any, not just AnyRef.  Rename the file which implements
streams to avoid misdirection/gross_error.  This is an re-organization of internal details and should
not change user-visible behavior.