### PR TITLE
Fix deprecations in `scala.scalanative.junit.AssertEqualsDoubleTest.scala`

### DIFF
--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_.txt
@@ -1,12 +1,10 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_a.txt
@@ -1,12 +1,10 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: java.lang.[31mAssertionError[0m: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: java.lang.[31mAssertionError[0m: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_n.txt
@@ -1,12 +1,10 @@
 ldTest run started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-ldTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_na.txt
@@ -1,12 +1,10 @@
 ldTest run started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble failed: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-ldTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nv.txt
@@ -1,12 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nva.txt
@@ -1,12 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble failed: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvc.txt
@@ -1,12 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvca.txt
@@ -1,12 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_v.txt
@@ -1,12 +1,10 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_va.txt
@@ -1,12 +1,10 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: java.lang.[31mAssertionError[0m: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: java.lang.[31mAssertionError[0m: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vc.txt
@@ -1,12 +1,10 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vs.txt
@@ -1,12 +1,10 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vsn.txt
@@ -1,12 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
-leTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
@@ -19,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/AssertEqualsDoubleTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/AssertEqualsDoubleTest.scala
@@ -9,11 +9,11 @@ import scala.scalanative.junit.utils._
 
 class AssertEqualsDoubleTest {
   @Test def failsWithDouble(): Unit = {
-    assertEquals(1.0, 1.0, 0)
+    assertEquals(1.0, 1.0, 0.0)
   }
 
   @Test def failsWithDoubleMessage(): Unit = {
-    assertEquals("Message", 1.0, 1.0, 0)
+    assertEquals("Message", 1.0, 1.0, 0.0)
   }
 
   @Test def worksWithEpsilon(): Unit = {

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/AssertEqualsDoubleTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/AssertEqualsDoubleTest.scala
@@ -9,11 +9,11 @@ import scala.scalanative.junit.utils._
 
 class AssertEqualsDoubleTest {
   @Test def failsWithDouble(): Unit = {
-    assertEquals(1.0, 1.0)
+    assertEquals(1.0, 1.0, 0)
   }
 
   @Test def failsWithDoubleMessage(): Unit = {
-    assertEquals("Message", 1.0, 1.0)
+    assertEquals("Message", 1.0, 1.0, 0)
   }
 
   @Test def worksWithEpsilon(): Unit = {


### PR DESCRIPTION
Hi all, 

When using Scala 3, `assertEquals(expected: Double, actual: Double)` throws a deprecation warning. Using `assertEquals(expected: Double, actual: Double, delta: Double)` suppresses the warning. This PR applies such fix to `AssertEqualsDoubleTest.scala`

Fix https://github.com/scala-native/scala-native/issues/3107 : New deprecations in AssertEqualsDoubleTest.scala