### PR TITLE
Remove URL related classes from supported javalib

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -222,9 +222,6 @@ java.net
 * ``URI``
 * ``URIEncoderDecoder``
 * ``URISyntaxException``
-* ``URL``
-* ``URLClassLoader``
-* ``URLConnection``
 * ``URLDecoder``
 * ``URLEncoder``
 * ``UnknownHostException``


### PR DESCRIPTION
Close https://github.com/scala-native/scala-native/issues/2785

Those classes (`URL`, `URLConnection`, and `URLClassLoader`) are already removed in https://github.com/scala-native/scala-native/pull/2788 Let's close the original issue by removing them from the list of supported classes in the doc.

(While I'm not sure this list is well maintained + is it useful for scala-native users to lookup 🤔 )