### PR TITLE
Build: Update sbt to 1.9.3

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.2
+sbt.version = 1.9.3


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.9.3.

Two weeks have passed since the release of sbt 1.9.3 and it has worked on all my
daily builds.  