### PR TITLE
Validate well known issues in provided or discovered NativeConfig

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -14,8 +14,8 @@ object Validator {
    */
   def validate(config: Config): Config =
     (validateMainClass _)
-      .andThen(validateBasename)
       .andThen(validateClasspath)
+      .andThen(validateCompileConfig)
       .apply(config)
 
   // throws if Application with no mainClass
@@ -33,18 +33,36 @@ object Validator {
     config
   }
 
-  // throws if moduleName or baseName is not set
-  private def validateBasename(config: Config): Config =
-    if (config.baseName.trim.isEmpty) { // trim for non default error
-      throw new BuildException(
-        "Config defaultBasename or NativeConfig baseName must be set."
-      )
-    } else config
-
   // filter so classpath only has jars or directories
   private def validateClasspath(config: Config): Config = {
     val fclasspath = NativeLib.filterClasspath(config.classPath)
     config.withClassPath(fclasspath)
+  }
+
+  private def validateCompileConfig(config: Config): Config = {
+    val c = config.compilerConfig
+    val issues = List.newBuilder[String]
+
+    if (c.multithreadingSupport) c.gc match {
+      case GC.Commix =>
+        issues += "CommixGC does not support multithreading yet, use other GC implementation (Immix, Boehm)"
+      case _ => ()
+    }
+    if (!Files.exists(c.clang))
+      issues += s"Provided clang path '${c.clang.toAbsolutePath()}' does not exist, specify a valid path to LLVM Toolchain distribution using config or LLVM_BIN environment variable"
+    if (!Files.exists(c.clangPP))
+      issues += s"Provided clang++ path '${c.clangPP.toAbsolutePath()}' does not exist, specify a valid path to LLVM Toolchain distribution using config or LLVM_BIN environment variable"
+    if (c.baseName.trim().isEmpty())
+      issues += s"Provided baseName is blank, provide a name of target artifact without extensions to allow for determinstic builds"
+
+    issues.result() match {
+      case Nil => config
+      case issues =>
+        throw new BuildException(
+          (s"Found ${issues.size} issue within provided confguration: " :: issues)
+            .mkString("\n  - ")
+        )
+    }
   }
 
 }

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -52,7 +52,8 @@ object Validator {
       issues += s"Provided clang path '${c.clang.toAbsolutePath()}' does not exist, specify a valid path to LLVM Toolchain distribution using config or LLVM_BIN environment variable"
     if (!Files.exists(c.clangPP))
       issues += s"Provided clang++ path '${c.clangPP.toAbsolutePath()}' does not exist, specify a valid path to LLVM Toolchain distribution using config or LLVM_BIN environment variable"
-    if (c.baseName.trim().isEmpty())
+    // config.baseName provides default value when config.compileConfig.baseName is empty
+    if (config.baseName.trim().isEmpty())
       issues += s"Provided baseName is blank, provide a name of target artifact without extensions to allow for determinstic builds"
 
     issues.result() match {


### PR DESCRIPTION
Adds validations for: 
* usage of multithreading with unsupported GC (Commix)  Addresses #3539
* not existing clang/clang++ paths
* blank baseName - integrated existing check with new logic to allow reporting all issues at once