### PR TITLE
Add a date when the document is built in the index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,8 @@
 Scala Native
 ============
 
-Version |release| 
+- Version: |release| 
+- Document built: |today|
 
 Scala Native is an optimizing ahead-of-time compiler and lightweight managed
 runtime designed specifically for Scala. It features:


### PR DESCRIPTION
Proposed by @LeeTibbert https://github.com/scala-native/scala-native/pull/3496#issuecomment-1731764669 👍 

This commit adds a description when this ScalaNative doc is built. e.g. `Document built: Sep 28, 2023`.
Using `|today|` substitutions by sphinx
https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#substitutions