### PR TITLE
Don't require scalalib to depend on javalib in the build.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -547,7 +547,8 @@ object Build {
     .enablePlugins(MyScalaNativePlugin)
     .settings(
       publishSettings(Some(VersionScheme.BreakOnMajor)),
-      commonJavalibSettings,
+      NIROnlySettings,
+      recompileAllOrNothingSettings,
       disabledDocsSettings
     )
     .dependsOn(nativelib, clib)
@@ -617,7 +618,7 @@ object Build {
             .value
         )
       }
-      .dependsOn(auxlib, javalib)
+      .dependsOn(auxlib)
 
   // Tests ------------------------------------------------
   lazy val tests = MultiScalaProject("tests", file("unit-tests") / "native")
@@ -703,7 +704,7 @@ object Build {
       .enablePlugins(MyScalaNativePlugin)
       .withNativeCompilerPlugin
       .withJUnitPlugin
-      .dependsOn(scalalib, testInterface % "test")
+      .dependsOn(scalalib, javalib, testInterface % "test")
 
 // Testing infrastructure ------------------------------------------------
   lazy val testingCompilerInterface =
@@ -757,6 +758,7 @@ object Build {
       .withJUnitPlugin
       .dependsOn(
         scalalib,
+        javalib,
         testInterfaceSbtDefs,
         junitRuntime,
         junitAsyncNative % "test"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -619,11 +619,7 @@ object Settings {
     incOptions ~= { _.withRecompileAllFraction(0.0001) }
   )
 
-  lazy val commonJavalibSettings = Def.settings(
-    recompileAllOrNothingSettings,
-    Compile / scalacOptions ++= scalaNativeCompilerOptions(
-      "genStaticForwardersForNonTopLevelObjects"
-    ),
+  lazy val NIROnlySettings = Def.settings(
     // Don't include classfiles for javalib in the packaged jar.
     Compile / packageBin / mappings := {
       val previous = (Compile / packageBin / mappings).value
@@ -633,6 +629,13 @@ object Settings {
       }
     },
     exportJars := true
+  )
+  lazy val commonJavalibSettings = Def.settings(
+    recompileAllOrNothingSettings,
+    Compile / scalacOptions ++= scalaNativeCompilerOptions(
+      "genStaticForwardersForNonTopLevelObjects"
+    ),
+    NIROnlySettings
   )
 
   // Calculates all prefixes of the current Scala version

--- a/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
+++ b/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
@@ -127,7 +127,7 @@ class IncCompilationTest extends codegen.CodeGenSpec {
       .withClassPath(classpath.toSeq)
       .withMainClass(Some(entry))
       .withCompilerConfig(setupNativeConfig)
-      // .withLogger(Logger.nullLogger)
+      .withLogger(Logger.nullLogger)
   }
 
   private lazy val defaultNativeConfig = build.NativeConfig.empty

--- a/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
+++ b/tools/src/test/scala/scala/scalanative/IncCompilationTest.scala
@@ -107,7 +107,7 @@ class IncCompilationTest extends codegen.CodeGenSpec {
 
   private def makeClasspath(outDir: Path)(implicit in: Scope) = {
     val parts: Array[Path] =
-      ScalaNativeBuildInfo.scalalibCp
+      ScalaNativeBuildInfo.nativeRuntimeClasspath
         .split(File.pathSeparator)
         .map(Paths.get(_))
 
@@ -127,7 +127,7 @@ class IncCompilationTest extends codegen.CodeGenSpec {
       .withClassPath(classpath.toSeq)
       .withMainClass(Some(entry))
       .withCompilerConfig(setupNativeConfig)
-      .withLogger(Logger.nullLogger)
+      // .withLogger(Logger.nullLogger)
   }
 
   private lazy val defaultNativeConfig = build.NativeConfig.empty

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -69,7 +69,7 @@ abstract class LinkerSpec {
 
   private def makeClasspath(outDir: Path)(implicit in: Scope) = {
     val parts: Array[Path] =
-      ScalaNativeBuildInfo.scalalibCp
+      ScalaNativeBuildInfo.nativeRuntimeClasspath
         .split(File.pathSeparator)
         .map(Paths.get(_))
 

--- a/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
@@ -140,7 +140,7 @@ class NIRCompiler(outDir: Path) {
       "-d",
       outPath.toString(),
       "-cp",
-      ScalaNativeBuildInfo.compileClasspath + File.pathSeparator + ScalaNativeBuildInfo.nativelibCp,
+      ScalaNativeBuildInfo.compileClasspath + File.pathSeparator + ScalaNativeBuildInfo.nativeRuntimeClasspath,
       s"-Xplugin:${ScalaNativeBuildInfo.pluginJar}"
     ) ++ fileArgs
     val procBuilder = new ProcessBuilder(args: _*)

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -93,7 +93,7 @@ trait ReachabilitySuite {
 
   private def makeClasspath(outDir: Path)(implicit in: Scope) = {
     val parts: Array[Path] =
-      ScalaNativeBuildInfo.scalalibCp
+      ScalaNativeBuildInfo.nativeRuntimeClasspath
         .split(File.pathSeparator)
         .map(Paths.get(_))
 


### PR DESCRIPTION
This change changes hierarchy of Scala Native projects. 
Previously `scalalib` had dependency on `javalib` which transitively forced its dependeny on not directly used `posixlib`, `windowslib`, even though all it requires is `nativelib` and `clib` for atomic ops.  

At the time of linking both `scalalib` and `javalib` have cyclic dependency on each other, however, at compile time non of each does emit `.class` or `.tasty` files and we only have a "weak" dependency enforced by used version of Scala compiler and provided JDK. 

New layout does reflect this change
```
                 ┌───────────┐
                 │Native lib ├──────────────────────────────────┐
                 └─────▲─────┘                                  │
                       │                                        │
       ┌───────────────┼────────────────┐                       │
       │               │                │                       │
   ┌───┴───┐     ┌─────┴────┐    ┌──────┴──────┐                │
   │ C lib │     │POSIX lib │    │ Windows lib │                │
   └───────┘     └──────────┘    └─────────────┘   Bytecode only│
       ▲  ▲            ▲                 ▲                      │
       │  │            │                 │                      │
       │  └────────────┴────────────┬────┘                      │
       │                            │                           │
┌──────┴────────┐                   │                           │
│(Scala)Aux lib │                   │                           │
└───────────────┘                   │                           │
        ▲                           │                           │
        │NIR only                   │                           ▼
   ┌────┴─────┐               ┌─────┴─────┐              ┌──────▼────────┐
   │Scala lib │               │ Java lib  ├─────────────►│ Java lib intf │
   └──────────┘               └───────────┘Bytecode-only └───────────────┘
         ▲                           ▲
         │                           │
         │NIR only                   │NIR only
         │                           │
         └────┬────────────────┬─────┴───────────┬──────────────┐
              │                │                 │              │
        ┌─────┴────┐   ┌───────┴───────┐   ┌─────┴─────┐  ┌─────┴────────┐
        │  Sandbox │   │ TestInterface │   │ UsersMain │  │JUnit runtime │
        └──────────┘   └───────────────┘   └───────────┘  └──────────────┘
                               ▲                 ▲              ▲
                               │                 │              │
                               └─────────────────┼──────────────┘
                                                 │
                                          ┌──────┴─────┐
                                          │ UsersTests │
                                          └────────────┘
```

What changes here is that scalalib no longer depends on javalib. Dependencies of scalalib need to explictly add dependency on javalib (done automatically in SBT plugin). 
Motivation: 
At some point we might follow the Scala.js path, and make `javalib` implementation independent form Scala standard library. (With minimal exceptions, like `scala.Predef.classOf[T]` at that point we would no longer need to cross compile Javalib for each Scala binary version. Instead, we would be able to compile it once, publish without Scala cross version and use it with any Scala standard library combination  

Immidiete improvement comming from this change is speedup of Scalalib publishing when using new model (artifact per each Scala version)