### PR TITLE
Fix C example in interop.rst

### DIFF
--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -189,26 +189,26 @@ You can also disable generation of library constructors by defining `-DSCALANATI
 
 .. code-block:: c
 
-    # libmylib.h
+    // libmylib.h
     int ScalaNativeInit(void);
     long addLongs(long, long);
     int addInts(int, int);
     int mylib_current_count();
     void mylib_set_counter(int);
 
-    # test.c
+    // test.c
     #include "libmylib.h"
     #include <assert.h>
 
     int main(int argc, char** argv){
-      # This function needs to be called before invoking any methods defined in Scala Native.
-      # Might be called automatically unless SCALANATIVE_NO_DYLIB_CTOR env variable is set.
+      // This function needs to be called before invoking any methods defined in Scala Native.
+      // Might be called automatically unless SCALANATIVE_NO_DYLIB_CTOR env variable is set.
       assert(ScalaNativeInit() == 0);
       addLongs(0L, 4L);
       mylib_addInts(4, 0);
       printf("Current count %d\n", mylib_current_count());
       mylib_set_counter(42);
-      ...
+      // ...
     }
 
 Pointer types

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -192,7 +192,7 @@ You can also disable generation of library constructors by defining `-DSCALANATI
     // libmylib.h
     int ScalaNativeInit(void);
     long addLongs(long, long);
-    int addInts(int, int);
+    int mylib_addInts(int, int);
     int mylib_current_count();
     void mylib_set_counter(int);
 

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -199,6 +199,7 @@ You can also disable generation of library constructors by defining `-DSCALANATI
     // test.c
     #include "libmylib.h"
     #include <assert.h>
+    #include <stdio.h>
 
     int main(int argc, char** argv){
       // This function needs to be called before invoking any methods defined in Scala Native.


### PR DESCRIPTION
Not sure why some of the comments were using `#` instead of `//`,I think it must have been an oversight.

The `addInts` function on the `.h` was wrong - it was exported as `mylib_addInts` and used as such in the `.c` file, but declared as `addInts` on the `.h` file.

I also added a missing `#include <stdio.h>`. I'm not sure if this is required, but clang was complaining that it was missing.

Now the syntax highlighting should look better and the example code can actually be copied and pasted.