### PR TITLE
Build: Update sbt to 1.9.7

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -43,9 +43,9 @@ object ScalaVersions {
   //   1.5.8 has log4j vulnerability fixed
   //   1.9.0 is required in order to use Java >= 21
   //   1.9.4 fixes (Common Vulnerabilities and Exposures) CVE-2022-46751
-  //   1.9.6 is current
+  //   1.9.7 fixes sbt IO.unzip vulnerability described in sbt release notes.
 
-  val sbt10Version: String = "1.9.6"
+  val sbt10Version: String = "1.9.7"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.6
+sbt.version = 1.9.7


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.9.4.

From the SBT GitHub [announcement](https://github.com/sbt/sbt/releases/tag/v1.9.7):
```
sbt 1.9.7 updates its IO module to 1.9.7, which fixes parent path traversal vulnerability
 in IO.unzip.
```