### PR TITLE
Restructure layout of workdir

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -45,10 +45,9 @@ private[codegen] abstract class AbstractCodeGen(
   private val externSigMembers = mutable.Map.empty[Sig, Global.Member]
 
   def gen(id: String, dir: VirtualDirectory): Path = {
-    val outputDir = Paths.get("generated")
-    val body = outputDir.resolve(s"$id-body.ll")
-    val headers = outputDir.resolve(s"$id.ll")
-    val metadata = outputDir.resolve(s"$id-metadata.ll")
+    val body = Paths.get(s"$id-body.ll")
+    val headers = Paths.get(s"$id.ll")
+    val metadata = Paths.get(s"$id-metadata.ll")
 
     dir.write(metadata) { metadataWriter =>
       implicit val metadata: MetadataCodeGen.Context =

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -45,9 +45,10 @@ private[codegen] abstract class AbstractCodeGen(
   private val externSigMembers = mutable.Map.empty[Sig, Global.Member]
 
   def gen(id: String, dir: VirtualDirectory): Path = {
-    val body = Paths.get(s"$id-body.ll")
-    val headers = Paths.get(s"$id.ll")
-    val metadata = Paths.get(s"$id-metadata.ll")
+    val outputDir = Paths.get("generated")
+    val body = outputDir.resolve(s"$id-body.ll")
+    val headers = outputDir.resolve(s"$id.ll")
+    val metadata = outputDir.resolve(s"$id-metadata.ll")
 
     dir.write(metadata) { metadataWriter =>
       implicit val metadata: MetadataCodeGen.Context =

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -100,6 +100,7 @@ object VirtualDirectory {
 
     override def write(path: Path)(fn: Writer => Unit): Path = {
       val fullPath = resolve(path)
+      Files.createDirectories(fullPath.getParent())
       val writer = Files.newBufferedWriter(fullPath)
       try fn(writer)
       finally writer.close()
@@ -107,13 +108,16 @@ object VirtualDirectory {
     }
 
     override def write(path: Path, buffer: ByteBuffer): Unit = {
-      val channel = open(resolve(path))
+      val fullPath = resolve(path)
+      Files.createDirectories(fullPath.getParent())
+      val channel = open(fullPath)
       try channel.write(buffer)
       finally channel.close
     }
 
     override def merge(sources: Seq[Path], target: Path): Path = {
       val outputPath = resolve(target)
+      Files.createDirectories(outputPath.getParent())
       val output = FileChannel.open(
         outputPath,
         StandardOpenOption.CREATE,


### PR DESCRIPTION
* Move generated LLVM ir to `$workdir/generated` 
* Move extracted jar with native code to `$workdir/dependenices` 

We restructure layout, due to big ammount of generated files (now LLVM IR files are identified by hash)