### PR TITLE
Fix emitting debug information for structe types with `SCALANATIVE_OPTIMIZE=false`

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -17,8 +17,6 @@ import scala.scalanative.codegen.{Metadata => CodeGenMetadata}
 
 import scala.language.implicitConversions
 import scala.scalanative.codegen.llvm.Metadata.conversions._
-import scala.scalanative.nir.Global.Member
-import scala.scalanative.nir.Global.Top
 
 private[codegen] abstract class AbstractCodeGen(
     env: Map[Global, Defn],

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -17,6 +17,8 @@ import scala.scalanative.codegen.{Metadata => CodeGenMetadata}
 
 import scala.language.implicitConversions
 import scala.scalanative.codegen.llvm.Metadata.conversions._
+import scala.scalanative.nir.Global.Member
+import scala.scalanative.nir.Global.Top
 
 private[codegen] abstract class AbstractCodeGen(
     env: Map[Global, Defn],

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
@@ -53,7 +53,14 @@ object Metadata {
   case class DIBasicType(name: String, size: Int, align: Int, encoding: DW_ATE)
       extends Type
   case class DIDerivedType(tag: DWTag, baseType: Type, size: Int) extends Type
+
   case class DISubroutineType(types: DITypes) extends Type
+  case class DICompositeType(
+      tag: DWTag,
+      // TODO: name: String
+      size: Int,
+      elements: Tuple
+  ) extends Type
 
   class DITypes(retTpe: Option[Type], arguments: Seq[Type])
       extends Tuple(retTpe.getOrElse(Metadata.Const("null")) +: arguments)
@@ -65,6 +72,8 @@ object Metadata {
   sealed class DWTag(tag: Predef.String) extends Const(tag)
   object DWTag {
     object Pointer extends DWTag("DW_TAG_pointer_type")
+    object StructureType extends DWTag("DW_TAG_structure_type")
+    object Member extends DWTag("DW_TAG_member")
   }
 
   sealed class DW_ATE(tag: Predef.String) extends Const(tag)


### PR DESCRIPTION
fix https://github.com/scala-native/scala-native/issues/3435

Now, the following Scala code without optimization will emit

```scala
import scala.scalanative.runtime.struct

object Main {
  @struct class SC1(val b: Int, val c: Boolean)

  def main(args: Array[String]): Unit = {
    val x = new SC1(5, true)
    println(x.b)
  }
}
```

```
!22 = !DIBasicType(name: "int", size: 32, align: 32, encoding: DW_ATE_signed)
!23 = !DIDerivedType(tag: DW_TAG_member, baseType: !22, size: 32)
!24 = !DIBasicType(name: "bool", size: 8, align: 8, encoding: DW_ATE_boolean)
!25 = !DIDerivedType(tag: DW_TAG_member, baseType: !24, size: 8)
!26 = !{!23, !25}
!27 = !DICompositeType(tag: DW_TAG_structure_type, size: 64, elements: !26)
```

Since we don't have `name` attributs in `DICompositeType` and `DIBasicType`, we will debugger can't show their type name and members' names.
In order to preserve those information, we need to somehow change the way of traversing NIR or adding name information into NIR

```
(__lldb_invalid_typedef_name) oldCar = {
   = 1980
   = false
   = 0xb96d000190b47e3c
}
(__lldb_invalid_typedef_name) myCar1 = {
   = 16260
   = true
   = 0x0000000100009c40
}
```