### PR TITLE
Fix #3477: javalib Channels.newChannel#read now reports EOF

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/Channels.scala
+++ b/javalib/src/main/scala/java/nio/channels/Channels.scala
@@ -74,10 +74,12 @@ object Channels {
         if ((written == 0) && eof) -1
         else written
       }
+
       override def close(): Unit = synchronized {
         in.close()
         closed = true
       }
+
       override def isOpen(): Boolean = synchronized { !closed }
     }
   }

--- a/javalib/src/main/scala/java/nio/channels/Channels.scala
+++ b/javalib/src/main/scala/java/nio/channels/Channels.scala
@@ -52,20 +52,27 @@ object Channels {
     new ReadableByteChannel {
       var closed = false
       override def read(dst: ByteBuffer): Int = synchronized {
-        if (closed) throw new ClosedChannelException()
+        if (closed)
+          throw new ClosedChannelException()
 
+        var eof = false
         var written = 0
         val capacity = dst.capacity()
+
         while ({
           val readByte = in.read()
-          if (readByte != -1) {
+          if (readByte == -1) {
+            eof = true
+            false
+          } else {
             dst.put(readByte.toByte)
             written += 1
             capacity > written
-          } else false
+          }
         }) ()
 
-        written
+        if ((written == 0) && eof) -1
+        else written
       }
       override def close(): Unit = synchronized {
         in.close()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/channels/ChannelsTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/channels/ChannelsTest.scala
@@ -25,6 +25,23 @@ class ChannelsTest {
     assertArrayEquals(expected, byteBuffer.array())
   }
 
+  // Issue 3477
+  @Test def newChannelInputStreamReportsEOF(): Unit = {
+    val expected = Array[Byte](1, 2, 3)
+    val in = new ByteArrayInputStream(expected, 0, 3)
+    val channel = Channels.newChannel(in)
+
+    val byteBuffer = ByteBuffer.allocate(3)
+
+    // Read, check, and then discard expected in order to get to EOF
+    channel.read(byteBuffer)
+    assertArrayEquals(expected, byteBuffer.array())
+    byteBuffer.rewind()
+
+    val nRead = channel.read(byteBuffer)
+    assertEquals("Read of channel at EOF)", -1, nRead)
+  }
+
   @Test def newChannelInputStreamThrows(): Unit = {
     assumeFalse(
       "Bug in the JVM, works for later versions than java 8",


### PR DESCRIPTION
Fix #3477

The `read()` method returned by  javalib `Channels.newChannel` now reports end of file (a.k.a EOF) 
as described in the corresponding JDK `ReadByteChannel` documentation (-1).