### PR TITLE
Invoke Scala compiler to compile Scala code into NIR in tools

### DIFF
--- a/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
+++ b/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
@@ -9,6 +9,7 @@ import scala.scalanative.build.{Config, NativeConfig, _}
 import scala.scalanative.util.Scope
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, duration}
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo
 
 // The test is used for incremental compilation
 
@@ -106,8 +107,7 @@ class IncCompilationTest extends codegen.CodeGenSpec {
 
   private def makeClasspath(outDir: Path)(implicit in: Scope) = {
     val parts: Array[Path] =
-      sys
-        .props("scalanative.nativeruntime.cp")
+      ScalaNativeBuildInfo.scalalibCp
         .split(File.pathSeparator)
         .map(Paths.get(_))
 

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -8,6 +8,7 @@ import scalanative.util.Scope
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo
 
 /** Base class to test the linker. */
 abstract class LinkerSpec {
@@ -44,8 +45,7 @@ abstract class LinkerSpec {
 
   private def makeClasspath(outDir: Path)(implicit in: Scope) = {
     val parts: Array[Path] =
-      sys
-        .props("scalanative.nativeruntime.cp")
+      ScalaNativeBuildInfo.scalalibCp
         .split(File.pathSeparator)
         .map(Paths.get(_))
 

--- a/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
@@ -2,29 +2,11 @@ package scala.scalanative
 
 import java.nio.file.{Files, Path}
 import java.io.{File, PrintWriter}
-import java.net.URLClassLoader
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo
+import java.lang.ProcessBuilder
+import java.nio.charset.StandardCharsets
 
 object NIRCompiler {
-
-  private val allow: String => Boolean =
-    n => n.startsWith("scala.scalanative.api.") || !n.startsWith("scala.")
-
-  private val classLoader = {
-    val parts = sys
-      .props("scalanative.testingcompiler.cp")
-      .split(File.pathSeparator)
-      .map(new java.io.File(_))
-      .filter(f => f.exists && f.getName.endsWith(".jar"))
-      .map(_.toURI.toURL)
-
-    // We must share some parts of our classpath with the classloader used for the NIR compiler,
-    // because we want to be able to cast the NIRCompiler that we get back to its interface and
-    // be able to use it seamlessly.
-    // We filter out the scala library from out classloader (so that it gets delegated to the
-    // scala library that is in `scalanative.testingcompiler.cp`, and we keep `api.NIRCompiler`.
-    val parent = new FilteredClassLoader(allow, this.getClass.getClassLoader)
-    new URLClassLoader(parts.toArray, parent)
-  }
 
   /** Returns an instance of the NIRCompiler that will compile to a temporary
    *  directory.
@@ -32,18 +14,8 @@ object NIRCompiler {
    *  @return
    *    An NIRCompiler that will compile to a temporary directory.
    */
-  def getCompiler(): api.NIRCompiler = {
-    val clazz =
-      classLoader.loadClass("scala.scalanative.NIRCompiler")
-    clazz.getDeclaredConstructor().newInstance() match {
-      case compiler: api.NIRCompiler => compiler
-      case other =>
-        throw new ReflectiveOperationException(
-          "Expected an object of type `scala.scalanative.NIRCompiler`, " +
-            s"but found `${other.getClass.getName}`."
-        )
-    }
-  }
+  def getCompiler(): api.NIRCompiler =
+    new NIRCompilerImpl()
 
   /** Returns an instance of the NIRCompiler that will compile to `outDir`.
    *
@@ -52,19 +24,8 @@ object NIRCompiler {
    *  @return
    *    An NIRCompiler that will compile to `outDir`.
    */
-  def getCompiler(outDir: Path): api.NIRCompiler = {
-    val clazz =
-      classLoader.loadClass("scala.scalanative.NIRCompiler")
-    val constructor = clazz.getConstructor(classOf[Path])
-    constructor.newInstance(outDir) match {
-      case compiler: api.NIRCompiler => compiler
-      case other =>
-        throw new ReflectiveOperationException(
-          "Expected an object of type `scala.scalanative.NIRCompiler`, but " +
-            s"found `${other.getClass.getName}`."
-        )
-    }
-  }
+  def getCompiler(outDir: Path): api.NIRCompiler =
+    new NIRCompilerImpl(outDir)
 
   /** Applies `fn` to an NIRCompiler that compiles to `outDir`.
    *
@@ -146,5 +107,58 @@ object NIRCompiler {
     writer.write(content)
     writer.close()
   }
+
+}
+
+class NIRCompilerImpl(outDir: Path) extends api.NIRCompiler {
+
+  def this() = this(Files.createTempDirectory("scala-native-target"))
+
+  override def compile(base: Path): Array[Path] = {
+    val files = getFiles(base.toFile(), _.getName endsWith ".scala")
+    compile(files)
+  }
+
+  override def compile(source: String): Array[Path] = {
+    val tempFile = File.createTempFile("scala-native-input", ".scala").toPath
+    val p = Files.write(tempFile, source.getBytes(StandardCharsets.UTF_8))
+    compile(Seq(p.toFile()))
+  }
+
+  private def compile(files: Seq[File]): Array[Path] = {
+    val mainClass =
+      if (ScalaNativeBuildInfo.scalaVersion.startsWith("3"))
+        "dotty.tools.dotc.Main"
+      else "scala.tools.nsc.Main"
+    val outPath = outDir.toAbsolutePath()
+    val fileArgs = files.map(_.getAbsolutePath())
+    // Invoke Scala compiler as an external process to compile Scala program into NIR
+    // We don't use testingCompiler that classload (which isn't supported by SN) the Scala compiler to native compile `tools`.
+    val args = Seq(
+      "java",
+      "-cp",
+      ScalaNativeBuildInfo.scalacJars,
+      mainClass,
+      "-d",
+      outPath.toString(),
+      "-cp",
+      ScalaNativeBuildInfo.compileClasspath + File.pathSeparator + ScalaNativeBuildInfo.nativelibCp,
+      s"-Xplugin:${ScalaNativeBuildInfo.pluginJar}"
+    ) ++ fileArgs
+    val procBuilder = new ProcessBuilder(args: _*)
+    val cmd = args.mkString(" ")
+    val proc = procBuilder.start()
+    val ret = proc.waitFor()
+    Array.empty[Path]
+  }
+
+  /** List of the files contained in `base` that sastisfy `filter`
+   */
+  private def getFiles(base: File, filter: File => Boolean): Seq[File] =
+    (if (filter(base)) Seq(base) else Seq.empty) ++
+      (Option(base.listFiles()) getOrElse Array.empty[File] flatMap (getFiles(
+        _,
+        filter
+      )))
 
 }

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -12,6 +12,7 @@ import scalanative.build.{ScalaNative, Logger, Discover}
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo
 
 trait ReachabilitySuite {
 
@@ -95,8 +96,7 @@ trait ReachabilitySuite {
 
   private def makeClasspath(outDir: Path)(implicit in: Scope) = {
     val parts: Array[Path] =
-      sys
-        .props("scalanative.nativeruntime.cp")
+      ScalaNativeBuildInfo.scalalibCp
         .split(File.pathSeparator)
         .map(Paths.get(_))
 


### PR DESCRIPTION
This PR aims to enable native compilation for the `toolsX / Test` scope in Scala Native. Currently, this is not possible due to the following reasons:

- `toolsX / Test` relies on `nscplugin` through a `ClassLoader`, which is not supported by Scala Native. The use of nscplugin allows us to test `tools` by writing Scala programs as input to the linker, rather than using hand-written NIR code.
- `toolsX / Test` retrieves information about `nscplugin`, `testingCompiler`, and `nativelib` from the build using system properties, which are not supported by Scala Native.

To address these issues, this PR modifies the approach used by `toolsX` by implementing the following changes:

- The Scala compiler (with `nscplugin`) is invoked as an external process to generate NIR from Scala code, avoiding the use of `ClassLoader`.
- `sbt-buildinfo` is utilized to obtain the `classpaths` necessary for invoking the Scala compiler along with the Scala Native plugin.

By making these adjustments, the` toolsX / Test` scope can be successfully compiled to native code (actually not yet 😅 since the `toolsX / compile isn't yet compile)`, allowing for the integration of Scala programs as input to the linker during testing, without relying on unsupported features like ClassLoader and system properties.

---

<details>

<summary>Solved</summary>

However, I'm failing to invoke scala compiler both in Scala 2 and 3 with the following failure,

```
sbt:scala-native> tools2_13 / Test / test
...
java -cp "/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.11/scala-library-2.13.11.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.11/scala-compiler-2.13.11.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.11/scala-reflect-2.13.11.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.22.0/jline-3.22.0.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar" scala.tools.nsc.Main -d /var/folders/xt/hyn73bjx4kl6hjj9sxnf1yzh0000gn/T/native-test-out13144123414556388598 -Xplugin:/Users/tanishiking/ghq/github.com/tanishiking/scala-native/nscplugin/.2.13/target/scala-2.13/nscplugin_2.13.11-0.5.0-SNAPSHOT.jar /var/folders/xt/hyn73bjx4kl6hjj9sxnf1yzh0000gn/T/scala-native-sources9991435057313360786/props.scala,/var/folders/xt/hyn73bjx4kl6hjj9sxnf1yzh0000gn/T/scala-native-sources9991435057313360786/main.scala
Error: Unable to initialize main class scala.tools.nsc.Main
Caused by: java.lang.NoClassDefFoundError: scala/Function1
```

```
sbt:scala-native> tools3 / Test / test
...
java -cp "/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.1.3/scala3-library_3-3.1.3.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.8/scala-library-2.13.8.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.1.3/scala3-compiler_3-3.1.3.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-interfaces/3.1.3/scala3-interfaces-3.1.3.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/tasty-core_3/3.1.3/tasty-core_3-3.1.3.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-asm/9.2.0-scala-1/scala-asm-9.2.0-scala-1.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.3.5/compiler-interface-1.3.5.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-reader/3.19.0/jline-reader-3.19.0.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal/3.19.0/jline-terminal-3.19.0.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal-jna/3.19.0/jline-terminal-jna-3.19.0.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.7.0/protobuf-java-3.7.0.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.3.0/util-interface-1.3.0.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scaladoc_3/3.1.3/scaladoc_3-3.1.3.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-tasty-inspector_3/3.1.3/scala3-tasty-inspector_3-3.1.3.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark/0.42.12/flexmark-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-html-parser/0.42.12/flexmark-html-parser-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-anchorlink/0.42.12/flexmark-ext-anchorlink-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-autolink/0.42.12/flexmark-ext-autolink-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-emoji/0.42.12/flexmark-ext-emoji-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-gfm-strikethrough/0.42.12/flexmark-ext-gfm-strikethrough-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-gfm-tables/0.42.12/flexmark-ext-gfm-tables-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-gfm-tasklist/0.42.12/flexmark-ext-gfm-tasklist-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-wikilink/0.42.12/flexmark-ext-wikilink-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-yaml-front-matter/0.42.12/flexmark-ext-yaml-front-matter-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/nl/big-o/liqp/0.8.2/liqp-0.8.2.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jsoup/jsoup/1.14.3/jsoup-1.14.3.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.12.1/jackson-dataformat-yaml-2.12.1.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-util/0.42.12/flexmark-util-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-formatter/0.42.12/flexmark-formatter-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/nibor/autolink/autolink/0.6.0/autolink-0.6.0.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-jira-converter/0.42.12/flexmark-jira-converter-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/antlr/antlr4-runtime/4.7.2/antlr4-runtime-4.7.2.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.12.1/jackson-annotations-2.12.1.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.1/jackson-core-2.12.1.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.1/jackson-databind-2.12.1.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.12.1/jackson-datatype-jsr310-2.12.1.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/ua/co/k/strftime4j/1.0.5/strftime4j-1.0.5.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/yaml/snakeyaml/1.27/snakeyaml-1.27.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-tables/0.42.12/flexmark-ext-tables-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-ins/0.42.12/flexmark-ext-ins-0.42.12.jar:/Users/tanishiking/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/vladsch/flexmark/flexmark-ext-superscript/0.42.12/flexmark-ext-superscript-0.42.12.jar" dotty.tools.dotc.Main -d /var/folders/xt/hyn73bjx4kl6hjj9sxnf1yzh0000gn/T/native-test-out2314721634826001507 -Xplugin:/Users/tanishiking/ghq/github.com/tanishiking/scala-native/nscplugin/.3/target/scala-3.1.3/nscplugin_3.1.3-0.5.0-SNAPSHOT.jar /var/folders/xt/hyn73bjx4kl6hjj9sxnf1yzh0000gn/T/scala-native-sources15568193069608834895/file0.scala
Exception in thread "main" java.lang.NoClassDefFoundError: scala/runtime/LazyVals$
        at dotty.tools.dotc.core.Contexts$ContextBase.<clinit>(Contexts.scala:847)
        at dotty.tools.dotc.Driver.initCtx(Driver.scala:59)
        at dotty.tools.dotc.Driver.process(Driver.scala:158)
        at dotty.tools.dotc.Driver.process(Driver.scala:175)
        at dotty.tools.dotc.Driver.main(Driver.scala:205)
        at dotty.tools.dotc.Main.main(Main.scala)
Caused by: java.lang.ClassNotFoundException: scala.runtime.LazyVals$
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        ... 6 more
```


</deiltas>