### PR TITLE
Adjust Publish and JDK compliance jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,26 +9,9 @@ on:
   - cron: '0 0 * * 1,3,5'
 
 jobs:
-  test-linux:
-    if: github.event_name != 'schedule' && github.repository == 'scala-native/scala-native'
-    uses: ./.github/workflows/run-tests-linux.yml
-  test-windows:
-    if: github.event_name != 'schedule' && github.repository == 'scala-native/scala-native'
-    uses: ./.github/workflows/run-tests-windows.yml
-  test-macos:
-    if: github.event_name != 'schedule' && github.repository == 'scala-native/scala-native'
-    uses: ./.github/workflows/run-tests-macos.yml
-  test-jdk-compliance:
-    if: github.event_name != 'schedule' && github.repository == 'scala-native/scala-native'
-    uses: ./.github/workflows/run-jdk-compliance-tests.yml
-  test-multiarch:
-    if: github.event_name != 'schedule' && github.repository == 'scala-native/scala-native'
-    uses: ./.github/workflows/run-tests-linux-multiarch.yml
-
   publish:
     name: Publish
     runs-on: ubuntu-22.04
-    needs: [test-linux, test-windows, test-macos, test-jdk-compliance, test-multiarch]
     if: github.repository == 'scala-native/scala-native'
     steps:
       - uses: actions/checkout@v3
@@ -42,6 +25,9 @@ jobs:
           echo -n "$PGP_SECRET" | base64 --decode | gpg --batch --import
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
+
+      - name: Compile everything
+        run: sbt "-v" "-J-Xmx5G" "++3.3.0; Test/compile; ++2.13.11; Test/compile; ++2.12.18; Test/compile"
 
       - name: Publish release
         env:

--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -20,10 +20,14 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-11]
         scala: [3]
-        java: [11, 17, 20]
+        java: [11, 17]
         include:
           - java: 20
             java-options: "--enable-preview"
+          - java: 17
+            scala: 2.13
+          - java: 17
+            scala: 2.12
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/macos-setup-env

--- a/auxlib/src/main/scala/scala/collection/concurrent/CNodeBase.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/CNodeBase.scala
@@ -12,7 +12,9 @@ private[concurrent] abstract class CNodeBase[K <: AnyRef, V <: AnyRef]
 
   final val updater: AtomicIntegerFieldUpdater[CNodeBase[_, _]] =
     new IntrinsicAtomicIntegerFieldUpdater(obj =>
-      fromRawPtr(classFieldRawPtr(obj, "csize"))
+      fromRawPtr(
+        classFieldRawPtr(obj.asInstanceOf[CNodeBase[AnyRef, AnyRef]], "csize")
+      )
     )
 
   @alwaysinline

--- a/auxlib/src/main/scala/scala/collection/concurrent/INodeBase.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/INodeBase.scala
@@ -11,7 +11,12 @@ object INodeBase {
   final val updater
       : AtomicReferenceFieldUpdater[INodeBase[_, _], MainNode[_, _]] =
     new IntrinsicAtomicReferenceFieldUpdater(obj =>
-      fromRawPtr(classFieldRawPtr(obj, "mainnode"))
+      fromRawPtr(
+        classFieldRawPtr(
+          obj.asInstanceOf[INodeBase[AnyRef, AnyRef]],
+          "mainnode"
+        )
+      )
     )
 
   final val RESTART = new Object {}

--- a/auxlib/src/main/scala/scala/collection/concurrent/MainNode.scala
+++ b/auxlib/src/main/scala/scala/collection/concurrent/MainNode.scala
@@ -10,7 +10,9 @@ object MainNode {
   final val updater
       : AtomicReferenceFieldUpdater[MainNode[_, _], MainNode[_, _]] =
     new IntrinsicAtomicReferenceFieldUpdater(obj =>
-      fromRawPtr(classFieldRawPtr(obj, "prev"))
+      fromRawPtr(
+        classFieldRawPtr(obj.asInstanceOf[MainNode[AnyRef, AnyRef]], "prev")
+      )
     )
 }
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -845,7 +845,7 @@ class StreamTest {
 
     val spliter =
       Stream
-        .iterate[jl.Integer](0, (n: jl.Integer) => n + 1)
+        .iterate[jl.Integer](0, ((n: jl.Integer) => n + 1): UnaryOperator[jl.Integer])
         .limit(srcSize)
         .spliterator()
 
@@ -952,7 +952,10 @@ class StreamTest {
 
     val unsizedSpliter =
       Stream
-        .iterate[jl.Integer](0, (n: jl.Integer) => n + 1)
+        .iterate[jl.Integer](
+          0,
+          ((n: jl.Integer) => n + 1): UnaryOperator[jl.Integer]
+        )
         .limit(srcSize)
         .spliterator()
 


### PR DESCRIPTION
* Simplifiy publish job to adjust it for snapshot releases - if any of need jobs is skipped the publish would also skip, instead only compile all projects projects with each binary versions
* Fix compilation of auxlib with older versions of Scala 2 
* Test JDK compliance for Scala 2.12 and 2.13 
* Fix StreamTest to pass JDK compliance job