### PR TITLE
Add variants of NativeConfig methods taking a mapping function instead of computed value

### DIFF
--- a/.github/workflows/run-tests-linux-multiarch.yml
+++ b/.github/workflows/run-tests-linux-multiarch.yml
@@ -167,12 +167,8 @@ jobs:
                 .withCheckFatalWarnings(true)
                 .withTargetTriple(sys.env.get("CROSS_TRIPLE"))
                 .withMultithreadingSupport(${{matrix.multithreading}})
-                .withCompileOptions(
-                  prev.compileOptions ++ sysRoot ++ List("-fuse-ld=lld")
-                )
-                .withLinkingOptions(
-                  prev.linkingOptions ++ sysRoot ++ List("-fuse-ld=lld", "-latomic")
-                )
+                .withCompileOptions(_ ++ sysRoot ++ List("-fuse-ld=lld"))
+                .withLinkingOptions(_ ++ sysRoot ++ List("-fuse-ld=lld", "-latomic"))
             }
           EOM
           )

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -90,10 +90,7 @@ jobs:
         # Linking on MacOS in GithubActions fails when using default linker (ld), use lld instead
         run: |
           SetConfigTemplate=$(cat << EOM
-            nativeConfig ~= { prev =>
-              prev
-                .withLinkingOptions(prev.linkingOptions ++ Seq("-fuse-ld=lld") )
-            }
+            nativeConfig ~= { _.withLinkingOptions(_ :+ "-fuse-ld=lld") }
           EOM
           )
           echo set-native-config=${SetConfigTemplate} >> $GITHUB_ENV
@@ -191,7 +188,7 @@ jobs:
                 .withCheck(true)
                 .withCheckFatalWarnings(true)
                 .withMultithreadingSupport(true)
-                .withLinkingOptions(prev.linkingOptions ++ Seq("-fuse-ld=lld") )
+                .withLinkingOptions(_ :+ "-fuse-ld=lld")
             }
           EOM
           )

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -137,7 +137,7 @@ To append a value to the right of any previous setting:
 
     // Enable verbose reporting during compilation
     nativeConfig ~= { c =>
-      c.withCompileOptions(c.compileOptions ++ Seq("-v"))
+      c.withCompileOptions(_ :+ "-v")
     }
 
     // Use an alternate linker


### PR DESCRIPTION
Most of config updates for linking/compile options is typically appending/filtering. Becouse of that we introduce a variant of NativeConfig methods taking a mapping function `T => T` instead of computed value`T`