### PR TITLE
Fix #3452: javalib Process.waitFor() now returns expected child exit code

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -64,7 +64,7 @@ private[lang] class UnixProcessGen2 private (
       if (waitStatus == 0) {
         throw new IllegalThreadStateException()
       } else {
-        _exitValue.getOrElse(-1) // -1 should never happen
+        _exitValue.getOrElse(1) // 1 should never happen
       }
     }
   }
@@ -172,10 +172,11 @@ private[lang] class UnixProcessGen2 private (
      *  process reports the child as exited.  This delay is not seen on Linux.
      *
      *  The alternative to allowing HANG on a process which kevent/ppoll has
-     *  just reported as having exited to a fussy busy-wait timing loop.
+     *  just reported as having exited is a fussy busy-wait timing loop.
      */
 
     waitpidImpl(pid, options = 0)
+    _exitValue.getOrElse(1) // 1 == EXIT_FAILURE, unknown cause
   }
 
   private def closeProcessStreams(): Unit = {

--- a/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
@@ -147,8 +147,8 @@ class NIRCompiler(outDir: Path) {
     val cmd = args.mkString(" ")
     val proc = procBuilder.start()
     val res = proc.waitFor()
-    // TODO: UnixProcessGen2 on Mac M1 can return PID instead of exitCode
-    if (res != 0 && proc.exitValue() != 0) {
+
+    if (res != 0) {
       val stderr =
         scala.io.Source.fromInputStream(proc.getErrorStream()).mkString
       throw new CompilationFailedException(stderr)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -9,6 +9,7 @@ import scala.io.Source
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
+
 import org.scalanative.testsuite.utils.Platform, Platform._
 import scala.scalanative.junit.utils.AssumesHelper._
 
@@ -143,6 +144,34 @@ class ProcessTest {
 
     assertEquals("", readInputStream(proc.getErrorStream))
     assertEquals("foobar", readInputStream(proc.getInputStream))
+  }
+
+  // Issue 3452
+  @Test def waitForReturnsExitCode(): Unit = {
+    /* This test neither robust nor CI friendly.
+     * A buggy implementation of waitFor(pid) and/or of processSleep()
+     * could cause it to hang forever.
+     *
+     * waitfor(pid, timeout) can not be used here because it returns a Boolean,
+     * not the exit code of the child.
+     *
+     * Scala Native does not implement junit "@Test(timeout)". That was
+     * designed for situations just like this.
+     *
+     * Let's see how this fairs in CI. Does it hang intermittently?
+     * Should it be a manual development & maintains only test, ignored
+     * in CI?
+     */
+
+    val proc = processSleep(0.1).start()
+
+    val expected = 0 // Successful completion
+
+    assertEquals(
+      s"waitFor return value",
+      expected,
+      proc.waitFor()
+    )
   }
 
   @Test def waitForWithTimeoutCompletes(): Unit = {


### PR DESCRIPTION
Fix #3452
 
javalib Process.waitFor() now returns the child exit code, as documented & implemented in the JVM.