### PR TITLE
Fix #3511: Build now implements better Java 21 support

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -38,8 +38,14 @@ object ScalaVersions {
   // List of nightly version can be found here: https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/
   lazy val scala3Nightly = "3.3.2-RC1-bin-20230601-8814760-NIGHTLY"
 
-  // minimum version - 1.5 is required for Scala 3 and 1.5.8 has log4j vulnerability fixed
-  val sbt10Version: String = "1.5.8"
+  // minimum version rationale:
+  //   1.5 is required for Scala 3 and
+  //   1.5.8 has log4j vulnerability fixed
+  //   1.9.0 is required in order to use Java >= 21
+  //   1.9.4 fixes (Common Vulnerabilities and Exposures) CVE-2022-46751
+  //   1.9.6 is current
+
+  val sbt10Version: String = "1.9.6"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/scripted-tests/run/backtrace/project/build.properties
+++ b/scripted-tests/run/backtrace/project/build.properties
@@ -1,1 +1,5 @@
-sbt.version=1.8.2
+## By having nothing specified here, the sbt10Version from
+## project/ScalaVersions.scala is used. That version is carefully chosen
+## so that the sbt used itself uses Scala > 2.12.17. Scala 2.12.18 is minimum
+## needed to allow working with Java 21.
+# sbt.version=1.8.2

--- a/scripted-tests/scala3/cross-version-compat/project/build.properties
+++ b/scripted-tests/scala3/cross-version-compat/project/build.properties
@@ -1,1 +1,5 @@
-sbt.version=1.6.2
+## By having nothing specified here, the sbt10Version from
+## project/ScalaVersions.scala is used. That version is carefully chosen
+## so that the sbt used itself uses Scala > 2.12.17. Scala 2.12.18 is minimum
+## needed to allow working with Java 21.
+# sbt.version=1.6.2


### PR DESCRIPTION
Fix #3511

`tests-tools`, `test-runtime`, and `test-scripted` now succeed when using Java 21 and 
either Scala 2.12.18 or Scala 2.13.12.

Once a blocking defect is corrected in SN 3.3.0 Java 21 support, that version should also enjoy the benefit of 
the changes of this PR. The blocking defect is described in the Issue.