### PR TITLE
Remove static calls mitigation logic from linker

### DIFF
--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -288,7 +288,7 @@ object BigDecimal {
       new BigDecimal(0, Int.MinValue)
   }
 
-  protected def bitLength(sValue: Long): Int = {
+  private def bitLength(sValue: Long): Int = {
     val smallValue = if (sValue < 0) ~sValue else sValue
     64 - java.lang.Long.numberOfLeadingZeros(smallValue)
   }

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
@@ -637,7 +637,7 @@ object ForkJoinTask {
     ForkJoinPool.getSurplusQueuedTaskCount()
 
   // The next 4 methods should be defined as `protected static`, however this kind of access
-  // does not make lots of sens in Scala. The most similiar would be `protected[concurrent]`
+  // does not make a lot of sense in Scala. The most similar access would be `protected[concurrent]`
   // Scala Native frontend does not emit static forwards for protected methods for compliance with the Scala JVM backend
   // The usecase of `protected static` in ported Scala code shall be replaced with public access instead.
   def peekNextLocalTask(): ForkJoinTask[_] = {

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinTask.scala
@@ -636,7 +636,11 @@ object ForkJoinTask {
   def getSurplusQueuedTaskCount(): Int =
     ForkJoinPool.getSurplusQueuedTaskCount()
 
-  protected def peekNextLocalTask(): ForkJoinTask[_] = {
+  // The next 4 methods should be defined as `protected static`, however this kind of access
+  // does not make lots of sens in Scala. The most similiar would be `protected[concurrent]`
+  // Scala Native frontend does not emit static forwards for protected methods for compliance with the Scala JVM backend
+  // The usecase of `protected static` in ported Scala code shall be replaced with public access instead.
+  def peekNextLocalTask(): ForkJoinTask[_] = {
     val q = Thread.currentThread() match {
       case t: ForkJoinWorkerThread => t.workQueue
       case _                       => ForkJoinPool.commonQueue()
@@ -644,20 +648,20 @@ object ForkJoinTask {
     if (q == null) null else q.peek()
   }
 
-  protected def pollNextLocalTask(): ForkJoinTask[_] = {
+  def pollNextLocalTask(): ForkJoinTask[_] = {
     Thread.currentThread() match {
       case t: ForkJoinWorkerThread => t.workQueue.nextLocalTask()
       case _                       => null
     }
   }
 
-  protected def pollTask(): ForkJoinTask[_] =
+  def pollTask(): ForkJoinTask[_] =
     Thread.currentThread() match {
       case wt: ForkJoinWorkerThread => wt.pool.nextTaskFor(wt.workQueue)
       case _                        => null
     }
 
-  protected def pollSubmission(): ForkJoinTask[_] =
+  def pollSubmission(): ForkJoinTask[_] =
     Thread.currentThread() match {
       case t: ForkJoinWorkerThread => t.pool.pollSubmission()
       case _                       => null

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -202,11 +202,8 @@ class Reach(
         reachUnavailable(name)
       } else {
         val maybeFixedDefn = defn match {
-          case defn: Defn.Define =>
-            (resolveLinktimeDefine _)
-              .andThen(mitigateStaticCalls _)
-              .apply(defn)
-          case _ => defn
+          case defn: Defn.Define => resolveLinktimeDefine(defn)
+          case _                 => defn
         }
         reachDefn(maybeFixedDefn)
       }
@@ -577,85 +574,6 @@ class Reach(
     )
     reachAttrs(attrs)
     reachType(ty)
-  }
-
-  // Mitigate static calls to methods compiled with Scala Native older then 0.4.3
-  // If given static method in not rechable replace it with call to method with the same
-  // name in the companion module
-  private def mitigateStaticCalls(defn: Defn.Define): Defn.Define = {
-    lazy val fresh = Fresh(defn.insts)
-    val newInsts = defn.insts.flatMap {
-      case inst @ Inst.Let(
-            n,
-            Op.Call(
-              ty: Type.Function,
-              Val.Global(
-                methodName @ Global.Member(Global.Top(methodOwner), sig),
-                _
-              ),
-              args
-            ),
-            unwind
-          )
-          if sig.isStatic && lookup(
-            methodName,
-            ignoreIfUnavailable = true
-          ).isEmpty =>
-        def findRewriteCandidate(inModule: Boolean): Option[List[Inst]] = {
-          val owner =
-            if (inModule) Global.Top(methodOwner + "$")
-            else Global.Top(methodOwner)
-          val newMethod = {
-            val Sig.Method(id, tps, scope) = sig.unmangled: @unchecked
-            val newScope = scope match {
-              case Sig.Scope.PublicStatic      => Sig.Scope.Public
-              case Sig.Scope.PrivateStatic(in) => Sig.Scope.Private(in)
-              case scope                       => scope
-            }
-            val newSig = Sig.Method(id, tps, newScope)
-            Val.Global(owner.member(newSig), Type.Ptr)
-          }
-          // Make sure that candidate exists
-          lookup(newMethod.name, ignoreIfUnavailable = true)
-            .map { _ =>
-              implicit val pos: nir.Position = defn.pos
-              implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
-
-              val newType = {
-                val newArgsTpe = Type.Ref(owner) +: ty.args
-                Type.Function(newArgsTpe, ty.ret)
-              }
-
-              if (inModule) {
-                val moduleV = Val.Local(fresh(), Type.Ref(owner))
-                val newArgs = moduleV +: args
-                Inst.Let(moduleV.id, Op.Module(owner), Next.None) ::
-                  Inst.Let(n, Op.Call(newType, newMethod, newArgs), unwind) ::
-                  Nil
-              } else {
-                Inst.Let(n, Op.Call(newType, newMethod, args), unwind) :: Nil
-              }
-            }
-        }
-
-        findRewriteCandidate(inModule = true)
-          //  special case for lifted methods
-          .orElse(findRewriteCandidate(inModule = false))
-          .getOrElse {
-            config.logger.warn(
-              s"Found a call to not defined static method ${methodName}. " +
-                "Static methods are generated since Scala Native 0.4.3, " +
-                "report this bug in the Scala Native issues. " +
-                s"Call defined at ${inst.pos.show}"
-            )
-            addMissing(methodName, inst.pos)
-            inst :: Nil
-          }
-
-      case inst =>
-        inst :: Nil
-    }
-    defn.copy(insts = newInsts)(defn.pos)
   }
 
   def reachDefine(defn: Defn.Define): Unit = {


### PR DESCRIPTION
Removes special handling for static methods from linker. That was required only for backward compatibilty with Scala Native 0.4.3-. 

