### PR TITLE
Try to limit amount of classloaded symbols 

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
@@ -12,7 +12,7 @@ import scalanative.unsafe._
   def malloc(size: CSize): Ptr[Byte] = extern
   def calloc(num: CSize, size: CSize): Ptr[Byte] = extern
   def realloc(ptr: Ptr[Byte], newSize: CSize): Ptr[Byte] = extern
-  def free(ptr: Ptr[Byte]): Unit = extern
+  def free(ptr: Ptr[_]): Unit = extern
   def aligned_alloc(alignment: CSize, size: CSize): Unit = extern
 
   // Program utilities

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -505,7 +505,7 @@ object Thread {
     override protected val tid: scala.Long = 0L
     inheritableThreadLocals = new ThreadLocal.Values()
     platformCtx.nativeThread = nativeCompanion.create(this, 0L)
-    JoinNonDaemonThreads.registerExitHook()
+    if (isMultithreadingEnabled) JoinNonDaemonThreads.registerExitHook()
   }
 
   @alwaysinline private[lang] def nativeCompanion: NativeThread.Companion =

--- a/javalib/src/main/scala/java/lang/ThreadLocal.scala
+++ b/javalib/src/main/scala/java/lang/ThreadLocal.scala
@@ -92,7 +92,8 @@ object ThreadLocal {
     private def inheritValues(fromParent: ThreadLocal.Values): Unit = {
       // Transfer values from parent to child thread.
       val table = this.table
-      for (i <- table.length - 2 to 0 by -2) {
+      var i = table.length - 2
+      while (i >= 0) {
         val k = table(i)
         // The table can only contain null, tombstones and references.
         k match {
@@ -119,6 +120,7 @@ object ThreadLocal {
             }
           case _ => ()
         }
+        i -= 2
       }
     }
 
@@ -191,14 +193,18 @@ object ThreadLocal {
       if (size == 0) return true
 
       // Move over entries.
-      for (i <- oldTable.length - 2 to 0 by -2) oldTable(i) match {
-        case reference: Reference[ThreadLocal[_]] @unchecked =>
-          val key = reference.get()
-          if (key != null) {
-            // Entry is still live. Move it over.
-            add(key, oldTable(i + 1))
-          } else size -= 1
-        case _ => ()
+      var i = oldTable.length - 2
+      while (i >= 0) {
+        oldTable(i) match {
+          case reference: Reference[ThreadLocal[_]] @unchecked =>
+            val key = reference.get()
+            if (key != null) {
+              // Entry is still live. Move it over.
+              add(key, oldTable(i + 1))
+            } else size -= 1
+          case _ => ()
+        }
+        i -= 2
       }
       true
     }

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -10,7 +10,6 @@ import scala.collection.concurrent.TrieMap
 import scala.scalanative.runtime.Backtrace
 import scala.scalanative.runtime.NativeThread
 import scala.scalanative.libc.stdlib.{malloc, calloc, free}
-import java.util.concurrent.ConcurrentHashMap
 
 private[lang] object StackTrace {
   private val cache = TrieMap.empty[CUnsignedLong, StackTraceElement]

--- a/nativelib/src/main/scala/scala/scalanative/runtime/MemoryPool.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/MemoryPool.scala
@@ -174,15 +174,15 @@ final class MemoryPoolZone(private[this] val pool: MemoryPool) extends Zone {
     if (largeAllocations == null) {
       largeAllocations = new scala.Array[Ptr[_]](16)
     }
-    if (largeOffset == largeAllocations.size) {
+    if (largeOffset == largeAllocations.length) {
       val newLargeAllocations =
-        new scala.Array[Ptr[_]](largeAllocations.size * 2)
+        new scala.Array[Ptr[_]](largeAllocations.length * 2)
       Array.copy(
         largeAllocations,
         0,
         newLargeAllocations,
         0,
-        largeAllocations.size
+        largeAllocations.length
       )
       largeAllocations = newLargeAllocations
     }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -96,6 +96,7 @@ object NativeThread {
     fromRawPtr[scala.Byte](castObjectToRawPtr(thread))
 
   object Registry {
+    // Replace with ConcurrentHashMap when thread-safe
     private val _aliveThreads = TrieMap.empty[Long, NativeThread]
 
     private[NativeThread] def add(thread: NativeThread): Unit =
@@ -112,7 +113,7 @@ object NativeThread {
     }
   }
 
-  val threadRoutine: ThreadStartRoutine = CFuncPtr1.fromScalaFunction {
+  def threadRoutine: ThreadStartRoutine = CFuncPtr1.fromScalaFunction {
     (arg: ThreadRoutineArg) =>
       val thread = castRawPtrToObject(toRawPtr(arg))
         .asInstanceOf[NativeThread]

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuDouble.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuDouble.scala
@@ -916,10 +916,12 @@ object RyuDouble {
 
     // Values in the interval [1E-3, 1E7) are special.
     if (scientificNotation) {
-      for (i <- 0 until olength - 1) {
+      var i = 0
+      while (i < olength - 1) {
         val c = (output % 10).toInt
         output /= 10
         result(index + olength - i) = ('0' + c).toChar
+        i += 1
       }
       result(index) = ('0' + output % 10).toChar
       result(index + 1) = '.'
@@ -958,26 +960,34 @@ object RyuDouble {
         result(index) = '.'
         index += 1
 
-        for (i <- exp until -1) {
+        var i = exp
+        while (i < -1) {
           result(index) = '0'
           index += 1
+          i += 1
         }
 
         val current = index
-        for (i <- 0 until olength) {
+        i = 0
+        while (i < olength) {
           result(current + olength - i - 1) = ('0' + output % 10).toChar
           output /= 10
           index += 1
+          i += 1
         }
       } else if (exp + 1 >= olength) {
-        for (i <- 0 until olength) {
+        var i = 0
+        while (i < olength) {
           result(index + olength - i - 1) = ('0' + output % 10).toChar
           output /= 10
+          i += 1
         }
         index += olength
-        for (i <- olength until exp + 1) {
+        i = olength
+        while (i <= exp) {
           result(index) = '0'
           index += 1
+          i += 1
         }
         result(index) = '.'
         index += 1
@@ -986,13 +996,15 @@ object RyuDouble {
       } else {
         // Decimal dot is somewhere between the digits.
         var current = index + 1
-        for (i <- 0 until olength) {
+        var i = 0
+        while (i < olength) {
           if (olength - i - 1 == exp) {
             result(current + olength - i - 1) = '.'
             current -= 1
           }
           result(current + olength - i - 1) = ('0' + output % 10).toChar
           output /= 10
+          i += 1
         }
         index += olength + 1
       }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
@@ -451,14 +451,14 @@ object RyuFloat {
         // Decimal dot is somewhere between the digits.
         var current = index + 1
         var i = 0
-        while (0 < olength) {
+        while (i < olength) {
           if (olength - i - 1 == exp) {
             result(current + olength - i - 1) = '.'
             current -= 1
-            i += 1
           }
           result(current + olength - i - 1) = ('0' + output % 10).toChar
           output /= 10
+          i += 1
         }
         index += olength + 1
       }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
@@ -379,10 +379,12 @@ object RyuFloat {
 
     // Values in the interval [1E-3, 1E7) are special.
     if (scientificNotation) {
-      for (i <- 0 until olength - 1) {
+      var i = 0
+      while (i < olength - 1) {
         val c = output % 10
         output /= 10
         result(index + olength - i) = ('0' + c).toChar
+        i += 1
       }
       result(index) = ('0' + output % 10).toChar
       result(index + 1) = '.'
@@ -420,20 +422,26 @@ object RyuFloat {
           i -= 1
         }
         val current = index
-        for (i <- 0 until olength) {
+        i = 0
+        while (i < olength) {
           result(current + olength - i - 1) = ('0' + output % 10).toChar
           output /= 10
           index += 1
+          i += 1
         }
       } else if (exp + 1 >= olength) {
-        for (i <- 0 until olength) {
+        var i = 0
+        while (i < olength) {
           result(index + olength - i - 1) = ('0' + output % 10).toChar
           output /= 10
+          i += 1
         }
         index += olength
-        for (i <- olength until exp + 1) {
+        i = olength
+        while (i <= exp) {
           result(index) = '0'
           index += 1
+          i += 1
         }
         result(index) = '.'
         index += 1
@@ -442,10 +450,12 @@ object RyuFloat {
       } else {
         // Decimal dot is somewhere between the digits.
         var current = index + 1
-        for (i <- 0 until olength) {
+        var i = 0
+        while (0 < olength) {
           if (olength - i - 1 == exp) {
             result(current + olength - i - 1) = '.'
             current -= 1
+            i += 1
           }
           result(current + olength - i - 1) = ('0' + output % 10).toChar
           output /= 10

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -7,9 +7,13 @@ import scalanative.runtime.Intrinsics._
 import scalanative.runtime.monitor._
 import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 
-package object runtime {
+// Extract any fields from runtime package to ensure it does not require initialization
+private object runtimeState {
+  var _filename: String = null
+}
 
-  private var _filename: String = null
+package object runtime {
+  import runtimeState._
 
   def filename = _filename
 

--- a/scalalib/overrides-2.13/scala/Array.scala.patch
+++ b/scalalib/overrides-2.13/scala/Array.scala.patch
@@ -1,6 +1,35 @@
---- 2.13.6/scala/Array.scala
+--- 2.13.12/scala/Array.scala
 +++ overrides-2.13/scala/Array.scala
-@@ -122,7 +122,8 @@
+@@ -32,7 +32,7 @@
+  *  where the array objects `a`, `b` and `c` have respectively the values
+  *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
+  */
+-object Array {
++private object EmptyArrays {
+   val emptyBooleanArray = new Array[Boolean](0)
+   val emptyByteArray    = new Array[Byte](0)
+   val emptyCharArray    = new Array[Char](0)
+@@ -42,7 +42,19 @@
+   val emptyLongArray    = new Array[Long](0)
+   val emptyShortArray   = new Array[Short](0)
+   val emptyObjectArray  = new Array[Object](0)
++}
+ 
++object Array {
++  @inline def emptyBooleanArray = EmptyArrays.emptyBooleanArray
++  @inline def emptyByteArray    = EmptyArrays.emptyByteArray
++  @inline def emptyCharArray    = EmptyArrays.emptyCharArray
++  @inline def emptyDoubleArray  = EmptyArrays.emptyDoubleArray
++  @inline def emptyFloatArray   = EmptyArrays.emptyFloatArray
++  @inline def emptyIntArray     = EmptyArrays.emptyIntArray
++  @inline def emptyLongArray    = EmptyArrays.emptyLongArray
++  @inline def emptyShortArray   = EmptyArrays.emptyShortArray
++  @inline def emptyObjectArray  = EmptyArrays.emptyObjectArray
++
+   /** Provides an implicit conversion from the Array object to a collection Factory */
+   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
+   @SerialVersionUID(3L)
+@@ -122,7 +134,8 @@
      * @see `java.util.Arrays#copyOf`
      */
    def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
@@ -10,7 +39,7 @@
      case x: Array[AnyRef]     => java.util.Arrays.copyOf(x, newLength)
      case x: Array[Int]        => java.util.Arrays.copyOf(x, newLength)
      case x: Array[Double]     => java.util.Arrays.copyOf(x, newLength)
-@@ -183,16 +184,7 @@
+@@ -183,16 +196,7 @@
    // Subject to a compiler optimization in Cleanup.
    // Array(e0, ..., en) is translated to { val a = new Array(3); a(i) = ei; a }
    def apply[T: ClassTag](xs: T*): Array[T] = {
@@ -28,7 +57,7 @@
          val iterator = xs.iterator
          var i = 0
          while (iterator.hasNext) {
-@@ -200,7 +192,6 @@
+@@ -200,7 +204,6 @@
          }
          array
      }
@@ -36,7 +65,7 @@
  
    /** Creates an array of `Boolean` objects */
    // Subject to a compiler optimization in Cleanup, see above.
-@@ -577,7 +568,7 @@
+@@ -577,7 +580,7 @@
    def unapplySeq[T](x: Array[T]): UnapplySeqWrapper[T] = new UnapplySeqWrapper(x)
  
    final class UnapplySeqWrapper[T](private val a: Array[T]) extends AnyVal {

--- a/scalalib/overrides-2.13/scala/Predef.scala.patch
+++ b/scalalib/overrides-2.13/scala/Predef.scala.patch
@@ -1,5 +1,16 @@
---- 2.13.6/scala/Predef.scala
+--- 2.13.12/scala/Predef.scala
 +++ overrides-2.13/scala/Predef.scala
+@@ -148,8 +148,8 @@
+   type Class[T]      = java.lang.Class[T]
+ 
+   // miscellaneous -----------------------------------------------------
+-  scala.`package`                         // to force scala package object to be seen.
+-  scala.collection.immutable.List         // to force Nil, :: to be seen.
++  // scala.`package`                         // to force scala package object to be seen.
++  // scala.collection.immutable.List         // to force Nil, :: to be seen.
+ 
+   /**  @group aliases */
+   type Function[-A, +B] = Function1[A, B]
 @@ -159,9 +159,9 @@
    /**  @group aliases */
    type Set[A]     = immutable.Set[A]
@@ -12,6 +23,15 @@
  
    /**
     * Allows destructuring tuples with the same syntax as constructing them.
+@@ -175,7 +175,7 @@
+    * }}}
+    * @group aliases
+    */
+-  val ->        = Tuple2
++  @inline def ->        = Tuple2
+ 
+   // Manifest types, companions, and incantations for summoning
+   // TODO undeprecated until Scala reflection becomes non-experimental
 @@ -187,10 +187,10 @@
    type Manifest[T]      = scala.reflect.Manifest[T]
    // TODO undeprecated until Scala reflection becomes non-experimental
@@ -25,7 +45,7 @@
  
    // TODO undeprecated until Scala reflection becomes non-experimental
    // @deprecated("use scala.reflect.classTag[T] and scala.reflect.runtime.universe.typeTag[T] instead", "2.10.0")
-@@ -369,7 +369,7 @@
+@@ -370,7 +370,7 @@
      @inline def formatted(fmtstr: String): String = fmtstr format self
    }
  

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -86,7 +86,7 @@ abstract class LinkerSpec {
       .withBaseDir(outDir)
       .withClassPath(classpath.toSeq)
       .withMainClass(Some(entry))
-      .withCompilerConfig(setupNativeConfig.andThen(withDefaults))
+      .withCompilerConfig(setupNativeConfig.compose(withDefaults))
       .withLogger(Logger.nullLogger)
   }
 

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -1,0 +1,131 @@
+package scala.scalanative.linker
+
+import scala.scalanative.LinkerSpec
+
+import org.junit.Test
+import org.junit.Assert._
+import scala.scalanative.build.{NativeConfig, Config}
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo
+
+import scala.scalanative.nir._
+
+/** Tests minimal number of NIR symbols required when linking minimal
+ *  application based on the predefined hard limits. In the future we shall try
+ *  to limit these number even further
+ */
+class MinimalRequiredSymbolsTest extends LinkerSpec {
+  private val mainClass = "Test"
+  private val sourceFile = "Test.scala"
+
+  def isScala3 = ScalaNativeBuildInfo.scalaVersion.startsWith("3.")
+  def isScala2_13 = ScalaNativeBuildInfo.scalaVersion.startsWith("2.13")
+  def isScala2_12 = ScalaNativeBuildInfo.scalaVersion.startsWith("2.12")
+
+  @Test def default(): Unit = checkMinimalRequiredSymbols()(expected =
+    if (isScala3) SymbolsCount(types = 930, members = 5300)
+    else if (isScala2_13) SymbolsCount(types = 820, members = 4900)
+    else SymbolsCount(types = 925, members = 6100)
+  )
+
+  @Test def debugMetadata(): Unit =
+    checkMinimalRequiredSymbols(withDebugMetadata = true)(expected =
+      if (isScala3) SymbolsCount(types = 930, members = 5300)
+      else if (isScala2_13) SymbolsCount(types = 820, members = 4900)
+      else SymbolsCount(types = 925, members = 6100)
+    )
+
+  // Only MacOS uses DWARF metadata currently
+  @Test def debugMetadataMacOs(): Unit =
+    checkMinimalRequiredSymbols(
+      withDebugMetadata = true,
+      withTargetTriple = "x86_64-apple-darwin22.6.0"
+    )(expected =
+      if (isScala3) SymbolsCount(types = 1590, members = 11500)
+      else if (isScala2_13) SymbolsCount(types = 1460, members = 11200)
+      else SymbolsCount(types = 1540, members = 12560)
+    )
+
+  @Test def multithreading(): Unit =
+    checkMinimalRequiredSymbols(withMultithreading = true)(expected =
+      if (isScala3) SymbolsCount(types = 1000, members = 5850)
+      else if (isScala2_13) SymbolsCount(types = 900, members = 5500)
+      else SymbolsCount(types = 1000, members = 6850)
+    )
+
+  private def checkMinimalRequiredSymbols(
+      withDebugMetadata: Boolean = false,
+      withMultithreading: Boolean = false,
+      withTargetTriple: String = "x86_64-unknown-unknown"
+  )(expected: SymbolsCount) = usingMinimalApp(
+    _.withDebugMetadata(withDebugMetadata)
+      .withMultithreadingSupport(withMultithreading)
+      .withTargetTriple(withTargetTriple)
+  ) { (config: Config, result: ReachabilityAnalysis.Result) =>
+    assertEquals(
+      "debugMetadata",
+      withDebugMetadata,
+      config.compilerConfig.debugMetadata
+    )
+    assertEquals(
+      "multithreading",
+      withMultithreading,
+      config.compilerConfig.multithreadingSupport
+    )
+    assertEquals(
+      "targetTriple",
+      withTargetTriple,
+      config.compilerConfig.targetTriple.getOrElse("none")
+    )
+
+    val mode =
+      s"{debugMetadata=$withDebugMetadata, multithreading=$withMultithreading, targetTriple=$withTargetTriple}"
+    val found = SymbolsCount(result.defns)
+    if (found.total > expected.total) {
+      fail(s"""
+          |Found more symbols then expected, config=$mode:
+          |Expected at most: ${expected}
+          |Found:            ${found}
+          |Diff:             ${expected - found}
+          |""".stripMargin)
+    } else {
+      println(s"""
+          |Ammount of found symbols in norm, config=$mode:
+          |Expected at most: ${expected}
+          |Found:            ${found}
+          |Diff:             ${expected - found}
+          |""".stripMargin)
+    }
+  }
+
+  private def usingMinimalApp(setupConfig: NativeConfig => NativeConfig)(
+      fn: (Config, ReachabilityAnalysis.Result) => Unit
+  ): Unit = link(
+    entry = mainClass,
+    setupConfig = setupConfig,
+    sources = Map(sourceFile -> s"""
+        |object $mainClass{
+        |  def main(args: Array[String]): Unit = ()
+        |}
+        """.stripMargin)
+  ) { case (config, result) => fn(config, result) }
+
+  case class SymbolsCount(types: Int, members: Int) {
+    def total: Int = types + members
+    def -(other: SymbolsCount): SymbolsCount = SymbolsCount(
+      types = types - other.types,
+      members = members - other.members
+    )
+    override def toString(): String =
+      s"{types=$types, members=$members, total=${total}}"
+  }
+  object SymbolsCount {
+    def apply(defns: Seq[Defn]): SymbolsCount = {
+      val names = defns.map(_.name)
+      SymbolsCount(
+        types = names.count(_.isInstanceOf[Global.Top]),
+        members = names.count(_.isInstanceOf[Global.Member])
+      )
+    }
+  }
+
+}

--- a/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
@@ -206,7 +206,10 @@ class LocalNamesTest extends OptimizerSpec {
             checkHasLetEither[Op.Field, Op.Copy]("field")
             // checkHasLet[Op.Method]("method")
             // checkHasLet[Op.Dynmethod]("dynMethod")
-            checkHasLetEither[Op.Module, Op.Call]("module")
+            if (scalaVersion.startsWith("2.12"))
+              checkHasLetEither[Op.Module, Op.Call]("module")
+            else
+              checkHasLetEither[Op.Module, Op.Copy]("module")
             if (usesOpaquePointers)
               checkHasLetEither[Op.As, Op.Copy]("as")
             else
@@ -228,7 +231,9 @@ class LocalNamesTest extends OptimizerSpec {
             checkHasLetEither[Op.Arrayload, Op.Load]("arrayLoad")
             checkHasLetEither[Op.Arraylength, Op.Load]("arrayLength")
             // Filter out inlined names
-            assertDistinct(lets.values.toSeq.diff(Seq("buffer", "addr")))
+            val filteredOut =
+              Seq("buffer", "addr", "rawptr", "toPtr", "fromPtr")
+            assertDistinct(lets.values.toSeq.filterNot(filteredOut.contains))
           }
       checkLocalNames(result.defns, beforeLowering = true)
       afterLowering(config, result) {


### PR DESCRIPTION
This change tries to limit ammount of classloaded, always required symbols. The changes allow to reduce this number from ~10k to ~4.8k loaded methods for builds with disabled debug metadata and multithread on macos.

 The changes are limit only changes which does not significentlly change runtime behaviour. Additional removal of loaded methods might be possible in the future.