### PR TITLE
Fix #3515: Build test-all command now locally publishes artifacts only once

### DIFF
--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -22,8 +22,7 @@ object Commands {
     "test-tools" ::
       "test-mima" ::
       "test-runtime" ::
-      "test-scripted" ::
-      "publish-local-dev" :: _
+      "test-scripted" :: _ // test-scripted will publish artifacts locally
   }
 
   // Compile and run the sandbox for each GC as a minimal check


### PR DESCRIPTION
Fix #3515 

The `test-all` command now locally publishes artifacts only once.