### PR TITLE
Fix #3408: Implement two javalib static String join() methods.

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -8,7 +8,7 @@ import java.util._
 import java.util.regex._
 import java.nio._
 import java.nio.charset._
-import java.util.{Objects, Arrays}
+import java.util.Objects
 import java.util.ScalaOps._
 import java.lang.constant.{Constable, ConstantDesc}
 import scala.annotation.{switch, tailrec}

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -8,7 +8,8 @@ import java.util._
 import java.util.regex._
 import java.nio._
 import java.nio.charset._
-import java.util.Objects
+import java.util.{Objects, Arrays}
+import java.util.ScalaOps._
 import java.lang.constant.{Constable, ConstantDesc}
 import scala.annotation.{switch, tailrec}
 import _String.{string2_string, _string2string}
@@ -1553,6 +1554,30 @@ object _String {
   def copyValueOf(data: Array[Char]): _String =
     new _String(data, 0, data.length)
 
+  def format(fmt: _String, args: Array[AnyRef]): _String =
+    new Formatter().format(fmt, args).toString
+
+  def format(loc: Locale, fmt: _String, args: Array[AnyRef]): _String =
+    new Formatter(loc).format(fmt, args).toString()
+
+  def join(delimiter: CharSequence, elements: Array[CharSequence]): String = {
+    val sj = new StringJoiner(delimiter)
+
+    for (j <- 0 until elements.length)
+      sj.add(elements(j))
+
+    sj.toString()
+  }
+
+  def join(
+      delimiter: CharSequence,
+      elements: Iterable[CharSequence]
+  ): String = {
+    elements.scalaOps
+      .foldLeft(new StringJoiner(delimiter))((j, e) => j.add(e))
+      .toString()
+  }
+
   def valueOf(data: Array[Char]): _String = new _String(data)
 
   def valueOf(data: Array[Char], start: Int, length: Int): _String =
@@ -1578,12 +1603,6 @@ object _String {
 
   def valueOf(value: AnyRef): _String =
     if (value != null) value.toString else "null"
-
-  def format(fmt: _String, args: Array[AnyRef]): _String =
-    new Formatter().format(fmt, args).toString
-
-  def format(loc: Locale, fmt: _String, args: Array[AnyRef]): _String =
-    new Formatter(loc).format(fmt, args).toString()
 
   import scala.language.implicitConversions
   @inline private[lang] implicit def _string2string(s: _String): String =

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
@@ -961,4 +961,42 @@ class StringTest {
     )
   }
 
+  /* selected Static methods
+   */
+  @Test def joinVarargs(): Unit = {
+    val strings = Array("one", "two", "three")
+    val delimiter = "-%-"
+
+    val expected = s"${strings(0)}${delimiter}" +
+      s"${strings(1)}${delimiter}" +
+      s"${strings(2)}"
+    val joined = String.join(delimiter, strings(0), strings(1), strings(2))
+
+    assertEquals(
+      s"unexpected join",
+      expected,
+      joined
+    )
+  }
+
+  @Test def joinIterable(): Unit = {
+    val strings = new java.util.ArrayList[String](3)
+    strings.add("zeta")
+    strings.add("eta")
+    strings.add("theta")
+
+    val delimiter = "-*-"
+
+    val expected = s"${strings.get(0)}${delimiter}" +
+      s"${strings.get(1)}${delimiter}" +
+      s"${strings.get(2)}"
+    val joined = String.join(delimiter, strings)
+
+    assertEquals(
+      s"unexpected join",
+      expected,
+      joined
+    )
+  }
+
 }


### PR DESCRIPTION
Fix #3408 

 Implement javalib static String join() methods & corresponding Tests.
This implementation uses the new `StringJoiner` code.