### PR TITLE
Do not emit single LLVM IR file for release mode + LTO none

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -16,7 +16,6 @@ object Validator {
     (validateMainClass _)
       .andThen(validateBasename)
       .andThen(validateClasspath)
-      .andThen(checkCompilerConfig)
       .apply(config)
 
   // throws if Application with no mainClass
@@ -46,19 +45,6 @@ object Validator {
   private def validateClasspath(config: Config): Config = {
     val fclasspath = NativeLib.filterClasspath(config.classPath)
     config.withClassPath(fclasspath)
-  }
-
-  private def checkCompilerConfig(config: Config): Config = {
-    val log = config.logger
-    (config.compilerConfig.mode, config.compilerConfig.lto) match {
-      case (mode: Mode.Release, LTO.None) =>
-        log.warn(
-          s"Build mode ${mode.name} combined with disabled LTO produces single, slow to compile output file." +
-            s" It's recommended to enable LTO.${LTO.thin.name} for best optimizations and faster builds."
-        )
-      case _ => ()
-    }
-    config
   }
 
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -125,23 +125,9 @@ object CodeGen {
           }
       }
 
-      // Generate a single LLVM IR file for the whole application.
-      // This is an adhoc form of LTO. We use it in release mode if
-      // Clang's LTO is not available.
-      def single(): Future[Seq[Path]] = Future {
-        val sorted = assembly.sortBy(_.name)
-        Impl(env, sorted).gen(id = "out", workDir) :: Nil
-      }
-
-      import build.Mode._
-      (config.mode, config.LTO) match {
-        case (ReleaseFast | ReleaseSize | ReleaseFull, build.LTO.None) =>
-          single()
-        case _ =>
-          if (config.compilerConfig.useIncrementalCompilation)
-            seperateIncrementally()
-          else separate()
-      }
+      if (config.compilerConfig.useIncrementalCompilation)
+        seperateIncrementally()
+      else separate()
     }
 
   object Impl {


### PR DESCRIPTION
fix https://github.com/scala-native/scala-native/issues/3502

This performance hack seems to be introduced when
there's no LTO option is available in scala-native (or LLVM at that time?)
https://github.com/scala-native/scala-native/pull/506

Am I correct that it's ok to remove this performance hack since we now have LTO option that optimize the LLVM IR by LTO option?