### PR TITLE
Restore heap size environment variables

### DIFF
--- a/docs/user/runtime.rst
+++ b/docs/user/runtime.rst
@@ -21,8 +21,8 @@ The following environment variables will be used for all GCs. They can go from 1
 the system memory maximum or up to about 512 GB. The size is in bytes,
 kilobytes(k or K), megabytes(m or M), or gigabytes(g or G). Examples: 1024k, 1M, or 1G etc.
 
-* GC_INITIAL_HEAP_SIZE changes the minimum heap size.
-* GC_MAXIMUM_MAX_HEAP_SIZE changes the maximum heap size.
+* SCALANATIVE_MIN_SIZE changes the minimum heap size.
+* SCALANATIVE_MAX_SIZE changes the maximum heap size.
 
 The plan is to add more GC settings in the future using the Boehm setting names where applicable.
 
@@ -42,8 +42,8 @@ Immix GC
 
 The following variables have not been changed to match the standard variables in Immix yet.
 
-* SCALANATIVE_MIN_HEAP_SIZE changes the minimum heap size.
-* SCALANATIVE_MAX_HEAP_SIZE changes the maximum heap size.
+* SCALANATIVE_MIN_SIZE changes the minimum heap size.
+* SCALANATIVE_MAX_SIZE changes the maximum heap size.
 
 Commix GC
 ---------
@@ -64,11 +64,11 @@ your executable as needed:
 
 .. code-block:: shell
 
-    $ export SCALANATIVE_MIN_SIZE=64k; export SCALANATIVE_MAX_SIZE=512k; sandbox/.2.13/target/scala-2.13/sandbox-out
-    SCALANATIVE_MAX_HEAP_SIZE too small to initialize heap.
+    $ SCALANATIVE_MIN_SIZE=64k SCALANATIVE_MAX_SIZE=512k sandbox/.2.13/target/scala-2.13/sandbox-out
+    SCALANATIVE_MAX_SIZE too small to initialize heap.
     Minimum required: 1m
 
-    $ export SCALANATIVE_MIN_SIZE=2m; export SCALANATIVE_MAX_SIZE=1m; sandbox/.2.13/target/scala-2.13/sandbox-out
-    SCALANATIVE_MAX_HEAP_SIZE should be at least SCALANATIVE_MIN_HEAP_SIZE
+    $ SCALANATIVE_MIN_SIZE=2m SCALANATIVE_MAX_SIZE=1m sandbox/.2.13/target/scala-2.13/sandbox-out
+    SCALANATIVE_MAX_SIZE should be at least SCALANATIVE_MIN_SIZE
 
 Continue to :ref:`lib`.

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -40,7 +40,7 @@ void *scalanative_alloc_atomic(void *info, size_t size) {
 }
 
 size_t scalanative_get_init_heapsize() {
-    return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
+    return Parse_Env_Or_Default("SCALANATIVE_MIN_SIZE", 0L);
 }
 
 size_t scalanative_get_max_heapsize() {
@@ -49,7 +49,7 @@ size_t scalanative_get_max_heapsize() {
     GC_get_prof_stats(stats, sizeof(struct GC_prof_stats_s));
     size_t heap_sz = stats->heapsize_full;
     free(stats);
-    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", heap_sz);
+    return Parse_Env_Or_Default("SCALANATIVE_MAX_SIZE", heap_sz);
 }
 
 void scalanative_collect() { GC_gcollect(); }

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -99,4 +99,3 @@ size_t scalanative_get_init_heapsize() { return Settings_MinHeapSize(); }
 /* then this size will be returned.*/
 /* Otherwise, the total size of the physical memory (guarded) will be returned*/
 size_t scalanative_get_max_heapsize() { return Settings_MaxHeapSize(); }
-}

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -98,4 +98,6 @@ size_t scalanative_get_init_heapsize() { return Settings_MinHeapSize(); }
 /* environment variable,*/
 /* then this size will be returned.*/
 /* Otherwise, the total size of the physical memory (guarded) will be returned*/
-size_t scalanative_get_max_heapsize() { return Settings_MaxHeapSize(); }
+size_t scalanative_get_max_heapsize() {
+    return Parse_Env_Or_Default("SCALANATIVE_MAX_SIZE", Heap_getMemoryLimit());
+}

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -87,17 +87,16 @@ INLINE void scalanative_register_weak_reference_handler(void *handler) {
 }
 
 /* Get the minimum heap size */
-/* If the user has set a minimum heap size using the GC_INITIAL_HEAP_SIZE
+/* If the user has set a minimum heap size using the SCALANATIVE_MIN_SIZE
  * environment variable, */
 /* then this size will be returned. */
 /* Otherwise, the default minimum heap size will be returned.*/
 size_t scalanative_get_init_heapsize() { return Settings_MinHeapSize(); }
 
 /* Get the maximum heap size */
-/* If the user has set a maximum heap size using the GC_MAXIMUM_HEAP_SIZE */
+/* If the user has set a maximum heap size using the SCALANATIVE_MAX_SIZE */
 /* environment variable,*/
 /* then this size will be returned.*/
 /* Otherwise, the total size of the physical memory (guarded) will be returned*/
-size_t scalanative_get_max_heapsize() {
-    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
+size_t scalanative_get_max_heapsize() { return Settings_MaxHeapSize(); }
 }

--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
@@ -89,7 +89,7 @@ void Heap_Init(Heap *heap, size_t minHeapSize, size_t maxHeapSize) {
     size_t memoryLimit = Heap_getMemoryLimit();
 
     if (maxHeapSize < MIN_HEAP_SIZE) {
-        fprintf(stderr, "GC_MAXIMUM_HEAP_SIZE too small to initialize heap.\n");
+        fprintf(stderr, "SCALANATIVE_MAX_SIZE too small to initialize heap.\n");
         fprintf(stderr, "Minimum required: %zum \n",
                 (size_t)(MIN_HEAP_SIZE / 1024 / 1024));
         fflush(stderr);
@@ -97,7 +97,7 @@ void Heap_Init(Heap *heap, size_t minHeapSize, size_t maxHeapSize) {
     }
 
     if (minHeapSize > memoryLimit) {
-        fprintf(stderr, "GC_INITIAL_HEAP_SIZE is too large.\n");
+        fprintf(stderr, "SCALANATIVE_MIN_SIZE is too large.\n");
         fprintf(stderr, "Maximum possible: %zug \n",
                 memoryLimit / 1024 / 1024 / 1024);
         fflush(stderr);
@@ -105,8 +105,8 @@ void Heap_Init(Heap *heap, size_t minHeapSize, size_t maxHeapSize) {
     }
 
     if (maxHeapSize < minHeapSize) {
-        fprintf(stderr, "GC_MAXIMUM_HEAP_SIZE should be at least "
-                        "GC_INITIAL_HEAP_SIZE\n");
+        fprintf(stderr, "SCALANATIVE_MAX_SIZE should be at least "
+                        "SCALANATIVE_MIN_SIZE\n");
         fflush(stderr);
         exit(1);
     }

--- a/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
@@ -63,17 +63,17 @@ INLINE void scalanative_register_weak_reference_handler(void *handler) {
 }
 
 /* Get the minimum heap size */
-/* If the user has set a minimum heap size using the GC_INITIAL_HEAP_SIZE
+/* If the user has set a minimum heap size using the SCALANATIVE_MIN_SIZE
  * environment variable, */
 /* then this size will be returned. */
 /* Otherwise, the default minimum heap size will be returned.*/
 size_t scalanative_get_init_heapsize() { return Settings_MinHeapSize(); }
 
 /* Get the maximum heap size */
-/* If the user has set a maximum heap size using the GC_MAXIMUM_HEAP_SIZE
+/* If the user has set a maximum heap size using the SCALANATIVE_MAX_SIZE
  * environment variable,*/
 /* then this size will be returned.*/
 /* Otherwise, the total size of the physical memory (guarded) will be returned*/
 size_t scalanative_get_max_heapsize() {
-    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
+    return Parse_Env_Or_Default("SCALANATIVE_MAX_SIZE", Heap_getMemoryLimit());
 }

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -35,11 +35,11 @@ void exitWithOutOfMemory() {
 }
 
 size_t scalanative_get_init_heapsize() {
-    return Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L);
+    return Parse_Env_Or_Default("SCALANATIVE_MIN_SIZE", 0L);
 }
 
 size_t scalanative_get_max_heapsize() {
-    return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", getMemorySize());
+    return Parse_Env_Or_Default("SCALANATIVE_MAX_SIZE", getMemorySize());
 }
 
 void Prealloc_Or_Default() {
@@ -49,12 +49,12 @@ void Prealloc_Or_Default() {
         size_t memorySize = getMemorySize();
 
         DEFAULT_CHUNK = // Default Maximum allocation Map 4GB
-            Choose_IF(Parse_Env_Or_Default_String("GC_MAXIMUM_HEAP_SIZE",
+            Choose_IF(Parse_Env_Or_Default_String("SCALANATIVE_MAX_SIZE",
                                                   DEFAULT_CHUNK_SIZE),
                       Less_OR_Equal, memorySize);
 
         PREALLOC_CHUNK = // Preallocation
-            Choose_IF(Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L),
+            Choose_IF(Parse_Env_Or_Default("SCALANATIVE_MIN_SIZE", 0L),
                       Less_OR_Equal, DEFAULT_CHUNK);
 
         if (PREALLOC_CHUNK == 0L) { // no prealloc settings.


### PR DESCRIPTION
The environment variables used to set minimum and maximum heap size were not consistent in error messages, docs and actual behavior. Some wrong backports from the `main` branch changed some places to the new names used in Scala Native 0.5