### PR TITLE
Emit local values for the debugger

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1446,7 +1446,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def negateBool(value: nir.Val)(implicit pos: nir.Position): Val =
       buf.bin(Bin.Xor, Type.Bool, Val.True, value, unwind)
 
-    def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(implicit pos: nir.Position): Val = {
+    def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(implicit
+        pos: nir.Position
+    ): Val = {
       import scalaPrimitives._
 
       val right = genExpr(rightp)
@@ -2409,7 +2411,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def genApplyTypeApply(app: Apply): Val = {
-      val Apply(tapp @ TypeApply(fun @ Select(receiverp, _), targs), argsp) = app
+      val Apply(tapp @ TypeApply(fun @ Select(receiverp, _), targs), argsp) =
+        app
 
       val fromty = genType(receiverp.tpe)
       val toty = genType(targs.head.tpe)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1446,10 +1446,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def negateBool(value: nir.Val)(implicit pos: nir.Position): Val =
       buf.bin(Bin.Xor, Type.Bool, Val.True, value, unwind)
 
-    def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type): Val = {
+    def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(implicit pos: nir.Position): Val = {
       import scalaPrimitives._
 
-      implicit val pos: nir.Position = rightp.pos
       val right = genExpr(rightp)
       val coerced = genCoercion(right, right.ty, opty)
 
@@ -1624,9 +1623,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         rightp: Tree,
         ref: Boolean,
         negated: Boolean
-    ): Val = {
+    )(implicit pos: nir.Position): Val = {
       val left = genExpr(leftp)
-      implicit val pos: nir.Position = rightp.pos
 
       if (ref) {
         val right = genExpr(rightp)
@@ -2411,7 +2409,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def genApplyTypeApply(app: Apply): Val = {
-      val Apply(TypeApply(fun @ Select(receiverp, _), targs), argsp) = app
+      val Apply(tapp @ TypeApply(fun @ Select(receiverp, _), targs), argsp) = app
 
       val fromty = genType(receiverp.tpe)
       val toty = genType(targs.head.tpe)
@@ -2419,7 +2417,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val value = genExpr(receiverp)
       lazy val boxed = boxValue(receiverp.tpe, value)(receiverp.pos)
 
-      implicit val pos: nir.Position = fun.pos
+      implicit val pos: nir.Position = tapp.pos
 
       fun.symbol match {
         case Object_isInstanceOf =>

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1040,7 +1040,9 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    private def genApplyBox(st: SimpleType, argp: Tree)(using nir.Position): Val = {
+    private def genApplyBox(st: SimpleType, argp: Tree)(using
+        nir.Position
+    ): Val = {
       val value = genExpr(argp)
       buf.box(genBoxType(st), value, unwind)
     }
@@ -1312,7 +1314,9 @@ trait NirGenExpr(using Context) {
     private def negateBool(value: nir.Val)(using nir.Position): Val =
       buf.bin(Bin.Xor, Type.Bool, Val.True, value, unwind)
 
-    private def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(using nir.Position): Val = {
+    private def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(using
+        nir.Position
+    ): Val = {
       val right = genExpr(rightp)
       val coerced = genCoercion(right, right.ty, opty)
       val tpe = coerced.ty

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1040,8 +1040,7 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    private def genApplyBox(st: SimpleType, argp: Tree): Val = {
-      given nir.Position = argp.span
+    private def genApplyBox(st: SimpleType, argp: Tree)(using nir.Position): Val = {
       val value = genExpr(argp)
       buf.box(genBoxType(st), value, unwind)
     }
@@ -1112,7 +1111,7 @@ trait NirGenExpr(using Context) {
     private def genApplyTypeApply(app: Apply): Val = {
       val Apply(tApply @ TypeApply(fun, targs), argsp) = app: @unchecked
       val Select(receiverp, _) = desugarTree(fun): @unchecked
-      given nir.Position = fun.span
+      given nir.Position = app.span
 
       val funSym = fun.symbol
       genExpr(receiverp)
@@ -1313,8 +1312,7 @@ trait NirGenExpr(using Context) {
     private def negateBool(value: nir.Val)(using nir.Position): Val =
       buf.bin(Bin.Xor, Type.Bool, Val.True, value, unwind)
 
-    private def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type): Val = {
-      given nir.Position = rightp.span
+    private def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(using nir.Position): Val = {
       val right = genExpr(rightp)
       val coerced = genCoercion(right, right.ty, opty)
       val tpe = coerced.ty
@@ -1495,8 +1493,7 @@ trait NirGenExpr(using Context) {
         rightp: Tree,
         ref: Boolean,
         negated: Boolean
-    ): Val = {
-      given nir.Position = leftp.span
+    )(using nir.Position): Val = {
       val left = genExpr(leftp)
 
       if (ref) {

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -236,7 +236,7 @@ object Generate {
         unwind: () => Next
     )(implicit fresh: Fresh): Seq[Inst] = {
       defns.collect {
-        case Defn.Define(_, name: Global.Member, _, _, _) if name.sig.isClinit =>
+        case defn @ Defn.Define(_, name: Global.Member, _, _, _) if name.sig.isClinit =>
           Inst.Let(
             Op.Call(
               Type.Function(Seq.empty, Type.Unit),
@@ -244,7 +244,7 @@ object Generate {
               Seq.empty
             ),
             unwind()
-          )
+          )(implicitly, defn.pos, implicitly)
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -937,14 +937,13 @@ private[codegen] abstract class AbstractCodeGen(
           genLocal(pointee)
           str(" to i8*")
         }
-
         dbgLocalVariable(pointee, ty)(inst.pos, inst.scopeId)
 
       case _ =>
         newline()
         genBind()
         genOp(op)
-        if (!isVoid(op.resty)) dbgLocalValue(id, ty)(inst.pos, inst.scopeId)
+        dbgLocalValue(id, ty)(inst.pos, inst.scopeId)
 
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -240,7 +240,7 @@ private[codegen] abstract class AbstractCodeGen(
     str(if (isDecl) "declare " else "define ")
     if (targetsWindows && !isDecl && attrs.isExtern) {
       // Generate export modifier only for extern (C-ABI compliant) signatures
-      val Global.Member(_, sig) = name
+      val Global.Member(_, sig) = name: @unchecked
       if (sig.isExtern) str("dllexport ")
     }
     genFunctionReturnType(retty)

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -18,6 +18,11 @@ import scala.scalanative.codegen.{Metadata => CodeGenMetadata}
 
 import scala.language.implicitConversions
 import scala.scalanative.codegen.llvm.Metadata.conversions._
+import scala.scalanative.nir.Defn.Const
+import scala.scalanative.nir.Defn.Declare
+import scala.scalanative.nir.Defn.Var
+import scala.scalanative.nir.Defn.Define
+import scala.scalanative.nir.Defn.Trait
 
 private[codegen] abstract class AbstractCodeGen(
     env: Map[Global, Defn],
@@ -223,7 +228,11 @@ private[codegen] abstract class AbstractCodeGen(
     import sb._
     import defn.{name, attrs, pos}
 
-    val Type.Function(argtys, retty) = defn.ty
+    val Type.Function(argtys, retty) = defn match {
+      case defn: Declare => defn.ty
+      case defn: Define  => defn.ty
+      case _             => unreachable
+    }
 
     val isDecl = insts.isEmpty
 

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
@@ -49,6 +49,9 @@ object Metadata {
       tpe: Type
   ) extends LLVMDebugInformation
 
+  // TOOD: actual DW_OP expressions as parameters
+  case class DIExpression() extends LLVMDebugInformation
+
   sealed trait Type extends LLVMDebugInformation
   case class DIBasicType(name: String, size: Int, align: Int, encoding: DW_ATE)
       extends Type

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
@@ -19,10 +19,7 @@ object Metadata {
 
   sealed trait LLVMDebugInformation extends SpecializedNode
   sealed trait Scope extends LLVMDebugInformation
-  object Scope{
-    // Dummy scope used when not generating debug info
-    case object NoScope extends Scope
-  }
+
   case class DICompileUnit(
       file: DIFile,
       producer: String,
@@ -40,6 +37,11 @@ object Metadata {
       tpe: DISubroutineType,
       unit: DICompileUnit
   ) extends Scope {
+    override def distinct: Boolean = true
+  }
+
+  case class DILexicalBlock(scope: Scope, file: DIFile, line: Int, column: Int)
+      extends Scope {
     override def distinct: Boolean = true
   }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
@@ -19,6 +19,10 @@ object Metadata {
 
   sealed trait LLVMDebugInformation extends SpecializedNode
   sealed trait Scope extends LLVMDebugInformation
+  object Scope{
+    // Dummy scope used when not generating debug info
+    case object NoScope extends Scope
+  }
   case class DICompileUnit(
       file: DIFile,
       producer: String,
@@ -43,6 +47,7 @@ object Metadata {
       extends LLVMDebugInformation
   case class DILocalVariable(
       name: String,
+      arg: Option[Int],
       scope: Scope,
       file: DIFile,
       line: Int,

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -58,6 +58,11 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
   )(implicit ctx: Context, sb: ShowBuilder): Unit =
     dbg("", v)
 
+  private def canHaveDebugValue(ty: nir.Type) = ty match {
+    case nir.Type.Unit | nir.Type.Nothing => false
+    case _                                => true
+  }
+
   def dbgLocalValue(id: Local, ty: nir.Type, argIdx: Option[Int] = None)(
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
@@ -67,7 +72,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
       metadataCtx: Context,
       sb: ShowBuilder
   ): Unit =
-    if (generateDebugMetadata) {
+    if (generateDebugMetadata && canHaveDebugValue(ty)) {
       debugInfo.localNames.get(id).foreach { localName =>
         `llvm.dbg.value`(
           address = Metadata.Value(Val.Local(id, ty)),
@@ -93,7 +98,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
       metadataCtx: Context,
       sb: ShowBuilder
   ): Unit =
-    if (generateDebugMetadata) {
+    if (generateDebugMetadata && canHaveDebugValue(ty)) {
       debugInfo.localNames.get(id).foreach { localName =>
         `llvm.dbg.declare`(
           address = Metadata.Value(Val.Local(id, ty)),

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
@@ -19,6 +19,7 @@ private[codegen] trait OsCompat {
   )(implicit
       fresh: Fresh,
       pos: Position,
+      scope: Metadata.Scope,
       sb: ShowBuilder,
       debugInfo: DebugInfo,
       dwf: MetadataCodeGen.Context

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
@@ -7,8 +7,9 @@ import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.nir.{Fresh, Next, Position}
 import scala.scalanative.util.ShowBuilder
 
-private[codegen] trait OsCompat {
-  protected def codegen: AbstractCodeGen
+private[codegen] abstract class OsCompat(
+    protected val codegen: AbstractCodeGen
+) {
   protected def osPersonalityType: String
 
   def useOpaquePointers = codegen.meta.platform.useOpaquePointers
@@ -19,10 +20,7 @@ private[codegen] trait OsCompat {
   )(implicit
       fresh: Fresh,
       pos: Position,
-      scope: Metadata.Scope,
-      sb: ShowBuilder,
-      debugInfo: DebugInfo,
-      dwf: MetadataCodeGen.Context
+      sb: ShowBuilder
   ): Unit
   def genBlockAlloca(block: Block)(implicit sb: ShowBuilder): Unit
 

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
@@ -3,6 +3,7 @@ package llvm
 package compat.os
 
 import scala.scalanative.nir.ControlFlow.Block
+import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.nir.{Fresh, Next, Position}
 import scala.scalanative.util.ShowBuilder
 
@@ -19,6 +20,7 @@ private[codegen] trait OsCompat {
       fresh: Fresh,
       pos: Position,
       sb: ShowBuilder,
+      debugInfo: DebugInfo,
       dwf: MetadataCodeGen.Context
   ): Unit
   def genBlockAlloca(block: Block)(implicit sb: ShowBuilder): Unit

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -7,8 +7,8 @@ import scala.scalanative.nir._
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 
-private[codegen] class UnixCompat(protected val codegen: AbstractCodeGen)
-    extends OsCompat {
+private[codegen] class UnixCompat(codegen: AbstractCodeGen)
+    extends OsCompat(codegen) {
   import codegen.{pointerType => ptrT}
   val ehWrapperTy = "@_ZTIN11scalanative16ExceptionWrapperE"
   val excRecTy = s"{ $ptrT, i32 }"
@@ -32,10 +32,7 @@ private[codegen] class UnixCompat(protected val codegen: AbstractCodeGen)
   )(implicit
       fresh: Fresh,
       pos: Position,
-      scope: Metadata.Scope,
       sb: ShowBuilder,
-      debugInfo: DebugInfo,
-      metaCtx: MetadataCodeGen.Context
   ): Unit = {
     import sb._
     val Next.Unwind(Val.Local(excname, _), next) = unwind
@@ -72,7 +69,8 @@ private[codegen] class UnixCompat(protected val codegen: AbstractCodeGen)
       line(s"$exc = load i8*, i8** $w2")
     }
     line(s"call void $endCatch()")
-    codegen.genInst(Inst.Jump(next), scope)
+    str("br ")
+    codegen.genNext(next)
     unindent()
 
     line(s"$excfail:")

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -4,6 +4,7 @@ package compat.os
 import scala.scalanative.codegen.llvm.AbstractCodeGen
 import scala.scalanative.nir.ControlFlow.Block
 import scala.scalanative.nir._
+import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 
 private[codegen] class UnixCompat(protected val codegen: AbstractCodeGen)
@@ -32,6 +33,7 @@ private[codegen] class UnixCompat(protected val codegen: AbstractCodeGen)
       fresh: Fresh,
       pos: Position,
       sb: ShowBuilder,
+      debugInfo: DebugInfo,
       metaCtx: MetadataCodeGen.Context
   ): Unit = {
     import sb._

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -32,7 +32,7 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
   )(implicit
       fresh: Fresh,
       pos: Position,
-      sb: ShowBuilder,
+      sb: ShowBuilder
   ): Unit = {
     import sb._
     val Next.Unwind(Val.Local(excname, _), next) = unwind

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -32,6 +32,7 @@ private[codegen] class UnixCompat(protected val codegen: AbstractCodeGen)
   )(implicit
       fresh: Fresh,
       pos: Position,
+      scope: Metadata.Scope,
       sb: ShowBuilder,
       debugInfo: DebugInfo,
       metaCtx: MetadataCodeGen.Context
@@ -71,7 +72,7 @@ private[codegen] class UnixCompat(protected val codegen: AbstractCodeGen)
       line(s"$exc = load i8*, i8** $w2")
     }
     line(s"call void $endCatch()")
-    codegen.genInst(Inst.Jump(next))
+    codegen.genInst(Inst.Jump(next), scope)
     unindent()
 
     line(s"$excfail:")

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
@@ -53,7 +53,7 @@ private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
   )(implicit
       fresh: Fresh,
       pos: Position,
-      sb: ShowBuilder,
+      sb: ShowBuilder
   ): Unit = {
     import codegen._
     import sb._

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
@@ -53,6 +53,7 @@ private[codegen] class WindowsCompat(protected val codegen: AbstractCodeGen)
   )(implicit
       fresh: Fresh,
       pos: Position,
+      scope: Metadata.Scope,
       sb: ShowBuilder,
       debugInfo: DebugInfo,
       metaCtx: MetadataCodeGen.Context

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
@@ -4,6 +4,7 @@ package compat.os
 import scala.scalanative.codegen.llvm.AbstractCodeGen
 import scala.scalanative.nir.ControlFlow.Block
 import scala.scalanative.nir.{Fresh, Next, Position, Val}
+import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 
 private[codegen] class WindowsCompat(protected val codegen: AbstractCodeGen)
@@ -53,6 +54,7 @@ private[codegen] class WindowsCompat(protected val codegen: AbstractCodeGen)
       fresh: Fresh,
       pos: Position,
       sb: ShowBuilder,
+      debugInfo: DebugInfo,
       metaCtx: MetadataCodeGen.Context
   ): Unit = {
     import codegen._

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
@@ -7,8 +7,8 @@ import scala.scalanative.nir.{Fresh, Next, Position, Val}
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 
-private[codegen] class WindowsCompat(protected val codegen: AbstractCodeGen)
-    extends OsCompat {
+private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
+    extends OsCompat(codegen) {
   import codegen.{pointerType => ptrT}
   val ehWrapperTy = "\"??_R0?AVExceptionWrapper@scalanative@@@8\""
   val ehWrapperName = "c\".?AVExceptionWrapper@scalanative@@\\00\""
@@ -53,10 +53,7 @@ private[codegen] class WindowsCompat(protected val codegen: AbstractCodeGen)
   )(implicit
       fresh: Fresh,
       pos: Position,
-      scope: Metadata.Scope,
       sb: ShowBuilder,
-      debugInfo: DebugInfo,
-      metaCtx: MetadataCodeGen.Context
   ): Unit = {
     import codegen._
     import sb._

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -576,7 +576,6 @@ object MergeProcessor {
             id = newMappingOf(id),
             parent = if (id.isTopLevel) parentScopeId else newMappingOf(parent)
           )
-
           scopes += newScope
       }
       else {


### PR DESCRIPTION
This uses local names and lexical scopes added in #3438  and #3386 to create LLVM `DILocalVariable` metadata, thus allowing to see local variables in the debuger. Scope of this PR is limited only to emitting local values using `llvm.dbg.value` intrinsic, and does not yet enrich generated metadata with the informations about reference types and their layout. These changes can be added in the follow up PRs. 
For local allocas we also doe define a metadata usign `llvm.dbg.declare` allowing to track state of local mutable variables, however, most of these is erased by the compiler. 
This PR does also fix the positions (line/column) in the backend to match offsets expected by the LLVM. We do not change logic of emiting positions in the frontend to make them compliant with JVM and Scala.js. 

During this works some new issues have been found and should be addressed in the future: 
* `llvm.dbg.value` is used to emit local state of variables, however, LLVM optimizer can erase some of the these information if it can prove that given value stored in the register is never used. To improve correctness of debug informations we might always allocate a memory on stack which would hold the state of local val, but this solution might be less efficient then current approach. 
* Optimizer can inline constants though it can eliminate any traces of local variables. We could mitigate this issue by introducing backend-only instructions, which would only hold debug info of partially-evaluated code. This new kinds of instructions would not be serializable in the NIR. 
* Function inlining can mess up iterating in the debugger. Stepping to the next instruction, can result in expected steping-into the inlined call. We would need to check if `inlinedAt` parameter for `DILocation` would be able to mitigate this issue. (It is emmited by the clang for inlined calls in C)
* Usage of URL's in `DIFile` is fruitless. LLVM cannot handle remote source files. To mitigate this issue we would need to download original sources (based on `mapSourceURI`) and used these instead if we want to allow for debugging foreign code.