### PR TITLE
Add information about lexical scopes to NIR debug informations

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -44,133 +44,189 @@ class Buffer(implicit fresh: Fresh) {
 
   // Compute ops
   def let(id: Local, op: Op, unwind: Next)(implicit
-      pos: Position
+      pos: Position,
+      scope: ScopeId
   ): Val.Local = {
     this += Inst.Let(id, op, unwind)
     Val.Local(id, op.resty)
   }
-  def let(op: Op, unwind: Next)(implicit pos: Position): Val.Local =
-    let(fresh(), op, unwind)
+  def let(op: Op, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(fresh(), op, unwind)
+
   def call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Call(ty, ptr, args), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Call(ty, ptr, args), unwind)
+
   def load(
       ty: Type,
       ptr: Val,
       unwind: Next,
       syncAttrs: Option[SyncAttrs] = None
-  )(implicit
-      pos: Position
-  ): Val.Local =
+  )(implicit pos: Position, scope: ScopeId): Val.Local =
     let(Op.Load(ty, ptr, syncAttrs), unwind)
+
   def store(
       ty: Type,
       ptr: Val,
       value: Val,
       unwind: Next,
       syncAttrs: Option[SyncAttrs] = None
-  )(implicit
-      pos: Position
-  ): Val.Local =
+  )(implicit pos: Position, scope: ScopeId): Val.Local =
     let(Op.Store(ty, ptr, value, syncAttrs), unwind)
+
   def elem(ty: Type, ptr: Val, indexes: Seq[Val], unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Elem(ty, ptr, indexes), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Elem(ty, ptr, indexes), unwind)
+
   def extract(aggr: Val, indexes: Seq[Int], unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Extract(aggr, indexes), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Extract(aggr, indexes), unwind)
+
   def insert(aggr: Val, value: Val, indexes: Seq[Int], unwind: Next)(implicit
-      pos: Position
+      pos: Position,
+      scope: ScopeId
   ): Val.Local =
     let(Op.Insert(aggr, value, indexes), unwind)
+
   def stackalloc(ty: Type, n: Val, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Stackalloc(ty, n), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Stackalloc(ty, n), unwind)
+
   def bin(bin: nir.Bin, ty: Type, l: Val, r: Val, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Bin(bin, ty, l, r), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Bin(bin, ty, l, r), unwind)
+
   def comp(comp: nir.Comp, ty: Type, l: Val, r: Val, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Comp(comp, ty, l, r), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Comp(comp, ty, l, r), unwind)
+
   def conv(conv: nir.Conv, ty: Type, value: Val, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Conv(conv, ty, value), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Conv(conv, ty, value), unwind)
+
   def classalloc(name: Global, unwind: Next, zone: Option[Val] = None)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Classalloc(name, zone), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Classalloc(name, zone), unwind)
+
   def fieldload(ty: Type, obj: Val, name: Global, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Fieldload(ty, obj, name), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Fieldload(ty, obj, name), unwind)
+
   def fieldstore(ty: Type, obj: Val, name: Global, value: Val, unwind: Next)(
-      implicit pos: Position
-  ): Val.Local =
-    let(Op.Fieldstore(ty, obj, name, value), unwind)
-  def field(obj: Val, name: Global, unwind: Next)(implicit pos: Position) =
+      implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Fieldstore(ty, obj, name, value), unwind)
+
+  def field(obj: Val, name: Global, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ) =
     let(Op.Field(obj, name), unwind)
+
   def method(obj: Val, sig: Sig, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Method(obj, sig), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Method(obj, sig), unwind)
+
   def dynmethod(obj: Val, sig: Sig, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Dynmethod(obj, sig), unwind)
-  def module(name: Global, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.Module(name), unwind)
-  def as(ty: Type, obj: Val, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.As(ty, obj), unwind)
-  def is(ty: Type, obj: Val, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.Is(ty, obj), unwind)
-  def copy(value: Val, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.Copy(value), unwind)
-  def sizeOf(ty: Type, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.SizeOf(ty), unwind)
-  def alignmentOf(ty: Type, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.AlignmentOf(ty), unwind)
-  def box(ty: Type, obj: Val, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.Box(ty, obj), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Dynmethod(obj, sig), unwind)
+
+  def module(name: Global, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Module(name), unwind)
+
+  def as(ty: Type, obj: Val, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.As(ty, obj), unwind)
+
+  def is(ty: Type, obj: Val, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Is(ty, obj), unwind)
+
+  def copy(value: Val, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Copy(value), unwind)
+
+  def sizeOf(ty: Type, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.SizeOf(ty), unwind)
+
+  def alignmentOf(ty: Type, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.AlignmentOf(ty), unwind)
+
+  def box(ty: Type, obj: Val, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Box(ty, obj), unwind)
+
   def unbox(ty: Type, obj: Val, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Unbox(ty, obj), unwind)
-  def var_(ty: Type, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.Var(ty), unwind)
-  def varload(slot: Val, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.Varload(slot), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Unbox(ty, obj), unwind)
+
+  def var_(ty: Type, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Var(ty), unwind)
+
+  def varload(slot: Val, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Varload(slot), unwind)
+
   def varstore(slot: Val, value: Val, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Varstore(slot, value), unwind)
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Varstore(slot, value), unwind)
+
   def arrayalloc(
       ty: Type,
       init: Val,
       unwind: Next,
       zone: Option[Val] = None
-  )(implicit
-      pos: Position
-  ): Val.Local =
+  )(implicit pos: Position, scope: ScopeId): Val.Local =
     let(Op.Arrayalloc(ty, init, zone), unwind)
-  def arrayload(ty: Type, arr: Val, idx: Val, unwind: Next)(implicit
-      pos: Position
-  ): Val.Local =
-    let(Op.Arrayload(ty, arr, idx), unwind)
-  def arraystore(ty: Type, arr: Val, idx: Val, value: Val, unwind: Next)(
-      implicit pos: Position
-  ): Val.Local =
-    let(Op.Arraystore(ty, arr, idx, value), unwind)
-  def arraylength(arr: Val, unwind: Next)(implicit pos: Position): Val.Local =
-    let(Op.Arraylength(arr), unwind)
 
-  def fence(memoryOrder: MemoryOrder)(implicit pos: Position): Val.Local =
+  def arrayload(ty: Type, arr: Val, idx: Val, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Arrayload(ty, arr, idx), unwind)
+
+  def arraystore(ty: Type, arr: Val, idx: Val, value: Val, unwind: Next)(
+      implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Arraystore(ty, arr, idx, value), unwind)
+
+  def arraylength(arr: Val, unwind: Next)(implicit
+      pos: Position,
+      scope: ScopeId
+  ): Val.Local = let(Op.Arraylength(arr), unwind)
+
+  def fence(
+      memoryOrder: MemoryOrder
+  )(implicit pos: Position, scope: ScopeId): Val.Local =
     let(
       Op.Fence(SyncAttrs(memoryOrder = memoryOrder, isVolatile = false)),
       Next.None

--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -38,30 +38,13 @@ object Defn {
     case class DebugInfo(
         localNames: LocalNames,
         lexicalScopes: Seq[DebugInfo.LexicalScope]
-    ) {
-      import DebugInfo._
-      def scopeOf(id: Local): Option[LexicalScope] = {
-        val idV = id.id
-        val containedBy = lexicalScopes.filter { scope =>
-          val LocalRange(start, end) = scope.range
-          idV >= start.id && idV <= end.id
-        }
-        if (containedBy.isEmpty) None
-        else if (containedBy.size == 1) Some(containedBy.head)
-        else Some(containedBy.minBy(_.range.end.id))
-      }
-    }
+    )
     object DebugInfo {
       val empty: DebugInfo =
         DebugInfo(localNames = Map.empty, lexicalScopes = Nil)
 
-      case class ScopeId(id: Long) extends AnyVal
-      object ScopeId {
-        def of(id: Local): ScopeId = ScopeId(id.id)
-        val TopLevel = ScopeId(0L)
-      }
-      case class LocalRange(start: Local, end: Local)
-      case class LexicalScope(id: ScopeId, parent: ScopeId, range: LocalRange) {
+     
+      case class LexicalScope(id: ScopeId, parent: ScopeId) {
         def isTopLevel: Boolean = id.id == 0
       }
     }

--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -1,7 +1,6 @@
 package scala.scalanative
 package nir
 import scala.scalanative.nir.Defn.Define
-import scala.collection.immutable.NumericRange
 
 sealed abstract class Defn {
   def name: Global
@@ -38,14 +37,24 @@ object Defn {
     case class DebugInfo(
         localNames: LocalNames,
         lexicalScopes: Seq[DebugInfo.LexicalScope]
-    )
+    ) {
+      lazy val lexicalScopeOf: Map[ScopeId, DebugInfo.LexicalScope] =
+        lexicalScopes.map {
+          case scope @ DebugInfo.LexicalScope(id, _) => (id, scope)
+        }.toMap
+    }
     object DebugInfo {
-      val empty: DebugInfo =
-        DebugInfo(localNames = Map.empty, lexicalScopes = Nil)
+      val empty: DebugInfo = DebugInfo(
+        localNames = Map.empty,
+        lexicalScopes = Seq(LexicalScope.TopLevel)
+      )
 
-     
       case class LexicalScope(id: ScopeId, parent: ScopeId) {
-        def isTopLevel: Boolean = id.id == 0
+        def isTopLevel: Boolean = id.isTopLevel
+      }
+      object LexicalScope {
+        val TopLevel = LexicalScope(ScopeId.TopLevel, ScopeId.TopLevel)
+        implicit val ordering: Ordering[LexicalScope] = Ordering.by(_.id.id)
       }
     }
 

--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -1,6 +1,7 @@
 package scala.scalanative
 package nir
 import scala.scalanative.nir.Defn.Define
+import scala.collection.immutable.NumericRange
 
 sealed abstract class Defn {
   def name: Global
@@ -8,7 +9,7 @@ sealed abstract class Defn {
   def pos: Position
   final def show: String = nir.Show(this)
   final def isEntryPoint = this match {
-    case Define(attrs, Global.Member(_, sig), _, _, _) =>
+    case Define(attrs, Global.Member(_, sig), _, _, _, _) =>
       sig.isClinit || attrs.isExtern
     case _ => false
   }
@@ -30,9 +31,15 @@ object Defn {
       name: Global,
       ty: Type,
       insts: Seq[Inst],
-      localNames: LocalNames = Map.empty
+      // debug metadata
+      localNames: LocalNames = Map.empty,
+      lexicalScopes: List[Define.LexicalScope] = Nil
   )(implicit val pos: Position)
       extends Defn
+  object Define {
+    case class LocalRange(start: Local, end: Local)
+    case class LexicalScope(id: Local, parent: Local, range: LocalRange)
+  }
 
   // high-level
   final case class Trait(attrs: Attrs, name: Global, traits: Seq[Global])(

--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -40,20 +40,27 @@ object Defn {
     ) {
       lazy val lexicalScopeOf: Map[ScopeId, DebugInfo.LexicalScope] =
         lexicalScopes.map {
-          case scope @ DebugInfo.LexicalScope(id, _) => (id, scope)
+          case scope @ DebugInfo.LexicalScope(id, _, _) => (id, scope)
         }.toMap
     }
     object DebugInfo {
       val empty: DebugInfo = DebugInfo(
         localNames = Map.empty,
-        lexicalScopes = Seq(LexicalScope.TopLevel)
+        lexicalScopes = Seq(LexicalScope.AnyTopLevel)
       )
 
-      case class LexicalScope(id: ScopeId, parent: ScopeId) {
+      case class LexicalScope(
+          id: ScopeId,
+          parent: ScopeId,
+          srcPosition: Position
+      ) {
         def isTopLevel: Boolean = id.isTopLevel
       }
       object LexicalScope {
-        val TopLevel = LexicalScope(ScopeId.TopLevel, ScopeId.TopLevel)
+        final val AnyTopLevel =
+          LexicalScope(ScopeId.TopLevel, ScopeId.TopLevel, Position.NoPosition)
+        def TopLevel(defnPosition: Position) =
+          AnyTopLevel.copy(srcPosition = defnPosition)
         implicit val ordering: Ordering[LexicalScope] = Ordering.by(_.id.id)
       }
     }

--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -37,31 +37,35 @@ object Defn {
   object Define {
     case class DebugInfo(
         localNames: LocalNames,
-        lexicalScopes: Seq[LexicalScope]
+        lexicalScopes: Seq[DebugInfo.LexicalScope]
     ) {
+      import DebugInfo._
       def scopeOf(id: Local): Option[LexicalScope] = {
         val idV = id.id
-        val containedBy = lexicalScopes.filter{scope => 
-          val LocalRange(start,end) = scope.range
+        val containedBy = lexicalScopes.filter { scope =>
+          val LocalRange(start, end) = scope.range
           idV >= start.id && idV <= end.id
         }
-        if(containedBy.isEmpty) None
-        else if(containedBy.size == 1) Some(containedBy.head)
-        else {
-          println(id)
-          println(containedBy)
-          val res = containedBy.minBy(_.range.end.id)
-          println(res)
-          Some(res)
-        }
+        if (containedBy.isEmpty) None
+        else if (containedBy.size == 1) Some(containedBy.head)
+        else Some(containedBy.minBy(_.range.end.id))
       }
     }
     object DebugInfo {
       val empty: DebugInfo =
         DebugInfo(localNames = Map.empty, lexicalScopes = Nil)
+
+      case class ScopeId(id: Long) extends AnyVal
+      object ScopeId {
+        def of(id: Local): ScopeId = ScopeId(id.id)
+        val TopLevel = ScopeId(0L)
+      }
+      case class LocalRange(start: Local, end: Local)
+      case class LexicalScope(id: ScopeId, parent: ScopeId, range: LocalRange) {
+        def isTopLevel: Boolean = id.id == 0
+      }
     }
-    case class LocalRange(start: Local, end: Local)
-    case class LexicalScope(id: Local, parent: Local, range: LocalRange)
+
   }
 
   // high-level

--- a/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
@@ -7,6 +7,7 @@ final class Fresh private (private var start: Long) {
     val value = start
     Local(value)
   }
+  def last = Local(start)
 }
 
 object Fresh {

--- a/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
@@ -8,6 +8,7 @@ final class Fresh private (private var start: Long) {
     Local(value)
   }
   def last = Local(start)
+  def skip(n: Long): Unit = start += n
 }
 
 object Fresh {

--- a/nir/src/main/scala/scala/scalanative/nir/Insts.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Insts.scala
@@ -12,13 +12,13 @@ object Inst {
   ) extends Inst
   final case class Let(id: Local, op: Op, unwind: Next)(implicit
       val pos: Position,
-      val scope: ScopeId
+      val scopeId: ScopeId
   ) extends Inst
   object Let {
     def apply(op: Op, unwind: Next)(implicit
         fresh: Fresh,
         pos: Position,
-        scope: ScopeId
+        scopeId: ScopeId
     ): Let =
       Let(fresh(), op, unwind)
   }

--- a/nir/src/main/scala/scala/scalanative/nir/Insts.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Insts.scala
@@ -11,10 +11,15 @@ object Inst {
       val pos: Position
   ) extends Inst
   final case class Let(id: Local, op: Op, unwind: Next)(implicit
-      val pos: Position
+      val pos: Position,
+      val scope: ScopeId
   ) extends Inst
   object Let {
-    def apply(op: Op, unwind: Next)(implicit fresh: Fresh, pos: Position): Let =
+    def apply(op: Op, unwind: Next)(implicit
+        fresh: Fresh,
+        pos: Position,
+        scope: ScopeId
+    ): Let =
       Let(fresh(), op, unwind)
   }
 

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -155,8 +155,8 @@ object Show {
         }
         str(":")
       case let @ Inst.Let(id, op, unwind) =>
-        if (!let.scope.isTopLevel) {
-          str(let.scope.id); str(": ")
+        if (!let.scopeId.isTopLevel) {
+          str(let.scopeId.id); str(": ")
         }
         onLocal(id)
         str(" = ")

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -155,7 +155,11 @@ object Show {
         }
         str(":")
       case Inst.Let(id, op, unwind) =>
-        debugInfo.scopeOf(id).foreach{v =>str(v.id.id); str(": ")}
+        debugInfo.scopeOf(id).foreach { v =>
+          if (!v.isTopLevel) {
+            str(v.id.id); str(": ")
+          }
+        }
         onLocal(id)
         str(" = ")
         onOp(op)

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -580,7 +580,7 @@ object Show {
         onGlobal(name)
         str(" : ")
         onType(ty)
-      case Defn.Define(attrs, name, ty, insts, localNames) =>
+      case Defn.Define(attrs, name, ty, insts, localNames, _) =>
         implicit val _localNames: LocalNames = localNames
         onAttrs(attrs)
         str("def ")

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -154,11 +154,9 @@ object Show {
           str(")")
         }
         str(":")
-      case Inst.Let(id, op, unwind) =>
-        debugInfo.scopeOf(id).foreach { v =>
-          if (!v.isTopLevel) {
-            str(v.id.id); str(": ")
-          }
+      case let @ Inst.Let(id, op, unwind) =>
+        if (!let.scope.isTopLevel) {
+          str(let.scope.id); str(": ")
         }
         onLocal(id)
         str(" = ")

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -37,7 +37,7 @@ trait Transform {
         }
         Inst.Label(n, newparams)
       case inst @ Inst.Let(_, op, unwind) =>
-        implicit val scope = inst.scope
+        implicit val scopeId: ScopeId = inst.scopeId
         inst.copy(op = onOp(op), unwind = onNext(unwind))
       case Inst.Ret(v) =>
         Inst.Ret(onVal(v))

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -14,8 +14,7 @@ trait Transform {
         defn.copy(ty = onType(ty), rhs = onVal(value))
       case defn @ Defn.Declare(_, _, ty) =>
         defn.copy(ty = onType(ty))
-      case defn @ Defn.Define(_, _, ty, insts, _, _) =>
-        // TODO: // new localNames from onInsts?
+      case defn @ Defn.Define(_, _, ty, insts, _) =>
         defn.copy(ty = onType(ty), insts = onInsts(insts))
       case defn @ Defn.Trait(_, _, _) =>
         defn

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -37,6 +37,7 @@ trait Transform {
         }
         Inst.Label(n, newparams)
       case inst @ Inst.Let(_, op, unwind) =>
+        implicit val scope = inst.scope
         inst.copy(op = onOp(op), unwind = onNext(unwind))
       case Inst.Ret(v) =>
         Inst.Ret(onVal(v))

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -14,7 +14,7 @@ trait Transform {
         defn.copy(ty = onType(ty), rhs = onVal(value))
       case defn @ Defn.Declare(_, _, ty) =>
         defn.copy(ty = onType(ty))
-      case defn @ Defn.Define(_, _, ty, insts, _) =>
+      case defn @ Defn.Define(_, _, ty, insts, _, _) =>
         // TODO: // new localNames from onInsts?
         defn.copy(ty = onType(ty), insts = onInsts(insts))
       case defn @ Defn.Trait(_, _, _) =>

--- a/nir/src/main/scala/scala/scalanative/nir/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/package.scala
@@ -3,4 +3,11 @@ package scala.scalanative
 package object nir {
   type LocalName = String
   type LocalNames = Map[Local, LocalName]
+  case class ScopeId(id: Long) extends AnyVal{
+    def isTopLevel: Boolean = this.id == ScopeId.TopLevel.id
+  }
+  object ScopeId {
+    def of(id: Local): ScopeId = ScopeId(id.id)
+    val TopLevel = ScopeId(0L)
+  }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/package.scala
@@ -3,11 +3,11 @@ package scala.scalanative
 package object nir {
   type LocalName = String
   type LocalNames = Map[Local, LocalName]
-  case class ScopeId(id: Long) extends AnyVal{
+  case class ScopeId(id: Int) extends AnyVal{
     def isTopLevel: Boolean = this.id == ScopeId.TopLevel.id
   }
   object ScopeId {
-    def of(id: Local): ScopeId = ScopeId(id.id)
-    val TopLevel = ScopeId(0L)
+    def of(id: Local): ScopeId = ScopeId(id.id.toInt)
+    val TopLevel = ScopeId(0)
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/package.scala
@@ -3,7 +3,7 @@ package scala.scalanative
 package object nir {
   type LocalName = String
   type LocalNames = Map[Local, LocalName]
-  case class ScopeId(id: Int) extends AnyVal{
+  case class ScopeId(id: Int) extends AnyVal {
     def isTopLevel: Boolean = this.id == ScopeId.TopLevel.id
   }
   object ScopeId {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -225,7 +225,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
     case T.XorBin  => Bin.Xor
   }
 
-  private def getScopeId() = new ScopeId(getLebUnsignedLong())
+  private def getScopeId() = new ScopeId(getLebUnsignedInt())
   private def getInsts(): Seq[Inst] = in(prelude.sections.insts) {
     getSeq(getInst())
   }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -225,12 +225,14 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
     case T.XorBin  => Bin.Xor
   }
 
+  private def getScopeId() = new ScopeId(getLebUnsignedLong())
   private def getInsts(): Seq[Inst] = in(prelude.sections.insts) {
     getSeq(getInst())
   }
   private def getInst(): Inst = {
     val tag = getTag()
     implicit val pos: nir.Position = getPosition()
+    implicit def scope: nir.ScopeId = getScopeId()
     (tag: @switch) match {
       case T.LabelInst       => Inst.Label(getLocal(), getParams())
       case T.LetInst         => Inst.Let(getLocal(), getOp(), Next.None)
@@ -284,12 +286,10 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
   }
 
   import Defn.Define.DebugInfo
-  private def getScopeId() = new DebugInfo.ScopeId(getLebUnsignedLong())
 
   private def getLexicalScope() = DebugInfo.LexicalScope(
     id =  getScopeId(),
-    parent = getScopeId(),
-    range = DebugInfo.LocalRange(start = getLocal(), end = getLocal())
+    parent = getScopeId()
   )
 
   private def getDebugInfo(): Defn.Define.DebugInfo =

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -283,6 +283,18 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
     case T.ZSizeCastConv => Conv.ZSizeCast
   }
 
+  private def getLexicalScope(): Defn.Define.LexicalScope = Defn.Define.LexicalScope(
+    id = getLocal(),
+    parent = getLocal(),
+    range = Defn.Define.LocalRange(start = getLocal(), end = getLocal())
+  )
+
+  private def getDebugInfo(): Defn.Define.DebugInfo =
+    Defn.Define.DebugInfo(
+      localNames = getLocalNames(),
+      lexicalScopes = getSeq(getLexicalScope())
+    )
+
   private def getDefn(): Defn = {
     val tag = getTag()
     val name = getGlobal()
@@ -292,7 +304,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
       case T.VarDefn     => Defn.Var(attrs, name, getType(), getVal())
       case T.ConstDefn   => Defn.Const(attrs, name, getType(), getVal())
       case T.DeclareDefn => Defn.Declare(attrs, name, getType())
-      case T.DefineDefn  => Defn.Define(attrs, name, getType(), getInsts(), getLocalNames())
+      case T.DefineDefn  => Defn.Define(attrs, name, getType(), getInsts(), getDebugInfo())
       case T.TraitDefn   => Defn.Trait(attrs, name, getGlobals())
       case T.ClassDefn   => Defn.Class(attrs, name, getGlobalOpt(), getGlobals())
       case T.ModuleDefn  => Defn.Module(attrs, name, getGlobalOpt(), getGlobals())

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -283,10 +283,13 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
     case T.ZSizeCastConv => Conv.ZSizeCast
   }
 
-  private def getLexicalScope(): Defn.Define.LexicalScope = Defn.Define.LexicalScope(
-    id = getLocal(),
-    parent = getLocal(),
-    range = Defn.Define.LocalRange(start = getLocal(), end = getLocal())
+  import Defn.Define.DebugInfo
+  private def getScopeId() = new DebugInfo.ScopeId(getLebUnsignedLong())
+
+  private def getLexicalScope() = DebugInfo.LexicalScope(
+    id =  getScopeId(),
+    parent = getScopeId(),
+    range = DebugInfo.LocalRange(start = getLocal(), end = getLocal())
   )
 
   private def getDebugInfo(): Defn.Define.DebugInfo =

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -288,8 +288,9 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
   import Defn.Define.DebugInfo
 
   private def getLexicalScope() = DebugInfo.LexicalScope(
-    id =  getScopeId(),
-    parent = getScopeId()
+    id = getScopeId(),
+    parent = getScopeId(),
+    srcPosition = getPosition()
   )
 
   private def getDebugInfo(): Defn.Define.DebugInfo =

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -215,9 +215,10 @@ final class BinarySerializer(channel: WritableByteChannel) {
 
     import nir.Defn.Define.DebugInfo
     private def putLexicalScope(scope: DebugInfo.LexicalScope): Unit = {
-      val DebugInfo.LexicalScope(id, parent) = scope
+      val DebugInfo.LexicalScope(id, parent, srcPosition) = scope
       putScopeId(id)
       putScopeId(parent)
+      putPosition(srcPosition)
     }
 
     private def putDebugInfo(debugInfo: nir.Defn.Define.DebugInfo): Unit = {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -212,10 +212,12 @@ final class BinarySerializer(channel: WritableByteChannel) {
       }
     }
 
-    private def putLexicalScope(scope: nir.Defn.Define.LexicalScope): Unit = {
-      val nir.Defn.Define.LexicalScope(id, parent, range) = scope
-      putLocal(id)
-      putLocal(parent)
+    import nir.Defn.Define.DebugInfo
+    private def putScopeId(scopeId: DebugInfo.ScopeId) = putLebUnsignedLong(scopeId.id)
+    private def putLexicalScope(scope: DebugInfo.LexicalScope): Unit = {
+      val DebugInfo.LexicalScope(id, parent, range) = scope
+      putScopeId(id)
+      putScopeId(parent)
       putLocal(range.start)
       putLocal(range.end)
     }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -585,14 +585,14 @@ final class BinarySerializer(channel: WritableByteChannel) {
           putTagAndPosition(T.LetInst)
           putLocal(id)
           putOp(op)
-          putScopeId(let.scope)
+          putScopeId(let.scopeId)
 
         case let @ Inst.Let(id, op, unwind) =>
           putTagAndPosition(T.LetUnwindInst)
           putLocal(id)
           putOp(op)
           putNext(unwind)
-          putScopeId(let.scope)
+          putScopeId(let.scopeId)
 
         case Inst.Ret(v) =>
           putTagAndPosition(T.RetInst)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExports.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExports.scala
@@ -163,7 +163,8 @@ trait NirGenExports[G <: nsc.Global with Singleton] {
         val fresh = curFresh.get
         scoped(
           curUnwindHandler := None,
-          curMethodThis := None
+          curMethodThis := None,
+          curScopeId := ScopeId.TopLevel
         ) {
           val entryParams = externParamTypes.map(Val.Local(fresh(), _))
           buf.label(fresh(), entryParams)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExports.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExports.scala
@@ -176,8 +176,7 @@ trait NirGenExports[G <: nsc.Global with Singleton] {
           buf.ret(unboxedRes)
         }
         buf.toSeq
-      },
-      localNames = Map.empty
+      }
     )
     ExportedSymbol(member, defn)
   }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -118,38 +118,37 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         genMatch(prologue, labels :+ last)
       }
 
-      def lastLocalId = curFresh.get.last
-      val blockScope = DebugInfo.ScopeId.of(curScopeFresh.get())
+      val blockScope = ScopeId.of(curFreshScope.get())
+      // Parent of top level points to itself
       val parentScope =
-        if (blockScope == DebugInfo.ScopeId.TopLevel) blockScope
+        if (blockScope.isTopLevel) blockScope
         else curScopeId.get
-      val blockStart = nir.Local(lastLocalId.id + 1)
 
-      def addScope(blockEnd: nir.Local): Unit =
-        curScopes.get += DebugInfo.LexicalScope(
-          blockScope,
-          // Parent of top level points to itself
-          if (blockScope.id == 0) blockScope else parentScope,
-          DebugInfo.LocalRange(blockStart, blockEnd)
-        )
+      curScopes.get += DebugInfo.LexicalScope(
+        id = blockScope,
+        parent = parentScope
+      )
+
       scoped(
         curScopeId := blockScope
       ) {
         last match {
           case label: LabelDef if isCaseLabelDef(label) =>
-            try translateMatch(label)
-            finally addScope(lastLocalId)
+            translateMatch(label)
+
           case Apply(
                 TypeApply(Select(label: LabelDef, nme.asInstanceOf_Ob), _),
                 _
               ) if isCaseLabelDef(label) =>
-            try translateMatch(label)
-            finally addScope(lastLocalId)
+            translateMatch(label)
 
           case _ =>
             stats.foreach(genExpr(_))
-            addScope(lastLocalId)
-            genExpr(last)
+            scoped(
+              curScopeId := parentScope
+            ) {
+              genExpr(last)
+            }
         }
       }
     }
@@ -186,7 +185,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       if (isStatic) {
         genExpr(label.rhs)
       } else {
-        scoped(curMethodThis := Some(params.head)) {
+        scoped(
+          curMethodThis := Some(params.head),
+          curScopeId := ScopeId.of(curFreshScope.get())
+        ) {
           genExpr(label.rhs)
         }
       }
@@ -210,7 +212,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
       if (isMutable) {
         val slot = curMethodEnv.resolve(vd.symbol)
-        buf.varstore(slot, rhs, unwind)(vd.pos)
+        buf.varstore(slot, rhs, unwind)
       } else {
         curMethodEnv.enter(vd.symbol, rhs)
         Val.Unit
@@ -420,25 +422,27 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       // Nested code gen to separate out try/catch-related instructions.
       val nested = new ExprBuffer
       locally {
-        scoped(curUnwindHandler := Some(handler)) {
+        scoped(
+          curUnwindHandler := Some(handler),
+          curScopeId := ScopeId.of(curFreshScope.get())
+        ) {
           nested.label(normaln)
           val res = nested.genExpr(expr)
           nested.jumpExcludeUnitValue(retty)(mergen, res)
         }
       }
-      locally {
+      scoped(
+        curScopeId := ScopeId.of(curFreshScope.get())
+      ) {
         nested.label(handler, Seq(excv))
-        val res = nested.genTryCatch(retty, excv, mergen, catches)(expr.pos)
+        val res = nested.genTryCatch(retty, excv, mergen, catches)
         nested.jumpExcludeUnitValue(retty)(mergen, res)
       }
 
       // Append finally to the try/catch instructions and merge them back.
       val insts =
-        if (finallyp.isEmpty) {
-          nested.toSeq
-        } else {
-          genTryFinally(finallyp, nested.toSeq)
-        }
+        if (finallyp.isEmpty) nested.toSeq
+        else genTryFinally(finallyp, nested.toSeq)
 
       // Append try/catch instructions to the outher instruction buffer.
       buf.jump(Next(normaln))
@@ -463,12 +467,16 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               (genType(pat.symbol.tpe), Some(pat.symbol))
           }
           val f = { () =>
-            symopt.foreach { sym =>
-              val cast = buf.as(excty, exc, unwind)(cd.pos)
-              curMethodEnv.enter(sym, cast)
+            scoped(
+              curScopeId := ScopeId.of(curFreshScope.get())
+            ) {
+              symopt.foreach { sym =>
+                val cast = buf.as(excty, exc, unwind)
+                curMethodEnv.enter(sym, cast)
+              }
+              val res = genExpr(body)
+              buf.jumpExcludeUnitValue(retty)(mergen, res)
             }
-            val res = genExpr(body)
-            buf.jumpExcludeUnitValue(retty)(mergen, res)
             Val.Unit
           }
           (excty, f, exprPos)
@@ -480,7 +488,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             buf.raise(exc, unwind)
             Val.Unit
           case (excty, f, pos) +: rest =>
-            val cond = buf.is(excty, exc, unwind)(pos)
+            val cond = buf.is(excty, exc, unwind)(pos, getScopeId)
             genIf(
               retty,
               ValTree(cond),
@@ -522,8 +530,12 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           // must first go through finally block if it's present. We generate
           // a new copy of the finally handler for every edge.
           val finallyn = fresh()
-          finalies.label(finallyn)(cf.pos)
-          val res = finalies.genExpr(finallyp)
+          scoped(
+            curScopeId := ScopeId.of(curFreshScope.get())
+          ) {
+            finalies.label(finallyn)(cf.pos)
+            val res = finalies.genExpr(finallyp)
+          }
           finalies += cf
           // The original jump outside goes through finally block first.
           Inst.Jump(Next(finallyn))(cf.pos)
@@ -615,7 +627,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         values.zip(elems).zipWithIndex.foreach {
           case ((v, elem), i) =>
             if (!v.isZero) {
-              buf.arraystore(elemty, alloc, Val.Int(i), v, unwind)(elem.pos)
+              buf.arraystore(elemty, alloc, Val.Int(i), v, unwind)(
+                elem.pos,
+                getScopeId
+              )
             }
         }
         alloc
@@ -1169,7 +1184,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genApplyBox(st: SimpleType, argp: Tree): Val = {
       val value = genExpr(argp)
 
-      buf.box(genBoxType(st), value, unwind)(argp.pos)
+      buf.box(genBoxType(st), value, unwind)(argp.pos, getScopeId)
     }
 
     def genApplyUnbox(st: SimpleType, argp: Tree)(implicit
@@ -1608,14 +1623,15 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         rightp: Tree,
         opty: nir.Type
     ): Val = {
+      implicit val leftPos: nir.Position = leftp.pos
       val leftty = genType(leftp.tpe)
       val left = genExpr(leftp)
-      val leftcoerced = genCoercion(left, leftty, opty)(leftp.pos)
+      val leftcoerced = genCoercion(left, leftty, opty)
       val rightty = genType(rightp.tpe)
       val right = genExpr(rightp)
       val rightcoerced = genCoercion(right, rightty, opty)(rightp.pos)
 
-      buf.let(op(opty, leftcoerced, rightcoerced), unwind)(leftp.pos)
+      buf.let(op(opty, leftcoerced, rightcoerced), unwind)
     }
 
     def genClassEquality(
@@ -1732,7 +1748,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genHashCode(argp: Tree)(implicit pos: nir.Position): Val = {
       val arg = boxValue(argp.tpe, genExpr(argp))
       val isnull =
-        buf.comp(Comp.Ieq, Rt.Object, arg, Val.Null, unwind)(argp.pos)
+        buf.comp(Comp.Ieq, Rt.Object, arg, Val.Null, unwind)(
+          argp.pos,
+          getScopeId
+        )
       val cond = ValTree(isnull)
       val thenp = ValTree(Val.Int(0))
       val elsep = ContTree { () =>
@@ -1824,6 +1843,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genRawPtrLoadOp(app: Apply, code: Int): Val = {
       val Apply(_, Seq(ptrp)) = app
+      implicit def pos: nir.Position = app.pos
 
       val ptr = genExpr(ptrp)
 
@@ -1843,11 +1863,12 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val syncAttrs =
         if (!ptrp.symbol.isVolatile) None
         else Some(SyncAttrs(MemoryOrder.Acquire))
-      buf.load(ty, ptr, unwind, syncAttrs)(app.pos)
+      buf.load(ty, ptr, unwind, syncAttrs)
     }
 
     def genRawPtrStoreOp(app: Apply, code: Int): Val = {
       val Apply(_, Seq(ptrp, valuep)) = app
+      implicit def pos: nir.Position = app.pos
 
       val ptr = genExpr(ptrp)
       val value = genExpr(valuep)
@@ -1868,29 +1889,32 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val syncAttrs =
         if (!ptrp.symbol.isVolatile) None
         else Some(SyncAttrs(MemoryOrder.Release))
-      buf.store(ty, ptr, value, unwind, syncAttrs)(app.pos)
+      buf.store(ty, ptr, value, unwind, syncAttrs)
     }
 
     def genRawPtrElemOp(app: Apply, code: Int): Val = {
       val Apply(_, Seq(ptrp, offsetp)) = app
+      implicit def pos: nir.Position = app.pos
 
       val ptr = genExpr(ptrp)
       val offset = genExpr(offsetp)
 
-      buf.elem(Type.Byte, ptr, Seq(offset), unwind)(app.pos)
+      buf.elem(Type.Byte, ptr, Seq(offset), unwind)
     }
 
     def genRawPtrCastOp(app: Apply, code: Int): Val = {
       val Apply(_, Seq(argp)) = app
+      implicit def pos: nir.Position = app.pos
 
       val fromty = genType(argp.tpe)
       val toty = genType(app.tpe)
       val value = genExpr(argp)
 
-      genCastOp(fromty, toty, value)(app.pos)
+      genCastOp(fromty, toty, value)
     }
 
     def genRawSizeCastOp(app: Apply, receiver: Tree, code: Int): Val = {
+      implicit def pos: nir.Position = app.pos
       val rec = genExpr(receiver)
       val (fromty, toty, conv) = code match {
         case CAST_RAWSIZE_TO_INT =>
@@ -1907,7 +1931,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           (nir.Type.Long, nir.Type.Size, Conv.SSizeCast)
       }
 
-      buf.conv(conv, toty, rec, unwind)(app.pos)
+      buf.conv(conv, toty, rec, unwind)
     }
 
     def castConv(fromty: nir.Type, toty: nir.Type): Option[nir.Conv] =
@@ -1965,7 +1989,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             /* buf.unboxValue does not handle Ref( Ptr | CArray | ... ) unboxing
              * That's why we're doing it directly */
             if (Type.unbox.isDefinedAt(tpe)) {
-              buf.unbox(tpe, obj, unwind)(arg.pos)
+              buf.unbox(tpe, obj, unwind)(arg.pos, getScopeId)
             } else {
               buf.unboxValue(fromType(ty), partial = false, obj)(arg.pos)
             }
@@ -2110,7 +2134,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             ) =>
           val bytes = Val.ByteString(StringUtils.processEscapes(str))
           val const = Val.Const(bytes)
-          buf.box(nir.Rt.BoxedPtr, const, unwind)(app.pos)
+          buf.box(nir.Rt.BoxedPtr, const, unwind)(app.pos, getScopeId)
 
         case _ =>
           unsupported(app)
@@ -2470,7 +2494,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       args.zip(argsp).zipWithIndex.foreach {
         case ((arg, argp), idx) =>
-          res = buf.insert(res, arg, Seq(idx), unwind)(argp.pos)
+          res = buf.insert(res, arg, Seq(idx), unwind)(argp.pos, getScopeId)
       }
 
       res

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -450,6 +450,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             withFreshBlockScope(body.pos) { _ =>
               symopt.foreach { sym =>
                 val cast = buf.as(excty, exc, unwind)
+                curMethodLocalNames.get.update(cast.id, genLocalName(sym))
                 curMethodEnv.enter(sym, cast)
               }
               val res = genExpr(body)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -185,7 +185,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case v @ Val.Local(id, _) =>
           if (localNames.contains(id) || isMutable) ()
           else localNames.update(id, name)
-           vd.rhs match {
+          vd.rhs match {
             // When rhs is a block patch the scopeId of it's result to match the current scopeId
             // This allows us to reflect that ValDef is accessible in this scope
             case _: Block | Typed(_: Block, _) | Try(_: Block, _, _) |

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -46,7 +46,7 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
     collection.mutable.Map.empty[(Symbol, Boolean), nir.Type.Function]
   protected var curMethodUsesLinktimeResolvedValues = false
 
-  protected var curScopes = new util.ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
+  protected var curScopes = new util.ScopedVar[mutable.Set[DebugInfo.LexicalScope]]
   protected val curFreshScope = new util.ScopedVar[nir.Fresh]
   protected val curScopeId = new util.ScopedVar[ScopeId]
   implicit protected def getScopeId: nir.ScopeId = curScopeId.get

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -46,7 +46,8 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
     collection.mutable.Map.empty[(Symbol, Boolean), nir.Type.Function]
   protected var curMethodUsesLinktimeResolvedValues = false
 
-  protected var curScopes = new util.ScopedVar[mutable.Set[DebugInfo.LexicalScope]]
+  protected var curScopes =
+    new util.ScopedVar[mutable.Set[DebugInfo.LexicalScope]]
   protected val curFreshScope = new util.ScopedVar[nir.Fresh]
   protected val curScopeId = new util.ScopedVar[ScopeId]
   implicit protected def getScopeId: nir.ScopeId = curScopeId.get
@@ -54,7 +55,6 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
     case _: Block => -1L // Conpensate the top-level block
     case _        => 0L
   })
-
 
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get.fold[Next](Next.None) { handler =>

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -7,6 +7,7 @@ import java.util.function.{Consumer => JConsumer}
 import scala.collection.mutable
 import scala.language.implicitConversions
 import scala.scalanative.nir._
+import nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ScopedVar.scoped
 import scala.tools.nsc.plugins._
 import scala.tools.nsc.{Global, util => _, _}
@@ -44,6 +45,10 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
   protected val cachedMethodSig =
     collection.mutable.Map.empty[(Symbol, Boolean), nir.Type.Function]
   protected var curMethodUsesLinktimeResolvedValues = false
+
+  protected var curScopes = new util.ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
+  protected val curScopeId = new util.ScopedVar[DebugInfo.ScopeId]
+  protected val curScopeFresh = new util.ScopedVar[nir.Fresh]
 
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get.fold[Next](Next.None) { handler =>

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -47,8 +47,14 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
   protected var curMethodUsesLinktimeResolvedValues = false
 
   protected var curScopes = new util.ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
-  protected val curScopeId = new util.ScopedVar[DebugInfo.ScopeId]
-  protected val curScopeFresh = new util.ScopedVar[nir.Fresh]
+  protected val curFreshScope = new util.ScopedVar[nir.Fresh]
+  protected val curScopeId = new util.ScopedVar[ScopeId]
+  implicit protected def getScopeId: nir.ScopeId = curScopeId.get
+  protected def initFreshScope(rhs: Tree) = Fresh(rhs match {
+    case _: Block => -1L // Conpensate the top-level block
+    case _        => 0L
+  })
+
 
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get.fold[Next](Next.None) { handler =>

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -647,7 +647,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val fresh = Fresh()
       val env = new MethodEnv(fresh)
 
-      val scopes = mutable.UnrolledBuffer.empty[DebugInfo.LexicalScope]
+      val scopes = mutable.Set.empty[DebugInfo.LexicalScope]
+      scopes += DebugInfo.LexicalScope.TopLevel
       implicit val pos: nir.Position = dd.pos
 
       scoped(

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -257,7 +257,6 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def withFreshExprBuffer[R](f: ExprBuffer => R): R = {
-      Predef.assert(!curScopeId.isInitialized)
       scoped(
         curFresh := Fresh(),
         curScopeId := ScopeId.TopLevel

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -698,7 +698,10 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                   name,
                   sig,
                   insts = body,
-                  localNames = curMethodLocalNames.get.toMap
+                  debugInfo = Defn.Define.DebugInfo(
+                    localNames = curMethodLocalNames.get.toMap,
+                    lexicalScopes = Nil
+                  ) // TODO
                 )
               )
             }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -647,9 +647,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val fresh = Fresh()
       val env = new MethodEnv(fresh)
 
-      val scopes = mutable.Set.empty[DebugInfo.LexicalScope]
-      scopes += DebugInfo.LexicalScope.TopLevel
       implicit val pos: nir.Position = dd.pos
+      val scopes = mutable.Set.empty[DebugInfo.LexicalScope]
+      scopes += DebugInfo.LexicalScope.TopLevel(dd.rhs.pos)
 
       scoped(
         curMethodSym := dd.symbol,

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -24,7 +24,9 @@ trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
     id
   }
 
-  protected def withFreshBlockScope[R](srcPosition: nir.Position)(f: nir.ScopeId => R): R = {
+  protected def withFreshBlockScope[R](
+      srcPosition: nir.Position
+  )(f: nir.ScopeId => R): R = {
     val blockScope = nir.ScopeId.of(curFreshScope.get())
     // Parent of top level points to itself
     val parentScope =

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -24,7 +24,7 @@ trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
     id
   }
 
-  protected def withFreshBlockScope[R](f: nir.ScopeId => R): R = {
+  protected def withFreshBlockScope[R](srcPosition: nir.Position)(f: nir.ScopeId => R): R = {
     val blockScope = nir.ScopeId.of(curFreshScope.get())
     // Parent of top level points to itself
     val parentScope =
@@ -33,7 +33,8 @@ trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
 
     curScopes.get += nir.Defn.Define.DebugInfo.LexicalScope(
       id = blockScope,
-      parent = parentScope
+      parent = parentScope,
+      srcPosition = srcPosition
     )
 
     ScopedVar.scoped(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNativeExports.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNativeExports.scala
@@ -165,6 +165,7 @@ trait GenNativeExports(using Context):
       insts = withFreshExprBuffer { buf ?=>
         val fresh = curFresh.get
         scoped(
+          curScopeId := ScopeId.TopLevel,
           curUnwindHandler := None,
           curMethodThis := None
         ) {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -55,6 +55,7 @@ trait GenReflectiveInstantisation(using Context) {
       scoped(
         curClassSym := sym,
         curFresh := Fresh(),
+        curScopeId := ScopeId.TopLevel,
         curUnwindHandler := None,
         curMethodThis := None
       ) {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -48,6 +48,10 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected var curMethodUsesLinktimeResolvedValues = false
 
   protected val curFresh = new util.ScopedVar[nir.Fresh]
+  protected var curScopes = new util.ScopedVar[mutable.UnrolledBuffer[nir.Defn.Define.LexicalScope]]
+  protected val curScopeId = new util.ScopedVar[Local]
+  protected val curScopeFresh = new util.ScopedVar[nir.Fresh]
+
   protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]
 
   protected val lazyValsAdapter = AdaptLazyVals(defnNir)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -49,9 +49,20 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected var curMethodUsesLinktimeResolvedValues = false
 
   protected val curFresh = new util.ScopedVar[nir.Fresh]
-  protected var curScopes = new util.ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
-  protected val curScopeId = new util.ScopedVar[DebugInfo.ScopeId]
-  protected val curScopeFresh = new util.ScopedVar[nir.Fresh]
+  protected var curScopes =
+    new util.ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
+  protected val curFreshScope = new util.ScopedVar[nir.Fresh]
+  protected val curScopeId = new util.ScopedVar[ScopeId]
+  implicit protected def getScopeId: nir.ScopeId = {
+    val res = curScopeId.get
+    assert(res.id >= ScopeId.TopLevel.id)
+    res
+  }
+  protected def initFreshScope(rhs: Tree) = Fresh(rhs match {
+    // Conpensate the top-level block
+    case Block(stats, _) => -1L
+    case _               => 0L
+  })
 
   protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -50,7 +50,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
 
   protected val curFresh = new util.ScopedVar[nir.Fresh]
   protected var curScopes =
-    new util.ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
+    new util.ScopedVar[mutable.Set[DebugInfo.LexicalScope]]
   protected val curFreshScope = new util.ScopedVar[nir.Fresh]
   protected val curScopeId = new util.ScopedVar[ScopeId]
   implicit protected def getScopeId: nir.ScopeId = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -2,6 +2,7 @@ package scala.scalanative.nscplugin
 
 import scala.scalanative.util
 import scala.scalanative.nir
+import nir.Defn.Define.DebugInfo
 import scalanative.nir.serialization.serializeBinary
 
 import dotty.tools.dotc.{CompilationUnit, report}
@@ -48,8 +49,8 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected var curMethodUsesLinktimeResolvedValues = false
 
   protected val curFresh = new util.ScopedVar[nir.Fresh]
-  protected var curScopes = new util.ScopedVar[mutable.UnrolledBuffer[nir.Defn.Define.LexicalScope]]
-  protected val curScopeId = new util.ScopedVar[Local]
+  protected var curScopes = new util.ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
+  protected val curScopeId = new util.ScopedVar[DebugInfo.ScopeId]
   protected val curScopeFresh = new util.ScopedVar[nir.Fresh]
 
   protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -859,6 +859,7 @@ trait NirGenExpr(using Context) {
             withFreshBlockScope(body.span) { _ =>
               symopt.foreach { sym =>
                 val cast = buf.as(excty, exc, unwind)(cd.span, getScopeId)
+                curMethodLocalNames.get.update(cast.id, genLocalName(sym))
                 curMethodEnv.enter(sym, cast)
               }
               val res = genExpr(body)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -238,7 +238,8 @@ trait NirGenStat(using Context) {
     implicit val pos: nir.Position = dd.span
     val fresh = Fresh()
     val freshScope = initFreshScope(dd.rhs)
-    val scopes = mutable.UnrolledBuffer.empty[DebugInfo.LexicalScope]
+    val scopes = mutable.Set.empty[DebugInfo.LexicalScope]
+    scopes += DebugInfo.LexicalScope.TopLevel
 
     scoped(
       curMethodSym := dd.symbol,

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -239,7 +239,7 @@ trait NirGenStat(using Context) {
     val fresh = Fresh()
     val freshScope = initFreshScope(dd.rhs)
     val scopes = mutable.Set.empty[DebugInfo.LexicalScope]
-    scopes += DebugInfo.LexicalScope.TopLevel
+    scopes += DebugInfo.LexicalScope.TopLevel(dd.rhs.span)
 
     scoped(
       curMethodSym := dd.symbol,

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -32,7 +32,8 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
 
   protected def withFreshExprBuffer[R](f: ExprBuffer ?=> R): R = {
     ScopedVar.scoped(
-      curFresh := Fresh()
+      curFresh := Fresh(),
+      curScopeId := scala.scalanative.nir.ScopeId.TopLevel
     ) {
       val buffer = new ExprBuffer(using curFresh)
       f(using buffer)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -41,7 +41,9 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
     }
   }
 
-  protected def withFreshBlockScope[R](f: nir.ScopeId => R): R = {
+  protected def withFreshBlockScope[R](
+      srcPosition: nir.Position
+  )(f: nir.ScopeId => R): R = {
     val blockScope = nir.ScopeId.of(curFreshScope.get())
     // Parent of top level points to itself
     val parentScope =
@@ -50,7 +52,8 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
 
     curScopes.get += nir.Defn.Define.DebugInfo.LexicalScope(
       id = blockScope,
-      parent = parentScope
+      parent = parentScope,
+      srcPosition = srcPosition
     )
 
     ScopedVar.scoped(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -8,6 +8,7 @@ import core.Types._
 import scala.scalanative.util.ScopedVar
 import scalanative.nir.{Fresh, Local, LocalName}
 import scala.collection.mutable
+import scala.scalanative.nir
 
 trait NirGenUtil(using Context) { self: NirCodeGen =>
 
@@ -38,6 +39,23 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
       val buffer = new ExprBuffer(using curFresh)
       f(using buffer)
     }
+  }
+
+  protected def withFreshBlockScope[R](f: nir.ScopeId => R): R = {
+    val blockScope = nir.ScopeId.of(curFreshScope.get())
+    // Parent of top level points to itself
+    val parentScope =
+      if (blockScope.isTopLevel) blockScope
+      else curScopeId.get
+
+    curScopes.get += nir.Defn.Define.DebugInfo.LexicalScope(
+      id = blockScope,
+      parent = parentScope
+    )
+
+    ScopedVar.scoped(
+      curScopeId := blockScope
+    )(f(parentScope))
   }
 
   protected def localNamesBuilder(): mutable.Map[Local, LocalName] =

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
@@ -37,13 +37,6 @@ class LexicalScopesTest {
       localNames.groupBy(identity).filter(_._2.size > 1).map(_._1)
     assertTrue(s"Found duplicated names of ${duplicated}", duplicated.isEmpty)
   }
-
-  def namedLets(defn: nir.Defn.Define): Map[Inst.Let, LocalName] =
-    defn.insts.collect {
-      case inst: Inst.Let if defn.localNames.contains(inst.id) =>
-        inst -> defn.localNames(inst.id)
-    }.toMap
-
   private object TestMain {
     val companionMain = Global
       .Top("Test$")
@@ -53,7 +46,7 @@ class LexicalScopesTest {
   }
   private def findDefinition(linked: Seq[Defn]) = linked
     .collectFirst {
-      case defn @ Defn.Define(_, TestMain(), _, _, _, _) =>
+      case defn @ Defn.Define(_, TestMain(), _, _, _) =>
         defn
     }
     .ensuring(_.isDefined, "Not found linked method")
@@ -76,6 +69,7 @@ class LexicalScopesTest {
     """.stripMargin
   ) { loaded =>
     findDefinition(loaded).foreach { defn =>
+      defn.debugInfo.lexicalScopes.foreach(println)
       println(defn.show)
     //   val lets = namedLets(defn).values
     //   val expectedLetNames =

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
@@ -1,0 +1,102 @@
+package scala.scalanative
+package compiler
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.collection.mutable
+
+import scala.scalanative.api.CompilationFailedException
+import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
+import scala.reflect.ClassTag
+
+class LexicalScopesTest {
+  import nir._
+
+  def assertContainsAll[T](
+      msg: String,
+      expected: Iterable[T],
+      actual: Iterable[T]
+  ) = {
+    val left = expected.toSeq
+    val right = actual.toSeq
+    val diff = left.diff(right)
+    assertTrue(s"$msg - not found ${diff} in $right", diff.isEmpty)
+  }
+
+  def assertContains[T](msg: String, expected: T, actual: Iterable[T]) = {
+    assertTrue(
+      s"$msg - not found ${expected} in ${actual.toSeq}",
+      actual.find(_ == expected).isDefined
+    )
+  }
+
+  def assertDistinct(localNames: Iterable[LocalName]) = {
+    val duplicated =
+      localNames.groupBy(identity).filter(_._2.size > 1).map(_._1)
+    assertTrue(s"Found duplicated names of ${duplicated}", duplicated.isEmpty)
+  }
+
+  def namedLets(defn: nir.Defn.Define): Map[Inst.Let, LocalName] =
+    defn.insts.collect {
+      case inst: Inst.Let if defn.localNames.contains(inst.id) =>
+        inst -> defn.localNames(inst.id)
+    }.toMap
+
+  private object TestMain {
+    val companionMain = Global
+      .Top("Test$")
+      .member(Rt.ScalaMainSig.copy(scope = Sig.Scope.Public))
+
+    def unapply(name: Global): Boolean = name == companionMain
+  }
+  private def findDefinition(linked: Seq[Defn]) = linked
+    .collectFirst {
+      case defn @ Defn.Define(_, TestMain(), _, _, _, _) =>
+        defn
+    }
+    .ensuring(_.isDefined, "Not found linked method")
+
+  // Ensure to use all the vals/vars, otherwise they might not be emmited by the compiler
+  @Test def simpleLexicalScoeps(): Unit = compileAndLoad(
+    sources = "Test.scala" -> """
+    |object Test {
+    |  def main(args: Array[String]): Unit = {
+    |    val a = args.size
+    |    val b = a + this.##
+    |    val scopeResult = {
+    |      val innerA = args.size + a
+    |      val innerB = innerA + b
+    |      innerA + innerB
+    |     }
+    |    assert(scopeResult != 0)
+    |  }
+    |}
+    """.stripMargin
+  ) { loaded =>
+    findDefinition(loaded).foreach { defn =>
+      println(defn.show)
+    //   val lets = namedLets(defn).values
+    //   val expectedLetNames =
+    //     Seq("localVal", "localVar", "innerVal", "innerVar", "scoped")
+    //   val expectedNames = Seq("args", "this") ++ expectedLetNames
+    //   assertContainsAll("lets defined", expectedLetNames, lets)
+    //   assertContainsAll("vals defined", expectedNames, defn.localNames.values)
+    //   assertDistinct(lets)
+    //   defn.insts.head match {
+    //     case Inst.Label(
+    //           _,
+    //           Seq(
+    //             Val.Local(thisId, Type.Ref(Global.Top("Test$"), _, _)),
+    //             Val.Local(argsId, Type.Array(Rt.String, _))
+    //           )
+    //         ) =>
+    //       assertTrue("thisArg", defn.localNames.get(thisId).contains("this"))
+    //       assertTrue("argsArg", defn.localNames.get(argsId).contains("args"))
+    //     case _ => fail("Invalid input label")
+    //   }
+    // }
+    }
+  }
+}

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
@@ -60,10 +60,10 @@ class LexicalScopesTest {
   def scopeOf(localName: LocalName)(implicit defn: Defn.Define) =
     namedLets(defn)
       .collectFirst {
-        case (let @ Inst.Let(id, _, _), `localName`) => let.scope
+        case (let @ Inst.Let(id, _, _), `localName`) => let.scopeId
       }
       .orElse { fail(s"Not found a local named: ${localName}"); None }
-      .flatMap(id => defn.debugInfo.lexicalScopes.find(_.id == id))
+      .flatMap(defn.debugInfo.lexicalScopeOf.get)
       .orElse { fail(s"Not found defined scope for ${localName}"); None }
       .get
 

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
@@ -51,46 +51,67 @@ class LexicalScopesTest {
     }
     .ensuring(_.isDefined, "Not found linked method")
 
+  def namedLets(defn: nir.Defn.Define): Map[Inst.Let, LocalName] =
+    defn.insts.collect {
+      case inst: Inst.Let if defn.debugInfo.localNames.contains(inst.id) =>
+        inst -> defn.debugInfo.localNames(inst.id)
+    }.toMap
+
+  def scopeOf(localName: LocalName)(implicit defn: Defn.Define) =
+    namedLets(defn)
+      .collectFirst {
+        case (Inst.Let(id, _, _), `localName`) => id
+      }
+      .orElse { fail(s"Not found a local named: ${localName}"); None }
+      .flatMap(defn.debugInfo.scopeOf)
+      .orElse { fail(s"Not found defined scope for ${localName}"); None }
+      .get
+
   // Ensure to use all the vals/vars, otherwise they might not be emmited by the compiler
-  @Test def simpleLexicalScoeps(): Unit = compileAndLoad(
+  @Test def scopesHierarchy(): Unit = compileAndLoad(
     sources = "Test.scala" -> """
     |object Test {
     |  def main(args: Array[String]): Unit = {
     |    val a = args.size
     |    val b = a + this.##
-    |    val scopeResult = {
+    |    val result = {
     |      val innerA = args.size + a
     |      val innerB = innerA + b
-    |      innerA + innerB
+    |      val innerResult = {
+    |         val deep = innerA + innerB
+    |         deep * 42
+    |      }
+    |      innerA * innerB * innerResult
     |     }
-    |    assert(scopeResult != 0)
+    |    assert(result != 0)
     |  }
     |}
     """.stripMargin
   ) { loaded =>
-    findDefinition(loaded).foreach { defn =>
-      defn.debugInfo.lexicalScopes.foreach(println)
-      println(defn.show)
-    //   val lets = namedLets(defn).values
-    //   val expectedLetNames =
-    //     Seq("localVal", "localVar", "innerVal", "innerVar", "scoped")
-    //   val expectedNames = Seq("args", "this") ++ expectedLetNames
-    //   assertContainsAll("lets defined", expectedLetNames, lets)
-    //   assertContainsAll("vals defined", expectedNames, defn.localNames.values)
-    //   assertDistinct(lets)
-    //   defn.insts.head match {
-    //     case Inst.Label(
-    //           _,
-    //           Seq(
-    //             Val.Local(thisId, Type.Ref(Global.Top("Test$"), _, _)),
-    //             Val.Local(argsId, Type.Array(Rt.String, _))
-    //           )
-    //         ) =>
-    //       assertTrue("thisArg", defn.localNames.get(thisId).contains("this"))
-    //       assertTrue("argsArg", defn.localNames.get(argsId).contains("args"))
-    //     case _ => fail("Invalid input label")
-    //   }
-    // }
+    findDefinition(loaded).foreach { implicit defn =>
+      assertContainsAll(
+        "named vals",
+        Seq("a", "b", "result", "innerA", "innerB", "innerResult", "deep"),
+        namedLets(defn).values
+      )
+      // top-level
+      val innerA = scopeOf("innerA")
+      val innerB = scopeOf("innerB")
+      val innerResult = scopeOf("innerResult")
+      val deep = scopeOf("deep")
+      val result = scopeOf("result")
+      assertTrue("scope-a", scopeOf("a").isTopLevel)
+      assertTrue("scope-b", scopeOf("b").isTopLevel)
+      assertFalse("inner-A", innerA.isTopLevel)
+      assertFalse("inner-B", innerB.isTopLevel)
+      assertFalse("inner-result", innerResult.isTopLevel)
+      assertFalse("deep", deep.isTopLevel)
+      assertTrue("result", result.isTopLevel)
+
+      assertEquals("innerA-parent", result.id, innerA.parent)
+      assertEquals("innerB-parent", innerA.parent, innerB.parent)
+      assertEquals("innerResult-parent", result.id, innerResult.parent)
+      assertEquals("deep-parent", innerResult.id, deep.parent)
     }
   }
 }

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
@@ -94,8 +94,6 @@ class LexicalScopesTest {
         Seq("a", "b", "result", "innerA", "innerB", "innerResult", "deep"),
         namedLets(defn).values
       )
-      println(defn.show)
-      defn.debugInfo.lexicalScopes.foreach(println)
       // top-level
       val innerA = scopeOf("innerA")
       val innerB = scopeOf("innerB")

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
@@ -60,10 +60,10 @@ class LexicalScopesTest {
   def scopeOf(localName: LocalName)(implicit defn: Defn.Define) =
     namedLets(defn)
       .collectFirst {
-        case (Inst.Let(id, _, _), `localName`) => id
+        case (let @ Inst.Let(id, _, _), `localName`) => let.scope
       }
       .orElse { fail(s"Not found a local named: ${localName}"); None }
-      .flatMap(defn.debugInfo.scopeOf)
+      .flatMap(id => defn.debugInfo.lexicalScopes.find(_.id == id))
       .orElse { fail(s"Not found defined scope for ${localName}"); None }
       .get
 
@@ -94,6 +94,8 @@ class LexicalScopesTest {
         Seq("a", "b", "result", "innerA", "innerB", "innerResult", "deep"),
         namedLets(defn).values
       )
+      println(defn.show)
+      defn.debugInfo.lexicalScopes.foreach(println)
       // top-level
       val innerA = scopeOf("innerA")
       val innerB = scopeOf("innerB")

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
@@ -158,8 +158,6 @@ class LexicalScopesTest {
     """.stripMargin
   ) { loaded =>
     findDefinition(loaded).foreach { implicit defn =>
-      println(defn.show)
-      defn.debugInfo.lexicalScopes.foreach(println)
       assertContainsAll(
         "named vals",
         // b passed as label argument
@@ -181,7 +179,6 @@ class LexicalScopesTest {
       assertContains("inTry-parents", a.id, scopeParents(inTry))
       assertEquals(ex1.id, n.parent)
       assertEquals(ex2.id, m.parent)
-      
     }
   }
 }

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LocalNamesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LocalNamesTest.scala
@@ -53,7 +53,7 @@ class LocalNamesTest {
   }
   private def findDefinition(linked: Seq[Defn]) = linked
     .collectFirst {
-      case defn @ Defn.Define(_, TestMain(), _, _, _) =>
+      case defn @ Defn.Define(_, TestMain(), _, _,_, _) =>
         defn
     }
     .ensuring(_.isDefined, "Not found linked method")

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/PositionsTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/PositionsTest.scala
@@ -42,7 +42,6 @@ class PositionsTest {
                 Global.Member(top: Global.Top, sig),
                 _,
                 insts,
-                _,
                 _
               ) =>
             Some((top, sig.unmangled, defn.pos, insts))

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/PositionsTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/PositionsTest.scala
@@ -42,6 +42,7 @@ class PositionsTest {
                 Global.Member(top: Global.Top, sig),
                 _,
                 insts,
+                _,
                 _
               ) =>
             Some((top, sig.unmangled, defn.pos, insts))

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -24,6 +24,7 @@ object Generate {
   implicit def linked(implicit meta: Metadata): linker.Result =
     meta.linked
   private implicit val pos: Position = Position.NoPosition
+  private implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
 
   private class Impl(entry: Option[Global.Top], defns: Seq[Defn])(implicit
       meta: Metadata

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable
 /** Created by lukaskellenberger on 17.12.16.
  */
 object GenerateReflectiveProxies {
+  implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
 
   private def genReflProxy(defn: Defn.Define): Defn.Define = {
     implicit val fresh: Fresh = Fresh()

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -142,7 +142,7 @@ object Lower {
 
       insts.foreach {
         case inst @ Inst.Let(n, Op.Var(ty), unwind) =>
-          buf.let(n, Op.Stackalloc(ty, one), unwind)(inst.pos, inst.scope)
+          buf.let(n, Op.Stackalloc(ty, one), unwind)(inst.pos, inst.scopeId)
         case _ => ()
       }
 
@@ -165,7 +165,7 @@ object Lower {
           ScopedVar.scoped(
             unwindHandler := newUnwindHandler(unwind)(inst.pos)
           ) {
-            lastScopeId = inst.scope
+            lastScopeId = inst.scopeId
             genLet(buf, n, op)(inst.pos, lastScopeId)
           }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -8,7 +8,6 @@ import scalanative.linker._
 import scalanative.interflow.UseDef.eliminateDeadCode
 
 object Lower {
-
   def apply(
       defns: Seq[Defn]
   )(implicit meta: Metadata, logger: build.Logger): Seq[Defn] =
@@ -143,7 +142,7 @@ object Lower {
 
       insts.foreach {
         case inst @ Inst.Let(n, Op.Var(ty), unwind) =>
-          buf.let(n, Op.Stackalloc(ty, one), unwind)(inst.pos)
+          buf.let(n, Op.Stackalloc(ty, one), unwind)(inst.pos, inst.scope)
         case _ => ()
       }
 
@@ -160,19 +159,21 @@ object Lower {
         () => newUnwindHandler(Next.None)(insts.head.pos)
       )
 
+      implicit var lastScopeId: ScopeId = ScopeId.TopLevel
       insts.tail.foreach {
         case inst @ Inst.Let(n, op, unwind) =>
           ScopedVar.scoped(
             unwindHandler := newUnwindHandler(unwind)(inst.pos)
           ) {
-            genLet(buf, n, op)(inst.pos)
+            lastScopeId = inst.scope
+            genLet(buf, n, op)(inst.pos, lastScopeId)
           }
 
         case inst @ Inst.Throw(v, unwind) =>
           ScopedVar.scoped(
             unwindHandler := newUnwindHandler(unwind)(inst.pos)
           ) {
-            genThrow(buf, v)(inst.pos)
+            genThrow(buf, v)(inst.pos, lastScopeId)
           }
 
         case inst @ Inst.Unreachable(unwind) =>
@@ -265,7 +266,9 @@ object Lower {
         case _ => onVal(value)
       }
 
-    def genNullPointerSlowPath(buf: Buffer)(implicit pos: Position): Unit = {
+    def genNullPointerSlowPath(
+        buf: Buffer
+    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
       nullPointerSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
@@ -283,7 +286,9 @@ object Lower {
       }
     }
 
-    def genDivisionByZeroSlowPath(buf: Buffer)(implicit pos: Position): Unit = {
+    def genDivisionByZeroSlowPath(
+        buf: Buffer
+    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
       divisionByZeroSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
@@ -301,7 +306,9 @@ object Lower {
       }
     }
 
-    def genClassCastSlowPath(buf: Buffer)(implicit pos: Position): Unit = {
+    def genClassCastSlowPath(
+        buf: Buffer
+    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
       classCastSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
@@ -323,7 +330,9 @@ object Lower {
       }
     }
 
-    def genUnreachableSlowPath(buf: Buffer)(implicit pos: Position): Unit = {
+    def genUnreachableSlowPath(
+        buf: Buffer
+    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
       unreachableSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
@@ -336,7 +345,9 @@ object Lower {
       }
     }
 
-    def genOutOfBoundsSlowPath(buf: Buffer)(implicit pos: Position): Unit = {
+    def genOutOfBoundsSlowPath(
+        buf: Buffer
+    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
       outOfBoundsSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
@@ -356,7 +367,9 @@ object Lower {
       }
     }
 
-    def genNoSuchMethodSlowPath(buf: Buffer)(implicit pos: Position): Unit = {
+    def genNoSuchMethodSlowPath(
+        buf: Buffer
+    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
       noSuchMethodSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
@@ -376,7 +389,10 @@ object Lower {
       }
     }
 
-    def genLet(buf: Buffer, n: Local, op: Op)(implicit pos: Position): Unit =
+    def genLet(buf: Buffer, n: Local, op: Op)(implicit
+        srcPosition: Position,
+        scopeId: ScopeId
+    ): Unit =
       op.resty match {
         case Type.Unit =>
           genOp(buf, fresh(), op)
@@ -389,7 +405,10 @@ object Lower {
           genOp(buf, n, op)
       }
 
-    def genThrow(buf: Buffer, exc: Val)(implicit pos: Position) = {
+    def genThrow(buf: Buffer, exc: Val)(implicit
+        srcPosition: Position,
+        scopeId: ScopeId
+    ) = {
       genGuardNotNull(buf, exc)
       genOp(buf, fresh(), Op.Call(throwSig, throw_, Seq(exc)))
       buf.unreachable(Next.None)
@@ -401,7 +420,10 @@ object Lower {
       buf.jump(Next(failL))
     }
 
-    def genOp(buf: Buffer, n: Local, op: Op)(implicit pos: Position): Unit = {
+    def genOp(buf: Buffer, n: Local, op: Op)(implicit
+        srcPosition: Position,
+        scopeId: ScopeId
+    ): Unit = {
       op match {
         case op: Op.Field =>
           genFieldOp(buf, n, op)
@@ -463,7 +485,10 @@ object Lower {
       }
     }
 
-    def genGuardNotNull(buf: Buffer, obj: Val)(implicit pos: Position): Unit =
+    def genGuardNotNull(buf: Buffer, obj: Val)(implicit
+        srcPosition: Position,
+        scopeId: ScopeId
+    ): Unit =
       obj.ty match {
         case ty: Type.RefKind if !ty.isNullable =>
           ()
@@ -484,7 +509,8 @@ object Lower {
       }
 
     def genGuardInBounds(buf: Buffer, idx: Val, len: Val)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       import buf._
 
@@ -500,7 +526,8 @@ object Lower {
     }
 
     def genFieldElemOp(buf: Buffer, obj: Val, name: Global)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ) = {
       import buf._
       val v = genVal(buf, obj)
@@ -515,7 +542,8 @@ object Lower {
     }
 
     def genFieldloadOp(buf: Buffer, n: Local, op: Op.Fieldload)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ) = {
       val Op.Fieldload(ty, obj, name) = op
       val field = name match {
@@ -538,7 +566,8 @@ object Lower {
     }
 
     def genFieldstoreOp(buf: Buffer, n: Local, op: Op.Fieldstore)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ) = {
       val Op.Fieldstore(ty, obj, name, value) = op
       val field = name match {
@@ -560,7 +589,8 @@ object Lower {
     }
 
     def genFieldOp(buf: Buffer, n: Local, op: Op)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ) = {
       val Op.Field(obj, name) = op: @unchecked
       val elem = genFieldElemOp(buf, obj, name)
@@ -568,7 +598,8 @@ object Lower {
     }
 
     def genLoadOp(buf: Buffer, n: Local, op: Op.Load)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       op match {
         // Convert synchronized load(bool) into load(byte)
@@ -603,7 +634,8 @@ object Lower {
     }
 
     def genStoreOp(buf: Buffer, n: Local, op: Op.Store)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       op match {
         // Convert synchronized store(bool) into store(byte)
@@ -639,7 +671,8 @@ object Lower {
     }
 
     def genCompOp(buf: Buffer, n: Local, op: Op.Comp)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Comp(comp, ty, l, r) = op
       val left = genVal(buf, l)
@@ -678,7 +711,8 @@ object Lower {
       }
     }
     private def genGCSafepoint(buf: Buffer, genUnwind: Boolean = true)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       if (shouldGenerateSafepoints(currentDefn.get)) {
         val handler = {
@@ -695,7 +729,8 @@ object Lower {
     }
 
     def genCallOp(buf: Buffer, n: Local, op: Op.Call)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Call(ty, ptr, args) = op
       def genCall() = {
@@ -736,7 +771,8 @@ object Lower {
     }
 
     def genMethodOp(buf: Buffer, n: Local, op: Op.Method)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ) = {
       import buf._
 
@@ -840,7 +876,8 @@ object Lower {
     }
 
     def genDynmethodOp(buf: Buffer, n: Local, op: Op.Dynmethod)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       import buf._
 
@@ -889,7 +926,8 @@ object Lower {
     }
 
     def genIsOp(buf: Buffer, n: Local, op: Op.Is)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       import buf._
 
@@ -919,7 +957,10 @@ object Lower {
       }
     }
 
-    def genIsOp(buf: Buffer, ty: Type, v: Val)(implicit pos: Position): Val = {
+    def genIsOp(buf: Buffer, ty: Type, v: Val)(implicit
+        srcPosition: Position,
+        scopeId: ScopeId
+    ): Val = {
       import buf._
       val obj = genVal(buf, v)
 
@@ -968,7 +1009,8 @@ object Lower {
     }
 
     def genAsOp(buf: Buffer, n: Local, op: Op.As)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       import buf._
 
@@ -1002,14 +1044,15 @@ object Lower {
     }
 
     def genSizeOfOp(buf: Buffer, n: Local, op: Op.SizeOf)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val size = op.ty match {
         case ClassRef(cls) if op.ty != Type.Unit =>
           if (!cls.allocated) {
             val Global.Top(clsName) = cls.name: @unchecked
             logger.warn(
-              s"Referencing size of non allocated type ${clsName} in ${pos.show}"
+              s"Referencing size of non allocated type ${clsName} in ${srcPosition.show}"
             )
           }
           meta.layout(cls).size
@@ -1019,14 +1062,16 @@ object Lower {
     }
 
     def genAlignmentOfOp(buf: Buffer, n: Local, op: Op.AlignmentOf)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val alignment = MemoryLayout.alignmentOf(op.ty)
       buf.let(n, Op.Copy(Val.Size(alignment)), unwind)
     }
 
     def genClassallocOp(buf: Buffer, n: Local, op: Op.Classalloc)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Classalloc(ClassRef(cls), v) = op: @unchecked
       val zone = v.map(genVal(buf, _))
@@ -1067,7 +1112,8 @@ object Lower {
     }
 
     def genConvOp(buf: Buffer, n: Local, op: Op.Conv)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       import buf._
 
@@ -1162,7 +1208,8 @@ object Lower {
     }
 
     def genBinOp(buf: Buffer, n: Local, op: Op.Bin)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       import buf._
 
@@ -1282,7 +1329,8 @@ object Lower {
     }
 
     def genBoxOp(buf: Buffer, n: Local, op: Op.Box)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Box(ty, v) = op
       val from = genVal(buf, v)
@@ -1301,7 +1349,8 @@ object Lower {
     }
 
     def genUnboxOp(buf: Buffer, n: Local, op: Op.Unbox)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Unbox(ty, v) = op
       val from = genVal(buf, v)
@@ -1320,7 +1369,8 @@ object Lower {
     }
 
     def genModuleOp(buf: Buffer, n: Local, op: Op.Module)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ) = {
       val Op.Module(name) = op
 
@@ -1338,7 +1388,8 @@ object Lower {
     }
 
     def genArrayallocOp(buf: Buffer, n: Local, op: Op.Arrayalloc)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Arrayalloc(ty, v1, v2) = op
       val init = genVal(buf, v1)
@@ -1388,7 +1439,8 @@ object Lower {
     private def arrayValuePath(idx: Val) = Seq(zero, one, idx)
 
     def genArrayloadOp(buf: Buffer, n: Local, op: Op.Arrayload)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Arrayload(ty, v, idx) = op
       val arr = genVal(buf, v)
@@ -1404,7 +1456,8 @@ object Lower {
     }
 
     def genArraystoreOp(buf: Buffer, n: Local, op: Op.Arraystore)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Arraystore(ty, arr, idx, v) = op
       val len = fresh()
@@ -1419,7 +1472,8 @@ object Lower {
     }
 
     def genArraylengthOp(buf: Buffer, n: Local, op: Op.Arraylength)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Arraylength(v) = op
       val arr = genVal(buf, v)
@@ -1434,7 +1488,8 @@ object Lower {
     }
 
     def genStackallocOp(buf: Buffer, n: Local, op: Op.Stackalloc)(implicit
-        pos: Position
+        srcPosition: Position,
+        scopeId: ScopeId
     ): Unit = {
       val Op.Stackalloc(ty, size) = op
       val initValue = Val.Zero(ty).canonicalize
@@ -1538,6 +1593,7 @@ object Lower {
           thisValue.ty match {
             case ref: Type.Ref if ref.isNullable && usesValue(thisValue) =>
               implicit def pos: Position = defn.pos
+              implicit def scopeId: ScopeId = ScopeId.TopLevel
               ScopedVar.scoped(
                 unwindHandler := createUnwindHandler()
               ) {

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -178,7 +178,7 @@ private[codegen] abstract class AbstractCodeGen(
       genGlobalDefn(attrs, name, isConst = true, ty, rhs)
     case Defn.Declare(attrs, name, sig) =>
       genFunctionDefn(attrs, name, sig, Seq.empty, Fresh(), defn.pos)
-    case Defn.Define(attrs, name, sig, insts, localNames) =>
+    case Defn.Define(attrs, name, sig, insts, _) =>
       genFunctionDefn(attrs, name, sig, insts, Fresh(insts), defn.pos)
     case defn =>
       unsupported(defn)

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -13,7 +13,8 @@ trait Combine { self: Interflow =>
 
   def combine(bin: Bin, ty: Type, l: Val, r: Val)(implicit
       state: State,
-      origPos: Position
+      srcPosition: Position,
+      scopeId: ScopeId
   ): Val = {
     import state.{materialize, delay, emit}
 
@@ -388,7 +389,9 @@ trait Combine { self: Interflow =>
   }
 
   def combine(comp: Comp, ty: Type, l: Val, r: Val)(implicit
-      state: State
+      state: State,
+      srcPosition: Position,
+      scopeId: ScopeId
   ): Val = {
     import state.{materialize, delay, emit}
 
@@ -557,7 +560,11 @@ trait Combine { self: Interflow =>
     }
   }
 
-  def combine(conv: Conv, ty: Type, value: Val)(implicit state: State): Val = {
+  def combine(conv: Conv, ty: Type, value: Val)(implicit
+      state: State,
+      srcPosition: Position,
+      scopeId: ScopeId
+  ): Val = {
     import state.{materialize, delay, emit}
 
     (conv, ty, value) match {

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -2,32 +2,33 @@ package scala.scalanative
 package interflow
 
 import scala.collection.mutable
-import scalanative.nir._
-import scalanative.linker._
-import scalanative.codegen.MemoryLayout
-import scalanative.util.{unreachable, And}
+import scala.scalanative.nir._
+import scala.scalanative.nir.Defn.Define.DebugInfo
+import scala.scalanative.linker._
+import scala.scalanative.codegen.MemoryLayout
+import scala.scalanative.util.{unreachable, And}
 
 trait Eval { self: Interflow =>
-  final val preserveLocalNames: Boolean =
+  def interflow: Interflow = self
+  final val preserveDebugInfo: Boolean =
     self.config.compilerConfig.debugMetadata
 
   def run(
       insts: Array[Inst],
       offsets: Map[Local, Int],
       from: Local,
-      localNames: LocalNames
-  )(implicit
-      state: State
-  ): Inst.Cf = {
+      debugInfo: DebugInfo,
+      scopeMapping: ScopeId => ScopeId
+  )(implicit state: State): Inst.Cf = {
     import state.{materialize, delay}
 
     var pc = offsets(from)
 
-    if (preserveLocalNames && pc == 0) {
+    if (preserveDebugInfo && pc == 0) {
       val Inst.Label(_, params) = insts.head: @unchecked
       for {
         param <- params
-        name <- localNames.get(param.id)
+        name <- debugInfo.localNames.get(param.id)
       } {
         state.localNames.getOrElseUpdate(param.id, name)
       }
@@ -35,28 +36,30 @@ trait Eval { self: Interflow =>
 
     pc += 1
 
+    // Implicit scopeId required for materialization of insts other then Inst.Let
+    implicit var lastScopeId = scopeMapping(ScopeId.TopLevel)
     while (true) {
       val inst = insts(pc)
-      implicit val pos: Position = inst.pos
+      implicit val srcPosition: Position = inst.pos
       def bailOut =
         throw BailOut("can't eval inst: " + inst.show)
       inst match {
         case _: Inst.Label =>
           unreachable
-        case Inst.Let(local, op, unwind) =>
+        case let @ Inst.Let(local, op, unwind) =>
+          lastScopeId = scopeMapping(let.scope)
           if (unwind ne Next.None) {
             throw BailOut("try-catch")
           }
           val value = eval(op)
-          if (preserveLocalNames) {
-            localNames.get(local).foreach { localName =>
-              value match {
-                case Val.Local(id, _) =>
-                  state.localNames.getOrElseUpdate(id, localName)
-                case Val.Virtual(addr) =>
-                  state.virtualNames.getOrElseUpdate(addr, localName)
-                case _ => ()
-              }
+          if (preserveDebugInfo) {
+            val localName = debugInfo.localNames.get(local)
+            value match {
+              case Val.Local(id, _) =>
+                localName.foreach(state.localNames.getOrElseUpdate(id, _))
+              case Val.Virtual(addr) =>
+                localName.foreach(state.virtualNames.getOrElseUpdate(addr, _))
+              case _ => ()
             }
           }
           if (value.ty == Type.Nothing) {
@@ -136,7 +139,12 @@ trait Eval { self: Interflow =>
 
   def eval(
       op: Op
-  )(implicit state: State, linked: linker.Result, origPos: Position): Val = {
+  )(implicit
+      state: State,
+      linked: linker.Result,
+      srcPosition: Position,
+      scopeId: ScopeId
+  ): Val = {
     import state.{emit, materialize, delay}
     def bailOut =
       throw BailOut("can't eval op: " + op.show)
@@ -497,7 +505,8 @@ trait Eval { self: Interflow =>
 
   def eval(bin: Bin, ty: Type, l: Val, r: Val)(implicit
       state: State,
-      origPos: Position
+      srcPosition: Position,
+      scopeId: ScopeId
   ): Val = {
     import state.{emit, materialize}
     def fallback =
@@ -963,7 +972,11 @@ trait Eval { self: Interflow =>
     }
   }
 
-  def eval(value: Val)(implicit state: State, origPos: Position): Val = {
+  def eval(value: Val)(implicit
+      state: State,
+      srcPosition: nir.Position,
+      scopeId: nir.ScopeId
+  ): Val = {
     value match {
       case Val.Local(local, _) if local.id >= 0 =>
         state.loadLocal(local) match {

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -47,7 +47,7 @@ trait Eval { self: Interflow =>
         case _: Inst.Label =>
           unreachable
         case let @ Inst.Let(local, op, unwind) =>
-          lastScopeId = scopeMapping(let.scope)
+          lastScopeId = scopeMapping(let.scopeId)
           if (unwind ne Next.None) {
             throw BailOut("try-catch")
           }

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -249,13 +249,14 @@ trait Inline { self: Interflow =>
             emit.updateLetInst(id)(i => i.copy()(i.pos, parentScopeId))
           case Val.Virtual(addr) =>
             endState.heap(addr) = endState.deref(addr) match {
-              case inst: EscapedInstance => println(inst); inst
+              case inst: EscapedInstance =>
+                inst.copy()(inst.srcPosition, parentScopeId)
               case inst: DelayedInstance =>
                 inst.copy()(inst.srcPosition, parentScopeId)
               case inst: VirtualInstance =>
                 inst.copy()(inst.srcPosition, parentScopeId)
             }
-          case other => ()
+          case _ => ()
         }
       }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -1,11 +1,13 @@
 package scala.scalanative
 package interflow
 
-import scalanative.nir._
-import scalanative.linker._
-import scalanative.util.unreachable
+import scala.scalanative.nir._
+import scala.scalanative.nir.Defn.Define.DebugInfo
+import scala.scalanative.linker._
+import scala.scalanative.util.unreachable
 
 trait Inline { self: Interflow =>
+
   private val maxInlineSize =
     config.compilerConfig.optimizerConfig.maxInlineSize
       .getOrElse(8)
@@ -113,7 +115,11 @@ trait Inline { self: Interflow =>
       }
   }
 
-  def adapt(value: Val, ty: Type)(implicit state: State): Val = {
+  def adapt(value: Val, ty: Type)(implicit
+      state: State,
+      srcPosition: nir.Position,
+      scopeId: nir.ScopeId
+  ): Val = {
     val valuety = value match {
       case InstanceRef(ty) => ty
       case _               => value.ty
@@ -125,7 +131,11 @@ trait Inline { self: Interflow =>
     }
   }
 
-  def adapt(args: Seq[Val], sig: Type)(implicit state: State): Seq[Val] = {
+  def adapt(args: Seq[Val], sig: Type)(implicit
+      state: State,
+      srcPosition: nir.Position,
+      scopeId: nir.ScopeId
+  ): Seq[Val] = {
     val Type.Function(argtys, _) = sig: @unchecked
 
     // Varargs signature might appear to have less
@@ -150,7 +160,7 @@ trait Inline { self: Interflow =>
   def `inline`(name: Global, args: Seq[Val])(implicit
       state: State,
       linked: linker.Result,
-      origPos: Position
+      parentScopeId: ScopeId
   ): Val =
     in(s"inlining ${name.show}") {
       val defn = mode match {
@@ -159,17 +169,16 @@ trait Inline { self: Interflow =>
       }
       val Type.Function(_, origRetTy) = defn.ty: @unchecked
 
-      val inlineArgs = adapt(args, defn.ty)
-      val inlineInsts = defn.insts.toArray
-      val blocks =
-        process(
-          inlineInsts,
-          defn.debugInfo.localNames,
-          inlineArgs,
-          state,
-          doInline = true,
-          origRetTy
-        )
+      implicit val srcPosition: nir.Position = defn.pos
+      val blocks = process(
+        insts = defn.insts.toArray,
+        debugInfo = defn.debugInfo,
+        args = adapt(args, defn.ty),
+        state = state,
+        doInline = true,
+        retTy = origRetTy,
+        parentScopeId = parentScopeId
+      )
 
       val emit = new nir.Buffer()(state.fresh)
 
@@ -227,7 +236,7 @@ trait Inline { self: Interflow =>
               (nothing, state)
             }
       }
-      if (self.preserveLocalNames) {
+      if (self.preserveDebugInfo) {
         blocks.foreach { block =>
           endState.localNames.addMissing(block.end.localNames)
           endState.virtualNames.addMissing(block.end.virtualNames)

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -164,7 +164,7 @@ trait Inline { self: Interflow =>
       val blocks =
         process(
           inlineInsts,
-          defn.localNames,
+          defn.debugInfo.localNames,
           inlineArgs,
           state,
           doInline = true,

--- a/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
@@ -19,10 +19,9 @@ sealed abstract class Instance(implicit
   }
 
   override def clone(): Instance = this match {
-    case EscapedInstance(value) => EscapedInstance(value)(this)
-    case DelayedInstance(op)    => DelayedInstance(op)
-    case VirtualInstance(kind, cls, values, zone) =>
-      VirtualInstance(kind, cls, values.clone(), zone)
+    case inst: EscapedInstance => inst.copy()
+    case inst: DelayedInstance => inst.copy()
+    case inst: VirtualInstance => inst.copy(values = inst.values.clone())
   }
 
   override def toString: String = this match {
@@ -36,8 +35,13 @@ sealed abstract class Instance(implicit
   }
 }
 
-final case class EscapedInstance(val escapedValue: Val)(instance: Instance)
-    extends Instance()(instance.srcPosition, instance.scopeId)
+final case class EscapedInstance(val escapedValue: Val)(implicit
+    srcPosition: nir.Position,
+    scopeId: nir.ScopeId
+) extends Instance {
+  def this(escapedValue: Val, instance: Instance) =
+    this(escapedValue)(instance.srcPosition, instance.scopeId)
+}
 
 final case class DelayedInstance(val delayedOp: Op)(implicit
     srcPosition: nir.Position,

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -42,7 +42,7 @@ class Interflow(val config: build.Config)(implicit
 
   def currentLexicalScopes = lexicalScopesTl.get()
   private val lexicalScopesTl = ThreadLocal.withInitial(() =>
-    new ScopedVar[mutable.Set[DebugInfo.LexicalScope]]
+    new ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
   )
 
   private val contextTl =

--- a/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
@@ -33,7 +33,8 @@ trait Intrinsics { self: Interflow =>
 
   def intrinsic(ty: Type, name: Global, rawArgs: Seq[Val])(implicit
       state: State,
-      origPos: Position
+      srcPosition: Position,
+      scopeId: ScopeId
   ): Option[Val] = {
     val Global.Member(_, sig) = name: @unchecked
 

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -26,6 +26,7 @@ final class MergeBlock(val label: Inst.Label, val id: Local) {
     import Interflow.LLVMIntrinsics._
     val block = this
     val result = new nir.Buffer()(Fresh(0))
+
     def mergeNext(next: Next.Label): Next.Label = {
       val nextBlock = outgoing(next.id)
 
@@ -100,6 +101,8 @@ final class MergeBlock(val label: Inst.Label, val id: Local) {
     }
     if (alreadyEmmited) false
     else {
+      // TODO: resolving actual scopeId. Currently not really important becouse used only to introduce stack guard intrinsics
+      implicit def scopeId: ScopeId = ScopeId.TopLevel
       result.let(id, op, Next.None)
       true
     }

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -160,9 +160,10 @@ final class MergeProcessor(
                       case _                      => Val.Virtual(addr)
                     }
                   }
-                  mergeHeap(addr) = EscapedInstance(
-                    mergePhi(values, None, virtualNameOf(addr))
-                  )(headInstance)
+                  mergeHeap(addr) = new EscapedInstance(
+                    mergePhi(values, None, virtualNameOf(addr)),
+                    headInstance
+                  )
                 case head: VirtualInstance =>
                   val mergeValues = head.values.zipWithIndex.map {
                     case (_, idx) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -570,7 +570,7 @@ object MergeProcessor {
         mapping.getOrElseUpdate(scopeId, ScopeId.of(freshScope()))
 
       if (doInline) lexicalScopes.foreach {
-        case scope @ DebugInfo.LexicalScope(id, parent) =>
+        case scope @ DebugInfo.LexicalScope(id, parent, _) =>
           val newScope = scope.copy(
             id = newMappingOf(id),
             parent = if (id.isTopLevel) parentScopeId else newMappingOf(parent)
@@ -580,7 +580,7 @@ object MergeProcessor {
       }
       else {
         lexicalScopes.foreach {
-          case scope @ DebugInfo.LexicalScope(id, parent) =>
+          case scope @ DebugInfo.LexicalScope(id, parent, _) =>
             scopes += scope
             mapping(id) = id
             mapping(parent) = parent

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -35,7 +35,8 @@ trait Opt { self: Interflow =>
         attrs = origdefn.attrs.copy(opt = Attr.DidOpt),
         ty = Type.Function(argtys, retty),
         insts = ControlFlow.removeDeadBlocks(rawInsts),
-        localNames = localNames
+        debugInfo = origdefn.debugInfo.copy(localNames = localNames) // TODO
+        
       )(origdefn.pos)
 
     // Create new fresh and state for the first basic block.
@@ -61,7 +62,7 @@ trait Opt { self: Interflow =>
         } else argty
 
         val id = fresh()
-        origdefn.localNames
+        origdefn.debugInfo.localNames
           .get(origarg.id)
           .foreach(state.localNames.update(id, _))
         Val.Local(id, ty)
@@ -79,7 +80,7 @@ trait Opt { self: Interflow =>
           pushBlockFresh(fresh)
           process(
             origdefn.insts.toArray,
-            localNames = origdefn.localNames,
+            localNames = origdefn.debugInfo.localNames,
             args = args,
             state = state,
             doInline = false,

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -82,7 +82,7 @@ trait Opt { self: Interflow =>
     } else
       scoped(
         currentFreshScope := Fresh(0L),
-        currentLexicalScopes := mutable.Set.empty
+        currentLexicalScopes := mutable.UnrolledBuffer.empty
       ) {
         // Run a merge processor starting from the entry basic block.
         val blocks =

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -1,10 +1,11 @@
 package scala.scalanative
 package interflow
 
-import scalanative.nir._
-import scalanative.linker._
+import scala.scalanative.nir._
+import scala.scalanative.nir.Defn.Define.DebugInfo
+import scala.scalanative.linker._
 import scala.collection.mutable
-import scala.annotation.tailrec
+import scala.scalanative.util.ScopedVar.scoped
 
 trait Opt { self: Interflow =>
 
@@ -29,19 +30,22 @@ trait Opt { self: Interflow =>
     val Inst.Label(_, origargs) = origdefn.insts.head: @unchecked
     implicit val pos = origdefn.pos
     // Wrap up the result.
-    def result(retty: Type, rawInsts: Seq[Inst], localNames: LocalNames) =
+    def result(retty: Type, rawInsts: Seq[Inst], debugInfo: DebugInfo) = {
+      val insts = ControlFlow.removeDeadBlocks(rawInsts)
+      // TODO: filter-out unreachable scopes
+      val scopes = debugInfo.lexicalScopes.sorted
       origdefn.copy(
         name = name,
         attrs = origdefn.attrs.copy(opt = Attr.DidOpt),
         ty = Type.Function(argtys, retty),
-        insts = ControlFlow.removeDeadBlocks(rawInsts),
-        debugInfo = origdefn.debugInfo.copy(localNames = localNames) // TODO
-        
+        insts = insts,
+        debugInfo = debugInfo.copy(lexicalScopes = scopes)
       )(origdefn.pos)
+    }
 
     // Create new fresh and state for the first basic block.
     val fresh = Fresh(0)
-    val state = new State(Local(0))
+    val state = new State(Local(0))(preserveDebugInfo)
 
     // Interflow usually infers better types on our erased type system
     // than scalac, yet we live it as a benefit of the doubt and make sure
@@ -62,9 +66,11 @@ trait Opt { self: Interflow =>
         } else argty
 
         val id = fresh()
-        origdefn.debugInfo.localNames
-          .get(origarg.id)
-          .foreach(state.localNames.update(id, _))
+        if (preserveDebugInfo) {
+          origdefn.debugInfo.localNames
+            .get(origarg.id)
+            .foreach(state.localNames.update(id, _))
+        }
         Val.Local(id, ty)
     }
 
@@ -72,82 +78,93 @@ trait Opt { self: Interflow =>
     // is never going to be called, so we don't have to visit it.
     if (args.exists(_.ty == Type.Nothing)) {
       val insts = Seq(Inst.Label(Local(0), args), Inst.Unreachable(Next.None))
-      result(Type.Nothing, insts, Map.empty)
-    } else {
-      // Run a merge processor starting from the entry basic block.
-      val blocks =
-        try {
-          pushBlockFresh(fresh)
-          process(
-            origdefn.insts.toArray,
-            localNames = origdefn.debugInfo.localNames,
-            args = args,
-            state = state,
-            doInline = false,
-            retTy = origRetTy
+      result(Type.Nothing, insts, DebugInfo.empty)
+    } else
+      scoped(
+        currentFreshScope := Fresh(0L),
+        currentLexicalScopes := mutable.Set.empty
+      ) {
+        // Run a merge processor starting from the entry basic block.
+        val blocks =
+          try {
+            pushBlockFresh(fresh)
+            process(
+              origdefn.insts.toArray,
+              debugInfo = origdefn.debugInfo,
+              args = args,
+              state = state,
+              doInline = false,
+              retTy = origRetTy,
+              parentScopeId = ScopeId.TopLevel
+            )
+          } finally {
+            popBlockFresh()
+          }
+
+        // Collect instructions, materialize all returned values
+        // and compute the result type.
+        val insts = blocks.flatMap { block =>
+          block.cf = block.cf match {
+            case inst @ Inst.Ret(retv) =>
+              Inst.Ret(block.end.materialize(retv))(inst.pos)
+            case inst @ Inst.Throw(excv, unwind) =>
+              Inst.Throw(block.end.materialize(excv), unwind)(inst.pos)
+            case cf =>
+              cf
+          }
+          block.toInsts()
+        }
+        val debugInfo: DebugInfo = if (preserveDebugInfo) {
+          val localNames = mutable.OpenHashMap.empty[Local, LocalName]
+          for {
+            block <- blocks
+            state = block.end
+          } {
+            localNames.addMissing(block.end.localNames)
+          }
+          DebugInfo(
+            localNames = localNames.toMap,
+            lexicalScopes = currentLexicalScopes.get.toSeq
           )
-        } finally {
-          popBlockFresh()
+        } else DebugInfo.empty
+
+        val rets = insts.collect {
+          case Inst.Ret(v) => v.ty
         }
 
-      // Collect instructions, materialize all returned values
-      // and compute the result type.
-      val insts = blocks.flatMap { block =>
-        block.cf = block.cf match {
-          case inst @ Inst.Ret(retv) =>
-            Inst.Ret(block.end.materialize(retv))(inst.pos)
-          case inst @ Inst.Throw(excv, unwind) =>
-            Inst.Throw(block.end.materialize(excv), unwind)(inst.pos)
-          case cf =>
-            cf
+        val retty0 = rets match {
+          case Seq()   => Type.Nothing
+          case Seq(ty) => ty
+          case tys     => Sub.lub(tys, Some(origRetTy))
         }
-        block.toInsts()
-      }
-      val localNames: LocalNames = {
-        val map = mutable.OpenHashMap.empty[Local, LocalName]
-        for {
-          block <- blocks
-          state = block.end
-        } map.addMissing(block.end.localNames)
-        map.toMap
-      }
-      val rets = insts.collect {
-        case Inst.Ret(v) => v.ty
-      }
+        // Make sure to not override expected BoxedUnit with primitive Unit
+        val retty =
+          if (retty0 == Type.Unit && origRetTy.isInstanceOf[Type.Ref]) origRetTy
+          else retty0
 
-      val retty0 = rets match {
-        case Seq()   => Type.Nothing
-        case Seq(ty) => ty
-        case tys     => Sub.lub(tys, Some(origRetTy))
+        result(retty, insts, debugInfo)
       }
-      // Make sure to not override expected BoxedUnit with primitive Unit
-      val retty =
-        if (retty0 == Type.Unit && origRetTy.isInstanceOf[Type.Ref]) origRetTy
-        else retty0
-
-      result(retty, insts, localNames)
-    }
   }
 
   def process(
       insts: Array[Inst],
-      localNames: LocalNames,
+      debugInfo: DebugInfo,
       args: Seq[Val],
       state: State,
       doInline: Boolean,
-      retTy: Type
-  )(implicit
-      originDefnPos: nir.Position
+      retTy: Type,
+      parentScopeId: ScopeId
   ): Seq[MergeBlock] = {
     val processor =
       MergeProcessor.fromEntry(
         insts = insts,
         args = args,
-        localNames = localNames,
+        debugInfo = debugInfo,
         state = state,
         doInline = doInline,
         blockFresh = blockFresh,
-        eval = this
+        eval = this,
+        parentScopeId = parentScopeId
       )
 
     try {

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -62,7 +62,8 @@ trait PolyInline { self: Interflow =>
   def polyInline(op: Op.Method, args: Seq[Val])(implicit
       state: State,
       linked: linker.Result,
-      origPos: Position
+      srcPosition: Position,
+      scopeIdId: ScopeId
   ): Val = {
     import state.{emit, fresh, materialize}
 

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -115,7 +115,10 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
     import instance.{srcPosition, scopeId}
 
     val value = emit(op, idempotent)
-    if (preserveDebugInfo) {
+    // there might cases when virtualName for given addres might be assigned to two different instances
+    // It can happend when we deal with partially-evaluated instances, eg. arrayalloc + arraystore
+    // Don't emit local names for ops returing unit value
+    if (preserveDebugInfo && op.resty != Type.Unit) {
       virtualNames.get(addr).foreach { name =>
         this.localNames += value.id -> name
       }

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -290,7 +290,7 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
         val instance = heap(addr)
         locals(addr) = local
         reachInit(local, addr)
-        heap(addr) = EscapedInstance(local)(instance)
+        heap(addr) = new EscapedInstance(local, instance)
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -191,7 +191,7 @@ final class Method(
     val name: Global,
     val ty: Type,
     val insts: Array[Inst],
-    val localNames: LocalNames
+    val debugInfo: Defn.Define.DebugInfo
 )(implicit val position: Position)
     extends MemberInfo {
   val value: Val =

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -88,7 +88,7 @@ trait LinktimeValueResolver { self: Reach =>
           case inst: Inst.LinktimeIf => resolveLinktimeIf(inst)
           case inst @ Inst.Let(_, ReferencedPropertyOp(propertyName), _) =>
             val resolvedVal = resolveLinktimeProperty(propertyName).nirValue
-            inst.copy(op = Op.Copy(resolvedVal))
+            inst.copy(op = Op.Copy(resolvedVal))(inst.pos, inst.scope)
           case inst => inst
         }
       }

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -88,7 +88,7 @@ trait LinktimeValueResolver { self: Reach =>
           case inst: Inst.LinktimeIf => resolveLinktimeIf(inst)
           case inst @ Inst.Let(_, ReferencedPropertyOp(propertyName), _) =>
             val resolvedVal = resolveLinktimeProperty(propertyName).nirValue
-            inst.copy(op = Op.Copy(resolvedVal))(inst.pos, inst.scope)
+            inst.copy(op = Op.Copy(resolvedVal))(inst.pos, inst.scopeId)
           case inst => inst
         }
       }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -572,7 +572,7 @@ class Reach(
         name,
         ty,
         insts = Array(),
-        localNames = Map.empty
+        debugInfo = Defn.Define.DebugInfo.empty
       )
     )
     reachAttrs(attrs)
@@ -657,7 +657,7 @@ class Reach(
   }
 
   def reachDefine(defn: Defn.Define): Unit = {
-    val Defn.Define(attrs, name, ty, insts, localNames) = defn
+    val Defn.Define(attrs, name, ty, insts, debugInfo) = defn
     implicit val pos: nir.Position = defn.pos
     newInfo(
       new Method(
@@ -666,7 +666,7 @@ class Reach(
         name,
         ty,
         insts.toArray,
-        localNames
+        debugInfo
       )
     )
     reachAttrs(attrs)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -619,6 +619,8 @@ class Reach(
           lookup(newMethod.name, ignoreIfUnavailable = true)
             .map { _ =>
               implicit val pos: nir.Position = defn.pos
+              implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
+
               val newType = {
                 val newArgsTpe = Type.Ref(owner) +: ty.args
                 Type.Function(newArgsTpe, ty.ret)

--- a/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
@@ -1,0 +1,87 @@
+package scala.scalanative
+package optimizer
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.collection.mutable
+
+class LexicalScopesTest extends OptimizerSpec {
+  import nir._
+
+  override def optimize[T](
+      entry: String,
+      sources: Map[String, String],
+      setupConfig: build.NativeConfig => build.NativeConfig = identity
+  )(fn: (build.Config, linker.Result) => T) =
+    super.optimize(
+      entry,
+      sources,
+      setupConfig.andThen(
+        _.withDebugMetadata(true)
+          .withMode(build.Mode.releaseFull)
+      )
+    )(fn)
+
+  def scopeOf(localName: LocalName)(implicit defn: Defn.Define) =
+    namedLets(defn)
+      .collectFirst {
+        case (Inst.Let(id, _, _), `localName`) => id
+      }
+      .orElse { fail(s"Not found a local named: ${localName}"); None }
+      .flatMap(defn.debugInfo.scopeOf)
+      .orElse { fail(s"Not found defined scope for ${localName}"); None }
+      .get
+
+  // Ensure to use all the vals/vars, otherwise they might not be emmited by the compiler
+  @Test def scopesHierarchy(): Unit = optimize(
+    entry = "Test",
+    sources = Map("Test.scala" -> """
+    |object Test {
+    |  def main(args: Array[String]): Unit = {
+    |    val a = args.size
+    |    val b = a + this.##
+    |    val result = {
+    |      val innerA = args.size + a
+    |      val innerB = innerA + b
+    |      val innerResult = {
+    |         val deep = innerA + innerB
+    |         deep * 42
+    |      }
+    |      innerA * innerB * innerResult
+    |     }
+    |    assert(result != 0)
+    |  }
+    |}
+    """.stripMargin)
+  ) {
+    case (config, result) =>
+      findEntry(result.defns).foreach { implicit defn =>
+        defn.debugInfo.lexicalScopes.foreach(println)
+        println(defn.show)
+
+        assertContainsAll(
+          "named vals",
+          Seq("a", "b", "result", "innerA", "innerB", "innerResult", "deep"),
+          namedLets(defn).values
+        )
+        val innerA = scopeOf("innerA")
+        val innerB = scopeOf("innerB")
+        val innerResult = scopeOf("innerResult")
+        val deep = scopeOf("deep")
+        val result = scopeOf("result")
+        assertTrue("scope-a", scopeOf("a").isTopLevel)
+        assertTrue("scope-b", scopeOf("b").isTopLevel)
+        assertFalse("inner-A", innerA.isTopLevel)
+        assertFalse("inner-B", innerB.isTopLevel)
+        assertFalse("inner-result", innerResult.isTopLevel)
+        assertFalse("deep", deep.isTopLevel)
+        assertTrue("result", result.isTopLevel)
+
+        assertEquals("innerA-parent", result.id, innerA.parent)
+        assertEquals("innerB-parent", innerA.parent, innerB.parent)
+        assertEquals("innerResult-parent", result.id, innerResult.parent)
+        assertEquals("deep-parent", innerResult.id, deep.parent)
+      }
+  }
+}

--- a/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
@@ -29,7 +29,7 @@ class LexicalScopesTest extends OptimizerSpec {
   def scopeOf(localName: LocalName)(implicit defn: Defn.Define) =
     namedLets(defn)
       .collectFirst {
-        case (let @ Inst.Let(id, _, _), `localName`) => let.scope
+        case (let @ Inst.Let(id, _, _), `localName`) => let.scopeId
       }
       .orElse { fail(s"Not found a local named: ${localName}"); None }
       .flatMap(id => defn.debugInfo.lexicalScopeOf.get(id))

--- a/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
@@ -5,6 +5,8 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.collection.mutable
+import scala.scalanative.build.NativeConfig
+import scala.scalanative.nir.Defn.Define.DebugInfo.LexicalScope
 
 class LexicalScopesTest extends OptimizerSpec {
   import nir._
@@ -17,26 +19,45 @@ class LexicalScopesTest extends OptimizerSpec {
     super.optimize(
       entry,
       sources,
-      setupConfig.andThen(
-        _.withDebugMetadata(true)
+      { (config: NativeConfig) =>
+        config
+          .withDebugMetadata(true)
           .withMode(build.Mode.releaseFull)
-      )
+      }.andThen(setupConfig)
     )(fn)
 
   def scopeOf(localName: LocalName)(implicit defn: Defn.Define) =
     namedLets(defn)
       .collectFirst {
-        case (Inst.Let(id, _, _), `localName`) => id
+        case (let @ Inst.Let(id, _, _), `localName`) => let.scope
       }
       .orElse { fail(s"Not found a local named: ${localName}"); None }
-      .flatMap(defn.debugInfo.scopeOf)
+      .flatMap(id => defn.debugInfo.lexicalScopeOf.get(id))
       .orElse { fail(s"Not found defined scope for ${localName}"); None }
       .get
 
+  def scopeParents(
+      scope: LexicalScope
+  )(implicit defn: Defn.Define): List[ScopeId] = {
+    if (scope.isTopLevel) Nil
+    else {
+      val stack = List.newBuilder[ScopeId]
+      var current = scope
+      while ({
+        val parent = defn.debugInfo.lexicalScopeOf(current.parent)
+        current = parent
+        stack += current.id
+        !parent.isTopLevel
+      }) ()
+      stack.result()
+    }
+  }
+
   // Ensure to use all the vals/vars, otherwise they might not be emmited by the compiler
-  @Test def scopesHierarchy(): Unit = optimize(
+  @Test def scopesHierarchyDebug(): Unit = optimize(
     entry = "Test",
-    sources = Map("Test.scala" -> """
+    sources = Map(
+      "Test.scala" -> """
     |object Test {
     |  def main(args: Array[String]): Unit = {
     |    val a = args.size
@@ -53,7 +74,9 @@ class LexicalScopesTest extends OptimizerSpec {
     |    assert(result != 0)
     |  }
     |}
-    """.stripMargin)
+    """.stripMargin
+    ),
+    setupConfig = _.withMode(build.Mode.debug)
   ) {
     case (config, result) =>
       findEntry(result.defns).foreach { implicit defn =>
@@ -65,23 +88,98 @@ class LexicalScopesTest extends OptimizerSpec {
           Seq("a", "b", "result", "innerA", "innerB", "innerResult", "deep"),
           namedLets(defn).values
         )
+        // top-level
+        val a = scopeOf("a")
+        val b = scopeOf("b")
         val innerA = scopeOf("innerA")
         val innerB = scopeOf("innerB")
         val innerResult = scopeOf("innerResult")
         val deep = scopeOf("deep")
         val result = scopeOf("result")
-        assertTrue("scope-a", scopeOf("a").isTopLevel)
-        assertTrue("scope-b", scopeOf("b").isTopLevel)
+        assertTrue("scope-a", a.isTopLevel)
+        assertTrue("scope-b", b.isTopLevel)
         assertFalse("inner-A", innerA.isTopLevel)
         assertFalse("inner-B", innerB.isTopLevel)
         assertFalse("inner-result", innerResult.isTopLevel)
         assertFalse("deep", deep.isTopLevel)
         assertTrue("result", result.isTopLevel)
 
+        // In debug mode calls to Array.size should not be inlined, so a and b should be defined in the same scope
+        assertEquals("a-b-scope", a.id, b.id)
+        assertEquals("result-scope", a.id, result.id)
         assertEquals("innerA-parent", result.id, innerA.parent)
         assertEquals("innerB-parent", innerA.parent, innerB.parent)
         assertEquals("innerResult-parent", result.id, innerResult.parent)
         assertEquals("deep-parent", innerResult.id, deep.parent)
+      }
+  }
+
+  @Test def scopesHierarchyRelease(): Unit = optimize(
+    entry = "Test",
+    sources = Map(
+      "Test.scala" -> """
+    |object Test {
+    |  def main(args: Array[String]): Unit = {
+    |    val a = args.size
+    |    val b = a + this.##
+    |    val result = {
+    |      val innerA = args.size + a
+    |      val innerB = innerA + b
+    |      val innerResult = {
+    |         val deep = innerA + innerB
+    |         deep * 42
+    |      }
+    |      innerA * innerB * innerResult
+    |     }
+    |    assert(result != 0)
+    |  }
+    |}
+    """.stripMargin
+    )
+  ) {
+    case (config, result) =>
+      assertEquals(config.compilerConfig.mode, build.Mode.releaseFull)
+      findEntry(result.defns).foreach { implicit defn =>
+        defn.debugInfo.lexicalScopes.foreach(println)
+        println(defn.show)
+
+        assertContainsAll(
+          "named vals",
+          Seq("a", "b", "result", "innerA", "innerB", "innerResult", "deep"),
+          namedLets(defn).values
+        )
+        // top-level
+        val a = scopeOf("a")
+        val b = scopeOf("b")
+        val innerA = scopeOf("innerA")
+        val innerB = scopeOf("innerB")
+        val innerResult = scopeOf("innerResult")
+        val deep = scopeOf("deep")
+        val result = scopeOf("result")
+
+        val aParents = scopeParents(a)
+        val bParents = scopeParents(b)
+        // value of 'a' is inlined call to Array.size, so it's scope would be different then b, but they should have a common ancestor
+        assertNotEquals("a-b-diff-scope", a.id, b.id)
+        assertTrue("a-b-common-parent", aParents.diff(bParents).nonEmpty)
+        // result and b don't have inlined calls so they shall be defined in the same scope
+        assertEquals("result-eq-b-scope", b.id, result.id)
+
+        assertEquals("innerA-parent", result.id, innerA.parent)
+        assertEquals("innerB-parent", innerA.parent, innerB.parent)
+        assertEquals("innerResult-parent", result.id, innerResult.parent)
+        assertEquals("deep-parent", innerResult.id, deep.parent)
+
+        val duplicateIds =
+          defn.debugInfo.lexicalScopes.groupBy(_.id).filter(_._2.size > 1)
+        assertEquals("duplicateIds", Map.empty, duplicateIds)
+
+        for (scope <- defn.debugInfo.lexicalScopes) {
+          assertTrue(
+            "state parent not defined",
+            defn.debugInfo.lexicalScopeOf.contains(scope.parent)
+          )
+        }
       }
   }
 }

--- a/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
@@ -28,21 +28,6 @@ class LocalNamesTest extends OptimizerSpec {
       )
     )(fn)
 
-  def afterLowering(config: build.Config, optimized: => linker.Result)(
-      fn: Seq[Defn] => Unit
-  ): Unit = {
-    import scala.scalanative.codegen._
-    import scala.concurrent.ExecutionContext.Implicits.global
-    import scala.concurrent._
-    val defns = optimized.defns
-    implicit def logger: build.Logger = config.logger
-    implicit val platform: PlatformInfo = PlatformInfo(config)
-    implicit val meta: Metadata =
-      new Metadata(optimized, config.compilerConfig, Nil)
-    val lowered = llvm.CodeGen.lower(defns)
-    Await.result(lowered.map(fn), duration.Duration.Inf)
-  }
-
   // Ensure to use all the vals/vars, otherwise they might not be emmited by the compiler
   @Test def localNamesExistence(): Unit = super.optimize(
     entry = "Test",

--- a/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
@@ -53,8 +53,8 @@ class LocalNamesTest extends OptimizerSpec {
 
   def namedLets(defn: nir.Defn.Define): Map[Inst.Let, LocalName] =
     defn.insts.collect {
-      case inst: Inst.Let if defn.localNames.contains(inst.id) =>
-        inst -> defn.localNames(inst.id)
+      case inst: Inst.Let if defn.debugInfo.localNames.contains(inst.id) =>
+        inst -> defn.debugInfo.localNames(inst.id)
     }.toMap
 
   private object TestMain {
@@ -127,7 +127,7 @@ class LocalNamesTest extends OptimizerSpec {
     case (config, result) =>
       def checkLocalNames(defns: Seq[Defn]) =
         findDefinition(defns).foreach { defn =>
-          val localNames = defn.localNames
+          val localNames = defn.debugInfo.localNames
           val lets = namedLets(defn).values
           val expectedLetNames =
             Seq("localVal", "localVar", "innerVal", "innerVar", "scoped")
@@ -148,7 +148,7 @@ class LocalNamesTest extends OptimizerSpec {
           assertContainsAll(
             "vals defined",
             expectedNames,
-            defn.localNames.values
+            defn.debugInfo.localNames.values
           )
           assertDistinct(lets)
         }
@@ -263,7 +263,7 @@ class LocalNamesTest extends OptimizerSpec {
               assertContainsAll(
                 s"hasVal in $stage",
                 Seq(localName),
-                defn.localNames.values
+                defn.debugInfo.localNames.values
               )
             }
             checkHasLet[Op.Call]("call")
@@ -349,14 +349,14 @@ class LocalNamesTest extends OptimizerSpec {
             val expectedNames = expectedLets ++ asParams
             assertContainsAll("lets", expectedLets, letsNames)
             assertEquals("asParams", asParams, asParams.diff(letsNames))
-            assertContainsAll("vals", expectedNames, defn.localNames.values)
+            assertContainsAll("vals", expectedNames, defn.debugInfo.localNames.values)
             // allowed, delayed and duplicated in each if-else branch
             assertDistinct(letsNames.diff(Seq("b")))
             defn.insts
               .find {
                 case Inst.Label(_, params) =>
                   asParams
-                    .diff(params.map(_.id).flatMap(defn.localNames.get))
+                    .diff(params.map(_.id).flatMap(defn.debugInfo.localNames.get))
                     .isEmpty
                 case _ => false
               }
@@ -403,7 +403,7 @@ class LocalNamesTest extends OptimizerSpec {
             // match merge block param
             val expectedNames = expectedLets ++ Seq("temp2")
             assertContainsAll("lets", expectedLets, lets)
-            assertContainsAll("vals", expectedNames, defn.localNames.values)
+            assertContainsAll("vals", expectedNames, defn.debugInfo.localNames.values)
           }
       checkLocalNames(result.defns)
   }
@@ -446,7 +446,7 @@ class LocalNamesTest extends OptimizerSpec {
               Seq("argInt", "impl", "temp", "temp1", "temp2", "temp3")
             val expectedNames = expectedLets ++ Seq("result", "args")
             assertContainsAll("lets", expectedLets, lets)
-            assertContainsAll("vals", expectedNames, defn.localNames.values)
+            assertContainsAll("vals", expectedNames, defn.debugInfo.localNames.values)
           }
       checkLocalNames(result.defns)
   }
@@ -486,7 +486,7 @@ class LocalNamesTest extends OptimizerSpec {
               Seq("argInt", "impl")
             val expectedNames = expectedLets ++ Seq("result")
             assertContainsAll("lets", expectedLets, lets)
-            assertContainsAll("vals", expectedNames, defn.localNames.values)
+            assertContainsAll("vals", expectedNames, defn.debugInfo.localNames.values)
           }
       checkLocalNames(result.defns)
   }

--- a/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
@@ -272,14 +272,20 @@ class LocalNamesTest extends OptimizerSpec {
             val expectedNames = expectedLets ++ asParams
             assertContainsAll("lets", expectedLets, letsNames)
             assertEquals("asParams", asParams, asParams.diff(letsNames))
-            assertContainsAll("vals", expectedNames, defn.debugInfo.localNames.values)
+            assertContainsAll(
+              "vals",
+              expectedNames,
+              defn.debugInfo.localNames.values
+            )
             // allowed, delayed and duplicated in each if-else branch
             assertDistinct(letsNames.diff(Seq("b")))
             defn.insts
               .find {
                 case Inst.Label(_, params) =>
                   asParams
-                    .diff(params.map(_.id).flatMap(defn.debugInfo.localNames.get))
+                    .diff(
+                      params.map(_.id).flatMap(defn.debugInfo.localNames.get)
+                    )
                     .isEmpty
                 case _ => false
               }
@@ -326,7 +332,11 @@ class LocalNamesTest extends OptimizerSpec {
             // match merge block param
             val expectedNames = expectedLets ++ Seq("temp2")
             assertContainsAll("lets", expectedLets, lets)
-            assertContainsAll("vals", expectedNames, defn.debugInfo.localNames.values)
+            assertContainsAll(
+              "vals",
+              expectedNames,
+              defn.debugInfo.localNames.values
+            )
           }
       checkLocalNames(result.defns)
   }
@@ -369,7 +379,11 @@ class LocalNamesTest extends OptimizerSpec {
               Seq("argInt", "impl", "temp", "temp1", "temp2", "temp3")
             val expectedNames = expectedLets ++ Seq("result", "args")
             assertContainsAll("lets", expectedLets, lets)
-            assertContainsAll("vals", expectedNames, defn.debugInfo.localNames.values)
+            assertContainsAll(
+              "vals",
+              expectedNames,
+              defn.debugInfo.localNames.values
+            )
           }
       checkLocalNames(result.defns)
   }
@@ -409,7 +423,11 @@ class LocalNamesTest extends OptimizerSpec {
               Seq("argInt", "impl")
             val expectedNames = expectedLets ++ Seq("result")
             assertContainsAll("lets", expectedLets, lets)
-            assertContainsAll("vals", expectedNames, defn.debugInfo.localNames.values)
+            assertContainsAll(
+              "vals",
+              expectedNames,
+              defn.debugInfo.localNames.values
+            )
           }
       checkLocalNames(result.defns)
   }

--- a/tools/src/test/scala/scala/scalanative/optimizer/package.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/package.scala
@@ -1,0 +1,71 @@
+package scala.scalanative
+
+import org.junit.Assert._
+
+package object optimizer {
+  import nir._
+
+  def assertContainsAll[T](
+      msg: String,
+      expected: Iterable[T],
+      actual: Iterable[T]
+  ) = {
+    val left = expected.toSeq
+    val right = actual.toSeq
+    val diff = left.diff(right)
+    assertTrue(s"$msg - not found ${diff} in $right", diff.isEmpty)
+  }
+
+  def assertContains[T](msg: String, expected: T, actual: Iterable[T]) = {
+    assertTrue(
+      s"$msg - not found ${expected} in ${actual.toSeq}",
+      actual.find(_ == expected).isDefined
+    )
+  }
+
+  def assertDistinct(localNames: Iterable[LocalName]) = {
+    val duplicated =
+      localNames.groupBy(identity).filter(_._2.size > 1).map(_._1)
+    assertTrue(s"Found duplicated names of ${duplicated}", duplicated.isEmpty)
+  }
+
+  def namedLets(defn: nir.Defn.Define): Map[Inst.Let, LocalName] =
+    defn.insts.collect {
+      case inst: Inst.Let if defn.debugInfo.localNames.contains(inst.id) =>
+        inst -> defn.debugInfo.localNames(inst.id)
+    }.toMap
+
+  protected def findEntry(
+      linked: Seq[Defn],
+      entryName: String = "Test"
+  ): Option[Defn.Define] = {
+    object TestMain {
+      val TestModule = Global.Top(s"$entryName$$")
+      val CompanionMain =
+        TestModule.member(Rt.ScalaMainSig.copy(scope = Sig.Scope.Public))
+
+      def unapply(name: Global): Boolean = name match {
+        case CompanionMain => true
+        case Global.Member(TestModule, sig) =>
+          sig.unmangled match {
+            case Sig.Duplicate(of, _) => of == CompanionMain.sig
+            case _                    => false
+          }
+        case _ => false
+      }
+    }
+    object TestMainForwarder {
+      val staticForwarder = Global.Top("Test").member(Rt.ScalaMainSig)
+      def unapply(name: Global): Boolean = name == staticForwarder
+    }
+    val companionMethod = linked
+      .collectFirst { case defn @ Defn.Define(_, TestMain(), _, _, _) => defn }
+    def staticForwarder = linked
+      .collectFirst {
+        case defn @ Defn.Define(_, TestMainForwarder(), _, _, _) => defn
+      }
+    companionMethod
+      .orElse(staticForwarder)
+      .ensuring(_.isDefined, "Not found linked method")
+  }
+}

--- a/tools/src/test/scala/scala/scalanative/optimizer/package.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/package.scala
@@ -35,7 +35,7 @@ package object optimizer {
         inst -> defn.debugInfo.localNames(inst.id)
     }.toMap
 
-  protected def findEntry(
+  protected[optimizer] def findEntry(
       linked: Seq[Defn],
       entryName: String = "Test"
   ): Option[Defn.Define] = {


### PR DESCRIPTION
Extends #3386 handling of local names and adds information about lexical scopes to code. This would allow to correctly render local variables in debugers by limiting their visibility to their lexical scope. We create a new lexical scope for each `Block` in Scala AST and possibly for try-catch-finally blocks. This change was reflected in optimizer and lowering phase making sure the original scopeIds and local names would be preserved in the transformations 

Each `Inst.Let` now contains the `scopeId` which contains Id scope in which given value should be accessible. The hierarchy of `LexicalScopes` is now stored in `Defn.Define.DebugInfo` along the `localNames` or variables. 

The NIR size has now again slightly increased, for Scalalib 2.13 it increased from 24 104kB to 24 727 kB (623 kB, ~2.5%) when compared to previous change of NIR encoding done in #3386