### PR TITLE
Unforce narrower types in NIR and toolchain

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -71,7 +71,7 @@ class Buffer(implicit fresh: Fresh) {
       scope: ScopeId
   ): Val.Local = let(fresh(), op, unwind)
 
-  def call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next)(implicit
+  def call(ty: Type.Function, ptr: Val, args: Seq[Val], unwind: Next)(implicit
       pos: Position,
       scope: ScopeId
   ): Val.Local = let(Op.Call(ty, ptr, args), unwind)
@@ -129,23 +129,29 @@ class Buffer(implicit fresh: Fresh) {
       scope: ScopeId
   ): Val.Local = let(Op.Conv(conv, ty, value), unwind)
 
-  def classalloc(name: Global, unwind: Next, zone: Option[Val] = None)(implicit
+  def classalloc(name: Global.Top, unwind: Next, zone: Option[Val] = None)(
+      implicit
       pos: Position,
       scope: ScopeId
   ): Val.Local = let(Op.Classalloc(name, zone), unwind)
 
-  def fieldload(ty: Type, obj: Val, name: Global, unwind: Next)(implicit
+  def fieldload(ty: Type, obj: Val, name: Global.Member, unwind: Next)(implicit
       pos: Position,
       scope: ScopeId
   ): Val.Local = let(Op.Fieldload(ty, obj, name), unwind)
 
-  def fieldstore(ty: Type, obj: Val, name: Global, value: Val, unwind: Next)(
-      implicit
+  def fieldstore(
+      ty: Type,
+      obj: Val,
+      name: Global.Member,
+      value: Val,
+      unwind: Next
+  )(implicit
       pos: Position,
       scope: ScopeId
   ): Val.Local = let(Op.Fieldstore(ty, obj, name, value), unwind)
 
-  def field(obj: Val, name: Global, unwind: Next)(implicit
+  def field(obj: Val, name: Global.Member, unwind: Next)(implicit
       pos: Position,
       scope: ScopeId
   ) =
@@ -161,7 +167,7 @@ class Buffer(implicit fresh: Fresh) {
       scope: ScopeId
   ): Val.Local = let(Op.Dynmethod(obj, sig), unwind)
 
-  def module(name: Global, unwind: Next)(implicit
+  def module(name: Global.Top, unwind: Next)(implicit
       pos: Position,
       scope: ScopeId
   ): Val.Local = let(Op.Module(name), unwind)

--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -16,19 +16,23 @@ sealed abstract class Defn {
 
 object Defn {
   // low-level
-  final case class Var(attrs: Attrs, name: Global, ty: Type, rhs: Val)(implicit
-      val pos: Position
-  ) extends Defn
-  final case class Const(attrs: Attrs, name: Global, ty: Type, rhs: Val)(
+  final case class Var(attrs: Attrs, name: Global.Member, ty: Type, rhs: Val)(
       implicit val pos: Position
   ) extends Defn
-  final case class Declare(attrs: Attrs, name: Global, ty: Type)(implicit
+  final case class Const(attrs: Attrs, name: Global.Member, ty: Type, rhs: Val)(
+      implicit val pos: Position
+  ) extends Defn
+  final case class Declare(
+      attrs: Attrs,
+      name: Global.Member,
+      ty: Type.Function
+  )(implicit
       val pos: Position
   ) extends Defn
   final case class Define(
       attrs: Attrs,
-      name: Global,
-      ty: Type,
+      name: Global.Member,
+      ty: Type.Function,
       insts: Seq[Inst],
       debugInfo: Define.DebugInfo = Define.DebugInfo.empty
   )(implicit val pos: Position)
@@ -68,21 +72,25 @@ object Defn {
   }
 
   // high-level
-  final case class Trait(attrs: Attrs, name: Global, traits: Seq[Global])(
-      implicit val pos: Position
+  final case class Trait(
+      attrs: Attrs,
+      name: Global.Top,
+      traits: Seq[Global.Top]
+  )(implicit
+      val pos: Position
   ) extends Defn
   final case class Class(
       attrs: Attrs,
-      name: Global,
-      parent: Option[Global],
-      traits: Seq[Global]
+      name: Global.Top,
+      parent: Option[Global.Top],
+      traits: Seq[Global.Top]
   )(implicit val pos: Position)
       extends Defn
   final case class Module(
       attrs: Attrs,
-      name: Global,
-      parent: Option[Global],
-      traits: Seq[Global]
+      name: Global.Top,
+      parent: Option[Global.Top],
+      traits: Seq[Global.Top]
   )(implicit val pos: Position)
       extends Defn
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Global.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Global.scala
@@ -22,15 +22,13 @@ object Global {
   }
 
   final case class Top(val id: String) extends Global {
-    override def top: Global.Top =
-      this
+    override def top: Global.Top = this
     override def member(sig: Sig): Global.Member =
       Global.Member(this, sig)
   }
 
-  final case class Member(val owner: Global, val sig: Sig) extends Global {
-    override def top: Global.Top =
-      owner.top
+  final case class Member(val owner: Top, val sig: Sig) extends Global {
+    override def top: Global.Top = owner
     override def member(sig: Sig): Global.Member =
       throw new Exception("Global.Member can't have any members.")
   }

--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -31,12 +31,8 @@ object Mangle {
         sb.str("T")
         mangleIdent(name.id)
       case name: Global.Member =>
-        val ownerId = name.owner match {
-          case owner: Global.Top => owner.id
-          case _                 => util.unreachable
-        }
         sb.str("M")
-        mangleIdent(ownerId)
+        mangleIdent(name.owner.id)
         mangleSig(name.sig)
       case _ =>
         util.unreachable
@@ -63,7 +59,7 @@ object Mangle {
         str("R")
         types.foreach(mangleType)
         str("E")
-      case Sig.Clinit() =>
+      case Sig.Clinit =>
         str("I")
         str("E")
       case Sig.Method(id, types, scope) =>

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -10,7 +10,6 @@ sealed abstract class Op {
 
   final def resty: Type = this match {
     case Op.Call(Type.Function(_, ret), _, _) => ret
-    case Op.Call(_, _, _)                     => unreachable
     case Op.Load(ty, _, _)                    => ty
     case Op.Store(_, _, _, _)                 => Type.Unit
     case Op.Elem(_, _, _)                     => Type.Ptr
@@ -114,7 +113,7 @@ sealed abstract class Op {
 }
 object Op {
   // low-level
-  final case class Call(ty: Type, ptr: Val, args: Seq[Val]) extends Op
+  final case class Call(ty: Type.Function, ptr: Val, args: Seq[Val]) extends Op
   final case class Load(ty: Type, ptr: Val, syncAttrs: Option[SyncAttrs] = None)
       extends Op
   final case class Store(
@@ -133,14 +132,18 @@ object Op {
   final case class Fence(syncAttrs: SyncAttrs) extends Op
 
   // high-level
-  final case class Classalloc(name: Global, zone: Option[Val]) extends Op
-  final case class Fieldload(ty: Type, obj: Val, name: Global) extends Op
-  final case class Fieldstore(ty: Type, obj: Val, name: Global, value: Val)
-      extends Op
-  final case class Field(obj: Val, name: Global) extends Op
+  final case class Classalloc(name: Global.Top, zone: Option[Val]) extends Op
+  final case class Fieldload(ty: Type, obj: Val, name: Global.Member) extends Op
+  final case class Fieldstore(
+      ty: Type,
+      obj: Val,
+      name: Global.Member,
+      value: Val
+  ) extends Op
+  final case class Field(obj: Val, name: Global.Member) extends Op
   final case class Method(obj: Val, sig: Sig) extends Op
   final case class Dynmethod(obj: Val, sig: Sig) extends Op
-  final case class Module(name: Global) extends Op
+  final case class Module(name: Global.Top) extends Op
   final case class As(ty: Type, obj: Val) extends Op
   final case class Is(ty: Type, obj: Val) extends Op
   final case class Copy(value: Val) extends Op

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -54,7 +54,7 @@ object Rt {
 
   val GenericArray = Ref(Global.Top("scala.scalanative.runtime.Array"))
 
-  val arrayAlloc: Map[Sig, Global] = Seq(
+  val arrayAlloc: Map[Sig, Global.Top] = Seq(
     "BooleanArray",
     "CharArray",
     "ByteArray",

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -75,7 +75,7 @@ object Sig {
   ) extends Unmangled
 
   final case class Ctor(types: Seq[Type]) extends Unmangled
-  final case class Clinit() extends Unmangled
+  case object Clinit extends Unmangled
   final case class Proxy(id: String, types: Seq[Type]) extends Unmangled
   final case class Extern(id: String) extends Unmangled
   final case class Generated(id: String) extends Unmangled

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -71,7 +71,7 @@ object Type {
 
   /** Reference types. */
   sealed abstract class RefKind extends Type {
-    final def className: Global = this match {
+    final def className: Global.Top = this match {
       case Type.Null            => Rt.BoxedNull.name
       case Type.Unit            => Rt.BoxedUnit.name
       case Type.Array(ty, _)    => toArrayClass(ty)
@@ -94,7 +94,7 @@ object Type {
   case object Unit extends RefKind
   final case class Array(ty: Type, nullable: Boolean = true) extends RefKind
   final case class Ref(
-      name: Global,
+      name: Global.Top,
       exact: Boolean = false,
       nullable: Boolean = true
   ) extends RefKind
@@ -173,7 +173,7 @@ object Type {
     case other               => other
   }
 
-  val typeToArray = Map[Type, Global](
+  val typeToArray = Map[Type, Global.Top](
     Type.Bool -> Global.Top("scala.scalanative.runtime.BooleanArray"),
     Type.Char -> Global.Top("scala.scalanative.runtime.CharArray"),
     Type.Byte -> Global.Top("scala.scalanative.runtime.ByteArray"),
@@ -184,19 +184,19 @@ object Type {
     Type.Double -> Global.Top("scala.scalanative.runtime.DoubleArray"),
     Rt.Object -> Global.Top("scala.scalanative.runtime.ObjectArray")
   )
-  val arrayToType =
+  val arrayToType: Map[Global.Top, Type] =
     typeToArray.map { case (k, v) => (v, k) }
-  def toArrayClass(ty: Type): Global = ty match {
+  def toArrayClass(ty: Type): Global.Top = ty match {
     case _ if typeToArray.contains(ty) =>
       typeToArray(ty)
     case _ =>
       typeToArray(Rt.Object)
   }
-  def fromArrayClass(name: Global): Option[Type] =
+  def fromArrayClass(name: Global.Top): Option[Type] =
     arrayToType.get(name)
   def isArray(clsTy: Type.Ref): Boolean =
     isArray(clsTy.name)
-  def isArray(clsName: Global): Boolean =
+  def isArray(clsName: Global.Top): Boolean =
     arrayToType.contains(clsName)
 
   def typeToName(tpe: Type): Global = tpe match {

--- a/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
@@ -20,12 +20,10 @@ object Unmangle {
     var pos = 0
 
     def readGlobal(): Global = read() match {
-      case 'T' =>
-        Global.Top(readIdent())
+      case 'T' => Global.Top(readIdent())
       case 'M' =>
         Global.Member(Global.Top(readIdent()), readUnmangledSig().mangled)
-      case ch =>
-        error(s"expected global, but got $ch")
+      case ch => error(s"expected global, but got $ch")
     }
 
     def readSigScope(): Sig.Scope = read() match {
@@ -36,24 +34,15 @@ object Unmangle {
     }
 
     def readUnmangledSig(): Sig.Unmangled = read() match {
-      case 'F' =>
-        Sig.Field(readIdent(), readSigScope())
-      case 'R' =>
-        Sig.Ctor(readTypes())
-      case 'I' =>
-        Sig.Clinit()
-      case 'D' =>
-        Sig.Method(readIdent(), readTypes(), readSigScope())
-      case 'P' =>
-        Sig.Proxy(readIdent(), readTypes())
-      case 'C' =>
-        Sig.Extern(readIdent())
-      case 'G' =>
-        Sig.Generated(readIdent())
-      case 'K' =>
-        Sig.Duplicate(readUnmangledSig(), readTypes())
-      case ch =>
-        error(s"expected sig, but got $ch")
+      case 'F' => Sig.Field(readIdent(), readSigScope())
+      case 'R' => Sig.Ctor(readTypes())
+      case 'I' => Sig.Clinit
+      case 'D' => Sig.Method(readIdent(), readTypes(), readSigScope())
+      case 'P' => Sig.Proxy(readIdent(), readTypes())
+      case 'C' => Sig.Extern(readIdent())
+      case 'G' => Sig.Generated(readIdent())
+      case 'K' => Sig.Duplicate(readUnmangledSig(), readTypes())
+      case ch  => error(s"expected sig, but got $ch")
     }
 
     def readType(): Type = peek() match {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -780,7 +780,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       val suffix = "$$Lambda$" + curClassFresh.get.apply().id
       val anonName = nir.Global.Top(genName(curClassSym).top.id + suffix)
-      val traitName = genName(funSym)
+      val traitName = genTypeName(funSym)
 
       statBuf += nir.Defn.Class(
         Attrs.None,

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -58,7 +58,7 @@ trait NirGenName[G <: Global with Singleton] {
     }
   }
 
-  def genFieldName(sym: Symbol): nir.Global = {
+  def genFieldName(sym: Symbol): nir.Global.Member = {
     val owner =
       if (sym.isStaticMember) genModuleName(sym.owner)
       else genTypeName(sym.owner)
@@ -80,7 +80,7 @@ trait NirGenName[G <: Global with Singleton] {
     }
   }
 
-  def genMethodName(sym: Symbol): nir.Global = {
+  def genMethodName(sym: Symbol): nir.Global.Member = {
     val owner = genTypeName(sym.owner)
     val id = nativeIdOf(sym)
     val tpe = sym.tpe.widen
@@ -120,7 +120,7 @@ trait NirGenName[G <: Global with Singleton] {
   def genStaticMemberName(
       sym: Symbol,
       explicitOwner: Symbol
-  ): nir.Global = {
+  ): nir.Global.Member = {
     // Use explicit owner in case if forwarder target was defined in the trait/interface
     // or was abstract. `sym.owner` would always point to original owner, even if it also defined
     // in the super class. This is important, becouse (on the JVM) static methods are resolved at
@@ -148,7 +148,7 @@ trait NirGenName[G <: Global with Singleton] {
     owner.member(sig)
   }
 
-  def genFuncPtrExternForwarderName(ownerSym: Symbol): nir.Global = {
+  def genFuncPtrExternForwarderName(ownerSym: Symbol): nir.Global.Member = {
     val owner = genTypeName(ownerSym)
     owner.member(nir.Sig.Generated("$extern$forwarder"))
   }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -135,7 +135,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       genMirrorClass(cd)
     }
 
-    def genClassParent(sym: Symbol): Option[nir.Global] = {
+    def genClassParent(sym: Symbol): Option[nir.Global.Top] = {
       if (sym.isExternType &&
           sym.superClass != ObjectClass) {
         reporter.error(
@@ -288,7 +288,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genRegisterReflectiveInstantiation(cd: ClassDef): Unit = {
       val owner = genTypeName(curClassSym)
-      val name = owner.member(nir.Sig.Clinit())
+      val name = owner.member(nir.Sig.Clinit)
 
       val staticInitBody =
         if (isStaticModule(curClassSym))
@@ -316,7 +316,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     // which is expected to extend one of scala.runtime.AbstractFunctionX.
     private def genReflectiveInstantiationConstructor(
         reflInstBuffer: ReflectiveInstantiationBuffer,
-        superClass: Global
+        superClass: Global.Top
     )(implicit pos: nir.Position): Unit = {
       withFreshExprBuffer { exprBuf =>
         val body = {
@@ -348,7 +348,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     // Allocate and construct an object, using the provided ExprBuffer.
     private def allocAndConstruct(
         exprBuf: ExprBuffer,
-        name: Global,
+        name: Global.Top,
         argTypes: Seq[nir.Type],
         args: Seq[Val]
     )(implicit pos: nir.Position): Val = {
@@ -718,7 +718,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    protected def genLinktimeResolved(dd: DefDef, name: Global)(implicit
+    protected def genLinktimeResolved(dd: DefDef, name: Global.Member)(implicit
         pos: nir.Position
     ): Option[nir.Defn] = {
       if (dd.symbol.isConstant) {
@@ -790,7 +790,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     private def genLinktimeResolvedMethod(
         dd: DefDef,
         retty: nir.Type,
-        methodName: nir.Global
+        methodName: nir.Global.Member
     )(genValue: ExprBuffer => nir.Val)(implicit pos: nir.Position): nir.Defn = {
       implicit val fresh: Fresh = Fresh()
       val buf = new ExprBuffer()
@@ -819,7 +819,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genExternMethod(
         attrs: nir.Attrs,
-        name: nir.Global,
+        name: nir.Global.Member,
         origSig: nir.Type,
         dd: DefDef
     ): Option[nir.Defn] = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -68,7 +68,7 @@ trait GenReflectiveInstantisation(using Context) {
     given nir.Position = td.span
     val sym: Symbol = curClassSym
     val owner = genTypeName(sym)
-    val name = owner.member(nir.Sig.Clinit())
+    val name = owner.member(nir.Sig.Clinit)
 
     val staticInitBody =
       if (curClassSym.get.is(flag = Module, butNot = Lifted))
@@ -158,7 +158,7 @@ trait GenReflectiveInstantisation(using Context) {
   // Generate the constructor for the class instantiator class,
   // which is expected to extend one of scala.runtime.AbstractFunctionX.
   private def genConstructor(
-      superClass: Global
+      superClass: Global.Top
   )(using
       nir.Position
   )(using reflInstBuffer: ReflectiveInstantiationBuffer): Unit = {
@@ -189,7 +189,7 @@ trait GenReflectiveInstantisation(using Context) {
 
 // Allocate and construct an object, using the provided ExprBuffer.
   private def allocAndConstruct(
-      name: Global,
+      name: Global.Top,
       argTypes: Seq[nir.Type],
       args: Seq[Val]
   )(using pos: nir.Position, buf: ExprBuffer): Val = {
@@ -204,7 +204,7 @@ trait GenReflectiveInstantisation(using Context) {
   }
 
   private def genModuleLoader(
-      fqSymName: Global
+      fqSymName: Global.Top
   )(using
       pos: nir.Position,
       buf: ExprBuffer,

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -45,7 +45,7 @@ trait NirGenName(using Context) {
     else Global.Top(typeName.id + "$")
   }
 
-  def genFieldName(sym: Symbol): nir.Global = {
+  def genFieldName(sym: Symbol): nir.Global.Member = {
     val owner =
       if (sym.isScalaStatic) genModuleName(sym.owner)
       else genTypeName(sym.owner)
@@ -65,7 +65,7 @@ trait NirGenName(using Context) {
     }
   }
 
-  def genMethodName(sym: Symbol): nir.Global = {
+  def genMethodName(sym: Symbol): nir.Global.Member = {
     def owner = genTypeName(sym.owner)
     def id = nativeIdOf(sym)
     def scope =
@@ -82,7 +82,7 @@ trait NirGenName(using Context) {
     if (sym == defn.`String_+`) genMethodName(defnNir.String_concat)
     else if (sym.isExtern) owner.member(genExternSigImpl(sym, id))
     else if (sym.isClassConstructor) owner.member(nir.Sig.Ctor(paramTypes))
-    else if (sym.isStaticConstructor) owner.member(nir.Sig.Clinit())
+    else if (sym.isStaticConstructor) owner.member(nir.Sig.Clinit)
     else if (sym.name == nme.TRAIT_CONSTRUCTOR)
       owner.member(nir.Sig.Method(id, Seq(nir.Type.Unit), scope))
     else
@@ -99,7 +99,7 @@ trait NirGenName(using Context) {
       nir.Sig.Extern(id)
     else nir.Sig.Extern(id)
 
-  def genStaticMemberName(sym: Symbol, explicitOwner: Symbol): Global = {
+  def genStaticMemberName(sym: Symbol, explicitOwner: Symbol): Global.Member = {
     val owner = {
       // Use explicit owner in case if forwarder target was defined in the trait/interface
       // or was abstract. `sym.owner` would always point to original owner, even if it also defined

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -82,7 +82,7 @@ trait NirGenStat(using Context) {
     Attrs.fromSeq(annotationAttrs ++ isAbstract)
   }
 
-  private def genClassParent(sym: ClassSymbol): Option[nir.Global] = {
+  private def genClassParent(sym: ClassSymbol): Option[nir.Global.Top] = {
     if sym.isExternType && sym.superClass != defn.ObjectClass then
       report.error("Extern object can only extend extern traits", sym.sourcePos)
 
@@ -94,7 +94,7 @@ trait NirGenStat(using Context) {
     }
   }
 
-  private def genClassInterfaces(sym: ClassSymbol): Seq[nir.Global] = {
+  private def genClassInterfaces(sym: ClassSymbol): Seq[nir.Global.Top] = {
     val isExtern = sym.isExternType
     def validate(clsSym: ClassSymbol) = {
       val parentIsExtern = clsSym.isExternType
@@ -428,7 +428,7 @@ trait NirGenStat(using Context) {
       )
   }
 
-  protected def genLinktimeResolved(dd: DefDef, name: Global)(using
+  protected def genLinktimeResolved(dd: DefDef, name: Global.Member)(using
       nir.Position
   ): Option[Defn] = {
     if (dd.symbol.isField) {
@@ -509,7 +509,7 @@ trait NirGenStat(using Context) {
   private def genLinktimeResolvedMethod(
       dd: DefDef,
       retty: nir.Type,
-      methodName: nir.Global
+      methodName: nir.Global.Member
   )(genValue: ExprBuffer => nir.Val)(using nir.Position): nir.Defn = {
     implicit val fresh: Fresh = Fresh()
     val freshScopes = initFreshScope(dd.rhs)
@@ -540,7 +540,7 @@ trait NirGenStat(using Context) {
 
   def genExternMethod(
       attrs: nir.Attrs,
-      name: nir.Global,
+      name: nir.Global.Member,
       origSig: nir.Type,
       dd: DefDef
   ): Option[Defn] = {

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -93,7 +93,7 @@ final class Check(implicit linked: linker.Result) extends NIRCheck {
     }
   }
   override def checkMethod(meth: Method): Unit = {
-    val Type.Function(_, methRetty) = meth.ty: @unchecked
+    val Type.Function(_, methRetty) = meth.ty
     retty = methRetty
 
     val insts = meth.insts
@@ -177,12 +177,7 @@ final class Check(implicit linked: linker.Result) extends NIRCheck {
   def checkOp(op: Op): Unit = op match {
     case Op.Call(ty, ptr, args) =>
       expect(Type.Ptr, ptr)
-      ty match {
-        case ty: Type.Function =>
-          checkCallArgs(ty, args)
-        case _ =>
-          error("call type must be a function type")
-      }
+      checkCallArgs(ty, args)
     case Op.Load(ty, ptr, _) =>
       expect(Type.Ptr, ptr)
     case Op.Store(ty, ptr, value, _) =>

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -11,7 +11,7 @@ object GenerateReflectiveProxies {
 
   private def genReflProxy(defn: Defn.Define): Defn.Define = {
     implicit val fresh: Fresh = Fresh()
-    val Global.Member(owner, sig) = defn.name: @unchecked
+    val Global.Member(owner, sig) = defn.name
     val defnType = defn.ty.asInstanceOf[Type.Function]
     implicit val pos: Position = defn.pos
 

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -6,13 +6,14 @@ import scalanative.linker.{Trait, Class}
 
 class HasTraitTables(meta: Metadata) {
   private implicit val pos: Position = Position.NoPosition
-
-  private val classHasTraitName = Global.Top("__class_has_trait")
+  def generated(id: String): Global.Member =
+    Global.Top("__scalanative_metadata").member(Sig.Generated(id))
+  private val classHasTraitName = generated("__class_has_trait")
   val classHasTraitVal = Val.Global(classHasTraitName, Type.Ptr)
   var classHasTraitTy: Type = _
   var classHasTraitDefn: Defn = _
 
-  private val traitHasTraitName = Global.Top("__trait_has_trait")
+  private val traitHasTraitName = generated("__trait_has_trait")
   val traitHasTraitVal = Val.Global(traitHasTraitName, Type.Ptr)
   var traitHasTraitTy: Type = _
   var traitHasTraitDefn: Defn = _

--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -155,7 +155,7 @@ private[scalanative] object ResourceEmbedder {
     generated
   }
 
-  private def extern(id: String): Global =
+  private def extern(id: String): Global.Member =
     Global.Member(Global.Top("__"), Sig.Extern(id))
 
   private val sourceExtensions =

--- a/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
@@ -7,7 +7,7 @@ import scalanative.linker.{ScopeInfo, Class, Trait}
 
 class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
   import RuntimeTypeInformation._
-  val name: Global = info.name.member(Sig.Generated("type"))
+  val name: Global.Member = info.name.member(Sig.Generated("type"))
   val const: Val.Global = Val.Global(name, Type.Ptr)
   val struct: Type.StructValue = info match {
     case cls: Class =>

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -6,7 +6,8 @@ import scalanative.nir._
 import scalanative.linker.{Method, Trait, Class}
 
 class TraitDispatchTable(meta: Metadata) {
-  val dispatchName = Global.Top("__dispatch")
+  val dispatchName =
+    Global.Top("__scalanative_metadata").member(Sig.Generated("dispatch_table"))
   val dispatchVal = Val.Global(dispatchName, Type.Ptr)
   var dispatchTy: Type = _
   var dispatchDefn: Defn = _

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -161,7 +161,7 @@ trait Eval { self: Interflow =>
           }
 
           val (dsig, dtarget) = emeth match {
-            case Val.Global(name, _) =>
+            case Val.Global(name: Global.Member, _) =>
               visitDuplicate(name, argtys)
                 .map { defn => (defn.ty, Val.Global(defn.name, Type.Ptr)) }
                 .getOrElse {
@@ -180,7 +180,8 @@ trait Eval { self: Interflow =>
           }
 
           dtarget match {
-            case Val.Global(name, _) if shallInline(name, eargs) =>
+            case Val.Global(name: Global.Member, _)
+                if shallInline(name, eargs) =>
               `inline`(name, eargs)
             case DelayedRef(op: Op.Method) if shallPolyInline(op, eargs) =>
               polyInline(op, eargs)
@@ -190,7 +191,8 @@ trait Eval { self: Interflow =>
         }
 
         emeth match {
-          case Val.Global(name, _) if intrinsics.contains(name) =>
+          case Val.Global(name: Global.Member, _)
+              if intrinsics.contains(name) =>
             intrinsic(sig, name, args).getOrElse {
               nonIntrinsic
             }
@@ -987,7 +989,7 @@ trait Eval { self: Interflow =>
         state.derefEscaped(addr).escapedValue
       case Val.String(value) =>
         Val.Virtual(state.allocString(value))
-      case Val.Global(name, _) =>
+      case Val.Global(name: Global.Member, _) =>
         maybeOriginal(name).foreach {
           case defn if defn.attrs.isExtern =>
             visitRoot(defn.name)
@@ -1008,10 +1010,10 @@ trait Eval { self: Interflow =>
     offset >= 0 && offset < length
   }
 
-  private def isPureModule(clsName: Global): Boolean = {
-    var visiting = List[Global]()
+  private def isPureModule(clsName: Global.Top): Boolean = {
+    var visiting = List[Global.Top]()
 
-    def isPureModule(clsName: Global): Boolean = {
+    def isPureModule(clsName: Global.Top): Boolean = {
       if (hasModulePurity(clsName)) {
         getModulePurity(clsName)
       } else {

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -17,7 +17,7 @@ trait Inline { self: Interflow =>
   private val maxInlineDepth =
     config.compilerConfig.optimizerConfig.maxInlineDepth
 
-  def shallInline(name: Global, args: Seq[Val])(implicit
+  def shallInline(name: Global.Member, args: Seq[Val])(implicit
       state: State,
       linked: linker.Result
   ): Boolean = {
@@ -131,12 +131,12 @@ trait Inline { self: Interflow =>
     }
   }
 
-  def adapt(args: Seq[Val], sig: Type)(implicit
+  def adapt(args: Seq[Val], sig: Type.Function)(implicit
       state: State,
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
   ): Seq[Val] = {
-    val Type.Function(argtys, _) = sig: @unchecked
+    val Type.Function(argtys, _) = sig
 
     // Varargs signature might appear to have less
     // argument types than arguments at the call site.
@@ -157,7 +157,7 @@ trait Inline { self: Interflow =>
     }
   }
 
-  def `inline`(name: Global, args: Seq[Val])(implicit
+  def `inline`(name: Global.Member, args: Seq[Val])(implicit
       state: State,
       linked: linker.Result,
       parentScopeId: ScopeId
@@ -167,7 +167,7 @@ trait Inline { self: Interflow =>
         case build.Mode.Debug      => getOriginal(name)
         case _: build.Mode.Release => getDone(name)
       }
-      val Type.Function(_, origRetTy) = defn.ty: @unchecked
+      val Type.Function(_, origRetTy) = defn.ty
 
       implicit val srcPosition: nir.Position = defn.pos
       val blocks = process(
@@ -263,7 +263,7 @@ trait Inline { self: Interflow =>
       state.emit ++= emit
       state.inherit(endState, res +: args)
 
-      val Type.Function(_, retty) = defn.ty: @unchecked
+      val Type.Function(_, retty) = defn.ty
       adapt(res, retty)
     }
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -29,12 +29,12 @@ class Interflow(val config: build.Config)(implicit
     out
   }
 
-  private val todo = mutable.Queue.empty[Global]
-  private val done = mutable.Map.empty[Global, Defn.Define]
-  private val started = mutable.Set.empty[Global]
-  private val blacklist = mutable.Set.empty[Global]
-  private val reached = mutable.HashSet.empty[Global]
-  private val modulePurity = mutable.Map.empty[Global, Boolean]
+  private val todo = mutable.Queue.empty[Global.Member]
+  private val done = mutable.Map.empty[Global.Member, Defn.Define]
+  private val started = mutable.Set.empty[Global.Member]
+  private val blacklist = mutable.Set.empty[Global.Member]
+  private val reached = mutable.HashSet.empty[Global.Member]
+  private val modulePurity = mutable.Map.empty[Global.Top, Boolean]
 
   def currentFreshScope = freshScopeTl.get()
   private val freshScopeTl =
@@ -52,11 +52,11 @@ class Interflow(val config: build.Config)(implicit
   private val blockFreshTl =
     ThreadLocal.withInitial(() => List.empty[Fresh])
 
-  def hasOriginal(name: Global): Boolean =
+  def hasOriginal(name: Global.Member): Boolean =
     originals.contains(name) && originals(name).isInstanceOf[Defn.Define]
-  def getOriginal(name: Global): Defn.Define =
+  def getOriginal(name: Global.Member): Defn.Define =
     originals(name).asInstanceOf[Defn.Define]
-  def maybeOriginal(name: Global): Option[Defn.Define] =
+  def maybeOriginal(name: Global.Member): Option[Defn.Define] =
     originals.get(name).collect { case defn: Defn.Define => defn }
 
   def popTodo(): Global =
@@ -67,63 +67,62 @@ class Interflow(val config: build.Config)(implicit
         todo.dequeue()
       }
     }
-  def pushTodo(name: Global): Unit =
+  def pushTodo(name: Global.Member): Unit =
     todo.synchronized {
-      assert(name ne Global.None)
       if (!reached.contains(name)) {
         todo.enqueue(name)
         reached += name
       }
     }
-  def allTodo(): Seq[Global] =
+  def allTodo(): Seq[Global.Member] =
     todo.synchronized {
       todo.toSeq
     }
 
-  def isDone(name: Global): Boolean =
+  def isDone(name: Global.Member): Boolean =
     done.synchronized {
       done.contains(name)
     }
-  def setDone(name: Global, value: Defn.Define) =
+  def setDone(name: Global.Member, value: Defn.Define) =
     done.synchronized {
       done(name) = value
     }
-  def getDone(name: Global): Defn.Define =
+  def getDone(name: Global.Member): Defn.Define =
     done.synchronized {
       done(name)
     }
-  def maybeDone(name: Global): Option[Defn.Define] =
+  def maybeDone(name: Global.Member): Option[Defn.Define] =
     done.synchronized {
       done.get(name)
     }
 
-  def hasStarted(name: Global): Boolean =
+  def hasStarted(name: Global.Member): Boolean =
     started.synchronized {
       started.contains(name)
     }
-  def markStarted(name: Global): Unit =
+  def markStarted(name: Global.Member): Unit =
     started.synchronized {
       started += name
     }
 
-  def isBlacklisted(name: Global): Boolean =
+  def isBlacklisted(name: Global.Member): Boolean =
     blacklist.synchronized {
       blacklist.contains(name)
     }
-  def markBlacklisted(name: Global): Unit =
+  def markBlacklisted(name: Global.Member): Unit =
     blacklist.synchronized {
       blacklist += name
     }
 
-  def hasModulePurity(name: Global): Boolean =
+  def hasModulePurity(name: Global.Top): Boolean =
     modulePurity.synchronized {
       modulePurity.contains(name)
     }
-  def setModulePurity(name: Global, value: Boolean): Unit =
+  def setModulePurity(name: Global.Top, value: Boolean): Unit =
     modulePurity.synchronized {
       modulePurity(name) = value
     }
-  def getModulePurity(name: Global): Boolean =
+  def getModulePurity(name: Global.Top): Boolean =
     modulePurity.synchronized {
       modulePurity(name)
     }

--- a/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
@@ -31,12 +31,13 @@ trait Intrinsics { self: Interflow =>
     Global.Member(Rt.Runtime.name, Rt.ToRawPtrSig)
   ) ++ arrayIntrinsics
 
-  def intrinsic(ty: Type, name: Global, rawArgs: Seq[Val])(implicit
+  def intrinsic(ty: Type.Function, name: Global.Member, rawArgs: Seq[Val])(
+      implicit
       state: State,
       srcPosition: Position,
       scopeId: ScopeId
   ): Option[Val] = {
-    val Global.Member(_, sig) = name: @unchecked
+    val Global.Member(_, sig) = name
 
     val args = rawArgs.map(eval)
 
@@ -66,7 +67,7 @@ trait Intrinsics { self: Interflow =>
         }
       case Rt.IsArraySig =>
         args match {
-          case Seq(Val.Global(clsName, ty)) if ty == Rt.Class =>
+          case Seq(Val.Global(clsName: Global.Top, ty)) if ty == Rt.Class =>
             Some(Val.Bool(Type.isArray(clsName)))
           case _ =>
             None
@@ -146,7 +147,7 @@ trait Intrinsics { self: Interflow =>
         }
       case _ if arrayApplyIntrinsics.contains(name) =>
         val Seq(arr, idx) = rawArgs
-        val Type.Function(_, elemty) = ty: @unchecked
+        val Type.Function(_, elemty) = ty
         Some(eval(Op.Arrayload(elemty, arr, idx)))
       case _ if arrayUpdateIntrinsics.contains(name) =>
         val Seq(arr, idx, value) = rawArgs

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -9,7 +9,7 @@ import scala.scalanative.util.ScopedVar.scoped
 
 trait Opt { self: Interflow =>
 
-  def shallOpt(name: Global): Boolean = {
+  def shallOpt(name: Global.Member): Boolean = {
     val defn =
       getOriginal(originalName(name))
     val noUnwind = defn.insts.forall {
@@ -22,7 +22,7 @@ trait Opt { self: Interflow =>
     defn.attrs.opt != Attr.NoOpt && noUnwind
   }
 
-  def opt(name: Global): Defn.Define = in(s"visit ${name.show}") {
+  def opt(name: Global.Member): Defn.Define = in(s"visit ${name.show}") {
     val orig = originalName(name)
     val origtys = argumentTypes(orig)
     val origdefn = getOriginal(orig)
@@ -50,7 +50,7 @@ trait Opt { self: Interflow =>
     // Interflow usually infers better types on our erased type system
     // than scalac, yet we live it as a benefit of the doubt and make sure
     // that if original return type is more specific, we keep it as is.
-    val Type.Function(_, origRetTy) = origdefn.ty: @unchecked
+    val Type.Function(_, origRetTy) = origdefn.ty
 
     // Compute opaque fresh locals for the arguments. Argument types
     // are always a subtype of the original declared type, but in

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -8,7 +8,7 @@ import scalanative.linker._
 trait PolyInline { self: Interflow =>
   private def polyTargets(
       op: Op.Method
-  )(implicit state: State): Seq[(Class, Global)] = {
+  )(implicit state: State): Seq[(Class, Global.Member)] = {
     val Op.Method(obj, sig) = op
 
     val objty = obj match {
@@ -24,7 +24,7 @@ trait PolyInline { self: Interflow =>
       case ClassRef(cls) if !sig.isVirtual =>
         cls.resolve(sig).map(g => (cls, g)).toSeq
       case ScopeRef(scope) =>
-        val targets = mutable.UnrolledBuffer.empty[(Class, Global)]
+        val targets = mutable.UnrolledBuffer.empty[(Class, Global.Member)]
         scope.implementors.foreach { cls =>
           if (cls.allocated) {
             cls.resolve(sig).foreach { g => targets += ((cls, g)) }
@@ -117,7 +117,7 @@ trait PolyInline { self: Interflow =>
       case (callLabel, m) =>
         emit.label(callLabel, Seq.empty)
         val ty = originalFunctionType(m)
-        val Type.Function(argtys, retty) = ty: @unchecked
+        val Type.Function(argtys, retty) = ty
         rettys += retty
 
         val cargs = margs.zip(argtys).map {

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -114,15 +114,12 @@ trait LinktimeValueResolver { self: Reach =>
 
     def canBeEvauluated =
       !defn.insts.exists(isRuntimeOnly) && {
-        defn.ty match {
-          case Type.Function(_, retty) =>
-            retty match {
-              case _: Type.ValueKind    => true
-              case Type.Ref(name, _, _) => name == Rt.String.name
-              case Type.Null            => true
-              case _                    => false
-            }
-          case _ => false
+        val Type.Function(_, retty) = defn.ty
+        retty match {
+          case _: Type.ValueKind    => true
+          case Type.Ref(name, _, _) => name == Rt.String.name
+          case Type.Null            => true
+          case _                    => false
         }
       }
 

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -14,7 +14,7 @@ class Reach(
   import Reach._
 
   val unavailable = mutable.Set.empty[Global]
-  val loaded = mutable.Map.empty[Global, mutable.Map[Global, Defn]]
+  val loaded = mutable.Map.empty[Global.Top, mutable.Map[Global, Defn]]
   val enqueued = mutable.Set.empty[Global]
   var todo = List.empty[Global]
   val done = mutable.Map.empty[Global, Defn]
@@ -24,9 +24,9 @@ class Reach(
   val from = mutable.Map.empty[Global, Global]
   val missing = mutable.Map.empty[Global, Set[NonReachablePosition]]
 
-  val dyncandidates = mutable.Map.empty[Sig, mutable.Set[Global]]
+  val dyncandidates = mutable.Map.empty[Sig, mutable.Set[Global.Member]]
   val dynsigs = mutable.Set.empty[Sig]
-  val dynimpls = mutable.Set.empty[Global]
+  val dynimpls = mutable.Set.empty[Global.Member]
 
   private case class DelayedMethod(owner: Global.Top, sig: Sig, pos: Position)
   private val delayedMethods = mutable.Set.empty[DelayedMethod]
@@ -260,17 +260,18 @@ class Reach(
     }
   }
 
-  def reachClinit(name: Global): Unit = {
+  def reachClinit(name: Global.Top): Unit = {
     reachGlobalNow(name)
-    infos.get(name).foreach { cls =>
-      val clinit = cls.name.member(Sig.Clinit())
-      if (loaded(cls.name).contains(clinit)) {
-        reachGlobal(clinit)
-      }
+    infos.get(name).collect {
+      case cls: ScopeInfo =>
+        val clinit = cls.name.member(Sig.Clinit)
+        if (loaded(cls.name).contains(clinit)) {
+          reachGlobal(clinit)
+        }
     }
   }
 
-  def reachExported(name: Global): Unit = {
+  def reachExported(name: Global.Top): Unit = {
     def isExported(defn: Defn) = defn match {
       case Defn.Define(attrs, Global.Member(_, sig), _, _, _) =>
         attrs.isExtern || sig.isExtern
@@ -278,7 +279,7 @@ class Reach(
     }
 
     for {
-      cls <- infos.get(name)
+      cls <- infos.get(name).collect { case info: ScopeInfo => info }
       defns <- loaded.get(cls.name)
       (name, defn) <- defns
     } if (isExported(defn)) reachGlobal(name)
@@ -334,7 +335,7 @@ class Reach(
         }
         loaded(info.name).foreach {
           case (_, defn: Defn.Define) =>
-            val Global.Member(_, sig) = defn.name: @unchecked
+            val Global.Member(_, sig) = defn.name
             info.responds(sig) = defn.name
           case _ =>
             ()
@@ -366,7 +367,7 @@ class Reach(
         }
         loaded(info.name).foreach {
           case (_, defn: Defn.Define) =>
-            val Global.Member(_, sig) = defn.name: @unchecked
+            val Global.Member(_, sig) = defn.name
             def update(sig: Sig): Unit = {
               info.responds(sig) = lookup(info, sig)
                 .getOrElse(
@@ -444,7 +445,10 @@ class Reach(
           val dynsig = sig.toProxy
           if (!dynsigs.contains(dynsig)) {
             val buf =
-              dyncandidates.getOrElseUpdate(dynsig, mutable.Set.empty[Global])
+              dyncandidates.getOrElseUpdate(
+                dynsig,
+                mutable.Set.empty[Global.Member]
+              )
             buf += impl
           } else {
             dynimpls += impl
@@ -461,7 +465,7 @@ class Reach(
       }
     }
 
-  def scopeInfo(name: Global): Option[ScopeInfo] = {
+  def scopeInfo(name: Global.Top): Option[ScopeInfo] = {
     reachGlobalNow(name)
     infos(name) match {
       case info: ScopeInfo => Some(info)
@@ -469,7 +473,7 @@ class Reach(
     }
   }
 
-  def scopeInfoOrUnavailable(name: Global): Info = {
+  def scopeInfoOrUnavailable(name: Global.Top): Info = {
     reachGlobalNow(name)
     infos(name) match {
       case info: ScopeInfo   => info
@@ -478,7 +482,7 @@ class Reach(
     }
   }
 
-  def classInfo(name: Global): Option[Class] = {
+  def classInfo(name: Global.Top): Option[Class] = {
     reachGlobalNow(name)
     infos(name) match {
       case info: Class => Some(info)
@@ -486,12 +490,12 @@ class Reach(
     }
   }
 
-  def classInfoOrObject(name: Global): Class =
+  def classInfoOrObject(name: Global.Top): Class =
     classInfo(name)
       .orElse(classInfo(Rt.Object.name))
       .getOrElse(fail(s"Class info not available for $name"))
 
-  def traitInfo(name: Global): Option[Trait] = {
+  def traitInfo(name: Global.Top): Option[Trait] = {
     reachGlobalNow(name)
     infos(name) match {
       case info: Trait => Some(info)
@@ -930,10 +934,10 @@ class Reach(
     }
   }
 
-  def lookup(cls: Class, sig: Sig): Option[Global] = {
+  def lookup(cls: Class, sig: Sig): Option[Global.Member] = {
     assert(loaded.contains(cls.name))
 
-    def lookupSig(cls: Class, sig: Sig): Option[Global] = {
+    def lookupSig(cls: Class, sig: Sig): Option[Global.Member] = {
       val tryMember = cls.name.member(sig)
       if (loaded(cls.name).contains(tryMember)) {
         Some(tryMember)

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -16,10 +16,10 @@ import scala.scalanative.buildinfo.ScalaNativeBuildInfo
 
 trait ReachabilitySuite {
 
-  def g(top: String): Global =
+  def g(top: String): Global.Top =
     Global.Top(top)
 
-  def g(top: String, sig: Sig): Global =
+  def g(top: String, sig: Sig): Global.Member =
     Global.Member(Global.Top(top), sig)
 
   private val MainMethodDependencies = Set(

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -18,7 +18,7 @@ class TraitReachabilitySuite extends ReachabilitySuite {
   val ScalaMainNonStaticSig =
     Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.Public)
 
-  val Parent: Global = g(ParentClsName)
+  val Parent: Global.Top = g(ParentClsName)
   // Scala 2.12.x
   val ParentInit: Global =
     g(ParentClsName, Sig.Method("$init$", Seq(Type.Unit)))

--- a/util/src/main/scala/scala/scalanative/util/TypeOps.scala
+++ b/util/src/main/scala/scala/scalanative/util/TypeOps.scala
@@ -1,0 +1,12 @@
+package scala.scalanative.util
+
+private[scalanative] object TypeOps {
+  implicit class TypeNarrowing[T](val value: T) extends AnyVal {
+    def narrow[S <: T](implicit classTag: scala.reflect.ClassTag[S]): S =
+      if (classTag.runtimeClass.isInstance(value)) value.asInstanceOf[S]
+      else
+        throw new IllegalStateException(
+          s"Unexpected instance of ${value.getClass().getSimpleName()} where type of ${classTag.runtimeClass.getSimpleName()} was expected"
+        )
+  }
+}


### PR DESCRIPTION
Changes to expected types of Global, Type to more narrow type if possible. This would allow to eliminate some of errors that could be catched at compile time. 
Also Sig.Clint was changed from empty parameter list case class to case object