### PR TITLE
Improve the API and documentation of build utilities

### DIFF
--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
@@ -160,7 +160,7 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
       resolvedVals = mutable.Map.empty
     )
 
-    val build = Build.findAndCompileNativeLibs(config, analysis)
+    val build = Build.findAndCompileNativeLibraries(config, analysis)
     Await.result(build, Duration.Inf)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -202,7 +202,7 @@ object Build {
     ).hashCode()
   }
 
-  /** Convenience method to combine finding and compiling native libaries.
+  /** Finds and compiles native libaries.
    *
    *  @param config
    *    the compiler configuration

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -209,7 +209,7 @@ object Build {
    *  @param analysis
    *    the result from the linker
    *  @return
-   *    a sequence of the object file paths
+   *    the paths to the compiled objects
    */
   def findAndCompileNativeLibs(
       config: Config,

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -204,7 +204,7 @@ object Build {
    *
    *  @param config
    *    the compiler configuration
-   *  @param linkerResult
+   *  @param analysis
    *    the result from the linker
    *  @return
    *    a sequence of the object file paths

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -152,7 +152,7 @@ object Build {
             /* Finds all the libraries on the classpath that contain native
              * code and then compiles them.
              */
-            findAndCompileNativeLibs(config, analysis)
+            findAndCompileNativeLibraries(config, analysis)
           case Some(libObjectPaths) =>
             Future.successful {
               libObjectPaths
@@ -212,7 +212,7 @@ object Build {
    *  @return
    *    the paths to the compiled objects
    */
-  def findAndCompileNativeLibs(
+  def findAndCompileNativeLibraries(
       config: Config,
       analysis: ReachabilityAnalysis.Result
   )(implicit ec: ExecutionContext): Future[Seq[Path]] = {

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -195,7 +195,7 @@ object Build {
     // One thing we miss is, we cannot detect changes in c libraries somewhere in `/usr/lib`.
     (
       config,
-      config.classPath.map(getLatestMtime(_)),
+      config.classPath.map(getLastModifiedChild(_)),
       getLastModified(config.artifactPath)
     ).hashCode()
   }
@@ -243,7 +243,7 @@ object Build {
    *  is the most recent value returned by `getLastModified` a node of this
    *  tree or `empty` if there is no file at `path`.
    */
-  private def getLatestMtime(path: Path): Optional[FileTime] =
+  private def getLastModifiedChild(path: Path): Optional[FileTime] =
     if (Files.exists(path))
       Files
         .walk(path, FileVisitOption.FOLLOW_LINKS)

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -188,6 +188,7 @@ object Build {
       artifact
     }
 
+  /** Returns a checksum of a compilation pipeline with the given `config`. */
   private def checkSum(config: Config): Int = {
     // skip the whole nativeLink process if the followings are unchanged since the previous build
     // - build configuration

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -154,6 +154,8 @@ private[scalanative] object LLVM {
     copyOutput(config, buildPath)
   }
 
+  /** Links the DWARF debug information found in the object file at `path`,
+   *  reading toolchain configuations from `config`. */
   def dsymutil(config: Config, path: Path): Unit =
     Discover.tryDiscover("dsymutil", "LLVM_BIN").flatMap { dsymutil =>
       val proc = Process(Seq(dsymutil.abs, path.abs), config.workDir.toFile())

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -155,7 +155,8 @@ private[scalanative] object LLVM {
   }
 
   /** Links the DWARF debug information found in the object file at `path`,
-   *  reading toolchain configuations from `config`. */
+   *  reading toolchain configuations from `config`.
+   */
   def dsymutil(config: Config, path: Path): Unit =
     Discover.tryDiscover("dsymutil", "LLVM_BIN").flatMap { dsymutil =>
       val proc = Process(Seq(dsymutil.abs, path.abs), config.workDir.toFile())


### PR DESCRIPTION
This PR brings various improvements to the public and internal API of build utilities (i.e. methods defined in `tools/src/main/build/Build.scala`).

The most significant change is 4373cf2f2231a98cff04d772d44ed33883335fb0, which removes a class that didn't actually represent any abstraction. Other changes are primarily about adding missing documentation.