### PR TITLE
Fix #3426: Towards a better javalib Stream.toArray(generator)

### DIFF
--- a/javalib/src/main/scala/java/util/stream/StreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamImpl.scala
@@ -677,12 +677,6 @@ private[stream] class StreamImpl[T](
     Arrays
       .sort[Object](buffer, comparator.asInstanceOf[Comparator[_ >: Object]])
 
-    /* // FIXME
-    val newCharacteristics = _spliter.characteristics() |
-      Spliterator.SORTED | Spliterator.ORDERED |
-      Spliterator.SIZED | Spliterator.SUBSIZED
-     */ // FIXME
-
     val startingBits = _spliter.characteristics()
     val alwaysSetBits =
       Spliterator.SORTED | Spliterator.ORDERED |
@@ -719,12 +713,113 @@ private[stream] class StreamImpl[T](
     }
   }
 
+  private class ArrayBuilder[A <: Object](generator: IntFunction[Array[A]]) {
+    /* The supplied generator is used to create the final Array and
+     * to allocate the accumulated chunks.
+     *
+     * This implementation honors the spirit but perhaps not the letter
+     * of the JVM description.
+     *
+     * The 'chunks' ArrayList accumulator is allocated using the 'normal'
+     * allocator for Java Objects.  One could write a custom ArrayList
+     * (or other) implementation which uses the supplied generator
+     * to allocate & grow the accumulator.  That is outside the bounds
+     * and resources of the current effort.
+     */
+
+    final val chunkSize = 1024 // A wild guestimate, see what experience brings
+
+    class ArrayChunk(val contents: Array[A]) {
+      var nUsed = 0
+
+      def add(e: A): Unit = {
+        /* By contract, the sole caller accept() has already checked for
+         * sufficient remaining size. Minimize number of index bounds checks.
+         */
+        contents(nUsed) = e
+        nUsed += 1
+      }
+    }
+
+    var currentChunk: ArrayChunk = _
+    val chunks = new ArrayList[ArrayChunk]()
+
+    def createChunk(): Unit = {
+      currentChunk = new ArrayChunk(generator(chunkSize))
+      chunks.add(currentChunk)
+    }
+
+    createChunk() // prime the list with an initial chunk.
+
+    def accept(e: A): Unit = {
+      if (currentChunk.nUsed >= chunkSize)
+        createChunk()
+
+      currentChunk.add(e)
+    }
+
+    def getTotalSize(): Int = { // Largest possible Array size is an Int
+
+      // Be careful with a potentially partially filled trailing chunk.
+      var total = 0
+
+      val spliter = chunks.spliterator()
+
+      // Be friendly to Scala 2.12
+      val action: Consumer[ArrayChunk] = (e: ArrayChunk) => total += e.nUsed
+
+      while (spliter.tryAdvance(action)) { /* side-effect */ }
+
+      total
+    }
+
+    def build(): Array[A] = {
+      /* Unfortunately, the chunks list is traversed twice.
+       * Someday fate & cleverness may bring a better algorithm.
+       * For now, existence & correctness bring more benefit than perfection.
+       */
+      val dest = generator(getTotalSize())
+
+      var srcPos = 0
+
+      val spliter = chunks.spliterator()
+
+      // Be friendly to Scala 2.12
+      val action: Consumer[ArrayChunk] = (e: ArrayChunk) => {
+        val length = e.nUsed
+        System.arraycopy(
+          e.contents,
+          0,
+          dest,
+          srcPos,
+          length
+        )
+
+        srcPos += length
+      }
+
+      while (spliter.tryAdvance(action)) { /* side-effect */ }
+
+      dest
+    }
+  }
+
+  private def toArrayUnknownSize[A <: Object](
+      generator: IntFunction[Array[A]]
+  ): Array[A] = {
+    val arrayBuilder = new ArrayBuilder[A](generator)
+
+    _spliter.forEachRemaining((e: T) => arrayBuilder.accept(e.asInstanceOf[A]))
+
+    arrayBuilder.build()
+  }
+
   def toArray[A <: Object](generator: IntFunction[Array[A]]): Array[A] = {
     commenceOperation()
 
     val knownSize = _spliter.getExactSizeIfKnown()
     if (knownSize < 0) {
-      toArray().asInstanceOf[Array[A]]
+      toArrayUnknownSize(generator)
     } else {
       val dst = generator(knownSize.toInt)
       var j = 0

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -48,6 +48,20 @@ class StreamTest {
     Arrays.stream(arr).asInstanceOf[Stream[T]]
   }
 
+  // Frequently used data
+  private def genHyadesList(): Tuple2[ArrayList[String], Int] = {
+    val nElements = 7
+    val sisters = new ArrayList[String](nElements)
+    sisters.add("Phaisyle")
+    sisters.add("Coronis")
+    sisters.add("Cleeia")
+    sisters.add("Phaeo")
+    sisters.add("Eudora")
+    sisters.add("Ambrosia")
+    sisters.add("Dione")
+    (sisters, nElements)
+  }
+
 // Methods specified in interface BaseStream ----------------------------
 
   @Test def streamUnorderedOnUnorderedStream(): Unit = {
@@ -624,15 +638,7 @@ class StreamTest {
   @Test def streamCollect_UsingSupplier(): Unit = {
     type U = ArrayList[String]
 
-    val nElements = 7
-    val sisters = new U(nElements)
-    sisters.add("Phaisyle")
-    sisters.add("Coronis")
-    sisters.add("Cleeia")
-    sisters.add("Phaeo")
-    sisters.add("Eudora")
-    sisters.add("Ambrosia")
-    sisters.add("Dione")
+    val (sisters, nElements) = genHyadesList()
 
     val s = sisters.stream()
 
@@ -1538,15 +1544,7 @@ class StreamTest {
   }
 
   @Test def streamToArrayObject(): Unit = {
-    val nElements = 7
-    val sisters = new ArrayList[String](nElements)
-    sisters.add("Phaisyle")
-    sisters.add("Coronis")
-    sisters.add("Cleeia")
-    sisters.add("Phaeo")
-    sisters.add("Eudora")
-    sisters.add("Ambrosia")
-    sisters.add("Dione")
+    val (sisters, nElements) = genHyadesList()
 
     val s = sisters.stream()
 
@@ -1557,19 +1555,11 @@ class StreamTest {
 
     // Proper elements, in encounter order
     for (j <- 0 until nElements)
-      assertEquals("elements do not match", sisters.get(j), resultantArray(j))
+      assertEquals("elements do not match, ", sisters.get(j), resultantArray(j))
   }
 
-  @Test def streamToArrayType(): Unit = {
-    val nElements = 7
-    val sisters = new ArrayList[String](nElements)
-    sisters.add("Phaisyle")
-    sisters.add("Coronis")
-    sisters.add("Cleeia")
-    sisters.add("Phaeo")
-    sisters.add("Eudora")
-    sisters.add("Ambrosia")
-    sisters.add("Dione")
+  @Test def streamToArrayTypeKnownSize(): Unit = {
+    val (sisters, nElements) = genHyadesList()
 
     val s = sisters.stream()
 
@@ -1590,7 +1580,37 @@ class StreamTest {
 
     // Proper elements, in encounter order
     for (j <- 0 until nElements)
-      assertEquals("elements do not match", sisters.get(j), resultantArray(j))
+      assertEquals("elements do not match, ", sisters.get(j), resultantArray(j))
+  }
+
+  @Test def streamToArrayTypeUnknownSize(): Unit = {
+    val (sisters, nElements) = genHyadesList()
+
+    val spliter = Spliterators.spliteratorUnknownSize(
+      sisters.iterator(),
+      Spliterator.ORDERED
+    )
+
+    val s = StreamSupport.stream(spliter, false)
+
+    val resultantArray = s.toArray(
+      new IntFunction[Array[String]]() {
+        def apply(value: Int): Array[String] = new Array[String](value)
+      }
+    )
+
+    // Proper type
+    assertTrue(
+      "Array element type not String",
+      resultantArray.isInstanceOf[Array[String]]
+    )
+
+    // Proper size
+    assertEquals("result size", nElements, resultantArray.size)
+
+    // Proper elements, in encounter order
+    for (j <- 0 until nElements)
+      assertEquals("elements do not match, ", sisters.get(j), resultantArray(j))
   }
 
 }


### PR DESCRIPTION
Fix #3426

Remove erroneous logic which caused a  `java.lang.IllegalStateException` when using `Stream.toArray(generator)`
with Streams where the size is not known.

Also, the implementation of that  method now more closely matches the  Java 8 description. This change should
be visible only those providing a custom generator and _scrutinizing_ all memory allocations. 

As usual, Streams where the size is know are more likely to have better performance. Sometimes one
just needs a correctly working  UNSIZED  Stream.