### PR TITLE
Better backtrace in classloading for unreachable symbols

### DIFF
--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
@@ -15,7 +15,7 @@ import _root_.sbt.testing._
 import java.net.URLClassLoader
 import java.io.File
 import scala.scalanative.build.Build
-import scala.scalanative.linker.Result
+import scala.scalanative.linker.ReachabilityAnalysis
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -150,7 +150,7 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
       }
 
     import scala.collection.mutable
-    val linkerResult = new Result(
+    val analysis = new ReachabilityAnalysis.Result(
       infos = mutable.Map.empty,
       entries = Nil,
       unavailable = Nil,

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
@@ -153,8 +153,6 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
     val analysis = new ReachabilityAnalysis.Result(
       infos = mutable.Map.empty,
       entries = Nil,
-      unavailable = Nil,
-      referencedFrom = mutable.Map.empty,
       links = Defaults.links,
       defns = Nil,
       dynsigs = Nil,
@@ -162,7 +160,7 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
       resolvedVals = mutable.Map.empty
     )
 
-    val build = Build.findAndCompileNativeLibs(config, linkerResult)
+    val build = Build.findAndCompileNativeLibs(config, analysis)
     Await.result(build, Duration.Inf)
   }
 }

--- a/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/testinterface/LinkerBench.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/testinterface/LinkerBench.scala
@@ -42,7 +42,6 @@ class LinkerBench {
 
     val entries = build.ScalaNative.entries(config)
     val link = build.ScalaNative.link(config, entries)
-    val linked = Await.result(link, Duration.Inf)
-    assert(linked.unavailable.size == 0)
+    Await.result(link, Duration.Inf)
   }
 }

--- a/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/testinterface/OptimizerBench.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/testinterface/OptimizerBench.scala
@@ -12,6 +12,7 @@ import scala.scalanative.build._
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.scalanative.linker.ReachabilityAnalysis
 
 @Fork(1)
 @State(Scope.Benchmark)
@@ -21,7 +22,7 @@ import scala.concurrent.duration._
 @Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
 abstract class OptimizerBench(mode: build.Mode) {
   var config: Config = _
-  var linked: linker.Result = _
+  var analysis: ReachabilityAnalysis.Result = _
 
   @Setup(Level.Trial)
   def setup(): Unit = {
@@ -33,7 +34,7 @@ abstract class OptimizerBench(mode: build.Mode) {
 
     val entries = build.ScalaNative.entries(config)
     util.Scope { implicit scope =>
-      linked = Await.result(
+      analysis = Await.result(
         ScalaNative.link(config, entries),
         Duration.Inf
       )
@@ -47,19 +48,19 @@ abstract class OptimizerBench(mode: build.Mode) {
       .walk(workdir)
       .sorted(Comparator.reverseOrder())
       .forEach(Files.delete)
-    linked = null
+    analysis = null
     config = null
   }
 
   @Benchmark
   def optimize(): Unit = {
-    val optimize = ScalaNative.optimize(config, linked)
+    val optimize = ScalaNative.optimize(config, analysis)
     val optimized = Await.result(optimize, Duration.Inf)
-    assert(optimized.unavailable.size == 0)
   }
 }
 
 class OptimizeDebug extends OptimizerBench(build.Mode.debug)
 class OptimizeReleaseFast extends OptimizerBench(build.Mode.releaseFast)
+
 // Commented out becouse of long build times ~13 min
 // class OptimizeReleaseFull extends OptimizerBench(build.Mode.releaseFull)

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Files, Path, Paths}
 
 import scalanative.build.IO.RichPath
 import scalanative.build.NativeLib._
+import scala.scalanative.linker.ReachabilityAnalysis
 
 private[scalanative] object Filter {
 
@@ -27,7 +28,7 @@ private[scalanative] object Filter {
    */
   def filterNativelib(
       config: Config,
-      linkerResult: linker.Result,
+      analysis: ReachabilityAnalysis.Result,
       destPath: Path,
       allPaths: Seq[Path]
   ): (Seq[Path], Config) = {
@@ -43,7 +44,7 @@ private[scalanative] object Filter {
       def include(path: String) = {
         if (path.contains(optPath)) {
           val name = Paths.get(path).toFile.getName.split("\\.").head
-          linkerResult.links.exists(_.name == name)
+          analysis.links.exists(_.name == name)
         } else {
           true
         }

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -6,6 +6,7 @@ import java.nio.file.{Files, Path}
 import java.util.Arrays
 import java.util.regex._
 import scala.concurrent._
+import scala.scalanative.linker.ReachabilityAnalysis
 
 /** Original jar or dir path and generated dir path for native code */
 private[scalanative] case class NativeLib(src: Path, dest: Path)
@@ -30,13 +31,13 @@ private[scalanative] object NativeLib {
    */
   def compileNativeLibrary(
       config: Config,
-      linkerResult: linker.Result,
+      analysis: ReachabilityAnalysis.Result,
       nativeLib: NativeLib
   )(implicit ec: ExecutionContext): Future[Seq[Path]] = {
     val destPath = NativeLib.unpackNativeCode(nativeLib)
     val paths = NativeLib.findNativePaths(config.workDir, destPath)
     val (projPaths, projConfig) =
-      Filter.filterNativelib(config, linkerResult, destPath, paths)
+      Filter.filterNativelib(config, analysis, destPath, paths)
     LLVM.compile(projConfig, projPaths)
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -7,11 +7,12 @@ import scala.scalanative.checker.Check
 import scala.scalanative.codegen.PlatformInfo
 import scala.scalanative.codegen.llvm.CodeGen
 import scala.scalanative.interflow.Interflow
-import scala.scalanative.linker.Link
+import scala.scalanative.linker.{ReachabilityAnalysis, Reach, Link}
 import scala.scalanative.nir._
 import scala.scalanative.util.Scope
 import scala.concurrent._
 import scala.util.Success
+import scala.scalanative.linker.LinkingException
 
 /** Internal utilities to instrument Scala Native linker, optimizer and codegen.
  */
@@ -32,75 +33,117 @@ private[scalanative] object ScalaNative {
   def link(config: Config, entries: Seq[Global])(implicit
       scope: Scope,
       ec: ExecutionContext
-  ): Future[linker.Result] =
-    check(config, forceQuickCheck = true) {
-      val mtSupport = config.compilerConfig.multithreadingSupport.toString()
-      val linkingMsg = s"Linking (multithreading ${mtSupport})"
-      config.logger.time(linkingMsg) {
-        Link(config, entries)
-      }
-    }.andThen {
-      case Success(result) =>
-        dumpDefns(config, "linked", result.defns)
+  ): Future[ReachabilityAnalysis.Result] = withReachabilityPostprocessing(
+    config,
+    stage = "classloading",
+    dumpFile = "linked",
+    forceQuickCheck = true
+  )(Future {
+    val mtSupport = config.compilerConfig.multithreadingSupport.toString()
+    val linkingMsg = s"Linking (multithreading ${mtSupport})"
+    config.logger.time(linkingMsg) {
+      Link(config, entries)
     }
-
-  /** Show linked universe stats or fail with missing symbols. */
-  def logLinked(config: Config, linked: linker.Result): Unit = {
-    def showLinkingErrors(): Nothing = {
-      config.logger.error("missing symbols:")
-      linked.unavailable.sortBy(_.show).foreach { name =>
-        config.logger.error("* " + name.mangle)
-        val from = linked.referencedFrom
-        var current = from(name)
-        while (from.contains(current) && current != Global.None) {
-          config.logger.error("  - from " + current.mangle)
-          current = from(current)
-        }
-      }
-      throw new BuildException("unable to link")
-    }
-
-    def showStats(): Unit = {
-      val classCount = linked.defns.count {
-        case _: nir.Defn.Class | _: nir.Defn.Module => true
-        case _                                      => false
-      }
-      val methodCount = linked.defns.count(_.isInstanceOf[nir.Defn.Define])
-      config.logger.info(
-        s"Discovered ${classCount} classes and ${methodCount} methods"
-      )
-    }
-
-    if (linked.unavailable.nonEmpty) {
-      showLinkingErrors()
-    } else {
-      showStats()
-    }
-  }
+  })
 
   /** Optimizer high-level NIR under closed-world assumption. */
-  def optimize(config: Config, linked: linker.Result)(implicit
+  def optimize(config: Config, analysis: ReachabilityAnalysis.Result)(implicit
       ec: ExecutionContext
-  ): Future[linker.Result] = {
+  ): Future[ReachabilityAnalysis.Result] = {
     import config.logger
     if (config.compilerConfig.optimize)
       logger.timeAsync(s"Optimizing (${config.mode} mode)") {
-        Interflow
-          .optimize(config, linked)
-          .map(Link(config, linked.entries, _))
-          .andThen {
-            case Success(result) => dumpDefns(config, "optimized", result.defns)
-          }
-          .flatMap(check(config)(_))
+        withReachabilityPostprocessing(
+          config,
+          stage = "optimization",
+          dumpFile = "optimized",
+          forceQuickCheck = false
+        ) {
+          Interflow
+            .optimize(config, analysis)
+            .map(Link(config, analysis.entries, _))
+        }
       }
     else {
       logger.info("Optimizing skipped")
-      Future.successful(linked)
+      Future.successful(analysis)
+    }
+  }
+
+  private def withReachabilityPostprocessing(
+      config: Config,
+      stage: String,
+      dumpFile: String,
+      forceQuickCheck: Boolean
+  )(
+      analysis: Future[ReachabilityAnalysis]
+  )(implicit ec: ExecutionContext): Future[ReachabilityAnalysis.Result] = {
+    analysis
+      .andThen {
+        case Success(result) => dumpDefns(config, dumpFile, result.defns)
+      }
+      .andThen {
+        case Success(result) => logLinked(config, result, stage)
+      }
+      .flatMap {
+        case result: ReachabilityAnalysis.Result =>
+          check(config, forceQuickCheck = forceQuickCheck)(result)
+        case result: ReachabilityAnalysis.UnreachableSymbolsFound =>
+          Future.failed(
+            new LinkingException(s"Unreachable symbols found after $stage")
+          )
+      }
+  }
+
+  /** Show linked universe stats or fail with missing symbols. */
+  private[scalanative] def logLinked(
+      config: Config,
+      analysis: ReachabilityAnalysis,
+      stage: String
+  ): Unit = {
+    def showUnreachable(
+        analysis: ReachabilityAnalysis.UnreachableSymbolsFound
+    ): Unit = {
+      val log = config.logger
+      log.error(s"Found ${analysis.unavailable.size} unreachable symbols")
+      analysis.unavailable.foreach {
+        case Reach.UnreachableSymbol(_, kind, name, backtrace) =>
+          // Build stacktrace in memory to prevent its spliting when logging asynchronously
+          val buf = new StringBuilder()
+          buf.append(s"Found unknown $kind $name, referenced from:\n")
+          val padding = backtrace.foldLeft(0)(_ max _.kind.length())
+          backtrace.foreach {
+            case Reach.BackTraceElement(_, kind, name, filename, line) =>
+              val pad = " " * (padding - kind.length())
+              buf.append(s"    $pad$kind at $name($filename:$line)\n")
+          }
+          buf.append("\n")
+          log.error(buf.toString())
+      }
+    }
+
+    def showStats(): Unit = {
+      val classCount = analysis.defns.count {
+        case _: nir.Defn.Class | _: nir.Defn.Module => true
+        case _                                      => false
+      }
+      val methodCount = analysis.defns.count(_.isInstanceOf[nir.Defn.Define])
+      config.logger.info(
+        s"Discovered ${classCount} classes and ${methodCount} methods after $stage"
+      )
+    }
+
+    analysis match {
+      case result: ReachabilityAnalysis.UnreachableSymbolsFound =>
+        showStats()
+        showUnreachable(result)
+      case _ =>
+        showStats()
     }
   }
 
   /** Given low-level assembly, emit LLVM IR for it to the buildDirectory. */
-  def codegen(config: Config, linked: linker.Result)(implicit
+  def codegen(config: Config, analysis: ReachabilityAnalysis.Result)(implicit
       ec: ExecutionContext
   ): Future[Seq[Path]] = {
     val withMetadata =
@@ -108,7 +151,7 @@ private[scalanative] object ScalaNative {
       else ""
 
     config.logger.timeAsync(s"Generating intermediate code$withMetadata") {
-      CodeGen(config, linked)
+      CodeGen(config, analysis)
         .andThen {
           case Success(paths) =>
             config.logger.info(s"Produced ${paths.length} files")
@@ -118,14 +161,14 @@ private[scalanative] object ScalaNative {
 
   /** Run NIR checker on the linker result. */
   def check(config: Config)(
-      linked: scalanative.linker.Result
-  )(implicit ec: ExecutionContext): Future[scalanative.linker.Result] = {
-    check(config, forceQuickCheck = false)(linked)
+      analysis: ReachabilityAnalysis.Result
+  )(implicit ec: ExecutionContext): Future[ReachabilityAnalysis.Result] = {
+    check(config, forceQuickCheck = false)(analysis)
   }
 
   private def check(config: Config, forceQuickCheck: Boolean)(
-      linked: scalanative.linker.Result
-  )(implicit ec: ExecutionContext): Future[scalanative.linker.Result] = {
+      analysis: ReachabilityAnalysis.Result
+  )(implicit ec: ExecutionContext): Future[ReachabilityAnalysis.Result] = {
     val performFullCheck = config.check
     val checkMode = if (performFullCheck) "full" else "quick"
     val fatalWarnings = config.compilerConfig.checkFatalWarnings
@@ -133,31 +176,32 @@ private[scalanative] object ScalaNative {
     if (config.check || forceQuickCheck) {
       config.logger
         .timeAsync(s"Checking intermediate code ($checkMode)") {
-          if (performFullCheck) Check(linked)
-          else Check.quick(linked)
+          if (performFullCheck) Check(analysis)
+          else Check.quick(analysis)
         }
         .map {
-          case Nil => linked
+          case Nil => analysis
           case errors =>
             showErrors(
               log =
                 if (fatalWarnings) config.logger.error(_)
                 else config.logger.warn(_),
               showContext = performFullCheck
-            )(errors, linked)
+            )(errors, analysis)
+
             if (fatalWarnings)
               throw new BuildException(
                 "Fatal warning(s) found; see the error output for details."
               )
-            linked
+            analysis
         }
-    } else Future.successful(linked)
+    } else Future.successful(analysis)
   }
 
   private def showErrors(
       log: String => Unit,
       showContext: Boolean
-  )(errors: Seq[Check.Error], linked: linker.Result): Unit = {
+  )(errors: Seq[Check.Error], analysis: ReachabilityAnalysis.Result): Unit = {
     errors
       .groupBy(_.name)
       .foreach {
@@ -165,7 +209,7 @@ private[scalanative] object ScalaNative {
           log(s"\nFound ${errs.length} errors on ${name.show} :")
           def showError(err: Check.Error): Unit = log("    " + err.msg)
           if (showContext) {
-            linked.defns
+            analysis.defns
               .collectFirst {
                 case defn if defn != null && defn.name == name => defn
               }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -90,7 +90,9 @@ private[scalanative] object ScalaNative {
           check(config, forceQuickCheck = forceQuickCheck)(result)
         case result: ReachabilityAnalysis.UnreachableSymbolsFound =>
           Future.failed(
-            new LinkingException(s"Unreachable symbols found after $stage")
+            new LinkingException(
+              s"Unreachable symbols found after $stage run. It can happen when using dependencies not cross-compiled for Scala Native or not yet ported JDK definitions."
+            )
           )
       }
   }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -105,8 +105,8 @@ private[scalanative] object ScalaNative {
         analysis: ReachabilityAnalysis.UnreachableSymbolsFound
     ): Unit = {
       val log = config.logger
-      log.error(s"Found ${analysis.unavailable.size} unreachable symbols")
-      analysis.unavailable.foreach {
+      log.error(s"Found ${analysis.unreachable.size} unreachable symbols")
+      analysis.unreachable.foreach {
         case Reach.UnreachableSymbol(_, kind, name, backtrace) =>
           // Build stacktrace in memory to prevent its spliting when logging asynchronously
           val buf = new StringBuilder()

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -37,7 +37,7 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
 
   // RTTI specific for classess, see class RuntimeTypeInformation
   object ClassRtti extends Layout() {
-    val usesDynMap = meta.linked.dynsigs.nonEmpty
+    val usesDynMap = meta.analysis.dynsigs.nonEmpty
     private val dynMapType = if (usesDynMap) Some(DynamicHashMap.ty) else None
     // Common layout not including variable-sized virtual table
     private val baseLayout =

--- a/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
@@ -19,5 +19,5 @@ class DynamicHashMap(cls: Class, proxies: Seq[Defn])(implicit meta: Metadata) {
       .fold(Seq.empty[Global.Member])(meta.dynmap(_).methods)
       .filterNot(m => sigs.contains(m.sig)) ++ own
   }
-  val value: Val = DynmethodPerfectHashMap(methods, meta.linked.dynsigs)
+  val value: Val = DynmethodPerfectHashMap(methods, meta.analysis.dynsigs)
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -121,7 +121,7 @@ object MemoryLayout {
     lazy val dynamicAlignmentWidth = {
       val propName =
         "scala.scalanative.meta.linktimeinfo.contendedPaddingWidth"
-      meta.linked.resolvedVals
+      meta.analysis.resolvedVals
         .get(propName)
         .collectFirst { case Val.Int(value) => value }
         .getOrElse(

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -3,10 +3,10 @@ package codegen
 
 import scala.collection.mutable
 import scalanative.nir._
-import scalanative.linker.{Trait, Class}
+import scalanative.linker.{Trait, Class, ReachabilityAnalysis}
 
 class Metadata(
-    val linked: linker.Result,
+    val analysis: ReachabilityAnalysis.Result,
     val config: build.NativeConfig,
     proxies: Seq[Defn]
 )(implicit val platform: PlatformInfo) {
@@ -35,7 +35,7 @@ class Metadata(
 
   def initTraitIds(): Seq[Trait] = {
     val traits =
-      linked.infos.valuesIterator
+      analysis.infos.valuesIterator
         .collect { case info: Trait => info }
         .toIndexedSeq
         .sortBy(_.name.show)
@@ -62,7 +62,7 @@ class Metadata(
       ranges(node) = start to end
     }
 
-    loop(linked.infos(Rt.Object.name).asInstanceOf[Class])
+    loop(analysis.infos(Rt.Object.name).asInstanceOf[Class])
 
     out.toSeq
   }

--- a/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
@@ -19,7 +19,7 @@ class ModuleArray(meta: Metadata) {
     Val.ArrayValue(
       Type.Ptr,
       modules.toSeq.map { cls =>
-        if (cls.isConstantModule(meta.linked))
+        if (cls.isConstantModule(meta.analysis))
           Val.Global(cls.name.member(Sig.Generated("instance")), Type.Ptr)
         else
           Val.Null

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -26,7 +26,7 @@ class TraitDispatchTable(meta: Metadata) {
       }
     }
 
-    val Object = meta.linked.infos(Rt.Object.name).asInstanceOf[Class]
+    val Object = meta.analysis.infos(Rt.Object.name).asInstanceOf[Class]
     sigs --= Object.calls
 
     sigs.toArray.sortBy(_.toString).zipWithIndex.toMap
@@ -82,7 +82,7 @@ class TraitDispatchTable(meta: Metadata) {
         sigs.foreach {
           case (sig, sigId) =>
             cls.resolve(sig).foreach { impl =>
-              val info = meta.linked.infos(impl).asInstanceOf[Method]
+              val info = meta.analysis.infos(impl).asInstanceOf[Method]
               put(clsId, sigId, info.value)
             }
         }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -325,9 +325,9 @@ private[codegen] abstract class AbstractCodeGen(
   private[codegen] def toDereferenceable(
       refty: Type.RefKind
   ): (Boolean, String, Long) = {
-    val size = meta.linked.infos(refty.className) match {
+    val size = meta.analysis.infos(refty.className) match {
       case info: linker.Trait =>
-        meta.layout(meta.linked.ObjectClass).size
+        meta.layout(meta.analysis.ObjectClass).size
       case info: linker.Class =>
         meta.layout(info).size
       case _ =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -141,7 +141,7 @@ trait Eval { self: Interflow =>
       op: Op
   )(implicit
       state: State,
-      linked: linker.Result,
+      analysis: ReachabilityAnalysis.Result,
       srcPosition: Position,
       scopeId: ScopeId
   ): Val = {
@@ -334,7 +334,7 @@ trait Eval { self: Interflow =>
           delay(Op.Method(materialize(obj), sig))
         }
       case Op.Dynmethod(obj, dynsig) =>
-        linked.dynimpls.foreach {
+        analysis.dynimpls.foreach {
           case impl @ Global.Member(_, sig) if sig.toProxy == dynsig =>
             visitRoot(impl)
           case _ =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -19,7 +19,7 @@ trait Inline { self: Interflow =>
 
   def shallInline(name: Global.Member, args: Seq[Val])(implicit
       state: State,
-      linked: linker.Result
+      analysis: ReachabilityAnalysis.Result
   ): Boolean = {
     val maybeDefn = mode match {
       case build.Mode.Debug =>
@@ -159,7 +159,7 @@ trait Inline { self: Interflow =>
 
   def `inline`(name: Global.Member, args: Seq[Val])(implicit
       state: State,
-      linked: linker.Result,
+      analysis: ReachabilityAnalysis.Result,
       parentScopeId: ScopeId
   ): Val =
     in(s"inlining ${name.show}") {

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -11,7 +11,7 @@ import java.util.function.Supplier
 import scala.concurrent._
 
 class Interflow(val config: build.Config)(implicit
-    val linked: linker.Result
+    val analysis: ReachabilityAnalysis.Result
 ) extends Visit
     with Opt
     with NoOpt
@@ -25,7 +25,7 @@ class Interflow(val config: build.Config)(implicit
 
   private val originals = {
     val out = mutable.Map.empty[Global, Defn]
-    linked.defns.foreach { defn => out(defn.name) = defn }
+    analysis.defns.foreach { defn => out(defn.name) = defn }
     out
   }
 
@@ -160,10 +160,10 @@ class Interflow(val config: build.Config)(implicit
 }
 
 object Interflow {
-  def optimize(config: build.Config, linked: linker.Result)(implicit
-      ec: ExecutionContext
+  def optimize(config: build.Config, analysis: ReachabilityAnalysis.Result)(
+      implicit ec: ExecutionContext
   ): Future[Seq[Defn]] = {
-    val interflow = new Interflow(config)(linked)
+    val interflow = new Interflow(config)(analysis)
     interflow.visitEntries()
     interflow
       .visitLoop()

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -15,7 +15,7 @@ final class MergeProcessor(
     doInline: Boolean,
     scopeMapping: ScopeId => ScopeId,
     eval: Eval
-)(implicit linked: linker.Result) {
+)(implicit analysis: ReachabilityAnalysis.Result) {
   import MergeProcessor.MergeBlockOffset
   assert(
     insts.length < MergeBlockOffset,
@@ -46,7 +46,7 @@ final class MergeProcessor(
 
   private def merge(
       block: MergeBlock
-  )(implicit linked: linker.Result): (Seq[MergePhi], State) = {
+  )(implicit analysis: ReachabilityAnalysis.Result): (Seq[MergePhi], State) = {
     import block.cfPos
     merge(block.id, block.label.params, block.incoming.toSeq.sortBy(_._1.id))
   }
@@ -55,7 +55,7 @@ final class MergeProcessor(
       merge: Local,
       params: Seq[Val.Local],
       incoming: Seq[(Local, (Seq[Val], State))]
-  )(implicit linked: linker.Result): (Seq[MergePhi], State) = {
+  )(implicit analysis: ReachabilityAnalysis.Result): (Seq[MergePhi], State) = {
     val localIds = incoming.map { case (n, (_, _)) => n }
     val states = incoming.map { case (_, (_, s)) => s }.toList
 
@@ -525,7 +525,7 @@ object MergeProcessor {
       blockFresh: Fresh,
       eval: Eval,
       parentScopeId: ScopeId
-  )(implicit linked: linker.Result): MergeProcessor = {
+  )(implicit analysis: ReachabilityAnalysis.Result): MergeProcessor = {
     val builder =
       new MergeProcessor(
         insts = insts,

--- a/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
@@ -92,13 +92,13 @@ trait NoOpt { self: Interflow =>
       obj.ty match {
         case refty: Type.RefKind =>
           val name = refty.className
-          val scope = linked.infos(name).asInstanceOf[ScopeInfo]
+          val scope = analysis.infos(name).asInstanceOf[ScopeInfo]
           scope.targets(sig).foreach(visitEntry)
         case _ =>
           ()
       }
     case Op.Dynmethod(obj, dynsig) =>
-      linked.dynimpls.foreach {
+      analysis.dynimpls.foreach {
         case impl @ Global.Member(_, sig) if sig.toProxy == dynsig =>
           visitEntry(impl)
         case _ =>

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -42,7 +42,7 @@ trait PolyInline { self: Interflow =>
 
   def shallPolyInline(op: Op.Method, args: Seq[Val])(implicit
       state: State,
-      linked: linker.Result
+      analysis: ReachabilityAnalysis.Result
   ): Boolean = mode match {
     case build.Mode.Debug =>
       false
@@ -61,7 +61,7 @@ trait PolyInline { self: Interflow =>
 
   def polyInline(op: Op.Method, args: Seq[Val])(implicit
       state: State,
-      linked: linker.Result,
+      analysis: ReachabilityAnalysis.Result,
       srcPosition: Position,
       scopeIdId: ScopeId
   ): Val = {

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -4,7 +4,7 @@ package interflow
 import scala.collection.mutable
 import scalanative.nir._
 import scalanative.util.unreachable
-import scalanative.linker.{Result, Ref}
+import scalanative.linker.Ref
 
 object UseDef {
   sealed abstract class Def {

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -15,7 +15,7 @@ trait Visit { self: Interflow =>
     } else {
       val defn = getOriginal(orig)
       val hasInsts = defn.insts.size > 0
-      val hasSema = linked.infos.contains(defn.name)
+      val hasSema = analysis.infos.contains(defn.name)
 
       hasInsts && hasSema
     }
@@ -48,16 +48,16 @@ trait Visit { self: Interflow =>
   def visitEntries(): Unit =
     mode match {
       case build.Mode.Debug =>
-        linked.defns.foreach(defn => visitEntry(defn.name))
+        analysis.defns.foreach(defn => visitEntry(defn.name))
       case _: build.Mode.Release =>
-        linked.entries.foreach(visitEntry)
+        analysis.entries.foreach(visitEntry)
     }
 
   def visitEntry(name: Global): Unit = {
     if (!name.isTop) {
       visitEntry(name.top)
     }
-    linked.infos(name) match {
+    analysis.infos(name) match {
       case meth: Method =>
         visitRoot(meth.name)
       case cls: Class if cls.isModule =>
@@ -183,7 +183,7 @@ trait Visit { self: Interflow =>
       argtys
     case _ =>
       val Type.Function(argtys, _) =
-        linked.infos(name).asInstanceOf[Method].ty: @unchecked
+        analysis.infos(name).asInstanceOf[Method].ty: @unchecked
       argtys
   }
 
@@ -192,6 +192,6 @@ trait Visit { self: Interflow =>
       val Sig.Duplicate(base, _) = sig.unmangled: @unchecked
       originalFunctionType(Global.Member(owner, base))
     case _ =>
-      linked.infos(name).asInstanceOf[Method].ty
+      analysis.infos(name).asInstanceOf[Method].ty
   }
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -232,7 +232,7 @@ sealed trait ReachabilityAnalysis {
 object ReachabilityAnalysis {
   final class UnreachableSymbolsFound(
       val defns: Seq[Defn],
-      val unavailable: Seq[Reach.UnreachableSymbol]
+      val unreachable: Seq[Reach.UnreachableSymbol]
   ) extends ReachabilityAnalysis
   final class Result(
       val infos: mutable.Map[Global, Info],

--- a/tools/src/main/scala/scala/scalanative/linker/Link.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Link.scala
@@ -9,7 +9,7 @@ object Link {
   /** Load all clases and methods reachable from the entry points. */
   def apply(config: build.Config, entries: Seq[Global])(implicit
       scope: Scope
-  ): Result =
+  ): ReachabilityAnalysis =
     Reach(config, entries, ClassLoader.fromDisk(config))
 
   /** Run reachability analysis on already loaded methods. */
@@ -17,6 +17,6 @@ object Link {
       config: build.Config,
       entries: Seq[Global],
       defns: Seq[Defn]
-  ): Result =
+  ): ReachabilityAnalysis =
     Reach(config, entries, ClassLoader.fromMemory(defns))
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -13,16 +13,15 @@ class Reach(
 ) extends LinktimeValueResolver {
   import Reach._
 
-  val unavailable = mutable.Set.empty[Global]
   val loaded = mutable.Map.empty[Global.Top, mutable.Map[Global, Defn]]
+  val unavailable = mutable.Map.empty[Global, UnreachableSymbol]
   val enqueued = mutable.Set.empty[Global]
   var todo = List.empty[Global]
   val done = mutable.Map.empty[Global, Defn]
   var stack = List.empty[Global]
   val links = mutable.Set.empty[Attr.Link]
   val infos = mutable.Map.empty[Global, Info]
-  val from = mutable.Map.empty[Global, Global]
-  val missing = mutable.Map.empty[Global, Set[NonReachablePosition]]
+  val from = mutable.Map.empty[Global, ReferencedFrom]
 
   val dyncandidates = mutable.Map.empty[Sig, mutable.Set[Global.Member]]
   val dynsigs = mutable.Set.empty[Sig]
@@ -31,7 +30,7 @@ class Reach(
   private case class DelayedMethod(owner: Global.Top, sig: Sig, pos: Position)
   private val delayedMethods = mutable.Set.empty[DelayedMethod]
 
-  entries.foreach(reachEntry)
+  entries.foreach(reachEntry(_)(nir.Position.NoPosition))
 
   // Internal hack used inside linker tests, for more information
   // check out comment in scala.scalanative.linker.ReachabilitySuite
@@ -41,34 +40,37 @@ class Reach(
     .forall(_ == true)
 
   loader.classesWithEntryPoints.foreach { clsName =>
-    if (reachStaticConstructors) reachClinit(clsName)
+    if (reachStaticConstructors) reachClinit(clsName)(nir.Position.NoPosition)
     config.compilerConfig.buildTarget match {
       case build.BuildTarget.Application => ()
       case _                             => reachExported(clsName)
     }
   }
 
-  def result(): Result = {
-    reportMissing()
+  def result(): ReachabilityAnalysis = {
     cleanup()
 
     val defns = mutable.UnrolledBuffer.empty[Defn]
-
+    defns.sizeHint(done.size)
     // drop the null values that have been introduced
     // in reachUnavailable
-    defns ++= done.valuesIterator.filter(_ != null)
+    done.valuesIterator.filter(_ != null).foreach(defns += _)
 
-    new Result(
-      infos,
-      entries,
-      unavailable.toSeq,
-      from,
-      links.toSeq,
-      defns.toSeq,
-      dynsigs.toSeq,
-      dynimpls.toSeq,
-      resolvedNirValues
-    )
+    if (unavailable.isEmpty)
+      new ReachabilityAnalysis.Result(
+        infos = infos,
+        entries = entries,
+        links = links.toSeq,
+        defns = defns.toSeq,
+        dynsigs = dynsigs.toSeq,
+        dynimpls = dynimpls.toSeq,
+        resolvedVals = resolvedNirValues
+      )
+    else
+      new ReachabilityAnalysis.UnreachableSymbolsFound(
+        defns = defns.toSeq,
+        unavailable = unavailable.values.toSeq
+      )
   }
 
   def cleanup(): Unit = {
@@ -76,8 +78,8 @@ class Reach(
     // responds and defaultResponds of every class.
     // Optimizer and codegen may never increase reachability
     // past what's known now, so it's safe to do this.
-    infos.values.foreach {
-      case cls: Class =>
+    infos.foreach {
+      case (_, cls: Class) =>
         val responds = cls.responds.toArray
         responds.foreach {
           case (sig, name) =>
@@ -94,8 +96,7 @@ class Reach(
             }
         }
 
-      case _ =>
-        ()
+      case _ => ()
     }
   }
 
@@ -111,9 +112,7 @@ class Reach(
       loader
         .load(owner)
         .fold[Unit] {
-          if (!ignoreIfUnavailable) {
-            unavailable += owner
-          }
+          if (!ignoreIfUnavailable) addMissing(owner)
         } { defns =>
           val scope = mutable.Map.empty[Global, Defn]
           defns.foreach { defn => scope(defn.name) = defn }
@@ -141,14 +140,7 @@ class Reach(
       .flatMap(_.get(global))
       .orElse(fallback)
       .orElse {
-        if (!ignoreIfUnavailable) {
-          val resolvedPosition = for {
-            invokedFrom <- from.get(global)
-            callerInfo <- infos.get(invokedFrom)
-          } yield callerInfo.position
-          val pos = resolvedPosition.getOrElse(nir.Position.NoPosition)
-          addMissing(global, pos)
-        }
+        if (!ignoreIfUnavailable) addMissing(global)
         None
       }
   }
@@ -172,8 +164,8 @@ class Reach(
        */
       delayedMethods.foreach {
         case DelayedMethod(top, sig, position) =>
-          def addMissing() = this.addMissing(top.member(sig), position)
-          scopeInfo(top).fold(addMissing()) { info =>
+          def addMissing() = this.addMissing(top.member(sig))
+          scopeInfo(top)(position).fold(addMissing()) { info =>
             val wasAllocated = info match {
               case value: Trait => value.implementors.exists(_.allocated)
               case clazz: Class => clazz.allocated
@@ -212,6 +204,7 @@ class Reach(
   }
 
   def reachDefn(defn: Defn): Unit = {
+    implicit val srcPosition = defn.pos
     defn match {
       case defn: Defn.Var =>
         reachVar(defn)
@@ -220,7 +213,7 @@ class Reach(
       case defn: Defn.Declare =>
         reachDeclare(defn)
       case defn: Defn.Define =>
-        val Global.Member(_, sig) = defn.name: @unchecked
+        val Global.Member(_, sig) = defn.name
         if (Rt.arrayAlloc.contains(sig)) {
           classInfo(Rt.arrayAlloc(sig)).foreach(reachAllocation)
         }
@@ -235,20 +228,20 @@ class Reach(
     done(defn.name) = defn
   }
 
-  def reachEntry(name: Global): Unit = {
+  def reachEntry(name: Global)(implicit srcPosition: nir.Position): Unit = {
     if (!name.isTop) {
       reachEntry(name.top)
     }
-    from(name) = Global.None
+    from.getOrElseUpdate(name, ReferencedFrom.root)
     reachGlobalNow(name)
     infos.get(name) match {
       case Some(cls: Class) =>
         if (!cls.attrs.isAbstract) {
-          reachAllocation(cls)
+          reachAllocation(cls)(cls.position)
           if (cls.isModule) {
             val init = cls.name.member(Sig.Ctor(Seq.empty))
             if (loaded(cls.name).contains(init)) {
-              reachGlobal(init)
+              reachGlobal(init)(cls.position)
             }
           }
         }
@@ -257,14 +250,15 @@ class Reach(
     }
   }
 
-  def reachClinit(name: Global.Top): Unit = {
-    reachGlobalNow(name)
-    infos.get(name).collect {
-      case cls: ScopeInfo =>
-        val clinit = cls.name.member(Sig.Clinit)
-        if (loaded(cls.name).contains(clinit)) {
-          reachGlobal(clinit)
-        }
+  def reachClinit(
+      clsName: Global.Top
+  )(implicit srcPosition: nir.Position): Unit = {
+    reachGlobalNow(clsName)
+    infos.get(clsName).foreach { cls =>
+      val clinit = clsName.member(Sig.Clinit)
+      if (loaded(clsName).contains(clinit)) {
+        reachGlobal(clinit)(cls.position)
+      }
     }
   }
 
@@ -279,21 +273,30 @@ class Reach(
       cls <- infos.get(name).collect { case info: ScopeInfo => info }
       defns <- loaded.get(cls.name)
       (name, defn) <- defns
-    } if (isExported(defn)) reachGlobal(name)
+    } if (isExported(defn)) reachGlobal(name)(defn.pos)
   }
 
-  def reachGlobal(name: Global): Unit =
+  def reachGlobal(name: Global)(implicit srcPosition: nir.Position): Unit =
     if (!enqueued.contains(name) && name.ne(Global.None)) {
       enqueued += name
-      from(name) = if (stack.isEmpty) Global.None else stack.head
+      from.getOrElseUpdate(
+        name,
+        if (stack.isEmpty) ReferencedFrom.root
+        else ReferencedFrom(stack.head, srcPosition)
+      )
       todo ::= name
     }
 
-  def reachGlobalNow(name: Global): Unit =
+  def reachGlobalNow(name: Global)(implicit srcPosition: nir.Position): Unit =
     if (done.contains(name)) {
       ()
     } else if (!stack.contains(name)) {
       enqueued += name
+      from.getOrElseUpdate(
+        name,
+        if (stack.isEmpty) ReferencedFrom.root
+        else ReferencedFrom(stack.head, srcPosition)
+      )
       reachDefn(name)
     } else {
       val lines = (s"cyclic reference to ${name.show}:" +:
@@ -402,7 +405,7 @@ class Reach(
     }
   }
 
-  def reachAllocation(info: Class): Unit =
+  def reachAllocation(info: Class)(implicit srcPosition: nir.Position): Unit =
     if (!info.allocated) {
       info.allocated = true
 
@@ -462,7 +465,9 @@ class Reach(
       }
     }
 
-  def scopeInfo(name: Global.Top): Option[ScopeInfo] = {
+  def scopeInfo(
+      name: Global.Top
+  )(implicit srcPosition: nir.Position): Option[ScopeInfo] = {
     reachGlobalNow(name)
     infos(name) match {
       case info: ScopeInfo => Some(info)
@@ -470,7 +475,9 @@ class Reach(
     }
   }
 
-  def scopeInfoOrUnavailable(name: Global.Top): Info = {
+  def scopeInfoOrUnavailable(
+      name: Global.Top
+  )(implicit srcPosition: nir.Position): Info = {
     reachGlobalNow(name)
     infos(name) match {
       case info: ScopeInfo   => info
@@ -479,7 +486,9 @@ class Reach(
     }
   }
 
-  def classInfo(name: Global.Top): Option[Class] = {
+  def classInfo(
+      name: Global.Top
+  )(implicit srcPosition: nir.Position): Option[Class] = {
     reachGlobalNow(name)
     infos(name) match {
       case info: Class => Some(info)
@@ -487,12 +496,16 @@ class Reach(
     }
   }
 
-  def classInfoOrObject(name: Global.Top): Class =
+  def classInfoOrObject(
+      name: Global.Top
+  )(implicit srcPosition: nir.Position): Class =
     classInfo(name)
       .orElse(classInfo(Rt.Object.name))
       .getOrElse(fail(s"Class info not available for $name"))
 
-  def traitInfo(name: Global.Top): Option[Trait] = {
+  def traitInfo(
+      name: Global.Top
+  )(implicit srcPosition: nir.Position): Option[Trait] = {
     reachGlobalNow(name)
     infos(name) match {
       case info: Trait => Some(info)
@@ -500,7 +513,9 @@ class Reach(
     }
   }
 
-  def methodInfo(name: Global): Option[Method] = {
+  def methodInfo(
+      name: Global
+  )(implicit srcPosition: nir.Position): Option[Method] = {
     reachGlobalNow(name)
     infos(name) match {
       case info: Method => Some(info)
@@ -508,7 +523,9 @@ class Reach(
     }
   }
 
-  def fieldInfo(name: Global): Option[Field] = {
+  def fieldInfo(
+      name: Global
+  )(implicit srcPosition: nir.Position): Option[Field] = {
     reachGlobalNow(name)
     infos(name) match {
       case info: Field => Some(info)
@@ -518,7 +535,7 @@ class Reach(
 
   def reachUnavailable(name: Global): Unit = {
     newInfo(new Unavailable(name))
-    unavailable += name
+    addMissing(name)
     // Put a null definition to indicate that name
     // is effectively done and doesn't need to be
     // visited any more. This saves us the need to
@@ -638,7 +655,7 @@ class Reach(
   def reachAttrs(attrs: Attrs): Unit =
     links ++= attrs.links
 
-  def reachType(ty: Type): Unit = ty match {
+  def reachType(ty: Type)(implicit srcPosition: nir.Position): Unit = ty match {
     case Type.ArrayValue(ty, n) =>
       reachType(ty)
     case Type.StructValue(tys) =>
@@ -656,49 +673,53 @@ class Reach(
       ()
   }
 
-  def reachVal(value: Val): Unit = value match {
-    case Val.Zero(ty)            => reachType(ty)
-    case Val.StructValue(values) => values.foreach(reachVal)
-    case Val.ArrayValue(ty, values) =>
-      reachType(ty)
-      values.foreach(reachVal)
-    case Val.Local(_, ty) => reachType(ty)
-    case Val.Global(n, ty) =>
-      reachGlobal(n)
-      reachType(ty)
-    case Val.Const(v)     => reachVal(v)
-    case Val.ClassOf(cls) => reachGlobal(cls)
-    case _                => ()
-  }
+  def reachVal(value: Val)(implicit srcPosition: nir.Position): Unit =
+    value match {
+      case Val.Zero(ty)            => reachType(ty)
+      case Val.StructValue(values) => values.foreach(reachVal)
+      case Val.ArrayValue(ty, values) =>
+        reachType(ty)
+        values.foreach(reachVal)
+      case Val.Local(_, ty) => reachType(ty)
+      case Val.Global(n, ty) =>
+        reachGlobal(n)
+        reachType(ty)
+      case Val.Const(v)     => reachVal(v)
+      case Val.ClassOf(cls) => reachGlobal(cls)
+      case _                => ()
+    }
 
   def reachInsts(insts: Seq[Inst]): Unit =
     insts.foreach(reachInst)
 
-  def reachInst(inst: Inst): Unit = inst match {
-    case Inst.Label(n, params) =>
-      params.foreach(p => reachType(p.ty))
-    case Inst.Let(_, op, unwind) =>
-      reachOp(op)(inst.pos)
-      reachNext(unwind)
-    case Inst.Ret(v) =>
-      reachVal(v)
-    case Inst.Jump(next) =>
-      reachNext(next)
-    case Inst.If(v, thenp, elsep) =>
-      reachVal(v)
-      reachNext(thenp)
-      reachNext(elsep)
-    case Inst.Switch(v, default, cases) =>
-      reachVal(v)
-      reachNext(default)
-      cases.foreach(reachNext)
-    case Inst.Throw(v, unwind) =>
-      reachVal(v)
-      reachNext(unwind)
-    case Inst.Unreachable(unwind) =>
-      reachNext(unwind)
-    case _: Inst.LinktimeIf =>
-      util.unreachable
+  def reachInst(inst: Inst): Unit = {
+    implicit val srcPosition: nir.Position = inst.pos
+    inst match {
+      case Inst.Label(n, params) =>
+        params.foreach(p => reachType(p.ty))
+      case Inst.Let(_, op, unwind) =>
+        reachOp(op)(inst.pos)
+        reachNext(unwind)
+      case Inst.Ret(v) =>
+        reachVal(v)
+      case Inst.Jump(next) =>
+        reachNext(next)
+      case Inst.If(v, thenp, elsep) =>
+        reachVal(v)
+        reachNext(thenp)
+        reachNext(elsep)
+      case Inst.Switch(v, default, cases) =>
+        reachVal(v)
+        reachNext(default)
+        cases.foreach(reachNext)
+      case Inst.Throw(v, unwind) =>
+        reachVal(v)
+        reachNext(unwind)
+      case Inst.Unreachable(unwind) =>
+        reachNext(unwind)
+      case _: Inst.LinktimeIf =>
+        util.unreachable
+    }
   }
 
   def reachOp(op: Op)(implicit pos: Position): Unit = op match {
@@ -767,7 +788,7 @@ class Reach(
     case Op.Module(n) =>
       classInfo(n).foreach(reachAllocation)
       val init = n.member(Sig.Ctor(Seq.empty))
-      loaded.get(n).fold(addMissing(n, pos)) { defn =>
+      loaded.get(n).fold(addMissing(n)) { defn =>
         if (defn.contains(init)) {
           reachGlobal(init)
         }
@@ -811,12 +832,13 @@ class Reach(
       reachVal(arr)
   }
 
-  def reachNext(next: Next): Unit = next match {
-    case Next.Label(_, args) =>
-      args.foreach(reachVal)
-    case _ =>
-      ()
-  }
+  def reachNext(next: Next)(implicit srcPosition: nir.Position): Unit =
+    next match {
+      case Next.Label(_, args) =>
+        args.foreach(reachVal)
+      case _ =>
+        ()
+    }
 
   def reachMethodTargets(ty: Type, sig: Sig)(implicit pos: Position): Unit =
     ty match {
@@ -839,7 +861,9 @@ class Reach(
         ()
     }
 
-  def reachDynamicMethodTargets(dynsig: Sig) = {
+  def reachDynamicMethodTargets(
+      dynsig: Sig
+  )(implicit srcPosition: nir.Position) = {
     if (!dynsigs.contains(dynsig)) {
       dynsigs += dynsig
       if (dyncandidates.contains(dynsig)) {
@@ -896,35 +920,63 @@ class Reach(
     }
   }
 
-  protected def addMissing(global: Global, pos: Position): Unit = {
-    val prev = missing.getOrElseUpdate(global, Set.empty)
-    if (pos != nir.Position.NoPosition) {
-      val position = NonReachablePosition(
-        uri = pos.source,
-        line = pos.sourceLine
-      )
-      missing(global) = prev + position
-    }
-  }
+  protected def addMissing(global: Global): Unit = unavailable.getOrElseUpdate(
+    global, {
+      def parseSig(owner: String, sig: Sig): (String, String) =
+        sig.unmangled match {
+          case Sig.Method(name, _, _) => "method" -> s"$owner.${name}"
+          case Sig.Ctor(tys) =>
+            val ctorTys = tys
+              .map {
+                case ty: Type.RefKind => ty.className.id
+                case ty               => ty.show
+              }
+              .mkString(",")
+            "constructor" -> s"$owner($ctorTys)"
+          case Sig.Clinit          => "static constructor" -> owner
+          case Sig.Field(name, _)  => "field" -> s"$owner.$name"
+          case Sig.Generated(name) => "generated method" -> s"$owner.${name}"
+          case Sig.Proxy(name, _)  => "proxy method" -> s"$owner.$name"
+          case Sig.Duplicate(sig, _) =>
+            val (kind, name) = parseSig(owner, sig)
+            s"duplicate $kind" -> s"$owner.name"
+          case Sig.Extern(name) => s"extern method" -> s"$owner.$name"
+        }
 
-  private def reportMissing(): Unit = {
-    if (missing.nonEmpty) {
-      unavailable
-        .foreach(missing.getOrElseUpdate(_, Set.empty))
-      val log = config.logger
-      log.error(s"Found ${missing.size} missing definitions while linking")
-      missing.toSeq.sortBy(_._1).foreach {
-        case (global, positions) =>
-          log.error(s"Not found $global")
-          positions.toList
-            .sortBy(p => (p.uri, p.line))
-            .foreach { pos =>
-              log.error(s"\tat ${pos.uri}:${pos.line}")
-            }
+      def parseSymbol(name: Global): (String, String) = name match {
+        case Global.Member(owner, sig) => parseSig(owner.id, sig)
+        case Global.Top(id)            => "type" -> id
+        case _                         => util.unreachable
       }
-      fail("Undefined definitions found in reachability phase")
+
+      val buf = List.newBuilder[BackTraceElement]
+      def getBackTrace(name: Global): List[BackTraceElement] = {
+        val current = from(name)
+        if (current == ReferencedFrom.root) buf.result()
+        else {
+          val file = current.srcPosition.filename.getOrElse("unknown")
+          val line = current.srcPosition.line
+          val (kind, symbol) = parseSymbol(current.referencedBy)
+          buf += BackTraceElement(
+            symbol = current.referencedBy,
+            kind = kind,
+            name = symbol,
+            filename = file,
+            line = line + 1
+          )
+          getBackTrace(current.referencedBy)
+        }
+      }
+
+      val (kind, symbol) = parseSymbol(global)
+      UnreachableSymbol(
+        symbol = global,
+        kind = kind,
+        name = symbol,
+        backtrace = getBackTrace(global)
+      )
     }
-  }
+  )
 
   private def fail(msg: => String): Nothing = {
     throw new LinkingException(msg)
@@ -936,15 +988,31 @@ object Reach {
       config: build.Config,
       entries: Seq[Global],
       loader: ClassLoader
-  ): Result = {
+  ): ReachabilityAnalysis = {
     val reachability = new Reach(config, entries, loader)
     reachability.process()
     reachability.processDelayed()
     reachability.result()
   }
 
-  private[scalanative] case class NonReachablePosition(
-      uri: java.net.URI,
+  private[scalanative] case class ReferencedFrom(
+      referencedBy: nir.Global,
+      srcPosition: nir.Position
+  )
+  object ReferencedFrom {
+    final val root = ReferencedFrom(nir.Global.None, nir.Position.NoPosition)
+  }
+  case class BackTraceElement(
+      symbol: Global,
+      kind: String,
+      name: String,
+      filename: String,
       line: Int
+  )
+  case class UnreachableSymbol(
+      symbol: Global,
+      kind: String,
+      name: String,
+      backtrace: List[BackTraceElement]
   )
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -34,7 +34,9 @@ import scalanative.util.unreachable
  */
 object Sub {
 
-  def is(l: Type, r: Type)(implicit linked: linker.Result): Boolean = {
+  def is(l: Type, r: Type)(implicit
+      analysis: ReachabilityAnalysis.Result
+  ): Boolean = {
     (l, r) match {
       case (l, r) if l == r =>
         true
@@ -52,7 +54,7 @@ object Sub {
   }
 
   def is(info: ScopeInfo, ty: Type.RefKind)(implicit
-      linked: linker.Result
+      analysis: ReachabilityAnalysis.Result
   ): Boolean = {
     ty match {
       case ScopeRef(other) =>
@@ -63,7 +65,7 @@ object Sub {
   }
 
   def lub(tys: Seq[Type], bound: Option[Type])(implicit
-      linked: linker.Result
+      analysis: ReachabilityAnalysis.Result
   ): Type = {
     tys match {
       case Seq() =>
@@ -74,7 +76,7 @@ object Sub {
   }
 
   def lub(lty: Type, rty: Type, bound: Option[Type])(implicit
-      linked: linker.Result
+      analysis: ReachabilityAnalysis.Result
   ): Type = {
     (lty, rty) match {
       case _ if lty == rty =>
@@ -108,7 +110,7 @@ object Sub {
   }
 
   def lub(linfo: ScopeInfo, rinfo: ScopeInfo, boundInfo: Option[ScopeInfo])(
-      implicit linked: linker.Result
+      implicit analysis: ReachabilityAnalysis.Result
   ): ScopeInfo = {
     if (linfo == rinfo) {
       linfo
@@ -131,7 +133,7 @@ object Sub {
 
       candidates match {
         case Seq() =>
-          linked.infos(Rt.Object.name).asInstanceOf[ScopeInfo]
+          analysis.infos(Rt.Object.name).asInstanceOf[ScopeInfo]
         case Seq(cand) =>
           cand
         case _ =>
@@ -146,7 +148,7 @@ object Sub {
           }
 
           minimums.headOption.getOrElse {
-            linked.infos(Rt.Object.name).asInstanceOf[ScopeInfo]
+            analysis.infos(Rt.Object.name).asInstanceOf[ScopeInfo]
           }
       }
     }

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -51,7 +51,7 @@ abstract class LinkerSpec {
       case _ => fail("Expected code to not link"); unreachable
     }
 
-  private def mayLink[T](
+  protected def mayLink[T](
       entry: String,
       sources: Map[String, String],
       setupConfig: NativeConfig => NativeConfig = identity
@@ -87,7 +87,7 @@ abstract class LinkerSpec {
       .withClassPath(classpath.toSeq)
       .withMainClass(Some(entry))
       .withCompilerConfig(setupNativeConfig.andThen(withDefaults))
-    // .withLogger(Logger.nullLogger)
+      .withLogger(Logger.nullLogger)
   }
 
   private def withDefaults(config: NativeConfig): NativeConfig = {

--- a/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
@@ -5,6 +5,7 @@ import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.scalanative.nir._
+import scala.scalanative.linker.ReachabilityAnalysis
 
 /** Base class to test the optimizer */
 abstract class OptimizerSpec extends LinkerSpec {
@@ -27,7 +28,7 @@ abstract class OptimizerSpec extends LinkerSpec {
       sources: Map[String, String],
       setupConfig: NativeConfig => NativeConfig = identity
   )(
-      fn: (Config, linker.Result) => T
+      fn: (Config, ReachabilityAnalysis.Result) => T
   ): T =
     link(entry, sources, setupConfig) {
       case (config, linked) =>

--- a/tools/src/test/scala/scala/scalanative/codegen/CodeGenSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/codegen/CodeGenSpec.scala
@@ -3,8 +3,8 @@ package codegen
 
 import java.nio.file.{Path, Paths}
 import scalanative.io.VirtualDirectory
-import scalanative.build.Config
-import scalanative.build.ScalaNative
+import scalanative.build.{Config, ScalaNative}
+import scala.scalanative.linker.ReachabilityAnalysis
 import scalanative.util.Scope
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -27,7 +27,7 @@ abstract class CodeGenSpec extends OptimizerSpec {
    *    The result of applying `fn` to the resulting file.
    */
   def codegen[T](entry: String, sources: Map[String, String])(
-      f: (Config, linker.Result, Path) => T
+      f: (Config, ReachabilityAnalysis.Result, Path) => T
   ): T =
     optimize(entry, sources) {
       case (config, optimized) =>

--- a/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
@@ -16,7 +16,7 @@ class IssuesSpec extends LinkerSpec {
   private val sourceFile = "Test.scala"
 
   private def testLinked(source: String, mainClass: String = mainClass)(
-      fn: Result => Unit
+      fn: ReachabilityAnalysis.Result => Unit
   ): Unit =
     link(mainClass, sources = Map("Test.scala" -> source)) {
       case (_, result) => fn(result)

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -152,7 +152,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
         case (_, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
           assertTrue(
             n.toString,
-            (result.unavailable.map(_.symbol).toSet - pathForNumber(n)).isEmpty
+            (result.unreachable.map(_.name).toSet - pathForNumber(n)).isEmpty
           )
       }
   }
@@ -183,7 +183,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
         case (_, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
           assertTrue(
             n.toString,
-            (result.unavailable.map(_.symbol).toSet - pathForNumber(n)).isEmpty
+            (result.unreachable.map(_.name).toSet - pathForNumber(n)).isEmpty
           )
       }
   }
@@ -238,7 +238,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
       ) {
         case (_, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
           assertTrue(
-            (result.unavailable.map(_.symbol).toSet -
+            (result.unreachable.map(_.name).toSet -
               pathForNumber(pathNumber)).isEmpty
           )
       }
@@ -286,7 +286,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
       ) {
         case (_, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
           assertTrue(
-            (result.unavailable.map(_.symbol).toSet -
+            (result.unreachable.map(_.name).toSet -
               pathForNumber(pathNumber)).isEmpty
           )
       }

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -448,7 +448,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
         .withTargetTriple("x86_64-unknown-linux-gnu")
         .withLinkStubs(false)
     }
-    link(entry, sources.toMap, setupConfig = setupConfig)(body)
+    mayLink(entry, sources.toMap, setupConfig = setupConfig)(body)
   }
   private def linkWithProps(
       sources: (String, String)*

--- a/tools/src/test/scala/scala/scalanative/linker/MissingSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MissingSymbolsTest.scala
@@ -1,0 +1,119 @@
+package scala.scalanative.linker
+
+import scala.scalanative.checker.Check
+import scala.scalanative.LinkerSpec
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.scalanative.nir._
+import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.scalanative.optimizer.assertContainsAll
+import java.sql.Time
+
+class MissingSymbolsTest extends LinkerSpec {
+  private val mainClass = "Test"
+  private val sourceFile = "Test.scala"
+
+  @Test def missingSymbolStacktrace(): Unit = {
+    doesNotLink(
+      entry = mainClass,
+      Map(sourceFile -> s"""
+        |object Foo{
+        |  def getTimeString(): String = Bar.getTimeString()
+        |}
+        |
+        |object Bar{
+        |  def getTimeString(): String = {
+        |    val time = java.sql.Time.valueOf("")
+        |    val time2 = new java.sql.Time(0L)
+        |    ???
+        |  }
+        |}
+        |
+        |object $mainClass{
+        | def main(args: Array[String]): Unit = {
+        |   val unreachable = Foo.getTimeString()
+        | }
+        |}
+        """.stripMargin)
+    ) {
+      case (config, result) =>
+        assertEquals("unreachable", 3, result.unreachable.size)
+        assertContainsAll(
+          "kind-symbols",
+          Seq(
+            "type" -> "java.sql.Time",
+            "constructor" -> "java.sql.Time(long)",
+            "method" -> "java.sql.Time.valueOf"
+          ),
+          result.unreachable.map(v => (v.kind, v.symbol))
+        )
+        val TimeType = Global.Top("java.sql.Time")
+        val TimeCtor = TimeType.member(Sig.Ctor(Seq(Type.Long)))
+        val TimeValueOf = TimeType.member(
+          Sig.Method(
+            "valueOf",
+            Seq(Rt.String, Type.Ref(TimeType)),
+            Sig.Scope.PublicStatic
+          )
+        )
+        assertContainsAll(
+          "names",
+          Seq(TimeType, TimeCtor, TimeValueOf),
+          result.unreachable.map(_.name)
+        )
+
+        result.unreachable.foreach { symbol =>
+          val backtrace =
+            symbol.backtrace.map(v => (v.kind, v.symbol, v.filename, v.line))
+          // format: off
+          assertEquals("backtrace", List(
+            ("method", "Bar$.getTimeString", sourceFile, if(symbol.name == TimeCtor) 9 else 8),
+            ("method", "Foo$.getTimeString", sourceFile, 3),
+            ("method", "Test$.main", sourceFile, 16),
+            ("method", "Test.main", sourceFile, 15)
+          ), backtrace)
+          // format: on
+        }
+    }
+  }
+
+  @Test def unreachableInTypeParent(): Unit = {
+    doesNotLink(
+      entry = mainClass,
+      Map(sourceFile -> s"""
+        |object $mainClass{
+        | def main(args: Array[String]): Unit = {
+        |   class Foo(n: Long) extends java.sql.Time(n)
+        |   val x = new Foo(0L)
+        | }
+        |}
+        """.stripMargin)
+    ) {
+      case (config, result) =>
+        scala.scalanative.build.ScalaNative.logLinked(config, result, "test")
+        assertEquals("unreachable", 2, result.unreachable.size)
+        assertContainsAll(
+          "kind-symbols",
+          Seq(
+            "type" -> "java.sql.Time",
+            "constructor" -> "java.sql.Time(long)"
+          ),
+          result.unreachable.map(v => (v.kind, v.symbol))
+        )
+
+        result.unreachable
+          .find(_.symbol == "java.sql.Time")
+          .map { symbol =>
+            val from = symbol.backtrace.head
+            assertEquals("type", from.kind)
+            assertEquals("Test$Foo$1", from.symbol)
+          }
+          .getOrElse(fail("Not found required unreachable symbol"))
+    }
+  }
+
+}

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -28,52 +28,55 @@ class StubSpec extends LinkerSpec {
                            |}""".stripMargin
 
   @Test def ignoreMethods(): Unit = {
-    link(entry, stubMethodSource, _.withLinkStubs(false)) { (cfg, result) =>
-      assertTrue(!cfg.linkStubs)
-      assertTrue(result.unavailable.length == 1)
-      assertEquals(
-        Global
-          .Top("Main$")
-          .member(Sig.Method("stubMethod", Seq(Type.Int))),
-        result.unavailable.head
-      )
+    doesNotLink(entry, stubMethodSource, _.withLinkStubs(false)) {
+      (cfg, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+        assertTrue(!cfg.linkStubs)
+        assertTrue(result.unavailable.length == 1)
+        assertEquals(
+          Global
+            .Top("Main$")
+            .member(Sig.Method("stubMethod", Seq(Type.Int))),
+          result.unavailable.head.symbol
+        )
     }
   }
 
   @Test def includeMethods(): Unit = {
     link(entry, stubMethodSource, _.withLinkStubs(true)) { (cfg, result) =>
       assertTrue(cfg.linkStubs)
-      assertTrue(result.unavailable.isEmpty)
+      assertTrue(result.isSuccessful)
     }
   }
 
   @Test def ignoreClasses(): Unit = {
-    link(entry, stubClassSource, _.withLinkStubs(false)) { (cfg, result) =>
-      assertTrue(!cfg.linkStubs)
-      assertTrue(result.unavailable.length == 1)
-      assertTrue(result.unavailable.head == Global.Top("StubClass"))
+    doesNotLink(entry, stubClassSource, _.withLinkStubs(false)) {
+      (cfg, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+        assertTrue(!cfg.linkStubs)
+        assertTrue(result.unavailable.length == 1)
+        assertTrue(result.unavailable.head.symbol == Global.Top("StubClass"))
     }
   }
 
   @Test def includeClasses(): Unit = {
     link(entry, stubClassSource, _.withLinkStubs(true)) { (cfg, result) =>
       assertTrue(cfg.linkStubs)
-      assertTrue(result.unavailable.isEmpty)
+      assertTrue(result.isSuccessful)
     }
   }
 
   @Test def ignoreModules(): Unit = {
-    link(entry, stubModuleSource, _.withLinkStubs(false)) { (cfg, result) =>
-      assertTrue(!cfg.linkStubs)
-      assertTrue(result.unavailable.length == 1)
-      assertTrue(result.unavailable.head == Global.Top("StubModule$"))
+    doesNotLink(entry, stubModuleSource, _.withLinkStubs(false)) {
+      case (cfg, result) =>
+        assertTrue(!cfg.linkStubs)
+        assertTrue(result.unavailable.length == 1)
+        assertTrue(result.unavailable.head.symbol == Global.Top("StubModule$"))
     }
   }
 
   @Test def includeModules(): Unit = {
     link(entry, stubModuleSource, _.withLinkStubs(true)) { (cfg, result) =>
       assertTrue(cfg.linkStubs)
-      assertTrue(result.unavailable.isEmpty)
+      assertTrue(result.isSuccessful)
     }
   }
 

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -31,12 +31,12 @@ class StubSpec extends LinkerSpec {
     doesNotLink(entry, stubMethodSource, _.withLinkStubs(false)) {
       (cfg, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
         assertTrue(!cfg.linkStubs)
-        assertTrue(result.unavailable.length == 1)
+        assertTrue(result.unreachable.length == 1)
         assertEquals(
           Global
             .Top("Main$")
             .member(Sig.Method("stubMethod", Seq(Type.Int))),
-          result.unavailable.head.symbol
+          result.unreachable.head.name
         )
     }
   }
@@ -52,8 +52,8 @@ class StubSpec extends LinkerSpec {
     doesNotLink(entry, stubClassSource, _.withLinkStubs(false)) {
       (cfg, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
         assertTrue(!cfg.linkStubs)
-        assertTrue(result.unavailable.length == 1)
-        assertTrue(result.unavailable.head.symbol == Global.Top("StubClass"))
+        assertTrue(result.unreachable.length == 1)
+        assertTrue(result.unreachable.head.name == Global.Top("StubClass"))
     }
   }
 
@@ -68,8 +68,8 @@ class StubSpec extends LinkerSpec {
     doesNotLink(entry, stubModuleSource, _.withLinkStubs(false)) {
       case (cfg, result) =>
         assertTrue(!cfg.linkStubs)
-        assertTrue(result.unavailable.length == 1)
-        assertTrue(result.unavailable.head.symbol == Global.Top("StubModule$"))
+        assertTrue(result.unreachable.length == 1)
+        assertTrue(result.unreachable.head.name == Global.Top("StubModule$"))
     }
   }
 

--- a/tools/src/test/scala/scala/scalanative/linker/SubSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/SubSuite.scala
@@ -25,8 +25,11 @@ class SubSuite extends ReachabilitySuite {
   val MainClass = "Main"
   val entry: Global.Member = Global.Top(MainClass).member(Rt.ScalaMainSig)
 
-  implicit val linked: linker.Result =
-    link(Seq(entry), Seq(source), MainClass)(x => x)
+  implicit val analysis: ReachabilityAnalysis.Result =
+    link(Seq(entry), Seq(source), MainClass) {
+      case result: ReachabilityAnalysis.Result => result
+      case _ => fail("Failed to link"); util.unreachable
+    }
 
   val primitiveTypes = Seq(
     Type.Bool,

--- a/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
@@ -6,6 +6,7 @@ import org.junit.Assert._
 
 import scala.collection.mutable
 import scala.scalanative.build.NativeConfig
+import scala.scalanative.linker.ReachabilityAnalysis
 import scala.scalanative.nir.Defn.Define.DebugInfo.LexicalScope
 
 class LexicalScopesTest extends OptimizerSpec {
@@ -15,7 +16,7 @@ class LexicalScopesTest extends OptimizerSpec {
       entry: String,
       sources: Map[String, String],
       setupConfig: build.NativeConfig => build.NativeConfig = identity
-  )(fn: (build.Config, linker.Result) => T) =
+  )(fn: (build.Config, ReachabilityAnalysis.Result) => T) =
     super.optimize(
       entry,
       sources,

--- a/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
@@ -9,6 +9,7 @@ import scala.collection.mutable
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
 import scala.reflect.ClassTag
 import scala.scalanative.nir.Global.Member
+import scala.scalanative.linker.ReachabilityAnalysis
 
 class LocalNamesTest extends OptimizerSpec {
   import nir._
@@ -17,7 +18,7 @@ class LocalNamesTest extends OptimizerSpec {
       entry: String,
       sources: Map[String, String],
       setupConfig: build.NativeConfig => build.NativeConfig = identity
-  )(fn: (build.Config, linker.Result) => T) =
+  )(fn: (build.Config, ReachabilityAnalysis.Result) => T) =
     super.optimize(
       entry,
       sources,

--- a/tools/src/test/scala/scala/scalanative/optimizer/package.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/package.scala
@@ -1,6 +1,7 @@
 package scala.scalanative
 
 import org.junit.Assert._
+import scala.scalanative.linker.ReachabilityAnalysis
 
 package object optimizer {
   import nir._
@@ -69,7 +70,10 @@ package object optimizer {
       .ensuring(_.isDefined, "Not found linked method")
   }
 
-  def afterLowering(config: build.Config, optimized: => linker.Result)(
+  def afterLowering(
+      config: build.Config,
+      optimized: => ReachabilityAnalysis.Result
+  )(
       fn: Seq[Defn] => Unit
   ): Unit = {
     import scala.scalanative.codegen._


### PR DESCRIPTION
This change modifies the scope of reachability analysis results to limit the scope of passed data, that is never used after classloading finishes (unavailable symbols and referenced from maps). It now returns either an `UnreachableSymbolsFound` containing only information required to correctly point to usages of unreachble symbols, and `Result` containing the full information required for later stages. 

This change also adds better backtraces for unreachable symbols. For example for this snippet: 
```Scala
object Test {
  def main(args: Array[String]): Unit = {
    class Foo(x: Long) extends java.sql.Time(x)
    trait Bar { self: java.sql.Types => }
    class Baz extends java.sql.Types with Bar
    0.until(10).foreach { _ =>
      println(Foo(1))
      println(Baz())
    }
  }
}
```

we would now get following output: 
```Scala 
[error] Found 4 unreachable symbols
[error] Found unknown type java.sql.Time, referenced from:
[error]       type at Test$Foo$1(Test.scala:4)
[error]     method at Test$.main$$anonfun$1(Test.scala:8)
[error]     method at Test$$$Lambda$1.apply$mcVI$sp(Test.scala:9)
[error]     method at Test$.main(Test.scala:9)
[error]     method at Test.main(Test.scala:2)
[error] 
[error] Found unknown constructor java.sql.Types(), referenced from:
[error]     constructor at Test$Baz$1()(Test.scala:6)
[error]          method at Test$.main$$anonfun$1(Test.scala:9)
[error]          method at Test$$$Lambda$1.apply$mcVI$sp(Test.scala:9)
[error]          method at Test$.main(Test.scala:9)
[error]          method at Test.main(Test.scala:2)
[error] 
[error] Found unknown type java.sql.Types, referenced from:
[error]       type at Test$Baz$1(Test.scala:6)
[error]     method at Test$.main$$anonfun$1(Test.scala:9)
[error]     method at Test$$$Lambda$1.apply$mcVI$sp(Test.scala:9)
[error]     method at Test$.main(Test.scala:9)
[error]     method at Test.main(Test.scala:2)
[error] 
[error] Found unknown constructor java.sql.Time(long), referenced from:
[error]     constructor at Test$Foo$1(long)(Test.scala:4)
[error]          method at Test$.main$$anonfun$1(Test.scala:8)
[error]          method at Test$$$Lambda$1.apply$mcVI$sp(Test.scala:9)
[error]          method at Test$.main(Test.scala:9)
[error]          method at Test.main(Test.scala:2)
[error] 
[info] Total (1508 ms)
[error] Unreachable symbols found after classloading run. It can happen when using dependencies not cross-compiled for Scala Native or not yet ported JDK definitions.
```