### PR TITLE
Detect block cycles using stackalloc op

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -11,6 +11,7 @@ class Buffer(implicit fresh: Fresh) {
 
   def toSeq: Seq[Inst] = buffer.toSeq
   def size: Int = buffer.size
+  def foreach(fn: Inst => Unit) = buffer.foreach(fn)
   def exists(pred: Inst => Boolean) = buffer.exists(pred)
 
   // Control-flow ops

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -4,6 +4,8 @@ package interflow
 import scalanative.nir._
 import scalanative.linker._
 import scalanative.util.unreachable
+import scala.annotation.tailrec
+import scala.collection.mutable
 
 trait Inline { self: Interflow =>
   private val maxInlineSize =
@@ -164,6 +166,18 @@ trait Inline { self: Interflow =>
       val blocks =
         process(inlineInsts, inlineArgs, state, doInline = true, origRetTy)
 
+        // Mark blocks taking part in cycle involving stackalloc
+        // Such blocks should emit stackSave/Restore ops to prevent StackOverflow
+      blocks
+        .find(b => b.allocatesOnStack && b.isPartOfCycle)
+        .flatMap(findStartOfCycle(blocks, _))
+        .foreach { b =>
+          // b.toInsts().map(_.show).foreach(println)
+          val stackSavePtrId = b.end.fresh()
+          b.emitStackSaveOp = Some(stackSavePtrId)
+          b.stackStatePtr = Val.Local(stackSavePtrId, Type.Ptr)
+        }
+
       val emit = new nir.Buffer()(state.fresh)
 
       def nothing = {
@@ -221,24 +235,45 @@ trait Inline { self: Interflow =>
             }
       }
 
-      // Check if inlined function performed stack allocation, if so add
-      // insert stacksave/stackrestore LLVM Intrinsics to prevent affecting.
-      // By definition every stack allocation of inlined function is only needed within it's body
-      val allocatesOnStack = emit.exists {
-        case Inst.Let(_, _: Op.Stackalloc, _) => true
-        case _                                => false
-      }
-      if (allocatesOnStack) {
-        import Interflow.LLVMIntrinsics._
-        val stackState = state.emit
-          .call(StackSaveSig, StackSave, Nil, Next.None)
-        state.emit ++= emit
-        state.emit
-          .call(StackRestoreSig, StackRestore, Seq(stackState), Next.None)
-      } else state.emit ++= emit
+      state.emit ++= emit
       state.inherit(endState, res +: args)
 
       val Type.Function(_, retty) = defn.ty: @unchecked
       adapt(res, retty)
     }
+
+  private def findStartOfCycle(
+      blocks: Iterable[MergeBlock],
+      expected: MergeBlock
+  ): Option[MergeBlock] = {
+    val visited = mutable.Set.empty[MergeBlock]
+    def visit(
+        current: MergeBlock,
+        path: List[MergeBlock]
+    ): Option[MergeBlock] = {
+      if (path.contains(current) && path.contains(expected)) Some(current)
+      else {
+        visited += current
+        current.outgoing.values.foldLeft(None: Option[MergeBlock]) {
+          case (done @ Some(_), _) => done
+          case (None, next)        => visit(next, current :: path)
+        }
+      }
+    }
+
+    @tailrec def loop(
+        remaining: List[MergeBlock]
+    ): Option[MergeBlock] = {
+      remaining match {
+        case Nil => None
+        case head :: tail =>
+          visit(head, Nil) match {
+            case None  => loop(tail)
+            case start => start
+          }
+      }
+    }
+    loop(blocks.toList)
+  }
+
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -3,6 +3,7 @@ package interflow
 
 import scala.collection.mutable
 import scalanative.nir._
+import scala.annotation.tailrec
 
 final class MergeBlock(val label: Inst.Label, val name: Local) {
   var incoming = mutable.Map.empty[Local, (Seq[Val], State)]
@@ -12,16 +13,56 @@ final class MergeBlock(val label: Inst.Label, val name: Local) {
   var end: State = _
   var cf: Inst.Cf = _
   var invalidations: Int = 0
+
+  // Check if inlined function performed stack allocation, if so add
+  // insert stacksave/stackrestore LLVM Intrinsics to prevent affecting.
+  // By definition every stack allocation of inlined function is only needed within it's body
+  lazy val allocatesOnStack = end.emit.exists {
+    case Inst.Let(_, _: Op.Stackalloc, _) => true
+    case _                                => false
+  }
+  var stackStatePtr: Val = Val.Null
+  var emitStackSaveOp: Option[Local] = None
+
   implicit def cfPos: Position = {
     if (cf != null) cf.pos
     else label.pos
   }
 
+  lazy val isPartOfCycle: Boolean = {
+    val visited = mutable.Set.empty[MergeBlock]
+    def outgoingList(block: MergeBlock): List[MergeBlock] =
+      block.outgoing.foldRight[List[MergeBlock]](Nil) {
+        case ((_, outgoing), acc) =>
+          if (visited.contains(outgoing)) acc
+          else outgoing :: acc
+      }
+    @tailrec def loop(todo: List[MergeBlock]): Boolean = todo match {
+      case Nil => false
+      case head :: tail =>
+        if (head eq this) true
+        else if (visited.add(head)) {
+          visited += head
+          loop(outgoingList(head) ::: tail)
+        } else loop(tail)
+    }
+    loop(todo = outgoingList(this))
+  }
+
   def toInsts(): Seq[Inst] = {
+    import Interflow.LLVMIntrinsics._
     val block = this
     val result = new nir.Buffer()(Fresh(0))
     def mergeNext(next: Next.Label): Next.Label = {
       val nextBlock = outgoing(next.name)
+      if (nextBlock.stackStatePtr != Val.Null && this.isPartOfCycle) {
+        result.call(
+          StackRestoreSig,
+          StackRestore,
+          Seq(nextBlock.stackStatePtr),
+          Next.None
+        )
+      }
       val mergeValues = nextBlock.phis.flatMap {
         case MergePhi(_, incoming) =>
           incoming.collect {
@@ -41,6 +82,21 @@ final class MergeBlock(val label: Inst.Label, val name: Local) {
     }
     val params = block.phis.map(_.param)
     result.label(block.name, params)
+    // Ooptionally emit StackSave op
+    // It is required when block is a start of cycle involving stackalloc op
+    emitStackSaveOp.foreach { n =>
+      val alreadyEmmited = block.end.emit.exists {
+        case Inst.Let(_, Op.Call(_, StackSave, _), _) => true
+        case _                                        => false
+      }
+      if (!alreadyEmmited) {
+        stackStatePtr = result.let(
+          name = n,
+          op = Op.Call(StackSaveSig, StackSave, Nil),
+          unwind = Next.None
+        )
+      }
+    }
     result ++= block.end.emit
     block.cf match {
       case ret: Inst.Ret =>

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -483,7 +483,7 @@ final class MergeProcessor(
     }
 
     orderedBlocks ++= sortedBlocks.filter(isExceptional)
-    orderedBlocks.toSeq
+    orderedBlocks.toList
   }
 }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -86,7 +86,7 @@ object UseDef {
     def enterInst(n: Local) = {
       val deps = mutable.UnrolledBuffer.empty[Def]
       val uses = mutable.UnrolledBuffer.empty[Def]
-      assert(!defs.contains(n))
+      assert(!defs.contains(n), s"duplicate local ids: $n")
       defs += ((n, InstDef(n, deps, uses)))
     }
     def deps(n: Local, deps: Seq[Local]) = {

--- a/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
@@ -4,6 +4,7 @@ import scala.scalanative.build.{Config, NativeConfig, Mode, ScalaNative}
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.scalanative.nir._
 
 /** Base class to test the optimizer */
 abstract class OptimizerSpec extends LinkerSpec {
@@ -35,4 +36,38 @@ abstract class OptimizerSpec extends LinkerSpec {
         fn(config, result)
     }
 
+  protected def findEntry(linked: Seq[Defn]): Option[Defn.Define] = {
+    import OptimizerSpec._
+    val companionMethod = linked
+      .collectFirst { case defn @ Defn.Define(_, TestMain(), _, _) => defn }
+    def staticForwarder = linked
+      .collectFirst {
+        case defn @ Defn.Define(_, TestMainForwarder(), _, _) => defn
+      }
+    companionMethod
+      .orElse(staticForwarder)
+      .ensuring(_.isDefined, "Not found linked method")
+  }
+}
+
+object OptimizerSpec {
+  private object TestMain {
+    val TestModule = Global.Top("Test$")
+    val CompanionMain =
+      TestModule.member(Rt.ScalaMainSig.copy(scope = Sig.Scope.Public))
+
+    def unapply(name: Global): Boolean = name match {
+      case CompanionMain => true
+      case Global.Member(TestModule, sig) =>
+        sig.unmangled match {
+          case Sig.Duplicate(of, _) => of == CompanionMain.sig
+          case _                    => false
+        }
+      case _ => false
+    }
+  }
+  private object TestMainForwarder {
+    val staticForwarder = Global.Top("Test").member(Rt.ScalaMainSig)
+    def unapply(name: Global): Boolean = name == staticForwarder
+  }
 }

--- a/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
@@ -32,7 +32,7 @@ abstract class OptimizerSpec extends LinkerSpec {
     link(entry, sources, setupConfig) {
       case (config, linked) =>
         val optimized = ScalaNative.optimize(config, linked)
-        val result = Await.result(optimized, 1.minute)
+        val result = Await.result(optimized, Duration.Inf)
         fn(config, result)
     }
 

--- a/tools/src/test/scala/scala/scalanative/optimizer/InlineStackallocTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/InlineStackallocTest.scala
@@ -8,7 +8,8 @@ import org.junit._
 import org.junit.Assert._
 
 class InlineStackallocTest extends OptimizerSpec {
-  @Test def alwaysInlineStackallocNoLoop(): Unit = {
+
+  @Test def noLoop(): Unit = {
     optimize(
       entry = "Test",
       sources = Map(
@@ -32,7 +33,7 @@ class InlineStackallocTest extends OptimizerSpec {
           |    println((ptr, ptr2))
           |  }
           |
-          |  def main(args: Array[String]): Unit = { 
+          |  def main(args: Array[String]): Unit = {
           |    val ptr = init()
           |    println(stackalloc[Int](64))
           |    val ptr2 = init()
@@ -42,12 +43,10 @@ class InlineStackallocTest extends OptimizerSpec {
           |  }
           |}
           |""".stripMargin
-      ),
-      setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFull)
+      )
     ) {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
-          println(defn.show)
           val stackallocId = defn.insts.collectFirst {
             case Inst.Let(id, Op.Stackalloc(_, _), _) => id
           }
@@ -65,7 +64,7 @@ class InlineStackallocTest extends OptimizerSpec {
     }
   }
 
-  @Test def alwaysInlineStackallocWithLoop(): Unit = {
+  @Test def tailRecursiveLoop(): Unit = {
     optimize(
       entry = "Test",
       sources = Map(
@@ -83,7 +82,7 @@ class InlineStackallocTest extends OptimizerSpec {
           |  }
           |
           |
-          |  def loop(n: Int): Unit = {
+          |  @alwaysinline def loop(n: Int): Unit = {
           |    val ptr = init()
           |    println(stackalloc[Int](64))
           |    println(ptr)
@@ -95,12 +94,10 @@ class InlineStackallocTest extends OptimizerSpec {
           |  }
           |}
           |""".stripMargin
-      ),
-      setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFull)
+      )
     ) {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
-          println(defn.show)
           val stackallocId = defn.insts.collectFirst {
             case Inst.Let(id, Op.Stackalloc(_, _), _) => id
           }
@@ -119,7 +116,161 @@ class InlineStackallocTest extends OptimizerSpec {
         }
     }
   }
-  // TODO: nested stackallocs
-  // TODO: allocation of multiple structs in loop and assignment to list
 
+  @Test def whileLoop(): Unit = {
+    optimize(
+      entry = "Test",
+      sources = Map(
+        "Test.scala" -> """
+          |import scala.scalanative.unsafe._
+          |import scala.scalanative.unsigned._
+          |import scala.scalanative.annotation.alwaysinline
+          |
+          |object Test {
+          |  @alwaysinline def allocatingFunction(): Int = {
+          |    val `64KB` = 64 * 1024
+          |    val chunk = stackalloc[Byte](`64KB`)
+          |    assert(chunk != null, "stackalloc was null")
+          |    `64KB`
+          |  }
+          |
+          |  def main(args: Array[String]): Unit = {
+          |    val toAllocate = 32 * 1024 * 1024
+          |    var allocated = 0
+          |    while (allocated < toAllocate) {
+          |      println(allocated)
+          |      allocated += allocatingFunction()
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      )
+    ) {
+      case (_, result) =>
+        findEntry(result.defns).foreach { defn =>
+          val stackallocId = defn.insts.collectFirst {
+            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+          }
+          assertTrue("No stackalloc op", stackallocId.isDefined)
+
+          val saveIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+          }
+          assertTrue("No StackSave ops", saveIds.nonEmpty)
+          assertEquals("StackSave ammount", 1, saveIds.size)
+
+          val restoreIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+          }
+          assertTrue("No StackRestore ops", restoreIds.nonEmpty)
+          assertEquals("StackRestore ammount", 1, restoreIds.size)
+        }
+    }
+  }
+
+  @Test def whileLoopNested(): Unit = {
+    optimize(
+      entry = "Test",
+      sources = Map(
+        "Test.scala" -> """
+          |import scala.scalanative.unsafe._
+          |import scala.scalanative.unsigned._
+          |import scala.scalanative.annotation.alwaysinline
+          |
+          |object Test {
+          |  def main(args: Array[String]): Unit = {
+          |    var i,j,k = 0
+          |    while (i < 3) {
+          |      val iAlloc = stackalloc[Byte](i)
+          |      while(j < 3){
+          |        val jAlloc = stackalloc[Short](j)
+          |        while(k < 3){
+          |          val kAlloc = stackalloc[Int](k)
+          |          println((iAlloc, jAlloc, kAlloc))
+          |          k += 1
+          |        }
+          |        j += 1
+          |      }
+          |      i += 1
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      )
+    ) {
+      case (_, result) =>
+        findEntry(result.defns).foreach { defn =>
+          val stackallocId = defn.insts.collectFirst {
+            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+          }
+          assertTrue("No stackalloc op", stackallocId.isDefined)
+
+          val saveIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+          }
+          assertTrue("No StackSave ops", saveIds.nonEmpty)
+          assertEquals("StackSave ammount", 3, saveIds.size)
+
+          val restoreIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+          }
+          assertTrue("No StackRestore ops", restoreIds.nonEmpty)
+          assertEquals("StackRestore ammount", 3, restoreIds.size)
+        }
+    }
+  }
+
+  @Test def whileLoopMultipleNested(): Unit = {
+    optimize(
+      entry = "Test",
+      sources = Map(
+        "Test.scala" -> """
+          |import scala.scalanative.unsafe._
+          |import scala.scalanative.unsigned._
+          |
+          |object Test {
+          |  def main(args: Array[String]): Unit = {
+          |    var i,j,k = 0
+          |    while (i < 3) {
+          |      val iAlloc = stackalloc[Ptr[Byte]](i)
+          |      !iAlloc = stackalloc[Byte](i)
+          |      while(j < 3){
+          |        val jAlloc = stackalloc[Short](j)
+          |        while(k < 3){
+          |          val kAlloc = stackalloc[Ptr[Ptr[Int]]](k)
+          |          !kAlloc = stackalloc[Ptr[Int]](k)
+          |          !(!kAlloc) = stackalloc[Int](k)
+          |          println((iAlloc, jAlloc, kAlloc))
+          |          k += 1
+          |        }
+          |        j += 1
+          |      }
+          |      i += 1
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      )
+    ) {
+      case (_, result) =>
+        findEntry(result.defns).foreach { defn =>
+          val stackallocId = defn.insts.collectFirst {
+            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+          }
+          assertTrue("No stackalloc op", stackallocId.isDefined)
+
+          val saveIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+          }
+          assertTrue("No StackSave ops", saveIds.nonEmpty)
+          assertEquals("StackSave ammount", 3, saveIds.size)
+
+          val restoreIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+          }
+          assertTrue("No StackRestore ops", restoreIds.nonEmpty)
+          assertEquals("StackRestore ammount", 3, restoreIds.size)
+        }
+    }
+  }
 }

--- a/tools/src/test/scala/scala/scalanative/optimizer/InlineStackallocTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/InlineStackallocTest.scala
@@ -1,0 +1,125 @@
+package scala.scalanative.optimizer
+
+import scala.scalanative.OptimizerSpec
+import scala.scalanative.interflow.Interflow.LLVMIntrinsics._
+import scala.scalanative.nir._
+
+import org.junit._
+import org.junit.Assert._
+
+class InlineStackallocTest extends OptimizerSpec {
+  @Test def alwaysInlineStackallocNoLoop(): Unit = {
+    optimize(
+      entry = "Test",
+      sources = Map(
+        "Test.scala" -> """
+          |import scala.scalanative.annotation.alwaysinline
+          |import scala.scalanative.unsafe._
+          |
+          |object Test {
+          |  type Foo = CStruct2[Int, Int]
+          |  @alwaysinline def init(): Ptr[Foo] = {
+          |    val ptr = stackalloc[Foo]()
+          |    ptr._1 = 21
+          |    ptr._2 = 42
+          |    ptr
+          |  }
+          |
+          |  def doSomething(x: Ptr[Foo]): Unit = {
+          |    val ptr = init()
+          |    println(stackalloc[Int](64))
+          |    val ptr2 = init()
+          |    println((ptr, ptr2))
+          |  }
+          |
+          |  def main(args: Array[String]): Unit = { 
+          |    val ptr = init()
+          |    println(stackalloc[Int](64))
+          |    val ptr2 = init()
+          |    doSomething(ptr2)
+          |    val ptr3 = init()
+          |    assert(ptr == ptr3)
+          |  }
+          |}
+          |""".stripMargin
+      ),
+      setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFull)
+    ) {
+      case (_, result) =>
+        findEntry(result.defns).foreach { defn =>
+          println(defn.show)
+          val stackallocId = defn.insts.collectFirst {
+            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+          }
+          assertTrue("No stackalloc op", stackallocId.isDefined)
+
+          val saveIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+          }
+          assertTrue("No StackSave ops", saveIds.isEmpty)
+          val restoreIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+          }
+          assertTrue("No StackRestore ops", restoreIds.isEmpty)
+        }
+    }
+  }
+
+  @Test def alwaysInlineStackallocWithLoop(): Unit = {
+    optimize(
+      entry = "Test",
+      sources = Map(
+        "Test.scala" -> """
+          |import scala.scalanative.annotation.alwaysinline
+          |import scala.scalanative.unsafe._
+          |
+          |object Test {
+          |  type Foo = CStruct2[Int, Int]
+          |  @alwaysinline def init(): Ptr[Foo] = {
+          |    val ptr = stackalloc[Foo]()
+          |    ptr._1 = 21
+          |    ptr._2 = 42
+          |    ptr
+          |  }
+          |
+          |
+          |  def loop(n: Int): Unit = {
+          |    val ptr = init()
+          |    println(stackalloc[Int](64))
+          |    println(ptr)
+          |    if (n > 0) loop(n - 1 )
+          |  }
+          |
+          |  def main(args: Array[String]): Unit = {
+          |    loop(10)
+          |  }
+          |}
+          |""".stripMargin
+      ),
+      setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFull)
+    ) {
+      case (_, result) =>
+        findEntry(result.defns).foreach { defn =>
+          println(defn.show)
+          val stackallocId = defn.insts.collectFirst {
+            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+          }
+          assertTrue("No stackalloc op", stackallocId.isDefined)
+
+          val saveIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+          }
+          assertTrue("No StackSave ops", saveIds.nonEmpty)
+          assertEquals("StackSave ammount", 1, saveIds.size)
+          val restoreIds = defn.insts.collect {
+            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+          }
+          assertTrue("No StackRestore ops", restoreIds.nonEmpty)
+          assertEquals("StackRestore ammount", 1, restoreIds.size)
+        }
+    }
+  }
+  // TODO: nested stackallocs
+  // TODO: allocation of multiple structs in loop and assignment to list
+
+}

--- a/tools/src/test/scala/scala/scalanative/optimizer/StackallocStateRestoreTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/StackallocStateRestoreTest.scala
@@ -94,7 +94,9 @@ class StackallocStateRestoreTest extends OptimizerSpec {
           |  }
           |}
           |""".stripMargin
-      )
+      ),
+      // Test is releaseMode to make it inline more
+      setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFast)
     ) {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>

--- a/tools/src/test/scala/scala/scalanative/optimizer/StackallocStateRestoreTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/StackallocStateRestoreTest.scala
@@ -274,7 +274,7 @@ class StackallocStateRestoreTest extends OptimizerSpec {
     }
   }
 
-  @Test def whileLoopEscapingStackalloc(): Unit = {
+  @Test def escapingStackalloc(): Unit = {
     optimize(
       entry = "Test",
       sources = Map(
@@ -327,7 +327,7 @@ class StackallocStateRestoreTest extends OptimizerSpec {
     }
   }
 
-  @Test def whileLoopEscapingStackalloc2(): Unit = {
+  @Test def escapingStackalloc2(): Unit = {
     optimize(
       entry = "Test",
       sources = Map(
@@ -390,7 +390,7 @@ class StackallocStateRestoreTest extends OptimizerSpec {
     }
   }
 
-    @Test def whileLoopEscapingStackalloc3(): Unit = {
+  @Test def escapingStackalloc3(): Unit = {
     optimize(
       entry = "Test",
       sources = Map(


### PR DESCRIPTION
Detect block cycles using stackalloc to improve stack memory managment of inlined, potentially looped functions. 
Previously, we've emitted a StackSave/Restore LLVM intrinnsics every time inlined code contained Op.Stackalloc instructions. These however where not required, when inlined code, was never part of a loop. Also in the past multiple subsequent inlines created multiple StackSave/Restore instructions leading to potentiall performance penalty. 

This change adds detection of cycles and stackallocation in MergeBlocks. Based on them we create exactly 1 StackSave operation at the entry of the loop, and exactly 1 StackRestore before each jump to block marked as start of loop.