### PR TITLE
Fix #3467: SN 0.4.x backport two missing javalib Exceptions

### DIFF
--- a/javalib/src/main/scala/java/nio/file/FileSystemAlreadyExistsException.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystemAlreadyExistsException.scala
@@ -1,0 +1,8 @@
+package java.nio.file
+
+class FileSystemAlreadyExistsException(message: String, cause: Throwable)
+    extends RuntimeException(message, cause) {
+  def this(message: String) = this(message, null)
+  def this(cause: Throwable) = this(null, cause)
+  def this() = this(null, null)
+}

--- a/javalib/src/main/scala/java/nio/file/ProviderNotFoundException.scala
+++ b/javalib/src/main/scala/java/nio/file/ProviderNotFoundException.scala
@@ -1,0 +1,8 @@
+package java.nio.file
+
+class ProviderNotFoundException(message: String, cause: Throwable)
+    extends RuntimeException(message, cause) {
+  def this(message: String) = this(message, null)
+  def this(cause: Throwable) = this(null, cause)
+  def this() = this(null, null)
+}


### PR DESCRIPTION
Fix #3467 
 
Backport two missing javalib Exceptions to SN 0.4.x branch.  

When this PR is released and scala-cli is upgraded to use that release, then
scala-cli should properly report `ProviderNotFoundException` & `FileSystemAlreadyExistsException`.
That establishes the "before" test case for Work In Progress zip file system support.