### PR TITLE
Detect at linktime usage of unsupported features

### DIFF
--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -15,6 +15,7 @@ import scala.scalanative.runtime.NativeThread.{State => _, _}
 import scala.scalanative.runtime.NativeThread.State._
 import scala.scalanative.libc.atomic.{CAtomicLongLong, atomic_thread_fence}
 import scala.scalanative.libc.atomic.memory_order._
+import scala.scalanative.runtime.UnsupportedFeature
 
 import scala.scalanative.runtime.JoinNonDaemonThreads
 
@@ -247,10 +248,7 @@ class Thread private[lang] (
   }
 
   def start(): Unit = synchronized {
-    if (!isMultithreadingEnabled)
-      throw new IllegalStateException(
-        "ScalaNative application linked with disabled multithreading support"
-      )
+    if (!isMultithreadingEnabled) UnsupportedFeature.threads()
     if (isVirtual())
       throw new UnsupportedOperationException(
         "VirtualThreads are not yet supported"

--- a/javalib/src/main/scala/java/lang/VirtualThread.scala
+++ b/javalib/src/main/scala/java/lang/VirtualThread.scala
@@ -1,5 +1,7 @@
 package java.lang
 
+import scala.scalanative.runtime.UnsupportedFeature
+
 final private[lang] class VirtualThread(
     name: String,
     characteristics: Int,
@@ -7,9 +9,7 @@ final private[lang] class VirtualThread(
 ) extends Thread(name, characteristics) {
 
   // TODO: continuations-based thread implementation
-  override def run(): Unit = throw new UnsupportedOperationException(
-    "Running VirtualThreads is not yet supported"
-  )
+  override def run(): Unit = UnsupportedFeature.virtualThreads()
 
   override def getState(): Thread.State = Thread.State.NEW
 }

--- a/nativelib/src/main/java/scala/scalanative/runtime/UnsupportedFeature.java
+++ b/nativelib/src/main/java/scala/scalanative/runtime/UnsupportedFeature.java
@@ -1,0 +1,26 @@
+package scala.scalanative.runtime;
+
+/**
+ * Mock methods used to detect at linktime usage of unsupported features. Use
+ * with caution and always use guarded with linktime-reasolved conditions. Eg.
+ * 
+ * <pre>
+ * {@code
+ * object MyThread extends Thread(){
+ *   override def run(): Unit = 
+ *    if !scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled 
+ *    then UnsupportedFeature.threads() // fail compilation if multithreading is disabled
+ *    else runLogic()
+ * }
+ * }
+ * </pre>
+ */
+public abstract class UnsupportedFeature {
+	// Always sync with tools/src/main/scala/scala/scalanative/linker/Reach.scala
+	// UnsupportedFeature and UnsupportedFeatureExtractor
+	public static void threads() {
+	}
+
+	public static void virtualThreads() {
+	}
+}

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -230,9 +230,10 @@ sealed trait ReachabilityAnalysis {
 }
 
 object ReachabilityAnalysis {
-  final class UnreachableSymbolsFound(
+  final class Failure(
       val defns: Seq[Defn],
-      val unreachable: Seq[Reach.UnreachableSymbol]
+      val unreachable: Seq[Reach.UnreachableSymbol],
+      val unsupportedFeatures: Seq[Reach.UnsupportedFeature]
   ) extends ReachabilityAnalysis
   final class Result(
       val infos: mutable.Map[Global, Info],

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -105,6 +105,7 @@ trait LinktimeValueResolver { self: Reach =>
       case Inst.Let(_, op, Next.None) =>
         op match {
           case Op.Call(_, Val.Global(name, _), _) =>
+            track(name)(inst.pos)
             name != Linktime.PropertyResolveFunctionName &&
               !lookup(name).exists(_.attrs.isLinktimeResolved)
           case _: Op.Comp => false
@@ -247,7 +248,7 @@ trait LinktimeValueResolver { self: Reach =>
             case Next.Label(_, values) =>
               locals ++= nextBlock.params.zip(values).toMap
             case _ =>
-              unsupported(
+              scalanative.util.unsupported(
                 "Only normal labels are expected in linktime resolved methods"
               )
           }
@@ -263,7 +264,7 @@ trait LinktimeValueResolver { self: Reach =>
 
         case _: Inst.If | _: Inst.Let | _: Inst.Switch | _: Inst.Throw |
             _: Inst.Unreachable =>
-          unsupported(
+          scalanative.util.unsupported(
             "Unexpected instruction found in linktime resolved method: " + inst
           )
       }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -15,6 +15,7 @@ class Reach(
 
   val loaded = mutable.Map.empty[Global.Top, mutable.Map[Global, Defn]]
   val unreachable = mutable.Map.empty[Global, UnreachableSymbol]
+  val unsupported = mutable.Map.empty[Global, UnsupportedFeature]
   val enqueued = mutable.Set.empty[Global]
   var todo = List.empty[Global]
   val done = mutable.Map.empty[Global, Defn]
@@ -56,7 +57,7 @@ class Reach(
     // in reachUnavailable
     done.valuesIterator.filter(_ != null).foreach(defns += _)
 
-    if (unreachable.isEmpty)
+    if (unreachable.isEmpty && unsupported.isEmpty)
       new ReachabilityAnalysis.Result(
         infos = infos,
         entries = entries,
@@ -67,9 +68,10 @@ class Reach(
         resolvedVals = resolvedNirValues
       )
     else
-      new ReachabilityAnalysis.UnreachableSymbolsFound(
+      new ReachabilityAnalysis.Failure(
         defns = defns.toSeq,
-        unreachable = unreachable.values.toSeq
+        unreachable = unreachable.values.toSeq,
+        unsupportedFeatures = unsupported.values.toSeq
       )
   }
 
@@ -915,71 +917,111 @@ class Reach(
     }
   }
 
-  protected def addMissing(global: Global): Unit = unreachable.getOrElseUpdate(
-    global, {
-      def parseSig(owner: String, sig: Sig): (String, String) =
-        sig.unmangled match {
-          case Sig.Method(name, _, _) => "method" -> s"$owner.${name}"
-          case Sig.Ctor(tys) =>
-            val ctorTys = tys
-              .map {
-                case ty: Type.RefKind => ty.className.id
-                case ty               => ty.show
-              }
-              .mkString(",")
-            "constructor" -> s"$owner($ctorTys)"
-          case Sig.Clinit          => "static constructor" -> owner
-          case Sig.Field(name, _)  => "field" -> s"$owner.$name"
-          case Sig.Generated(name) => "generated method" -> s"$owner.${name}"
-          case Sig.Proxy(name, _)  => "proxy method" -> s"$owner.$name"
-          case Sig.Duplicate(sig, _) =>
-            val (kind, name) = parseSig(owner, sig)
-            s"duplicate $kind" -> s"$owner.name"
-          case Sig.Extern(name) => s"extern method" -> s"$owner.$name"
-        }
-
-      def parseSymbol(name: Global): (String, String) = name match {
-        case Global.Member(owner, sig) => parseSig(owner.id, sig)
-        case Global.Top(id)            => "type" -> id
-        case _                         => util.unreachable
-      }
-
-      val buf = List.newBuilder[BackTraceElement]
-      def getBackTrace(name: Global): List[BackTraceElement] = {
-        // orElse just in case if we messed something up and failed to correctly track references
-        // Accept possibly empty backtrace instead of crashing
-        val current = from.getOrElse(name, ReferencedFrom.Root)
-        if (current == ReferencedFrom.Root) buf.result()
-        else {
-          val file = current.srcPosition.filename.getOrElse("unknown")
-          val line = current.srcPosition.line
-          val (kind, symbol) = parseSymbol(current.referencedBy)
-          buf += BackTraceElement(
-            name = current.referencedBy,
-            kind = kind,
-            symbol = symbol,
-            filename = file,
-            line = line + 1
-          )
-          getBackTrace(current.referencedBy)
-        }
-      }
-
-      val (kind, symbol) = parseSymbol(global)
-      UnreachableSymbol(
-        name = global,
-        kind = kind,
-        symbol = symbol,
-        backtrace = getBackTrace(global)
-      )
+  protected def addMissing(global: Global): Unit =
+    global match {
+      case UnsupportedFeatureExtractor(details) =>
+        unsupported.getOrElseUpdate(global, details)
+      case _ =>
+        unreachable.getOrElseUpdate(
+          global, {
+            val (kind, symbol) = parseSymbol(global)
+            UnreachableSymbol(
+              name = global,
+              kind = kind,
+              symbol = symbol,
+              backtrace = getBackTrace(global)
+            )
+          }
+        )
     }
-  )
+
+  private def parseSymbol(name: Global): (String, String) = {
+    def parseSig(owner: String, sig: Sig): (String, String) =
+      sig.unmangled match {
+        case Sig.Method(name, _, _) => "method" -> s"$owner.${name}"
+        case Sig.Ctor(tys) =>
+          val ctorTys = tys
+            .map {
+              case ty: Type.RefKind => ty.className.id
+              case ty               => ty.show
+            }
+            .mkString(",")
+          "constructor" -> s"$owner($ctorTys)"
+        case Sig.Clinit         => "static constructor" -> owner
+        case Sig.Field(name, _) => "field" -> s"$owner.$name"
+        case Sig.Generated(name) =>
+          "generated method" -> s"$owner.${name}"
+        case Sig.Proxy(name, _) => "proxy method" -> s"$owner.$name"
+        case Sig.Duplicate(sig, _) =>
+          val (kind, name) = parseSig(owner, sig)
+          s"duplicate $kind" -> s"$owner.name"
+        case Sig.Extern(name) => s"extern method" -> s"$owner.$name"
+      }
+
+    name match {
+      case Global.Member(owner, sig) => parseSig(owner.id, sig)
+      case Global.Top(id)            => "type" -> id
+      case _                         => util.unreachable
+    }
+  }
+
+  private def getBackTrace(referencedFrom: Global): List[BackTraceElement] = {
+    val buf = List.newBuilder[BackTraceElement]
+    def loop(name: Global): List[BackTraceElement] = {
+      // orElse just in case if we messed something up and failed to correctly track references
+      // Accept possibly empty backtrace instead of crashing
+      val current = from.getOrElse(name, ReferencedFrom.Root)
+      if (current == ReferencedFrom.Root) buf.result()
+      else {
+        val file = current.srcPosition.filename.getOrElse("unknown")
+        val line = current.srcPosition.line
+        val (kind, symbol) = parseSymbol(current.referencedBy)
+        buf += BackTraceElement(
+          name = current.referencedBy,
+          kind = kind,
+          symbol = symbol,
+          filename = file,
+          line = line + 1
+        )
+        loop(current.referencedBy)
+      }
+    }
+    loop(referencedFrom)
+  }
+
+  private object UnsupportedFeatureExtractor {
+    import UnsupportedFeature._
+    private val UnsupportedSymbol =
+      Global.Top("scala.scalanative.runtime.UnsupportedFeature")
+
+    private def details(sig: Sig): UnsupportedFeature.Kind =
+      sig.unmangled match {
+        case Sig.Method("threads", _, _)        => SystemThreads
+        case Sig.Method("virtualThreads", _, _) => VirtualThreads
+        case _                                  => Other
+      }
+
+    def unapply(name: Global): Option[UnsupportedFeature] = name match {
+      case Global.Member(UnsupportedSymbol, sig) =>
+        unsupported
+          .get(name)
+          .orElse(
+            Some(
+              UnsupportedFeature(
+                kind = details(sig),
+                backtrace = getBackTrace(name)
+              )
+            )
+          )
+      case _ => None
+    }
+  }
 
   private def fail(msg: => String): Nothing = {
     throw new LinkingException(msg)
   }
 
-  private def track(name: Global)(implicit srcPosition: nir.Position) =
+  protected def track(name: Global)(implicit srcPosition: nir.Position) =
     from.getOrElseUpdate(
       name,
       if (stack.isEmpty) ReferencedFrom.Root
@@ -1019,4 +1061,19 @@ object Reach {
       symbol: String,
       backtrace: List[BackTraceElement]
   )
+
+  case class UnsupportedFeature(
+      kind: UnsupportedFeature.Kind,
+      backtrace: List[BackTraceElement]
+  )
+  object UnsupportedFeature {
+    sealed abstract class Kind(val details: String)
+    case object SystemThreads
+        extends Kind(
+          "Application linked with disabled multithreading support. Adjust nativeConfig and try again"
+        )
+    case object VirtualThreads
+        extends Kind("VirtualThreads are not supported yet on this platform")
+    case object Other extends Kind("Other unsupported feature")
+  }
 }

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -44,9 +44,9 @@ abstract class LinkerSpec {
       entry: String,
       sources: Map[String, String],
       setupConfig: NativeConfig => NativeConfig = identity
-  )(fn: (Config, ReachabilityAnalysis.UnreachableSymbolsFound) => T): T =
+  )(fn: (Config, ReachabilityAnalysis.Failure) => T): T =
     mayLink(entry, sources, setupConfig) {
-      case (config, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+      case (config, result: ReachabilityAnalysis.Failure) =>
         fn(config, result)
       case _ => fail("Expected code to not link"); unreachable
     }

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -149,7 +149,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
                           |  }
                           |}""".stripMargin
       )("int" -> n) {
-        case (_, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+        case (_, result: ReachabilityAnalysis.Failure) =>
           assertTrue(
             n.toString,
             (result.unreachable.map(_.name).toSet - pathForNumber(n)).isEmpty
@@ -180,7 +180,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
           |  }
           |}""".stripMargin
       )("float" -> n.toFloat) {
-        case (_, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+        case (_, result: ReachabilityAnalysis.Failure) =>
           assertTrue(
             n.toString,
             (result.unreachable.map(_.name).toSet - pathForNumber(n)).isEmpty
@@ -236,7 +236,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
         "prop.string" -> stringValue,
         "inner.countFrom" -> longValue
       ) {
-        case (_, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+        case (_, result: ReachabilityAnalysis.Failure) =>
           assertTrue(
             (result.unreachable.map(_.name).toSet -
               pathForNumber(pathNumber)).isEmpty
@@ -284,7 +284,7 @@ class LinktimeConditionsSpec extends OptimizerSpec {
         "prop.bool.1" -> bool1,
         "prop.bool.2" -> bool2
       ) {
-        case (_, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+        case (_, result: ReachabilityAnalysis.Failure) =>
           assertTrue(
             (result.unreachable.map(_.name).toSet -
               pathForNumber(pathNumber)).isEmpty
@@ -465,10 +465,10 @@ class LinktimeConditionsSpec extends OptimizerSpec {
   private def doesNotLinkWithProps(
       sources: (String, String)*
   )(props: (String, Any)*)(
-      body: (Config, ReachabilityAnalysis.UnreachableSymbolsFound) => Unit
+      body: (Config, ReachabilityAnalysis.Failure) => Unit
   ): Unit = {
     mayLinkWithProps(sources: _*)(props: _*) {
-      case (config, analysis: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+      case (config, analysis: ReachabilityAnalysis.Failure) =>
         body(config, analysis)
       case _ =>
         fail("Expected code to not link"); scala.scalanative.util.unreachable

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -29,7 +29,7 @@ class StubSpec extends LinkerSpec {
 
   @Test def ignoreMethods(): Unit = {
     doesNotLink(entry, stubMethodSource, _.withLinkStubs(false)) {
-      (cfg, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+      (cfg, result: ReachabilityAnalysis.Failure) =>
         assertTrue(!cfg.linkStubs)
         assertTrue(result.unreachable.length == 1)
         assertEquals(
@@ -50,7 +50,7 @@ class StubSpec extends LinkerSpec {
 
   @Test def ignoreClasses(): Unit = {
     doesNotLink(entry, stubClassSource, _.withLinkStubs(false)) {
-      (cfg, result: ReachabilityAnalysis.UnreachableSymbolsFound) =>
+      (cfg, result: ReachabilityAnalysis.Failure) =>
         assertTrue(!cfg.linkStubs)
         assertTrue(result.unreachable.length == 1)
         assertTrue(result.unreachable.head.name == Global.Top("StubClass"))


### PR DESCRIPTION
This change allows us to detect usage of unsupported features early at linktime based of linktime-resolved conditions. 
Thanks to this feature, we can guard against of runtime failures for some well known execution flows. One of them is running Thread with disabled multithreading support. 
By defining `scala.scalanative.runtime.UnsupportedFeature` as Java file it would never contain NIR. We can collect it's usages and adapt them to present more user friendly messages. 