### PR TITLE
Javalib housekeeping: add two missing classes

### DIFF
--- a/javalib/src/main/scala/java/nio/file/AccessMode.scala
+++ b/javalib/src/main/scala/java/nio/file/AccessMode.scala
@@ -1,0 +1,21 @@
+package java.nio.file
+
+sealed class AccessMode(name: String, ordinal: Int)
+    extends _Enum[AccessMode](name, ordinal) {
+  override def toString() = this.name
+}
+
+object AccessMode {
+  final val EXECUTE = new AccessMode("EXECUTE", 0)
+  final val READ = new AccessMode("READ", 1)
+  final val WRITE = new AccessMode("WRITE", 1)
+
+  private[this] val cachedValues =
+    Array(EXECUTE, READ, WRITE)
+  def values(): Array[AccessMode] = cachedValues.clone()
+  def valueOf(name: String): AccessMode = {
+    cachedValues.find(_.name() == name).getOrElse {
+      throw new IllegalArgumentException("No enum const AccessMode." + name)
+    }
+  }
+}

--- a/javalib/src/main/scala/java/nio/file/ReadOnlyFileSystemException.scala
+++ b/javalib/src/main/scala/java/nio/file/ReadOnlyFileSystemException.scala
@@ -1,0 +1,3 @@
+package java.nio.file
+
+class ReadOnlyFileSystemException extends UnsupportedOperationException

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/ReadOnlyFileSystemExceptionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/ReadOnlyFileSystemExceptionTest.scala
@@ -1,0 +1,18 @@
+package org.scalanative.testsuite.javalib.nio.file
+
+import java.nio.file._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ReadOnlyFileSystemExceptionTest {
+
+  @Test def readOnlyFileSystemExceptionExists(): Unit = {
+    assertThrows(
+      classOf[ReadOnlyFileSystemException],
+      throw new ReadOnlyFileSystemException()
+    )
+  }
+}


### PR DESCRIPTION
Implement two javalib `java.nio.file` classes:  `AccessMode` & `ReadOnlyFileSystemException`.