### PR TITLE
Update fmt to 3.7.14

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+#scalafmt
+2bde51a900a0d653fab1ed8224c4773069def77f

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,7 +3,7 @@
 # settings is preferred over adding especially as
 # the Scala language evolves and styles change.
 # Test upgrades: $ scripts/scalafmt --test 2> diff.txt
-version = 3.6.1
+version = 3.7.14
 docstrings.style = AsteriskSpace
 project.git = true
 project.excludePaths = [

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -1671,7 +1671,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
           // To test if after discard bits, a new carry is generated
           if (((bits & 3) == 3) ||
               (((bits & 1) == 1) && (tempBits != 0) &&
-                (lowestSetBit < discardedSize))) {
+              (lowestSetBit < discardedSize))) {
             bits += 1
           }
           exponent = 0

--- a/javalib/src/main/scala/java/net/URIEncoderDecoder.scala
+++ b/javalib/src/main/scala/java/net/URIEncoderDecoder.scala
@@ -34,7 +34,7 @@ object URIEncoderDecoder {
       } else if (!((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
             (ch >= '0' && ch <= '9') || legal.indexOf(ch) > -1 ||
             (ch > 127 && !java.lang.Character.isSpaceChar(ch) &&
-              !java.lang.Character.isISOControl(ch)))) {
+            !java.lang.Character.isISOControl(ch)))) {
         throw new URISyntaxException(s, "Illegal character", i)
       }
       if (!continue) i += 1
@@ -61,7 +61,7 @@ object URIEncoderDecoder {
           (ch >= '0' && ch <= '9') ||
           legal.indexOf(ch) > -1 ||
           (ch > 127 && !java.lang.Character.isSpaceChar(ch) &&
-            !java.lang.Character.isISOControl(ch))) {
+          !java.lang.Character.isISOControl(ch))) {
         buf.append(ch)
       } else {
         val bytes: Array[Byte] = new String(Array(ch)).getBytes(encoding)

--- a/javalib/src/main/scala/java/util/concurrent/SynchronousQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/SynchronousQueue.scala
@@ -545,9 +545,9 @@ object SynchronousQueue {
                   (d eq dp) || // d is off list or
                   !d.isCancelled() || // d not cancelled or
                   ((d ne t) && // d not tail and
-                    dn != null && //   has successor
-                    (dn ne d) && //   that is on list
-                    dp.casNext(d, dn))) { // d unspliced
+                  dn != null && //   has successor
+                  (dn ne d) && //   that is on list
+                  dp.casNext(d, dn))) { // d unspliced
                 casCleanMe(dp, null)
               }
               if (dp eq pred) return // s is already saved node

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
@@ -485,8 +485,8 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     val s = if (h != null) h.next else null
     var first = if (s != null) s.waiter else null
     if (h != null && (s == null ||
-          first == null ||
-          s.prev == null)) {
+        first == null ||
+        s.prev == null)) {
       first = getFirstQueuedThread()
     }
     first != null && (first ne Thread.currentThread())

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
@@ -483,8 +483,8 @@ abstract class AbstractQueuedSynchronizer protected ()
     val s = if (h != null) h.next else null
     var first = if (s != null) s.waiter else null
     if (h != null && (s == null ||
-          first == null ||
-          s.prev == null)) {
+        first == null ||
+        s.prev == null)) {
       first = getFirstQueuedThread()
     }
     first != null && (first ne Thread.currentThread())

--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -92,10 +92,10 @@ class Parser(wholeRegexp: String, _flags: Int) {
           Unicode.simpleFold(re.runes(0)) == re.runes(2) &&
           Unicode.simpleFold(re.runes(2)) == re.runes(0)) ||
         (re.op == ROP.CHAR_CLASS &&
-          re.runes.length == 2 &&
-          re.runes(0) + 1 == re.runes(1) &&
-          Unicode.simpleFold(re.runes(0)) == re.runes(1) &&
-          Unicode.simpleFold(re.runes(1)) == re.runes(0))) {
+        re.runes.length == 2 &&
+        re.runes(0) + 1 == re.runes(1) &&
+        Unicode.simpleFold(re.runes(0)) == re.runes(1) &&
+        Unicode.simpleFold(re.runes(1)) == re.runes(0))) {
       // Case-insensitive rune like [Aa] or [Δδ].
       if (maybeConcat(re.runes(0), flags | RE2.FOLD_CASE)) {
         returnNull = true
@@ -507,8 +507,8 @@ class Parser(wholeRegexp: String, _flags: Int) {
 
           if (first != null && first.equals(ifirst) &&
               (isCharClass(first) ||
-                (first.op == ROP.REPEAT &&
-                  first.min == first.max && isCharClass(first.subs(0))))) {
+              (first.op == ROP.REPEAT &&
+              first.min == first.max && isCharClass(first.subs(0))))) {
             continue = true
           }
         }
@@ -587,7 +587,7 @@ class Parser(wholeRegexp: String, _flags: Int) {
               val subJ = array(s + j)
               if ((subMax.op < subJ.op) ||
                   ((subMax.op == subJ.op) &&
-                    (subMax.runes.length < subJ.runes.length))) {
+                  (subMax.runes.length < subJ.runes.length))) {
                 max = j
               }
               j += 1

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -1036,9 +1036,9 @@ class StreamTest {
         s"unexpected map element: ${e}",
         e.startsWith(prefix) &&
           (e.endsWith("_A") ||
-            e.endsWith("_B") ||
-            e.endsWith("_C") ||
-            e.endsWith("_D"))
+          e.endsWith("_B") ||
+          e.endsWith("_C") ||
+          e.endsWith("_D"))
       )
     )
 


### PR DESCRIPTION
Motivation:

3.7.14 can be used with `scala-cli fmt`, which is fast.

Will submit another following pr for ignore this commit once this get merged.