### PR TITLE
Fixes #2731: Need better way to detect 32-bit platforms

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -83,22 +83,19 @@ sealed trait NativeConfig {
 
   /** Are we targeting a 32-bit platform?
    *
-   *  This should perhaps list known 32-bit architectures and search for others
-   *  containing "32" and assume everything else is 64-bit. Printing the
-   *  architecture for a name that is not found seems excessive perhaps?
+   *  @return
+   *    true if 32 bit, false if 64 bit, unknown, or 16 bit
    */
   def is32BitPlatform = {
-    configuredOrDetectedTriple.arch match {
-      case "x86_64"  => false
-      case "aarch64" => false
-      case "arm64"   => false
-      case "i386"    => true
-      case "i686"    => true
-      case o =>
-        println(
-          s"Unexpected architecture in target triple: ${o}, defaulting to 64-bit"
-        )
-        false
+    import TargetTriple._
+    val arch = configuredOrDetectedTriple.arch
+    if (isArch32Bit(arch)) true
+    else if (isArch64Bit(arch)) false
+    else {
+      println(
+        s"Unexpected architecture in target triple: ${arch}, defaulting to 64-bit"
+      )
+      false
     }
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/TargetTriple.scala
+++ b/tools/src/main/scala/scala/scalanative/build/TargetTriple.scala
@@ -1,4 +1,5 @@
 // ported from LLVM 887d6ab dated 2023-04-16
+// updated 2023-08-16 from https://llvm.org/doxygen/Triple_8cpp_source.html
 
 //===--- Triple.cpp - Target triple helper class --------------------------===//
 //

--- a/tools/src/main/scala/scala/scalanative/build/TargetTriple.scala
+++ b/tools/src/main/scala/scala/scalanative/build/TargetTriple.scala
@@ -35,6 +35,11 @@ private[scalanative] object TargetTriple {
     )
   }
 
+  def isArch32Bit(arch: String): Boolean =
+    Arch.getArchPointerBitWidth(arch) == 32
+  def isArch64Bit(arch: String): Boolean =
+    Arch.getArchPointerBitWidth(arch) == 64
+
   object Arch {
     def parse(str: String): String = str match {
       case "i386" | "i486" | "i586" | "i686"          => x86
@@ -123,6 +128,26 @@ private[scalanative] object TargetTriple {
           parseBpf(other)
         else
           unknown
+    }
+
+    def getArchPointerBitWidth(arch: String): Int = {
+      parse(arch) match {
+        case `unknown`        => 0
+        case `avr` | `msp430` => 16
+        case `aarch64_32` | `amdil` | `arc` | `arm` | `armeb` | `csky` |
+            `dxil` | `hexagon` | `hsail` | `kalimba` | `lanai` | `le32` |
+            `loongarch32` | `m68k` | `mips` | `mipsel` | `nvptx` | `ppc` |
+            `ppcle` | `r600` | `renderscript32` | `riscv32` | `shave` |
+            `sparc` | `sparcel` | `spir` | `spirv32` | `tce` | `tcele` |
+            `thumb` | `thumbeb` | `wasm32` | `x86` | `xcore` | `xtensa` =>
+          32
+        case `aarch64` | `aarch64_be` | `amdgcn` | `amdil64` | `bpfeb` |
+            `bpfel` | `hsail64` | `le64` | `loongarch64` | `mips64` |
+            `mips64el` | `nvptx64` | `ppc64` | `ppc64le` | `renderscript64` |
+            `riscv64` | `sparcv9` | `spir64` | `spirv64` | `systemz` | `ve` |
+            `wasm64` | `x86_64` =>
+          64
+      }
     }
 
     private def parseArm(str: String): String = {

--- a/tools/src/test/scala/scala/scalanative/build/TargetTripleTest.scala
+++ b/tools/src/test/scala/scala/scalanative/build/TargetTripleTest.scala
@@ -26,9 +26,87 @@ class TargetTripleTest {
       TargetTriple("x86_64", "unknown", "freebsd", "unknown")
   )
 
+  // samples based on parsed to type
+  val cases32Bit = List(
+    "aarch64_32",
+    "amdil",
+    "arc",
+    "arm",
+    "armeb",
+    "csky",
+    "dxil",
+    "hexagon",
+    "hsail",
+    "kalimba",
+    "lanai",
+    "le32",
+    "loongarch32",
+    "m68k",
+    "mips",
+    "mipsel",
+    "nvptx",
+    "ppc",
+    "ppcle",
+    "r600",
+    "renderscript32",
+    "riscv32",
+    "shave",
+    "sparc",
+    "sparcel",
+    "spir",
+    "spirv32",
+    "tce",
+    "tcele",
+    "thumb",
+    "thumbeb",
+    "wasm32",
+    "i386", // parsed to x86
+    "xcore",
+    "xtensa"
+  )
+
+  // samples based on parsed to type
+  val cases64Bit = List(
+    "aarch64",
+    "aarch64_be",
+    "amdgcn",
+    "amdil64",
+    "bpfeb",
+    "bpfel",
+    "hsail64",
+    "le64",
+    "loongarch64",
+    "mips64",
+    "mips64el",
+    "nvptx64",
+    "ppc64",
+    "ppc64le",
+    "renderscript64",
+    "riscv64",
+    "sparcv9",
+    "spir64",
+    "spirv64",
+    "systemz",
+    "ve",
+    "wasm64",
+    "x86_64"
+  )
+
   @Test
   def testParser(): Unit = cases.foreach {
     case (triple, expected) =>
       assertEquals(triple, expected, TargetTriple.parse(triple))
+  }
+
+  @Test
+  def isArch32Bit(): Unit = cases32Bit.foreach {
+    case arch =>
+      assertEquals(arch, true, TargetTriple.isArch32Bit(arch))
+  }
+
+  @Test
+  def isArch64Bit(): Unit = cases64Bit.foreach {
+    case arch =>
+      assertEquals(arch, true, TargetTriple.isArch64Bit(arch))
   }
 }


### PR DESCRIPTION
Thanks to the previous work on TargetTriple - https://github.com/scala-native/scala-native/pull/3258

Now we should be technically able to support all 32 bit and 64 bit with only "unknown" for 16 bit and unknown. At least there are no restrictions.