### PR TITLE
doc: add new javalib Piped classes to documentation

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -46,6 +46,10 @@ java.io
 * ``ObjectStreamException``
 * ``OutputStream``
 * ``OutputStreamWriter``
+* ``PipedInputStream``
+* ``PipedOutputStream``
+* ``PipedReader``
+* ``PipedWriter``
 * ``PrintStream``
 * ``PrintWriter``
 * ``PushbackInputStream``


### PR DESCRIPTION
PR #2691 added four methods to javalib. This PR adds those methods to the list of implemented classes
in `javalib.rst`. 