### PR TITLE
Always add -DNDEBUG flag when compiling nativelib. 

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -71,7 +71,7 @@ private[scalanative] object Filter {
 
       val projectConfig = config.withCompilerConfig(
         _.withCompileOptions(
-          _ ++ Seq(s"-I$gcPath", gcFlag, s"-I$libunwindPath")
+          _ ++ Seq(s"-I$gcPath", gcFlag, s"-I$libunwindPath", "-DNDEBUG")
         )
       )
 


### PR DESCRIPTION
Use it to ignore spurious, harmless warnings from libuwind, especially visible in MacOS ARM and some Windows builds