### PR TITLE
Make `BoundaryLabel` invariant

### DIFF
--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
@@ -11,7 +11,11 @@ import scala.scalanative.meta.LinktimeInfo.isWindows
 object Continuations:
   import Impl.*
 
-  opaque type BoundaryLabel[-T] = Impl.BoundaryLabel
+  /** A marker for a given `boundary`. Use `break` or `suspend` to suspend the
+   *  continuation up to the specified `boundary`. This value MUST NOT escape
+   *  the `boundary` that created it.
+   */
+  opaque type BoundaryLabel[T] = Impl.BoundaryLabel
 
   /** The C implementation lets us set up how the Continuation structs (holding
    *  the reified stack fragment) is allocated, through a custom function that


### PR DESCRIPTION
Unlike `scala.util.boundary`'s `Label`, the label in continuations are not contravariant.
We can see both the covariance and contravariance requirement for `T` from the signature of
(the simplified version of) `suspend`:
```scala
def suspend[R, T](onSuspend: (R => T) => T): R
```

Thanks @maxm123 for spotting this out!
