### PR TITLE
Remove unused class declaration

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -59,18 +59,6 @@ class PrepNativeInterop extends PluginPhase {
         sym.hasAnnotation(defnNir.ExportAccessorsClass)
   end extension
 
-  private class DealiasTypeMapper(using Context) extends TypeMap {
-    override def apply(tp: Type): Type =
-      val sym = tp.typeSymbol
-      val dealiased =
-        if sym.isOpaqueAlias then sym.opaqueAlias
-        else tp
-      dealiased.widenDealias match
-        case AppliedType(tycon, args) =>
-          AppliedType(this(tycon), args.map(this))
-        case ty => ty
-  }
-
   override def transformDefDef(dd: DefDef)(using Context): Tree = {
     val sym = dd.symbol
     lazy val rhsSym = dd.rhs.symbol


### PR DESCRIPTION
This PR removes a seemingly unused class declaration.

Note that an exact copy of `DealiasTypeMappter` (i.e., the class being removed) is present in `PrepNativeInteropLate.scala`, where it is actually used. Should it be also required in `PrepNativeInterop`, its declaration should be factored out per DRY principle.