### PR TITLE
Fix #3378: javalib {Stream, DoubleStream}#sorted now delays actual sort to a terminal operation

### DIFF
--- a/javalib/src/main/scala/java/util/stream/DoubleStreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/DoubleStreamImpl.scala
@@ -584,35 +584,47 @@ private[stream] class DoubleStreamImpl(
   def sorted(): DoubleStream = {
     // No commenceOperation() here. This is an intermediate operation.
 
-    /* Be aware that this method will/should throw on first use if type
-     * T is not Comparable[T]. This is described in the Java Stream doc.
-     *
-     * Implementation note:
-     *   It would seem that Comparator.naturalOrder()
-     *   could be used here. The SN complier complains, rightly, that
-     *   T is not known to be  [T <: Comparable[T]]. That is because
-     *   T may actually not _be_ comparable. The comparator below punts
-     *   the issue and raises an exception if T is, indeed, not comparable.
-     */
+    class SortingSpliterOfDoubleSupplier(
+        srcSpliter: Spliterator.OfDouble
+    ) extends Supplier[Spliterator.OfDouble] {
 
-    val buffer = toArray()
+      def get(): Spliterator.OfDouble = {
+        val knownSize = _spliter.getExactSizeIfKnown()
 
-    Arrays.sort(buffer)
+        if (knownSize > Integer.MAX_VALUE) {
+          throw new IllegalArgumentException(
+            "Stream size exceeds max array size"
+          )
+        } else {
+          /* Sufficiently large streams, with either known or unknown size may
+           * eventually throw an OutOfMemoryError exception, same as JVM.
+           *
+           * sorting streams of unknown size is likely to be _slow_.
+           */
 
-    val startingBits = _spliter.characteristics()
-    val alwaysSetBits =
-      Spliterator.SORTED | Spliterator.ORDERED |
-        Spliterator.SIZED | Spliterator.SUBSIZED
+          val buffer = toArray()
 
-    // Time & experience may show that additional bits need to be cleared here.
-    val alwaysClearedBits = Spliterator.IMMUTABLE
+          Arrays.sort(buffer)
 
-    val newCharacteristics =
-      (startingBits | alwaysSetBits) & ~alwaysClearedBits
+          val startingBits = _spliter.characteristics()
+          val alwaysSetBits =
+            Spliterator.SORTED | Spliterator.ORDERED |
+              Spliterator.SIZED | Spliterator.SUBSIZED
 
-    val spl = Spliterators.spliterator(buffer, newCharacteristics)
+          // Time & experience may show that additional bits need to be cleared
+          val alwaysClearedBits = Spliterator.IMMUTABLE
 
-    new DoubleStreamImpl(spl, _parallel, pipeline)
+          val newCharacteristics =
+            (startingBits | alwaysSetBits) & ~alwaysClearedBits
+
+          Spliterators.spliterator(buffer, newCharacteristics)
+        }
+      }
+    }
+
+    // Do the sort in the eventual terminal operation, not now.
+    val spl = new SortingSpliterOfDoubleSupplier(_spliter)
+    new DoubleStreamImpl(spl, 0, _parallel)
   }
 
   def sum(): scala.Double = {

--- a/javalib/src/main/scala/java/util/stream/StreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamImpl.scala
@@ -669,28 +669,56 @@ private[stream] class StreamImpl[T](
      * specifying T <: AnyRef so that the coercion will work at
      * runtime.
      */
-    val buffer = toArray()
 
-    /* Scala 3 and 2.13.11 both allow ""Arrays.sort(" here.
-     * Scala 2.12.18 requires "sort[Object](".
-     */
-    Arrays
-      .sort[Object](buffer, comparator.asInstanceOf[Comparator[_ >: Object]])
+    class SortingSpliterSupplier[T](
+        srcSpliter: Spliterator[T],
+        comparator: Comparator[_ >: T]
+    ) extends Supplier[Spliterator[T]] {
 
-    val startingBits = _spliter.characteristics()
-    val alwaysSetBits =
-      Spliterator.SORTED | Spliterator.ORDERED |
-        Spliterator.SIZED | Spliterator.SUBSIZED
+      def get(): Spliterator[T] = {
+        val knownSize = _spliter.getExactSizeIfKnown()
 
-    // Time & experience may show that additional bits need to be cleared here.
-    val alwaysClearedBits = Spliterator.IMMUTABLE
+        if (knownSize > Integer.MAX_VALUE) {
+          throw new IllegalArgumentException(
+            "Stream size exceeds max array size"
+          )
+        } else {
+          /* Sufficiently large streams, with either known or unknown size may
+           * eventually throw an OutOfMemoryError exception, same as JVM.
+           *
+           * sorting streams of unknown size is likely to be _slow_.
+           */
 
-    val newCharacteristics =
-      (startingBits | alwaysSetBits) & ~alwaysClearedBits
+          val buffer = toArray()
 
-    val spl = Spliterators.spliterator[T](buffer, newCharacteristics)
+          /* Scala 3 and 2.13.11 both allow ""Arrays.sort(" here.
+           * Scala 2.12.18 requires "sort[Object](".
+           */
+          Arrays
+            .sort[Object](
+              buffer,
+              comparator.asInstanceOf[Comparator[_ >: Object]]
+            )
 
-    new StreamImpl[T](spl, _parallel, pipeline)
+          val startingBits = _spliter.characteristics()
+          val alwaysSetBits =
+            Spliterator.SORTED | Spliterator.ORDERED |
+              Spliterator.SIZED | Spliterator.SUBSIZED
+
+          // Time & experience may show that additional bits need to be cleared
+          val alwaysClearedBits = Spliterator.IMMUTABLE
+
+          val newCharacteristics =
+            (startingBits | alwaysSetBits) & ~alwaysClearedBits
+
+          Spliterators.spliterator[T](buffer, newCharacteristics)
+        }
+      }
+    }
+
+    // Do the sort in the eventual terminal operation, not now.
+    val spl = new SortingSpliterSupplier[T](_spliter, comparator)
+    new StreamImpl[T](spl, 0, false)
   }
 
   def toArray(): Array[Object] = {

--- a/javalib/src/main/scala/java/util/stream/StreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamImpl.scala
@@ -718,7 +718,7 @@ private[stream] class StreamImpl[T](
 
     // Do the sort in the eventual terminal operation, not now.
     val spl = new SortingSpliterSupplier[T](_spliter, comparator)
-    new StreamImpl[T](spl, 0, false)
+    new StreamImpl[T](spl, 0, _parallel)
   }
 
   def toArray(): Array[Object] = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
@@ -12,7 +12,7 @@ package org.scalanative.testsuite.javalib.util.stream
 import java.{lang => jl}
 
 import java.{util => ju}
-import java.util.Arrays
+import java.util.{Arrays, ArrayList}
 import java.util.{OptionalDouble, DoubleSummaryStatistics}
 import java.util.Spliterator
 import java.util.Spliterators
@@ -38,11 +38,6 @@ import org.scalanative.testsuite.utils.AssertThrows.assertThrows
  *     - doubleStreamMapToInt, required IntStream
  *     - doubleStreamMapToLong, requires LongStream
  */
-
-object DoubleStreamTest {
-  @BeforeClass def checkLimitMethodCharacteristics(): Unit =
-    StreamTestHelpers.requireJDK8CompatibleCharacteristics()
-}
 
 class DoubleStreamTest {
 
@@ -869,8 +864,6 @@ class DoubleStreamTest {
   }
 
   @Test def doubleStreamLimit(): Unit = {
-    StreamTestHelpers.requireJDK8CompatibleCharacteristics()
-
     val expectedCount = 10
     var data = -1
 
@@ -1531,6 +1524,147 @@ class DoubleStreamTest {
       sortedSeqSpliter.characteristics()
     )
 
+  }
+
+  @Test def doubleStreamSortedUnknownSizeButSmall(): Unit = {
+
+    /* To fit array, nElements should be <= Integer.MAX_VALUE.
+     * Machine must have sufficient memory to support chosen number of
+     * elements.
+     */
+    val nElements = 20 // Use a few more than usual 2 or 8.
+
+    // Are the characteristics correct?
+    val rng = new ju.Random(567890123)
+
+    val wild = rng
+      .doubles(nElements, 0.0, jl.Double.MAX_VALUE)
+      .toArray()
+
+    val ordered = wild.clone()
+    Arrays.sort(ordered)
+
+    // do some contortions to get an stream with unknown size.
+    val iter0 = Spliterators.iterator(Spliterators.spliterator(wild, 0))
+    val spliter0 = Spliterators.spliteratorUnknownSize(iter0, 0)
+
+    val s0 = StreamSupport.doubleStream(spliter0, false)
+
+    val s0Spliter = s0.spliterator()
+    assertFalse(
+      "Unexpected SIZED stream",
+      s0Spliter.hasCharacteristics(Spliterator.SIZED)
+    )
+
+    // Validating un-SIZED terminated s0, so need fresh similar stream
+    val iter1 = Spliterators.iterator(Spliterators.spliterator(wild, 0))
+    val spliter1 = Spliterators.spliteratorUnknownSize(iter1, 0)
+
+    val s = StreamSupport.doubleStream(spliter1, false)
+
+    val ascending = s.sorted()
+
+    var count = 0
+
+    ascending.forEachOrdered((e) => {
+      assertEquals("mismatched elements", ordered(count), e, epsilon)
+      count += 1
+    })
+
+    val msg =
+      if (count == 0) "unexpected empty stream"
+      else "unexpected number of elements"
+
+    assertEquals(msg, nElements, count)
+
+  }
+
+  @Ignore
+  @Test def doubleStreamSortedUnknownSizeButHuge(): Unit = {
+    /* This test is for development and Issue verification.
+     * It is Ignored in normal Continuous Integration because it takes
+     * a long time.
+     *
+     * See note for similar Test in StreamTest.scala for details.
+     * No sense copying same text to DoubleStreamTest, IntStreamTest,
+     * & LongStreamTest.
+     */
+
+    val rng = new ju.Random(567890123)
+
+    // Are the characteristics correct?
+    val rs0 = rng
+      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+
+    val iter0 = rs0.iterator()
+    val spliter0 = Spliterators.spliteratorUnknownSize(iter0, 0)
+    val s0 = StreamSupport.doubleStream(spliter0, false)
+
+    val s0Spliter = s0.spliterator()
+    assertFalse(
+      "Unexpected SIZED stream",
+      s0Spliter.hasCharacteristics(Spliterator.SIZED)
+    )
+
+    // Validating un-SIZED terminated s0, so need fresh similar stream.
+    val rs1 = rng
+      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+
+    val spliter1 = Spliterators.spliteratorUnknownSize(iter0, 0)
+    val s = StreamSupport.doubleStream(spliter1, false)
+
+    val uut = s.sorted() // unit-under-test
+
+    // May take tens of seconds or more to get to Exception.
+    assertThrows(classOf[OutOfMemoryError], uut.findFirst())
+  }
+
+  @Test def doubleStreamSortedZeroSize(): Unit = {
+    val nElements = 0
+
+    val rng = new ju.Random(567890123)
+
+    val wild = rng
+      .doubles(nElements, 0.0, jl.Double.MAX_VALUE)
+      .toArray()
+
+    val ordered = wild.clone()
+    Arrays.sort(ordered)
+
+    val spliter = Spliterators.spliterator(wild, 0)
+
+    val s = StreamSupport.doubleStream(spliter, false)
+
+    val sorted = s.sorted()
+    val count = sorted.count()
+
+    assertEquals("expected an empty stream", 0, count)
+  }
+
+  // Issue 3378
+  @Test def doubleStreamSortedLongSize(): Unit = {
+    /* This tests streams with the SIZED characteristics and a
+     *  know length is larger than the largest possible Java array:
+     *  approximately Integer.MAX_VALUE.
+     */
+    val rng = new ju.Random(1234567890)
+
+    val s = rng
+      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+
+    /* The sorted() implementation should be a late binding, intermediate
+     * operation. Expect no "max array size" error here, but later.
+     */
+
+    val uut = s.sorted() // unit-under-test
+
+    /* Stream#findFirst() is a terminal operation, so expect any errors
+     * to happen here, not earlier.  In particular, expect code being tested
+     * to detect and report the huge size rather than taking a long time
+     * and then running out of memory.
+     */
+
+    assertThrows(classOf[IllegalArgumentException], uut.findFirst())
   }
 
   @Test def doubleStreamSum(): Unit = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -1573,7 +1573,7 @@ class StreamTest {
       s0Spliter.hasCharacteristics(Spliterator.SIZED)
     )
 
-    // Validating un-SIZED terminated s0, so need fresh, identical stream
+    // Validating un-SIZED terminated s0, so need fresh similar stream
     val iter1 = wild.stream().iterator()
     val spliter1 = Spliterators.spliteratorUnknownSize(iter0, 0)
     val s = StreamSupport.stream(spliter1, false)
@@ -1594,16 +1594,28 @@ class StreamTest {
     assertEquals(msg, nElements, count)
   }
 
-  /* Manual test, not run regularly in CI. Because it takes tens of seconds,
-   * 21 or so on Apple M1 development machine. Useful during development
-   * to verify that code-under-test matches JVM; that is, eventually terminates.
+  /* A manual test, not run regularly in CI.
+   * Where is the end-of-the-world and how long does it take to get there?
+   *
+   * It takes tens of seconds, 21 or so on Apple M1 development machine
+   * using Scala 2.12.18, TestsJVM3, and Java 20.
+   *
+   * Similar Scala Native Test3 runs takes 200+ seconds.
+   *
+   * Scala 2.12.18 TestsJVM3 and Java 8 takes longer than a lunch break.
+   *
+   * Your experience may vary. The time variation is most likely
+   * due to memory handling, not the Stream code under test.
+   *
+   * Useful during development to verify code-under-test matches JVM;
+   * that is, eventually terminates or exceeds developers patience.
    */
 
   @Ignore
   @Test def streamSortedUnknownSizeButHuge(): Unit = {
     /* This test is for development and Issue verification.
      * It is Ignored in normal Continuous Integration because it takes
-     * tens of seconds.
+     * a long time.
      *
      *  It tests streams without the SIZED characteristics which have a length
      *  larger than the largest possible Java array:
@@ -1627,7 +1639,7 @@ class StreamTest {
       s0Spliter.hasCharacteristics(Spliterator.SIZED)
     )
 
-    // Validating un-SIZED terminated s0, so need fresh, identical stream
+    // Validating un-SIZED terminated s0, so need fresh similar stream
     val rs1 = rng
       .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
       .mapToObj(d => d.toString())


### PR DESCRIPTION
Fix #3378

javalib `Stream#sorted` method is an intermediate operation. The requested sort, implying argument checking,
should not be performed immediately. It should only happen in any eventual terminal operation.

This change allows javalib `Stream#sorted`  on a SIZED stream with a size > Integer.MAX_VALUE to have the
same behavior as JVM: quietly succeeding and any eventual terminal operation throwing 
` IllegalArgumentException("Stream size exceeds max array size")`.

