### PR TITLE
Build: fix SN publish-local-dev command

### DIFF
--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -145,6 +145,8 @@ object Commands {
     Command.args(name, "<args>") {
       case (state, args) =>
         val version = args.headOption
+          .flatMap(MultiScalaProject.scalaVersions.get)
+          .orElse(state.getSetting(scalaVersion))
           .getOrElse(
             "Used command needs explicit full Scala version as an argument"
           )


### PR DESCRIPTION
Issue #3486 reports a number of defects related to verifying the environment for a new Scala Native
contributor.   In exploring that issue, I found that the Scala Native `test-all` command failed.
`test-all` calls a series of other Scala Native commands. Further localization, and the hint from
the original failure message showed the fault to be in the `publish-local-dev` command.

This PR skips lightly over the passing strangeness of having a "publish" command inside a "test" command
and corrects the default in the `publish-local-dev` command.  

This is a partial fix for Issue #3486. I believe that Issue should remain open because it will probably 
lead to more PRs.

Because the defect addressed by this PR has remained hidden for so long, I doubt that either `test-all` or,
more specifically, `publish-local-dev` are exercised in CI.  CI should at least show that these changes
do not break anything else in CI.

