### PR TITLE
Correct defect in javalib ThreadLocalRandom doubleStreams forEachRemaining

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -209,7 +209,7 @@ object ThreadLocalRandom {
         var i = index
         index = fence
         while ({
-          rng.internalNextDouble()(origin, bound)
+          consumer.accept(rng.internalNextDouble()(origin, bound))
           i += 1
           i < fence
         }) ()


### PR DESCRIPTION
The foreachRemaining method on spliterators used in javalib ThreadLocalRandom doubleStreams now
correctly applies the supplied action.

Previous to this PR, the DoubleConsumer routine never got called.   

ThreadLocalRandom IntStreams and LongStreams did not have this defect.