### PR TITLE
Trigger Scala Native CLI CI on Nightly publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
           MAVEN_USER: "${{ secrets.SONATYPE_USER }}"
           MAVEN_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"
           PGP_PASSPHRASE: "${{ secrets.PGP_PASSWORD }}"
-        run: sbt "-v" "-J-Xmx7G" "publish-release-for-version ${{ matrix.scala }}"
+        run: sbt "-v" "-J-Xmx7G" "-J-XX:+UseG1GC" "publish-release-for-version ${{ matrix.scala }}"
 
   dispatch:
     name: Dispatch trigger builds for dependant projects

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,3 +51,21 @@ jobs:
           MAVEN_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"
           PGP_PASSPHRASE: "${{ secrets.PGP_PASSWORD }}"
         run: sbt "-v" "-J-Xmx7G" "publish-release-for-version ${{ matrix.scala }}"
+
+  dispatch:
+    name: Dispatch trigger builds for dependant projects
+    runs-on: ubuntu-latest
+    needs: [publish]
+    if: github.event_name == 'schedule' && github.repository == 'scala-native/scala-native'
+    strategy:
+      matrix:
+        repo: ['scala-native/scala-native-cli']
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch to workflows of dependant projects
+        run: |
+            curl -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Authorization: token ${{ secrets.DISPATCH_TOKEN }}" \
+            --request POST \
+            --data '{"event_type": "nightly-published", "client_payload": {} }' \
+            https://api.github.com/repos/${{ matrix.repo }}/dispatches

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -321,7 +321,7 @@ object Build {
         case Seq(nscPlugin, nativelib, scalalib) =>
           toolsBuildInfoSettings(nscPlugin, nativelib, scalalib)
       }
-      .dependsOn(nir, util)
+      .dependsOn(nirJVM, utilJVM)
 
   private def toolsBuildInfoSettings(
       nscPlugin: LocalProject,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -65,15 +65,18 @@ object Build {
   private def setDepenencyForCurrentBinVersion[T](
       key: TaskKey[T],
       projects: Seq[MultiScalaProject],
-      includeSbtPlugin: Boolean = true
+      includeNoCrossProjects: Boolean = true
   ) = {
     key := Def.taskDyn {
       val binVersion = scalaBinaryVersion.value
-      val optSbtPlugin = Seq(sbtScalaNative).filter(_ =>
-        includeSbtPlugin && binVersion == "2.12"
+      // There are 2 not cross build projects:
+      // sbt-plugin which needs to build with 2.12
+      // javalib-intf which contains only Java code and can be compiled with any version
+      val optNoCrossProjects = noCrossProjects.filter(_ =>
+        includeNoCrossProjects && binVersion == "2.12"
       )
       val dependenices =
-        optSbtPlugin ++ projects.map(_.forBinaryVersion(binVersion))
+        optNoCrossProjects ++ projects.map(_.forBinaryVersion(binVersion))
       val prev = key.value
       Def
         .task { prev }
@@ -111,7 +114,7 @@ object Build {
           setDepenencyForCurrentBinVersion(
             _,
             crossPublishedMultiScalaProjects,
-            includeSbtPlugin = false
+            includeNoCrossProjects = false
           )
         )
       )

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -132,14 +132,16 @@ private[scalanative] object ScalaNative {
               modifiers -> s"$BOLD$YELLOW$name$RESET$typeInfo at $BOLD$filename:$line"
             }
         }
-        val padding = elems
-          .map(_._1.length)
-          .max
-          .min(14) + 2
-        elems.foreach {
-          case (modifiers, tracedDescriptor) =>
-            val pad = " " * (padding - modifiers.length)
-            buf.append(s"$pad$modifiers$tracedDescriptor\n")
+        if (elems.nonEmpty) {
+          val padding = elems
+            .map(_._1.length)
+            .max
+            .min(14) + 2
+          elems.foreach {
+            case (modifiers, tracedDescriptor) =>
+              val pad = " " * (padding - modifiers.length)
+              buf.append(s"$pad$modifiers$tracedDescriptor\n")
+          }
         }
         buf.append("\n")
       }


### PR DESCRIPTION
Trigger Scala Native CLI to publish a new version of nightly CLI upon finished nightly release
Fix flow in build skipping publising javalib-intf module
Fixes bugs found when integrating with ScalaNativeCLI