### PR TITLE
doc: add javalib Vector and many concurrent classes

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -457,25 +457,77 @@ java.util
 * ``UUID``
 * ``UnknownFormatConversionException``
 * ``UnknownFormatFlagsException``
+* ``Vector``
 * ``WeakHashMap``
+
+..
+    util.concurrent classes are listed as in JVM documentation.
+    This varies in some cases from strictly alphabetical order.
+    Yes, mind bending, but that is how JVM does it.
+    Classes in sub-directories are at the end of the list.
+..
 
 java.util.concurrent
 """"""""""""""""""""
+* ``AbstractExecutorService``
+* ``ArrayBlockingQueue``
+* ``BlockingDeque``
+* ``BlockingQueue``
+* ``BrokenBarrierException``
 * ``Callable``
 * ``CancellationException``
+* ``CompletionService``
 * ``ConcurrentHashMap``
 * ``ConcurrentHashMap.KeySetView``
 * ``ConcurrentLinkedQueue``
 * ``ConcurrentMap``
+* ``ConcurrentNavigableMap``
+* ``CopyOnWriteArrayList``
 * ``ConcurrentSkipListSet``
+* ``CountDownLatch``
+* ``CountedCompleter``
+* ``CyclicBarrier``
+* ``Delayed``
 * ``ExecutionException``
 * ``Executor``
+* ``ExecutorCompletionService``
+* ``Executors``
+* ``ExecutorService``
+* ``Flow``
+* ``Flow.Processor``
+* ``Flow.Publisher``
+* ``Flow.Subscriber``
+* ``Flow.Subscripton``
+* ``ForkJoinPool``
+* ``ForkJoinPoo.ForkJoinWorkerThreadFactory``
+* ``ForkJoinPoo.ManagedBlocker``
+* ``ForkJoinTask``
+* ``ForkJoinWorkerThread``
+* ``Future``
+* ``FutureTask``
+* ``LinkedBlockingQueue``
+* ``PriorityBlockingQueue``
+* ``RecursiveAction``
+* ``RecursiveTask``
 * ``RejectedExecutionException``
+* ``RejectedExecutionHandler``
+* ``RunnableFuture``
+* ``RunnableScheduledFuture``
+* ``ScheduledExecutorService``
+* ``ScheduledFuture``
+* ``ScheduledThreadPoolExecutor``
 * ``Semaphore``
+* ``SynchronousQueue``
 * ``ThreadFactory``
 * ``ThreadLocalRandom``
-* ``TimeUnit``
+* ``ThreadPoolExecutor``
+* ``ThreadPoolExecutor.AbortPolicy``
+* ``ThreadPoolExecutor.CallerRunsPolicy``
+* ``ThreadPoolExecutor.DiscardOldestPolicy``
+* ``ThreadPoolExecutor.DiscardPolicy``
 * ``TimeoutException``
+* ``TimeUnit``
+* ``TransferQueue``
 * ``atomic.AtomicBoolean``
 * ``atomic.AtomicInteger``
 * ``atomic.AtomicLong``


### PR DESCRIPTION
* Add entry for newly ported  `util.Vector` class to list of implemented javalib classes.
* Many `util.concurrent`  classes were not in the list of implemented javalib classes.
   These have now been added.

Someday, these additions will be automated or done by an eager middle-schooler.
For now, there are enough quirks that they are done manually.