### PR TITLE
Fix #3530: Improve javalib InetAddress name-to-address resolution

### DIFF
--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -12,7 +12,7 @@ import scala.scalanative.unsigned._
 import scala.annotation.tailrec
 
 import java.io.IOException
-import java.net.SocketHelpers.sockaddrToByteArray
+
 import java.{util => ju}
 
 import scala.scalanative.posix.arpa.inet._
@@ -258,7 +258,7 @@ object InetAddress {
   private def addrinfoToByteArray(
       addrinfoP: Ptr[addrinfo]
   ): Array[Byte] = {
-    sockaddrToByteArray(addrinfoP.ai_addr)
+    SocketHelpers.sockaddrToByteArray(addrinfoP.ai_addr)
   }
 
   private def extractIP4Bytes(pb: Ptr[Byte]): Array[Byte] = {
@@ -346,44 +346,68 @@ object InetAddress {
 
   private def getByNonNumericName(host: String): InetAddress = Zone {
     implicit z =>
-      /* To prevent circular dependencies, javalib is not supposed to use
-       * the quite powerful Scala Collections library.
+      /* Design Note:
+       *   Host-to-ip-address translation is known to be fraught with
+       *   complexity. The java.net API reflects the simplicity of 1995 or so.
        *
-       * Use tail recursion to avoid an even nastier while loop. Let
-       * the Scala compiler do the work.
+       *   This method makes the following simplifying assumptions.
+       *   Viewed from a different light, one can also say that it has the
+       *   following defects/bugs.
+       *
+       *   1) The hardware may have more than one interface, each having
+       *      the same name but a different ip address. This method
+       *      assumes that getaddrinfo() will sort out any address preference.
+       *      That is probably a bad assumption. Successive calls to this
+       *      method may return different addresses. InetAddress.getLocalHost()
+       *      calls this method. In complex configurations, it may return
+       *      astonishing results.
+       *
+       *   2) This method assumes that tcp and udp protocols resolve to
+       *      the same address. This is the normal/usual case, but not
+       *      required. By the Gell-Mann principle, it is bound to occur in
+       *      the wild.
        */
 
       @tailrec
-      def findPreferrredAddrinfo(
+      def findFirstAcceptableAddrinfo(
           preference: Option[Boolean],
-          ai: Ptr[addrinfo]
+          ai: Ptr[addrinfo],
+          fallback: Option[Ptr[addrinfo]]
       ): Option[Ptr[addrinfo]] = {
+        /* To prevent circular dependencies, javalib is not supposed to use
+         * the quite powerful Scala Collections library.
+         *
+         * Use tail recursion to avoid an even nastier while loop. Let
+         * the Scala compiler do the work.
+         */
 
         if (ai == null) {
-          None
+          fallback
         } else {
-          val result =
-            if (ai.ai_family == AF_INET) {
-              if ((preference == None) || (preference.get == false)) {
-                Some(ai)
-              } else {
-                None
-              }
-            } else if (ai.ai_family == AF_INET6) {
-              if ((preference == None) || (preference.get == true)) {
-                Some(ai)
-              } else {
-                None
-              }
-            } else { // skip AF_UNSPEC & other unknown families
-              None
-            }
+          val aiNext = ai.ai_next.asInstanceOf[Ptr[addrinfo]]
 
-          if (result != None) {
-            result
-          } else {
-            val aiNext = ai.ai_next.asInstanceOf[Ptr[addrinfo]]
-            findPreferrredAddrinfo(preference, aiNext)
+          if (ai.ai_family == AF_INET) {
+            if ((preference == None) || (preference.get == false)) {
+              Some(ai)
+            } else {
+              findFirstAcceptableAddrinfo(
+                preference,
+                aiNext,
+                if (fallback.isEmpty) Some(ai) else fallback
+              )
+            }
+          } else if (ai.ai_family == AF_INET6) {
+            if ((preference == None) || (preference.get == true)) {
+              Some(ai)
+            } else {
+              findFirstAcceptableAddrinfo(
+                preference,
+                aiNext,
+                if (fallback.isEmpty) Some(ai) else fallback
+              )
+            }
+          } else { // skip AF_UNSPEC & other unknown families
+            findFirstAcceptableAddrinfo(preference, aiNext, fallback)
           }
         }
       }
@@ -391,10 +415,11 @@ object InetAddress {
       val hints = stackalloc[addrinfo]() // stackalloc clears its memory
       val addrinfo = stackalloc[Ptr[addrinfo]]()
 
-      hints.ai_family = SocketHelpers.getGaiHintsAddressFamily()
-      hints.ai_socktype = SOCK_STREAM
-      hints.ai_protocol = IPPROTO_TCP
-      if (hints.ai_family == AF_INET6) {
+      val preferIPv6Ai = SocketHelpers.getPreferIPv6Addresses()
+
+      // Let hints.ai_socktype & hints.ai_protocol remain 0, indicating any.
+      hints.ai_family = AF_UNSPEC
+      if (preferIPv6Ai.getOrElse(false)) {
         hints.ai_flags |= (AI_V4MAPPED | AI_ADDRCONFIG)
       }
 
@@ -405,8 +430,7 @@ object InetAddress {
         throw new UnknownHostException(host + ": " + gaiMsg)
       } else
         try {
-          val preferIPv6 = SocketHelpers.getPreferIPv6Addresses()
-          findPreferrredAddrinfo(preferIPv6, !addrinfo) match {
+          findFirstAcceptableAddrinfo(preferIPv6Ai, !addrinfo, None) match {
             case None =>
               throw new UnknownHostException(s"${host}: Name does not resolve")
             case Some(ai) => InetAddress(ai, host, isNumeric = false)
@@ -726,10 +750,23 @@ object InetAddress {
     if (ghnStatus != 0) {
       throw new UnknownHostException(fromCString(strerror(errno)))
     } else {
-      /* OS library routine should have NUL terminated 'hostName'.
-       * If not, hostName(MAXHOSTNAMELEN) should be NUL from stackalloc.
-       */
-      InetAddress.getByName(fromCString(hostName))
+      try {
+        /* OS library routine should have NUL terminated 'hostName'.
+         * If not, hostName(MAXHOSTNAMELEN) should be NUL from stackalloc.
+         */
+        InetAddress.getByName(fromCString(hostName))
+      } catch {
+        /* Issue 2530:
+         *   At this point, no translation from hostName to an IP address
+         *   has been found by searching the 4 combinations of the 2x2 matrix:
+         *   IPv4/IPv6 by TCP/UDP.
+         *
+         *   Java 8 does not throw in this situation, it appears to fallback
+         *   to creating an InetAddress using the hostname and the IPv4
+         *   loopback address 127.0.0.1.  Be robust and do the same here.
+         */
+        case e: UnknownHostException => SocketHelpers.loopbackIPv4()
+      }
     }
   }
 

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -159,10 +159,10 @@ object SocketHelpers {
   // Create copies of loopback & wildcard, so that originals never get changed
 
   // ScalaJVM shows loopbacks with null host, wildcards with numeric host.
-  private def loopbackIPv4(): InetAddress =
+  private[net] def loopbackIPv4(): InetAddress =
     InetAddress.getByAddress(Array[Byte](127, 0, 0, 1))
 
-  private def loopbackIPv6(): InetAddress = InetAddress.getByAddress(
+  private[net] def loopbackIPv6(): InetAddress = InetAddress.getByAddress(
     Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
   )
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/InetAddressTest.scala
@@ -155,14 +155,10 @@ class InetAddressTest {
   }
 
   @Test def getLocalHost(): Unit = {
-    assumeFalse(
-      "Spuriously fails in the CI on MacOS-12",
-      Platform.isMacOs && sys.env.contains("CI")
-    )
-    /* If compiler does not optimize away, check that no Exception is thrown
-     * and something other than null is returned.
-     * This code will be run on many machines, with varied names.
-     * It is hard to check the actual InetAddress returned.
+    /* Check that no Exception is thrown and something other than null is
+     * returned.
+     * This code will be run on many machines, with varied names and
+     * configurations. It is hard to check the actual InetAddress returned.
      */
     assertNotNull(InetAddress.getLocalHost())
   }


### PR DESCRIPTION
Fix #3530: 

Improve javalib InetAddress name-to-address resolution

1) When an internet address can not be found for a given hostname, follow the JDK 8 practice
    of returning an InternetAddress containing the hostname and the IPv4 127.0.0.1 local address.

   This makes InetAddress.getLocalHost() robust to intermittent irregular configuration in
   Scala Native Continuous Integration (CI) runs using macOS-12 (and probably above).

2) InetAddress name-to-address resolution now checks all 4 cells of the 2x2 matrix: IPv4/IPv6 by TCP/UDP.
    This increases the chances of finding a corresponding internet address if such exists. 

    The first address returned by `getaddrinfo` which matches that matrix and is allowed by the java
    property `java.net.preferIPv6Addresses` is returned.  If not such address exists but an address
    which does not match the property exists, that address is returned. That is, "prefer, not require", say, IPv6,
    but not fail if an IPv6 address does not exist but an IPv4 address does.

    In practical terms, this means that if two interfaces exist on a system and they have the same name
    but different addresses (say, a "fast" and a "slow" connection) it is hard to know, using javalib, which
    address will be returned.  For that level of precision, please use posixlib or clib.