### PR TITLE
Remove usages of `Object.__scala_##`

### DIFF
--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -56,21 +56,6 @@ final class Double(val _value: scala.Double)
   @inline override def toString(): String =
     Double.toString(_value)
 
-  @inline override def __scala_## : scala.Int = {
-    val dv = _value
-    val iv = _value.toInt
-    if (iv == dv) iv
-    else {
-      val lv = _value.toLong
-      if (lv == dv) Long.hashCode(lv)
-      else {
-        val fv = _value.toFloat
-        if (fv == dv) Float.hashCode(fv)
-        else Double.hashCode(dv)
-      }
-    }
-  }
-
   @inline def isNaN(): scala.Boolean =
     Double.isNaN(_value)
 

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -56,17 +56,6 @@ final class Float(val _value: scala.Float)
   @inline override def toString(): String =
     Float.toString(_value)
 
-  @inline override def __scala_## : scala.Int = {
-    val fv = _value
-    val iv = _value.toInt
-    if (iv == fv) iv
-    else {
-      val lv = _value.toLong
-      if (lv == fv) Long.hashCode(lv)
-      else Float.hashCode(fv)
-    }
-  }
-
   @inline def isNaN(): scala.Boolean =
     Float.isNaN(_value)
 

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -47,13 +47,6 @@ final class Long(val _value: scala.Long)
   @inline override def toString(): String =
     Long.toString(_value)
 
-  @inline override def __scala_## : scala.Int = {
-    val lv = _value
-    val iv = _value.toInt
-    if (iv == lv) iv
-    else Long.hashCode(lv)
-  }
-
   /*
    * Ported from ScalaJS
    *

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -44,14 +44,6 @@ class _Object {
       getMonitor(this)._wait(timeout, nanos)
     }
 
-  @inline def __scala_## : scala.Int = {
-    // This implementation is only called for classes that don't override
-    // hashCode. Otherwise, whenever hashCode is overriden, we also update the
-    // vtable entry for scala_## to point to the override directly.
-    val addr = castRawPtrToLong(castObjectToRawPtr(this))
-    addr.toInt ^ (addr >> 32).toInt
-  }
-
   protected def __clone(): _Object = this match {
     case _: Cloneable =>
       val cls = __getClass()

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -17,9 +17,6 @@ object Rt {
   val BoxedUnitModule = Ref(Global.Top("scala.scalanative.runtime.BoxedUnit$"))
 
   val GetClassSig = Sig.Method("getClass", Seq(Rt.Class)).mangled
-  val JavaEqualsSig = Sig.Method("equals", Seq(Object, Bool)).mangled
-  val JavaHashCodeSig = Sig.Method("hashCode", Seq(Int)).mangled
-  val ScalaHashCodeSig = Sig.Method("scala_$hash$hash", Seq(Int)).mangled
   val ScalaMainSig =
     Sig.Method("main", Seq(Array(Rt.String), Unit), Sig.Scope.PublicStatic)
   val IsArraySig = Sig.Method("isArray", Seq(Bool)).mangled

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -321,8 +321,6 @@ trait NirDefinitions {
 
     lazy val NObjectClass = getRequiredClass("java.lang._Object")
     lazy val NObjectInitMethod = getDecl(NObjectClass, TermName("<init>"))
-    lazy val NObjectHashCodeMethod =
-      getDecl(NObjectClass, TermName("__scala_$hash$hash"))
 
     lazy val NStringClass = getRequiredClass("java.lang._String")
     lazy val NStringModule = getRequiredModule("java.lang._String")

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1805,19 +1805,11 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def genHashCode(argp: Tree)(implicit pos: nir.Position): Val = {
-      val arg = boxValue(argp.tpe, genExpr(argp))
-      val isnull =
-        buf.comp(Comp.Ieq, Rt.Object, arg, Val.Null, unwind)(
-          argp.pos,
-          getScopeId
-        )
-      val cond = ValTree(isnull)
-      val thenp = ValTree(Val.Int(0))
-      val elsep = ContTree { () =>
-        val meth = NObjectHashCodeMethod
-        genApplyMethod(meth, statically = false, arg, Seq.empty)
-      }
-      genIf(Type.Int, cond, thenp, elsep)
+      genApplyStaticMethod(
+        getMemberMethod(RuntimeStaticsModule, nme.anyHash),
+        defn.RuntimeStaticsModule,
+        Seq(argp)
+      )
     }
 
     def genArrayOp(app: Apply, code: Int): Val = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -273,7 +273,6 @@ final class NirDefinitions()(using ctx: Context) {
   // Java library
   @tu lazy val NObjectClass = requiredClass("java.lang._Object")
   @tu lazy val NObject_init = NObjectClass.requiredMethod("<init>")
-  @tu lazy val NObject_hashCode = NObjectClass.requiredMethod("__scala_##")
 
   @tu lazy val NStringClass = requiredClass("java.lang._String")
   @tu lazy val NStringModuleType = requiredModule("java.lang._String")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1720,21 +1720,12 @@ trait NirGenExpr(using Context) {
       else buf.arraylength(array, unwind)
     }
 
-    private def genHashCode(argp: Tree)(using nir.Position): Val = {
-      val arg = boxValue(argp.tpe, genExpr(argp))
-      val isnull =
-        buf.comp(Comp.Ieq, Rt.Object, arg, Val.Null, unwind)(using
-          argp.span: nir.Position,
-          getScopeId
-        )
-      val cond = ValTree(isnull)
-      val thenp = ValTree(Val.Int(0))
-      val elsep = ContTree { () =>
-        val meth = defnNir.NObject_hashCode
-        genApplyMethod(meth, statically = false, arg, Seq.empty)
-      }
-      genIf(Type.Int, cond, thenp, elsep)
-    }
+    private def genHashCode(argp: Tree)(using nir.Position): Val =
+      genApplyStaticMethod(
+        defn.staticsMethod(nme.anyHash),
+        defn.ScalaStaticsModule,
+        Seq(argp)
+      )
 
     private def genStringConcat(leftp: Tree, rightp: Tree): Val = {
       def stringify(sym: Symbol, value: Val)(using nir.Position): Val = {

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -167,9 +167,6 @@ object CodeGen {
     val buf = mutable.UnrolledBuffer.empty[Global]
     buf ++= Lower.depends
     buf ++= Generate.depends
-    buf += Rt.Object.name member Rt.ScalaHashCodeSig
-    buf += Rt.Object.name member Rt.JavaEqualsSig
-    buf += Rt.Object.name member Rt.JavaHashCodeSig
     buf.toSeq
   }
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -364,9 +364,10 @@ class Reach(
                   fail(s"Required method ${sig} not found in ${info.name}")
                 )
             }
-            if (sig.isMethod || sig.isCtor || sig.isClinit || sig.isGenerated){
-                update(sig)
+            if (sig.isMethod || sig.isCtor || sig.isClinit || sig.isGenerated) {
+              update(sig)
             }
+          case _ => ()
         }
 
         // Initialize the scope of the default methods that can


### PR DESCRIPTION
Removes `Object.__scala_##` which typically is not used at runtime. Scala compiler already dispatches calls to `Any.##` to dedicated `scala.runtime.Statics.*Hash` or dedicated versions for float/long/double etc. Now we dispatch remaining calls if existing to the `Statics` instead of using custom mechanism