### PR TITLE
Faster `unsafe.Ptr.{apply, update}` by skipping unnecessary GC allocations

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
@@ -20,9 +20,12 @@ import scalanative.runtime.Intrinsics._
 sealed abstract class Tag[T] {
   def size: CSize
   def alignment: CSize
+  @alwaysinline def load(ptr: unsafe.Ptr[T]): T = load(toRawPtr(ptr))
+  @alwaysinline def store(ptr: unsafe.Ptr[T], value: T): Unit = store(toRawPtr(ptr), value)
+
   @noinline def offset(idx: CSize): CSize = throwUndefined()
-  @noinline def load(ptr: unsafe.Ptr[T]): T = throwUndefined()
-  @noinline def store(ptr: unsafe.Ptr[T], value: T): Unit = throwUndefined()
+  @noinline private[unsafe] def load(rawptr: RawPtr): T = throwUndefined()
+  @noinline private[unsafe] def store(rawptr: RawPtr, value: T): Unit = throwUndefined()
 }
 
 object Tag {
@@ -32,168 +35,168 @@ object Tag {
       extends Tag[unsafe.Ptr[T]] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.Ptr[T]]): unsafe.Ptr[T] =
-      fromRawPtr[T](loadRawPtr(toRawPtr(ptr)))
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.Ptr[T]], value: unsafe.Ptr[T]): Unit =
-      storeRawPtr(toRawPtr(ptr), toRawPtr(value))
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.Ptr[T] =
+      fromRawPtr[T](loadRawPtr(rawptr))
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.Ptr[T]): Unit =
+      storeRawPtr(rawptr, toRawPtr(value))
   }
 
   case object Size extends Tag[unsafe.Size] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.Size]): unsafe.Size =
-      unsafe.Size.valueOf(loadRawSize(toRawPtr(ptr)))
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.Size], value: unsafe.Size): Unit =
-      storeRawSize(toRawPtr(ptr), value.rawSize)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.Size =
+      unsafe.Size.valueOf(loadRawSize(rawptr))
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.Size): Unit =
+      storeRawSize(rawptr, value.rawSize)
   }
 
   case object USize extends Tag[unsigned.USize] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.USize]): unsigned.USize =
-      unsigned.USize.valueOf(loadRawSize(toRawPtr(ptr)))
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.USize], value: unsigned.USize): Unit =
-      storeRawSize(toRawPtr(ptr), value.rawSize)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsigned.USize =
+      unsigned.USize.valueOf(loadRawSize(rawptr))
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsigned.USize): Unit =
+      storeRawSize(rawptr, value.rawSize)
   }
 
   final case class Class[T <: AnyRef](of: java.lang.Class[T])
       extends Tag[T] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[T]): T =
-      loadObject(toRawPtr(ptr)).asInstanceOf[T]
-    @alwaysinline override def store(ptr: unsafe.Ptr[T], value: T): Unit =
-      storeObject(toRawPtr(ptr), value.asInstanceOf[Object])
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): T =
+      loadObject(rawptr).asInstanceOf[T]
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: T): Unit =
+      storeObject(rawptr, value.asInstanceOf[Object])
   }
 
 
   object Unit extends Tag[scala.Unit] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Unit]): scala.Unit =
-      loadObject(toRawPtr(ptr)).asInstanceOf[Unit]
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Unit], value: scala.Unit): Unit =
-      storeObject(toRawPtr(ptr), value.asInstanceOf[Object])
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Unit =
+      loadObject(rawptr).asInstanceOf[Unit]
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Unit): Unit =
+      storeObject(rawptr, value.asInstanceOf[Object])
   }
 
 
   object Boolean extends Tag[scala.Boolean] {
     @alwaysinline def size: CSize = 1.toUSize
     @alwaysinline def alignment: CSize = 1.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Boolean]): scala.Boolean =
-      loadBoolean(toRawPtr(ptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Boolean], value: scala.Boolean): Unit =
-      storeBoolean(toRawPtr(ptr), value)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Boolean =
+      loadBoolean(rawptr)
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Boolean): Unit =
+      storeBoolean(rawptr, value)
   }
 
 
   object Char extends Tag[scala.Char] {
     @alwaysinline def size: CSize = 2.toUSize
     @alwaysinline def alignment: CSize = 2.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Char]): scala.Char =
-      loadChar(toRawPtr(ptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Char], value: scala.Char): Unit =
-      storeChar(toRawPtr(ptr), value)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Char =
+      loadChar(rawptr)
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Char): Unit =
+      storeChar(rawptr, value)
   }
 
 
   object Byte extends Tag[scala.Byte] {
     @alwaysinline def size: CSize = 1.toUSize
     @alwaysinline def alignment: CSize = 1.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Byte]): scala.Byte =
-      loadByte(toRawPtr(ptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Byte], value: scala.Byte): Unit =
-      storeByte(toRawPtr(ptr), value)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Byte =
+      loadByte(rawptr)
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Byte): Unit =
+      storeByte(rawptr, value)
   }
 
 
   object UByte extends Tag[unsigned.UByte] {
     @alwaysinline def size: CSize = 1.toUSize
     @alwaysinline def alignment: CSize = 1.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.UByte]): unsigned.UByte =
-      loadByte(toRawPtr(ptr)).toUByte
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.UByte], value: unsigned.UByte): Unit =
-      storeByte(toRawPtr(ptr), value.toByte)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsigned.UByte =
+      loadByte(rawptr).toUByte
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsigned.UByte): Unit =
+      storeByte(rawptr, value.toByte)
   }
 
 
   object Short extends Tag[scala.Short] {
     @alwaysinline def size: CSize = 2.toUSize
     @alwaysinline def alignment: CSize = 2.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Short]): scala.Short =
-      loadShort(toRawPtr(ptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Short], value: scala.Short): Unit =
-      storeShort(toRawPtr(ptr), value)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Short =
+      loadShort(rawptr)
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Short): Unit =
+      storeShort(rawptr, value)
   }
 
 
   object UShort extends Tag[unsigned.UShort] {
     @alwaysinline def size: CSize = 2.toUSize
     @alwaysinline def alignment: CSize = 2.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.UShort]): unsigned.UShort =
-      loadShort(toRawPtr(ptr)).toUShort
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.UShort], value: unsigned.UShort): Unit =
-      storeShort(toRawPtr(ptr), value.toShort)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsigned.UShort =
+      loadShort(rawptr).toUShort
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsigned.UShort): Unit =
+      storeShort(rawptr, value.toShort)
   }
 
 
   object Int extends Tag[scala.Int] {
     @alwaysinline def size: CSize = 4.toUSize
     @alwaysinline def alignment: CSize = 4.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Int]): scala.Int =
-      loadInt(toRawPtr(ptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Int], value: scala.Int): Unit =
-      storeInt(toRawPtr(ptr), value)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Int =
+      loadInt(rawptr)
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Int): Unit =
+      storeInt(rawptr, value)
   }
 
 
   object UInt extends Tag[unsigned.UInt] {
     @alwaysinline def size: CSize = 4.toUSize
     @alwaysinline def alignment: CSize = 4.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.UInt]): unsigned.UInt =
-      loadInt(toRawPtr(ptr)).toUInt
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.UInt], value: unsigned.UInt): Unit =
-      storeInt(toRawPtr(ptr), value.toInt)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsigned.UInt =
+      loadInt(rawptr).toUInt
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsigned.UInt): Unit =
+      storeInt(rawptr, value.toInt)
   }
 
 
   object Long extends Tag[scala.Long] {
     @alwaysinline def size: CSize = 8.toUSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Long]): scala.Long =
-      loadLong(toRawPtr(ptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Long], value: scala.Long): Unit =
-      storeLong(toRawPtr(ptr), value)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Long =
+      loadLong(rawptr)
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Long): Unit =
+      storeLong(rawptr, value)
   }
 
 
   object ULong extends Tag[unsigned.ULong] {
     @alwaysinline def size: CSize = 8.toUSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.ULong]): unsigned.ULong =
-      loadLong(toRawPtr(ptr)).toULong
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.ULong], value: unsigned.ULong): Unit =
-      storeLong(toRawPtr(ptr), value.toLong)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsigned.ULong =
+      loadLong(rawptr).toULong
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsigned.ULong): Unit =
+      storeLong(rawptr, value.toLong)
   }
 
 
   object Float extends Tag[scala.Float] {
     @alwaysinline def size: CSize = 4.toUSize
     @alwaysinline def alignment: CSize = 4.toUSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Float]): scala.Float =
-      loadFloat(toRawPtr(ptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Float], value: scala.Float): Unit =
-      storeFloat(toRawPtr(ptr), value)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Float =
+      loadFloat(rawptr)
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Float): Unit =
+      storeFloat(rawptr, value)
   }
 
 
   object Double extends Tag[scala.Double] {
     @alwaysinline def size: CSize = 8.toUSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Double]): scala.Double =
-      loadDouble(toRawPtr(ptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Double], value: scala.Double): Unit =
-      storeDouble(toRawPtr(ptr), value)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): scala.Double =
+      loadDouble(rawptr)
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: scala.Double): Unit =
+      storeDouble(rawptr, value)
   }
 
 
@@ -401,11 +404,11 @@ object Tag {
     @alwaysinline def size: CSize = of.size * n.asInstanceOf[NatTag].toUInt
     @alwaysinline def alignment: CSize = of.alignment
     @alwaysinline override def offset(idx: CSize): CSize = of.size * idx.toUInt
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CArray[T, N]]): unsafe.CArray[T, N] = {
-      new unsafe.CArray[T, N](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CArray[T, N] = {
+      new unsafe.CArray[T, N](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CArray[T, N]], value: unsafe.CArray[T, N]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CArray[T, N]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -440,11 +443,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct0]): unsafe.CStruct0 = {
-      new unsafe.CStruct0(ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct0 = {
+      new unsafe.CStruct0(rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct0], value: unsafe.CStruct0): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct0): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -473,11 +476,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct1[T1]]): unsafe.CStruct1[T1] = {
-      new unsafe.CStruct1[T1](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct1[T1] = {
+      new unsafe.CStruct1[T1](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct1[T1]], value: unsafe.CStruct1[T1]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct1[T1]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -512,11 +515,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct2[T1, T2]]): unsafe.CStruct2[T1, T2] = {
-      new unsafe.CStruct2[T1, T2](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct2[T1, T2] = {
+      new unsafe.CStruct2[T1, T2](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct2[T1, T2]], value: unsafe.CStruct2[T1, T2]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct2[T1, T2]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -558,11 +561,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct3[T1, T2, T3]]): unsafe.CStruct3[T1, T2, T3] = {
-      new unsafe.CStruct3[T1, T2, T3](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct3[T1, T2, T3] = {
+      new unsafe.CStruct3[T1, T2, T3](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct3[T1, T2, T3]], value: unsafe.CStruct3[T1, T2, T3]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct3[T1, T2, T3]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -612,11 +615,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct4[T1, T2, T3, T4]]): unsafe.CStruct4[T1, T2, T3, T4] = {
-      new unsafe.CStruct4[T1, T2, T3, T4](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct4[T1, T2, T3, T4] = {
+      new unsafe.CStruct4[T1, T2, T3, T4](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct4[T1, T2, T3, T4]], value: unsafe.CStruct4[T1, T2, T3, T4]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct4[T1, T2, T3, T4]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -675,11 +678,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct5[T1, T2, T3, T4, T5]]): unsafe.CStruct5[T1, T2, T3, T4, T5] = {
-      new unsafe.CStruct5[T1, T2, T3, T4, T5](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct5[T1, T2, T3, T4, T5] = {
+      new unsafe.CStruct5[T1, T2, T3, T4, T5](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct5[T1, T2, T3, T4, T5]], value: unsafe.CStruct5[T1, T2, T3, T4, T5]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct5[T1, T2, T3, T4, T5]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -748,11 +751,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]]): unsafe.CStruct6[T1, T2, T3, T4, T5, T6] = {
-      new unsafe.CStruct6[T1, T2, T3, T4, T5, T6](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct6[T1, T2, T3, T4, T5, T6] = {
+      new unsafe.CStruct6[T1, T2, T3, T4, T5, T6](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]], value: unsafe.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -832,11 +835,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]]): unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7] = {
-      new unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7] = {
+      new unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]], value: unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -928,11 +931,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]]): unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] = {
-      new unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] = {
+      new unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]], value: unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -1037,11 +1040,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]): unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] = {
-      new unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] = {
+      new unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]], value: unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -1160,11 +1163,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]]): unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] = {
-      new unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] = {
+      new unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]], value: unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -1298,11 +1301,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]]): unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] = {
-      new unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] = {
+      new unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]], value: unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -1452,11 +1455,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]]): unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] = {
-      new unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] = {
+      new unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]], value: unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -1623,11 +1626,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]]): unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13] = {
-      new unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13] = {
+      new unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]], value: unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -1812,11 +1815,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]]): unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14] = {
-      new unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14] = {
+      new unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]], value: unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -2020,11 +2023,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]]): unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15] = {
-      new unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15] = {
+      new unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]], value: unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -2248,11 +2251,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]]): unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16] = {
-      new unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16] = {
+      new unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]], value: unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -2497,11 +2500,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]]): unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17] = {
-      new unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17] = {
+      new unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]], value: unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -2768,11 +2771,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]]): unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18] = {
-      new unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18] = {
+      new unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]], value: unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -3062,11 +3065,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]]): unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19] = {
-      new unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19] = {
+      new unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]], value: unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -3380,11 +3383,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]]): unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20] = {
-      new unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20] = {
+      new unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]], value: unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -3723,11 +3726,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]]): unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21] = {
-      new unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21] = {
+      new unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]], value: unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -4092,11 +4095,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]]): unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22] = {
-      new unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22] = {
+      new unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]], value: unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -4114,11 +4117,11 @@ object Tag {
 
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[F]): F =
-      fromRawPtr(loadRawPtr(ptr.rawptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[F], value: F): Unit = {
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): F =
+      fromRawPtr(loadRawPtr(rawptr))
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: F): Unit = {
       val valuePtr = if(value != null) value.rawptr else null
-      storeRawPtr(toRawPtr(ptr), valuePtr)
+      storeRawPtr(rawptr, valuePtr)
     }
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
@@ -20,9 +20,12 @@ import scalanative.runtime.Intrinsics._
 sealed abstract class Tag[T] {
   def size: CSize
   def alignment: CSize
+  @alwaysinline def load(ptr: unsafe.Ptr[T]): T = load(toRawPtr(ptr))
+  @alwaysinline def store(ptr: unsafe.Ptr[T], value: T): Unit = store(toRawPtr(ptr), value)
+
   @noinline def offset(idx: CSize): CSize = throwUndefined()
-  @noinline def load(ptr: unsafe.Ptr[T]): T = throwUndefined()
-  @noinline def store(ptr: unsafe.Ptr[T], value: T): Unit = throwUndefined()
+  @noinline private[unsafe] def load(rawptr: RawPtr): T = throwUndefined()
+  @noinline private[unsafe] def store(rawptr: RawPtr, value: T): Unit = throwUndefined()
 }
 
 object Tag {
@@ -32,38 +35,38 @@ object Tag {
       extends Tag[unsafe.Ptr[T]] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.Ptr[T]]): unsafe.Ptr[T] =
-      fromRawPtr[T](loadRawPtr(toRawPtr(ptr)))
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.Ptr[T]], value: unsafe.Ptr[T]): Unit =
-      storeRawPtr(toRawPtr(ptr), toRawPtr(value))
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.Ptr[T] =
+      fromRawPtr[T](loadRawPtr(rawptr))
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.Ptr[T]): Unit =
+      storeRawPtr(rawptr, toRawPtr(value))
   }
 
   case object Size extends Tag[unsafe.Size] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.Size]): unsafe.Size =
-      unsafe.Size.valueOf(loadRawSize(toRawPtr(ptr)))
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.Size], value: unsafe.Size): Unit =
-      storeRawSize(toRawPtr(ptr), value.rawSize)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.Size =
+      unsafe.Size.valueOf(loadRawSize(rawptr))
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.Size): Unit =
+      storeRawSize(rawptr, value.rawSize)
   }
 
   case object USize extends Tag[unsigned.USize] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.USize]): unsigned.USize =
-      unsigned.USize.valueOf(loadRawSize(toRawPtr(ptr)))
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.USize], value: unsigned.USize): Unit =
-      storeRawSize(toRawPtr(ptr), value.rawSize)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsigned.USize =
+      unsigned.USize.valueOf(loadRawSize(rawptr))
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsigned.USize): Unit =
+      storeRawSize(rawptr, value.rawSize)
   }
 
   final case class Class[T <: AnyRef](of: java.lang.Class[T])
       extends Tag[T] {
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[T]): T =
-      loadObject(toRawPtr(ptr)).asInstanceOf[T]
-    @alwaysinline override def store(ptr: unsafe.Ptr[T], value: T): Unit =
-      storeObject(toRawPtr(ptr), value.asInstanceOf[Object])
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): T =
+      loadObject(rawptr).asInstanceOf[T]
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: T): Unit =
+      storeObject(rawptr, value.asInstanceOf[Object])
   }
 
   % prims = [('Unit', 'scala.Unit', 'ptrSize', 'ptrSize'),
@@ -84,23 +87,23 @@ object Tag {
   object ${name} extends Tag[${T}] {
     @alwaysinline def size: CSize = ${size}
     @alwaysinline def alignment: CSize = ${align}
-    @alwaysinline override def load(ptr: unsafe.Ptr[${T}]): ${T} =
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): ${T} =
       % if name == 'Unit':
-      loadObject(toRawPtr(ptr)).asInstanceOf[Unit]
+      loadObject(rawptr).asInstanceOf[Unit]
       % elif name.startswith('U'):
       %   signed = name[1:]
-      load${signed}(toRawPtr(ptr)).to${name}
+      load${signed}(rawptr).to${name}
       % else:
-      load${name}(toRawPtr(ptr))
+      load${name}(rawptr)
       % end
-    @alwaysinline override def store(ptr: unsafe.Ptr[${T}], value: ${T}): Unit =
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: ${T}): Unit =
       % if name == 'Unit':
-      storeObject(toRawPtr(ptr), value.asInstanceOf[Object])
+      storeObject(rawptr, value.asInstanceOf[Object])
       % elif name.startswith('U'):
       %   signed = name[1:]
-      store${signed}(toRawPtr(ptr), value.to${signed})
+      store${signed}(rawptr, value.to${signed})
       % else:
-      store${name}(toRawPtr(ptr), value)
+      store${name}(rawptr, value)
       % end
   }
 
@@ -147,11 +150,11 @@ object Tag {
     @alwaysinline def size: CSize = of.size * n.asInstanceOf[NatTag].toUInt
     @alwaysinline def alignment: CSize = of.alignment
     @alwaysinline override def offset(idx: CSize): CSize = of.size * idx.toUInt
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CArray[T, N]]): unsafe.CArray[T, N] = {
-      new unsafe.CArray[T, N](ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CArray[T, N] = {
+      new unsafe.CArray[T, N](rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CArray[T, N]], value: unsafe.CArray[T, N]): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CArray[T, N]): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -205,11 +208,11 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct${N}${JustTs}]): unsafe.CStruct${N}${JustTs} = {
-      new unsafe.CStruct${N}${JustTs}(ptr.rawptr)
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CStruct${N}${JustTs} = {
+      new unsafe.CStruct${N}${JustTs}(rawptr)
     }
-    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct${N}${JustTs}], value: unsafe.CStruct${N}${JustTs}): Unit = {
-      val dst = ptr.rawptr
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CStruct${N}${JustTs}): Unit = {
+      val dst = rawptr
       if (value != null) {
         val src = value.rawptr
         libc.memcpy(dst, src, size)
@@ -228,11 +231,11 @@ object Tag {
 
     @alwaysinline def size: CSize = ptrSize
     @alwaysinline def alignment: CSize = ptrSize
-    @alwaysinline override def load(ptr: unsafe.Ptr[F]): F =
-      fromRawPtr(loadRawPtr(ptr.rawptr))
-    @alwaysinline override def store(ptr: unsafe.Ptr[F], value: F): Unit = {
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): F =
+      fromRawPtr(loadRawPtr(rawptr))
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: F): Unit = {
       val valuePtr = if(value != null) value.rawptr else null
-      storeRawPtr(toRawPtr(ptr), valuePtr)
+      storeRawPtr(rawptr, valuePtr)
     }
   }
 


### PR DESCRIPTION
Reimplements Ptr appply/update methods to new create a new Ptr instance. In benchmarks made for #3521 from before rewrite of ByteArrayBits skipping GC allocations allowed to drop execution time from ~500ms to ~17ms when running in release-fast mode + lto=full 

This change does also add additional `def {+,-}(offset: Int): Ptr[T]` methods allowing to skip unneccessary boxing of primitive int to sized numbers