### PR TITLE
Fix test-llvm-versions on mac

### DIFF
--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -243,7 +243,7 @@ jobs:
           if [[ "${{ matrix.llvm-version }}" == "latest" ]]; then 
             export LLVM_BIN=$(brew --prefix llvm)/bin
           else 
-            export LLVM_BIN=$(brew --prefix llvm@${{ matrix.llvm-version }})/bin
+            export LLVM_BIN=$(brew --prefix llvm@${{ matrix.llvm }})/bin
           fi
           echo "LLVM_BIN=${LLVM_BIN}"
           $LLVM_BIN/clang --version


### PR DESCRIPTION
It failed with

```
Error: No available formula with the name "llvm@". Did you mean llvm, llm, llvm@9, llvm@8, llvm@7 or wllvm?
/Users/runner/work/_temp/954b4bca-24bb-42be-84cf-bcea761ccdf5.sh: line 7: /bin/clang: No such file or directory
LLVM_BIN=/bin
```

https://github.com/scala-native/scala-native/actions/runs/6477129003/job/17586835436