### PR TITLE
Upgrade JUnit interface to 0.13.3

### DIFF
--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitFramework.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitFramework.scala
@@ -46,7 +46,8 @@ final class JUnitFramework extends Framework {
     def unsupported(name: String) =
       throw new UnsupportedOperationException(name)
 
-      for (str <- args) str match {
+    for (str <- args) {
+      str match {
         case "-v" => verbosity = RunSettings.Verbosity.Started
         case "+v" => verbosity = RunSettings.Verbosity.Terse
         case s"--verbosity=$id" =>
@@ -67,6 +68,7 @@ final class JUnitFramework extends Framework {
         case s if !s.startsWith("-") && !s.startsWith("+") => unsupported(s)
         case _                                             => ()
       }
+    }
     for (s <- args) {
       s match {
         case "+q" => unsupported("+q")

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitFramework.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitFramework.scala
@@ -50,23 +50,32 @@ final class JUnitFramework extends Framework {
       str match {
         case "-v" => verbosity = RunSettings.Verbosity.Started
         case "+v" => verbosity = RunSettings.Verbosity.Terse
-        case s"--verbosity=$id" =>
-          verbosity = RunSettings.Verbosity.ofOrdinal(id.toInt)
+        case s if s.startsWith("--verbosity=") =>
+          val n = s.stripPrefix("--verbosity=").toInt
+          verbosity = RunSettings.Verbosity.ofOrdinal(n)
         case "-n" => noColor = true
         case "-s" => decodeScalaNames = true
         case "-a" => logAssert = true
         case "-c" => logExceptionClass = false
+        case "-q" => unsupported("-q")
 
-        case "-q"                       => unsupported("-q")
-        case s"--tests=$v"              => unsupported("--tests")
-        case s"--ignore-runners=$v"     => unsupported("--ignore-runners")
-        case s"--run-listener=$v"       => unsupported("--run-listener")
-        case s"--include-categories=$v" => unsupported("--include-categories")
-        case s"--exclude-categories=$v" => unsupported("--exclude-categories")
-        case s"-D$key=$value"           => unsupported("-Dkey=value")
-        case s"--summary=$id"           => unsupported("--summary")
-        case s if !s.startsWith("-") && !s.startsWith("+") => unsupported(s)
-        case _                                             => ()
+        case s if s.startsWith("--summary=") =>
+          unsupported("--summary=")
+        case s if s.startsWith("--tests=") =>
+          unsupported("--tests")
+        case s if s.startsWith("--ignore-runners=") =>
+          unsupported("--ignore-runners")
+        case s if s.startsWith("--run-listener=") =>
+          unsupported("--run-listener")
+        case s if s.startsWith("--include-categories=") =>
+          unsupported("--include-categories")
+        case s if s.startsWith("--exclude-categories=") =>
+          unsupported("--exclude-categories")
+        case s if s.startsWith("-D") && s.contains("=") =>
+          unsupported("-Dkey=value")
+        case s if !s.startsWith("-") && !s.startsWith("+") =>
+          unsupported(s)
+        case _ => ()
       }
     }
     for (s <- args) {

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitFramework.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitFramework.scala
@@ -37,62 +37,52 @@ final class JUnitFramework extends Framework {
   }
 
   private def parseRunSettings(args: Array[String]): RunSettings = {
-    var verbose = false
     var noColor = false
     var decodeScalaNames = false
-    var logAssert = false
-    var notLogExceptionClass = false
-    for (str <- args) {
-      str match {
-        case "-v" => verbose = true
+    var logAssert = true
+    var logExceptionClass = true
+    var verbosity: RunSettings.Verbosity = RunSettings.Verbosity.Terse
+
+    def unsupported(name: String) =
+      throw new UnsupportedOperationException(name)
+
+      for (str <- args) str match {
+        case "-v" => verbosity = RunSettings.Verbosity.Started
+        case "+v" => verbosity = RunSettings.Verbosity.Terse
+        case s"--verbosity=$id" =>
+          verbosity = RunSettings.Verbosity.ofOrdinal(id.toInt)
         case "-n" => noColor = true
         case "-s" => decodeScalaNames = true
         case "-a" => logAssert = true
-        case "-c" => notLogExceptionClass = true
+        case "-c" => logExceptionClass = false
 
-        case s if s.startsWith("-tests=") =>
-          throw new UnsupportedOperationException("-tests")
-
-        case s if s.startsWith("--tests=") =>
-          throw new UnsupportedOperationException("--tests")
-
-        case s if s.startsWith("--ignore-runners=") =>
-          throw new UnsupportedOperationException("--ignore-runners")
-
-        case s if s.startsWith("--run-listener=") =>
-          throw new UnsupportedOperationException("--run-listener")
-
-        case s if s.startsWith("--include-categories=") =>
-          throw new UnsupportedOperationException("--include-categories")
-
-        case s if s.startsWith("--exclude-categories=") =>
-          throw new UnsupportedOperationException("--exclude-categories")
-
-        case s if s.startsWith("-D") && s.contains("=") =>
-          throw new UnsupportedOperationException("-Dkey=value")
-
-        case s if !s.startsWith("-") && !s.startsWith("+") =>
-          throw new UnsupportedOperationException(s)
-
-        case _ =>
+        case "-q"                       => unsupported("-q")
+        case s"--tests=$v"              => unsupported("--tests")
+        case s"--ignore-runners=$v"     => unsupported("--ignore-runners")
+        case s"--run-listener=$v"       => unsupported("--run-listener")
+        case s"--include-categories=$v" => unsupported("--include-categories")
+        case s"--exclude-categories=$v" => unsupported("--exclude-categories")
+        case s"-D$key=$value"           => unsupported("-Dkey=value")
+        case s"--summary=$id"           => unsupported("--summary")
+        case s if !s.startsWith("-") && !s.startsWith("+") => unsupported(s)
+        case _                                             => ()
       }
-    }
     for (s <- args) {
       s match {
-        case "+v" => verbose = false
+        case "+q" => unsupported("+q")
         case "+n" => noColor = false
         case "+s" => decodeScalaNames = false
         case "+a" => logAssert = false
-        case "+c" => notLogExceptionClass = false
-        case _    =>
+        case "+c" => logExceptionClass = true
+        case _    => ()
       }
     }
     new RunSettings(
       !noColor,
       decodeScalaNames,
-      verbose,
+      verbosity,
       logAssert,
-      notLogExceptionClass
+      logExceptionClass
     )
   }
 }

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
@@ -134,7 +134,7 @@ private[junit] final class JUnitTask(
         es.size
     }
 
-    reporter.reportTestFinished(test.name, errors.isEmpty, timeInSeconds)
+    reporter.reportTestFinished(test.name, failed == 0, timeInSeconds)
 
     failed
   }

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/RunSettings.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/RunSettings.scala
@@ -4,17 +4,36 @@ package junit
 // Ported from Scala.js
 
 import scala.util.Try
+import RunSettings._
 
 private[junit] final class RunSettings(
     val color: Boolean,
     decodeScalaNames: Boolean,
-    val verbose: Boolean,
+    val verbosity: Verbosity,
     val logAssert: Boolean,
-    val notLogExceptionClass: Boolean
+    val logExceptionClass: Boolean
 ) {
   def decodeName(name: String): String = {
     if (decodeScalaNames)
       Try(scala.reflect.NameTransformer.decode(name)).getOrElse(name)
     else name
+  }
+}
+
+object RunSettings {
+  sealed abstract class Verbosity(val ordinal: Int)
+  object Verbosity {
+    case object Terse extends Verbosity(0)
+    case object RunFinished extends Verbosity(1)
+    case object Started extends Verbosity(2)
+    case object TestFinished extends Verbosity(3)
+
+    def ofOrdinal(v: Int): Verbosity = v match {
+      case 0 => Terse
+      case 1 => RunFinished
+      case 2 => Started
+      case 3 => TestFinished
+      case n => throw new IllegalArgumentException(s"--verbosity=$n")
+    }
   }
 }

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_a.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_n.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertEquals2Test started
 ldTest scala.scalanative.junit.AssertEquals2Test.test started
-leTest scala.scalanative.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_na.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertEquals2Test started
 ldTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nv.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
-leTest scala.scalanative.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nva.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nvc.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nvca.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_v.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_va.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vc.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=0.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
+e2scala.scalanative.junit.AssertEquals2Test.test
+ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=1.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
+e2scala.scalanative.junit.AssertEquals2Test.test
+ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=2.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
+e2scala.scalanative.junit.AssertEquals2Test.test
+ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=3.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
+e2scala.scalanative.junit.AssertEquals2Test.test
+liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vs.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vsn.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
-leTest scala.scalanative.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEquals2Test.test
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_a.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_n.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-ldTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
+ldTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_na.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-ldTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
+ldTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nv.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nva.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvc.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvca.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_v.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_va.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vc.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=0.txt
@@ -1,0 +1,21 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=1.txt
@@ -1,0 +1,21 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=2.txt
@@ -1,0 +1,21 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
+ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=3.txt
@@ -1,0 +1,21 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
+liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vs.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vsn.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
@@ -17,5 +17,5 @@ e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
 e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
-liTest run finished: 0 failed, 0 ignored, 6 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_a.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_n.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertEqualsTest started
 ldTest scala.scalanative.junit.AssertEqualsTest.test started
-leTest scala.scalanative.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_na.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertEqualsTest started
 ldTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nv.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
-leTest scala.scalanative.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nva.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_v.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_va.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vc.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=0.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
+e2scala.scalanative.junit.AssertEqualsTest.test
+ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=1.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
+e2scala.scalanative.junit.AssertEqualsTest.test
+ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=2.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
+e2scala.scalanative.junit.AssertEqualsTest.test
+ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=3.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
+e2scala.scalanative.junit.AssertEqualsTest.test
+liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vs.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
-leTest scala.scalanative.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
+leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
 e2scala.scalanative.junit.AssertEqualsTest.test
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
+leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_a.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_n.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertFalse2Test started
 ldTest scala.scalanative.junit.AssertFalse2Test.test started
-leTest scala.scalanative.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
+leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_na.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertFalse2Test started
 ldTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nv.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
-leTest scala.scalanative.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
+leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nva.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nvc.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nvca.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_v.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
+leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_va.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vc.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=0.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
+e2scala.scalanative.junit.AssertFalse2Test.test
+ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=1.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
+e2scala.scalanative.junit.AssertFalse2Test.test
+ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=2.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
+e2scala.scalanative.junit.AssertFalse2Test.test
+ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=3.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
+e2scala.scalanative.junit.AssertFalse2Test.test
+liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vs.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
+leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vsn.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
-leTest scala.scalanative.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
+leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
 e2scala.scalanative.junit.AssertFalse2Test.test
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
+leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_a.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_n.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertFalseTest started
 ldTest scala.scalanative.junit.AssertFalseTest.test started
-leTest scala.scalanative.junit.AssertFalseTest.test failed: null, took <TIME>
+leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_na.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertFalseTest started
 ldTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nv.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
-leTest scala.scalanative.junit.AssertFalseTest.test failed: null, took <TIME>
+leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nva.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_v.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
+leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_va.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vc.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=0.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
+e2scala.scalanative.junit.AssertFalseTest.test
+ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=1.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
+e2scala.scalanative.junit.AssertFalseTest.test
+ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=2.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
+e2scala.scalanative.junit.AssertFalseTest.test
+ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=3.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
+e2scala.scalanative.junit.AssertFalseTest.test
+liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vs.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
+leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
-leTest scala.scalanative.junit.AssertFalseTest.test failed: null, took <TIME>
+leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertFalseTest.test
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_a.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_n.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertStringEqualsTest started
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test started
-leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_na.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertStringEqualsTest started
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nv.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
-leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nva.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_v.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_va.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vc.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=0.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+e2scala.scalanative.junit.AssertStringEqualsTest.test
+ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=1.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+e2scala.scalanative.junit.AssertStringEqualsTest.test
+ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=2.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+e2scala.scalanative.junit.AssertStringEqualsTest.test
+ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=3.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+e2scala.scalanative.junit.AssertStringEqualsTest.test
+liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vs.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
-leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
+leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
 e2scala.scalanative.junit.AssertStringEqualsTest.test
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_.txt
@@ -1,7 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_a.txt
@@ -1,8 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_n.txt
@@ -1,7 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertThrows2Test started
 ldTest scala.scalanative.junit.AssertThrows2Test.test started
-leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_na.txt
@@ -1,8 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertThrows2Test started
 ldTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nv.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
-leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nva.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvc.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvca.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_v.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_va.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vc.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=0.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=1.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=2.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=3.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vs.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vsn.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
-leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
 e2scala.scalanative.junit.AssertThrows2Test.test
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_.txt
@@ -1,7 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_a.txt
@@ -1,8 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_n.txt
@@ -1,7 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertThrowsTest started
 ldTest scala.scalanative.junit.AssertThrowsTest.test started
-leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_na.txt
@@ -1,8 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertThrowsTest started
 ldTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nv.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
-leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nva.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvc.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvca.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_v.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_va.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vc.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=0.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=1.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=2.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=3.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vs.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
-leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vsn.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
-leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
 e2scala.scalanative.junit.AssertThrowsTest.test
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_.txt
@@ -1,10 +1,10 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
-leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
+leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_a.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
@@ -6,5 +6,5 @@ ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finishe
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_n.txt
@@ -1,10 +1,10 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertTrueTest started
 ldTest scala.scalanative.junit.AssertTrueTest.failTest started
-leTest scala.scalanative.junit.AssertTrueTest.failTest failed: null, took <TIME>
+leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 ldTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-ldTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+ldTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_na.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssertTrueTest started
 ldTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
@@ -6,5 +6,5 @@ ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 ldTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-ldTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+ldTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nv.txt
@@ -1,10 +1,10 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
-leTest scala.scalanative.junit.AssertTrueTest.failTest failed: null, took <TIME>
+leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nva.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
@@ -6,5 +6,5 @@ ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nvc.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
@@ -6,5 +6,5 @@ ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nvca.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
@@ -6,5 +6,5 @@ ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_v.txt
@@ -1,10 +1,10 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
-leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
+leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_va.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
@@ -6,5 +6,5 @@ ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finishe
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vc.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
@@ -6,5 +6,5 @@ ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finishe
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=0.txt
@@ -1,0 +1,10 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
+leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
+e2scala.scalanative.junit.AssertTrueTest.failTest
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertTrueTest.successTest
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=1.txt
@@ -1,0 +1,10 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
+leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
+e2scala.scalanative.junit.AssertTrueTest.failTest
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertTrueTest.successTest
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=2.txt
@@ -1,0 +1,10 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
+leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
+e2scala.scalanative.junit.AssertTrueTest.failTest
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
+liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
+ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertTrueTest.successTest
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=3.txt
@@ -1,0 +1,10 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
+leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
+e2scala.scalanative.junit.AssertTrueTest.failTest
+liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
+liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
+liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssertTrueTest.successTest
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vs.txt
@@ -1,10 +1,10 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
-leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
+leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vsn.txt
@@ -1,10 +1,10 @@
-liTest run started
+liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
-leTest scala.scalanative.junit.AssertTrueTest.failTest failed: null, took <TIME>
+leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
 e2scala.scalanative.junit.AssertTrueTest.failTest
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
 e0scala.scalanative.junit.AssertTrueTest.successTest
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_a.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_n.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeAfterAssume started
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssumeAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_na.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeAfterAssume started
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssumeAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nv.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nva.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvc.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvca.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_v.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_va.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vc.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=0.txt
@@ -1,0 +1,10 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=1.txt
@@ -1,0 +1,10 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=2.txt
@@ -1,0 +1,10 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=3.txt
@@ -1,0 +1,10 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vs.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vsn.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
@@ -6,5 +6,5 @@ e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_.txt
@@ -1,8 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_a.txt
@@ -1,8 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_n.txt
@@ -1,8 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeAfterClassTest started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_na.txt
@@ -1,8 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeAfterClassTest started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nv.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nva.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvc.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvca.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_v.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_va.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vc.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=0.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeAfterClassTest.test
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeAfterClassTest
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=1.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeAfterClassTest.test
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeAfterClassTest
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=2.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeAfterClassTest.test
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeAfterClassTest
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=3.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
+liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeAfterClassTest.test
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeAfterClassTest
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vs.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vsn.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_.txt
@@ -1,9 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_a.txt
@@ -1,9 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_n.txt
@@ -1,9 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeAfterException started
 ldTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssumeAfterException finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_na.txt
@@ -1,9 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeAfterException started
 ldTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.AssumeAfterException finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nv.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterException finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nva.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterException finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvc.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterException finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvca.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterException finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_v.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_va.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vc.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=0.txt
@@ -1,0 +1,9 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
+e2scala.scalanative.junit.AssumeAfterException.test
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=1.txt
@@ -1,0 +1,9 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
+e2scala.scalanative.junit.AssumeAfterException.test
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=2.txt
@@ -1,0 +1,9 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
+e2scala.scalanative.junit.AssumeAfterException.test
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=3.txt
@@ -1,0 +1,9 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
+e2scala.scalanative.junit.AssumeAfterException.test
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vs.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vsn.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.AssumeAfterException finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_.txt
@@ -1,7 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeInAfter.test
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_a.txt
@@ -1,7 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeInAfter.test
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_n.txt
@@ -1,7 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeInAfter started
 ldTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+ldTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_na.txt
@@ -1,7 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeInAfter started
 ldTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+ldTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nv.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nva.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nvc.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nvca.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_v.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeInAfter.test
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_va.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeInAfter.test
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vc.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeInAfter.test
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=0.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeInAfter.test
+ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=1.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeInAfter.test
+ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=2.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeInAfter.test
+ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=3.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeInAfter.test
+liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vs.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeInAfter.test
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vsn.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeInAfter.test
+liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_.txt
@@ -1,7 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeTest.assumeFail
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_a.txt
@@ -1,7 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeTest.assumeFail
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_n.txt
@@ -1,7 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeTest started
 ldTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+ldTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_na.txt
@@ -1,7 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AssumeTest started
 ldTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+ldTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nv.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nva.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nvc.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nvca.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_v.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeTest.assumeFail
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_va.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeTest.assumeFail
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vc.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeTest.assumeFail
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=0.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeTest.assumeFail
+ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=1.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeTest.assumeFail
+ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=2.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeTest.assumeFail
+ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=3.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.AssumeTest.assumeFail
+liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vs.txt
@@ -1,7 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+e0scala.scalanative.junit.AssumeTest.assumeFail
+li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vsn.txt
@@ -1,7 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+e0scala.scalanative.junit.AssumeTest.assumeFail
+liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_a.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_n.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AsyncTest started
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 ldTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-ldTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
+ldTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_na.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.AsyncTest started
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 ldTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-ldTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
+ldTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nv.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nva.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nvc.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nvca.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_v.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_va.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vc.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=0.txt
@@ -1,0 +1,13 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
+leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
+e2scala.scalanative.junit.AsyncTest.asyncFailure
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
+e0scala.scalanative.junit.AsyncTest.expectedException
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
+e0scala.scalanative.junit.AsyncTest.success
+ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=1.txt
@@ -1,0 +1,13 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
+leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
+e2scala.scalanative.junit.AsyncTest.asyncFailure
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
+e0scala.scalanative.junit.AsyncTest.expectedException
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
+e0scala.scalanative.junit.AsyncTest.success
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=2.txt
@@ -1,0 +1,13 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
+leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
+e2scala.scalanative.junit.AsyncTest.asyncFailure
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
+e0scala.scalanative.junit.AsyncTest.expectedException
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
+ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
+e0scala.scalanative.junit.AsyncTest.success
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=3.txt
@@ -1,0 +1,13 @@
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
+leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
+e2scala.scalanative.junit.AsyncTest.asyncFailure
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
+e0scala.scalanative.junit.AsyncTest.expectedException
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
+liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
+e0scala.scalanative.junit.AsyncTest.success
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vs.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vsn.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
 e2scala.scalanative.junit.AsyncTest.asyncFailure
@@ -9,5 +9,5 @@ e0scala.scalanative.junit.AsyncTest.expectedException
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
 e0scala.scalanative.junit.AsyncTest.success
-liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_a.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_n.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_na.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nv.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nva.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvc.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvca.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_v.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_va.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vc.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=0.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=1.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=2.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=3.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
+liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vs.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterClassTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_a.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_n.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.BeforeAndAfterTest started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_na.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.BeforeAndAfterTest started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nv.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nva.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nvc.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nvca.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_v.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_va.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vc.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=0.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterTest.test
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=1.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterTest.test
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=2.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
+ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterTest.test
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=3.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
+liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
+e0scala.scalanative.junit.BeforeAndAfterTest.test
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vs.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
 e0scala.scalanative.junit.BeforeAndAfterTest.test
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=0.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.BeforeAssumeFailTest
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=1.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.BeforeAssumeFailTest
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=2.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.BeforeAssumeFailTest
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=3.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.BeforeAssumeFailTest
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_.txt
@@ -1,9 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_a.txt
@@ -1,9 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_n.txt
@@ -1,9 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionAfterAssume started
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_na.txt
@@ -1,9 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionAfterAssume started
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nv.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nva.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvc.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvca.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_v.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_va.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vc.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=0.txt
@@ -1,0 +1,9 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
+ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=1.txt
@@ -1,0 +1,9 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
+ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=2.txt
@@ -1,0 +1,9 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
+ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=3.txt
@@ -1,0 +1,9 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
+liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vs.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vsn.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finis
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_a.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finis
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_n.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionAfterClass started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-ldTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_na.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionAfterClass started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-ldTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nv.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nva.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nvc.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.ExceptionAfterClass failed: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nvca.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.ExceptionAfterClass failed: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_v.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finis
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_va.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finis
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vc.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finis
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=0.txt
@@ -1,0 +1,11 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
+e0scala.scalanative.junit.ExceptionAfterClass.test1
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
+e0scala.scalanative.junit.ExceptionAfterClass.test2
+leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
+e2scala.scalanative.junit.ExceptionAfterClass
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=1.txt
@@ -1,0 +1,11 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
+e0scala.scalanative.junit.ExceptionAfterClass.test1
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
+e0scala.scalanative.junit.ExceptionAfterClass.test2
+leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
+e2scala.scalanative.junit.ExceptionAfterClass
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=2.txt
@@ -1,0 +1,11 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
+e0scala.scalanative.junit.ExceptionAfterClass.test1
+liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
+ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
+e0scala.scalanative.junit.ExceptionAfterClass.test2
+leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
+e2scala.scalanative.junit.ExceptionAfterClass
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=3.txt
@@ -1,0 +1,11 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
+liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
+e0scala.scalanative.junit.ExceptionAfterClass.test1
+liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
+liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
+e0scala.scalanative.junit.ExceptionAfterClass.test2
+leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
+e2scala.scalanative.junit.ExceptionAfterClass
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vs.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finis
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vsn.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test1
@@ -7,5 +7,5 @@ ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
 e0scala.scalanative.junit.ExceptionAfterClass.test2
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionAfterClass
-liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
-leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_a.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_n.txt
@@ -1,6 +1,6 @@
-ldTest run started
-leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
+ldTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
+leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_na.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nv.txt
@@ -1,6 +1,6 @@
-liTest run started
-leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
+leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nva.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nvc.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: after, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nvca.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: after, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_v.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
-leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_va.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vc.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: after, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=0.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=1.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=2.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=3.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vs.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
-leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vsn.txt
@@ -1,6 +1,6 @@
-liTest run started
-leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
+leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_a.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_n.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-ldTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_na.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-ldTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nv.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nva.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nvc.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nvca.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_v.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_va.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vc.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=0.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
+e2scala.scalanative.junit.ExceptionBeforeClass
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=1.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
+e2scala.scalanative.junit.ExceptionBeforeClass
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=2.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
+e2scala.scalanative.junit.ExceptionBeforeClass
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=3.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
+e2scala.scalanative.junit.ExceptionBeforeClass
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vs.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vsn.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
 e2scala.scalanative.junit.ExceptionBeforeClass
-liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
-leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
-leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_a.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_n.txt
@@ -1,6 +1,6 @@
-ldTest run started
-leTest scala.scalanative.junit.ExceptionEverywhere failed: before class, took <TIME>
+ldTest run scala.scalanative.junit.ExceptionEverywhere started
+leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
-leTest scala.scalanative.junit.ExceptionEverywhere failed: after class, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
+ldTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_na.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nv.txt
@@ -1,6 +1,6 @@
-liTest run started
-leTest scala.scalanative.junit.ExceptionEverywhere failed: before class, took <TIME>
+liTest run scala.scalanative.junit.ExceptionEverywhere started
+leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
-leTest scala.scalanative.junit.ExceptionEverywhere failed: after class, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
+liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nva.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nvc.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
 leTest scala.scalanative.junit.ExceptionEverywhere failed: after class, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nvca.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
 leTest scala.scalanative.junit.ExceptionEverywhere failed: after class, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_v.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
-leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
-leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_va.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vc.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=0.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
+e2scala.scalanative.junit.ExceptionEverywhere
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=1.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
+e2scala.scalanative.junit.ExceptionEverywhere
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=2.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
+e2scala.scalanative.junit.ExceptionEverywhere
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=3.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
+e2scala.scalanative.junit.ExceptionEverywhere
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vs.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
-leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
-leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vsn.txt
@@ -1,6 +1,6 @@
-liTest run started
-leTest scala.scalanative.junit.ExceptionEverywhere failed: before class, took <TIME>
+liTest run scala.scalanative.junit.ExceptionEverywhere started
+leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
 e2scala.scalanative.junit.ExceptionEverywhere
-leTest scala.scalanative.junit.ExceptionEverywhere failed: after class, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
+leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
+liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_a.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_n.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionInAfterTest started
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_na.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionInAfterTest started
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nv.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nva.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_v.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_va.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vc.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=0.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
+e2scala.scalanative.junit.ExceptionInAfterTest.test
+ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=1.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
+e2scala.scalanative.junit.ExceptionInAfterTest.test
+ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=2.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
+e2scala.scalanative.junit.ExceptionInAfterTest.test
+ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=3.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
+e2scala.scalanative.junit.ExceptionInAfterTest.test
+liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vs.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
 e2scala.scalanative.junit.ExceptionInAfterTest.test
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_.txt
@@ -1,8 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_a.txt
@@ -1,8 +1,8 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_n.txt
@@ -1,8 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionInBeforeTest started
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_na.txt
@@ -1,8 +1,8 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionInBeforeTest started
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
-ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nv.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nva.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nvc.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nvca.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_v.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_va.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vc.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=0.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
+e2scala.scalanative.junit.ExceptionInBeforeTest.test
+leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
+ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=1.txt
@@ -1,0 +1,8 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
+e2scala.scalanative.junit.ExceptionInBeforeTest.test
+leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
+ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=2.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
+e2scala.scalanative.junit.ExceptionInBeforeTest.test
+leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
+ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=3.txt
@@ -1,0 +1,8 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
+e2scala.scalanative.junit.ExceptionInBeforeTest.test
+leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
+liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vs.txt
@@ -1,8 +1,8 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vsn.txt
@@ -1,8 +1,8 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
 e2scala.scalanative.junit.ExceptionInBeforeTest.test
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
-liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_a.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_n.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionInConstructorTest started
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_na.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionInConstructorTest started
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nv.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nva.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_v.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_va.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vc.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=0.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
+e2scala.scalanative.junit.ExceptionInConstructorTest.test
+ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=1.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
+e2scala.scalanative.junit.ExceptionInConstructorTest.test
+ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=2.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
+e2scala.scalanative.junit.ExceptionInConstructorTest.test
+ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=3.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
+e2scala.scalanative.junit.ExceptionInConstructorTest.test
+liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vs.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
 e2scala.scalanative.junit.ExceptionInConstructorTest.test
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_a.txt
@@ -1,7 +1,7 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_n.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionTest started
 ldTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_na.txt
@@ -1,7 +1,7 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExceptionTest started
 ldTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
-ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nv.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nva.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_v.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_va.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vc.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=0.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
+e2scala.scalanative.junit.ExceptionTest.test
+ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=1.txt
@@ -1,0 +1,7 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
+e2scala.scalanative.junit.ExceptionTest.test
+ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=2.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
+e2scala.scalanative.junit.ExceptionTest.test
+ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=3.txt
@@ -1,0 +1,7 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
+e2scala.scalanative.junit.ExceptionTest.test
+liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vs.txt
@@ -1,7 +1,7 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
-liTest run started
+liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
 e2scala.scalanative.junit.ExceptionTest.test
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
-liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -6,7 +6,7 @@ ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectNormal
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
-leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: Expected exception: java.lang.AssertionError, took <TIME>
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectAssert
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
@@ -15,8 +15,8 @@ leCaused by: java.lang.IllegalArgumentException
 e2scala.scalanative.junit.ExpectTest.failExpectDifferent
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
-leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_a.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -18,5 +18,5 @@ ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m st
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
-ld[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_n.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExpectTest started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -6,7 +6,7 @@ ldTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectNormal
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert started
-leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
+leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectAssert
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
@@ -15,8 +15,8 @@ leCaused by: java.lang.IllegalArgumentException
 e2scala.scalanative.junit.ExpectTest.failExpectDifferent
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
-leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
+leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
-ldTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
+ldTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_na.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.ExpectTest started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -18,5 +18,5 @@ ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
-ldTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
+ldTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nv.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -6,7 +6,7 @@ liTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectNormal
 liTest scala.scalanative.junit.ExpectTest.failExpectAssert started
-leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
+leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectAssert
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
@@ -15,8 +15,8 @@ leCaused by: java.lang.IllegalArgumentException
 e2scala.scalanative.junit.ExpectTest.failExpectDifferent
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
-leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
+leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
-liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nva.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -18,5 +18,5 @@ liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
-liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nvc.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -18,5 +18,5 @@ liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
-liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nvca.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -18,5 +18,5 @@ liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
-liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_v.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -6,7 +6,7 @@ liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectNormal
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
-leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: Expected exception: java.lang.AssertionError, took <TIME>
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectAssert
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
@@ -15,8 +15,8 @@ leCaused by: java.lang.IllegalArgumentException
 e2scala.scalanative.junit.ExpectTest.failExpectDifferent
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
-leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_va.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -18,5 +18,5 @@ liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m st
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vc.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -18,5 +18,5 @@ liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m st
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=0.txt
@@ -1,0 +1,22 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
+e0scala.scalanative.junit.ExpectTest.expectAssert
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
+e0scala.scalanative.junit.ExpectTest.expectNormal
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
+e2scala.scalanative.junit.ExpectTest.failExpectAssert
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
+ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=1.txt
@@ -1,0 +1,22 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
+e0scala.scalanative.junit.ExpectTest.expectAssert
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
+e0scala.scalanative.junit.ExpectTest.expectNormal
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
+e2scala.scalanative.junit.ExpectTest.failExpectAssert
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=2.txt
@@ -1,0 +1,22 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
+e0scala.scalanative.junit.ExpectTest.expectAssert
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
+e0scala.scalanative.junit.ExpectTest.expectNormal
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
+e2scala.scalanative.junit.ExpectTest.failExpectAssert
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=3.txt
@@ -1,0 +1,22 @@
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
+e0scala.scalanative.junit.ExpectTest.expectAssert
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
+e0scala.scalanative.junit.ExpectTest.expectNormal
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
+e2scala.scalanative.junit.ExpectTest.failExpectAssert
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vs.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -6,7 +6,7 @@ liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectNormal
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
-leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: Expected exception: java.lang.AssertionError, took <TIME>
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectAssert
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
@@ -15,8 +15,8 @@ leCaused by: java.lang.IllegalArgumentException
 e2scala.scalanative.junit.ExpectTest.failExpectDifferent
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
-leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
+leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
-li[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vsn.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectAssert
@@ -6,7 +6,7 @@ liTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
 e0scala.scalanative.junit.ExpectTest.expectNormal
 liTest scala.scalanative.junit.ExpectTest.failExpectAssert started
-leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
+leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectAssert
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
@@ -15,8 +15,8 @@ leCaused by: java.lang.IllegalArgumentException
 e2scala.scalanative.junit.ExpectTest.failExpectDifferent
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
-leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
+leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
 e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
-liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e3scala.scalanative.junit.IgnoreAllTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTest
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_a.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e3scala.scalanative.junit.IgnoreAllTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTest
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_n.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e3scala.scalanative.junit.IgnoreAllTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTest
+ldTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_na.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e3scala.scalanative.junit.IgnoreAllTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTest
+ldTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nv.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e3scala.scalanative.junit.IgnoreAllTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTest
+liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nva.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e3scala.scalanative.junit.IgnoreAllTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTest
+liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e3scala.scalanative.junit.IgnoreAllTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTest
+liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e3scala.scalanative.junit.IgnoreAllTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTest
+liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_v.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e3scala.scalanative.junit.IgnoreAllTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_va.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e3scala.scalanative.junit.IgnoreAllTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vc.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e3scala.scalanative.junit.IgnoreAllTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=0.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e4scala.scalanative.junit.IgnoreAllTest
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=1.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e4scala.scalanative.junit.IgnoreAllTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=2.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e4scala.scalanative.junit.IgnoreAllTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=3.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e4scala.scalanative.junit.IgnoreAllTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vs.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e3scala.scalanative.junit.IgnoreAllTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e3scala.scalanative.junit.IgnoreAllTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTest
+liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_a.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_n.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+ldTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_na.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+ldTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nv.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nva.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvc.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvca.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_v.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_va.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vc.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=0.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=1.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=2.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=3.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vs.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vsn.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e3scala.scalanative.junit.IgnoreAllTestWithReason
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_a.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_n.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+ldTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_na.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+ldTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nv.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nva.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_v.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_va.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vc.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=0.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=1.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=2.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=3.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vs.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e3scala.scalanative.junit.IgnoreTest.onlyTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.IgnoreTest.onlyTest
+liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_a.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_n.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MethodNameDecodeTest started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_na.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MethodNameDecodeTest started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+ldTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nv.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nva.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nvc.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nvca.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_v.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_va.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vc.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=0.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
+ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=1.txt
@@ -1,0 +1,6 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
+ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=2.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
+ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=3.txt
@@ -1,0 +1,6 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
+liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vs.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd ∆ƒ 😀 * #&$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd ∆ƒ 😀 * #&$[0m finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$ finished, took <TIME>
 e0scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$
-liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
+liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_.txt
@@ -1,9 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_a.txt
@@ -1,9 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_n.txt
@@ -1,9 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.Multi1Test started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-ldTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
+ldTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_na.txt
@@ -1,9 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.Multi1Test started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-ldTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
+ldTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nv.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nva.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nvc.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nvca.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_v.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_va.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vc.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=0.txt
@@ -1,0 +1,9 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi1Test.multiTest2
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=1.txt
@@ -1,0 +1,9 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi1Test.multiTest2
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=2.txt
@@ -1,0 +1,9 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi1Test.multiTest1
+liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi1Test.multiTest2
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=3.txt
@@ -1,0 +1,9 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
+liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi1Test.multiTest1
+liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
+liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi1Test.multiTest2
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vs.txt
@@ -1,9 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vsn.txt
@@ -1,9 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest1
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.Multi1Test.multiTest2
-liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
+liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_a.txt
@@ -1,4 +1,4 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_n.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.Multi2Test started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+ldTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_na.txt
@@ -1,4 +1,4 @@
-ldTest run started
+ldTest run scala.scalanative.junit.Multi2Test started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+ldTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nv.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nva.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nvc.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nvca.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_v.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_va.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vc.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=0.txt
@@ -1,0 +1,18 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest2
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest3
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest5
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=1.txt
@@ -1,0 +1,18 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest2
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest3
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=2.txt
@@ -1,0 +1,18 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest1
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest2
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest3
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest4
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=3.txt
@@ -1,0 +1,18 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest1
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest2
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest3
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest4
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
+liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.Multi2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vs.txt
@@ -1,4 +1,4 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vsn.txt
@@ -1,4 +1,4 @@
-liTest run started
+liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest1
@@ -14,5 +14,5 @@ e0scala.scalanative.junit.Multi2Test.multiTest4
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.Multi2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_.txt
@@ -1,8 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_a.txt
@@ -1,8 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_n.txt
@@ -1,8 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiAssumeFail1Test started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+ldTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_na.txt
@@ -1,8 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiAssumeFail1Test started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+ldTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nv.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nva.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nvc.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nvca.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_v.txt
@@ -1,8 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_va.txt
@@ -1,8 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vc.txt
@@ -1,8 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=0.txt
@@ -1,0 +1,20 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=1.txt
@@ -1,0 +1,20 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=2.txt
@@ -1,0 +1,20 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=3.txt
@@ -1,0 +1,20 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
+liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vs.txt
@@ -1,8 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vsn.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
@@ -15,5 +16,5 @@ e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_.txt
@@ -1,8 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_a.txt
@@ -1,8 +1,9 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_n.txt
@@ -1,8 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiAssumeFail2Test started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+ldTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_na.txt
@@ -1,8 +1,9 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiAssumeFail2Test started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+ldTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nv.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nva.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nvc.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nvca.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_v.txt
@@ -1,8 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_va.txt
@@ -1,8 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vc.txt
@@ -1,8 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=0.txt
@@ -1,0 +1,22 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=1.txt
@@ -1,0 +1,22 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=2.txt
@@ -1,0 +1,22 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=3.txt
@@ -1,0 +1,22 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
+liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vs.txt
@@ -1,8 +1,9 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vsn.txt
@@ -1,8 +1,9 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
@@ -13,8 +14,9 @@ liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
-liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
+liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+ldTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=0.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=1.txt
@@ -1,0 +1,5 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=2.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=3.txt
@@ -1,0 +1,5 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
+liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_a.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_n.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-ldTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
+ldTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_na.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-ldTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
+ldTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nv.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nva.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nvc.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nvca.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_v.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_va.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vc.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=0.txt
@@ -1,0 +1,17 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=1.txt
@@ -1,0 +1,17 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=2.txt
@@ -1,0 +1,17 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=3.txt
@@ -1,0 +1,17 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
+liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vs.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vsn.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
@@ -13,5 +13,5 @@ e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
-liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m sta
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_a.txt
@@ -1,6 +1,6 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m sta
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_n.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-ldTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
+ldTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_na.txt
@@ -1,6 +1,6 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-ldTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
+ldTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nv.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nva.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nvc.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nvca.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_v.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m sta
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_va.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m sta
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vc.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m sta
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=0.txt
@@ -1,0 +1,16 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=1.txt
@@ -1,0 +1,16 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=2.txt
@@ -1,0 +1,16 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
+ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=3.txt
@@ -1,0 +1,16 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
+liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vs.txt
@@ -1,6 +1,6 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m sta
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vsn.txt
@@ -1,6 +1,6 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
@@ -8,9 +8,9 @@ liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
 e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
-liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
+liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_.txt
@@ -1,13 +1,13 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_a.txt
@@ -1,13 +1,13 @@
-ld[34mTest run started[0m
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_n.txt
@@ -1,13 +1,13 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-ldTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+ldTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_na.txt
@@ -1,13 +1,13 @@
-ldTest run started
+ldTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-ldTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+ldTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nv.txt
@@ -1,13 +1,13 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nva.txt
@@ -1,13 +1,13 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nvc.txt
@@ -1,13 +1,13 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nvca.txt
@@ -1,13 +1,13 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_v.txt
@@ -1,13 +1,13 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_va.txt
@@ -1,13 +1,13 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vc.txt
@@ -1,13 +1,13 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=0.txt
@@ -1,0 +1,13 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=1.txt
@@ -1,0 +1,13 @@
+ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=2.txt
@@ -1,0 +1,13 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=3.txt
@@ -1,0 +1,13 @@
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vs.txt
@@ -1,13 +1,13 @@
-li[34mTest run started[0m
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vsn.txt
@@ -1,13 +1,13 @@
-liTest run started
+liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
-liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/utils/JUnitTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/utils/JUnitTest.scala
@@ -15,8 +15,7 @@ abstract class JUnitTest {
   import JUnitTest._
 
   // appropriate class loader for platform, needs platform extension
-  private val classLoader: ClassLoader =
-    JUnitTestPlatformImpl.getClassLoader
+  private val classLoader: ClassLoader = JUnitTestPlatformImpl.getClassLoader
 
   private val recordOutput =
     sys.props.contains("org.scalajs.junit.utils.record")
@@ -28,26 +27,31 @@ abstract class JUnitTest {
     myName.stripSuffix("Assertions")
   }
 
-  private val frameworkArgss: List[List[Char]] = List(
+  def simple(args: Char*): List[String] = args.map("-" + _).toList
+  private val frameworkArgss: List[List[String]] = List(
     List.empty,
-    List('a'),
-    List('v'),
-    List('n'),
-    List('n', 'a'),
-    List('n', 'v'),
-    List('n', 'v', 'a'),
-    List('n', 'v', 'c'),
-    List('n', 'v', 'c', 'a'),
-    List('v', 'a'),
-    List('v', 'c'),
-    List('v', 's'),
-    List('v', 's', 'n')
+    simple('a'),
+    simple('v'),
+    simple('n'),
+    simple('n', 'a'),
+    simple('n', 'v'),
+    simple('n', 'v', 'a'),
+    simple('n', 'v', 'c'),
+    simple('n', 'v', 'c', 'a'),
+    simple('v', 'a'),
+    simple('v', 'c'),
+    simple('v', 's'),
+    simple('v', 's', 'n'),
+    List("--verbosity=0"),
+    List("--verbosity=1"),
+    List("--verbosity=2"),
+    List("--verbosity=3")
   )
 
   @Test def testJUnitOutput(): Unit = await {
     val futs = for (args <- frameworkArgss) yield {
       for {
-        rawOut <- runTests(args.map("-" + _))
+        rawOut <- runTests(args)
       } yield {
         val out = postprocessOutput(rawOut)
 
@@ -153,9 +157,11 @@ abstract class JUnitTest {
     prefix ++ chunks.toSeq.sortBy(_._1).flatMap(_._2) ++ suffix
   }
 
-  private def recordPath(args: List[Char]): String = {
+  private def recordPath(args: List[String]): String = {
     val fname =
-      getClass.getName.replace('.', '/') + "_" + args.mkString("") + ".txt"
+      getClass.getName.replace('.', '/') + "_" + args
+        .map(_.dropWhile(_ == '-'))
+        .mkString("") + ".txt"
     recordDir + "/" + fname
   }
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -19,7 +19,7 @@ object Deps {
 
   lazy val SbtPlatformDeps  = "org.portable-scala" % "sbt-platform-deps" % "1.0.1"
   lazy val SbtTestInterface = "org.scala-sbt"      % "test-interface"    % "1.0"
-  lazy val JUnitInterface   = "com.novocode"       % "junit-interface"   % "0.11"
+  lazy val JUnitInterface   = "com.github.sbt"     % "junit-interface"   % "0.13.3"
   lazy val JUnit            = "junit"              % "junit"             % "4.13.2"
 
   def NativeLib(scalaVersion: String) = scalaVersionsDependendent(scalaVersion) {


### PR DESCRIPTION
Upgrades the JUnit interface to 0.13.3 and fixes the implementation to match new settings/behaviour. 
No new features are added in this change.