### PR TITLE
Build: Update sbt to 1.9.4

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.3
+sbt.version = 1.9.4


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.9.4.

Usually I linger in the protective cover of Arman having gone first and privately exercise the proposed
update for a fortnight or so before submitting it as a PR.  I am waving that practice and submitting
just after Arman, because this sbt update contains a fix to a CVE (security defect report). I do not 
know how hard or easy it is to exploit the reported defect but there seems to be some buzz for
users of SBT to update prudently.

From the SBT GitHub [announcement](https://github.com/sbt/sbt/releases/tag/v1.9.4):
```
CVE-2022-46751 is a security vulnerability discovered in Apache Ivy, but found also in Coursier.
```

As a smoke test, I ran "test2_12/test" once on my personal machine before creating this PR.

As always, thank you for going first Arman.
