### PR TITLE
Add `@define` annotation to propagate linktime reachability to native code compile phase

### DIFF
--- a/javalib/src/main/resources/scala-native/scala-native.properties
+++ b/javalib/src/main/resources/scala-native/scala-native.properties
@@ -2,5 +2,3 @@
 project.organization = org.scala-native
 project.name = javalib
 
-# defines SCALANATIVE_LINK_Z if @link("z") annnotation is used (found in NIR)
-nir.link.names = z

--- a/nativelib/src/main/resources/scala-native/z.c
+++ b/nativelib/src/main/resources/scala-native/z.c
@@ -1,4 +1,4 @@
-#ifdef SCALANATIVE_LINK_Z
+#ifdef SCALANATIVE_Z
 
 #include <zlib.h>
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/zlib.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/zlib.scala
@@ -5,6 +5,7 @@ import scala.scalanative.unsafe._
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
 @link("z")
+@define("SCALANATIVE_Z")
 @extern
 object zlib {
   import zlibExt._

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/define.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/define.scala
@@ -1,0 +1,18 @@
+package scala.scalanative
+package unsafe
+
+import scala.annotation.meta._
+
+/** An annotation that is used to automatically define a macro when the
+ *  annotated symbol is used.
+ */
+@field @getter @setter
+final class define private () extends scala.annotation.StaticAnnotation {
+
+  /** Define a macro like `-Dname` */
+  def this(name: String) = this()
+
+  /** Define a macro like `-Dname=definition` */
+  def this(name: String, definition: String) = this()
+
+}

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/define.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/define.scala
@@ -12,7 +12,4 @@ final class define private () extends scala.annotation.StaticAnnotation {
   /** Define a macro like `-Dname` */
   def this(name: String) = this()
 
-  /** Define a macro like `-Dname=definition` */
-  def this(name: String, definition: String) = this()
-
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -28,7 +28,7 @@ object Attr {
   case object Stub extends Attr
   case class Extern(blocking: Boolean) extends Attr
   final case class Link(name: String) extends Attr
-  final case class Define(name: String, definition: Option[String]) extends Attr
+  final case class Define(name: String) extends Attr
   case object Abstract extends Attr
   case object Volatile extends Attr
   case object Final extends Attr

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -28,6 +28,7 @@ object Attr {
   case object Stub extends Attr
   case class Extern(blocking: Boolean) extends Attr
   final case class Link(name: String) extends Attr
+  final case class Define(name: String, definition: Option[String]) extends Attr
   case object Abstract extends Attr
   case object Volatile extends Attr
   case object Final extends Attr
@@ -52,7 +53,8 @@ final case class Attrs(
     isVolatile: Boolean = false,
     isFinal: Boolean = false,
     isLinktimeResolved: Boolean = false,
-    links: Seq[Attr.Link] = Seq.empty
+    links: Seq[Attr.Link] = Seq.empty,
+    preprocessorDefinitions: Seq[Attr.Define] = Seq.empty
 ) {
   def toSeq: Seq[Attr] = {
     val out = Seq.newBuilder[Attr]
@@ -69,6 +71,7 @@ final case class Attrs(
     if (isFinal) out += Final
     if (isLinktimeResolved) out += LinktimeResolved
     out ++= links
+    out ++= preprocessorDefinitions
 
     out.result()
   }
@@ -90,6 +93,7 @@ object Attrs {
     var isFinal = false
     var isLinktimeResolved = false
     val links = Seq.newBuilder[Attr.Link]
+    val preprocessorDefinitions = Seq.newBuilder[Attr.Define]
 
     attrs.foreach {
       case attr: Inline     => inline = attr
@@ -100,12 +104,13 @@ object Attrs {
       case Extern(blocking) =>
         isExtern = true
         isBlocking = blocking
-      case Dyn             => isDyn = true
-      case Stub            => isStub = true
-      case link: Attr.Link => links += link
-      case Abstract        => isAbstract = true
-      case Volatile        => isVolatile = true
-      case Final           => isFinal = true
+      case Dyn                 => isDyn = true
+      case Stub                => isStub = true
+      case link: Attr.Link     => links += link
+      case define: Attr.Define => preprocessorDefinitions += define
+      case Abstract            => isAbstract = true
+      case Volatile            => isVolatile = true
+      case Final               => isFinal = true
 
       case LinktimeResolved => isLinktimeResolved = true
     }
@@ -123,7 +128,8 @@ object Attrs {
       isVolatile = isVolatile,
       isFinal = isFinal,
       isLinktimeResolved = isLinktimeResolved,
-      links = links.result()
+      links = links.result(),
+      preprocessorDefinitions = preprocessorDefinitions.result()
     )
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -104,13 +104,9 @@ object Show {
         str("link(\"")
         str(escapeQuotes(name))
         str("\")")
-      case Attr.Define(name, definition) =>
+      case Attr.Define(name) =>
         str("define(\"")
         str(escapeQuotes(name))
-        definition.foreach { defn =>
-          str("=")
-          str(escapeQuotes(defn))
-        }
         str("\")")
       case Attr.Abstract =>
         str("abstract")

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -104,6 +104,14 @@ object Show {
         str("link(\"")
         str(escapeQuotes(name))
         str("\")")
+      case Attr.Define(name, definition) =>
+        str("define(\"")
+        str(escapeQuotes(name))
+        definition.foreach { defn =>
+          str("=")
+          str(escapeQuotes(defn))
+        }
+        str("\")")
       case Attr.Abstract =>
         str("abstract")
       case Attr.Volatile =>

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -197,7 +197,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
     case T.StubAttr     => Attr.Stub
     case T.ExternAttr   => Attr.Extern(getBool())
     case T.LinkAttr     => Attr.Link(getString())
-    case T.DefineAttr   => Attr.Define(getString(), getOpt(getString()))
+    case T.DefineAttr   => Attr.Define(getString())
     case T.AbstractAttr => Attr.Abstract
     case T.VolatileAttr => Attr.Volatile
     case T.FinalAttr    => Attr.Final

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -197,6 +197,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
     case T.StubAttr     => Attr.Stub
     case T.ExternAttr   => Attr.Extern(getBool())
     case T.LinkAttr     => Attr.Link(getString())
+    case T.DefineAttr   => Attr.Define(getString(), getOpt(getString()))
     case T.AbstractAttr => Attr.Abstract
     case T.VolatileAttr => Attr.Volatile
     case T.FinalAttr    => Attr.Final

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -188,7 +188,7 @@ final class BinarySerializer(channel: WritableByteChannel) {
       case Attr.Stub               => putTag(T.StubAttr)
       case Attr.Extern(isBlocking) => putTag(T.ExternAttr); putBool(isBlocking)
       case Attr.Link(s)            => putTag(T.LinkAttr); putString(s)
-      case Attr.Define(n, d)       => putTag(T.DefineAttr); putString(n); putOpt(d)(putString)
+      case Attr.Define(n)          => putTag(T.DefineAttr); putString(n)
       case Attr.Abstract           => putTag(T.AbstractAttr)
       case Attr.Volatile           => putTag(T.VolatileAttr)
       case Attr.Final              => putTag(T.FinalAttr)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -188,6 +188,7 @@ final class BinarySerializer(channel: WritableByteChannel) {
       case Attr.Stub               => putTag(T.StubAttr)
       case Attr.Extern(isBlocking) => putTag(T.ExternAttr); putBool(isBlocking)
       case Attr.Link(s)            => putTag(T.LinkAttr); putString(s)
+      case Attr.Define(n, d)       => putTag(T.DefineAttr); putString(n); putOpt(d)(putString)
       case Attr.Abstract           => putTag(T.AbstractAttr)
       case Attr.Volatile           => putTag(T.VolatileAttr)
       case Attr.Final              => putTag(T.FinalAttr)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -28,6 +28,7 @@ object Tags {
   final val FinalAttr = 1 + VolatileAttr
   final val LinktimeResolvedAttr = 1 + FinalAttr
   final val AlignAttr = 1 + LinktimeResolvedAttr
+  final val DefineAttr = 1 + AlignAttr
 
   // Binary ops
   final val IaddBin = 1

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -40,6 +40,7 @@ trait NirDefinitions {
 
     lazy val NameClass = getRequiredClass("scala.scalanative.unsafe.name")
     lazy val LinkClass = getRequiredClass("scala.scalanative.unsafe.link")
+    lazy val DefineClass = getRequiredClass("scala.scalanative.unsafe.define")
     lazy val ExternClass = getRequiredClass(
       "scala.scalanative.unsafe.package$extern"
     )

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -161,18 +161,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val Apply(_, Seq(Literal(Constant(name: String)))) = ann.tree
           Attr.Link(name)
         case ann if ann.symbol == DefineClass =>
-          (ann.tree: @unchecked) match {
-            case Apply(_, Seq(Literal(Constant(name: String)))) =>
-              Attr.Define(name, None)
-            case Apply(
-                  _,
-                  Seq(
-                    Literal(Constant(name: String)),
-                    Literal(Constant(definition: String))
-                  )
-                ) =>
-              Attr.Define(name, Some(definition))
-          }
+          val Apply(_, Seq(Literal(Constant(name: String)))) = ann.tree
+          Attr.Define(name)
         case ann if ann.symbol == StubClass =>
           Attr.Stub
       }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -160,6 +160,19 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case ann if ann.symbol == LinkClass =>
           val Apply(_, Seq(Literal(Constant(name: String)))) = ann.tree
           Attr.Link(name)
+        case ann if ann.symbol == DefineClass =>
+          (ann.tree: @unchecked) match {
+            case Apply(_, Seq(Literal(Constant(name: String)))) =>
+              Attr.Define(name, None)
+            case Apply(
+                  _,
+                  Seq(
+                    Literal(Constant(name: String)),
+                    Literal(Constant(definition: String))
+                  )
+                ) =>
+              Attr.Define(name, Some(definition))
+          }
         case ann if ann.symbol == StubClass =>
           Attr.Stub
       }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -29,6 +29,7 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val AlignClass = requiredClass("scala.scalanative.annotation.align")
   @tu lazy val NameClass = requiredClass("scala.scalanative.unsafe.name")
   @tu lazy val LinkClass = requiredClass("scala.scalanative.unsafe.link")
+  @tu lazy val DefineClass = requiredClass("scala.scalanative.unsafe.define")
   @tu lazy val ExternClass = requiredClass("scala.scalanative.unsafe.extern")
   @tu lazy val NonExternClass = requiredClass("scala.scalanative.annotation.nonExtern")
   @tu lazy val BlockingClass = requiredClass("scala.scalanative.unsafe.blocking")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -77,6 +77,19 @@ trait NirGenStat(using Context) {
         val Apply(_, Seq(Literal(Constant(name: String)))) =
           ann.tree: @unchecked
         Attr.Link(name)
+      case ann if ann.symbol == defnNir.DefineClass =>
+        (ann.tree: @unchecked) match {
+          case Apply(_, Seq(Literal(Constant(name: String)))) =>
+            Attr.Define(name, None)
+          case Apply(
+                _,
+                Seq(
+                  Literal(Constant(name: String)),
+                  Literal(Constant(definition: String))
+                )
+              ) =>
+            Attr.Define(name, Some(definition))
+        }
     }
     val isAbstract = Option.when(sym.is(Abstract))(Attr.Abstract)
     Attrs.fromSeq(annotationAttrs ++ isAbstract)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -78,18 +78,9 @@ trait NirGenStat(using Context) {
           ann.tree: @unchecked
         Attr.Link(name)
       case ann if ann.symbol == defnNir.DefineClass =>
-        (ann.tree: @unchecked) match {
-          case Apply(_, Seq(Literal(Constant(name: String)))) =>
-            Attr.Define(name, None)
-          case Apply(
-                _,
-                Seq(
-                  Literal(Constant(name: String)),
-                  Literal(Constant(definition: String))
-                )
-              ) =>
-            Attr.Define(name, Some(definition))
-        }
+        val Apply(_, Seq(Literal(Constant(name: String)))) =
+          ann.tree: @unchecked
+        Attr.Define(name)
     }
     val isAbstract = Option.when(sym.is(Abstract))(Attr.Abstract)
     Attrs.fromSeq(annotationAttrs ++ isAbstract)

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
@@ -154,7 +154,7 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
       infos = mutable.Map.empty,
       entries = Nil,
       links = Defaults.links,
-      macros = Nil,
+      preprocessorDefinitions = Nil,
       defns = Nil,
       dynsigs = Nil,
       dynimpls = Nil,

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
@@ -154,6 +154,7 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
       infos = mutable.Map.empty,
       entries = Nil,
       links = Defaults.links,
+      macros = Nil,
       defns = Nil,
       dynsigs = Nil,
       dynimpls = Nil,

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -69,8 +69,7 @@ private[scalanative] object NativeLib {
     // Apply global configuraiton changes based on reachability analysis results
     def withAnalysisInfo(config: Config): Config = {
       val preprocessorFlags = analysis.preprocessorDefinitions.map {
-        case Attr.Define(name, None)             => s"-D$name"
-        case Attr.Define(name, Some(definition)) => s"-D$name=$definition"
+        case Attr.Define(name) => s"-D$name"
       }
       config.withCompilerConfig(_.withCompileOptions(_ ++ preprocessorFlags))
     }

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -12,6 +12,7 @@ import scala.util.Success
 
 import scalanative.build.IO.RichPath
 import scala.scalanative.linker.ReachabilityAnalysis
+import scala.scalanative.nir.Attr
 
 /** Original jar or dir path and generated dir path for native code */
 private[scalanative] case class NativeLib(src: Path, dest: Path)
@@ -43,7 +44,7 @@ private[scalanative] object NativeLib {
   )(implicit ec: ExecutionContext): Future[Seq[Path]] = {
     val destPath = unpackNativeCode(nativeLib)
     val paths = findNativePaths(config.workDir, destPath)
-    val projConfig = configureNativelib(config, analysis, destPath)
+    val projConfig = configureNativeLibrary(config, analysis, destPath)
     LLVM.compile(projConfig, paths)
   }
 
@@ -58,17 +59,26 @@ private[scalanative] object NativeLib {
    *  @return
    *    The config for this native library.
    */
-  private def configureNativelib(
-      config: Config,
+  private def configureNativeLibrary(
+      initialConfig: Config,
       analysis: ReachabilityAnalysis.Result,
       destPath: Path
   ): Config = {
     val nativeCodePath = destPath.resolve(nativeCodeDir)
-    // apply descriptor settings if found
-    findDescriptor(nativeCodePath).fold(config) { filepath =>
 
-      val desc =
-        Descriptor.load(filepath) match {
+    // Apply global configuraiton changes based on reachability analysis results
+    def withAnalysisInfo(config: Config): Config = {
+      val preprocessorFlags = analysis.preprocessorDefinitions.map {
+        case Attr.Define(name, None)             => s"-D$name"
+        case Attr.Define(name, Some(definition)) => s"-D$name=$definition"
+      }
+      config.withCompilerConfig(_.withCompileOptions(_ ++ preprocessorFlags))
+    }
+
+    // Apply dependency specific configuratin based on descriptor if found
+    def withProjectDescriptor(config: Config): Config = {
+      findDescriptor(nativeCodePath).fold(config) { filepath =>
+        val descriptor = Descriptor.load(filepath) match {
           case Success(v) => v
           case Failure(e) =>
             throw new BuildException(
@@ -76,19 +86,29 @@ private[scalanative] object NativeLib {
             )
         }
 
-      config.logger.debug(s"Compilation settings: ${desc.toString()}")
+        config.logger.debug(s"Compilation settings: ${descriptor.toString()}")
 
-      // update config based on descriptor setting
-      updateConfig(desc, config, analysis, nativeCodePath)
+        val projectSettings = resolveDescriptorFlags(
+          desc = descriptor,
+          gc = config.compilerConfig.gc,
+          analysis = analysis,
+          nativeCodePath = nativeCodePath
+        )
+        config.withCompilerConfig(_.withCompileOptions(_ ++ projectSettings))
+      }
     }
+
+    (withAnalysisInfo _)
+      .andThen(withProjectDescriptor)
+      .apply(initialConfig)
   }
 
-  private def updateConfig(
+  private def resolveDescriptorFlags(
       desc: Descriptor,
-      config: Config,
+      gc: GC,
       analysis: ReachabilityAnalysis.Result,
       nativeCodePath: Path
-  ): Config = {
+  ): Seq[String] = {
     val linkDefines =
       desc.links
         .filter(name => analysis.links.exists(_.name == name))
@@ -110,17 +130,10 @@ private[scalanative] object NativeLib {
      */
     val gcDefine = desc.gcProject match {
       case false => None
-      case true => {
-        val gc = config.compilerConfig.gc.toString
-        Some(s"-DSCALANATIVE_GC_${gc.toUpperCase}")
-      }
+      case true  => Some(s"-DSCALANATIVE_GC_${gc.toString.toUpperCase}")
     }
 
-    config.withCompilerConfig(
-      _.withCompileOptions(
-        _ ++ linkDefines ++ defines ++ gcDefine ++ includePaths
-      )
-    )
+    linkDefines ++ defines ++ gcDefine ++ includePaths
   }
 
   /** Create a platform path string from a base path and unix path string

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -239,6 +239,7 @@ object ReachabilityAnalysis {
       val infos: mutable.Map[Global, Info],
       val entries: Seq[Global],
       val links: Seq[Attr.Link],
+      val preprocessorDefinitions: Seq[Attr.Define],
       val defns: Seq[Defn],
       val dynsigs: Seq[Sig],
       val dynimpls: Seq[Global.Member],

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -21,6 +21,7 @@ class Reach(
   val done = mutable.Map.empty[Global, Defn]
   var stack = List.empty[Global]
   val links = mutable.Set.empty[Attr.Link]
+  val preprocessorDefinitions = mutable.Set.empty[Attr.Define]
   val infos = mutable.Map.empty[Global, Info]
   val from = mutable.Map.empty[Global, ReferencedFrom]
 
@@ -72,6 +73,7 @@ class Reach(
         infos = infos,
         entries = entries,
         links = links.toSeq,
+        preprocessorDefinitions = preprocessorDefinitions.toSeq,
         defns = defns.toSeq,
         dynsigs = dynsigs.toSeq,
         dynimpls = dynimpls.toSeq,
@@ -640,8 +642,10 @@ class Reach(
     reachAttrs(attrs)
   }
 
-  def reachAttrs(attrs: Attrs): Unit =
+  def reachAttrs(attrs: Attrs): Unit = {
     links ++= attrs.links
+    preprocessorDefinitions ++= attrs.preprocessorDefinitions
+  }
 
   def reachType(ty: Type)(implicit srcPosition: nir.Position): Unit = ty match {
     case Type.ArrayValue(ty, n) =>


### PR DESCRIPTION
Inspired by @ekrich in https://github.com/scala-native/scala-native/pull/3389. Fixes https://github.com/scala-native/scala-native/issues/2778.

This PR introduces a new `@define` annotation. It is similar to the `@link` annotation which automatically adds an `-l` flag to the linker options if an extern object is linktime-reachable. In this case, `@define` adds a `-D` macro definition flag to the compiler options if the object is linktime-reachable.

**In short: this annotation enables us to propagate Scala linktime reachability to the native code compile phase.**

Furthermore, it does so independently of the `@link` annotation: it is an orthogonal feature that may be useful in other situations.

In nativelib we now use `@define("SCALANATIVE_Z")` to make compilation of zlib glue code conditional on its linktime reachability.

All naming subject to bikeshed: "define" is a bit overloaded in the codebase so in some places I refer to these as "macros" as in "macro definitions". So we might want to make this more consistent.