### PR TITLE
Remove incorrect and no longer needed Reach.lookup fallback 

### DIFF
--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -131,26 +131,10 @@ class Reach(
           loaded(owner) = scope
         }
     }
-    def fallback = global match {
-      case Global.Member(owner, sig) =>
-        infos
-          .get(owner)
-          .collect {
-            case scope: ScopeInfo =>
-              scope.linearized
-                .find(_.responds.contains(sig))
-                .map(_.responds(sig))
-                .flatMap(lookup)
-          }
-          .flatten
-
-      case _ => None
-    }
 
     loaded
       .get(owner)
       .flatMap(_.get(global))
-      .orElse(fallback)
       .orElse {
         if (!ignoreIfUnavailable) addMissing(global)
         None


### PR DESCRIPTION
Fixes #3476 - now the missing method called statically would be reported as missing symbol
The Reach lookup fallback was used to find a main method defined in subclass of main class. It's no longer needed since we're generating static forwarders. Fallback lead to skipping report of missing static methods