### PR TITLE
Fix String.offsetByCodePoints for unpaired surrogates

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -378,7 +378,7 @@ object Character {
         }
         if (isHighSurrogate(seq(i))) {
           val next = i + 1
-          if (next <= end && isLowSurrogate(seq(next))) {
+          if (next < end && isLowSurrogate(seq(next))) {
             i += 1
           }
         }
@@ -396,7 +396,7 @@ object Character {
         }
         if (isLowSurrogate(seq(i))) {
           val prev = i - 1
-          if (prev >= start && isHighSurrogate(seq(prev))) {
+          if (prev > start && isHighSurrogate(seq(prev))) {
             i -= 1
           }
         }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
@@ -127,6 +127,32 @@ class StringTest {
     )
   }
 
+  @Test def offsetByCodePoints(): Unit = {
+    assertTrue("abc".offsetByCodePoints(0, 3) == 3)
+    assertTrue("abc".offsetByCodePoints(1, 2) == 3)
+
+    assertTrue("abc".offsetByCodePoints(3, -3) == 0)
+    assertTrue("abc".offsetByCodePoints(3, -2) == 1)
+
+    assertTrue("\uD800\uDC00".offsetByCodePoints(0, 1) == 2)
+    assertTrue("\uD800\uDC00".offsetByCodePoints(1, -1) == 0)
+  }
+
+  @Test def offsetByCodePointsUnpairedSurrogates(): Unit = {
+    assertTrue("\uD800".offsetByCodePoints(0, 1) == 1)
+    assertTrue("\uDBFF".offsetByCodePoints(0, 1) == 1)
+    assertTrue("\uDC00".offsetByCodePoints(0, 1) == 1)
+    assertTrue("\uDFFF".offsetByCodePoints(0, 1) == 1)
+
+    assertTrue("\uD800".offsetByCodePoints(1, -1) == 0)
+    assertTrue("\uDBFF".offsetByCodePoints(1, -1) == 0)
+    assertTrue("\uDC00".offsetByCodePoints(1, -1) == 0)
+    assertTrue("\uDFFF".offsetByCodePoints(1, -1) == 0)
+
+    assertTrue("\uD800x".offsetByCodePoints(0, 2) == 2)
+    assertTrue("x\uD800".offsetByCodePoints(0, 2) == 2)
+  }
+
   @Test def compareTo(): Unit = {
     assertTrue("test".compareTo("utest") < 0)
     assertTrue("test".compareTo("test") == 0)


### PR DESCRIPTION
fix https://github.com/scala-native/scala-native/issues/3470

Previously, String.offsetByCodePoints had an error when the offsetByCodePoints ends with the unpaired higher surrogate.

```
❯ cat test.scala
@main def main = {
    println("\uD800".offsetByCodePoints(0, 1))
}

❯ scala-cli test.scala
Compiling project (Scala 3.3.0, JVM)
Compiled project (Scala 3.3.0, JVM)
1

❯ scala-cli test.scala --native
Compiling project (Scala 3.3.0, Scala Native)
Compiled project (Scala 3.3.0, Scala Native)
[info] Linking (756 ms)
[info] Discovered 680 classes and 3771 methods
[info] Optimizing (debug mode) (889 ms)
[info] Generating intermediate code (856 ms)
[info] Produced 8 files
[info] Compiling to native code (1649 ms)
[info] Total (4257 ms)
java.lang.ArrayIndexOutOfBoundsException: 1
        at java.lang.StackTrace$.currentStackTrace$$anonfun$1(Unknown Source)
        at java.lang.StackTrace$$$Lambda$2.applyVoid(Unknown Source)
        at scala.runtime.function.JProcedure1.apply(Unknown Source)
        at scala.scalanative.unsafe.Zone$.apply(Unknown Source)
        at java.lang.StackTrace$.currentStackTrace(Unknown Source)
        at java.lang.Throwable.fillInStackTrace(Unknown Source)
        at scala.scalanative.runtime.package$.throwOutOfBounds(Unknown Source)
        at java.lang.Character$.offsetByCodePoints(Unknown Source)
        at java.lang.String.offsetByCodePoints(Unknown Source)
        at test$package$.main(Unknown Source)
        at main.main(Unknown Source)
        at <none>.main(Unknown Source)
```

This commit fix the bound check in the offsetByCodePoints not to check the next index is the lower surrogate after the higher surrogate.