### PR TITLE
Fix #3340: Provide a restricted implementation of  javalib Array parallel methods

### DIFF
--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -1,6 +1,11 @@
 // Ported from Scala.js commit: ba618ed dated: 2020-10-05
-// Arrays.spliterator() methods added for Scala Native.
-// Arrays.stream() methods added for Scala Native.
+
+/*
+ Arrays.spliterator() methods added for Scala Native.
+ Arrays.stream() methods added for Scala Native.
+ Arrays.setAll*() methods added for Scala Native.
+ Arrays.parallel*() methods added for Scala Native.
+ */
 
 package java.util
 
@@ -1003,6 +1008,236 @@ object Arrays {
   }
 
 // Scala Native additions --------------------------------------------------
+
+  /* Note:
+   *   For now all of parallelPrefix(), parallelSetAll() and parallelSort()
+   *   methods are restricted to a parallelism of 1, i.e. sequential.
+   *
+   *   Later evolutions could/should increase the parallelism when
+   *   multithreading has been enabled.
+   */
+
+  def parallelPrefix(array: Array[Double], op: DoubleBinaryOperator): Unit = {
+    parallelPrefix(array, 0, array.length, op)
+  }
+
+  def parallelPrefix(
+      array: Array[Double],
+      fromIndex: Int,
+      toIndex: Int,
+      op: DoubleBinaryOperator
+  ): Unit = {
+    checkRangeIndices(array, fromIndex, toIndex)
+    val rangeSize = toIndex - fromIndex
+
+    if (rangeSize >= 2) { // rangeSize == 0 or 1 leaves array unmodified.
+      for (j <- (fromIndex + 1) until toIndex) {
+        array(j) = op.applyAsDouble(array(j - 1), array(j))
+      }
+    }
+  }
+
+  def parallelPrefix(array: Array[Int], op: IntBinaryOperator): Unit = {
+    parallelPrefix(array, 0, array.length, op)
+  }
+
+  def parallelPrefix(
+      array: Array[Int],
+      fromIndex: Int,
+      toIndex: Int,
+      op: IntBinaryOperator
+  ): Unit = {
+    checkRangeIndices(array, fromIndex, toIndex)
+    val rangeSize = toIndex - fromIndex
+
+    if (rangeSize >= 2) { // rangeSize == 0 or 1 leaves array unmodified.
+      for (j <- (fromIndex + 1) until toIndex) {
+        array(j) = op.applyAsInt(array(j - 1), array(j))
+      }
+    }
+  }
+
+  def parallelPrefix(array: Array[Long], op: LongBinaryOperator): Unit = {
+    parallelPrefix(array, 0, array.length, op)
+  }
+
+  def parallelPrefix(
+      array: Array[Long],
+      fromIndex: Int,
+      toIndex: Int,
+      op: LongBinaryOperator
+  ): Unit = {
+    checkRangeIndices(array, fromIndex, toIndex)
+    val rangeSize = toIndex - fromIndex
+
+    if (rangeSize >= 2) { // rangeSize == 0 or 1 leaves array unmodified.
+      for (j <- (fromIndex + 1) until toIndex) {
+        array(j) = op.applyAsLong(array(j - 1), array(j))
+      }
+    }
+  }
+
+  def parallelPrefix[T <: AnyRef](
+      array: Array[T],
+      op: BinaryOperator[T]
+  ): Unit = {
+    parallelPrefix[T](array, 0, array.length, op)
+  }
+
+  def parallelPrefix[T <: AnyRef](
+      array: Array[T],
+      fromIndex: Int,
+      toIndex: Int,
+      op: BinaryOperator[T]
+  ): Unit = {
+    checkRangeIndices(array, fromIndex, toIndex)
+    val rangeSize = toIndex - fromIndex
+
+    if (rangeSize >= 2) { // rangeSize == 0 or 1 leaves array unmodified.
+      for (j <- (fromIndex + 1) until toIndex) {
+        array(j) = op.apply(array(j - 1), array(j))
+      }
+    }
+  }
+
+  def parallelSetAll(
+      array: Array[Double],
+      generator: IntToDoubleFunction
+  ): Unit = {
+    setAll(array, generator)
+  }
+
+  def parallelSetAll(array: Array[Int], generator: IntUnaryOperator): Unit = {
+    setAll(array, generator)
+  }
+
+  def parallelSetAll(array: Array[Long], generator: IntToLongFunction): Unit = {
+    setAll(array, generator)
+  }
+
+  def parallelSetAll[T <: AnyRef](
+      array: Array[T],
+      generator: IntFunction[_ <: T]
+  ): Unit = {
+    setAll(array, generator)
+  }
+
+// parallelSort(byte[])
+  def parallelSort(a: Array[Byte]): Unit =
+    sort(a)
+
+// parallelSort(byte[] a, int fromIndex, int toIndex)
+  def parallelSort(
+      a: Array[Byte],
+      fromIndex: Int,
+      toIndex: Int
+  ): Unit =
+    sort(a, fromIndex, toIndex)
+
+// parallelSort(char[])
+  def parallelSort(a: Array[Char]): Unit =
+    sort(a)
+
+// parallelSort(char[] a, int fromIndex, int toIndex)
+  def parallelSort(
+      a: Array[Char],
+      fromIndex: Int,
+      toIndex: Int
+  ): Unit =
+    sort(a, fromIndex, toIndex)
+
+// parallelSort(double[])
+  def parallelSort(array: Array[Double]): Unit =
+    sort(array)
+
+// parallelSort(double[] a, int fromIndex, int toIndex)
+  def parallelSort(
+      array: Array[Double],
+      fromIndex: Int,
+      toIndex: Int
+  ): Unit =
+    sort(array, fromIndex, toIndex)
+
+// parallelSort(float[])
+  def parallelSort(a: Array[Float]): Unit =
+    sort(a)
+
+// parallelSort(float[] a, int fromIndex, int toIndex)
+  def parallelSort(
+      a: Array[Float],
+      fromIndex: Int,
+      toIndex: Int
+  ): Unit =
+    sort(a, fromIndex, toIndex)
+
+// parallelSort(int[])
+  def parallelSort(a: Array[Int]): Unit =
+    sort(a)
+
+// parallelSort(int[] a, int fromIndex, int toIndex)
+  def parallelSort(a: Array[Int], fromIndex: Int, toIndex: Int): Unit =
+    sort(a, fromIndex, toIndex)
+
+// parallelSort(long[])
+  def parallelSort(a: Array[Long]): Unit =
+    sort(a)
+// parallelSort(long[] a, int fromIndex, int toIndex)
+  def parallelSort(
+      a: Array[Long],
+      fromIndex: Int,
+      toIndex: Int
+  ): Unit =
+    sort(a, fromIndex, toIndex)
+
+// parallelSort(short[])
+  def parallelSort(a: Array[Short]): Unit =
+    sort(a)
+
+// parallelSort(short[] a, int fromIndex, int toIndex)
+  def parallelSort(
+      a: Array[Short],
+      fromIndex: Int,
+      toIndex: Int
+  ): Unit =
+    sort(a, fromIndex, toIndex)
+
+// parallelSort(T[])
+//  def parallelSort(a: Array[AnyRef]): Unit =
+//    sort(a)
+
+//  def parallelSort[T <: Comparable[AnyRef]](
+  def parallelSort[T <: Comparable[_ <: AnyRef]](
+      array: Array[T]
+  ): Unit = {
+    sort(array.asInstanceOf[Array[AnyRef]])
+  }
+
+// parallelSort(T[] a, Comparator<? super T> cmp)
+  def parallelSort[T <: AnyRef](
+      array: Array[T],
+      comparator: Comparator[_ >: T]
+  ): Unit = {
+    sort[T](array, comparator)
+  }
+
+// parallelSort(T[] a, int fromIndex, int toIndex)
+  def parallelSort[T <: Comparable[_ <: AnyRef]](
+      array: Array[T],
+      fromIndex: Int,
+      toIndex: Int
+  ): Unit =
+    sort(array.asInstanceOf[Array[AnyRef]], fromIndex, toIndex)
+
+// parallelSort(T[] a, int fromIndex, int toIndex, Comparator<? super T> cmp)
+
+  def parallelSort[T <: AnyRef](
+      array: Array[T],
+      fromIndex: Int,
+      toIndex: Int,
+      comparator: Comparator[_ >: T]
+  ): Unit = {
+    sort[T](array, fromIndex, toIndex, comparator)
+  }
 
   def setAll(array: Array[Double], generator: IntToDoubleFunction): Unit = {
     for (j <- 0 until array.size)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArraysTest.scala
@@ -1,6 +1,6 @@
 // Ported from Scala.js commit: ba618ed dated: 2020-10-05
 //
-// Tests for sequential "setAll()" methods added for Scala Native.
+// Additional Tests added for methods implemented only in Scala Native.
 
 package org.scalanative.testsuite.javalib.util
 
@@ -1345,6 +1345,340 @@ class ArraysTest {
 
   final val epsilon = 0.0000001 // tolerance for Floating point comparisons.
 
+  private def testParallelSort[T: ClassTag](
+      elem: Int => T,
+      newArray: Int => Array[T],
+      sort: Array[T] => Unit,
+      sort2: (Array[T], Int, Int) => Unit
+  ): Unit = {
+    val values = Array(5, 3, 6, 1, 2, 4).map(elem)
+    val arr = newArray(values.length)
+
+    for (i <- 0 until values.length)
+      arr(i) = values(i)
+    sort(arr)
+    assertArrayEquals(arr, Array(1, 2, 3, 4, 5, 6).map(elem))
+
+    for (i <- 0 until values.length)
+      arr(i) = values(i)
+    sort2(arr, 0, 3)
+    assertArrayEquals(arr, Array(3, 5, 6, 1, 2, 4).map(elem))
+
+    sort2(arr, 2, 5)
+    assertArrayEquals(arr, Array(3, 5, 1, 2, 6, 4).map(elem))
+
+    sort2(arr, 0, 6)
+    assertArrayEquals(arr, Array(1, 2, 3, 4, 5, 6).map(elem))
+
+    // check zero length doesn't fail.
+    sort2(arr, 1, 1)
+  }
+
+  @Test def parallelPrefix_Double(): Unit = {
+    val srcSize = 16
+    val arr = new Array[Double](srcSize)
+
+    for (j <- 0 until srcSize) // setAll() may not have been tested yet.
+      arr(j) = (j + 1).toDouble
+
+    Arrays.parallelPrefix(arr, (e1: Double, e2: Double) => e1 + e2)
+
+    val expected = 136.0
+    assertEquals("cumulative sum", expected, arr(srcSize - 1), epsilon)
+  }
+
+  @Test def parallelPrefix_DoubleSubRange(): Unit = {
+    val srcSize = 16
+    val rangeStart = srcSize - 4 // inclusive
+    val rangeEnd = srcSize - 1 // exclusive
+
+    val arr = new Array[Double](srcSize)
+
+    for (j <- 0 until srcSize) // setAll() may not have been tested yet.
+      arr(j) = (j + 1).toDouble
+
+    Arrays.parallelPrefix(
+      arr,
+      rangeStart,
+      rangeEnd,
+      (e1: Double, e2: Double) => e1 + e2
+    )
+
+    val expected = 42.0
+    assertEquals("range sum", expected, arr(rangeEnd - 1), epsilon)
+  }
+
+  @Test def parallelPrefix_Int(): Unit = {
+    val srcSize = 16
+    val arr = new Array[Int](srcSize)
+
+    for (j <- 0 until srcSize) // setAll() may not have been tested yet.
+      arr(j) = j + 1
+
+    Arrays.parallelPrefix(arr, (e1: Int, e2: Int) => e1 + e2)
+
+    val expected = 136
+    assertEquals("cumulative sum", expected, arr(srcSize - 1))
+  }
+
+  @Test def parallelPrefix_IntSubRange(): Unit = {
+    val srcSize = 16
+    val rangeStart = srcSize - 5 // inclusive
+    val rangeEnd = srcSize - 2 // exclusive
+
+    val arr = new Array[Int](srcSize)
+
+    for (j <- 0 until srcSize) // setAll() may not have been tested yet.
+      arr(j) = j + 1
+
+    Arrays.parallelPrefix(
+      arr,
+      rangeStart,
+      rangeEnd,
+      (e1: Int, e2: Int) => e1 + e2
+    )
+
+    val expected = 39
+    assertEquals("range sum", expected, arr(rangeEnd - 1), epsilon)
+  }
+
+  @Test def parallelPrefix_Long(): Unit = {
+    val srcSize = 16
+    val arr = new Array[Long](srcSize)
+
+    for (j <- 0 until srcSize) // setAll() may not have been tested yet.
+      arr(j) = (j + 1).toLong
+
+    Arrays.parallelPrefix(arr, (e1: Long, e2: Long) => e1 + e2)
+
+    val expected = 136L
+    assertEquals("cumulative sum", expected, arr(srcSize - 1))
+  }
+
+  @Test def parallelPrefix_LongSubRange(): Unit = {
+    val srcSize = 16
+    val rangeStart = srcSize - 6 // inclusive
+    val rangeEnd = srcSize - 3 // exclusive
+
+    val arr = new Array[Long](srcSize)
+
+    for (j <- 0 until srcSize) // setAll() may not have been tested yet.
+      arr(j) = (j + 1).toLong
+
+    Arrays.parallelPrefix(
+      arr,
+      rangeStart,
+      rangeEnd,
+      (e1: Long, e2: Long) => e1 + e2
+    )
+
+    val expected = 36L
+    assertEquals("range sum", expected, arr(rangeEnd - 1))
+  }
+
+  @Test def parallelPrefix_AnyRef(): Unit = {
+    val srcSize = 16
+
+    val data = "abcdefhijklmnopq"
+    val dataChars = data.toCharArray()
+
+    val arr = new Array[String](srcSize)
+    for (j <- 0 until srcSize)
+      arr(j) = String.valueOf(dataChars, j, 1)
+
+    Arrays.parallelPrefix(
+      arr,
+      (e1: String, e2: String) => e1.concat(e2)
+    )
+
+    val expected = data
+    assertEquals("cumulative concat", expected, arr(srcSize - 1))
+  }
+
+  @Test def parallelPrefix_AnyRefSubRange(): Unit = {
+    val srcSize = 16
+    val rangeStart = srcSize - 7 // inclusive
+    val rangeEnd = srcSize - 2 // exclusive
+
+    val data = "abcdefhijklmnopq"
+    val dataChars = data.toCharArray()
+
+    val arr = new Array[String](srcSize)
+    for (j <- 0 until srcSize)
+      arr(j) = String.valueOf(dataChars, j, 1)
+
+    Arrays.parallelPrefix(
+      arr,
+      rangeStart,
+      rangeEnd,
+      (e1: String, e2: String) => e1.concat(e2)
+    )
+
+    val expected = data.substring(rangeStart, rangeEnd)
+    assertEquals("range concat", expected, arr(rangeEnd - 1))
+  }
+
+  /* The parallelSetAll_* Tests should use a srcSize  which large enough
+   * that any truely parallel implemtation is likely to fork at least
+   * once.
+   */
+
+  lazy val parallelSetAllSrcSize = {
+    /* An arbitrary power-of-2, large enough to cause splits, small enough
+     * not to tax CI.
+     */
+    val factor = 16
+    java.util.concurrent.ForkJoinPool.getCommonPoolParallelism() * factor
+  }
+
+  @Test def parallelSetAll_Double(): Unit = {
+    val srcSize = parallelSetAllSrcSize
+
+    val arr = new Array[Double](srcSize)
+    Arrays.setAll(arr, (idx: Int) => (idx + 1).toDouble)
+
+    val expectedAtFirstInRangeRange = 1.0
+    assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0), epsilon)
+
+    val expectedAtLastInRangeRange = srcSize.toDouble
+    assertEquals(
+      "lastInRange",
+      expectedAtLastInRangeRange,
+      arr(srcSize - 1),
+      epsilon
+    )
+  }
+
+  @Test def parallelSetAll_Int(): Unit = {
+    val srcSize = parallelSetAllSrcSize
+
+    val arr = new Array[Int](srcSize)
+    Arrays.setAll(arr, (idx: Int) => (idx + 1))
+
+    val expectedAtFirstInRangeRange = 1
+    assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))
+
+    val expectedAtLastInRangeRange = srcSize
+    assertEquals(
+      "lastInRange",
+      expectedAtLastInRangeRange,
+      arr(srcSize - 1)
+    )
+  }
+
+  @Test def parallelSetAll_Long(): Unit = {
+    val srcSize = parallelSetAllSrcSize
+
+    val arr = new Array[Long](srcSize)
+    Arrays.setAll(arr, (idx: Int) => (idx + 1).toLong)
+
+    val expectedAtFirstInRangeRange = 1L
+    assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))
+
+    val expectedAtLastInRangeRange = srcSize.toLong
+    assertEquals(
+      "lastInRange",
+      expectedAtLastInRangeRange,
+      arr(srcSize - 1)
+    )
+  }
+
+  @Test def parallelSetAll_AnyRef(): Unit = {
+    val srcSize = parallelSetAllSrcSize
+
+    val arr = new Array[String](srcSize)
+
+    // Scala 2 needs [String] here, Scala 3 can usually figure out its absence.
+    Arrays.setAll[String](arr, (idx: Int) => (idx + 1).toString())
+
+    val expectedAtFirstInRangeRange = "1"
+    assertEquals("firstInRange", expectedAtFirstInRangeRange, arr(0))
+
+    val expectedAtLastInRangeRange = srcSize.toString()
+    assertEquals(
+      "lastInRange",
+      expectedAtLastInRangeRange,
+      arr(srcSize - 1)
+    )
+  }
+
+  /* Scala.js practice, as seen in the sort_*() tests at top of this file is
+   * to test the no-argument and three-argument methods in the same helper.
+   * Do the same here to stay consistent with prior art.
+   */
+
+  @Test def parallelSort_Byte(): Unit =
+    testParallelSort[Byte](
+      _.toByte,
+      new Array(_),
+      Arrays.parallelSort(_),
+      Arrays.parallelSort(_, _, _)
+    )
+
+  @Test def parallelSort_Char(): Unit =
+    testParallelSort[Char](
+      _.toChar,
+      new Array(_),
+      Arrays.parallelSort(_),
+      Arrays.parallelSort(_, _, _)
+    )
+
+  @Test def parallelSort_Double(): Unit =
+    testParallelSort[Double](
+      _.toDouble,
+      new Array(_),
+      Arrays.parallelSort(_),
+      Arrays.parallelSort(_, _, _)
+    )
+
+  @Test def parallelSort_Float(): Unit =
+    testParallelSort[Float](
+      _.toFloat,
+      new Array(_),
+      Arrays.parallelSort(_),
+      Arrays.parallelSort(_, _, _)
+    )
+
+  @Test def parallelSort_Int(): Unit =
+    testParallelSort[Int](
+      _.toInt,
+      new Array(_),
+      Arrays.parallelSort(_),
+      Arrays.parallelSort(_, _, _)
+    )
+
+  @Test def parallelSort_Long(): Unit =
+    testParallelSort[Long](
+      _.toLong,
+      new Array(_),
+      Arrays.parallelSort(_),
+      Arrays.parallelSort(_, _, _)
+    )
+
+  @Test def parallelSort_Short(): Unit =
+    testParallelSort[Short](
+      _.toShort,
+      new Array(_),
+      Arrays.parallelSort(_),
+      Arrays.parallelSort(_, _, _)
+    )
+
+  @Test def parallelSort_String(): Unit =
+    testParallelSort[String](
+      _.toString,
+      new Array(_),
+      Arrays.parallelSort[String](_),
+      Arrays.parallelSort[String](_, _, _)
+    )
+
+  @Test def parallelSort_StringNullComparator(): Unit =
+    testParallelSort[AnyRef](
+      _.toString,
+      new Array(_),
+      Arrays.parallelSort(_, null),
+      Arrays.parallelSort(_, _, _, null)
+    )
+
   @Test def setAll_Double(): Unit = {
     val srcSize = 16
 
@@ -1402,7 +1736,7 @@ class ArraysTest {
 
     val arr = new Array[String](srcSize)
 
-    // Scala 2 needs [String] here, Scala 3 can usually figure out its absence
+    // Scala 2 needs [String] here, Scala 3 can usually figure out its absence.
     Arrays.setAll[String](arr, (idx: Int) => (idx + 1).toString())
 
     val expectedAtFirstInRangeRange = "1"


### PR DESCRIPTION
Fix #3340 

Provide some previously missing javalib Array parallel methods.

The provided methods are currently restricted to a parallelism of 1.  

This approach allows the methods to be available for porting, albeit with no execution advantage,
whilst more capable implementations are developed.
