### PR TITLE
Fix #3431: javalib Matcher.reset(input) now updates underlying regex.

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -93,7 +93,7 @@ final class Matcher private[regex] (
   }
 
   def reset(input: CharSequence): Matcher = {
-    reset()
+    underlying.reset(input)
     _inputSequence = input
     this
   }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/regex/MatcherTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/regex/MatcherTest.scala
@@ -207,6 +207,37 @@ class MatcherTest {
     )
   }
 
+  // Issue 3431
+  @Test def findAfterResetInput(): Unit = {
+    val needle = "Twinkle"
+    val prefix = "Sing the song: "
+    // "Sing the song: Twinkle, Twinkle, Little Star"
+    val haystack = s"${prefix}${needle}, ${needle}, Little Star"
+    val notHaystack = s"Repent"
+
+    val m = Pattern.compile(needle).matcher(haystack)
+
+    assertTrue(
+      s"first find should have found '${needle}' in '${haystack}'",
+      m.find()
+    )
+
+    val expectedStart = prefix.length
+    val foundStart = m.start()
+    assertTrue(
+      s"first start index: ${foundStart} != expected: ${expectedStart}",
+      foundStart == expectedStart
+    )
+
+    m.reset(notHaystack)
+
+    assertFalse(
+      s"find after reset(input) should not have found " +
+        s"'${needle}' in '${haystack}'",
+      m.find()
+    )
+  }
+
   @Test def findStartInvalidStartValues(): Unit = {
     val pattern = "Isaac"
     val sample = "Asimov"


### PR DESCRIPTION
Fix #3431

javalib Matcher.reset(input) now updates the value used in the underlying scalanative.regex.Matcher.

