### PR TITLE
Use `/usr/bin/env bash` for shebangs

### DIFF
--- a/scripts/check-cla.sh
+++ b/scripts/check-cla.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/check-lint.sh
+++ b/scripts/check-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
For NixOS users and users of less popular distros, `/bin/bash` is not a path that exists ;)
`/usr/bin/env` however is included in way more distros (including NixOS).
