### PR TITLE
Two location-fragile date/time tests are now more robust.

### DIFF
--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
@@ -79,6 +79,15 @@ class TimeTest {
         Platform.isFreeBSD
       )
 
+      val haveCI =
+        java.lang.Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"))
+
+      // Test has proven to fragile to run outside known environments.
+      assumeTrue(
+        "Tested only by GitHub continuous integration or developer bypass.",
+        haveCI
+      )
+
       /* unix epoch is defined as 0 seconds UTC (Universal Time).
        * 'timezone' is defined in Posix as seconds WEST of UTC. Yes WEST.
        * At 'epoch + timezone seconds' it will be 0 seconds local time.

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/DateTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/DateTest.scala
@@ -61,11 +61,37 @@ class DateTest {
       executingInScalaNative && isWindows
     )
 
-    val result = new Date().toString // actual time this test is run.
-    // regex should match, but not be: "Fri Mar 31 14:47:44 EDT 2020"
-    // Two decade year range in regex is coarse sanity check.
+    /*
+     * The JDK Date.toString() description defines the format for most of
+     * the fields returned by toString(). One can expect "Mon" instead of, say
+     * "Lundi".
+     *
+     * The timezone name, "zzz" in the description, can be any name in the
+     * IANA (Internet Assigned Numbers Authority) Time Zone Database
+     * URL: https://www.iana.org/time-zones.
+     *
+     * The timezone name is controlled/known in the GitHub Continuous
+     * Integration (CI) environment as is the matching regex
+     * (regular expression)
+     *
+     * Use a wildcard regex outside the CI environment to avoid having to
+     * parse the whole Time Zone Database.
+     */
+
+    val haveCI =
+      java.lang.Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"))
+
+    val tzRegex =
+      if (haveCI) "[A-Z]{2,5} "
+      else ".*"
+
+    /* regex should match, but not be: "Fri Mar 31 14:47:44 EDT 2020"
+     * Two decade year range in regex is coarse sanity check.
+     */
     val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
-      "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[2-3]\\d"
+      s"\\d\\d \\d{2}:\\d{2}:\\d{2} ${tzRegex}20[2-3]\\d"
+
+    val result = new Date().toString // actual time this test is run.
 
     assertTrue(
       s"""Result "${result}" does not match regex "${expected}"""",


### PR DESCRIPTION
javalib `util.DateTest` and posixlib `TimeTest` were reported on Discord as being fragile when run outside
of the GitHub Continuous environment. This PR maintains the prior strength of the test when run in CI
but weakens the tests when run locally.

This should make it easier for developers new to Scala Native to "clone & go" and reduce barriers
to entry.


In each of these cases, an explicit bypass is available so that determined developers can run the test locally. 

`DateTest` continues to test the timezone name, which is known in CI, but no longer tests that field
when run locally.  

`TimeTest` has an `assumeTrue` that it is running on CI.