### PR TITLE
Fix #3483: linux-arm64 multiarch CI runs now succeed

### DIFF
--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -1,19 +1,65 @@
 #if defined(__linux__)
 
-#if __has_include(<sys/syscall.h>)
+#if __has_include(<sys/syscall.h>) // Should almost always be true
 #include <sys/syscall.h>
 #endif
 
 #ifndef SYS_pidfd_open
-// Provide a fallback for developers who many not have a full linux
-// installation.
-#define SYS_pidfd_open 434
+/* There are at least two cases to consider here. Both mean that pidfd_open()
+ * is not available for use.
+ *
+ * This code may be compiled in varied build environments. It is possible
+ * to get a false negatives.
+ *
+ * To aid future tracing and debugging:
+ *
+ * 1) sys/syscall.h did not exist.  This is probably because it is missing
+ *    on the local/user include path. The file should almost always be
+ *    present.
+ *
+ *    Solution: add the file to the default include path. If the target OS
+ *    supports pidfd_open() and that support is intended to be used, make
+ *    sure syscall.h defines the SYS_pidfd_open macro.
+ *
+ * 2) sys/syscall.h exists but does not define SYS_pid_open. If one makes
+ *    the reasonable assumption that the .h files and OS correspond, then
+ *    this most probably means that the OS does not support pidfd_open().
+ *    An example would be Linux before V5.3.
+ *
+ *    This path avoids a nasty Linux version parse.
+ */
+
+#define SYS_pidfd_open -1L // all valid syscall numbers are >= 0.
 #endif
 
+#include <stdbool.h>
 #include <unistd.h>
 
 // pidfd_open was first introduced in Linux 5.3. Be sure to check return status.
 int scalanative_linux_pidfd_open(pid_t pid, unsigned int flags) {
+#if (SYS_pidfd_open <= 0)
+    return -1;
+#else
     return syscall(SYS_pidfd_open, pid, flags);
+#endif
+}
+
+bool scalanative_linux_has_pidfd_open() {
+#if (SYS_pidfd_open <= 0)
+    false; // SYS_pidfd_open not in syscall.h, so probably not in this kernel
+#else
+    /* For those following along:
+     * By this point, the OS is known to be Linux. The distribution and
+     * compilation environment are know to support pidfd_open(). linux-arm64
+     * build failures seem to indicate there is a way to tailor off pidfd_open()
+     * support. Ask the OS itself exactly what it supports.
+     */
+    int pid = getpid(); // self
+
+    int pidfd = scalanative_linux_pidfd_open(pid, 0);
+    close(pidfd);
+
+    return pidfd > 0;
+#endif
 }
 #endif // __linux__

--- a/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
+++ b/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
@@ -10,35 +10,17 @@ import scala.scalanative.posix.sys.types.pid_t
 import scalanative.meta.LinktimeInfo.isLinux
 
 object LinuxOsSpecific {
-  lazy val _hasPidfdOpen: Boolean = {
-    // True when Platform.isLinux & "os.version" >= 5.3.
+  private lazy val _hasPidfdOpen: Boolean =
     if (!isLinux) false
-    else {
-      // Opportunities abound for simplifying and/or improving this parsing.
-      val osVersion = System.getProperty("os.version", "0.0")
-
-      // This parse will start to report bad results at Linux 10.0
-      val verdict =
-        if (osVersion.isEmpty() ||
-            (osVersion(0) <= '4') || (osVersion(0) > '9')) false
-        else {
-          osVersion match {
-            case e if (e(0) > '5') => true
-            case e if (e(0) == '5') =>
-              !(e.startsWith("5.0") ||
-                e.startsWith("5.1") ||
-                e.startsWith("5.2"))
-            case _ => false
-          }
-        }
-      verdict
-    }
-  }
+    else Extern.linux_has_pidfd_open()
 
   def hasPidfdOpen(): Boolean = _hasPidfdOpen
 
   @extern
   object Extern {
+    @name("scalanative_linux_has_pidfd_open")
+    def linux_has_pidfd_open(): CBool = extern
+
     @name("scalanative_linux_pidfd_open")
     def pidfd_open(pid: pid_t, flags: CUnsignedInt): CInt = extern
 


### PR DESCRIPTION

Add code to make linux-arm64 multiarch builds and others more robust to the recent change in 
the CI environment and others like it in the future.

This PR effectively forces the old `ProcessMonitor` code used by `UnixProcessGen1.scala` to be
used by linux-arm64 CI.  That code was superseded by the `UnixProcessGen2` code because 
the former was buggy.  linux-arm64 builds may start having the kind of intermittent failures
that the latter was meant to eliminate. Time will tell.