### PR TITLE
WIP: Chasing Cheshire Cat multiarch linux-arm-64 pidfd_open failure

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -3,6 +3,11 @@
 Java Standard Library
 =====================
 
+Lee T.:  a throwaway change to force mainline CI to run.
+         I am chasing a Cheshire Cat build bug related to
+	 pidfd_open failures on multiarch linux-arm-64:
+	 now you see it, now you don't!   #1 
+
 Scala Native supports a subset of the JDK core libraries reimplemented in Scala.
 
 Supported classes

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -4,11 +4,13 @@
 #include <sys/syscall.h>
 #endif
 
+#if 0 // Cheshire Cat debug
 #ifndef SYS_pidfd_open
 // Provide a fallback for developers who many not have a full linux
 // installation.
 #define SYS_pidfd_open 434
 #endif
+#endif // Cheshire Cat debug
 
 #include <unistd.h>
 

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -38,7 +38,7 @@
 // pidfd_open was first introduced in Linux 5.3. Be sure to check return status.
 int scalanative_linux_pidfd_open(pid_t pid, unsigned int flags) {
 #if (SYS_pidfd_open <= 0)
-    -1
+    return -1;
 #else
     return syscall(SYS_pidfd_open, pid, flags);
 #endif

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -5,12 +5,31 @@
 #endif
 
 #ifndef SYS_pidfd_open
-/* If syscall.h did not define, force syscall() error by giving known bad value
+/* There are at least two cases to consider here. Both mean that pidfd_open()
+ * is not available for use.
  *
- * This could give a false negative in the unexpected case where this file is
- * being compiled on a system which does not have 'sys/syscall.h' available.
+ * This code may be compiled in varied build environments. It is possible
+ * to get a false negatives.
+ *
+ * To aid future tracing and debugging:
+ *
+ * 1) sys/syscall.h did not exist.  This is probably because it is missing
+ *    on the local/user include path. The file should almost always be
+ *    present.
+ *
+ *    Solution: add the file to the default include path. If the target OS
+ *    supports pidfd_open() and that support is intended to be used, make
+ *    sure syscall.h defines the SYS_pidfd_open macro.
+ *
+ * 2) sys/syscall.h exists but does not define SYS_pid_open. If one makes
+ *    the reasonable assumption that the .h files and OS correspond, then
+ *    this most probably means that the OS does not support pidfd_open().
+ *    An example would be Linux before V5.3.
+ *
+ *    This path avoids a nasty Linux version parse.
  */
-#define SYS_pidfd_open -1L
+
+#define SYS_pidfd_open -1L // all valid syscall numbers are >= 0.
 #endif
 
 #include <stdbool.h>
@@ -18,13 +37,23 @@
 
 // pidfd_open was first introduced in Linux 5.3. Be sure to check return status.
 int scalanative_linux_pidfd_open(pid_t pid, unsigned int flags) {
+#if (SYS_pidfd_open <= 0)
+    -1
+#else
     return syscall(SYS_pidfd_open, pid, flags);
+#endif
 }
 
 bool scalanative_linux_has_pidfd_open() {
-#if (SYS_pidfd_open == -1L)
-    false // SYS_pidfd_open not in syscall.h, so probably not in this kernel
+#if (SYS_pidfd_open <= 0)
+    false; // SYS_pidfd_open not in syscall.h, so probably not in this kernel
 #else
+    /* For those following along:
+     * By this point, the OS is known to be Linux. The distribution and
+     * compilation environment are know to support pidfd_open(). linux-arm64
+     * build failures seem to indicate there is a way to tailor off pidfd_open()
+     * support. Ask the OS itself exactly what it supports.
+     */
     int pid = getpid(); // self
 
     int pidfd = scalanative_linux_pidfd_open(pid, 0);

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -2,7 +2,7 @@
 
 #if __has_include(<sys/syscall.h>)
 #include <sys/syscall.h>
-#endif // syscall.h
+#endif
 
 // 2023-09-16 07:16 -0400 Lee -- If you decide at somepoint to go the
 // path of defining SYS_pidfd_open, it should probably be to -1, NOT 434.
@@ -19,7 +19,6 @@
 // by the UnixProcess() code.  The presence or absence of a working
 // pidfd_open() is not going to change over the lifetime of the execution.
 //
-// Looks like the underlying issue is that 
 
 #ifndef SYS_pidfd_open
 // Provide a fallback for developers who many not have a full linux

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -2,14 +2,30 @@
 
 #if __has_include(<sys/syscall.h>)
 #include <sys/syscall.h>
+#endif // syscall.h
 
-#if 0 // Cheshire Cat debug
+// 2023-09-16 07:16 -0400 Lee -- If you decide at somepoint to go the
+// path of defining SYS_pidfd_open, it should probably be to -1, NOT 434.
+//
+// 434 was intended to be "helpful". Almost a year's experience has shown
+// that path not to be helpful at all.  If one does not know the constant,
+// one should probably __not__ be using what could well be a j-random value
+// used for another syscall entirely.
+//
+// Looks like the next evolution should first check if the value is defined.
+// if not, return "false". If true, probe the actually OS by trying to
+// use that constant to pidfd_open the current process (getpid()).  This
+// should probably be done in an init() method, and lazily called (once)
+// by the UnixProcess() code.  The presence or absence of a working
+// pidfd_open() is not going to change over the lifetime of the execution.
+//
+// Looks like the underlying issue is that 
+
 #ifndef SYS_pidfd_open
 // Provide a fallback for developers who many not have a full linux
 // installation.
-#define SYS_pidfd_open 434
+#define SYS_pidfd_open -1 // Force InvalidArgument failure is ever executed.
 #endif
-#endif // Cheshire Cat debug
 
 #include <unistd.h>
 
@@ -18,5 +34,4 @@ int scalanative_linux_pidfd_open(pid_t pid, unsigned int flags) {
     return syscall(SYS_pidfd_open, pid, flags);
 }
 
-#endif // syscall.h
 #endif // __linux__

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -2,7 +2,6 @@
 
 #if __has_include(<sys/syscall.h>)
 #include <sys/syscall.h>
-#endif
 
 #if 0 // Cheshire Cat debug
 #ifndef SYS_pidfd_open
@@ -18,4 +17,6 @@
 int scalanative_linux_pidfd_open(pid_t pid, unsigned int flags) {
     return syscall(SYS_pidfd_open, pid, flags);
 }
+
+#endif // syscall.h
 #endif // __linux__

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -1,31 +1,19 @@
 #if defined(__linux__)
 
-#if __has_include(<sys/syscall.h>)
+#if __has_include(<sys/syscall.h>) // Should almost always be true
 #include <sys/syscall.h>
 #endif
 
-// 2023-09-16 07:16 -0400 Lee -- If you decide at somepoint to go the
-// path of defining SYS_pidfd_open, it should probably be to -1, NOT 434.
-//
-// 434 was intended to be "helpful". Almost a year's experience has shown
-// that path not to be helpful at all.  If one does not know the constant,
-// one should probably __not__ be using what could well be a j-random value
-// used for another syscall entirely.
-//
-// Looks like the next evolution should first check if the value is defined.
-// if not, return "false". If true, probe the actually OS by trying to
-// use that constant to pidfd_open the current process (getpid()).  This
-// should probably be done in an init() method, and lazily called (once)
-// by the UnixProcess() code.  The presence or absence of a working
-// pidfd_open() is not going to change over the lifetime of the execution.
-//
-
 #ifndef SYS_pidfd_open
-// Provide a fallback for developers who many not have a full linux
-// installation.
-#define SYS_pidfd_open -1 // Force InvalidArgument failure is ever executed.
+/* If syscall.h did not define, force syscall() error by giving known bad value
+ *
+ * This could give a false negative in the unexpected case where this file is
+ * being compiled on a system which does not have 'sys/syscall.h' available.
+ */
+#define SYS_pidfd_open -1L
 #endif
 
+#include <stdbool.h>
 #include <unistd.h>
 
 // pidfd_open was first introduced in Linux 5.3. Be sure to check return status.
@@ -33,4 +21,16 @@ int scalanative_linux_pidfd_open(pid_t pid, unsigned int flags) {
     return syscall(SYS_pidfd_open, pid, flags);
 }
 
+bool scalanative_linux_has_pidfd_open() {
+#if (SYS_pidfd_open == -1L)
+    false // SYS_pidfd_open not in syscall.h, so probably not in this kernel
+#else
+    int pid = getpid(); // self
+
+    int pidfd = scalanative_linux_pidfd_open(pid, 0);
+    close(pidfd);
+
+    return pidfd > 0;
+#endif
+}
 #endif // __linux__

--- a/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
+++ b/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
@@ -7,7 +7,7 @@ import scala.scalanative.posix.signal.sigset_t
 import scala.scalanative.posix.time.timespec
 import scala.scalanative.posix.sys.types.pid_t
 
-import scalanative.meta.LinktimeInfo.{isLinux, target)
+import scalanative.meta.LinktimeInfo.{isLinux, target}
 
 object LinuxOsSpecific {
   lazy val _hasPidfdOpen: Boolean = {

--- a/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
+++ b/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
@@ -7,13 +7,14 @@ import scala.scalanative.posix.signal.sigset_t
 import scala.scalanative.posix.time.timespec
 import scala.scalanative.posix.sys.types.pid_t
 
-import scalanative.meta.LinktimeInfo.isLinux
+import scalanative.meta.LinktimeInfo.{isLinux, target)
 
 object LinuxOsSpecific {
   lazy val _hasPidfdOpen: Boolean = {
     // True when Platform.isLinux & "os.version" >= 5.3.
+
     if (!isLinux) false
-    else if (System.getProperty("os.arch", "unknown") == "arm64") {
+    else if (target.arch == "aarch64") {
       false
     } else {
       // Opportunities abound for simplifying and/or improving this parsing.

--- a/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
+++ b/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
@@ -13,7 +13,9 @@ object LinuxOsSpecific {
   lazy val _hasPidfdOpen: Boolean = {
     // True when Platform.isLinux & "os.version" >= 5.3.
     if (!isLinux) false
-    else {
+    else if (System.getProperty("os.arch", "unknown") == "arm64") {
+      false
+    } else {
       // Opportunities abound for simplifying and/or improving this parsing.
       val osVersion = System.getProperty("os.version", "0.0")
 


### PR DESCRIPTION
Trying to determine the recent change which is causing the "Now you see it, now you don't" Cheshire Cat
build failures in multiarch linux-arm-64,  as seen in PR #3478 and others.