### PR TITLE
Fixing Bug in Lowering: Handling Op.Copy for ClassOf Transformation

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -480,6 +480,9 @@ object Lower {
           genArraylengthOp(buf, n, op)
         case op: Op.Stackalloc =>
           genStackallocOp(buf, n, op)
+        case op: Op.Copy =>
+          val v = genVal(buf, op.value)
+          buf.let(n, Op.Copy(v), unwind)
         case _ =>
           buf.let(n, op, unwind)
       }


### PR DESCRIPTION
fix https://github.com/scala-native/scala-native/issues/3442

Previously, we didn't exhaustiely
Prior to this change, there was an issue in the lowering process where the value of `Op.Copy` was not being appropriately adjusted during the lowering procedure. This issue became clear when attempting to lower a value represented as `Val.ClassOf`

For instance, the transformation of `ClassOf(Top(scala.scalanative.runtime.DoubleArray))` needed to be lowered to `Global(Member(Top(scala.scalanative.runtime.DoubleArray), G4type), Ptr)`.

However, this transformation was failing with the error message 'Lowering ClassOf needs nir.Buffer' because the value represented by `Val.ClassOf` was not being properly lowered, especially with `SCALANATIVE_OPTIMIZE=false`.