### PR TITLE
Allow to prefetch debug info to mitigate spurious failures in the CI

### DIFF
--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Test runtime
         run: >
           _JAVA_OPTIONS='${{ matrix.java-options }}'
-          PREFETCH_DEBUG_INFO=1
+          SCALANATIVE_TEST_PREFETCH_DEBUG_INFO=1
           sbt 
           -Dscala.scalanative.multithreading.enable=true 
           "-J-Xmx3G" 
@@ -81,7 +81,7 @@ jobs:
           set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&
           set SCALANATIVE &
           set _JAVA_OPTIONS=${{ matrix.java-options }} &
-          set PREFETCH_DEBUG_INFO=1 &
+          set SCALANATIVE_TEST_PREFETCH_DEBUG_INFO=1 &
           sbt 
           -Dscala.scalanative.multithreading.enable=true 
           "test-runtime ${{matrix.scala}}"

--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Test runtime
         run: >
-          _JAVA_OPTIONS='${{ matrix.java-options }}' 
+          _JAVA_OPTIONS='${{ matrix.java-options }}'
+          PREFETCH_DEBUG_INFO=1
           sbt 
           -Dscala.scalanative.multithreading.enable=true 
           "-J-Xmx3G" 
@@ -80,6 +81,7 @@ jobs:
           set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&
           set SCALANATIVE &
           set _JAVA_OPTIONS=${{ matrix.java-options }} &
+          set PREFETCH_DEBUG_INFO=1 &
           sbt 
           -Dscala.scalanative.multithreading.enable=true 
           "test-runtime ${{matrix.scala}}"

--- a/.github/workflows/run-tests-linux-multiarch.yml
+++ b/.github/workflows/run-tests-linux-multiarch.yml
@@ -76,6 +76,7 @@ jobs:
     needs: build-image
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true
+      PREFETCH_DEBUG_INFO: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-linux-multiarch.yml
+++ b/.github/workflows/run-tests-linux-multiarch.yml
@@ -76,7 +76,7 @@ jobs:
     needs: build-image
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true
-      PREFETCH_DEBUG_INFO: 1
+      SCALANATIVE_TEST_PREFETCH_DEBUG_INFO: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -239,7 +239,7 @@ jobs:
     needs: tests-tools
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true
-      PREFETCH_DEBUG_INFO: 1
+      SCALANATIVE_TEST_PREFETCH_DEBUG_INFO: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -239,6 +239,7 @@ jobs:
     needs: tests-tools
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true
+      PREFETCH_DEBUG_INFO: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -143,6 +143,7 @@ jobs:
     runs-on: macos-11
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true
+      PREFETCH_DEBUG_INFO: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: macos-11
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true
-      PREFETCH_DEBUG_INFO: 1
+      SCALANATIVE_TEST_PREFETCH_DEBUG_INFO: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -208,7 +208,7 @@ jobs:
           set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&
           set SCALANATIVE_CI_NO_DEBUG_SYMBOLS=true&
           set SCALANATIVE &
-          set PREFETCH_DEBUG_INFO=1&
+          set SCALANATIVE_TEST_PREFETCH_DEBUG_INFO=1&
           sbt -Dscala.scalanative.multithreading.enable=true
           sandbox${{env.project-version}}/run;
           testsJVM${{env.project-version}}/test;

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -208,6 +208,7 @@ jobs:
           set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&
           set SCALANATIVE_CI_NO_DEBUG_SYMBOLS=true&
           set SCALANATIVE &
+          set PREFETCH_DEBUG_INFO=1&
           sbt -Dscala.scalanative.multithreading.enable=true
           sandbox${{env.project-version}}/run;
           testsJVM${{env.project-version}}/test;

--- a/docs/user/testing.rst
+++ b/docs/user/testing.rst
@@ -56,7 +56,7 @@ Debug builds with enabled debug metadata allows to produce stack traces containi
 however, to obtain them runtime needs to parse the produced debug metadata.
 This operation is performed when generating stack traces for the first time and can take more than 1 second.
 This behavior can influence tests expecting to finish within some fixed amount of time. 
-To mitigate this issue set the environment variable `PREFETCH_DEBUG_INFO=1` to ensure that debug info would be loaded
+To mitigate this issue set the environment variable `SCALANATIVE_TEST_PREFETCH_DEBUG_INFO=1` to ensure that debug info would be loaded
 before starting test execution.
 
 Continue to :ref:`profiling`.

--- a/docs/user/testing.rst
+++ b/docs/user/testing.rst
@@ -50,4 +50,13 @@ You may also use `testOnly` to run a particular test, for example:
     testOnly MyTest
     testOnly MyTest.superComplicatedTest
 
+Testing with debug metadata
+---------------------------
+Debug builds with enabled debug metadata allows to produce stack traces containing source positions,
+however, to obtain them runtime needs to parse the produced debug metadata.
+This operation is performed when generating stack traces for the first time and can take more than 1 second.
+This behavior can influence tests expecting to finish within some fixed amount of time. 
+To mitigate this issue set the environment variable `PREFETCH_DEBUG_INFO=1` to ensure that debug info would be loaded
+before starting test execution.
+
 Continue to :ref:`profiling`.

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
@@ -92,7 +92,9 @@ object TestMain {
     // Prefetch the debug metadata before the actual tests do start
     if (LinktimeInfo.hasDebugMetadata) {
       val shouldPrefetch =
-        sys.env.get("SCALANATIVE_TEST_PREFETCH_DEBUG_INFO").exists(v => v.isEmpty() || v == "1")
+        sys.env
+          .get("SCALANATIVE_TEST_PREFETCH_DEBUG_INFO")
+          .exists(v => v.isEmpty() || v == "1")
       if (shouldPrefetch)
         new RuntimeException().fillInStackTrace().ensuring(_ != null)
     }

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
@@ -88,6 +88,15 @@ object TestMain {
 
     SignalConfig.setDefaultHandlers()
 
+    // Loading debug metadata can take up to few seconds which might mess up timeout specific tests
+    // Prefetch the debug metadata before the actual tests do start
+    if (LinktimeInfo.hasDebugMetadata) {
+      val shouldPrefetch =
+        sys.env.get("PREFETCH_DEBUG_INFO").exists(v => v.isEmpty() || v == "1")
+      if (shouldPrefetch)
+        new RuntimeException().fillInStackTrace().ensuring(_ != null)
+    }
+
     val serverAddr =
       if (!LinktimeInfo.isFreeBSD) iPv4Loopback
       else getFreeBSDLoopbackAddr()

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
@@ -92,7 +92,7 @@ object TestMain {
     // Prefetch the debug metadata before the actual tests do start
     if (LinktimeInfo.hasDebugMetadata) {
       val shouldPrefetch =
-        sys.env.get("PREFETCH_DEBUG_INFO").exists(v => v.isEmpty() || v == "1")
+        sys.env.get("SCALANATIVE_TEST_PREFETCH_DEBUG_INFO").exists(v => v.isEmpty() || v == "1")
       if (shouldPrefetch)
         new RuntimeException().fillInStackTrace().ensuring(_ != null)
     }


### PR DESCRIPTION
Loading debug info can take almost 1s on MacOS M1 for a simple tests (1 test in sandbox) or even 3s for our current unit tests. This can influence the assertions that expect code to finish withing some time interval, especially in multithreading builds. 
Mitigate this issue by introducing env var `PREFETCH_DEBUG_INFO=1` to ensure that debug info would be parsed before starting to execute tests
