### PR TITLE
Improve implementation of implicit class defined in extern object

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/annotation/nonExtern.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/nonExtern.scala
@@ -1,0 +1,8 @@
+package scala.scalanative
+package annotation
+
+/** Internal annotation used in compiler plugin to exclude subset of extern type
+ *  definitions from of being treated as extern
+ */
+private final abstract class nonExtern()
+    extends scala.annotation.StaticAnnotation

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -43,6 +43,9 @@ trait NirDefinitions {
     lazy val ExternClass = getRequiredClass(
       "scala.scalanative.unsafe.package$extern"
     )
+    lazy val NonExternClass = getRequiredClass(
+      "scala.scalanative.annotation.nonExtern"
+    )
     lazy val BlockingClass = getRequiredClass(
       "scala.scalanative.unsafe.package$blocking"
     )

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -685,7 +685,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       } else {
         val ty = genType(tree.symbol.tpe)
         val name = genFieldName(tree.symbol)
-        if (sym.owner.isExternType) {
+        if (sym.isExtern) {
           val externTy = genExternType(tree.symbol.tpe)
           genLoadExtern(ty, externTy, tree.symbol)
         } else {
@@ -712,7 +712,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val qual = genExpr(qualp)
           val rhs = genExpr(rhsp)
           val name = genFieldName(sym)
-          if (sym.owner.isExternType) {
+          if (sym.isExtern) {
             val externTy = genExternType(sym.tpe)
             genStoreExtern(externTy, sym, rhs)
           } else {
@@ -2516,7 +2516,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         selfp: Tree,
         argsp: Seq[Tree]
     )(implicit pos: nir.Position): Val = {
-      if (sym.owner.isExternType && sym.isAccessor) {
+      if (sym.isExtern && sym.isAccessor) {
         genApplyExternAccessor(sym, argsp)
       } else if (sym.isStaticMember) {
         genApplyStaticMethod(sym, selfp, argsp)
@@ -2531,7 +2531,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         receiver: Tree,
         argsp: Seq[Tree]
     )(implicit pos: nir.Position): Val = {
-      require(!sym.owner.isExternType, sym.owner)
+      require(!sym.isExtern, sym.owner)
       val name = genStaticMemberName(sym, receiver.symbol)
       val method = Val.Global(name, nir.Type.Ptr)
       val sig = genMethodSig(sym)
@@ -2556,7 +2556,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genLoadExtern(ty: nir.Type, externTy: nir.Type, sym: Symbol)(implicit
         pos: nir.Position
     ): Val = {
-      assert(sym.owner.isExternType, "loadExtern was not extern")
+      assert(sym.isExtern, "loadExtern was not extern")
 
       val name = Val.Global(genName(sym), Type.Ptr)
       val syncAttrs =
@@ -2572,7 +2572,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genStoreExtern(externTy: nir.Type, sym: Symbol, value: Val)(implicit
         pos: nir.Position
     ): Val = {
-      assert(sym.owner.isExternType, "storeExtern was not extern")
+      assert(sym.isExtern, "storeExtern was not extern")
       val name = Val.Global(genName(sym), Type.Ptr)
       val externValue = toExtern(externTy, value)
       val syncAttrs =
@@ -2615,7 +2615,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val owner = sym.owner
       val name = genMethodName(sym)
       val origSig = genMethodSig(sym)
-      val isExtern = owner.isExternType
+      val isExtern = sym.isExtern
       val sig =
         if (isExtern) {
           genExternMethodSig(sym)
@@ -2645,7 +2645,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def genMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[Val] =
-      if (sym.owner.isExternType) genExternMethodArgs(sym, argsp)
+      if (sym.isExtern) genExternMethodArgs(sym, argsp)
       else genSimpleArgs(argsp)
 
     private def genSimpleArgs(argsp: Seq[Tree]): Seq[Val] = argsp.map(genExpr)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -72,7 +72,7 @@ trait NirGenName[G <: Global with Singleton] {
     }
 
     owner.member {
-      if (sym.owner.isExternType) {
+      if (sym.isExtern) {
         nir.Sig.Extern(id)
       } else {
         nir.Sig.Field(id, scope)
@@ -94,7 +94,7 @@ trait NirGenName[G <: Global with Singleton] {
 
     val paramTypes = tpe.params.toSeq.map(p => genType(p.info))
 
-    def isExtern = sym.owner.isExternType
+    def isExtern = sym.isExtern
 
     if (sym == String_+)
       genMethodName(StringConcatMethod)
@@ -156,7 +156,7 @@ trait NirGenName[G <: Global with Singleton] {
   private def nativeIdOf(sym: Symbol): String = {
     sym.getAnnotation(NameClass).flatMap(_.stringArg(0)).getOrElse {
       val name = sym.javaSimpleName.toString()
-      val id: String = if (sym.owner.isExternType) {
+      val id: String = if (sym.isExtern) {
         // Don't use encoded names for externs
         sym.decodedName.trim()
       } else if (sym.isField) {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -30,6 +30,7 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val NameClass = requiredClass("scala.scalanative.unsafe.name")
   @tu lazy val LinkClass = requiredClass("scala.scalanative.unsafe.link")
   @tu lazy val ExternClass = requiredClass("scala.scalanative.unsafe.extern")
+  @tu lazy val NonExternClass = requiredClass("scala.scalanative.annotation.nonExtern")
   @tu lazy val BlockingClass = requiredClass("scala.scalanative.unsafe.blocking")
   @tu lazy val StructClass = requiredClass("scala.scalanative.runtime.struct")
   @tu lazy val ResolvedAtLinktimeClass = requiredClass("scala.scalanative.unsafe.resolvedAtLinktime")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -93,7 +93,14 @@ trait NirGenExpr(using Context) {
       def qualifier = qualifier0.withSpan(qualifier0.span.orElse(fun.span))
       def arg = args.head
 
+      inline def fail(msg: String)(using Context) = {
+        report.error(msg, app.srcPos)
+        Val.Null
+      }
       fun match {
+        case _ if sym == defnNir.UnsafePackage_extern =>
+          fail(s"extern can be used only from non-inlined extern methods")
+
         case _: TypeApply => genApplyTypeApply(app)
         case Select(Super(_, _), _) =>
           genApplyMethod(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -259,17 +259,7 @@ trait NirGenStat(using Context) {
       val sym = dd.symbol
       val owner = curClassSym.get
 
-      // warning: In Scala3 we cannot reliably distinguish implicit class from implicit def!
-      // This means that non-extern implicit def methods can be defined in extern object
-      // To distinguish betwen extern def and allowed implicit class check rhs = unsafe.extern()
-      // Extensions can be easilly identified via flag
-      def isExtension =
-        sym.flags.is(Extension) || {
-          sym.flags.isAllOf(Implicit | Final) &&
-          dd.paramss.headOption.exists(_.size == 1) &&
-          !ApplyExtern.unapply(dd.rhs)
-        }
-      val isExtern = sym.isExtern && !isExtension
+      val isExtern = sym.isExtern
 
       val attrs = genMethodAttrs(sym, isExtern)
       val name = genMethodName(sym)
@@ -727,7 +717,7 @@ trait NirGenStat(using Context) {
   }
 
   /** Gen the static forwarders for the methods of a module class.
-   *
+   *l
    *  Precondition: `isCandidateForForwarders(moduleClass)` is true
    */
   private def genStaticForwardersFromModuleClass(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -716,8 +716,7 @@ trait NirGenStat(using Context) {
     }
   }
 
-  /** Gen the static forwarders for the methods of a module class.
-   *l
+  /** Gen the static forwarders for the methods of a module class. l
    *  Precondition: `isCandidateForForwarders(moduleClass)` is true
    */
   private def genStaticForwardersFromModuleClass(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -52,7 +52,9 @@ trait NirGenType(using Context) {
       sym.owner.isExternType ||
       sym.hasAnnotation(defnNir.ExternClass) ||
       (sym.is(Accessor) && sym.field.isExtern)
-    } && !sym.hasAnnotation(defnNir.NonExternClass)  // Added in PrepNativeInterop
+    } && !sym.hasAnnotation(
+      defnNir.NonExternClass
+    ) // Added in PrepNativeInterop
 
     def isExtensionMethod: Boolean =
       sym.flags.isAllOf(Extension | Method) || {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -52,7 +52,12 @@ trait NirGenType(using Context) {
       sym.owner.isExternType ||
       sym.hasAnnotation(defnNir.ExternClass) ||
       (sym.is(Accessor) && sym.field.isExtern)
-    }
+    } && !sym.hasAnnotation(defnNir.NonExternClass)  // Added in PrepNativeInterop
+
+    def isExtensionMethod: Boolean =
+      sym.flags.isAllOf(Extension | Method) || {
+        sym.flags.isAllOf(Final | Implicit | Method)
+      }
 
     def isExternType: Boolean =
       (isScalaModule || sym.isTraitOrInterface) &&

--- a/nscplugin/src/test/scala-3/scala/NativeCompilerTest.scala
+++ b/nscplugin/src/test/scala-3/scala/NativeCompilerTest.scala
@@ -112,3 +112,21 @@ class NativeCompilerTest:
       |}
       |""".stripMargin
   )
+
+  @Test def disallowExtensionInExternWithExtern(): Unit = {
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () => NIRCompiler(_.compile("""import scala.scalanative.unsafe.extern
+        |@extern object Dummy { 
+        |  extension(v: Int) { 
+        |    def convert(): Long = extern
+        |  }
+        |}
+        |""".stripMargin))
+    )
+    assertTrue(
+      err
+        .getMessage()
+        .contains("Extensions cannot be defined as extern methods")
+    )
+  }

--- a/nscplugin/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
+++ b/nscplugin/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.api.CompilationFailedException
-import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.linker.compileAndLoad
 import scala.scalanative.nir.*
 
 class NIRCompilerTest3 {

--- a/nscplugin/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
+++ b/nscplugin/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
@@ -69,7 +69,28 @@ class NIRCompilerTest3 {
         |var foo = extern
         |""".stripMargin))
     )
-    assertTrue(err.getMessage().contains("extern field foo needs result type"))
+    assertTrue(
+      err
+        .getMessage()
+        .contains("extern can be used only from non-inlined extern methods")
+    )
+  }
+
+  @Test def inlinedMethodUsingExtern(): Unit = {
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () => NIRCompiler(_.compile("""
+           |import scala.scalanative.unsafe.*
+           |
+           |inline def foo(): Int = locally{ val x = extern; x }
+           |def x = foo()
+           |""".stripMargin))
+    )
+    assertTrue(
+      err
+        .getMessage()
+        .contains("extern can be used only from non-inlined extern methods")
+    )
   }
 
   val ErrorBothExternAndExported =
@@ -216,4 +237,5 @@ class NIRCompilerTest3 {
     )
     assertTrue(err.getMessage().contains("Exported field cannot be inlined"))
   }
+
 }

--- a/nscplugin/src/test/scala-3/scala/scalanative/linker/StaticForwardersSuiteScala3.scala
+++ b/nscplugin/src/test/scala-3/scala/scalanative/linker/StaticForwardersSuiteScala3.scala
@@ -4,7 +4,6 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.nir._
-import scala.scalanative.linker.StaticForwardersSuite._
 
 class StaticForwardersSuiteScala3 {
 

--- a/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.api.CompilationFailedException
-import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.linker.compileAndLoad
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
 
 class NIRCompilerTest {
@@ -257,7 +257,7 @@ class NIRCompilerTest {
     )
   }
 
-  @Test def allowImplicitAnyValClassInExtern(): Unit = NIRCompiler(
+  @Test def allowImplicitClassInExtern(): Unit = NIRCompiler(
     _.compile(
       """import scala.scalanative.unsafe.extern
           |@extern object Dummy { 

--- a/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -292,6 +292,23 @@ class NIRCompilerTest {
     )
   }
 
+  @Test def applyExtern(): Unit = {
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () => NIRCompiler(_.compile("""
+           |import scala.scalanative.unsafe._
+           |object Foo{
+           |  def foo(): Int = locally{ val x = extern; x }
+           |}
+           |""".stripMargin))
+    )
+    assertTrue(
+      err
+        .getMessage()
+        .contains("extern can be used only from non-inlined extern methods")
+    )
+  }
+
   @Test def nonExistingClassFieldPointer(): Unit = {
     val err = assertThrows(
       classOf[CompilationFailedException],

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LexicalScopesTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 import scala.collection.mutable
 
 import scala.scalanative.api.CompilationFailedException
-import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.linker.compileAndLoad
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
 import scala.reflect.ClassTag
 import scala.scalanative.nir.Defn.Define.DebugInfo.LexicalScope

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LocalNamesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LocalNamesTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 import scala.collection.mutable
 
 import scala.scalanative.api.CompilationFailedException
-import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.linker.compileAndLoad
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
 import scala.reflect.ClassTag
 

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/PositionsTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/PositionsTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.api.CompilationFailedException
-import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.linker.compileAndLoad
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
 
 class PositionsTest {

--- a/nscplugin/src/test/scala/scala/scalanative/linker/ExternObjectWithImplicitClass.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/ExternObjectWithImplicitClass.scala
@@ -1,0 +1,81 @@
+package scala.scalanative.linker
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.scalanative.nir._
+import scala.scalanative.util.Scope
+
+class ExternObjectWithImplicitClass {
+
+  @Test def createsValidDefns(): Unit = {
+    compileAndLoad(
+      "Test.scala" ->
+        """import scala.scalanative.unsafe.extern
+          |@extern object Foo { 
+          |  implicit class Ext(v: Int) { 
+          |    def convert(): Long = Foo.implicitConvert(v) + Foo.doConvert(v)
+          |    def add(x: Int) = v + x 
+          |  }
+          |  implicit def implicitConvert(v: Int): Long = extern
+          |  def doConvert(v: Int): Long = extern
+          |}
+          |""".stripMargin
+    ) { defns =>
+      val ExternModule = Global.Top("Foo$")
+      val ImplicitClass = Global.Top("Foo$Ext")
+      val expected: Seq[Global] = Seq(
+        ExternModule,
+        // All ExternModule members shall be extern with exception of Ext implicit class constructor
+        ExternModule.member(Sig.Extern("doConvert")),
+        ExternModule.member(Sig.Extern("implicitConvert")),
+        ExternModule.member(
+          Sig.Method("Ext", Seq(Type.Int, Type.Ref(ImplicitClass)))
+        ),
+        ImplicitClass,
+        ImplicitClass.member(Sig.Method("convert", Seq(Type.Long))),
+        ImplicitClass.member(Sig.Method("add", Seq(Type.Int, Type.Int)))
+      )
+      assertEquals(Set.empty, expected.diff(defns.map(_.name)).toSet)
+    }
+  }
+
+  @Test def createsValidDefnsForAnyVal(): Unit = {
+    compileAndLoad(
+      "Test.scala" ->
+        """import scala.scalanative.unsafe.extern
+          |@extern object Foo { 
+          |  implicit class Ext(val v: Int) extends AnyVal { 
+          |    def convert(): Long = Foo.implicitConvert(v) + Foo.doConvert(v)
+          |    def add(x: Int) = v + x 
+          |  }
+          |  implicit def implicitConvert(v: Int): Long = extern
+          |  def doConvert(v: Int): Long = extern
+          |}
+          |""".stripMargin
+    ) { defns =>
+      val ExternModule = Global.Top("Foo$")
+      val ImplicitClass = Global.Top("Foo$Ext")
+      val ImplicitModule = Global.Top("Foo$Ext$")
+      val expected: Seq[Global] = Seq(
+        ExternModule,
+        // All ExternModule members shall be extern with exception of Ext implicit class constructor
+        ExternModule.member(Sig.Extern("doConvert")),
+        ExternModule.member(Sig.Extern("implicitConvert")),
+        ExternModule.member(Sig.Method("Ext", Seq(Type.Int, Type.Int))),
+        ImplicitClass,
+        ImplicitClass.member(Sig.Method("convert", Seq(Type.Long))),
+        ImplicitClass.member(Sig.Method("add", Seq(Type.Int, Type.Int))),
+        ImplicitModule,
+        ImplicitModule.member(
+          Sig.Method("convert$extension", Seq(Type.Int, Type.Long))
+        ),
+        ImplicitModule.member(
+          Sig.Method("add$extension", Seq.fill(3)(Type.Int))
+        )
+      )
+      assertEquals(Set.empty, expected.diff(defns.map(_.name)).toSet)
+    }
+  }
+
+}

--- a/nscplugin/src/test/scala/scala/scalanative/linker/StaticForwardersSuite.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/StaticForwardersSuite.scala
@@ -5,12 +5,8 @@ import org.junit.Assert._
 
 import scala.scalanative.nir._
 import scala.scalanative.util.Scope
-import scala.scalanative.io._
-import scala.scalanative.NIRCompiler
-import java.nio.file.{Files, Path, Paths}
 
 class StaticForwardersSuite {
-  import StaticForwardersSuite._
 
   @Test def generateStaticForwarders(): Unit = {
     compileAndLoad(
@@ -73,30 +69,6 @@ class StaticForwardersSuite {
         Module.member(Sig.Method("bar", Seq(Rt.String)))
       )
       assertTrue(expected.diff(defns.map(_.name)).isEmpty)
-    }
-  }
-}
-
-object StaticForwardersSuite {
-  def compileAndLoad(
-      sources: (String, String)*
-  )(fn: Seq[Defn] => Unit): Unit = {
-    Scope { implicit in =>
-      val outDir = Files.createTempDirectory("native-test-out")
-      val compiler = NIRCompiler.getCompiler(outDir)
-      val sourcesDir = NIRCompiler.writeSources(sources.toMap)
-      val dir = VirtualDirectory.real(outDir)
-
-      val defns = compiler
-        .compile(sourcesDir)
-        .toSeq
-        .filter(_.toString.endsWith(".nir"))
-        .map(outDir.relativize(_))
-        .flatMap { path =>
-          val buffer = dir.read(path)
-          serialization.deserializeBinary(buffer, path.toString)
-        }
-      fn(defns)
     }
   }
 }

--- a/nscplugin/src/test/scala/scala/scalanative/linker/package.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/package.scala
@@ -1,0 +1,30 @@
+package scala.scalanative
+
+import java.nio.file.{Files, Path, Paths}
+import scala.scalanative.io._
+import scala.scalanative.nir.{Defn, serialization}
+import scala.scalanative.util.Scope
+
+package object linker {
+  def compileAndLoad(
+      sources: (String, String)*
+  )(fn: Seq[Defn] => Unit): Unit = {
+    Scope { implicit in =>
+      val outDir = Files.createTempDirectory("native-test-out")
+      val compiler = NIRCompiler.getCompiler(outDir)
+      val sourcesDir = NIRCompiler.writeSources(sources.toMap)
+      val dir = VirtualDirectory.real(outDir)
+
+      val defns = compiler
+        .compile(sourcesDir)
+        .toSeq
+        .filter(_.toString.endsWith(".nir"))
+        .map(outDir.relativize(_))
+        .flatMap { path =>
+          val buffer = dir.read(path)
+          serialization.deserializeBinary(buffer, path.toString)
+        }
+      fn(defns)
+    }
+  }
+}

--- a/nscplugin/src/test/scala/scala/scalanative/unsafe/ExportedMembersReachabilityTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/unsafe/ExportedMembersReachabilityTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 
 import scala.scalanative.api.CompilationFailedException
 import scala.scalanative.nir._
-import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.linker.compileAndLoad
 
 class ExportedMembersReachabilityTest {
   val Lib = Global.Top("lib$")

--- a/nscplugin/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import scala.scalanative.api.CompilationFailedException
-import scala.scalanative.linker.StaticForwardersSuite.compileAndLoad
+import scala.scalanative.linker.compileAndLoad
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
 import scala.scalanative.NIRCompiler
 

--- a/unit-tests/native/src/test/scala-3/scala/scala/scalanative/IssuesTestScala3.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalanative/IssuesTestScala3.scala
@@ -25,13 +25,7 @@ class IssuesTestScala3 {
   }
 
   @Test def i3231(): Unit = {
-    @extern object extern_functions:
-      @name("sprintf")
-      def test(buffer: CString, format: CString, args: Any*): CInt = extern
-
-    object functions:
-      export extern_functions.test // should compile
-
+    import issue3231.*
     val buff: Ptr[CChar] = stackalloc[CChar](128)
     functions.test(buff, c"%d %d %d", -1, 1, 42)
     assertEquals("-1 1 42", fromCString(buff))
@@ -57,3 +51,11 @@ object issue3063:
       extension (struct: mu_Context)
         def text_width: CFuncPtr2[mu_Font, CString, CInt] = ???
         def text_width_=(value: CFuncPtr2[mu_Font, CString, CInt]): Unit = ()
+
+object issue3231:
+  @extern object extern_functions:
+    @name("sprintf")
+    def test(buffer: CString, format: CString, args: Any*): CInt = extern
+
+  object functions:
+    export extern_functions.test // should compile


### PR DESCRIPTION
The implementation of implicit class constructor defined in extern object had a bug leading to incorrect NIR generation - Sig.Extern instead of Sig.Method, even though if implicit class / extensions methods was defining actual Scala logic. The main issue of that was checking only AST trees, and not symbols, leading to diverging  outcomes depending on usage. 
To fix this issue we introduce internal annotation not available to users `@nonExtern`. Based on the information provided in the `PrepNativeInterop` phases we're able to detect implicit class constructors and correctly handle them when generating NIR. 

Additionally we add checks for calls to `unsafe.extern` used in non-extern methods leading to throwing an exception at runtime. Now, all such calls would be detected at compile-time which resolves #3380