### PR TITLE
Overhaul of `scala.scalanative.unsafe.{stackalloc,alloc}`

### DIFF
--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -721,7 +721,7 @@ object File {
         }
         fromCWideString(buff, StandardCharsets.UTF_16LE)
       } else {
-        val buff: CString = alloc[CChar](4096.toUInt)
+        val buff: CString = alloc[CChar](4096)
         if (getcwd(buff, 4095.toUInt) == 0.toUInt) {
           val errMsg = fromCString(string.strerror(errno.errno))
           throw new IOException(

--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -67,7 +67,7 @@ private[java] object IEEE754Helpers {
     if (nChars == 0)
       throw new NumberFormatException(exceptionMsg(s))
 
-    val cStr: CString = stackalloc[scala.Byte]((nChars + 1).toUInt)
+    val cStr: CString = stackalloc[scala.Byte](nChars + 1)
 
     if (_numericCharSeqToCString(s, nChars, cStr) == false) {
       throw new NumberFormatException(exceptionMsg(s))

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -48,8 +48,8 @@ private[lang] object StackTraceElement {
   object Fail extends scala.util.control.NoStackTrace
 
   def fromSymbol(sym: CString): StackTraceElement = {
-    val className: Ptr[CChar] = stackalloc[CChar](1024.toUSize)
-    val methodName: Ptr[CChar] = stackalloc[CChar](1024.toUSize)
+    val className: Ptr[CChar] = stackalloc[CChar](1024)
+    val methodName: Ptr[CChar] = stackalloc[CChar](1024)
     SymbolFormatter.asyncSafeFromSymbol(sym, className, methodName)
 
     new StackTraceElement(

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -15,7 +15,7 @@ private[lang] object StackTrace {
       cursor: Ptr[scala.Byte]
   )(implicit zone: Zone): StackTraceElement = {
     val nameMax = 1024
-    val name = alloc[CChar](nameMax.toUSize)
+    val name = alloc[CChar](nameMax)
     val offset = stackalloc[scala.Long]()
 
     unwind.get_proc_name(cursor, name, nameMax.toUSize, offset)

--- a/javalib/src/main/scala/java/lang/impl/PosixThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/PosixThread.scala
@@ -187,7 +187,7 @@ private[java] class PosixThread(val thread: Thread, stackSize: Long)
     import scala.scalanative.posix.pollEvents._
 
     type PipeFDs = CArray[CInt, Nat._2]
-    val pipefd = stackalloc[PipeFDs](1.toUInt)
+    val pipefd = stackalloc[PipeFDs](1)
     checkStatus("create sleep interrupt event") {
       pipe(pipefd.at(0))
     }

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -151,10 +151,10 @@ object UnixProcessGen1 {
     ProcessMonitor.waitForPid(pid, ts, res)
 
   def apply(builder: ProcessBuilder): Process = Zone { implicit z =>
-    val infds: Ptr[CInt] = stackalloc[CInt](2.toUInt)
-    val outfds: Ptr[CInt] = stackalloc[CInt](2.toUInt)
+    val infds: Ptr[CInt] = stackalloc[CInt](2)
+    val outfds: Ptr[CInt] = stackalloc[CInt](2)
     val errfds =
-      if (builder.redirectErrorStream()) outfds else stackalloc[CInt](2.toUInt)
+      if (builder.redirectErrorStream()) outfds else stackalloc[CInt](2)
 
     throwOnError(unistd.pipe(infds), s"Couldn't create pipe.")
     throwOnError(unistd.pipe(outfds), s"Couldn't create pipe.")
@@ -260,7 +260,7 @@ object UnixProcessGen1 {
   @inline private def nullTerminate(
       list: java.util.List[String]
   )(implicit z: Zone) = {
-    val res: Ptr[CString] = alloc[CString]((list.size() + 1).toUInt)
+    val res: Ptr[CString] = alloc[CString]((list.size() + 1))
     val li = list.listIterator()
     while (li.hasNext()) {
       !(res + li.nextIndex()) = toCString(li.next())

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -248,7 +248,7 @@ private[lang] class UnixProcessGen2 private (
       throw new IOException(msg)
     }
 
-    val fds = stackalloc[struct_pollfd](1.toUInt)
+    val fds = stackalloc[struct_pollfd](1)
     (fds + 0).fd = pidFd
     (fds + 0).events = (pollEvents.POLLIN | pollEvents.POLLRDNORM).toShort
 
@@ -373,11 +373,11 @@ object UnixProcessGen2 {
   }
 
   private def forkChild(builder: ProcessBuilder)(implicit z: Zone): Process = {
-    val infds: Ptr[CInt] = stackalloc[CInt](2.toUInt)
-    val outfds: Ptr[CInt] = stackalloc[CInt](2.toUInt)
+    val infds: Ptr[CInt] = stackalloc[CInt](2)
+    val outfds: Ptr[CInt] = stackalloc[CInt](2)
     val errfds =
       if (builder.redirectErrorStream()) outfds
-      else stackalloc[CInt](2.toUInt)
+      else stackalloc[CInt](2)
 
     throwOnError(unistd.pipe(infds), s"Couldn't create infds pipe.")
     throwOnError(unistd.pipe(outfds), s"Couldn't create outfds pipe.")
@@ -476,11 +476,11 @@ object UnixProcessGen2 {
   )(implicit z: Zone): Process = {
     val pidPtr = stackalloc[pid_t]()
 
-    val infds: Ptr[CInt] = stackalloc[CInt](2.toUInt)
-    val outfds: Ptr[CInt] = stackalloc[CInt](2.toUInt)
+    val infds: Ptr[CInt] = stackalloc[CInt](2)
+    val outfds: Ptr[CInt] = stackalloc[CInt](2)
     val errfds =
       if (builder.redirectErrorStream()) outfds
-      else stackalloc[CInt](2.toUInt)
+      else stackalloc[CInt](2)
 
     throwOnError(unistd.pipe(infds), s"Couldn't create infds pipe.")
     throwOnError(unistd.pipe(outfds), s"Couldn't create outfds pipe.")
@@ -661,7 +661,7 @@ object UnixProcessGen2 {
   private def nullTerminate(
       list: java.util.List[String]
   )(implicit z: Zone) = {
-    val res: Ptr[CString] = alloc[CString]((list.size() + 1).toUInt)
+    val res: Ptr[CString] = alloc[CString]((list.size() + 1))
     val li = list.listIterator()
     while (li.hasNext()) {
       !(res + li.nextIndex()) = toCString(li.next())

--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -226,7 +226,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     }
     val family =
       storage.asInstanceOf[Ptr[socket.sockaddr_storage]].ss_family.toInt
-    val ipstr: Ptr[CChar] = stackalloc[CChar](in.INET6_ADDRSTRLEN.toUSize)
+    val ipstr: Ptr[CChar] = stackalloc[CChar](in.INET6_ADDRSTRLEN)
 
     val (srcPtr, port) = if (family == socket.AF_INET) {
       val sa = storage.asInstanceOf[Ptr[in.sockaddr_in]]

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -125,7 +125,7 @@ object Inet6Address {
       val suffix =
         try {
           val ifIndex = Integer.parseInt(zi)
-          val ifName = stackalloc[Byte](IF_NAMESIZE.toUSize)
+          val ifName = stackalloc[Byte](IF_NAMESIZE)
           if (if_indextoname(ifIndex.toUInt, ifName) == stddef.NULL) zi
           else fromCString(ifName)
         } catch {

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -273,7 +273,7 @@ object InetAddress {
   private def formatIn4Addr(pb: Ptr[Byte]): String = {
     // By contract, pb isInstanceOf[Ptr[in_addr]]
     val dstSize = INET_ADDRSTRLEN
-    val dst = stackalloc[Byte](dstSize.toUSize)
+    val dst = stackalloc[Byte](dstSize)
 
     val result = inet_ntop(AF_INET, pb, dst, dstSize.toUInt)
 

--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -303,7 +303,7 @@ object NetworkInterface {
   }
 
   private def unixGetByIndex(index: Int): NetworkInterface = {
-    val buf = stackalloc[Byte](IF_NAMESIZE.toUInt)
+    val buf = stackalloc[Byte](IF_NAMESIZE)
 
     val ret = if_indextoname(index.toUInt, buf)
 

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -820,7 +820,7 @@ object Files {
             fromCWideString(buffer, StandardCharsets.UTF_16LE)
           }
         } else {
-          val buf: CString = alloc[Byte](limits.PATH_MAX.toUInt)
+          val buf: CString = alloc[Byte](limits.PATH_MAX)
           if (unistd.readlink(
                 toCString(link.toString),
                 buf,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystemProvider.scala
@@ -24,7 +24,7 @@ class UnixFileSystemProvider extends GenericFileSystemProvider {
   }
 
   private def getUserDir(): String = {
-    val buff: Ptr[CChar] = stackalloc[CChar](4096.toUInt)
+    val buff: Ptr[CChar] = stackalloc[CChar](4096)
     val res = unistd.getcwd(buff, 4095.toUInt)
     if (res == null)
       throw UnixException(

--- a/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -161,7 +161,7 @@ private object MacroImpl {
     size match {
       case lit @ Literal(Constant(size: Int)) =>
         if (size == 0)
-          c.error(c.enclosingPosition, "Allocatation of size 0 is fruitless")
+          c.error(c.enclosingPosition, "Allocation of size 0 is fruitless")
         else if (size < 0)
           c.error(
             c.enclosingPosition,

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
@@ -40,7 +40,7 @@ private object LazyVals {
     val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
     if (isMultithreadingEnabled) {
       // multi-threaded
-      val expected = stackalloc(sizeOf[Long])
+      val expected = stackalloc[Long]()
       storeLong(expected, e)
       atomic_compare_exchange_llong(bitmap, expected, n)
     } else {
@@ -56,7 +56,7 @@ private object LazyVals {
   def objCAS(objPtr: RawPtr, exp: Object, n: Object): Boolean = {
     if (isMultithreadingEnabled) {
       // multi-threaded
-      val expected = stackalloc(sizeOf[RawPtr])
+      val expected = stackalloc[RawPtr]()
       storeObject(expected, exp)
       atomic_compare_exchange_intptr(objPtr, expected, castObjectToRawPtr(n))
     } else {

--- a/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -116,7 +116,7 @@ private object UnsafePackageCompat {
     val validatedSize = size.asTerm match {
       case lit @ Literal(IntConstant(n)) =>
         if n == 0 then
-          report.errorAndAbort("Allocatation of size 0 is fruitless", size)
+          report.errorAndAbort("Allocation of size 0 is fruitless", size)
         else if n < 0 then
           report.errorAndAbort("Cannot allocate memory of negative size", size)
         else size

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -6,6 +6,7 @@ import scala.scalanative.unsigned._
 
 object Intrinsics {
 
+  def stackalloc(cls: Class[_], size: Any): RawPtr = intrinsic
   // /** Intrinsified stack allocation of n bytes. */
   // def stackalloc(ofSize: RawSize): RawPtr = intrinsic
 
@@ -13,12 +14,10 @@ object Intrinsics {
   // def stackalloc(ofSize: RawSize, elements: RawSize): RawPtr = intrinsic
 
   /** Intrinsified stack allocation of n bytes. */
-  def stackalloc[T]: RawPtr = intrinsic
-  def stackalloc(cls: Class[_]): RawPtr = intrinsic
+  def stackalloc[T](): RawPtr = intrinsic
 
   /** Intrinsified stack allocation of ofSize * elements bytes. */
   def stackalloc[T](size: RawSize): RawPtr = intrinsic
-  def stackalloc(cls: Class[_], size: RawSize): RawPtr = intrinsic
 
   /** Intrinsified unsigned devision on ints. */
   def divUInt(l: Int, r: Int): Int = intrinsic

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -12,6 +12,9 @@ object Intrinsics {
   /** Intrinsified stack allocation of n bytes. */
   def stackalloc(size: CSize): RawPtr = intrinsic
 
+  /** Intrinsified stack allocation of num * size bytes. */
+  def stackalloc(num: Long, size: RawSize): RawPtr = intrinsic
+
   /** Intrinsified unsigned devision on ints. */
   def divUInt(l: Int, r: Int): Int = intrinsic
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -5,13 +5,11 @@ import scalanative.unsafe._
 import scala.scalanative.unsigned._
 
 object Intrinsics {
-
-  def stackalloc(cls: Class[_], size: Any): RawPtr = intrinsic
-  // /** Intrinsified stack allocation of n bytes. */
-  // def stackalloc(ofSize: RawSize): RawPtr = intrinsic
-
-  // /** Intrinsified stack allocation of ofSize * elements bytes. */
-  // def stackalloc(ofSize: RawSize, elements: RawSize): RawPtr = intrinsic
+  object internal {
+    def stackalloc(cls: Class[_], size: Any): RawPtr = intrinsic
+    def alignmentOf(cls: Class[_]): RawSize = intrinsic
+    def sizeOf(cls: Class[_]): RawSize = intrinsic
+  }
 
   /** Intrinsified stack allocation of n bytes. */
   def stackalloc[T](): RawPtr = intrinsic
@@ -182,18 +180,8 @@ object Intrinsics {
   /** Intrinsified resolving of memory layout size of given type */
   def sizeOf[T]: RawSize = intrinsic
 
-  /** Internal intrinsified resolving of memory layout size of given type
-   *  Accepts only class literals. Whenever possible use `sizeOf[T]` instead
-   */
-  def sizeOf(cls: Class[_]): RawSize = intrinsic
-
   /** Intrinsified resolving of memory layout alignment of given type */
   def alignmentOf[T]: RawSize = intrinsic
-
-  /** Internal intrinsified resolving of memory layout alignment of given type
-   *  Accepts only class literals. Whenever possible use `alignment[T]` instead
-   */
-  def alignmentOf(cls: Class[_]): RawSize = intrinsic
 
   // Efficient intrinsic boxing of Scala primitives into unsigned type
   // Allows to skip unnecesary module and conversion methods, emits Op.Box(prim) instead

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -11,10 +11,10 @@ object Intrinsics {
     def sizeOf(cls: Class[_]): RawSize = intrinsic
   }
 
-  /** Intrinsified stack allocation of n bytes. */
+  /** Intrinsified stack allocation of sizeOf[T] bytes. */
   def stackalloc[T](): RawPtr = intrinsic
 
-  /** Intrinsified stack allocation of ofSize * elements bytes. */
+  /** Intrinsified stack allocation of sizeOf[T] * size bytes. */
   def stackalloc[T](size: RawSize): RawPtr = intrinsic
 
   /** Intrinsified unsigned devision on ints. */

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -6,14 +6,19 @@ import scala.scalanative.unsigned._
 
 object Intrinsics {
 
-  /** Intrinsified stack allocation of n bytes. */
-  def stackalloc(size: RawSize): RawPtr = intrinsic
+  // /** Intrinsified stack allocation of n bytes. */
+  // def stackalloc(ofSize: RawSize): RawPtr = intrinsic
+
+  // /** Intrinsified stack allocation of ofSize * elements bytes. */
+  // def stackalloc(ofSize: RawSize, elements: RawSize): RawPtr = intrinsic
 
   /** Intrinsified stack allocation of n bytes. */
-  def stackalloc(size: CSize): RawPtr = intrinsic
+  def stackalloc[T]: RawPtr = intrinsic
+  def stackalloc(cls: Class[_]): RawPtr = intrinsic
 
-  /** Intrinsified stack allocation of num * size bytes. */
-  def stackalloc(num: Long, size: RawSize): RawPtr = intrinsic
+  /** Intrinsified stack allocation of ofSize * elements bytes. */
+  def stackalloc[T](size: RawSize): RawPtr = intrinsic
+  def stackalloc(cls: Class[_], size: RawSize): RawPtr = intrinsic
 
   /** Intrinsified unsigned devision on ints. */
   def divUInt(l: Int, r: Int): Int = intrinsic

--- a/nativelib/src/main/scala/scala/scalanative/runtime/SymbolFormatter.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/SymbolFormatter.scala
@@ -20,8 +20,8 @@ object SymbolFormatter {
     var pos = 0
     val ident =
       fromRawPtr[CChar](
-        Intrinsics.stackalloc(
-          fromRawUSize(Intrinsics.sizeOf[CChar]) * 1024.toUSize
+        Intrinsics.stackalloc[CChar](
+          Intrinsics.castIntToRawSizeUnsigned(1024)
         )
       )
     classNameOut(0) = 0.toByte

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
@@ -109,7 +109,7 @@ private[runtime] final class BasicMonitor(val lockWordRef: RawPtr)
 
   @inline
   private def tryLock(threadId: ThreadId) = {
-    val expected = stackalloc(sizeOfPtr)
+    val expected = stackalloc[RawPtr]()
     // ThreadId set to 0, recursion set to 0
     storeRawSize(expected, castIntToRawSize(0))
     atomic_compare_exchange_intptr(

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
@@ -109,7 +109,7 @@ private[runtime] final class BasicMonitor(val lockWordRef: RawPtr)
 
   @inline
   private def tryLock(threadId: ThreadId) = {
-    val expected = stackalloc(new CSize(sizeOfPtr))
+    val expected = stackalloc(sizeOfPtr)
     // ThreadId set to 0, recursion set to 0
     storeRawSize(expected, castIntToRawSize(0))
     atomic_compare_exchange_intptr(

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
@@ -327,7 +327,7 @@ private[monitor] class ObjectMonitor() {
       expected: Thread,
       value: Thread
   ): Boolean = {
-    val expectedPtr = stackalloc(sizeOfPtr)
+    val expectedPtr = stackalloc[Ptr[_]]()
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(
       ownerThreadPtr,
@@ -340,7 +340,7 @@ private[monitor] class ObjectMonitor() {
       expected: Thread,
       value: Thread
   ): Boolean = {
-    val expectedPtr = stackalloc(sizeOfPtr)
+    val expectedPtr = stackalloc[Ptr[_]]()
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(
       activeWaiterThreadPtr,
@@ -354,13 +354,13 @@ private[monitor] class ObjectMonitor() {
       expected: WaiterNode,
       value: WaiterNode
   ): Boolean = {
-    val expectedPtr = stackalloc(sizeOfPtr)
+    val expectedPtr = stackalloc[Ptr[_]]()
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(ref, expectedPtr, castObjectToRawPtr(value))
   }
 
   private def acquireWaitList(): Unit = {
-    val expected = stackalloc(sizeOf[Byte])
+    val expected = stackalloc[Byte]()
     def tryAcquire() = {
       storeByte(expected, 0)
       atomic_compare_exchange_byte(

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
@@ -327,7 +327,7 @@ private[monitor] class ObjectMonitor() {
       expected: Thread,
       value: Thread
   ): Boolean = {
-    val expectedPtr = stackalloc(SizeOfPtr)
+    val expectedPtr = stackalloc(sizeOfPtr)
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(
       ownerThreadPtr,
@@ -340,7 +340,7 @@ private[monitor] class ObjectMonitor() {
       expected: Thread,
       value: Thread
   ): Boolean = {
-    val expectedPtr = stackalloc(SizeOfPtr)
+    val expectedPtr = stackalloc(sizeOfPtr)
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(
       activeWaiterThreadPtr,
@@ -354,7 +354,7 @@ private[monitor] class ObjectMonitor() {
       expected: WaiterNode,
       value: WaiterNode
   ): Boolean = {
-    val expectedPtr = stackalloc(SizeOfPtr)
+    val expectedPtr = stackalloc(sizeOfPtr)
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(ref, expectedPtr, castObjectToRawPtr(value))
   }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala
@@ -382,11 +382,11 @@ final class Size(private[scalanative] val rawSize: RawSize) {
 }
 
 object Size {
-  @inline implicit def byteToSize(x: Byte): Size = 
+  @inline implicit def fromByte(x: Byte): Size = 
     Size.valueOf(castIntToRawSize(x))
-  @inline implicit def shortToSize(x: Short): Size = 
+  @inline implicit def fromShort(x: Short): Size = 
     Size.valueOf(castIntToRawSize(x))
-  @inline implicit def intToSize(x: Int): Size = 
+  @inline implicit def fromInt(x: Int): Size = 
     Size.valueOf(castIntToRawSize(x))
 
   @inline def valueOf(rawSize: RawSize): Size = {

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala
@@ -381,9 +381,9 @@ final class USize(private[scalanative] val rawSize: RawSize) {
 }
 
 object USize {
-  @inline implicit def ubyteToUSize(x: UByte): USize = x.toUSize
-  @inline implicit def ushortToUSize(x: UShort): USize = x.toUSize
-  @inline implicit def uintToUSize(x: UInt): USize = x.toUSize
+  @inline implicit def fromUByte(x: UByte): USize = x.toUSize
+  @inline implicit def fromUShort(x: UShort): USize = x.toUSize
+  @inline implicit def fromUInt(x: UInt): USize = x.toUSize
 
   @inline def valueOf(rawSize: RawSize): USize = {
     import USizeCache.cache

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -24,6 +24,17 @@ trait NirDefinitions {
     lazy val RawSizeClass = getRequiredClass(
       "scala.scalanative.runtime.RawSize"
     )
+
+    lazy val USizeModule = getRequiredModule("scala.scalanative.unsigned.USize")
+    lazy val USize_fromUByte = getDecl(USizeModule, TermName("fromUByte"))
+    lazy val USize_fromUShort = getDecl(USizeModule, TermName("fromUShort"))
+    lazy val USize_fromUInt = getDecl(USizeModule, TermName("fromUInt"))
+
+    lazy val SizeModule = getRequiredModule("scala.scalanative.unsafe.Size")
+    lazy val Size_fromByte = getDecl(SizeModule, TermName("fromByte"))
+    lazy val Size_fromShort = getDecl(SizeModule, TermName("fromShort"))
+    lazy val Size_fromInt = getDecl(SizeModule, TermName("fromInt"))
+
     lazy val PtrClass = getRequiredClass("scala.scalanative.unsafe.Ptr")
     lazy val RawPtrClass = getRequiredClass("scala.scalanative.runtime.RawPtr")
 
@@ -103,6 +114,13 @@ trait NirDefinitions {
       getDecl(RuntimePackage, TermName("enterMonitor"))
     lazy val RuntimeExitMonitorMethod =
       getDecl(RuntimePackage, TermName("exitMonitor"))
+    lazy val RuntimePackage_fromRawSize =
+      getDecl(RuntimePackage, TermName("fromRawSize"))
+    lazy val RuntimePackage_fromRawUSize =
+      getDecl(RuntimePackage, TermName("fromRawUSize"))
+    lazy val RuntimePackage_toRawSizeAlts =
+      getDecl(RuntimePackage, TermName("toRawSize")).alternatives
+        .ensuring(_.size == 2)
 
     lazy val RuntimeTypeClass = getRequiredClass(
       "scala.scalanative.runtime.Type"
@@ -202,6 +220,8 @@ trait NirDefinitions {
       getMember(IntrinsicsModule, TermName("castLongToRawPtr"))
     lazy val StackallocMethods =
       getMember(IntrinsicsModule, TermName("stackalloc")).alternatives
+    lazy val StackallocRawMethod =
+      StackallocMethods.find(_.paramss.flatten.size == 2).get
     lazy val ClassFieldRawPtrMethod =
       getMember(IntrinsicsModule, TermName("classFieldRawPtr"))
     lazy val SizeOfMethods =

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -132,6 +132,8 @@ trait NirDefinitions {
     lazy val IntrinsicsModule = getRequiredModule(
       "scala.scalanative.runtime.Intrinsics"
     )
+    lazy val IntrinsicsInternalModule =
+      getMember(IntrinsicsModule, TermName("internal"))
     lazy val DivUIntMethod = getMember(IntrinsicsModule, TermName("divUInt"))
     lazy val DivULongMethod = getMember(IntrinsicsModule, TermName("divULong"))
     lazy val RemUIntMethod = getMember(IntrinsicsModule, TermName("remUInt"))
@@ -220,22 +222,18 @@ trait NirDefinitions {
       getMember(IntrinsicsModule, TermName("castLongToRawPtr"))
     lazy val StackallocMethods =
       getMember(IntrinsicsModule, TermName("stackalloc")).alternatives
-    lazy val StackallocRawMethod =
-      StackallocMethods.find(_.paramss.flatten.size == 2).get
+    lazy val StackallocInternalMethod =
+      getMember(IntrinsicsInternalModule, TermName("stackalloc"))
     lazy val ClassFieldRawPtrMethod =
       getMember(IntrinsicsModule, TermName("classFieldRawPtr"))
-    lazy val SizeOfMethods =
-      getMember(IntrinsicsModule, TermName("sizeOf")).alternatives
     lazy val SizeOfMethod =
-      SizeOfMethods.find(_.paramss.flatten.nonEmpty).get
-    lazy val SizeOfTypeMethod =
-      SizeOfMethods.find(_.paramss.flatten.isEmpty).get
-    lazy val AlignmentOfMethods =
-      getMember(IntrinsicsModule, TermName("alignmentOf")).alternatives
+      getMember(IntrinsicsModule, TermName("sizeOf"))
+    lazy val SizeOfInternalMethod =
+      getMember(IntrinsicsInternalModule, TermName("sizeOf"))
     lazy val AlignmentOfMethod =
-      AlignmentOfMethods.find(_.paramss.flatten.nonEmpty).get
-    lazy val AlignmentOfTypeMethod =
-      AlignmentOfMethods.find(_.paramss.flatten.isEmpty).get
+      getMember(IntrinsicsModule, TermName("alignmentOf"))
+    lazy val AlignmentOfInternalMethod =
+      getMember(IntrinsicsInternalModule, TermName("alignmentOf"))
 
     lazy val CFuncPtrApplyMethods = CFuncPtrNClass.map(
       getMember(_, TermName("apply"))

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1954,31 +1954,76 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     ): Val =
       castConv(fromty, toty).fold(value)(buf.conv(_, toty, value, unwind))
 
-    def getUnboxedSize(sizep: Tree)(implicit pos: Position): Val = {
-      val size = genExpr(sizep)
-      val sizeTy = Type.normalize(size.ty)
-      if (Type.isSizeBox(sizeTy))
-        buf.unbox(sizeTy, size, unwind)(sizep.pos)
-      else {
-        assert(Type.box.contains(sizeTy), s"Not a primitive type: ${sizeTy}")
-        if (sizeTy != nir.Type.Size)
-          buf.conv(Conv.SSizeCast, nir.Type.Size, size, unwind)(pos)
-        else size
-      }
+    private lazy val optimizedFunctions = {
+      // Included functions should be pure, and should not not narrow the result type
+      Set[Symbol](
+        CastIntToRawSize,
+        CastIntToRawSizeUnsigned,
+        CastLongToRawSize,
+        CastRawSizeToInt,
+        CastRawSizeToLong,
+        CastRawSizeToLongUnsigned,
+        Size_fromByte,
+        Size_fromShort,
+        Size_fromInt,
+        USize_fromUByte,
+        USize_fromUShort,
+        USize_fromUInt,
+        RuntimePackage_fromRawSize,
+        RuntimePackage_fromRawUSize
+      ) ++ UnsignedOfMethods ++ RuntimePackage_toRawSizeAlts
     }
 
-    def genStackalloc(app: Apply): Val = app match {
-      case Apply(_, Seq(sizep)) =>
-        val unboxed = getUnboxedSize(sizep)(app.pos)
-        buf.stackalloc(nir.Type.Byte, unboxed, unwind)(app.pos)
-      case Apply(_, Seq(nump, sizep)) =>
-        val num = getUnboxedSize(nump)(app.pos)
-        val size = getUnboxedSize(sizep)(app.pos)
-        val total =
-          buf.bin(nir.Bin.Imul, nir.Type.Size, num, size, unwind)(app.pos)
-        buf.stackalloc(nir.Type.Byte, total, unwind)(app.pos)
-      case _ => ???
+    private def getUnboxedSize(sizep: Tree)(implicit pos: nir.Position): Val =
+      sizep match {
+        // Optimize call, strip numeric conversions
+        case Literal(Constant(size: Int)) => Val.Size(size)
+        case Block(Nil, expr)             => getUnboxedSize(expr)
+        case Apply(fun, List(arg))
+            if optimizedFunctions.contains(fun.symbol) ||
+              arg.symbol.exists && optimizedFunctions.contains(arg.symbol) =>
+          getUnboxedSize(arg)
+        case Typed(expr, _) => getUnboxedSize(expr)
+        case _              =>
+          // actual unboxing
+          val size = genExpr(sizep)
+          val sizeTy = Type.normalize(size.ty)
+          val unboxed =
+            if (Type.unbox.contains(sizeTy)) buf.unbox(sizeTy, size, unwind)
+            else if (Type.box.contains(sizeTy)) size
+            else {
+              reporter.error(
+                sizep.pos,
+                s"Invalid usage of Intrinsic.stackalloc, argument is not an integer type: ${sizeTy}"
+              )
+              Val.Size(0)
+            }
 
+          if (unboxed.ty == nir.Type.Size) unboxed
+          else buf.conv(Conv.SSizeCast, nir.Type.Size, unboxed, unwind)
+      }
+
+    private def genStackalloc(app: Apply): Val = app match {
+      case Apply(_, args) => {
+        implicit val pos: nir.Position = app.pos
+        val tpe = app.attachments
+          .get[NonErasedType]
+          .map(v => genType(v.tpe, deconstructValueTypes = true))
+          .getOrElse {
+            reporter.error(
+              app.pos,
+              "Not found type attachment for stackalloc operation, report it as a bug."
+            )
+            Type.Nothing
+          }
+
+        val size = args match {
+          case Seq()         => Val.Size(1)
+          case Seq(sizep)    => getUnboxedSize(sizep)
+          case Seq(_, sizep) => getUnboxedSize(sizep)
+        }
+        buf.stackalloc(tpe, size, unwind)
+      }
     }
 
     def genCQuoteOp(app: Apply): Val = {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1954,20 +1954,31 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     ): Val =
       castConv(fromty, toty).fold(value)(buf.conv(_, toty, value, unwind))
 
-    def genStackalloc(app: Apply): Val = {
-      val Apply(_, Seq(sizep)) = app
-
+    def getUnboxedSize(sizep: Tree)(implicit pos: Position): Val = {
       val size = genExpr(sizep)
       val sizeTy = Type.normalize(size.ty)
-      val unboxed =
-        if (Type.isSizeBox(sizeTy))
-          buf.unbox(sizeTy, size, unwind)(sizep.pos)
-        else {
-          assert(Type.box.contains(sizeTy), s"Not a primitive type: ${sizeTy}")
-          size
-        }
+      if (Type.isSizeBox(sizeTy))
+        buf.unbox(sizeTy, size, unwind)(sizep.pos)
+      else {
+        assert(Type.box.contains(sizeTy), s"Not a primitive type: ${sizeTy}")
+        if (sizeTy != nir.Type.Size)
+          buf.conv(Conv.SSizeCast, nir.Type.Size, size, unwind)(pos)
+        else size
+      }
+    }
 
-      buf.stackalloc(nir.Type.Byte, unboxed, unwind)(app.pos)
+    def genStackalloc(app: Apply): Val = app match {
+      case Apply(_, Seq(sizep)) =>
+        val unboxed = getUnboxedSize(sizep)(app.pos)
+        buf.stackalloc(nir.Type.Byte, unboxed, unwind)(app.pos)
+      case Apply(_, Seq(nump, sizep)) =>
+        val num = getUnboxedSize(nump)(app.pos)
+        val size = getUnboxedSize(sizep)(app.pos)
+        val total =
+          buf.bin(nir.Bin.Imul, nir.Type.Size, num, size, unwind)(app.pos)
+        buf.stackalloc(nir.Type.Byte, total, unwind)(app.pos)
+      case _ => ???
+
     }
 
     def genCQuoteOp(app: Apply): Val = {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -134,6 +134,7 @@ abstract class NirPrimitives {
     addPrimitive(Array_clone, ARRAY_CLONE)
     addPrimitive(CQuoteMethod, CQUOTE)
     addPrimitives(StackallocMethods, STACKALLOC)
+    addPrimitive(StackallocInternalMethod, STACKALLOC)
     addPrimitive(DivUIntMethod, DIV_UINT)
     addPrimitive(DivULongMethod, DIV_ULONG)
     addPrimitive(RemUIntMethod, REM_UINT)
@@ -194,7 +195,7 @@ abstract class NirPrimitives {
     addPrimitives(CFuncPtrApplyMethods, CFUNCPTR_APPLY)
     addPrimitives(CFuncPtrFromFunctionMethods, CFUNCPTR_FROM_FUNCTION)
     addPrimitive(ClassFieldRawPtrMethod, CLASS_FIELD_RAWPTR)
-    addPrimitives(SizeOfMethods, SIZE_OF)
-    addPrimitives(AlignmentOfMethods, ALIGNMENT_OF)
+    addPrimitive(SizeOfInternalMethod, SIZE_OF)
+    addPrimitive(AlignmentOfInternalMethod, ALIGNMENT_OF)
   }
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -132,6 +132,12 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
             .updateAttachment(NonErasedType(tpe))
             .setPos(tree.pos)
 
+        case Apply(fun, args) if StackallocMethods.contains(fun.symbol) =>
+          val tpe = fun match {
+            case TypeApply(_, Seq(argTpe)) => widenDealiasType(argTpe.tpe)
+          }
+          tree.updateAttachment(NonErasedType(tpe))
+
         // Catch the definition of scala.Enumeration itself
         case cldef: ClassDef if cldef.symbol == EnumerationClass =>
           enterOwner(OwnerKind.EnumImpl) { super.transform(cldef) }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -112,22 +112,22 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
           }
 
         // sizeOf[T] -> sizeOf(classOf[T]) + attachment
-        case TypeApply(fun, List(tpeArg)) if fun.symbol == SizeOfTypeMethod =>
+        case TypeApply(fun, List(tpeArg)) if fun.symbol == SizeOfMethod =>
           val tpe = widenDealiasType(tpeArg.tpe)
           typer
             .typed {
-              Apply(SizeOfMethod, Literal(Constant(tpe)))
+              Apply(SizeOfInternalMethod, Literal(Constant(tpe)))
             }
             .updateAttachment(NonErasedType(tpe))
             .setPos(tree.pos)
 
         // alignmentOf[T] -> alignmentOf(classOf[T]) + attachment
         case TypeApply(fun, List(tpeArg))
-            if fun.symbol == AlignmentOfTypeMethod =>
+            if fun.symbol == AlignmentOfMethod =>
           val tpe = widenDealiasType(tpeArg.tpe)
           typer
             .typed {
-              Apply(AlignmentOfMethod, Literal(Constant(tpe)))
+              Apply(AlignmentOfInternalMethod, Literal(Constant(tpe)))
             }
             .updateAttachment(NonErasedType(tpe))
             .setPos(tree.pos)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -122,8 +122,7 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
             .setPos(tree.pos)
 
         // alignmentOf[T] -> alignmentOf(classOf[T]) + attachment
-        case TypeApply(fun, List(tpeArg))
-            if fun.symbol == AlignmentOfMethod =>
+        case TypeApply(fun, List(tpeArg)) if fun.symbol == AlignmentOfMethod =>
           val tpe = widenDealiasType(tpeArg.tpe)
           typer
             .typed {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -135,6 +135,11 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
           val tpe = fun match {
             case TypeApply(_, Seq(argTpe)) => widenDealiasType(argTpe.tpe)
           }
+          if (tpe.isAny || tpe.isNothing)
+            reporter.error(
+              tree.pos,
+              s"Stackalloc requires concreate type, but ${show(tpe)} found"
+            )
           tree.updateAttachment(NonErasedType(tpe))
 
         // Catch the definition of scala.Enumeration itself

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -138,7 +138,7 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
           if (tpe.isAny || tpe.isNothing)
             reporter.error(
               tree.pos,
-              s"Stackalloc requires concreate type, but ${show(tpe)} found"
+              s"Stackalloc requires concrete type, but ${show(tpe)} found"
             )
           tree.updateAttachment(NonErasedType(tpe))
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -88,7 +88,7 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val RuntimePackage_exitMonitor = RuntimePackageClass.requiredMethod("exitMonitor")
   @tu lazy val RuntimePackage_fromRawSize = RuntimePackageClass.requiredMethod("fromRawSize")
   @tu lazy val RuntimePackage_fromRawUSize = RuntimePackageClass.requiredMethod("fromRawUSize")
-  
+
   @tu lazy val RuntimePackage_toRawSizeAlts = RuntimePackageClass.info
     .member(termName("toRawSize"))
     .alternatives
@@ -103,6 +103,7 @@ final class NirDefinitions()(using ctx: Context) {
 
   // Runtime intriniscs
   @tu lazy val IntrinsicsModule = requiredModule("scala.scalanative.runtime.Intrinsics")
+  @tu lazy val IntrinsicsInternalModule = requiredModule("scala.scalanative.runtime.Intrinsics.internal")
   @tu lazy val Intrinsics_divUInt = IntrinsicsModule.requiredMethod("divUInt")
   @tu lazy val Intrinsics_divULong = IntrinsicsModule.requiredMethod("divULong")
   @tu lazy val Intrinsics_remUInt = IntrinsicsModule.requiredMethod("remUInt")
@@ -159,23 +160,13 @@ final class NirDefinitions()(using ctx: Context) {
     .member(termName("stackalloc"))
     .alternatives
     .map(_.symbol)
-    .ensuring(_.size == 3)
+    .ensuring(_.size == 2)
+  @tu lazy val IntrinsicsInternal_stackalloc = IntrinsicsInternalModule.requiredMethod("stackalloc")
   @tu lazy val Intrinsics_classFieldRawPtr = IntrinsicsModule.requiredMethod("classFieldRawPtr")
-  @tu lazy val Intrinsics_sizeOfAlts = IntrinsicsModule.info
-    .member(termName("sizeOf"))
-    .alternatives
-    .map(_.symbol)
-    .ensuring(_.size == 2)
-  @tu lazy val Intrinsics_sizeOf = Intrinsics_sizeOfAlts.find(_.info.paramInfoss.flatten.nonEmpty).get
-  @tu lazy val Intrinsics_sizeOfType = Intrinsics_sizeOfAlts.find(_.info.paramInfoss.flatten.isEmpty).get
-  @tu lazy val Intrinsics_alignmentOfAlts = IntrinsicsModule.info
-    .member(termName("alignmentOf"))
-    .alternatives
-    .map(_.symbol)
-    .ensuring(_.size == 2)
-  @tu lazy val Intrinsics_alignmentOf = Intrinsics_alignmentOfAlts.find(_.info.paramInfoss.flatten.nonEmpty).get
-  @tu lazy val Intrinsics_alignmentOfType = Intrinsics_alignmentOfAlts.find(_.info.paramInfoss.flatten.isEmpty).get
-
+  @tu lazy val Intrinsics_sizeOf = IntrinsicsModule.requiredMethod("sizeOf")
+  @tu lazy val IntrinsicsInternal_sizeOf = IntrinsicsInternalModule.requiredMethod("sizeOf")
+  @tu lazy val Intrinsics_alignmentOf = IntrinsicsModule.requiredMethod("alignmentOf")
+  @tu lazy val IntrinsicsInternal_alignmentOf = IntrinsicsInternalModule.requiredMethod("alignmentOf")
   @tu lazy val Intrinsics_unsignedOfAlts =
     IntrinsicsModule.info
       .member(termName("unsignedOf"))

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -141,7 +141,7 @@ final class NirDefinitions()(using ctx: Context) {
     .member(termName("stackalloc"))
     .alternatives
     .map(_.symbol)
-    .ensuring(_.size == 2)
+    .ensuring(_.size == 3)
   @tu lazy val Intrinsics_classFieldRawPtr = IntrinsicsModule.requiredMethod("classFieldRawPtr")
   @tu lazy val Intrinsics_sizeOfAlts = IntrinsicsModule.info
     .member(termName("sizeOf"))

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -45,6 +45,16 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val USizeClass = requiredClass("scala.scalanative.unsigned.USize")
   @tu lazy val RawSizeClass = requiredClass("scala.scalanative.runtime.RawSize")
 
+  @tu lazy val USizeModule = requiredModule("scala.scalanative.unsigned.USize")
+  @tu lazy val USize_fromUByte = USizeModule.requiredMethod("fromUByte")
+  @tu lazy val USize_fromUShort = USizeModule.requiredMethod("fromUShort")
+  @tu lazy val USize_fromUInt = USizeModule.requiredMethod("fromUInt")
+
+  @tu lazy val SizeModule = requiredModule("scala.scalanative.unsafe.Size")
+  @tu lazy val Size_fromByte = SizeModule.requiredMethod("fromByte")
+  @tu lazy val Size_fromShort = SizeModule.requiredMethod("fromShort")
+  @tu lazy val Size_fromInt = SizeModule.requiredMethod("fromInt")
+
   // Pointers
   @tu lazy val PtrClass = requiredClass("scala.scalanative.unsafe.Ptr")
   @tu lazy val RawPtrClass = requiredClass("scala.scalanative.runtime.RawPtr")
@@ -76,6 +86,14 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val RuntimePackageClass = requiredModule("scala.scalanative.runtime.package")
   @tu lazy val RuntimePackage_enterMonitor = RuntimePackageClass.requiredMethod("enterMonitor")
   @tu lazy val RuntimePackage_exitMonitor = RuntimePackageClass.requiredMethod("exitMonitor")
+  @tu lazy val RuntimePackage_fromRawSize = RuntimePackageClass.requiredMethod("fromRawSize")
+  @tu lazy val RuntimePackage_fromRawUSize = RuntimePackageClass.requiredMethod("fromRawUSize")
+  
+  @tu lazy val RuntimePackage_toRawSizeAlts = RuntimePackageClass.info
+    .member(termName("toRawSize"))
+    .alternatives
+    .map(_.symbol)
+    .ensuring(_.size == 2)
 
   @tu lazy val RuntimeSafeZoneAllocatorModuleRef = requiredModuleRef("scala.scalanative.runtime.SafeZoneAllocator")
   @tu lazy val RuntimeSafeZoneAllocatorModule = RuntimeSafeZoneAllocatorModuleRef.symbol

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2179,19 +2179,33 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    private def genStackalloc(app: Apply): Val = {
-      val Apply(_, Seq(sizep)) = app
-
+    private def getUnboxedSize(sizep: Tree)(implicit pos: Position): Val = {
       val size = genExpr(sizep)
       val sizeTy = Type.normalize(size.ty)
-      val unboxed =
-        if Type.isSizeBox(sizeTy) then
-          buf.unbox(sizeTy, size, unwind)(using sizep.span)
-        else
-          assert(Type.box.contains(sizeTy), s"Not a primitive type: ${sizeTy}")
-          size
+      println(s"getting unboxed size $size ($sizeTy) from ${sizep}")
+      if Type.isSizeBox(sizeTy) then
+        buf.unbox(sizeTy, size, unwind)(using sizep.span)
+      else
+        assert(Type.box.contains(sizeTy), s"Not a primitive type: ${sizeTy}")
+        if sizeTy != nir.Type.Size then
+          // (nir.Type.Long, nir.Type.Size, Conv.SSizeCast)
+          buf.conv(Conv.SSizeCast, nir.Type.Size, size, unwind)
+        else size
+    }
 
-      buf.stackalloc(nir.Type.Byte, unboxed, unwind)(using app.span)
+    private def genStackalloc(app: Apply): Val = app match {
+      case Apply(_, Seq(sizep)) =>
+        val unboxed = getUnboxedSize(sizep)(using app.span)
+        buf.stackalloc(nir.Type.Byte, unboxed, unwind)(using app.span)
+      case Apply(_, Seq(nump, sizep)) =>
+        val num = getUnboxedSize(nump)(using app.span)
+        val size = getUnboxedSize(sizep)(using app.span)
+        val total =
+          buf.bin(nir.Bin.Imul, nir.Type.Size, num, size, unwind)(using
+            app.span
+          )
+        buf.stackalloc(nir.Type.Byte, total, unwind)(using app.span)
+      case _ => ???
     }
 
     def genSafeZoneAlloc(app: Apply): Val = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2188,7 +2188,6 @@ trait NirGenExpr(using Context) {
       else
         assert(Type.box.contains(sizeTy), s"Not a primitive type: ${sizeTy}")
         if sizeTy != nir.Type.Size then
-          // (nir.Type.Long, nir.Type.Size, Conv.SSizeCast)
           buf.conv(Conv.SSizeCast, nir.Type.Size, size, unwind)
         else size
     }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -32,6 +32,8 @@ import scala.scalanative.util.unsupported
 import scala.scalanative.util.StringUtils
 import dotty.tools.dotc.ast.desugar
 import dotty.tools.dotc.util.Property
+import scala.scalanative.nscplugin.NirDefinitions.NonErasedType
+import scala.scalanative.util.unreachable
 
 trait NirGenExpr(using Context) {
   self: NirCodeGen =>
@@ -2179,32 +2181,76 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    private def getUnboxedSize(sizep: Tree)(implicit pos: Position): Val = {
-      val size = genExpr(sizep)
-      val sizeTy = Type.normalize(size.ty)
-      println(s"getting unboxed size $size ($sizeTy) from ${sizep}")
-      if Type.isSizeBox(sizeTy) then
-        buf.unbox(sizeTy, size, unwind)(using sizep.span)
-      else
-        assert(Type.box.contains(sizeTy), s"Not a primitive type: ${sizeTy}")
-        if sizeTy != nir.Type.Size then
-          buf.conv(Conv.SSizeCast, nir.Type.Size, size, unwind)
-        else size
+    private lazy val optimizedFunctions = {
+      // Included functions should be pure, and should not not narrow the result type
+      Set[Symbol](
+        defnNir.Intrinsics_castIntToRawSize,
+        defnNir.Intrinsics_castIntToRawSizeUnsigned,
+        defnNir.Intrinsics_castLongToRawSize,
+        defnNir.Intrinsics_castRawSizeToInt,
+        defnNir.Intrinsics_castRawSizeToLong,
+        defnNir.Intrinsics_castRawSizeToLongUnsigned,
+        defnNir.Size_fromByte,
+        defnNir.Size_fromShort,
+        defnNir.Size_fromInt,
+        defnNir.USize_fromUByte,
+        defnNir.USize_fromUShort,
+        defnNir.USize_fromUInt,
+        defnNir.RuntimePackage_fromRawSize,
+        defnNir.RuntimePackage_fromRawUSize
+      ) ++ defnNir.Intrinsics_unsignedOfAlts ++ defnNir.RuntimePackage_toRawSizeAlts
     }
 
-    private def genStackalloc(app: Apply): Val = app match {
-      case Apply(_, Seq(sizep)) =>
-        val unboxed = getUnboxedSize(sizep)(using app.span)
-        buf.stackalloc(nir.Type.Byte, unboxed, unwind)(using app.span)
-      case Apply(_, Seq(nump, sizep)) =>
-        val num = getUnboxedSize(nump)(using app.span)
-        val size = getUnboxedSize(sizep)(using app.span)
-        val total =
-          buf.bin(nir.Bin.Imul, nir.Type.Size, num, size, unwind)(using
-            app.span
+    private def getUnboxedSize(sizep: Tree)(using Position): Val =
+      sizep match {
+        // Optimize call, strip numeric conversions
+        case Literal(Constant(size: Int)) => Val.Size(size)
+        case Block(Nil, expr)             => getUnboxedSize(expr)
+        case Apply(fun, List(arg))
+            if optimizedFunctions.contains(fun.symbol) ||
+              arg.symbol.exists && optimizedFunctions.contains(arg.symbol) =>
+          getUnboxedSize(arg)
+        case Typed(expr, _) => getUnboxedSize(expr)
+        case _              =>
+          // actual unboxing
+          val size = genExpr(sizep)
+          val sizeTy = Type.normalize(size.ty)
+          val unboxed =
+            if Type.unbox.contains(sizeTy) then buf.unbox(sizeTy, size, unwind)
+            else if Type.box.contains(sizeTy) then size
+            else {
+              report.error(
+                s"Invalid usage of Intrinsic.stackalloc, argument is not an integer type: ${sizeTy}",
+                sizep.srcPos
+              )
+              Val.Size(0)
+            }
+
+          if (unboxed.ty == nir.Type.Size) unboxed
+          else buf.conv(Conv.SSizeCast, nir.Type.Size, unboxed, unwind)
+      }
+
+    def genStackalloc(app: Apply): Val = {
+      given nir.Position = app.span
+      val Apply(_, args) = app
+      val tpe = app
+        .getAttachment(NonErasedType)
+        .map(genType(_, deconstructValueTypes = true))
+        .getOrElse {
+          report.error(
+            "Not found type attachment for stackalloc operation, report it as a bug.",
+            app.srcPos
           )
-        buf.stackalloc(nir.Type.Byte, total, unwind)(using app.span)
-      case _ => ???
+          Type.Nothing
+        }
+
+      val size = args match {
+        case Seq()         => Val.Size(1)
+        case Seq(sizep)    => getUnboxedSize(sizep)
+        case Seq(_, sizep) => getUnboxedSize(sizep)
+        case _             => scalanative.util.unreachable
+      }
+      buf.stackalloc(tpe, size, unwind)
     }
 
     def genSafeZoneAlloc(app: Apply): Val = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -155,6 +155,7 @@ class NirPrimitives(using ctx: Context) extends DottyPrimitives(ctx) {
     addPrimitive(defn.Array_clone, ARRAY_CLONE)
     addPrimitive(defnNir.CQuote_c, CQUOTE)
     addPrimitives(defnNir.Intrinsics_stackallocAlts, STACKALLOC)
+    addPrimitive(defnNir.IntrinsicsInternal_stackalloc, STACKALLOC)
     addPrimitive(defnNir.Intrinsics_divUInt, DIV_UINT)
     addPrimitive(defnNir.Intrinsics_divULong, DIV_ULONG)
     addPrimitive(defnNir.Intrinsics_remUInt, REM_UINT)
@@ -211,8 +212,8 @@ class NirPrimitives(using ctx: Context) extends DottyPrimitives(ctx) {
     addPrimitives(defnNir.CFuncPtr_apply, CFUNCPTR_APPLY)
     addPrimitives(defnNir.CFuncPtr_fromScalaFunction, CFUNCPTR_FROM_FUNCTION)
     addPrimitive(defnNir.Intrinsics_classFieldRawPtr, CLASS_FIELD_RAWPTR)
-    addPrimitives(defnNir.Intrinsics_sizeOfAlts, SIZE_OF)
-    addPrimitives(defnNir.Intrinsics_alignmentOfAlts, ALIGNMENT_OF)
+    addPrimitive(defnNir.IntrinsicsInternal_sizeOf, SIZE_OF)
+    addPrimitive(defnNir.IntrinsicsInternal_alignmentOf, ALIGNMENT_OF)
     addPrimitive(
       defnNir.ReflectSelectable_selectDynamic,
       REFLECT_SELECTABLE_SELECTDYN

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
@@ -84,21 +84,21 @@ class PostInlineNativeInterop extends PluginPhase {
 
     // sizeOf[T] -> sizeOf(classOf[T])
     fun.symbol match
-      case defnNir.Intrinsics_sizeOfType =>
+      case defnNir.Intrinsics_sizeOf =>
         val tpe = dealiasTypeMapper(tArgs.head.tpe)
         cpy
           .Apply(tree)(
-            ref(defnNir.Intrinsics_sizeOf),
+            ref(defnNir.IntrinsicsInternal_sizeOf),
             List(Literal(Constant(tpe)))
           )
           .withAttachment(NirDefinitions.NonErasedType, tpe)
 
       // alignmentOf[T] -> alignmentOf(classOf[T])
-      case defnNir.Intrinsics_alignmentOfType =>
+      case defnNir.Intrinsics_alignmentOf =>
         val tpe = dealiasTypeMapper(tArgs.head.tpe)
         cpy
           .Apply(tree)(
-            ref(defnNir.Intrinsics_alignmentOf),
+            ref(defnNir.IntrinsicsInternal_alignmentOf),
             List(Literal(Constant(tpe)))
           )
           .withAttachment(NirDefinitions.NonErasedType, tpe)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
@@ -10,10 +10,10 @@ import core.Definitions
 import core.Names._
 import core.Symbols._
 import core.Types._
+import core.Flags._
 import core.StdNames._
 import core.Constants.Constant
 import NirGenUtil.ContextCached
-import dotty.tools.dotc.core.Flags
 
 /** This phase does:
  *    - handle TypeApply -> Apply conversion for intrinsic methods
@@ -71,7 +71,9 @@ class PostInlineNativeInterop extends PluginPhase {
         val tpe = fun match {
           case TypeApply(_, Seq(argTpe)) => dealiasTypeMapper(argTpe.tpe)
         }
-        if (tpe.isAny || tpe.isNothingType || tpe.isNullType || tpe.typeSymbol.isAbstractOrAliasType)
+        val tpeSym = tpe.typeSymbol
+        if (tpe.isAny || tpe.isNothingType || tpe.isNullType ||
+            tpeSym.isAbstractType && !tpeSym.isAllOf(DeferredType | TypeParam))
           report.error(
             s"Stackalloc requires concreate type but ${tpe.show} found",
             tree.srcPos

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
@@ -66,6 +66,13 @@ class PostInlineNativeInterop extends PluginPhase {
             dealiasTypeMapper(tree.tpe.finalResultType)
         tree.withAttachment(NirDefinitions.NonErasedTypes, paramTypes)
 
+      case Apply(fun, args)
+          if defnNir.Intrinsics_stackallocAlts.contains(fun.symbol) =>
+        val tpe = fun match {
+          case TypeApply(_, Seq(argTpe)) => dealiasTypeMapper(argTpe.tpe)
+        }
+        tree.withAttachment(NirDefinitions.NonErasedType, tpe)
+
       case _ => tree
 
   }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
@@ -71,6 +71,11 @@ class PostInlineNativeInterop extends PluginPhase {
         val tpe = fun match {
           case TypeApply(_, Seq(argTpe)) => dealiasTypeMapper(argTpe.tpe)
         }
+        if (tpe.isAny || tpe.isNothingType || tpe.isNullType || tpe.typeSymbol.isAbstractOrAliasType)
+          report.error(
+            s"Stackalloc requires concreate type but ${tpe.show} found",
+            tree.srcPos
+          )
         tree.withAttachment(NirDefinitions.NonErasedType, tpe)
 
       case _ => tree

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInteropLate.scala
@@ -75,7 +75,7 @@ class PostInlineNativeInterop extends PluginPhase {
         if (tpe.isAny || tpe.isNothingType || tpe.isNullType ||
             tpeSym.isAbstractType && !tpeSym.isAllOf(DeferredType | TypeParam))
           report.error(
-            s"Stackalloc requires concreate type but ${tpe.show} found",
+            s"Stackalloc requires concrete type but ${tpe.show} found",
             tree.srcPos
           )
         tree.withAttachment(NirDefinitions.NonErasedType, tpe)

--- a/nscplugin/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
@@ -1,0 +1,113 @@
+package scala.scalanative.unsafe
+
+import java.nio.file.Files
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalanative.api.CompilationFailedException
+import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
+import scala.scalanative.NIRCompiler
+
+class StackallocTest {
+  val StackallocConcreateType = "Stackalloc requires concreate type"
+  @Test def stackallocNoType(): Unit = {
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () =>
+        NIRCompiler(
+          _.compile(
+            """import scala.scalanative.unsafe._
+          |object Test {
+          |  val x = stackalloc()
+          |}""".stripMargin
+          )
+        )
+    )
+    assertTrue(err.getMessage().contains(StackallocConcreateType))
+  }
+
+  @Test def stackallocInferedType(): Unit = NIRCompiler(
+    _.compile(
+      """import scala.scalanative.unsafe._
+          |object Test {
+          |  val x: Ptr[Int] = stackalloc()
+          |  val y: Ptr[Ptr[_]] = stackalloc(10)
+          |}""".stripMargin
+    )
+  )
+
+  @Test def stackallocAny(): Unit = {
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () =>
+        NIRCompiler(
+          _.compile(
+            """import scala.scalanative.unsafe._
+          |object Test {
+          |  val x = stackalloc[Any](10)
+          |}""".stripMargin
+          )
+        )
+    )
+    assertTrue(err.getMessage().contains(StackallocConcreateType))
+  }
+
+  @Test def stackallocNothing(): Unit = {
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () =>
+        NIRCompiler(
+          _.compile(
+            """import scala.scalanative.unsafe._
+          |object Test {
+          |  val x = stackalloc[Nothing](10)
+          |}""".stripMargin
+          )
+        )
+    )
+    assertTrue(err.getMessage().contains(StackallocConcreateType))
+  }
+
+  @Test def stackallocAnyAlias(): Unit = {
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () =>
+        NIRCompiler(
+          _.compile(
+            """import scala.scalanative.unsafe._
+          |object Test {
+          |  type A = Any
+          |  type B = A
+          |  val x = stackalloc[B]()
+          |}""".stripMargin
+          )
+        )
+    )
+    assertTrue(err.getMessage().contains(StackallocConcreateType))
+  }
+
+  @Test def stackallocAbstractType(): Unit = {
+    assumeTrue(
+      "Not possible to express in Scala 2",
+      scalaVersion.startsWith("3.")
+    )
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () =>
+        NIRCompiler(
+          _.compile(
+            """import scala.scalanative.unsafe._
+          |object Test {
+          |  type A
+          |  val x = stackalloc[A]()
+          |}""".stripMargin
+          )
+        )
+    )
+    assertTrue(err.getMessage().contains(StackallocConcreateType))
+  }
+
+}

--- a/nscplugin/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
@@ -17,7 +17,7 @@ class StackallocTest {
     scalaVersion.startsWith("3.")
   )
 
-  val StackallocConcreateType = "Stackalloc requires concreate type"
+  val StackallocConcreteType = "Stackalloc requires concrete type"
   @Test def noType(): Unit = {
     val err = assertThrows(
       classOf[CompilationFailedException],
@@ -31,10 +31,10 @@ class StackallocTest {
           )
         )
     )
-    assertTrue(err.getMessage().contains(StackallocConcreateType))
+    assertTrue(err.getMessage().contains(StackallocConcreteType))
   }
 
-  @Test def inferedType(): Unit = NIRCompiler(
+  @Test def inferredType(): Unit = NIRCompiler(
     _.compile(
       """import scala.scalanative.unsafe._
           |object Test {
@@ -60,7 +60,7 @@ class StackallocTest {
           )
         )
     )
-    assertTrue(err.getMessage().contains(StackallocConcreateType))
+    assertTrue(err.getMessage().contains(StackallocConcreteType))
   }
 
   @Test def inlineGenericParamType(): Unit = {
@@ -90,7 +90,7 @@ class StackallocTest {
           )
         )
     )
-    assertTrue(err.getMessage().contains(StackallocConcreateType))
+    assertTrue(err.getMessage().contains(StackallocConcreteType))
   }
 
   @Test def nothing(): Unit = {
@@ -106,7 +106,7 @@ class StackallocTest {
           )
         )
     )
-    assertTrue(err.getMessage().contains(StackallocConcreateType))
+    assertTrue(err.getMessage().contains(StackallocConcreteType))
   }
 
   @Test def anyAlias(): Unit = {
@@ -124,7 +124,7 @@ class StackallocTest {
           )
         )
     )
-    assertTrue(err.getMessage().contains(StackallocConcreateType))
+    assertTrue(err.getMessage().contains(StackallocConcreteType))
   }
 
   @Test def abstractType(): Unit = {
@@ -142,7 +142,7 @@ class StackallocTest {
           )
         )
     )
-    assertTrue(err.getMessage().contains(StackallocConcreateType))
+    assertTrue(err.getMessage().contains(StackallocConcreteType))
   }
 
 }

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
@@ -43,7 +43,7 @@ private[testinterface] object SignalConfig {
       }
 
     def signalToCString(str: CString, signal: Int): Unit = {
-      val reversedStr: Ptr[CChar] = stackalloc[CChar](8.toUInt)
+      val reversedStr: Ptr[CChar] = stackalloc[CChar](8)
       var index = 0
       var signalPart = signal
       while (signalPart > 0) {
@@ -64,12 +64,12 @@ private[testinterface] object SignalConfig {
         import scala.scalanative.posix.string.strsignal
         strsignal(sig)
       } else {
-        val str: Ptr[CChar] = stackalloc[CChar](8.toUInt)
+        val str: Ptr[CChar] = stackalloc[CChar](8)
         signalToCString(str, sig)
         str
       }
 
-    val stackTraceHeader: Ptr[CChar] = stackalloc[CChar](100.toUInt)
+    val stackTraceHeader: Ptr[CChar] = stackalloc[CChar](100)
     strcat(stackTraceHeader, errorTag)
     strcat(stackTraceHeader, c" Fatal signal ")
     strcat(stackTraceHeader, signalNumberStr)
@@ -87,7 +87,7 @@ private[testinterface] object SignalConfig {
       unwind.get_reg(cursor, unwind.UNW_REG_IP, pc)
       if (!pc == 0.toUInt) return
       val symMax = 1024
-      val sym: Ptr[CChar] = stackalloc[CChar](symMax.toUInt)
+      val sym: Ptr[CChar] = stackalloc[CChar](symMax)
       if (unwind.get_proc_name(
             cursor,
             sym,
@@ -95,11 +95,11 @@ private[testinterface] object SignalConfig {
             offset
           ) == 0) {
         sym(symMax - 1) = 0.toByte
-        val className: Ptr[CChar] = stackalloc[CChar](512.toUInt)
-        val methodName: Ptr[CChar] = stackalloc[CChar](512.toUInt)
+        val className: Ptr[CChar] = stackalloc[CChar](512)
+        val methodName: Ptr[CChar] = stackalloc[CChar](512)
         SymbolFormatter.asyncSafeFromSymbol(sym, className, methodName)
 
-        val formattedSymbol: Ptr[CChar] = stackalloc[CChar](1100.toUInt)
+        val formattedSymbol: Ptr[CChar] = stackalloc[CChar](1100)
         formattedSymbol(0) = 0.toByte
         strcat(formattedSymbol, errorTag)
         strcat(formattedSymbol, c"   at ")

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1457,12 +1457,7 @@ object Lower {
                 unwind
               )
           }
-          buf.call(
-            memsetSig,
-            memset,
-            Seq(pointee, Val.Int(0), size, nir.Val.False),
-            unwind
-          )
+          buf.call(memsetSig, memset, Seq(pointee, Val.Int(0), size), unwind)
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -457,6 +457,8 @@ object Lower {
           genArraystoreOp(buf, n, op)
         case op: Op.Arraylength =>
           genArraylengthOp(buf, n, op)
+        case op: Op.Stackalloc =>
+          genStackallocOp(buf, n, op)
         case _ =>
           buf.let(n, op, unwind)
       }
@@ -1432,6 +1434,38 @@ object Lower {
       buf.let(n, Op.Load(Type.Int, lenPtr), unwind)
     }
 
+    def genStackallocOp(buf: Buffer, n: Local, op: Op.Stackalloc)(implicit
+        pos: Position
+    ): Unit = {
+      val Op.Stackalloc(ty, size) = op
+      val initValue = Val.Zero(ty).canonicalize
+      val pointee = buf.let(n, op, unwind)
+      size match {
+        case Val.Size(1) if initValue.isCanonical =>
+          buf.let(
+            Op.Store(ty, pointee, initValue, None),
+            unwind
+          )
+        case sizeV =>
+          val elemSize = MemoryLayout.sizeOf(ty)
+          val size = sizeV match {
+            case Val.Size(v)        => Val.Size(v * elemSize)
+            case _ if elemSize == 1 => sizeV
+            case _ =>
+              buf.let(
+                Op.Bin(Bin.Imul, Type.Size, sizeV, Val.Size(elemSize)),
+                unwind
+              )
+          }
+          buf.call(
+            memsetSig,
+            memset,
+            Seq(pointee, Val.Int(0), size, nir.Val.False),
+            unwind
+          )
+      }
+    }
+
     def genStringVal(value: String): Val = {
       val StringCls = ClassRef.unapply(Rt.StringName).get
       val CharArrayCls = ClassRef.unapply(CharArrayName).get
@@ -1769,6 +1803,10 @@ object Lower {
     Type.Ptr
   )
 
+  val memsetSig =
+    Type.Function(Seq(Type.Ptr, Type.Int, Type.Size), Type.Unit)
+  val memset = Val.Global(extern("memset"), Type.Ptr)
+
   val RuntimeNull = Type.Ref(Global.Top("scala.runtime.Null$"))
   val RuntimeNothing = Type.Ref(Global.Top("scala.runtime.Nothing$"))
 
@@ -1779,6 +1817,7 @@ object Lower {
     buf += Defn.Declare(Attrs.None, largeAllocName, allocSig)
     buf += Defn.Declare(Attrs.None, dyndispatchName, dyndispatchSig)
     buf += Defn.Declare(Attrs.None, throwName, throwSig)
+    buf += Defn.Declare(Attrs(isExtern = true), memset.name, memsetSig)
     buf.toSeq
   }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1804,7 +1804,7 @@ object Lower {
   )
 
   val memsetSig =
-    Type.Function(Seq(Type.Ptr, Type.Int, Type.Size), Type.Unit)
+    Type.Function(Seq(Type.Ptr, Type.Int, Type.Size), Type.Ptr)
   val memset = Val.Global(extern("memset"), Type.Ptr)
 
   val RuntimeNull = Type.Ref(Global.Top("scala.runtime.Null$"))

--- a/unit-tests/native/src/test/scala-3/scala/scala/scalnative/IssuesTestScala3.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalnative/IssuesTestScala3.scala
@@ -32,7 +32,7 @@ class IssuesTestScala3 {
     object functions:
       export extern_functions.test // should compile
 
-    val buff: Ptr[CChar] = stackalloc[CChar](128.toUSize)
+    val buff: Ptr[CChar] = stackalloc[CChar](128)
     functions.test(buff, c"%d %d %d", -1, 1, 42)
     assertEquals("-1 1 42", fromCString(buff))
   }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
@@ -67,7 +67,7 @@ class TimeTest {
       val anno_zero_ptr = stackalloc[tm]()
       anno_zero_ptr.tm_mday = 1
       anno_zero_ptr.tm_wday = 1
-      val cstr: CString = asctime_r(anno_zero_ptr, stackalloc[Byte](26.toUSize))
+      val cstr: CString = asctime_r(anno_zero_ptr, stackalloc[Byte](26))
       val str: String = fromCString(cstr)
       assertEquals("Mon Jan  1 00:00:00 1900\n", str)
     }
@@ -112,7 +112,7 @@ class TimeTest {
         val time_ptr = stackalloc[time_t]()
         !time_ptr = epoch + timezone
         val time: Ptr[tm] = localtime_r(time_ptr, alloc[tm]())
-        val cstr: CString = asctime_r(time, alloc[Byte](26.toUSize))
+        val cstr: CString = asctime_r(time, alloc[Byte](26))
         val str: String = fromCString(cstr)
 
         assertEquals("Thu Jan  1 00:00:00 1970\n", str)
@@ -213,7 +213,7 @@ class TimeTest {
 
   @Test def strftimeForJanOne1900ZeroZulu(): Unit = if (!isWindows) {
     Zone { implicit z =>
-      val isoDatePtr: Ptr[CChar] = alloc[CChar](70.toUSize)
+      val isoDatePtr: Ptr[CChar] = alloc[CChar](70)
       val timePtr = alloc[tm]()
 
       timePtr.tm_mday = 1
@@ -229,7 +229,7 @@ class TimeTest {
   @Test def strftimeForMondayJanOne1990ZeroTime(): Unit = if (!isWindows) {
     Zone { implicit z =>
       val timePtr = alloc[tm]()
-      val datePtr: Ptr[CChar] = alloc[CChar](70.toUSize)
+      val datePtr: Ptr[CChar] = alloc[CChar](70)
 
       timePtr.tm_mday = 1
       timePtr.tm_wday = 1

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/MsgIoSocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/MsgIoSocketTest.scala
@@ -95,7 +95,7 @@ class MsgIoSocketTest {
         val outData1 = chunk3
 
         val nOutIovs = 2
-        val outVec = alloc[iovec](nOutIovs.toUSize)
+        val outVec = alloc[iovec](nOutIovs)
 
         // outData created with only 1 byte UTF-8 chars, so length method OK.
 
@@ -127,13 +127,13 @@ class MsgIoSocketTest {
         // To mix things up, read data in reverse order of how it was sent.
 
         val inData0Size = outData1.size
-        val inData0: Ptr[Byte] = alloc[Byte](inData0Size.toInt.toUSize)
+        val inData0: Ptr[Byte] = alloc[Byte](inData0Size.toInt)
 
         val inData1Size = outData0.size
-        val inData1: Ptr[Byte] = alloc[Byte](inData1Size.toInt.toUSize)
+        val inData1: Ptr[Byte] = alloc[Byte](inData1Size.toInt)
 
         val nInIovs = 2
-        val inVec = alloc[iovec](nInIovs.toUSize)
+        val inVec = alloc[iovec](nInIovs)
 
         inVec(0).iov_base = inData0
         inVec(0).iov_len = inData0Size.toUInt
@@ -250,7 +250,7 @@ class MsgIoSocketTest {
         val SCM_TIMESTAMP = 0x1d // decimal 29
         val SOF_TIMESTAMPING_SOFTWARE = 0x10 // decimal 16
 
-        val sOpt = stackalloc[Int](1.toUSize)
+        val sOpt = stackalloc[Int](1)
         !sOpt = SOF_TIMESTAMPING_SOFTWARE
 
         val ssoStatus = setsockopt(
@@ -267,7 +267,7 @@ class MsgIoSocketTest {
         val outData1 = chunk3
 
         val nOutIovs = 2
-        val outVec = alloc[iovec](nOutIovs.toUSize)
+        val outVec = alloc[iovec](nOutIovs)
 
         // outData created with only 1 byte UTF-8 chars, so length method OK.
 
@@ -300,10 +300,10 @@ class MsgIoSocketTest {
         // Read all in one gulp. We are only marginally interested in data.
 
         val inData0Size = nBytesSent
-        val inData0: Ptr[Byte] = alloc[Byte](inData0Size.toInt.toUSize)
+        val inData0: Ptr[Byte] = alloc[Byte](inData0Size.toInt)
 
         val nInIovs = 1
-        val inVec = alloc[iovec](nInIovs.toUSize)
+        val inVec = alloc[iovec](nInIovs)
 
         inVec(0).iov_base = inData0
         inVec(0).iov_len = inData0Size.toUInt
@@ -324,7 +324,7 @@ class MsgIoSocketTest {
          */
 
         val nCtlBuf = 40 // sizeof[linux cmsghdr] + 8 // 8 is a guess
-        val ctlBuf = alloc[Byte](nCtlBuf.toUInt)
+        val ctlBuf = alloc[Byte](nCtlBuf)
 
         val inMsgHdr = alloc[msghdr]()
         inMsgHdr.msg_iov = inVec

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/SocketTestHelpers.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/SocketTestHelpers.scala
@@ -297,7 +297,7 @@ object SocketTestHelpers {
     // timeout is in milliseconds.
 
     if (isWindows) {
-      val fds = stackalloc[WSAPollFd](1.toUInt)
+      val fds = stackalloc[WSAPollFd](1)
       fds.socket = fd.toPtr[Byte]
       fds.events = WinSocketApiExt.POLLIN
 
@@ -310,7 +310,7 @@ object SocketTestHelpers {
         fail(s"poll for input failed - $reason")
       }
     } else {
-      val fds = stackalloc[struct_pollfd](1.toUInt)
+      val fds = stackalloc[struct_pollfd](1)
       (fds + 0).fd = fd
       (fds + 0).events = pollEvents.POLLIN | pollEvents.POLLRDNORM
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/Udp6SocketTest.scala
@@ -66,7 +66,7 @@ class Udp6SocketTest {
 
   private def formatIn6addr(addr: in6_addr): String = Zone { implicit z =>
     val dstSize = INET6_ADDRSTRLEN + 1
-    val dst = alloc[Byte](dstSize.toUSize)
+    val dst = alloc[Byte](dstSize)
 
     val result = inet_ntop(
       AF_INET6,
@@ -120,7 +120,7 @@ class Udp6SocketTest {
 
       // Provide extra room to allow detecting extra junk being sent.
       val maxInData = 2 * outData.length
-      val inData: Ptr[Byte] = alloc[Byte](maxInData.toUSize)
+      val inData: Ptr[Byte] = alloc[Byte](maxInData)
 
       // Test not fetching remote address. Exercise last two arguments.
       val nBytesPeekedAt =

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UdpSocketTest.scala
@@ -67,7 +67,7 @@ class UdpSocketTest {
 
       // Provide extra room to allow detecting extra junk being sent.
       val maxInData = 2 * outData.length
-      val inData: Ptr[Byte] = alloc[Byte](maxInData.toUSize)
+      val inData: Ptr[Byte] = alloc[Byte](maxInData)
 
       // Test not fetching remote address. Exercise last two args as nulls.
       val nBytesPeekedAt =

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UioTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UioTest.scala
@@ -133,7 +133,7 @@ class UioTest {
 
         // Design Note: Gather write more than 2 buffers
         val nOutIovs = 3
-        val outVec = alloc[iovec](nOutIovs.toUSize)
+        val outVec = alloc[iovec](nOutIovs)
 
         outVec(0).iov_base = toCString(outData0)
         outVec(0).iov_len = outData0.length.toUSize
@@ -175,19 +175,19 @@ class UioTest {
          */
 
         val inData0Size = outData0.size + outData1.size
-        val inData0: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+        val inData0: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1))
 
         val inData1Size = 1.toSize // odd read, just to throw things off.
-        val inData1: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+        val inData1: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1))
 
         val inData2Size = (verse4.length - 1).toSize
-        val inData2: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+        val inData2: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1))
 
         val inData3Size = verse5.length.toSize
-        val inData3: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+        val inData3: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1))
 
         val nInIovs = 4
-        val inVec = alloc[iovec](nInIovs.toUSize)
+        val inVec = alloc[iovec](nInIovs)
 
         inVec(0).iov_base = inData0
         inVec(0).iov_len = inData0Size.toUInt

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/WaitTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/WaitTest.scala
@@ -44,7 +44,7 @@ class WaitTest {
   @Test def waitBindingsShouldCompileAndLink(): Unit = {
     if (!isWindows) {
       // zero initialized placeholder
-      val wstatus = stackalloc[CInt](1.toUSize)
+      val wstatus = stackalloc[CInt](1)
 
       // idtype_t
       blackHole(P_ALL)

--- a/unit-tests/native/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationTest.scala
@@ -226,7 +226,7 @@ class ReflectiveInstantiationTest {
     // test with array of bytes
     Zone { implicit z =>
       val size = 64
-      val buffer: Ptr[Byte] = alloc[Byte](size.toUInt)
+      val buffer: Ptr[Byte] = alloc[Byte](size)
 
       def fn(idx: Int) = size - idx
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
@@ -16,7 +16,7 @@ import scala.scalanative.junit.utils.AssumesHelper._
 class CVarArgListTest {
   def vatest(cstr: CString, varargs: Seq[CVarArg], output: String): Unit =
     Zone { implicit z =>
-      val buff: Ptr[CChar] = alloc[CChar](1024.toUSize)
+      val buff: Ptr[CChar] = alloc[CChar](1024)
       stdio.vsprintf(buff, cstr, toCVarArgList(varargs))
       val got = fromCString(buff)
       assertTrue(s"$got != $output", got == output)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgTest.scala
@@ -15,7 +15,7 @@ class CVarArgTest {
   def vatest(cstr: CString, output: String)(
       generator: (CString, Ptr[CChar]) => Unit
   ): Unit = {
-    val buff: Ptr[CChar] = stackalloc[CChar](1024.toUSize)
+    val buff: Ptr[CChar] = stackalloc[CChar](1024)
     generator(buff, cstr)
     val got = fromCString(buff)
     assertEquals(got, output)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -64,7 +64,7 @@ class ExternTest {
     val args = Seq("skipped", "skipped", "skipped", "-b", "-f", "farg")
 
     Zone { implicit z =>
-      val argv: Ptr[CString] = stackalloc[CString](args.length.toUInt)
+      val argv: Ptr[CString] = stackalloc[CString](args.length)
 
       for ((arg, i) <- args.zipWithIndex) {
         argv(i) = toCString(arg)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrOpsTest.scala
@@ -19,13 +19,13 @@ class PtrOpsTest {
       assertTrue(cptr - carr == 3)
       assertTrue(carr - cptr == -3)
 
-      val iarr: Ptr[CInt] = stackalloc[CInt](8.toUInt)
+      val iarr: Ptr[CInt] = stackalloc[CInt](8)
       val iptr: Ptr[CInt] = iarr + 4
       assertTrue(iptr - iarr == 4)
       assertTrue(iarr - iptr == -4)
 
       type StructType = CStruct4[CChar, CInt, CLong, CDouble]
-      val sarr: Ptr[StructType] = stackalloc[StructType](8.toUInt)
+      val sarr: Ptr[StructType] = stackalloc[StructType](8)
       val sptr: Ptr[StructType] = sarr + 7
       assertTrue(sptr - sarr == 7)
       assertTrue(sarr - sptr == -7)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
@@ -17,7 +17,7 @@ class StackallocTest {
   }
 
   @Test def stackallocInt4(): Unit = {
-    val ptr: Ptr[Int] = stackalloc[Int](4.toUInt)
+    val ptr: Ptr[Int] = stackalloc[Int](4)
 
     ptr(0) = 1
     ptr(1) = 2

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
@@ -32,7 +32,7 @@ class ZoneTest {
 
       assertAccessible(ptr, 64)
 
-      val ptr2: Ptr[Int] = alloc[Int](128.toUInt)
+      val ptr2: Ptr[Int] = alloc[Int](128)
 
       assertAccessible(ptr2, 128)
     }
@@ -47,7 +47,7 @@ class ZoneTest {
 
     assertAccessible(ptr, 64)
 
-    val ptr2: Ptr[Int] = alloc[Int](128.toUInt)
+    val ptr2: Ptr[Int] = alloc[Int](128)
 
     assertAccessible(ptr2, 128)
 


### PR DESCRIPTION
Deprecation and further removal of stackalloc/alloc methods taking a primitive Int was a mistake - it made the Scala Native code less readable and did not improved typesafety in any way (-1.toUnsigned = 0xFFFFFFF...). In this PR we revert some of this changes, and provide new mechanisms for safer interop. 

* Restore `stackalloc[T](Int)` and `alloc[T](Int)` methods. The now have special handling for literals integers and detect zero and negative literals at compile time. Non-literal values now have a runtime check to ensure that provide integer is positive integer. Unsigned variants are still present and have the same sementics as before. 
* `Intrinsic.stackalloc`signature has changed, methods take now generic `T` type used to resolve size of required memory. The `size: RawSize` argument no longer describes size of the allocated memory, instead it describe number of elements of sizeOf[T] to allocate. This change allows to skip some arithmetic operations at runtime/optimizer and allows to use the `nir.Type` argument of `nir.Op.Stackalloc` (previously always Byte). This work is based on #3260 
* 0-initialization of stackallocated memory is now moved to `Lowering` stage. Thanks to having a full information about allocated type, we can calculate exactly the required amount of memory at linktime after optimizer run, and allows to add optimizer runs designed to removal of zero-initialization of manually initialized memory. 
* All special intrinsic operations used as intermiediete step of compilation were moved to `Intrinsics.internal` object
* Removed most of no longer required `toUnsigned` conversion 