### PR TITLE
Fix #3439: Implement javalib sequential setAll methods

### DIFF
--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -1019,7 +1019,10 @@ object Arrays {
       array(j) = generator.applyAsLong(j)
   }
 
-  def setAll[T <: AnyRef](array: Array[T], generator: IntFunction[T]): Unit = {
+  def setAll[T <: AnyRef](
+      array: Array[T],
+      generator: IntFunction[_ <: T]
+  ): Unit = {
     for (j <- 0 until array.size)
       array(j) = generator.apply(j)
   }

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -8,6 +8,7 @@ import scala.annotation.tailrec
 
 import scala.reflect.ClassTag
 
+import java.util.function._
 import java.{util => ju}
 import java.util.stream.StreamSupport
 
@@ -1002,6 +1003,27 @@ object Arrays {
   }
 
 // Scala Native additions --------------------------------------------------
+
+  def setAll(array: Array[Double], generator: IntToDoubleFunction): Unit = {
+    for (j <- 0 until array.size)
+      array(j) = generator.applyAsDouble(j)
+  }
+
+  def setAll(array: Array[Int], generator: IntUnaryOperator): Unit = {
+    for (j <- 0 until array.size)
+      array(j) = generator.applyAsInt(j)
+  }
+
+  def setAll(array: Array[Long], generator: IntToLongFunction): Unit = {
+    for (j <- 0 until array.size)
+      array(j) = generator.applyAsLong(j)
+  }
+
+  def setAll[T <: AnyRef](array: Array[T], generator: IntFunction[T]): Unit = {
+    for (j <- 0 until array.size)
+      array(j) = generator.apply(j)
+  }
+
   private final val standardArraySpliteratorCharacteristics =
     Spliterator.SIZED |
       Spliterator.SUBSIZED |
@@ -1180,4 +1202,5 @@ object Arrays {
 
     StreamSupport.stream(spliter, parallel = false)
   }
+
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
@@ -1,4 +1,6 @@
 // Ported from Scala.js commit: ba618ed dated: 2020-10-05
+//
+// Tests for sequential "setAll()" methods added for Scala Native.
 
 package org.scalanative.testsuite.javalib.util
 
@@ -1338,4 +1340,78 @@ class ArraysTest {
       Arrays.deepToString(recArr)
     )
   }
+
+// Tests added for Scala Native.
+
+  final val epsilon = 0.0000001 // tolerance for Floating point comparisons.
+
+  @Test def setAll_Double(): Unit = {
+    val srcSize = 16
+
+    val arr = new Array[Double](srcSize)
+    Arrays.setAll(arr, e => (e + 1).toDouble)
+
+    val expectedAtFirstInRangeRange = 1.0
+    assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0), epsilon)
+
+    val expectedAtLastInRangeRange = srcSize.toDouble
+    assertEquals(
+      "lastInRange",
+      expectedAtLastInRangeRange,
+      arr(srcSize - 1),
+      epsilon
+    )
+  }
+
+  @Test def setAll_Int(): Unit = {
+    val srcSize = 16
+
+    val arr = new Array[Int](srcSize)
+    Arrays.setAll(arr, e => (e + 1))
+
+    val expectedAtFirstInRangeRange = 1
+    assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))
+
+    val expectedAtLastInRangeRange = srcSize
+    assertEquals(
+      "lastInRange",
+      expectedAtLastInRangeRange,
+      arr(srcSize - 1)
+    )
+  }
+
+  @Test def setAll_Long(): Unit = {
+    val srcSize = 16
+
+    val arr = new Array[Long](srcSize)
+    Arrays.setAll(arr, e => (e + 1).toLong)
+
+    val expectedAtFirstInRangeRange = 1L
+    assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))
+
+    val expectedAtLastInRangeRange = srcSize.toLong
+    assertEquals(
+      "lastInRange",
+      expectedAtLastInRangeRange,
+      arr(srcSize - 1)
+    )
+  }
+
+  @Test def setAll_AnyRef(): Unit = {
+    val srcSize = 16
+
+    val arr = new Array[String](srcSize)
+    Arrays.setAll(arr, e => (e + 1).toString())
+
+    val expectedAtFirstInRangeRange = "1"
+    assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))
+
+    val expectedAtLastInRangeRange = srcSize.toString()
+    assertEquals(
+      "lastInRange",
+      expectedAtLastInRangeRange,
+      arr(srcSize - 1)
+    )
+  }
+
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
@@ -1401,7 +1401,7 @@ class ArraysTest {
     val srcSize = 16
 
     val arr = new Array[String](srcSize)
-    Arrays.setAll(arr, (idx: Int) => (idx + 1).toString())
+    Arrays.setAll[String](arr, (idx: Int) => (idx + 1).toString())
 
     val expectedAtFirstInRangeRange = "1"
     assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
@@ -1401,6 +1401,8 @@ class ArraysTest {
     val srcSize = 16
 
     val arr = new Array[String](srcSize)
+
+    // Scala 2 needs [String] here, Scala 3 can usually figure out its absence.
     Arrays.setAll[String](arr, (idx: Int) => (idx + 1).toString())
 
     val expectedAtFirstInRangeRange = "1"

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
@@ -1349,7 +1349,7 @@ class ArraysTest {
     val srcSize = 16
 
     val arr = new Array[Double](srcSize)
-    Arrays.setAll(arr, e => (e + 1).toDouble)
+    Arrays.setAll(arr, (idx: Int) => (idx + 1).toDouble)
 
     val expectedAtFirstInRangeRange = 1.0
     assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0), epsilon)
@@ -1367,7 +1367,7 @@ class ArraysTest {
     val srcSize = 16
 
     val arr = new Array[Int](srcSize)
-    Arrays.setAll(arr, e => (e + 1))
+    Arrays.setAll(arr, (idx: Int) => (idx + 1))
 
     val expectedAtFirstInRangeRange = 1
     assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))
@@ -1384,7 +1384,7 @@ class ArraysTest {
     val srcSize = 16
 
     val arr = new Array[Long](srcSize)
-    Arrays.setAll(arr, e => (e + 1).toLong)
+    Arrays.setAll(arr, (idx: Int) => (idx + 1).toLong)
 
     val expectedAtFirstInRangeRange = 1L
     assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))
@@ -1401,7 +1401,7 @@ class ArraysTest {
     val srcSize = 16
 
     val arr = new Array[String](srcSize)
-    Arrays.setAll(arr, e => (e + 1).toString())
+    Arrays.setAll(arr, (idx: Int) => (idx + 1).toString())
 
     val expectedAtFirstInRangeRange = "1"
     assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
@@ -1402,7 +1402,7 @@ class ArraysTest {
 
     val arr = new Array[String](srcSize)
 
-    // Scala 2 needs [String] here, Scala 3 can usually figure out its absence.
+    // Scala 2 needs [String] here, Scala 3 can usually figure out its absence
     Arrays.setAll[String](arr, (idx: Int) => (idx + 1).toString())
 
     val expectedAtFirstInRangeRange = "1"


### PR DESCRIPTION
Fix #3439

 Implement 4 javalib sequential setAll methods and their corresponding Tests.