### PR TITLE
Cleanup stacktraces to not contain intrinsic method calls

### DIFF
--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -4,6 +4,7 @@ import scalanative.unsafe.{CString, fromCString}
 import scalanative.unsigned._
 import scala.scalanative.unsafe._
 import scala.scalanative.runtime.SymbolFormatter
+import scala.scalanative.runtime.Backtrace
 
 final class StackTraceElement(
     val getClassName: String,
@@ -47,7 +48,11 @@ final class StackTraceElement(
 private[lang] object StackTraceElement {
   object Fail extends scala.util.control.NoStackTrace
 
-  def fromSymbol(sym: CString): StackTraceElement = {
+  // ScalaNative specific
+  private[lang] def apply(
+      sym: CString,
+      position: Backtrace.Position
+  ): StackTraceElement = {
     val className: Ptr[CChar] = stackalloc[CChar](1024)
     val methodName: Ptr[CChar] = stackalloc[CChar](1024)
     SymbolFormatter.asyncSafeFromSymbol(sym, className, methodName)
@@ -55,8 +60,8 @@ private[lang] object StackTraceElement {
     new StackTraceElement(
       fromCString(className),
       fromCString(methodName),
-      null,
-      0
+      position.filename,
+      position.line
     )
   }
 }

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -632,7 +632,8 @@ private[java] case class PlatformThreadContext(
     task: Runnable,
     stackSize: scala.Long,
     @volatile var priority: Int = Thread.NORM_PRIORITY,
-    @volatile var daemon: scala.Boolean = false
+    @volatile var daemon: scala.Boolean = false,
+    var isFillingStackTrace: scala.Boolean = false
 ) {
   var nativeThread: NativeThread = _
 

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -13,7 +13,8 @@ private[lang] object StackTrace {
   private val cache = TrieMap.empty[CUnsignedLong, StackTraceElement]
 
   private def makeStackTraceElement(
-      cursor: Ptr[scala.Byte]
+      cursor: Ptr[scala.Byte],
+      ip: CUnsignedLong
   )(implicit zone: Zone): StackTraceElement = {
     val nameMax = 1024
     val name = alloc[CChar](nameMax)
@@ -25,8 +26,10 @@ private[lang] object StackTrace {
     // Unmangler is going to use strlen on this name and it's
     // behavior is not defined for non-zero-terminated strings.
     name(nameMax - 1) = 0.toByte
-
-    StackTraceElement.fromSymbol(name)
+    val position =
+      if (LinktimeInfo.isMac) Backtrace.decodePosition(ip.toLong)
+      else Backtrace.Position.empty
+    StackTraceElement(name, position)
   }
 
   /** Creates a stack trace element in given unwind context. Finding a name of
@@ -37,66 +40,33 @@ private[lang] object StackTrace {
       cursor: Ptr[scala.Byte],
       ip: CUnsignedLong
   )(implicit zone: Zone): StackTraceElement =
-    cache.getOrElseUpdate(ip, makeStackTraceElement(cursor))
+    cache.getOrElseUpdate(ip, makeStackTraceElement(cursor, ip))
+
+  // Used to prevent filling stacktraces inside `currentStackTrace` which might lead to infinite loop
+  private val suppressStrackTrace: ThreadLocal[Boolean] =
+    ThreadLocal.withInitial(() => false)
 
   @noinline private[lang] def currentStackTrace(): Array[StackTraceElement] = {
-    var buffer = mutable.ArrayBuffer.empty[(StackTraceElement, CUnsignedLong)]
-    if (!LinktimeInfo.asanEnabled) {
-      Zone { implicit z =>
-        val cursor = alloc[scala.Byte](unwind.sizeOfCursor)
-        val context = alloc[scala.Byte](unwind.sizeOfContext)
-        val ip = stackalloc[CSize]()
-        unwind.get_context(context)
-        unwind.init_local(cursor, context)
-        while (unwind.step(cursor) > 0) {
-          unwind.get_reg(cursor, unwind.UNW_REG_IP, ip)
-          val elem = (cachedStackTraceElement(cursor, !ip), !ip)
-          buffer += elem
-        }
-      }
-    }
+    if (suppressStrackTrace.get()) Array.empty
+    else if (LinktimeInfo.asanEnabled) Array.empty
+    else
+      try {
+        suppressStrackTrace.set(true)
+        var buffer = mutable.ArrayBuffer.empty[StackTraceElement]
+        Zone { implicit z =>
+          val cursor = alloc[scala.Byte](unwind.sizeOfCursor)
+          val context = alloc[scala.Byte](unwind.sizeOfContext)
+          val ip = stackalloc[CSize]()
+          unwind.get_context(context)
+          unwind.init_local(cursor, context)
+          while (unwind.step(cursor) > 0) {
+            unwind.get_reg(cursor, unwind.UNW_REG_IP, ip)
+            buffer += cachedStackTraceElement(cursor, !ip)
+          }
 
-    if (LinktimeInfo.isMac && LinktimeInfo.hasDebugMetadata) {
-      // Add filename and line number informatiion
-      // When analyzing the stack trace, if the entry "currentStackTrace" appears more than once, it indicates that a Throwable object
-      // was generated within the same "currentStackTrace" method, causing recursive calls. This recursive behavior can lead to an
-      // infinite loop, ultimately resulting in a stack overflow exception.
-      //
-      // To prevent excessive recursion, it's preferable to minimize multiple consecutive calls to the "currentStackTrace" method.
-      //
-      // The "currentStackTrace" process is straightforward and typically doesn't trigger exceptions.
-      // On the other hand, the "BackTrace.decodeFileline" is intricate, and if an exception thrown, it's likely to originate from that method.
-      //
-      // Consequently, to mitigate the risk of cascading recursive exceptions,
-      // skip executing "BackTrace.decodeFileline" if "currentStackTrace" is already being invoked recursively.
-      val recur =
-        buffer.count(e => e._1.getMethodName == "currentStackTrace") > 1
-      buffer.map { e =>
-        val elem = e._1
-        val ip = e._2
-        if (recur || // Skip decoding if we're calling currentStackTrace in recursively
-            elem.getFileName != null // Skip decoding if we already have filename information
-        ) elem
-        else {
-          try {
-            Backtrace.decodeFileline(ip.toLong) match {
-              case None =>
-                elem
-              case Some(v) =>
-                val updated = new StackTraceElement(
-                  elem.getClassName,
-                  elem.getMethodName,
-                  v._1,
-                  v._2
-                )
-                // Update cache with the updated stacktrace element
-                cache.update(ip, updated)
-                updated
-            }
-          } catch { case ex: Throwable => elem }
         }
-      }.toArray
-    } else buffer.map(_._1).toArray
+        buffer.toArray
+      } finally suppressStrackTrace.set(false)
   }
 }
 


### PR DESCRIPTION
Before: 
```Scala 
java.lang.RuntimeException
        at java.lang.StackTrace$.currentStackTrace$$anonfun$1(Throwables.scala:57)
        at java.lang.StackTrace$$$Lambda$3.applyVoid(Throwables.scala:87)
        at scala.runtime.function.JProcedure1.apply(JProcedure.scala:28)
        at scala.scalanative.unsafe.Zone$.apply(Zone.scala:29)
        at java.lang.StackTrace$.currentStackTrace(Throwables.scala:50)
        at java.lang.Throwable.fillInStackTrace(Throwables.scala:146)
        at Test$.main(Test.scala:3)
        at Test.main(Test.scala:3)
        at <none>.main(unknown:2)
```


After: 
```Scala
java.lang.RuntimeException
        at Test$.main(Test.scala:3)
        at Test.main(Test.scala:3)
        at <none>.main(unknown:2)
```