### PR TITLE
Harmonize NIR imports and qualification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bin/
 
 # Configuration for clangd
 **/compile_flags.txt
+
+# macOS
+.DS_Store

--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -3,7 +3,6 @@ package nir
 
 import scala.collection.mutable
 import util.unsupported
-import nir._
 
 /** Analysis that's used to answer following questions:
  *

--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -1,5 +1,6 @@
 package scala.scalanative
 package nir
+
 import scala.scalanative.nir.Defn.Define
 
 /** A definition in NIR.

--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -1,5 +1,6 @@
 package scala.scalanative
 package nir
+
 import scala.scalanative.nir.Sig.Scope._
 import scala.scalanative.util.ShowBuilder.InMemoryShowBuilder
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -10,7 +10,6 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import scala.scalanative.nir.serialization.{Tags => T}
-import scala.scalanative.nir.Global.{Top, Member}
 import scala.scalanative.util.TypeOps.TypeNarrowing
 
 import scala.annotation.{tailrec, switch}
@@ -307,17 +306,17 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
     val attrs = getAttrs()
     implicit val position: nir.Position = getPosition()
     (tag: @switch) match {
-      case T.VarDefn   => Defn.Var(attrs, name.narrow[Member], getType(), getVal())
-      case T.ConstDefn => Defn.Const(attrs, name.narrow[Member], getType(), getVal())
+      case T.VarDefn   => Defn.Var(attrs, name.narrow[nir.Global.Member], getType(), getVal())
+      case T.ConstDefn => Defn.Const(attrs, name.narrow[nir.Global.Member], getType(), getVal())
       case T.DeclareDefn =>
-        Defn.Declare(attrs, name.narrow[Member], getType().narrow[Type.Function])
+        Defn.Declare(attrs, name.narrow[nir.Global.Member], getType().narrow[Type.Function])
       case T.DefineDefn =>
-        Defn.Define(attrs, name.narrow[Member], getType().narrow[Type.Function], getInsts(), getDebugInfo())
-      case T.TraitDefn => Defn.Trait(attrs, name.narrow[Top], getGlobals().narrow[Seq[Top]])
+        Defn.Define(attrs, name.narrow[nir.Global.Member], getType().narrow[Type.Function], getInsts(), getDebugInfo())
+      case T.TraitDefn => Defn.Trait(attrs, name.narrow[nir.Global.Top], getGlobals().narrow[Seq[nir.Global.Top]])
       case T.ClassDefn =>
-        Defn.Class(attrs, name.narrow[Top], getGlobalOpt().narrow[Option[Top]], getGlobals().narrow[Seq[Top]])
+        Defn.Class(attrs, name.narrow[nir.Global.Top], getGlobalOpt().narrow[Option[nir.Global.Top]], getGlobals().narrow[Seq[nir.Global.Top]])
       case T.ModuleDefn =>
-        Defn.Module(attrs, name.narrow[Top], getGlobalOpt().narrow[Option[Top]], getGlobals().narrow[Seq[Top]])
+        Defn.Module(attrs, name.narrow[nir.Global.Top], getGlobalOpt().narrow[Option[nir.Global.Top]], getGlobals().narrow[Seq[nir.Global.Top]])
     }
   }
 
@@ -325,9 +324,9 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
   private def getGlobalOpt(): Option[Global] = getOpt(getGlobal())
   private def getGlobal(): Global = in(prelude.sections.globals) {
     (getTag(): @switch) match {
-      case T.NoneGlobal   => Global.None
-      case T.TopGlobal    => Global.Top(getString())
-      case T.MemberGlobal => Global.Member(getGlobal().narrow[Top], getSig())
+      case T.NoneGlobal   => nir.Global.None
+      case T.TopGlobal    => nir.Global.Top(getString())
+      case T.MemberGlobal => nir.Global.Member(getGlobal().narrow[nir.Global.Top], getSig())
     }
   }
 
@@ -359,14 +358,14 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
       case T.ConvOp       => Op.Conv(getConv(), getType(), getVal())
       case T.FenceOp      => Op.Fence(getSyncAttrs())
 
-      case T.ClassallocOp     => Op.Classalloc(getGlobal().narrow[Top], None)
-      case T.ClassallocZoneOp => Op.Classalloc(getGlobal().narrow[Top], Some(getVal()))
-      case T.FieldloadOp      => Op.Fieldload(getType(), getVal(), getGlobal().narrow[Member])
-      case T.FieldstoreOp     => Op.Fieldstore(getType(), getVal(), getGlobal().narrow[Member], getVal())
-      case T.FieldOp          => Op.Field(getVal(), getGlobal().narrow[Member])
+      case T.ClassallocOp     => Op.Classalloc(getGlobal().narrow[nir.Global.Top], None)
+      case T.ClassallocZoneOp => Op.Classalloc(getGlobal().narrow[nir.Global.Top], Some(getVal()))
+      case T.FieldloadOp      => Op.Fieldload(getType(), getVal(), getGlobal().narrow[nir.Global.Member])
+      case T.FieldstoreOp     => Op.Fieldstore(getType(), getVal(), getGlobal().narrow[nir.Global.Member], getVal())
+      case T.FieldOp          => Op.Field(getVal(), getGlobal().narrow[nir.Global.Member])
       case T.MethodOp         => Op.Method(getVal(), getSig())
       case T.DynmethodOp      => Op.Dynmethod(getVal(), getSig())
-      case T.ModuleOp         => Op.Module(getGlobal().narrow[Top])
+      case T.ModuleOp         => Op.Module(getGlobal().narrow[nir.Global.Top])
       case T.AsOp             => Op.As(getType(), getVal())
       case T.IsOp             => Op.Is(getType(), getVal())
       case T.CopyOp           => Op.Copy(getVal())
@@ -411,7 +410,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
       case T.VarType     => Type.Var(getType())
       case T.UnitType    => Type.Unit
       case T.ArrayType   => Type.Array(getType(), getBool())
-      case T.RefType     => Type.Ref(getGlobal().narrow[Top], getBool(), getBool())
+      case T.RefType     => Type.Ref(getGlobal().narrow[nir.Global.Top], getBool(), getBool())
       case T.SizeType    => Type.Size
     }
   }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -314,9 +314,19 @@ final class BinaryDeserializer(buffer: ByteBuffer, fileName: String) {
         Defn.Define(attrs, name.narrow[nir.Global.Member], getType().narrow[Type.Function], getInsts(), getDebugInfo())
       case T.TraitDefn => Defn.Trait(attrs, name.narrow[nir.Global.Top], getGlobals().narrow[Seq[nir.Global.Top]])
       case T.ClassDefn =>
-        Defn.Class(attrs, name.narrow[nir.Global.Top], getGlobalOpt().narrow[Option[nir.Global.Top]], getGlobals().narrow[Seq[nir.Global.Top]])
+        Defn.Class(
+          attrs,
+          name.narrow[nir.Global.Top],
+          getGlobalOpt().narrow[Option[nir.Global.Top]],
+          getGlobals().narrow[Seq[nir.Global.Top]]
+        )
       case T.ModuleDefn =>
-        Defn.Module(attrs, name.narrow[nir.Global.Top], getGlobalOpt().narrow[Option[nir.Global.Top]], getGlobals().narrow[Seq[nir.Global.Top]])
+        Defn.Module(
+          attrs,
+          name.narrow[nir.Global.Top],
+          getGlobalOpt().narrow[Option[nir.Global.Top]],
+          getGlobals().narrow[Seq[nir.Global.Top]]
+        )
     }
   }
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -4,8 +4,6 @@ package nscplugin
 import scala.annotation.{tailrec, switch}
 import scala.collection.mutable
 import scala.tools.nsc
-import scala.scalanative.nir._
-import scala.scalanative.nir.Defn.Define.DebugInfo
 import scalanative.util.{StringUtils, unsupported}
 import scalanative.util.ScopedVar.scoped
 import scalanative.nscplugin.NirPrimitives._
@@ -21,10 +19,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
   sealed case class ValTree(value: nir.Val) extends Tree
   sealed case class ContTree(f: () => nir.Val) extends Tree
 
-  class FixupBuffer(implicit fresh: Fresh) extends nir.Buffer {
+  class FixupBuffer(implicit fresh: nir.Fresh) extends nir.Buffer {
     private var labeled = false
 
-    override def +=(inst: Inst): Unit = {
+    override def +=(inst: nir.Inst): Unit = {
       implicit val pos: nir.Position = inst.pos
       inst match {
         case inst: nir.Inst.Label =>
@@ -40,7 +38,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
       super.+=(inst)
       inst match {
-        case Inst.Let(_, op, _) if op.resty == Type.Nothing =>
+        case nir.Inst.Let(_, op, _) if op.resty == nir.Type.Nothing =>
           unreachable(unwind)
           label(fresh())
         case _ =>
@@ -48,17 +46,17 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    override def ++=(insts: Seq[Inst]): Unit =
+    override def ++=(insts: Seq[nir.Inst]): Unit =
       insts.foreach { inst => this += inst }
 
     override def ++=(other: nir.Buffer): Unit =
       this ++= other.toSeq
   }
 
-  class ExprBuffer(implicit fresh: Fresh) extends FixupBuffer { buf =>
-    def genExpr(tree: Tree): Val = tree match {
+  class ExprBuffer(implicit fresh: nir.Fresh) extends FixupBuffer { buf =>
+    def genExpr(tree: Tree): nir.Val = tree match {
       case EmptyTree =>
-        Val.Unit
+        nir.Val.Unit
       case ValTree(value) =>
         value
       case ContTree(f) =>
@@ -106,7 +104,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         )
     }
 
-    def genBlock(block: Block): Val = {
+    def genBlock(block: Block): nir.Val = {
       val Block(stats, last) = block
 
       def isCaseLabelDef(tree: Tree) =
@@ -136,16 +134,16 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genLabelDef(label: LabelDef): Val = {
+    def genLabelDef(label: LabelDef): nir.Val = {
       assert(label.params.isEmpty, "empty LabelDef params")
-      buf.jump(Next(curMethodEnv.enterLabel(label)))(label.pos)
+      buf.jump(nir.Next(curMethodEnv.enterLabel(label)))(label.pos)
       genLabel(label)
     }
 
-    def genLabel(label: LabelDef): Val = {
+    def genLabel(label: LabelDef): nir.Val = {
       val local = curMethodEnv.resolveLabel(label)
       val params = label.params.map { id =>
-        val local = Val.Local(fresh(), genType(id.tpe))
+        val local = nir.Val.Local(fresh(), genType(id.tpe))
         curMethodEnv.enter(id.symbol, local)
         local
       }
@@ -154,11 +152,11 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       genExpr(label.rhs)
     }
 
-    def genTailRecLabel(dd: DefDef, isStatic: Boolean, label: LabelDef): Val = {
+    def genTailRecLabel(dd: DefDef, isStatic: Boolean, label: LabelDef): nir.Val = {
       val local = curMethodEnv.resolveLabel(label)
       val params = label.params.zip(genParamSyms(dd, isStatic)).map {
         case (lparam, mparamopt) =>
-          val local = Val.Local(fresh(), genType(lparam.tpe))
+          val local = nir.Val.Local(fresh(), genType(lparam.tpe))
           curMethodEnv.enter(lparam.symbol, local)
           mparamopt.foreach(curMethodEnv.enter(_, local))
           local
@@ -175,14 +173,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         }
     }
 
-    def genValDef(vd: ValDef): Val = {
+    def genValDef(vd: ValDef): nir.Val = {
       implicit val pos: nir.Position = vd.pos
       val localNames = curMethodLocalNames.get
       val isMutable = curMethodInfo.mutableVars.contains(vd.symbol)
       def name = genLocalName(vd.symbol)
 
       val rhs = genExpr(vd.rhs) match {
-        case v @ Val.Local(id, _) =>
+        case v @ nir.Val.Local(id, _) =>
           if (localNames.contains(id) || isMutable) ()
           else localNames.update(id, name)
           vd.rhs match {
@@ -194,21 +192,21 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             case _ => ()
           }
           v
-        case Val.Unit => Val.Unit
+        case nir.Val.Unit => nir.Val.Unit
         case v =>
           if (isMutable) v
-          else buf.let(namedId(fresh)(name), Op.Copy(v), unwind)
+          else buf.let(namedId(fresh)(name), nir.Op.Copy(v), unwind)
       }
       if (isMutable) {
         val slot = curMethodEnv.resolve(vd.symbol)
         buf.varstore(slot, rhs, unwind)
       } else {
         curMethodEnv.enter(vd.symbol, rhs)
-        Val.Unit
+        nir.Val.Unit
       }
     }
 
-    def genIf(tree: If): Val = {
+    def genIf(tree: If): nir.Val = {
       val If(cond, thenp, elsep) = tree
       val retty = genType(tree.tpe)
       genIf(retty, cond, thenp, elsep)(tree.pos)
@@ -220,9 +218,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         thenp: Tree,
         elsep: Tree,
         ensureLinktime: Boolean = false
-    )(implicit ifPos: nir.Position): Val = {
+    )(implicit ifPos: nir.Position): nir.Val = {
       val thenn, elsen, mergen = fresh()
-      val mergev = Val.Local(fresh(), retty)
+      val mergev = nir.Val.Local(fresh(), retty)
 
       getLinktimeCondition(condp).fold {
         if (ensureLinktime) {
@@ -232,10 +230,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           )
         }
         val cond = genExpr(condp)
-        buf.branch(cond, Next(thenn), Next(elsen))(condp.pos)
+        buf.branch(cond, nir.Next(thenn), nir.Next(elsen))(condp.pos)
       } { cond =>
         curMethodUsesLinktimeResolvedValues = true
-        buf.branchLinktime(cond, Next(thenn), Next(elsen))(condp.pos)
+        buf.branchLinktime(cond, nir.Next(thenn), nir.Next(elsen))(condp.pos)
       }
 
       locally {
@@ -251,9 +249,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       buf.labelExcludeUnitValue(mergen, mergev)
     }
 
-    def genMatch(m: Match): Val = {
+    def genMatch(m: Match): nir.Val = {
       val Match(scrutp, allcaseps) = m
-      type Case = (Local, Val, Tree, nir.Position)
+      type Case = (nir.Local, nir.Val, Tree, nir.Position)
 
       // Extract switch cases and assign unique names to them.
       val caseps: Seq[Case] = allcaseps.flatMap {
@@ -261,7 +259,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           Seq.empty
         case cd @ CaseDef(pat, guard, body) =>
           assert(guard.isEmpty, "CaseDef guard was not empty")
-          val vals: Seq[Val] = pat match {
+          val vals: Seq[nir.Val] = pat match {
             case lit: Literal =>
               List(genLiteralValue(lit))
             case Alternative(alts) =>
@@ -283,12 +281,12 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val scrut = genExpr(scrutp)
 
       // Generate code for the switch and its cases.
-      def genSwitch(): Val = {
+      def genSwitch(): nir.Val = {
         // Generate some more fresh names and types.
-        val casenexts = caseps.map { case (n, v, _, _) => Next.Case(v, n) }
-        val defaultnext = Next(fresh())
+        val casenexts = caseps.map { case (n, v, _, _) => nir.Next.Case(v, n) }
+        val defaultnext = nir.Next(fresh())
         val merge = fresh()
-        val mergev = Val.Local(fresh(), retty)
+        val mergev = nir.Val.Local(fresh(), retty)
 
         implicit val pos: nir.Position = m.pos
 
@@ -308,7 +306,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         buf.labelExcludeUnitValue(merge, mergev)
       }
 
-      def genIfsChain(): Val = {
+      def genIfsChain(): nir.Val = {
         /* Default label needs to be generated before any others and then added to
          * current MethodEnv. It's label might be referenced in any of them in
          * case of match with guards, eg.:
@@ -338,7 +336,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case _               => None
         }
 
-        def loop(cases: List[Case]): Val = {
+        def loop(cases: List[Case]): nir.Val = {
           cases match {
             case (_, caze, body, p) :: elsep =>
               implicit val pos: nir.Position = p
@@ -365,27 +363,27 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       /* Since 2.13 we need to enforce that only Int switch cases reach backend
        * For all other cases we're generating If-else chain */
-      val isIntMatch = scrut.ty == Type.Int &&
-        caseps.forall(_._2.ty == Type.Int)
+      val isIntMatch = scrut.ty == nir.Type.Int &&
+        caseps.forall(_._2.ty == nir.Type.Int)
 
       if (isIntMatch) genSwitch()
       else genIfsChain()
     }
 
-    def genMatch(prologue: List[Tree], lds: List[LabelDef]): Val = {
+    def genMatch(prologue: List[Tree], lds: List[LabelDef]): nir.Val = {
       // Generate prologue expressions.
       prologue.foreach(genExpr(_))
 
       // Enter symbols for all labels and jump to the first one.
       lds.foreach(curMethodEnv.enterLabel)
       val firstLd = lds.head
-      buf.jump(Next(curMethodEnv.resolveLabel(firstLd)))(firstLd.pos)
+      buf.jump(nir.Next(curMethodEnv.resolveLabel(firstLd)))(firstLd.pos)
 
       // Generate code for all labels and return value of the last one.
       lds.map(genLabel(_)).last
     }
 
-    def genTry(tree: Try): Val = tree match {
+    def genTry(tree: Try): nir.Val = tree match {
       case Try(expr, catches, finalizer)
           if catches.isEmpty && finalizer.isEmpty =>
         genExpr(expr)
@@ -399,13 +397,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         expr: Tree,
         catches: List[Tree],
         finallyp: Tree
-    ): Val = {
+    ): nir.Val = {
       val handler = fresh()
       val excn = fresh()
       val normaln = fresh()
       val mergen = fresh()
-      val excv = Val.Local(fresh(), Rt.Object)
-      val mergev = Val.Local(fresh(), retty)
+      val excv = nir.Val.Local(fresh(), nir.Rt.Object)
+      val mergev = nir.Val.Local(fresh(), retty)
 
       implicit val pos: nir.Position = expr.pos
       // Nested code gen to separate out try/catch-related instructions.
@@ -431,17 +429,17 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         else genTryFinally(finallyp, nested.toSeq)
 
       // Append try/catch instructions to the outher instruction buffer.
-      buf.jump(Next(normaln))
+      buf.jump(nir.Next(normaln))
       buf ++= insts
       buf.labelExcludeUnitValue(mergen, mergev)
     }
 
     def genTryCatch(
         retty: nir.Type,
-        exc: Val,
-        mergen: Local,
+        exc: nir.Val,
+        mergen: nir.Local,
         catches: List[Tree]
-    )(implicit exprPos: nir.Position): Val = {
+    )(implicit exprPos: nir.Position): nir.Val = {
       val cases = catches.map {
         case cd @ CaseDef(pat, _, body) =>
           val (excty, symopt) = pat match {
@@ -462,16 +460,16 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               val res = genExpr(body)
               buf.jumpExcludeUnitValue(retty)(mergen, res)
             }
-            Val.Unit
+            nir.Val.Unit
           }
           (excty, f, exprPos)
       }
 
-      def wrap(cases: Seq[(nir.Type, () => Val, nir.Position)]): Val =
+      def wrap(cases: Seq[(nir.Type, () => nir.Val, nir.Position)]): nir.Val =
         cases match {
           case Seq() =>
             buf.raise(exc, unwind)
-            Val.Unit
+            nir.Val.Unit
           case (excty, f, pos) +: rest =>
             val cond = buf.is(excty, exc, unwind)(pos, getScopeId)
             genIf(
@@ -485,32 +483,32 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       wrap(cases)
     }
 
-    def genTryFinally(finallyp: Tree, insts: Seq[nir.Inst]): Seq[Inst] = {
+    def genTryFinally(finallyp: Tree, insts: Seq[nir.Inst]): Seq[nir.Inst] = {
       val labels =
         insts.collect {
-          case Inst.Label(n, _) => n
+          case nir.Inst.Label(n, _) => n
         }.toSet
-      def internal(cf: Inst.Cf) = cf match {
-        case inst @ Inst.Jump(n) =>
+      def internal(cf: nir.Inst.Cf) = cf match {
+        case inst @ nir.Inst.Jump(n) =>
           labels.contains(n.id)
-        case inst @ Inst.If(_, n1, n2) =>
+        case inst @ nir.Inst.If(_, n1, n2) =>
           labels.contains(n1.id) && labels.contains(n2.id)
-        case inst @ Inst.LinktimeIf(_, n1, n2) =>
+        case inst @ nir.Inst.LinktimeIf(_, n1, n2) =>
           labels.contains(n1.id) && labels.contains(n2.id)
-        case inst @ Inst.Switch(_, n, ns) =>
+        case inst @ nir.Inst.Switch(_, n, ns) =>
           labels.contains(n.id) && ns.forall(n => labels.contains(n.id))
-        case inst @ Inst.Throw(_, n) =>
-          (n ne Next.None) && labels.contains(n.id)
+        case inst @ nir.Inst.Throw(_, n) =>
+          (n ne nir.Next.None) && labels.contains(n.id)
         case _ =>
           false
       }
 
       val finalies = new ExprBuffer
       val transformed = insts.map {
-        case cf: Inst.Cf if internal(cf) =>
+        case cf: nir.Inst.Cf if internal(cf) =>
           // We don't touch control-flow within try/catch block.
           cf
-        case cf: Inst.Cf =>
+        case cf: nir.Inst.Cf =>
           // All control-flow edges that jump outside the try/catch block
           // must first go through finally block if it's present. We generate
           // a new copy of the finally handler for every edge.
@@ -521,38 +519,38 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           }
           finalies += cf
           // The original jump outside goes through finally block first.
-          Inst.Jump(Next(finallyn))(cf.pos)
+          nir.Inst.Jump(nir.Next(finallyn))(cf.pos)
         case inst =>
           inst
       }
       transformed ++ finalies.toSeq
     }
 
-    def genThrow(tree: Throw): Val = {
+    def genThrow(tree: Throw): nir.Val = {
       val Throw(exprp) = tree
       val res = genExpr(exprp)
       buf.raise(res, unwind)(tree.pos)
-      Val.Unit
+      nir.Val.Unit
     }
 
-    def genReturn(tree: Return): Val = {
+    def genReturn(tree: Return): nir.Val = {
       val Return(exprp) = tree
       genReturn(genExpr(exprp))(exprp.pos)
     }
 
-    def genReturn(value: Val)(implicit pos: nir.Position): Val = {
+    def genReturn(value: nir.Val)(implicit pos: nir.Position): nir.Val = {
       val retv =
         if (curMethodIsExtern.get) {
-          val Type.Function(_, retty) = genExternMethodSig(curMethodSym)
+          val nir.Type.Function(_, retty) = genExternMethodSig(curMethodSym)
           toExtern(retty, value)
         } else {
           value
         }
       buf.ret(retv)
-      Val.Unit
+      nir.Val.Unit
     }
 
-    def genLiteral(lit: Literal): Val = {
+    def genLiteral(lit: Literal): nir.Val = {
       val value = lit.value
       implicit val pos: nir.Position = lit.pos
       value.tag match {
@@ -568,35 +566,35 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genLiteralValue(lit: Literal): Val = {
+    def genLiteralValue(lit: Literal): nir.Val = {
       val value = lit.value
       value.tag match {
         case UnitTag =>
-          Val.Unit
+          nir.Val.Unit
         case NullTag =>
-          Val.Null
+          nir.Val.Null
         case BooleanTag =>
-          if (value.booleanValue) Val.True else Val.False
+          if (value.booleanValue) nir.Val.True else nir.Val.False
         case ByteTag =>
-          Val.Byte(value.intValue.toByte)
+          nir.Val.Byte(value.intValue.toByte)
         case ShortTag =>
-          Val.Short(value.intValue.toShort)
+          nir.Val.Short(value.intValue.toShort)
         case CharTag =>
-          Val.Char(value.intValue.toChar)
+          nir.Val.Char(value.intValue.toChar)
         case IntTag =>
-          Val.Int(value.intValue)
+          nir.Val.Int(value.intValue)
         case LongTag =>
-          Val.Long(value.longValue)
+          nir.Val.Long(value.longValue)
         case FloatTag =>
-          Val.Float(value.floatValue)
+          nir.Val.Float(value.floatValue)
         case DoubleTag =>
-          Val.Double(value.doubleValue)
+          nir.Val.Double(value.doubleValue)
         case StringTag =>
-          Val.String(value.stringValue)
+          nir.Val.String(value.stringValue)
       }
     }
 
-    def genArrayValue(av: ArrayValue): Val = {
+    def genArrayValue(av: ArrayValue): nir.Val = {
       val ArrayValue(tpt, elems) = av
       implicit val pos: nir.Position = av.pos
 
@@ -604,13 +602,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val values = genSimpleArgs(elems)
 
       if (values.forall(_.isCanonical) && values.exists(v => !v.isZero)) {
-        buf.arrayalloc(elemty, Val.ArrayValue(elemty, values), unwind)
+        buf.arrayalloc(elemty, nir.Val.ArrayValue(elemty, values), unwind)
       } else {
-        val alloc = buf.arrayalloc(elemty, Val.Int(elems.length), unwind)
+        val alloc = buf.arrayalloc(elemty, nir.Val.Int(elems.length), unwind)
         values.zip(elems).zipWithIndex.foreach {
           case ((v, elem), i) =>
             if (!v.isZero) {
-              buf.arraystore(elemty, alloc, Val.Int(i), v, unwind)(
+              buf.arraystore(elemty, alloc, nir.Val.Int(i), v, unwind)(
                 elem.pos,
                 getScopeId
               )
@@ -620,14 +618,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genThis(tree: This): Val =
+    def genThis(tree: This): nir.Val =
       if (curMethodThis.nonEmpty && tree.symbol == curClassSym.get) {
         curMethodThis.get.get
       } else {
         genModule(tree.symbol)(tree.pos)
       }
 
-    def genModule(sym: Symbol)(implicit pos: nir.Position): Val = {
+    def genModule(sym: Symbol)(implicit pos: nir.Position): nir.Val = {
       if (sym.isModule && sym.isScala3Defined &&
           sym.hasAttachment[DottyEnumSingletonCompat.type]) {
         /* #2983 This is a reference to a singleton `case` from a Scala 3 `enum`.
@@ -636,15 +634,15 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
          * We use `originalOwner` and `rawname` because that's what the JVM back-end uses.
          */
         val className = genTypeName(sym.originalOwner.companionClass)
-        val getterMethodName = Sig.Method(
+        val getterMethodName = nir.Sig.Method(
           sym.rawname.toString(),
           Seq(genType(sym.tpe)),
-          Sig.Scope.PublicStatic
+          nir.Sig.Scope.PublicStatic
         )
         val name = className.member(getterMethodName)
         buf.call(
           ty = genMethodSig(sym),
-          ptr = Val.Global(name, nir.Type.Ptr),
+          ptr = nir.Val.Global(name, nir.Type.Ptr),
           args = Nil,
           unwind = unwind
         )
@@ -653,7 +651,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genIdent(tree: Ident): Val = {
+    def genIdent(tree: Ident): nir.Val = {
       val sym = tree.symbol
       implicit val pos: nir.Position = tree.pos
       if (curMethodInfo.mutableVars.contains(sym)) {
@@ -665,7 +663,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genSelect(tree: Select): Val = {
+    def genSelect(tree: Select): nir.Val = {
       val Select(qualp, selp) = tree
 
       val sym = tree.symbol
@@ -697,12 +695,12 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genStaticMember(receiver: Tree, sym: Symbol)(implicit
         pos: nir.Position
-    ): Val = {
-      if (sym == BoxedUnit_UNIT) Val.Unit
+    ): nir.Val = {
+      if (sym == BoxedUnit_UNIT) nir.Val.Unit
       else genApplyStaticMethod(sym, receiver.symbol, Seq.empty)
     }
 
-    def genAssign(tree: Assign): Val = {
+    def genAssign(tree: Assign): nir.Val = {
       val Assign(lhsp, rhsp) = tree
       implicit val pos: nir.Position = tree.pos
 
@@ -728,7 +726,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genTyped(tree: Typed): Val = tree match {
+    def genTyped(tree: Typed): nir.Val = tree match {
       case Typed(Super(_, _), _) =>
         curMethodThis.get.get
       case Typed(expr, _) =>
@@ -761,7 +759,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     //   }
     //
     // Bridges might require multiple samMethod variants to be created.
-    def genFunction(tree: Function): Val = {
+    def genFunction(tree: Function): nir.Val = {
       val Function(
         paramTrees,
         callTree @ Apply(targetTree @ Select(_, _), functionArgs)
@@ -783,7 +781,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val traitName = genTypeName(funSym)
 
       statBuf += nir.Defn.Class(
-        Attrs.None,
+        nir.Attrs.None,
         anonName,
         Some(nir.Rt.Object.name),
         Seq(traitName)
@@ -800,34 +798,34 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case (sym, idx) =>
             val name = anonName.member(nir.Sig.Field("capture" + idx))
             val ty = genType(sym.tpe)
-            statBuf += nir.Defn.Var(Attrs.None, name, ty, Val.Zero(ty))
+            statBuf += nir.Defn.Var(nir.Attrs.None, name, ty, nir.Val.Zero(ty))
             name
         }
 
       // Generate an anonymous class constructor that initializes all the fields.
 
-      val ctorName = anonName.member(Sig.Ctor(captureTypes))
+      val ctorName = anonName.member(nir.Sig.Ctor(captureTypes))
       val ctorTy =
-        nir.Type.Function(Type.Ref(anonName) +: captureTypes, Type.Unit)
-      val ctorBody = scoped(curScopeId := ScopeId.TopLevel) {
-        val fresh = Fresh()
+        nir.Type.Function(nir.Type.Ref(anonName) +: captureTypes, nir.Type.Unit)
+      val ctorBody = scoped(curScopeId := nir.ScopeId.TopLevel) {
+        val fresh = nir.Fresh()
         val buf = new nir.Buffer()(fresh)
-        val self = Val.Local(fresh(), Type.Ref(anonName))
-        val captureFormals = captureTypes.map { ty => Val.Local(fresh(), ty) }
+        val self = nir.Val.Local(fresh(), nir.Type.Ref(anonName))
+        val captureFormals = captureTypes.map { ty => nir.Val.Local(fresh(), ty) }
         buf.label(fresh(), self +: captureFormals)
-        val superTy = nir.Type.Function(Seq(Rt.Object), Type.Unit)
-        val superName = Rt.Object.name.member(Sig.Ctor(Seq.empty))
-        val superCtor = Val.Global(superName, Type.Ptr)
-        buf.call(superTy, superCtor, Seq(self), Next.None)
+        val superTy = nir.Type.Function(Seq(nir.Rt.Object), nir.Type.Unit)
+        val superName = nir.Rt.Object.name.member(nir.Sig.Ctor(Seq.empty))
+        val superCtor = nir.Val.Global(superName, nir.Type.Ptr)
+        buf.call(superTy, superCtor, Seq(self), nir.Next.None)
         captureNames.zip(captureFormals).foreach {
           case (name, capture) =>
-            buf.fieldstore(capture.ty, self, name, capture, Next.None)
+            buf.fieldstore(capture.ty, self, name, capture, nir.Next.None)
         }
-        buf.ret(Val.Unit)
+        buf.ret(nir.Val.Unit)
         buf.toSeq
       }
 
-      statBuf += new Defn.Define(Attrs.None, ctorName, ctorTy, ctorBody)
+      statBuf += new nir.Defn.Define(nir.Attrs.None, ctorName, ctorTy, ctorBody)
 
       // Generate methods that implement SAM interface each of the required signatures.
 
@@ -835,24 +833,24 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val funSig = genName(funSym).asInstanceOf[nir.Global.Member].sig
         val funName = anonName.member(funSig)
 
-        val selfType = Type.Ref(anonName)
-        val Sig.Method(_, sigTypes :+ retType, _) = funSig.unmangled
+        val selfType = nir.Type.Ref(anonName)
+        val nir.Sig.Method(_, sigTypes :+ retType, _) = funSig.unmangled
         val paramTypes = selfType +: sigTypes
 
-        val bodyFresh = Fresh()
+        val bodyFresh = nir.Fresh()
         val bodyEnv = new MethodEnv(fresh)
 
         val body = scoped(
           curMethodEnv := bodyEnv,
           curMethodInfo := (new CollectMethodInfo).collect(EmptyTree),
           curFresh := bodyFresh,
-          curScopeId := ScopeId.TopLevel,
+          curScopeId := nir.ScopeId.TopLevel,
           curUnwindHandler := None
         ) {
-          val fresh = Fresh()
+          val fresh = nir.Fresh()
           val buf = new ExprBuffer()(fresh)
-          val self = Val.Local(fresh(), selfType)
-          val params = sigTypes.map { ty => Val.Local(fresh(), ty) }
+          val self = nir.Val.Local(fresh(), selfType)
+          val params = sigTypes.map { ty => nir.Val.Local(fresh(), ty) }
           buf.label(fresh(), self +: params)
 
           // At this point, the type parameter symbols are all Objects.
@@ -872,7 +870,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                     case tpe if tpe.sym.isPrimitiveValueClass =>
                       val targetTpe = genType(tpe)
                       if (targetTpe == value.ty) value
-                      else buf.unbox(genBoxType(tpe), value, Next.None)
+                      else buf.unbox(genBoxType(tpe), value, nir.Next.None)
 
                     case ErasedValueType(valueClazz, underlying) =>
                       val unboxMethod = valueClazz.derivedValueClassUnbox
@@ -901,16 +899,16 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
           captureSymsWithEnclThis.zip(captureNames).foreach {
             case (sym, name) =>
-              val value = buf.fieldload(genType(sym.tpe), self, name, Next.None)
+              val value = buf.fieldload(genType(sym.tpe), self, name, nir.Next.None)
               curMethodEnv.enter(sym, value)
           }
 
           val sym = targetTree.symbol
-          val method = Val.Global(genMethodName(sym), Type.Ptr)
+          val method = nir.Val.Global(genMethodName(sym), nir.Type.Ptr)
           val values =
             buf.genMethodArgs(sym, Ident(curClassSym.get) +: functionArgs)
           val sig = genMethodSig(sym)
-          val res = buf.call(sig, method, values, Next.None)
+          val res = buf.call(sig, method, values, nir.Next.None)
 
           // Get the result type of the lambda after erasure, when entering posterasure.
           // This allows to recover the correct type in case value classes are involved.
@@ -931,10 +929,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           buf.toSeq
         }
 
-        statBuf += new Defn.Define(
-          Attrs.None,
+        statBuf += new nir.Defn.Define(
+          nir.Attrs.None,
           funName,
-          Type.Function(paramTypes, retType),
+          nir.Type.Function(paramTypes, retType),
           body
         )
       }
@@ -949,7 +947,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
       buf.call(
         ctorTy,
-        Val.Global(ctorName, Type.Ptr),
+        nir.Val.Global(ctorName, nir.Type.Ptr),
         alloc +: captureVals,
         unwind
       )
@@ -957,10 +955,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def ensureBoxed(
-        value: Val,
+        value: nir.Val,
         tpeEnteringPosterasure: Type,
         targetTpe: Type
-    )(implicit buf: ExprBuffer, pos: nir.Position): Val = {
+    )(implicit buf: ExprBuffer, pos: nir.Position): nir.Val = {
       tpeEnteringPosterasure match {
         case tpe if isPrimitiveValueType(tpe) =>
           buf.boxValue(targetTpe, value)
@@ -970,7 +968,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val ctorName = genMethodName(boxedClass.primaryConstructor)
           val ctorSig = genMethodSig(boxedClass.primaryConstructor)
 
-          val alloc = buf.classalloc(Global.Top(boxedClass.fullName), unwind)
+          val alloc = buf.classalloc(nir.Global.Top(boxedClass.fullName), unwind)
           val ctor = buf.method(
             alloc,
             ctorName.asInstanceOf[nir.Global.Member].sig,
@@ -1000,7 +998,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         }
 
         val samsBuilder = List.newBuilder[Symbol]
-        val seenSignatures = mutable.Set.empty[Sig]
+        val seenSignatures = mutable.Set.empty[nir.Sig]
 
         val synthCls = samInfo.synthCls
         // On Scala < 2.12.5, `synthCls` is polyfilled to `NoSymbol`
@@ -1018,7 +1016,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         for (sam <- samInfo.sam :: samBridges) {
           // Remove duplicates, e.g., if we override the same method declared
           // in two super traits.
-          val sig = genName(sam).asInstanceOf[Global.Member].sig
+          val sig = genName(sam).asInstanceOf[nir.Global.Member].sig
           if (seenSignatures.add(sig))
             samsBuilder += sam
         }
@@ -1027,7 +1025,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genApplyDynamic(app: ApplyDynamic): Val = {
+    def genApplyDynamic(app: ApplyDynamic): nir.Val = {
       val ApplyDynamic(obj, args) = app
       val sym = app.symbol
       implicit val pos: nir.Position = app.pos
@@ -1049,10 +1047,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genApplyDynamic(sym: Symbol, self: Val, argsp: Seq[Tree])(implicit
+    def genApplyDynamic(sym: Symbol, self: nir.Val, argsp: Seq[Tree])(implicit
         pos: nir.Position
-    ): Val = {
-      val methodSig = genMethodSig(sym).asInstanceOf[Type.Function]
+    ): nir.Val = {
+      val methodSig = genMethodSig(sym).asInstanceOf[nir.Type.Function]
       val params = sym.tpe.params
 
       def isArrayLikeOp = {
@@ -1063,18 +1061,18 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       def genDynCall(arrayUpdate: Boolean) = {
 
         // In the case of an array update we need to manually erase the return type.
-        val methodName: Sig =
+        val methodName: nir.Sig =
           if (arrayUpdate) {
-            Sig.Proxy("update", Seq(Type.Int, Rt.Object))
+            nir.Sig.Proxy("update", Seq(nir.Type.Int, nir.Rt.Object))
           } else {
-            val Global.Member(_, sig) = genMethodName(sym)
+            val nir.Global.Member(_, sig) = genMethodName(sym)
             sig.toProxy
           }
 
         val sig =
-          Type.Function(
+          nir.Type.Function(
             methodSig.args.head ::
-              methodSig.args.tail.map(ty => Type.box.getOrElse(ty, ty)).toList,
+              methodSig.args.tail.map(ty => nir.Type.box.getOrElse(ty, ty)).toList,
             nir.Type.Ref(nir.Global.Top("java.lang.Object"))
           )
 
@@ -1122,13 +1120,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genApply(app: Apply): Val = {
+    def genApply(app: Apply): nir.Val = {
       val Apply(fun, args) = app
 
       implicit val pos: nir.Position = app.pos
       def fail(msg: String) = {
         reporter.error(app.pos, msg)
-        Val.Null
+        nir.Val.Null
       }
       fun match {
         case _ if fun.symbol == ExternMethod =>
@@ -1162,15 +1160,15 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genApplyLabel(tree: Tree): Val = {
+    def genApplyLabel(tree: Tree): nir.Val = {
       val Apply(fun, argsp) = tree
-      val Val.Local(label, _) = curMethodEnv.resolve(fun.symbol)
+      val nir.Val.Local(label, _) = curMethodEnv.resolve(fun.symbol)
       val args = genSimpleArgs(argsp)
       buf.jump(label, args)(tree.pos)
-      Val.Unit
+      nir.Val.Unit
     }
 
-    def genApplyBox(st: SimpleType, argp: Tree): Val = {
+    def genApplyBox(st: SimpleType, argp: Tree): nir.Val = {
       val value = genExpr(argp)
 
       buf.box(genBoxType(st), value, unwind)(argp.pos, getScopeId)
@@ -1178,10 +1176,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genApplyUnbox(st: SimpleType, argp: Tree)(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       val value = genExpr(argp)
       value.ty match {
-        case _: scalanative.nir.Type.I | _: scalanative.nir.Type.F =>
+        case _: nir.Type.I | _: nir.Type.F =>
           // No need for unboxing, fixing some slack generated by the general
           // purpose Scala compiler.
           value
@@ -1190,7 +1188,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genApplyPrimitive(app: Apply): Val = {
+    def genApplyPrimitive(app: Apply): nir.Val = {
       import scalaPrimitives._
 
       val Apply(fun @ Select(receiver, _), args) = app
@@ -1211,7 +1209,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case SIZE_OF            => genSizeOf(app)
         case ALIGNMENT_OF       => genAlignmentOf(app)
         case CQUOTE             => genCQuoteOp(app)
-        case BOXED_UNIT         => Val.Unit
+        case BOXED_UNIT         => nir.Val.Unit
         case code =>
           if (isArithmeticOp(code) || isLogicalOp(code) || isComparisonOp(code))
             genSimpleOp(app, receiver :: args, code)
@@ -1233,17 +1231,17 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    private final val ExternForwarderSig = Sig.Generated("$extern$forwarder")
+    private final val ExternForwarderSig = nir.Sig.Generated("$extern$forwarder")
 
-    def getLinktimeCondition(condp: Tree): Option[LinktimeCondition] = {
-      import LinktimeCondition._
-      def genComparsion(name: Name, value: Val): Comp = {
-        def intOrFloatComparison(onInt: Comp, onFloat: Comp)(implicit
+    def getLinktimeCondition(condp: Tree): Option[nir.LinktimeCondition] = {
+      import nir.LinktimeCondition._
+      def genComparsion(name: Name, value: nir.Val): nir.Comp = {
+        def intOrFloatComparison(onInt: nir.Comp, onFloat: nir.Comp)(implicit
             tpe: nir.Type
         ) =
-          if (tpe.isInstanceOf[Type.F]) onFloat else onInt
+          if (tpe.isInstanceOf[nir.Type.F]) onFloat else onInt
 
-        import Comp._
+        import nir.Comp._
         implicit val tpe: nir.Type = value.ty
         name match {
           case nme.EQ => intOrFloatComparison(Ieq, Feq)
@@ -1253,7 +1251,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case nme.LT => intOrFloatComparison(Slt, Flt)
           case nme.LE => intOrFloatComparison(Sle, Fle)
           case nme =>
-            globalError(condp.pos, s"Unsupported condition '$nme'"); Comp.Ine
+            globalError(condp.pos, s"Unsupported condition '$nme'"); nir.Comp.Ine
         }
       }
 
@@ -1263,8 +1261,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           Some {
             SimpleCondition(
               propertyName = name,
-              comparison = Comp.Ieq,
-              value = Val.True
+              comparison = nir.Comp.Ieq,
+              value = nir.Val.True
             )(position)
           }
 
@@ -1279,8 +1277,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           Some {
             SimpleCondition(
               propertyName = name,
-              comparison = Comp.Ieq,
-              value = Val.False
+              comparison = nir.Comp.Ieq,
+              value = nir.Val.False
             )(position)
           }
 
@@ -1303,8 +1301,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           (getLinktimeCondition(cond1), getLinktimeCondition(cond2)) match {
             case (Some(c1), Some(c2)) =>
               val bin = op match {
-                case nme.ZAND => Bin.And
-                case nme.ZOR  => Bin.Or
+                case nme.ZAND => nir.Bin.And
+                case nme.ZOR  => nir.Bin.Or
               }
               Some(ComplexCondition(bin, c1, c2)(condp.pos))
             case (None, None) => None
@@ -1320,50 +1318,50 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genFuncExternForwarder(funcName: Global, treeSym: Symbol)(implicit
+    def genFuncExternForwarder(funcName: nir.Global, treeSym: Symbol)(implicit
         pos: nir.Position
-    ): Defn = {
-      val attrs = Attrs(isExtern = true)
+    ): nir.Defn = {
+      val attrs = nir.Attrs(isExtern = true)
 
       val sig = genMethodSig(treeSym)
       val externSig = genExternMethodSig(treeSym)
 
-      val Type.Function(origtys, _) = sig
-      val Type.Function(paramtys, retty) = externSig
+      val nir.Type.Function(origtys, _) = sig
+      val nir.Type.Function(paramtys, retty) = externSig
 
       val methodName = genMethodName(treeSym)
-      val method = Val.Global(methodName, Type.Ptr)
-      val methodRef = Val.Global(methodName, origtys.head)
+      val method = nir.Val.Global(methodName, nir.Type.Ptr)
+      val methodRef = nir.Val.Global(methodName, origtys.head)
 
       val forwarderName = funcName.member(ExternForwarderSig)
       val forwarderBody = scoped(
         curUnwindHandler := None,
-        curScopeId := ScopeId.TopLevel
+        curScopeId := nir.ScopeId.TopLevel
       ) {
-        val fresh = Fresh()
+        val fresh = nir.Fresh()
         val buf = new ExprBuffer()(fresh)
 
-        val params = paramtys.map(ty => Val.Local(fresh(), ty))
+        val params = paramtys.map(ty => nir.Val.Local(fresh(), ty))
         buf.label(fresh(), params)
         val boxedParams = params.zip(origtys.tail).map {
           case (param, ty) => buf.fromExtern(ty, param)
         }
 
-        val res = buf.call(sig, method, methodRef +: boxedParams, Next.None)
+        val res = buf.call(sig, method, methodRef +: boxedParams, nir.Next.None)
         val unboxedRes = buf.toExtern(retty, res)
         buf.ret(unboxedRes)
 
         buf.toSeq
       }
-      new Defn.Define(attrs, forwarderName, externSig, forwarderBody)
+      new nir.Defn.Define(attrs, forwarderName, externSig, forwarderBody)
     }
 
-    def genCFuncFromScalaFunction(app: Apply): Val = {
+    def genCFuncFromScalaFunction(app: Apply): nir.Val = {
       implicit val pos: nir.Position = app.pos
       val fn = app.args.head
 
-      def withGeneratedForwarder(fnRef: Val)(sym: Symbol): Val = {
-        val Type.Ref(className, _, _) = fnRef.ty
+      def withGeneratedForwarder(fnRef: nir.Val)(sym: Symbol): nir.Val = {
+        val nir.Type.Ref(className, _, _) = fnRef.ty
         curStatBuffer += genFuncExternForwarder(className, sym)
         fnRef
       }
@@ -1375,7 +1373,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         )
 
       @tailrec
-      def resolveFunction(tree: Tree): Val = tree match {
+      def resolveFunction(tree: Tree): nir.Val = tree match {
         case Typed(expr, _) => resolveFunction(expr)
         case Block(_, expr) => resolveFunction(expr)
         case fn @ Function(
@@ -1403,34 +1401,34 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val className = genTypeName(app.tpe.sym)
 
       val ctorTy = nir.Type.Function(
-        Seq(Type.Ref(className), Type.Ptr),
-        Type.Unit
+        Seq(nir.Type.Ref(className), nir.Type.Ptr),
+        nir.Type.Unit
       )
-      val ctorName = className.member(Sig.Ctor(Seq(Type.Ptr)))
+      val ctorName = className.member(nir.Sig.Ctor(Seq(nir.Type.Ptr)))
       val rawptr = buf.method(fnRef, ExternForwarderSig, unwind)
 
       val alloc = buf.classalloc(className, unwind)
       buf.call(
         ctorTy,
-        Val.Global(ctorName, Type.Ptr),
+        nir.Val.Global(ctorName, nir.Type.Ptr),
         Seq(alloc, rawptr),
         unwind
       )
       alloc
     }
 
-    def numOfType(num: Int, ty: nir.Type): Val = ty match {
-      case Type.Byte              => Val.Byte(num.toByte)
-      case Type.Short | Type.Char => Val.Short(num.toShort)
-      case Type.Int               => Val.Int(num)
-      case Type.Long              => Val.Long(num.toLong)
-      case Type.Size              => Val.Size(num.toLong)
-      case Type.Float             => Val.Float(num.toFloat)
-      case Type.Double            => Val.Double(num.toDouble)
-      case _                      => unsupported(s"num = $num, ty = ${ty.show}")
+    def numOfType(num: Int, ty: nir.Type): nir.Val = ty match {
+      case nir.Type.Byte                  => nir.Val.Byte(num.toByte)
+      case nir.Type.Short | nir.Type.Char => nir.Val.Short(num.toShort)
+      case nir.Type.Int                   => nir.Val.Int(num)
+      case nir.Type.Long                  => nir.Val.Long(num.toLong)
+      case nir.Type.Size                  => nir.Val.Size(num.toLong)
+      case nir.Type.Float                 => nir.Val.Float(num.toFloat)
+      case nir.Type.Double                => nir.Val.Double(num.toDouble)
+      case _                              => unsupported(s"num = $num, ty = ${ty.show}")
     }
 
-    def genSimpleOp(app: Apply, args: List[Tree], code: Int): Val = {
+    def genSimpleOp(app: Apply, args: List[Tree], code: Int): nir.Val = {
       val retty = genType(app.tpe)
 
       implicit val pos: nir.Position = app.pos
@@ -1442,36 +1440,36 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def negateInt(value: nir.Val)(implicit pos: nir.Position): Val =
-      buf.bin(Bin.Isub, value.ty, numOfType(0, value.ty), value, unwind)
-    def negateFloat(value: nir.Val)(implicit pos: nir.Position): Val =
-      buf.bin(Bin.Fmul, value.ty, numOfType(-1, value.ty), value, unwind)
-    def negateBits(value: nir.Val)(implicit pos: nir.Position): Val =
-      buf.bin(Bin.Xor, value.ty, numOfType(-1, value.ty), value, unwind)
-    def negateBool(value: nir.Val)(implicit pos: nir.Position): Val =
-      buf.bin(Bin.Xor, Type.Bool, Val.True, value, unwind)
+    def negateInt(value: nir.Val)(implicit pos: nir.Position): nir.Val =
+      buf.bin(nir.Bin.Isub, value.ty, numOfType(0, value.ty), value, unwind)
+    def negateFloat(value: nir.Val)(implicit pos: nir.Position): nir.Val =
+      buf.bin(nir.Bin.Fmul, value.ty, numOfType(-1, value.ty), value, unwind)
+    def negateBits(value: nir.Val)(implicit pos: nir.Position): nir.Val =
+      buf.bin(nir.Bin.Xor, value.ty, numOfType(-1, value.ty), value, unwind)
+    def negateBool(value: nir.Val)(implicit pos: nir.Position): nir.Val =
+      buf.bin(nir.Bin.Xor, nir.Type.Bool, nir.Val.True, value, unwind)
 
     def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       import scalaPrimitives._
 
       val right = genExpr(rightp)
       val coerced = genCoercion(right, right.ty, opty)
 
       (opty, code) match {
-        case (_: Type.I | _: Type.F, POS) => coerced
-        case (_: Type.I, NOT)             => negateBits(coerced)
-        case (_: Type.F, NEG)             => negateFloat(coerced)
-        case (_: Type.I, NEG)             => negateInt(coerced)
-        case (Type.Bool, ZNOT)            => negateBool(coerced)
+        case (_: nir.Type.I | _: nir.Type.F, POS) => coerced
+        case (_: nir.Type.I, NOT)                 => negateBits(coerced)
+        case (_: nir.Type.F, NEG)                 => negateFloat(coerced)
+        case (_: nir.Type.I, NEG)                 => negateInt(coerced)
+        case (nir.Type.Bool, ZNOT)                => negateBool(coerced)
         case _ => abort("Unknown unary operation code: " + code)
       }
     }
 
     def genBinaryOp(code: Int, left: Tree, right: Tree, retty: nir.Type)(
         implicit exprPos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       import scalaPrimitives._
 
       val lty = genType(left.tpe)
@@ -1488,31 +1486,31 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         }
 
       val binres = opty match {
-        case _: Type.F =>
+        case _: nir.Type.F =>
           code match {
             case ADD =>
-              genBinaryOp(Op.Bin(Bin.Fadd, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Fadd, _, _, _), left, right, opty)
             case SUB =>
-              genBinaryOp(Op.Bin(Bin.Fsub, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Fsub, _, _, _), left, right, opty)
             case MUL =>
-              genBinaryOp(Op.Bin(Bin.Fmul, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Fmul, _, _, _), left, right, opty)
             case DIV =>
-              genBinaryOp(Op.Bin(Bin.Fdiv, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Fdiv, _, _, _), left, right, opty)
             case MOD =>
-              genBinaryOp(Op.Bin(Bin.Frem, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Frem, _, _, _), left, right, opty)
 
             case EQ =>
-              genBinaryOp(Op.Comp(Comp.Feq, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Feq, _, _, _), left, right, opty)
             case NE =>
-              genBinaryOp(Op.Comp(Comp.Fne, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Fne, _, _, _), left, right, opty)
             case LT =>
-              genBinaryOp(Op.Comp(Comp.Flt, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Flt, _, _, _), left, right, opty)
             case LE =>
-              genBinaryOp(Op.Comp(Comp.Fle, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Fle, _, _, _), left, right, opty)
             case GT =>
-              genBinaryOp(Op.Comp(Comp.Fgt, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Fgt, _, _, _), left, right, opty)
             case GE =>
-              genBinaryOp(Op.Comp(Comp.Fge, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Fge, _, _, _), left, right, opty)
 
             case _ =>
               abort(
@@ -1520,44 +1518,44 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               )
           }
 
-        case Type.Bool | _: Type.I =>
+        case nir.Type.Bool | _: nir.Type.I =>
           code match {
             case ADD =>
-              genBinaryOp(Op.Bin(Bin.Iadd, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Iadd, _, _, _), left, right, opty)
             case SUB =>
-              genBinaryOp(Op.Bin(Bin.Isub, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Isub, _, _, _), left, right, opty)
             case MUL =>
-              genBinaryOp(Op.Bin(Bin.Imul, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Imul, _, _, _), left, right, opty)
             case DIV =>
-              genBinaryOp(Op.Bin(Bin.Sdiv, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Sdiv, _, _, _), left, right, opty)
             case MOD =>
-              genBinaryOp(Op.Bin(Bin.Srem, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Srem, _, _, _), left, right, opty)
 
             case OR =>
-              genBinaryOp(Op.Bin(Bin.Or, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Or, _, _, _), left, right, opty)
             case XOR =>
-              genBinaryOp(Op.Bin(Bin.Xor, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Xor, _, _, _), left, right, opty)
             case AND =>
-              genBinaryOp(Op.Bin(Bin.And, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.And, _, _, _), left, right, opty)
             case LSL =>
-              genBinaryOp(Op.Bin(Bin.Shl, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Shl, _, _, _), left, right, opty)
             case LSR =>
-              genBinaryOp(Op.Bin(Bin.Lshr, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Lshr, _, _, _), left, right, opty)
             case ASR =>
-              genBinaryOp(Op.Bin(Bin.Ashr, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Bin(nir.Bin.Ashr, _, _, _), left, right, opty)
 
             case EQ =>
-              genBinaryOp(Op.Comp(Comp.Ieq, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Ieq, _, _, _), left, right, opty)
             case NE =>
-              genBinaryOp(Op.Comp(Comp.Ine, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Ine, _, _, _), left, right, opty)
             case LT =>
-              genBinaryOp(Op.Comp(Comp.Slt, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Slt, _, _, _), left, right, opty)
             case LE =>
-              genBinaryOp(Op.Comp(Comp.Sle, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Sle, _, _, _), left, right, opty)
             case GT =>
-              genBinaryOp(Op.Comp(Comp.Sgt, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Sgt, _, _, _), left, right, opty)
             case GE =>
-              genBinaryOp(Op.Comp(Comp.Sge, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Sge, _, _, _), left, right, opty)
 
             case ZOR =>
               genIf(retty, left, Literal(Constant(true)), right)
@@ -1568,7 +1566,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               abort("Unknown integer type binary operation code: " + code)
           }
 
-        case _: Type.RefKind =>
+        case _: nir.Type.RefKind =>
           def genEquals(ref: Boolean, negated: Boolean) = (left, right) match {
             // If null is present on either side, we must always
             // generate reference equality, regardless of where it
@@ -1593,12 +1591,12 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               abort("Unknown reference type operation code: " + code)
           }
 
-        case Type.Ptr =>
+        case nir.Type.Ptr =>
           code match {
             case EQ | ID =>
-              genBinaryOp(Op.Comp(Comp.Ieq, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Ieq, _, _, _), left, right, opty)
             case NE | NI =>
-              genBinaryOp(Op.Comp(Comp.Ine, _, _, _), left, right, opty)
+              genBinaryOp(nir.Op.Comp(nir.Comp.Ine, _, _, _), left, right, opty)
           }
 
         case ty =>
@@ -1609,11 +1607,11 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def genBinaryOp(
-        op: (nir.Type, Val, Val) => Op,
+        op: (nir.Type, nir.Val, nir.Val) => nir.Op,
         leftp: Tree,
         rightp: Tree,
         opty: nir.Type
-    ): Val = {
+    ): nir.Val = {
       implicit val leftPos: nir.Position = leftp.pos
       val leftty = genType(leftp.tpe)
       val left = genExpr(leftp)
@@ -1630,20 +1628,20 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         rightp: Tree,
         ref: Boolean,
         negated: Boolean
-    )(implicit pos: nir.Position): Val = {
+    )(implicit pos: nir.Position): nir.Val = {
 
       if (ref) {
         // referencial equality
         val left = genExpr(leftp)
         val right = genExpr(rightp)
-        val comp = if (negated) Comp.Ine else Comp.Ieq
-        buf.comp(comp, Rt.Object, left, right, unwind)
+        val comp = if (negated) nir.Comp.Ine else nir.Comp.Ieq
+        buf.comp(comp, nir.Rt.Object, left, right, unwind)
       } else genClassUniversalEquality(leftp, rightp, negated)
     }
 
     private def genClassUniversalEquality(l: Tree, r: Tree, negated: Boolean)(
         implicit pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
 
       /* True if the equality comparison is between values that require the use of the rich equality
        * comparator (scala.runtime.BoxesRunTime.equals). This is the case when either side of the
@@ -1676,8 +1674,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
       def isNonNullExpr(t: Tree) =
         isLiteral(t) || ((t.symbol ne null) && t.symbol.isModule)
-      def maybeNegate(v: Val): Val = if (negated) negateBool(v) else v
-      def comparator = if (negated) Comp.Ine else Comp.Ieq
+      def maybeNegate(v: nir.Val): nir.Val = if (negated) negateBool(v) else v
+      def comparator = if (negated) nir.Comp.Ine else nir.Comp.Ieq
       if (mustUseAnyComparator) maybeNegate {
         val equalsMethod: Symbol = {
           if (l.tpe <:< BoxedNumberClass.tpe) {
@@ -1691,10 +1689,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
       else if (isNull(l)) {
         // null == expr -> expr eq null
-        buf.comp(comparator, Rt.Object, genExpr(r), Val.Null, unwind)
+        buf.comp(comparator, nir.Rt.Object, genExpr(r), nir.Val.Null, unwind)
       } else if (isNull(r)) {
         // expr == null -> expr eq null
-        buf.comp(comparator, Rt.Object, genExpr(l), Val.Null, unwind)
+        buf.comp(comparator, nir.Rt.Object, genExpr(l), nir.Val.Null, unwind)
       } else if (isNonNullExpr(l)) maybeNegate {
         // SI-7852 Avoid null check if L is statically non-null.
         genApplyMethod(
@@ -1708,14 +1706,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         maybeNegate {
           // l == r -> if (l eq null) r eq null else l.equals(r)
           val thenn, elsen, mergen = fresh()
-          val mergev = Val.Local(fresh(), nir.Type.Bool)
+          val mergev = nir.Val.Local(fresh(), nir.Type.Bool)
           val left = genExpr(l)
-          val isnull = buf.comp(Comp.Ieq, Rt.Object, left, Val.Null, unwind)
-          buf.branch(isnull, Next(thenn), Next(elsen))
+          val isnull = buf.comp(nir.Comp.Ieq, nir.Rt.Object, left, nir.Val.Null, unwind)
+          buf.branch(isnull, nir.Next(thenn), nir.Next(elsen))
           locally {
             buf.label(thenn)
             val right = genExpr(r)
-            val thenv = buf.comp(Comp.Ieq, Rt.Object, right, Val.Null, unwind)
+            val thenv = buf.comp(nir.Comp.Ieq, nir.Rt.Object, right, nir.Val.Null, unwind)
             buf.jump(mergen, Seq(thenv))
           }
           locally {
@@ -1735,8 +1733,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def binaryOperationType(lty: nir.Type, rty: nir.Type) = (lty, rty) match {
       // Bug compatibility with scala/bug/issues/11253
-      case (Type.Long, Type.Float) =>
-        Type.Double
+      case (nir.Type.Long, nir.Type.Float) =>
+        nir.Type.Double
       case (nir.Type.Ptr, _: nir.Type.RefKind) =>
         lty
       case (_: nir.Type.RefKind, nir.Type.Ptr) =>
@@ -1755,24 +1753,24 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       case (nir.Type.F(lwidth), nir.Type.F(rwidth)) =>
         if (lwidth >= rwidth) lty else rty
       case (_: nir.Type.RefKind, _: nir.Type.RefKind) =>
-        Rt.Object
+        nir.Rt.Object
       case (ty1, ty2) if ty1 == ty2 =>
         ty1
-      case (Type.Nothing, ty) => ty
-      case (ty, Type.Nothing) => ty
+      case (nir.Type.Nothing, ty) => ty
+      case (ty, nir.Type.Nothing) => ty
 
       case _ =>
         abort(s"can't perform binary operation between $lty and $rty")
     }
 
-    def genStringConcat(leftp: Tree, rightp: Tree): Val = {
-      def stringify(sym: Symbol, value: Val)(implicit
+    def genStringConcat(leftp: Tree, rightp: Tree): nir.Val = {
+      def stringify(sym: Symbol, value: nir.Val)(implicit
           pos: nir.Position
-      ): Val = {
+      ): nir.Val = {
         val cond = ContTree { () =>
-          buf.comp(Comp.Ieq, Rt.Object, value, Val.Null, unwind)
+          buf.comp(nir.Comp.Ieq, nir.Rt.Object, value, nir.Val.Null, unwind)
         }
-        val thenp = ContTree { () => Val.String("null") }
+        val thenp = ContTree { () => nir.Val.String("null") }
         val elsep = ContTree { () =>
           if (sym == StringClass) {
             value
@@ -1781,7 +1779,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             genApplyMethod(meth, statically = false, value, Seq.empty)
           }
         }
-        genIf(Rt.String, cond, thenp, elsep)
+        genIf(nir.Rt.String, cond, thenp, elsep)
       }
 
       val left = {
@@ -1804,7 +1802,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       )
     }
 
-    def genHashCode(argp: Tree)(implicit pos: nir.Position): Val = {
+    def genHashCode(argp: Tree)(implicit pos: nir.Position): nir.Val = {
       genApplyStaticMethod(
         getMemberMethod(RuntimeStaticsModule, nme.anyHash),
         defn.RuntimeStaticsModule,
@@ -1812,12 +1810,12 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       )
     }
 
-    def genArrayOp(app: Apply, code: Int): Val = {
+    def genArrayOp(app: Apply, code: Int): nir.Val = {
       import scalaPrimitives._
 
       val Apply(Select(arrayp, _), argsp) = app
 
-      val Type.Array(elemty, _) = genType(arrayp.tpe)
+      val nir.Type.Array(elemty, _) = genType(arrayp.tpe)
 
       def elemcode = genArrayCode(arrayp.tpe)
       val array = genExpr(arrayp)
@@ -1839,7 +1837,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def boxValue(st: SimpleType, value: Val)(implicit pos: nir.Position): Val =
+    def boxValue(st: SimpleType, value: nir.Val)(implicit pos: nir.Position): nir.Val =
       st.sym match {
         case UByteClass | UShortClass | UIntClass | ULongClass | USizeClass =>
           genApplyModuleMethod(
@@ -1855,9 +1853,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           }
       }
 
-    def unboxValue(st: SimpleType, partial: Boolean, value: Val)(implicit
+    def unboxValue(st: SimpleType, partial: Boolean, value: nir.Val)(implicit
         pos: nir.Position
-    ): Val = st.sym match {
+    ): nir.Val = st.sym match {
       case UByteClass | UShortClass | UIntClass | ULongClass | USizeClass =>
         // Results of asInstanceOfs are partially unboxed, meaning
         // that non-standard value types remain to be boxed.
@@ -1878,7 +1876,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         }
     }
 
-    def genRawPtrOp(app: Apply, code: Int): Val = code match {
+    def genRawPtrOp(app: Apply, code: Int): nir.Val = code match {
       case _ if nirPrimitives.isRawPtrLoadOp(code) =>
         genRawPtrLoadOp(app, code)
       case _ if nirPrimitives.isRawPtrStoreOp(code) =>
@@ -1892,7 +1890,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         )
     }
 
-    def genRawPtrLoadOp(app: Apply, code: Int): Val = {
+    def genRawPtrLoadOp(app: Apply, code: Int): nir.Val = {
       val Apply(_, Seq(ptrp)) = app
       implicit def pos: nir.Position = app.pos
 
@@ -1909,15 +1907,15 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case LOAD_DOUBLE   => nir.Type.Double
         case LOAD_RAW_PTR  => nir.Type.Ptr
         case LOAD_RAW_SIZE => nir.Type.Size
-        case LOAD_OBJECT   => Rt.Object
+        case LOAD_OBJECT   => nir.Rt.Object
       }
       val syncAttrs =
         if (!ptrp.symbol.isVolatile) None
-        else Some(SyncAttrs(MemoryOrder.Acquire))
+        else Some(nir.SyncAttrs(nir.MemoryOrder.Acquire))
       buf.load(ty, ptr, unwind, syncAttrs)
     }
 
-    def genRawPtrStoreOp(app: Apply, code: Int): Val = {
+    def genRawPtrStoreOp(app: Apply, code: Int): nir.Val = {
       val Apply(_, Seq(ptrp, valuep)) = app
       implicit def pos: nir.Position = app.pos
 
@@ -1935,25 +1933,25 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case STORE_DOUBLE   => nir.Type.Double
         case STORE_RAW_PTR  => nir.Type.Ptr
         case STORE_RAW_SIZE => nir.Type.Size
-        case STORE_OBJECT   => Rt.Object
+        case STORE_OBJECT   => nir.Rt.Object
       }
       val syncAttrs =
         if (!ptrp.symbol.isVolatile) None
-        else Some(SyncAttrs(MemoryOrder.Release))
+        else Some(nir.SyncAttrs(nir.MemoryOrder.Release))
       buf.store(ty, ptr, value, unwind, syncAttrs)
     }
 
-    def genRawPtrElemOp(app: Apply, code: Int): Val = {
+    def genRawPtrElemOp(app: Apply, code: Int): nir.Val = {
       val Apply(_, Seq(ptrp, offsetp)) = app
       implicit def pos: nir.Position = app.pos
 
       val ptr = genExpr(ptrp)
       val offset = genExpr(offsetp)
 
-      buf.elem(Type.Byte, ptr, Seq(offset), unwind)
+      buf.elem(nir.Type.Byte, ptr, Seq(offset), unwind)
     }
 
-    def genRawPtrCastOp(app: Apply, code: Int): Val = {
+    def genRawPtrCastOp(app: Apply, code: Int): nir.Val = {
       val Apply(_, Seq(argp)) = app
       implicit def pos: nir.Position = app.pos
 
@@ -1964,22 +1962,22 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       genCastOp(fromty, toty, value)
     }
 
-    def genRawSizeCastOp(app: Apply, receiver: Tree, code: Int): Val = {
+    def genRawSizeCastOp(app: Apply, receiver: Tree, code: Int): nir.Val = {
       implicit def pos: nir.Position = app.pos
       val rec = genExpr(receiver)
       val (fromty, toty, conv) = code match {
         case CAST_RAWSIZE_TO_INT =>
-          (nir.Type.Size, nir.Type.Int, Conv.SSizeCast)
+          (nir.Type.Size, nir.Type.Int, nir.Conv.SSizeCast)
         case CAST_RAWSIZE_TO_LONG =>
-          (nir.Type.Size, nir.Type.Long, Conv.SSizeCast)
+          (nir.Type.Size, nir.Type.Long, nir.Conv.SSizeCast)
         case CAST_RAWSIZE_TO_LONG_UNSIGNED =>
-          (nir.Type.Size, nir.Type.Long, Conv.ZSizeCast)
+          (nir.Type.Size, nir.Type.Long, nir.Conv.ZSizeCast)
         case CAST_INT_TO_RAWSIZE =>
-          (nir.Type.Int, nir.Type.Size, Conv.SSizeCast)
+          (nir.Type.Int, nir.Type.Size, nir.Conv.SSizeCast)
         case CAST_INT_TO_RAWSIZE_UNSIGNED =>
-          (nir.Type.Int, nir.Type.Size, Conv.ZSizeCast)
+          (nir.Type.Int, nir.Type.Size, nir.Conv.ZSizeCast)
         case CAST_LONG_TO_RAWSIZE =>
-          (nir.Type.Long, nir.Type.Size, Conv.SSizeCast)
+          (nir.Type.Long, nir.Type.Size, nir.Conv.SSizeCast)
       }
 
       buf.conv(conv, toty, rec, unwind)
@@ -1987,20 +1985,20 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def castConv(fromty: nir.Type, toty: nir.Type): Option[nir.Conv] =
       (fromty, toty) match {
-        case (_: Type.I, Type.Ptr)              => Some(nir.Conv.Inttoptr)
-        case (Type.Ptr, _: Type.I)              => Some(nir.Conv.Ptrtoint)
-        case (_: Type.RefKind, Type.Ptr)        => Some(nir.Conv.Bitcast)
-        case (Type.Ptr, _: Type.RefKind)        => Some(nir.Conv.Bitcast)
-        case (_: Type.RefKind, _: Type.RefKind) => Some(nir.Conv.Bitcast)
-        case (_: Type.RefKind, _: Type.I)       => Some(nir.Conv.Ptrtoint)
-        case (_: Type.I, _: Type.RefKind)       => Some(nir.Conv.Inttoptr)
-        case (Type.FixedSizeI(w1, _), Type.F(w2)) if w1 == w2 =>
+        case (_: nir.Type.I, nir.Type.Ptr)              => Some(nir.Conv.Inttoptr)
+        case (nir.Type.Ptr, _: nir.Type.I)              => Some(nir.Conv.Ptrtoint)
+        case (_: nir.Type.RefKind, nir.Type.Ptr)        => Some(nir.Conv.Bitcast)
+        case (nir.Type.Ptr, _: nir.Type.RefKind)        => Some(nir.Conv.Bitcast)
+        case (_: nir.Type.RefKind, _: nir.Type.RefKind) => Some(nir.Conv.Bitcast)
+        case (_: nir.Type.RefKind, _: nir.Type.I)       => Some(nir.Conv.Ptrtoint)
+        case (_: nir.Type.I, _: nir.Type.RefKind)       => Some(nir.Conv.Inttoptr)
+        case (nir.Type.FixedSizeI(w1, _), nir.Type.F(w2)) if w1 == w2 =>
           Some(nir.Conv.Bitcast)
-        case (Type.F(w1), Type.FixedSizeI(w2, _)) if w1 == w2 =>
+        case (nir.Type.F(w1), nir.Type.FixedSizeI(w2, _)) if w1 == w2 =>
           Some(nir.Conv.Bitcast)
         case _ if fromty == toty       => None
-        case (Type.Float, Type.Double) => Some(nir.Conv.Fpext)
-        case (Type.Double, Type.Float) => Some(nir.Conv.Fptrunc)
+        case (nir.Type.Float, nir.Type.Double) => Some(nir.Conv.Fpext)
+        case (nir.Type.Double, nir.Type.Float) => Some(nir.Conv.Fptrunc)
         case _ =>
           unsupported(s"cast from $fromty to $toty")
       }
@@ -2011,7 +2009,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
      *    - 0..N args
      *    - return type evidence
      */
-    def genCFuncPtrApply(app: Apply, code: Int): Val = {
+    def genCFuncPtrApply(app: Apply, code: Int): nir.Val = {
       val Apply(appRec @ Select(receiverp, _), aargs) = app
 
       val paramTypes = app.attachments.get[NonErasedTypes] match {
@@ -2028,7 +2026,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       val self = genExpr(receiverp)
       val retType = genType(paramTypes.last)
-      val unboxedRetType = Type.unbox.getOrElse(retType, retType)
+      val unboxedRetType = nir.Type.unbox.getOrElse(retType, retType)
 
       val args = aargs
         .zip(paramTypes)
@@ -2039,20 +2037,20 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
             /* buf.unboxValue does not handle Ref( Ptr | CArray | ... ) unboxing
              * That's why we're doing it directly */
-            if (Type.unbox.isDefinedAt(tpe)) {
+            if (nir.Type.unbox.isDefinedAt(tpe)) {
               buf.unbox(tpe, obj, unwind)(arg.pos, getScopeId)
             } else {
               buf.unboxValue(fromType(ty), partial = false, obj)(arg.pos)
             }
         }
       val argTypes = args.map(_.ty)
-      val funcSig = Type.Function(argTypes, unboxedRetType)
+      val funcSig = nir.Type.Function(argTypes, unboxedRetType)
 
       val selfName = genTypeName(CFuncPtrClass)
       val getRawPtrName = selfName
-        .member(Sig.Field("rawptr", Sig.Scope.Private(selfName)))
+        .member(nir.Sig.Field("rawptr", nir.Sig.Scope.Private(selfName)))
 
-      val target = buf.fieldload(Type.Ptr, self, getRawPtrName, unwind)
+      val target = buf.fieldload(nir.Type.Ptr, self, getRawPtrName, unwind)
       val result = buf.call(funcSig, target, args, unwind)
       if (retType != unboxedRetType)
         buf.box(retType, result, unwind)
@@ -2061,9 +2059,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genCastOp(fromty: nir.Type, toty: nir.Type, value: Val)(implicit
+    def genCastOp(fromty: nir.Type, toty: nir.Type, value: nir.Val)(implicit
         pos: nir.Position
-    ): Val =
+    ): nir.Val =
       castConv(fromty, toty).fold(value)(buf.conv(_, toty, value, unwind))
 
     private lazy val optimizedFunctions = {
@@ -2086,10 +2084,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       ) ++ UnsignedOfMethods ++ RuntimePackage_toRawSizeAlts
     }
 
-    private def getUnboxedSize(sizep: Tree)(implicit pos: nir.Position): Val =
+    private def getUnboxedSize(sizep: Tree)(implicit pos: nir.Position): nir.Val =
       sizep match {
         // Optimize call, strip numeric conversions
-        case Literal(Constant(size: Int)) => Val.Size(size)
+        case Literal(Constant(size: Int)) => nir.Val.Size(size)
         case Block(Nil, expr)             => getUnboxedSize(expr)
         case Apply(fun, List(arg))
             if optimizedFunctions.contains(fun.symbol) ||
@@ -2099,23 +2097,23 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case _              =>
           // actual unboxing
           val size = genExpr(sizep)
-          val sizeTy = Type.normalize(size.ty)
+          val sizeTy = nir.Type.normalize(size.ty)
           val unboxed =
-            if (Type.unbox.contains(sizeTy)) buf.unbox(sizeTy, size, unwind)
-            else if (Type.box.contains(sizeTy)) size
+            if (nir.Type.unbox.contains(sizeTy)) buf.unbox(sizeTy, size, unwind)
+            else if (nir.Type.box.contains(sizeTy)) size
             else {
               reporter.error(
                 sizep.pos,
                 s"Invalid usage of Intrinsic.stackalloc, argument is not an integer type: ${sizeTy}"
               )
-              Val.Size(0)
+              nir.Val.Size(0)
             }
 
           if (unboxed.ty == nir.Type.Size) unboxed
-          else buf.conv(Conv.SSizeCast, nir.Type.Size, unboxed, unwind)
+          else buf.conv(nir.Conv.SSizeCast, nir.Type.Size, unboxed, unwind)
       }
 
-    private def genStackalloc(app: Apply): Val = app match {
+    private def genStackalloc(app: Apply): nir.Val = app match {
       case Apply(_, args) => {
         implicit val pos: nir.Position = app.pos
         val tpe = app.attachments
@@ -2126,11 +2124,11 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               app.pos,
               "Not found type attachment for stackalloc operation, report it as a bug."
             )
-            Type.Nothing
+            nir.Type.Nothing
           }
 
         val size = args match {
-          case Seq()         => Val.Size(1)
+          case Seq()         => nir.Val.Size(1)
           case Seq(sizep)    => getUnboxedSize(sizep)
           case Seq(_, sizep) => getUnboxedSize(sizep)
         }
@@ -2138,7 +2136,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genCQuoteOp(app: Apply): Val = {
+    def genCQuoteOp(app: Apply): nir.Val = {
       app match {
         // Sometimes I really miss quasiquotes.
         //
@@ -2183,8 +2181,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               ),
               _
             ) =>
-          val bytes = Val.ByteString(StringUtils.processEscapes(str))
-          val const = Val.Const(bytes)
+          val bytes = nir.Val.ByteString(StringUtils.processEscapes(str))
+          val const = nir.Val.Const(bytes)
           buf.box(nir.Rt.BoxedPtr, const, unwind)(app.pos, getScopeId)
 
         case _ =>
@@ -2192,7 +2190,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genUnsignedOp(app: Tree, code: Int): Val = {
+    def genUnsignedOp(app: Tree, code: Int): nir.Val = {
       implicit val pos: nir.Position = app.pos
       app match {
         case Apply(_, Seq(argp)) if code == UNSIGNED_OF =>
@@ -2206,14 +2204,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val ty = genType(app.tpe)
           val arg = genExpr(argp)
 
-          buf.conv(Conv.Zext, ty, arg, unwind)
+          buf.conv(nir.Conv.Zext, ty, arg, unwind)
 
         case Apply(_, Seq(argp))
             if code >= UINT_TO_FLOAT && code <= ULONG_TO_DOUBLE =>
           val ty = genType(app.tpe)
           val arg = genExpr(argp)
 
-          buf.conv(Conv.Uitofp, ty, arg, unwind)
+          buf.conv(nir.Conv.Uitofp, ty, arg, unwind)
 
         case Apply(_, Seq(leftp, rightp)) =>
           val bin = code match {
@@ -2228,7 +2226,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genClassFieldRawPtr(app: Apply)(implicit pos: nir.Position): Val = {
+    def genClassFieldRawPtr(app: Apply)(implicit pos: nir.Position): nir.Val = {
       val Apply(_, List(target, fieldName: Literal)) = app
       val fieldNameId = fieldName.value.stringValue
       val classInfo = target.tpe.finalResultType
@@ -2259,24 +2257,24 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             app.pos,
             s"${classInfoSym} does not contain field ${fieldNameId}"
           )
-          Val.Int(-1)
+          nir.Val.Int(-1)
         }
 
     }
 
-    def genSizeOf(app: Apply)(implicit pos: nir.Position): Val =
+    def genSizeOf(app: Apply)(implicit pos: nir.Position): nir.Val =
       genLayoutValueOf("sizeOf", buf.sizeOf(_, unwind))(app)
 
-    def genAlignmentOf(app: Apply)(implicit pos: nir.Position): Val =
+    def genAlignmentOf(app: Apply)(implicit pos: nir.Position): nir.Val =
       genLayoutValueOf("alignmentOf", buf.alignmentOf(_, unwind))(app)
 
     // used as internal implementation of sizeOf / alignmentOf
-    private def genLayoutValueOf(opType: String, toVal: nir.Type => Val)(
+    private def genLayoutValueOf(opType: String, toVal: nir.Type => nir.Val)(
         app: Apply
-    )(implicit pos: nir.Position): Val = {
+    )(implicit pos: nir.Position): nir.Val = {
       def fail(msg: => String) = {
         reporter.error(app.pos, msg)
-        Val.Zero(Type.Size)
+        nir.Val.Zero(nir.Type.Size)
       }
       app.attachments.get[NonErasedType] match {
         case None =>
@@ -2308,13 +2306,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genSynchronized(receiverp: Tree, bodyp: Tree)(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       genSynchronized(receiverp)(_.genExpr(bodyp))
     }
 
     def genSynchronized(
         receiverp: Tree
-    )(bodyGen: ExprBuffer => Val)(implicit pos: nir.Position): Val = {
+    )(bodyGen: ExprBuffer => nir.Val)(implicit pos: nir.Position): nir.Val = {
       // Here we wrap the synchronized call into the try-finally block
       // to ensure that monitor would be released even in case of the exception
       // or in case of non-local returns
@@ -2338,77 +2336,77 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       // dummy exception handler,
       // monitor$.exit() call would be added to it in genTryFinally transformer
       locally {
-        val excv = Val.Local(fresh(), Rt.Object)
+        val excv = nir.Val.Local(fresh(), nir.Rt.Object)
         nested.label(handler, Seq(excv))
         nested.raise(excv, unwind)
-        nested.jumpExcludeUnitValue(retty)(mergen, Val.Zero(retty))
+        nested.jumpExcludeUnitValue(retty)(mergen, nir.Val.Zero(retty))
       }
 
       // Append try/catch instructions to the outher instruction buffer.
-      buf.jump(Next(normaln))
+      buf.jump(nir.Next(normaln))
       buf ++= genTryFinally(
         // scalanative.runtime.`package`.exitMonitor(receiver)
         finallyp =
           treeBuild.mkMethodCall(RuntimeExitMonitorMethod, List(receiverp)),
         insts = nested.toSeq
       )
-      val mergev = Val.Local(fresh(), retty)
+      val mergev = nir.Val.Local(fresh(), retty)
       buf.labelExcludeUnitValue(mergen, mergev)
     }
 
-    def genCoercion(app: Apply, receiver: Tree, code: Int): Val = {
+    def genCoercion(app: Apply, receiver: Tree, code: Int): nir.Val = {
       val rec = genExpr(receiver)
       val (fromty, toty) = coercionTypes(code)
 
       genCoercion(rec, fromty, toty)(app.pos)
     }
 
-    def genCoercion(value: Val, fromty: nir.Type, toty: nir.Type)(implicit
+    def genCoercion(value: nir.Val, fromty: nir.Type, toty: nir.Type)(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       if (fromty == toty) {
         value
       } else {
         val conv = (fromty, toty) match {
           case (nir.Type.Ptr, _: nir.Type.RefKind) =>
-            Conv.Bitcast
+            nir.Conv.Bitcast
           case (_: nir.Type.RefKind, nir.Type.Ptr) =>
-            Conv.Bitcast
+            nir.Conv.Bitcast
           case (
                 nir.Type.FixedSizeI(fromw, froms),
                 nir.Type.FixedSizeI(tow, tos)
               ) =>
             if (fromw < tow) {
               if (froms) {
-                Conv.Sext
+                nir.Conv.Sext
               } else {
-                Conv.Zext
+                nir.Conv.Zext
               }
             } else if (fromw > tow) {
-              Conv.Trunc
+              nir.Conv.Trunc
             } else {
-              Conv.Bitcast
+              nir.Conv.Bitcast
             }
           case (i: nir.Type.I, _: nir.Type.F) if i.signed =>
-            Conv.Sitofp
+            nir.Conv.Sitofp
           case (i: nir.Type.I, _: nir.Type.F) if !i.signed =>
-            Conv.Uitofp
+            nir.Conv.Uitofp
           case (_: nir.Type.F, nir.Type.FixedSizeI(iwidth, true)) =>
             if (iwidth < 32) {
-              val ivalue = genCoercion(value, fromty, Type.Int)
-              return genCoercion(ivalue, Type.Int, toty)
+              val ivalue = genCoercion(value, fromty, nir.Type.Int)
+              return genCoercion(ivalue, nir.Type.Int, toty)
             }
-            Conv.Fptosi
+            nir.Conv.Fptosi
           case (_: nir.Type.F, nir.Type.FixedSizeI(iwidth, false)) =>
             if (iwidth < 32) {
-              val ivalue = genCoercion(value, fromty, Type.Int)
-              return genCoercion(ivalue, Type.Int, toty)
+              val ivalue = genCoercion(value, fromty, nir.Type.Int)
+              return genCoercion(ivalue, nir.Type.Int, toty)
             }
-            Conv.Fptoui
+            nir.Conv.Fptoui
           case (nir.Type.Double, nir.Type.Float) =>
-            Conv.Fptrunc
+            nir.Conv.Fptrunc
           case (nir.Type.Float, nir.Type.Double) =>
-            Conv.Fpext
+            nir.Conv.Fpext
         }
         buf.conv(conv, toty, value, unwind)
       }
@@ -2476,7 +2474,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genApplyTypeApply(app: Apply): Val = {
+    def genApplyTypeApply(app: Apply): nir.Val = {
       val Apply(tapp @ TypeApply(fun @ Select(receiverp, _), targs), argsp) =
         app
 
@@ -2494,21 +2492,21 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
         case Object_asInstanceOf =>
           (fromty, toty) match {
-            case (_: Type.PrimitiveKind, _: Type.PrimitiveKind) =>
+            case (_: nir.Type.PrimitiveKind, _: nir.Type.PrimitiveKind) =>
               genCoercion(value, fromty, toty)
             case _ if boxed.ty =?= boxty => boxed
-            case (_, Type.Nothing) =>
+            case (_, nir.Type.Nothing) =>
               val runtimeNothing = genType(RuntimeNothingClass)
               val isNullL, notNullL = fresh()
-              val isNull = buf.comp(Comp.Ieq, boxed.ty, boxed, Val.Null, unwind)
-              buf.branch(isNull, Next(isNullL), Next(notNullL))
+              val isNull = buf.comp(nir.Comp.Ieq, boxed.ty, boxed, nir.Val.Null, unwind)
+              buf.branch(isNull, nir.Next(isNullL), nir.Next(notNullL))
               buf.label(isNullL)
-              buf.raise(Val.Null, unwind)
+              buf.raise(nir.Val.Null, unwind)
               buf.label(notNullL)
               buf.as(runtimeNothing, boxed, unwind)
               buf.unreachable(unwind)
               buf.label(fresh())
-              Val.Zero(Type.Nothing)
+              nir.Val.Zero(nir.Type.Nothing)
             case _ =>
               val cast = buf.as(boxty, boxed, unwind)
               unboxValue(app.tpe, partial = true, cast)(app.pos)
@@ -2520,7 +2518,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genApplyNew(app: Apply): Val = {
+    def genApplyNew(app: Apply): nir.Val = {
       val Apply(fun @ Select(New(tpt), nme.CONSTRUCTOR), args) = app
       implicit val pos: nir.Position = app.pos
 
@@ -2539,10 +2537,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genApplyNewStruct(st: SimpleType, argsp: Seq[Tree]): Val = {
+    def genApplyNewStruct(st: SimpleType, argsp: Seq[Tree]): nir.Val = {
       val ty = genType(st)
       val args = genSimpleArgs(argsp)
-      var res: Val = Val.Zero(ty)
+      var res: nir.Val = nir.Val.Zero(ty)
 
       args.zip(argsp).zipWithIndex.foreach {
         case ((arg, argp), idx) =>
@@ -2554,7 +2552,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genApplyNewArray(targ: SimpleType, argsp: Seq[Tree])(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       val Seq(lengthp) = argsp
       val length = genExpr(lengthp)
 
@@ -2563,7 +2561,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genApplyNew(clssym: Symbol, ctorsym: Symbol, args: List[Tree])(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       val alloc = buf.classalloc(genTypeName(clssym), unwind)
       val call = genApplyMethod(ctorsym, statically = true, alloc, args)
       alloc
@@ -2571,7 +2569,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genApplyModuleMethod(module: Symbol, method: Symbol, args: Seq[Tree])(
         implicit pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       val self = genModule(module)
       genApplyMethod(method, statically = true, self, args)
     }
@@ -2581,7 +2579,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         statically: Boolean,
         selfp: Tree,
         argsp: Seq[Tree]
-    )(implicit pos: nir.Position): Val = {
+    )(implicit pos: nir.Position): nir.Val = {
       if (sym.isExtern && sym.isAccessor) {
         genApplyExternAccessor(sym, argsp)
       } else if (sym.isStaticMember) {
@@ -2596,10 +2594,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         sym: Symbol,
         receiver: Symbol,
         argsp: Seq[Tree]
-    )(implicit pos: nir.Position): Val = {
+    )(implicit pos: nir.Position): nir.Val = {
       require(!sym.isExtern, sym.owner)
       val name = genStaticMemberName(sym, receiver)
-      val method = Val.Global(name, nir.Type.Ptr)
+      val method = nir.Val.Global(name, nir.Type.Ptr)
       val sig = genMethodSig(sym)
       val args = genMethodArgs(sym, argsp)
       buf.call(sig, method, args, unwind)
@@ -2607,7 +2605,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genApplyExternAccessor(sym: Symbol, argsp: Seq[Tree])(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       argsp match {
         case Seq() =>
           val ty = genMethodSig(sym).ret
@@ -2621,13 +2619,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genLoadExtern(ty: nir.Type, externTy: nir.Type, sym: Symbol)(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       assert(sym.isExtern, "loadExtern was not extern")
 
-      val name = Val.Global(genName(sym), Type.Ptr)
+      val name = nir.Val.Global(genName(sym), nir.Type.Ptr)
       val syncAttrs =
         if (!sym.isVolatile) None
-        else Some(SyncAttrs(MemoryOrder.Acquire))
+        else Some(nir.SyncAttrs(nir.MemoryOrder.Acquire))
 
       fromExtern(
         ty,
@@ -2635,39 +2633,39 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       )
     }
 
-    def genStoreExtern(externTy: nir.Type, sym: Symbol, value: Val)(implicit
+    def genStoreExtern(externTy: nir.Type, sym: Symbol, value: nir.Val)(implicit
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       assert(sym.isExtern, "storeExtern was not extern")
-      val name = Val.Global(genName(sym), Type.Ptr)
+      val name = nir.Val.Global(genName(sym), nir.Type.Ptr)
       val externValue = toExtern(externTy, value)
       val syncAttrs =
         if (!sym.isVolatile) None
-        else Some(SyncAttrs(MemoryOrder.Release))
+        else Some(nir.SyncAttrs(nir.MemoryOrder.Release))
 
       buf.store(externTy, name, externValue, unwind, syncAttrs)
     }
 
-    def toExtern(expectedTy: nir.Type, value: Val)(implicit
+    def toExtern(expectedTy: nir.Type, value: nir.Val)(implicit
         pos: nir.Position
-    ): Val =
+    ): nir.Val =
       (expectedTy, value.ty) match {
-        case (_, refty: Type.Ref)
-            if Type.boxClasses.contains(refty.name)
-              && Type.unbox(Type.Ref(refty.name)) == expectedTy =>
-          buf.unbox(Type.Ref(refty.name), value, unwind)
+        case (_, refty: nir.Type.Ref)
+            if nir.Type.boxClasses.contains(refty.name)
+              && nir.Type.unbox(nir.Type.Ref(refty.name)) == expectedTy =>
+          buf.unbox(nir.Type.Ref(refty.name), value, unwind)
         case _ =>
           value
       }
 
-    def fromExtern(expectedTy: nir.Type, value: Val)(implicit
+    def fromExtern(expectedTy: nir.Type, value: nir.Val)(implicit
         pos: nir.Position
-    ): Val =
+    ): nir.Val =
       (expectedTy, value.ty) match {
         case (refty: nir.Type.Ref, ty)
-            if Type.boxClasses.contains(refty.name)
-              && Type.unbox(Type.Ref(refty.name)) == ty =>
-          buf.box(Type.Ref(refty.name), value, unwind)
+            if nir.Type.boxClasses.contains(refty.name)
+              && nir.Type.unbox(nir.Type.Ref(refty.name)) == ty =>
+          buf.box(nir.Type.Ref(refty.name), value, unwind)
         case _ =>
           value
       }
@@ -2675,9 +2673,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genApplyMethod(
         sym: Symbol,
         statically: Boolean,
-        self: Val,
+        self: nir.Val,
         argsp: Seq[Tree]
-    )(implicit pos: nir.Position): Val = {
+    )(implicit pos: nir.Position): nir.Val = {
       val owner = sym.owner
       val name = genMethodName(sym)
       val origSig = genMethodSig(sym)
@@ -2688,9 +2686,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val args = genMethodArgs(sym, argsp)
       val method =
         if (statically || owner.isStruct || isExtern) {
-          Val.Global(name, nir.Type.Ptr)
+          nir.Val.Global(name, nir.Type.Ptr)
         } else {
-          val Global.Member(_, sig) = name
+          val nir.Global.Member(_, sig) = name
           buf.method(self, sig, unwind)
         }
       val values =
@@ -2702,19 +2700,19 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       if (!isExtern) {
         res
       } else {
-        val Type.Function(_, retty) = origSig
+        val nir.Type.Function(_, retty) = origSig
         fromExtern(retty, res)
       }
     }
 
-    def genMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[Val] =
+    def genMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[nir.Val] =
       if (sym.isExtern) genExternMethodArgs(sym, argsp)
       else genSimpleArgs(argsp)
 
-    private def genSimpleArgs(argsp: Seq[Tree]): Seq[Val] = argsp.map(genExpr)
+    private def genSimpleArgs(argsp: Seq[Tree]): Seq[nir.Val] = argsp.map(genExpr)
 
-    private def genExternMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[Val] = {
-      val res = Seq.newBuilder[Val]
+    private def genExternMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[nir.Val] = {
+      val res = Seq.newBuilder[nir.Val]
       val nir.Type.Function(argTypes, _) = genExternMethodSig(sym)
       val paramSyms = sym.tpe.params
       assert(
@@ -2728,17 +2726,17 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       ): nir.Val = {
         implicit def pos: nir.Position = argp.pos
         val externType = genExternType(paramTpe)
-        val value = (genExpr(argp), Type.box.get(externType)) match {
-          case (value @ Val.Null, Some(unboxedType)) =>
+        val value = (genExpr(argp), nir.Type.box.get(externType)) match {
+          case (value @ nir.Val.Null, Some(unboxedType)) =>
             externType match {
-              case Type.Ptr | _: Type.RefKind => value
+              case nir.Type.Ptr | _: nir.Type.RefKind => value
               case _ =>
                 reporter.warning(
                   argp.pos,
                   s"Passing null as argument of type ${paramTpe} to the extern method is unsafe. " +
                     s"The argument would be unboxed to primitive value of type $externType."
                 )
-                Val.Zero(unboxedType)
+                nir.Val.Zero(unboxedType)
             }
           case (value, _) => value
         }
@@ -2758,23 +2756,23 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                       tree.symbol.tpe.finalResultType
                     else tree.tpe
                   val arg = genArg(tree, tpe)
-                  def isUnsigned = Type.isUnsignedType(genType(tpe))
+                  def isUnsigned = nir.Type.isUnsignedType(genType(tpe))
                   // Decimal varargs needs to be promoted to at least Int, and float needs to be promoted to Double
                   val promotedArg = arg.ty match {
-                    case Type.Float =>
-                      this.genCastOp(Type.Float, Type.Double, arg)
-                    case Type.FixedSizeI(width, _) if width < Type.Int.width =>
+                    case nir.Type.Float =>
+                      this.genCastOp(nir.Type.Float, nir.Type.Double, arg)
+                    case nir.Type.FixedSizeI(width, _) if width < nir.Type.Int.width =>
                       val conv =
                         if (isUnsigned) nir.Conv.Zext
                         else nir.Conv.Sext
-                      buf.conv(conv, Type.Int, arg, unwind)
-                    case Type.Long =>
+                      buf.conv(conv, nir.Type.Int, arg, unwind)
+                    case nir.Type.Long =>
                       // On 32-bit systems Long needs to be truncated to Int
                       // Cast it to size to make undependent from architecture
                       val conv =
                         if (isUnsigned) nir.Conv.ZSizeCast
                         else nir.Conv.SSizeCast
-                      buf.conv(conv, Type.Size, arg, unwind)
+                      buf.conv(conv, nir.Type.Size, arg, unwind)
                     case _ => arg
                   }
                   res += promotedArg
@@ -2793,20 +2791,24 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       res.result()
     }
 
-    private def labelExcludeUnitValue(label: Local, value: nir.Val.Local)(
+    private def labelExcludeUnitValue(label: nir.Local, value: nir.Val.Local)(
         implicit pos: nir.Position
     ): nir.Val =
       value.ty match {
-        case Type.Unit => buf.label(label); Val.Unit
-        case _         => buf.label(label, Seq(value)); value
+        case nir.Type.Unit =>
+          buf.label(label); nir.Val.Unit
+        case _  =>
+          buf.label(label, Seq(value)); value
       }
 
     private def jumpExcludeUnitValue(
         mergeType: nir.Type
-    )(label: Local, value: nir.Val)(implicit pos: nir.Position): Unit =
+    )(label: nir.Local, value: nir.Val)(implicit pos: nir.Position): Unit =
       mergeType match {
-        case Type.Unit => buf.jump(label, Nil)
-        case _         => buf.jump(label, Seq(value))
+        case nir.Type.Unit =>
+          buf.jump(label, Nil)
+        case _ =>
+          buf.jump(label, Seq(value))
       }
   }
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenFile.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenFile.scala
@@ -3,7 +3,6 @@ package nscplugin
 
 import java.io.FileOutputStream
 import java.nio.file.{Path, Paths}
-import scala.scalanative.nir.serialization.serializeBinary
 import scala.tools.nsc.Global
 import scala.tools.nsc.io.AbstractFile
 import java.nio.channels.Channels
@@ -28,7 +27,7 @@ trait NirGenFile[G <: Global with Singleton] { self: NirGenPhase[G] =>
 
   def genIRFile(path: AbstractFile, defns: Seq[nir.Defn]): Unit = {
     val channel = Channels.newChannel(path.bufferedOutput)
-    try serializeBinary(defns, channel)
+    try nir.serialization.serializeBinary(defns, channel)
     finally channel.close()
   }
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -6,7 +6,6 @@ import java.util.stream.{Stream => JStream}
 import java.util.function.{Consumer => JConsumer}
 import scala.collection.mutable
 import scala.language.implicitConversions
-import scala.scalanative.nir._
 import nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ScopedVar.scoped
 import scala.tools.nsc.plugins._
@@ -35,9 +34,9 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
   protected val curMethodSig = new util.ScopedVar[nir.Type]
   protected val curMethodInfo = new util.ScopedVar[CollectMethodInfo]
   protected val curMethodEnv = new util.ScopedVar[MethodEnv]
-  protected val curMethodThis = new util.ScopedVar[Option[Val]]
+  protected val curMethodThis = new util.ScopedVar[Option[nir.Val]]
   protected val curMethodLocalNames =
-    new util.ScopedVar[mutable.Map[Local, LocalName]]
+    new util.ScopedVar[mutable.Map[nir.Local, nir.LocalName]]
   protected val curMethodIsExtern = new util.ScopedVar[Boolean]
   protected val curFresh = new util.ScopedVar[nir.Fresh]
   protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]
@@ -49,17 +48,17 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
   protected var curScopes =
     new util.ScopedVar[mutable.Set[DebugInfo.LexicalScope]]
   protected val curFreshScope = new util.ScopedVar[nir.Fresh]
-  protected val curScopeId = new util.ScopedVar[ScopeId]
+  protected val curScopeId = new util.ScopedVar[nir.ScopeId]
   implicit protected def getScopeId: nir.ScopeId = curScopeId.get
-  protected def initFreshScope(rhs: Tree) = Fresh(rhs match {
+  protected def initFreshScope(rhs: Tree) = nir.Fresh(rhs match {
     case _: Block => -1L // Conpensate the top-level block
     case _        => 0L
   })
 
-  protected def unwind(implicit fresh: Fresh): Next =
-    curUnwindHandler.get.fold[Next](Next.None) { handler =>
-      val exc = Val.Local(fresh(), nir.Rt.Object)
-      Next.Unwind(exc, Next.Label(handler, Seq(exc)))
+  protected def unwind(implicit fresh: nir.Fresh): nir.Next =
+    curUnwindHandler.get.fold[nir.Next](nir.Next.None) { handler =>
+      val exc = nir.Val.Local(fresh(), nir.Rt.Object)
+      nir.Next.Unwind(exc, nir.Next.Label(handler, Seq(exc)))
     }
 
   override def newPhase(prev: Phase): StdPhase =

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -3,9 +3,7 @@ package nscplugin
 
 import scala.collection.mutable
 import scala.reflect.internal.Flags._
-import scala.scalanative.nir._
 import scala.scalanative.nir.Defn.Define.DebugInfo
-import scala.scalanative.nir.Defn.Define.DebugInfo._
 import scala.tools.nsc.Properties
 import scala.scalanative.util.unsupported
 import scala.scalanative.util.ScopedVar.scoped
@@ -33,25 +31,25 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
   def isStaticModule(sym: Symbol): Boolean =
     sym.isModuleClass && !sym.isLifted
 
-  class MethodEnv(val fresh: Fresh) {
-    private val env = mutable.Map.empty[Symbol, Val]
+  class MethodEnv(val fresh: nir.Fresh) {
+    private val env = mutable.Map.empty[Symbol, nir.Val]
 
-    def enter(sym: Symbol, value: Val): Unit = {
+    def enter(sym: Symbol, value: nir.Val): Unit = {
       env += ((sym, value))
     }
 
-    def enterLabel(ld: LabelDef): Local = {
+    def enterLabel(ld: LabelDef): nir.Local = {
       val local = fresh()
-      enter(ld.symbol, Val.Local(local, Type.Ptr))
+      enter(ld.symbol, nir.Val.Local(local, nir.Type.Ptr))
       local
     }
 
-    def resolve(sym: Symbol): Val = {
+    def resolve(sym: Symbol): nir.Val = {
       env(sym)
     }
 
-    def resolveLabel(ld: LabelDef): Local = {
-      val Val.Local(n, Type.Ptr) = resolve(ld.symbol)
+    def resolveLabel(ld: LabelDef): nir.Local = {
+      val nir.Val.Local(n, nir.Type.Ptr) = resolve(ld.symbol)
       n
     }
   }
@@ -108,11 +106,11 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val fields = genStructFields(sym)
       val body = cd.impl.body
 
-      buf += Defn.Class(attrs, name, None, Seq.empty)(cd.pos)
+      buf += nir.Defn.Class(attrs, name, None, Seq.empty)(cd.pos)
       genMethods(cd)
     }
 
-    def genStructAttrs(sym: Symbol): Attrs = Attrs.None
+    def genStructAttrs(sym: Symbol): nir.Attrs = nir.Attrs.None
 
     def genNormalClass(cd: ClassDef): Unit = {
       val sym = cd.symbol
@@ -124,9 +122,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       implicit val pos: nir.Position = cd.pos
 
       buf += {
-        if (sym.isScalaModule) Defn.Module(attrs, name, parent, traits)
-        else if (sym.isTraitOrInterface) Defn.Trait(attrs, name, traits)
-        else Defn.Class(attrs, name, parent, traits)
+        if (sym.isScalaModule) nir.Defn.Module(attrs, name, parent, traits)
+        else if (sym.isTraitOrInterface) nir.Defn.Trait(attrs, name, traits)
+        else nir.Defn.Class(attrs, name, parent, traits)
       }
 
       genReflectiveInstantiation(cd)
@@ -152,24 +150,24 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         Some(genTypeName(sym.superClass))
     }
 
-    def genClassAttrs(cd: ClassDef): Attrs = {
+    def genClassAttrs(cd: ClassDef): nir.Attrs = {
       val sym = cd.symbol
       val annotationAttrs = sym.annotations.collect {
         case ann if ann.symbol == ExternClass =>
-          Attr.Extern(sym.isBlocking)
+          nir.Attr.Extern(sym.isBlocking)
         case ann if ann.symbol == LinkClass =>
           val Apply(_, Seq(Literal(Constant(name: String)))) = ann.tree
-          Attr.Link(name)
+          nir.Attr.Link(name)
         case ann if ann.symbol == DefineClass =>
           val Apply(_, Seq(Literal(Constant(name: String)))) = ann.tree
-          Attr.Define(name)
+          nir.Attr.Define(name)
         case ann if ann.symbol == StubClass =>
-          Attr.Stub
+          nir.Attr.Stub
       }
       val abstractAttr =
-        if (sym.isAbstract) Seq(Attr.Abstract) else Seq.empty
+        if (sym.isAbstract) Seq(nir.Attr.Abstract) else Seq.empty
 
-      Attrs.fromSeq(annotationAttrs ++ abstractAttr)
+      nir.Attrs.fromSeq(annotationAttrs ++ abstractAttr)
     }
 
     def genClassInterfaces(sym: Symbol) = {
@@ -256,14 +254,14 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           align = getAlignmentAttr(f).orElse(classAlign)
         )
 
-        buf += Defn.Var(fieldAttrs, name, ty, Val.Zero(ty))(pos)
+        buf += nir.Defn.Var(fieldAttrs, name, ty, nir.Val.Zero(ty))(pos)
       }
     }
 
     def withFreshExprBuffer[R](f: ExprBuffer => R): R = {
       scoped(
-        curFresh := Fresh(),
-        curScopeId := ScopeId.TopLevel
+        curFresh := nir.Fresh(),
+        curScopeId := nir.ScopeId.TopLevel
       ) {
         val exprBuffer = new ExprBuffer()(curFresh)
         f(exprBuffer)
@@ -281,9 +279,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       if (enableReflectiveInstantiation) {
         scoped(
           curClassSym := cd.symbol,
-          curFresh := Fresh(),
+          curFresh := nir.Fresh(),
           curUnwindHandler := None,
-          curScopeId := ScopeId.TopLevel
+          curScopeId := nir.ScopeId.TopLevel
         ) {
           genRegisterReflectiveInstantiation(cd)
         }
@@ -306,10 +304,10 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       staticInitBody.foreach {
         case body if body.nonEmpty =>
-          buf += new Defn.Define(
-            Attrs(),
+          buf += new nir.Defn.Define(
+            nir.Attrs(),
             name,
-            nir.Type.Function(Seq.empty[nir.Type], Type.Unit),
+            nir.Type.Function(Seq.empty[nir.Type], nir.Type.Unit),
             body
           )(cd.pos)
         case _ => ()
@@ -320,30 +318,30 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     // which is expected to extend one of scala.runtime.AbstractFunctionX.
     private def genReflectiveInstantiationConstructor(
         reflInstBuffer: ReflectiveInstantiationBuffer,
-        superClass: Global.Top
+        superClass: nir.Global.Top
     )(implicit pos: nir.Position): Unit = {
       withFreshExprBuffer { exprBuf =>
         val body = {
           // first argument is this
-          val thisArg = Val.Local(curFresh(), Type.Ref(reflInstBuffer.name))
+          val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
           exprBuf.label(curFresh(), Seq(thisArg))
 
           // call to super constructor
           exprBuf.call(
-            Type.Function(Seq(Type.Ref(superClass)), Type.Unit),
-            Val.Global(superClass.member(Sig.Ctor(Seq.empty)), Type.Ptr),
+            nir.Type.Function(Seq(nir.Type.Ref(superClass)), nir.Type.Unit),
+            nir.Val.Global(superClass.member(nir.Sig.Ctor(Seq.empty)), nir.Type.Ptr),
             Seq(thisArg),
             unwind(curFresh)
           )
 
-          exprBuf.ret(Val.Unit)
+          exprBuf.ret(nir.Val.Unit)
           exprBuf.toSeq
         }
 
-        reflInstBuffer += new Defn.Define(
-          Attrs(),
-          reflInstBuffer.name.member(Sig.Ctor(Seq.empty)),
-          nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name)), Type.Unit),
+        reflInstBuffer += new nir.Defn.Define(
+          nir.Attrs(),
+          reflInstBuffer.name.member(nir.Sig.Ctor(Seq.empty)),
+          nir.Type.Function(Seq(nir.Type.Ref(reflInstBuffer.name)), nir.Type.Unit),
           body
         )
       }
@@ -352,15 +350,15 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     // Allocate and construct an object, using the provided ExprBuffer.
     private def allocAndConstruct(
         exprBuf: ExprBuffer,
-        name: Global.Top,
+        name: nir.Global.Top,
         argTypes: Seq[nir.Type],
-        args: Seq[Val]
-    )(implicit pos: nir.Position): Val = {
+        args: Seq[nir.Val]
+    )(implicit pos: nir.Position): nir.Val = {
 
       val alloc = exprBuf.classalloc(name, unwind(curFresh))
       exprBuf.call(
-        Type.Function(Type.Ref(name) +: argTypes, Type.Unit),
-        Val.Global(name.member(Sig.Ctor(argTypes)), Type.Ptr),
+        nir.Type.Function(nir.Type.Ref(name) +: argTypes, nir.Type.Unit),
+        nir.Val.Global(name.member(nir.Sig.Ctor(argTypes)), nir.Type.Ptr),
         alloc +: args,
         unwind(curFresh)
       )
@@ -369,20 +367,20 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genRegisterReflectiveInstantiationForModuleClass(
         cd: ClassDef
-    ): Seq[Inst] = {
+    ): Seq[nir.Inst] = {
       import NirGenSymbols._
 
       val fqSymId = curClassSym.fullName + "$"
-      val fqSymName = Global.Top(fqSymId)
+      val fqSymName = nir.Global.Top(fqSymId)
 
       implicit val pos: nir.Position = cd.pos
 
       reflectiveInstantiationInfo += ReflectiveInstantiationBuffer(fqSymId)
       val reflInstBuffer = reflectiveInstantiationInfo.last
 
-      def genModuleLoaderAnonFun(exprBuf: ExprBuffer): Val = {
+      def genModuleLoaderAnonFun(exprBuf: ExprBuffer): nir.Val = {
         val applyMethodSig =
-          Sig.Method("apply", Seq(jlObjectRef))
+          nir.Sig.Method("apply", Seq(jlObjectRef))
 
         // Generate the module loader class. The generated class extends
         // AbstractFunction0[Any], i.e. has an apply method, which loads the module.
@@ -390,7 +388,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         withFreshExprBuffer { exprBuf =>
           val body = {
             // first argument is this
-            val thisArg = Val.Local(curFresh(), Type.Ref(reflInstBuffer.name))
+            val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
             exprBuf.label(curFresh(), Seq(thisArg))
 
             val m = exprBuf.module(fqSymName, unwind(curFresh))
@@ -398,10 +396,10 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             exprBuf.toSeq
           }
 
-          reflInstBuffer += new Defn.Define(
-            Attrs(),
+          reflInstBuffer += new nir.Defn.Define(
+            nir.Attrs(),
             reflInstBuffer.name.member(applyMethodSig),
-            nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name)), jlObjectRef),
+            nir.Type.Function(Seq(nir.Type.Ref(reflInstBuffer.name)), jlObjectRef),
             body
           )
         }
@@ -412,8 +410,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           srAbstractFunction0
         )
 
-        reflInstBuffer += Defn.Class(
-          Attrs(),
+        reflInstBuffer += nir.Defn.Class(
+          nir.Attrs(),
           reflInstBuffer.name,
           Some(srAbstractFunction0),
           Seq(serializable)
@@ -426,8 +424,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       withFreshExprBuffer { exprBuf =>
         exprBuf.label(curFresh(), Seq.empty)
 
-        val fqcnArg = Val.String(fqSymId)
-        val runtimeClassArg = Val.ClassOf(fqSymName)
+        val fqcnArg = nir.Val.String(fqSymId)
+        val runtimeClassArg = nir.Val.ClassOf(fqSymName)
         val loadModuleFunArg = genModuleLoaderAnonFun(exprBuf)
 
         exprBuf.genApplyModuleMethod(
@@ -436,23 +434,23 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           Seq(fqcnArg, runtimeClassArg, loadModuleFunArg).map(ValTree(_))
         )
 
-        exprBuf.ret(Val.Unit)
+        exprBuf.ret(nir.Val.Unit)
         exprBuf.toSeq
       }
     }
 
     def genRegisterReflectiveInstantiationForNormalClass(
         cd: ClassDef
-    ): Seq[Inst] = {
+    ): Seq[nir.Inst] = {
       import NirGenSymbols._
 
       val fqSymId = curClassSym.fullName
-      val fqSymName = Global.Top(fqSymId)
+      val fqSymName = nir.Global.Top(fqSymId)
 
       // Create a new Tuple2 and initialise it with the provided values.
-      def createTuple2(exprBuf: ExprBuffer, _1: Val, _2: Val)(implicit
+      def createTuple2(exprBuf: ExprBuffer, _1: nir.Val, _2: nir.Val)(implicit
           pos: nir.Position
-      ): Val = {
+      ): nir.Val = {
         allocAndConstruct(
           exprBuf,
           tuple2,
@@ -464,17 +462,17 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       def genClassConstructorsInfo(
           exprBuf: ExprBuffer,
           ctors: Seq[global.Symbol]
-      )(implicit pos: nir.Position): Val = {
+      )(implicit pos: nir.Position): nir.Val = {
         val applyMethodSig =
-          Sig.Method("apply", Seq(jlObjectRef, jlObjectRef))
+          nir.Sig.Method("apply", Seq(jlObjectRef, jlObjectRef))
 
         // Constructors info is an array of Tuple2 (tpes, inst), where:
         // - tpes is an array with the runtime classes of the constructor arguments.
         // - inst is a function, which accepts an array with tpes and returns a new
         //   instance of the class.
         val ctorsInfo = exprBuf.arrayalloc(
-          Type.Array(tuple2Ref),
-          Val.Int(ctors.length),
+          nir.Type.Array(tuple2Ref),
+          nir.Val.Int(ctors.length),
           unwind(curFresh)
         )
 
@@ -497,9 +495,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           withFreshExprBuffer { exprBuf =>
             val body = {
               // first argument is this
-              val thisArg = Val.Local(curFresh(), Type.Ref(reflInstBuffer.name))
+              val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
               // second argument is parameters sequence
-              val argsArg = Val.Local(curFresh(), Type.Array(jlObjectRef))
+              val argsArg = nir.Val.Local(curFresh(), nir.Type.Array(jlObjectRef))
               exprBuf.label(curFresh(), Seq(thisArg, argsArg))
 
               // Extract and cast arguments to proper types.
@@ -509,12 +507,12 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                     exprBuf.arrayload(
                       jlObjectRef,
                       argsArg,
-                      Val.Int(argIdx),
+                      nir.Val.Int(argIdx),
                       unwind(curFresh)
                     )
                   // If the expected argument type can be boxed (i.e. is a primitive
                   // type), then we need to unbox it before passing it to C.
-                  Type.box.get(arg) match {
+                  nir.Type.box.get(arg) match {
                     case Some(bt) =>
                       exprBuf.unbox(bt, elem, unwind(curFresh))
                     case None =>
@@ -534,11 +532,11 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               exprBuf.toSeq
             }
 
-            reflInstBuffer += new Defn.Define(
-              Attrs(),
+            reflInstBuffer += new nir.Defn.Define(
+              nir.Attrs(),
               reflInstBuffer.name.member(applyMethodSig),
               nir.Type.Function(
-                Seq(Type.Ref(reflInstBuffer.name), Type.Array(jlObjectRef)),
+                Seq(nir.Type.Ref(reflInstBuffer.name), nir.Type.Array(jlObjectRef)),
                 jlObjectRef
               ),
               body
@@ -551,8 +549,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             srAbstractFunction1
           )
 
-          reflInstBuffer += Defn.Class(
-            Attrs(),
+          reflInstBuffer += nir.Defn.Class(
+            nir.Attrs(),
             reflInstBuffer.name,
             Some(srAbstractFunction1),
             Seq(serializable)
@@ -572,7 +570,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           // - the instantiator function created above (instantiator).
           val rtClasses = exprBuf.arrayalloc(
             jlClassRef,
-            Val.Int(ctorSig.args.tail.length),
+            nir.Val.Int(ctorSig.args.tail.length),
             unwind(curFresh)
           )
           for ((arg, argIdx) <- ctorSig.args.tail.zipWithIndex) {
@@ -580,8 +578,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             exprBuf.arraystore(
               jlClassRef,
               rtClasses,
-              Val.Int(argIdx),
-              Val.ClassOf(Type.typeToName(arg)),
+              nir.Val.Int(argIdx),
+              nir.Val.ClassOf(nir.Type.typeToName(arg)),
               unwind(curFresh)
             )
           }
@@ -592,7 +590,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           exprBuf.arraystore(
             tuple2Ref,
             ctorsInfo,
-            Val.Int(ctorIdx),
+            nir.Val.Int(ctorIdx),
             to,
             unwind(curFresh)
           )
@@ -617,8 +615,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         withFreshExprBuffer { exprBuf =>
           exprBuf.label(curFresh(), Seq.empty)
 
-          val fqcnArg = Val.String(fqSymId)
-          val runtimeClassArg = Val.ClassOf(fqSymName)
+          val fqcnArg = nir.Val.String(fqSymId)
+          val runtimeClassArg = nir.Val.ClassOf(fqSymName)
 
           val instantiateClassFunArg =
             genClassConstructorsInfo(exprBuf, ctors)
@@ -631,7 +629,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             )
           )
 
-          exprBuf.ret(Val.Unit)
+          exprBuf.ret(nir.Val.Unit)
           exprBuf.toSeq
         }
     }
@@ -647,7 +645,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def genMethod(dd: DefDef): Option[nir.Defn] = {
-      val fresh = Fresh()
+      val fresh = nir.Fresh()
       val env = new MethodEnv(fresh)
 
       implicit val pos: nir.Position = dd.pos
@@ -662,7 +660,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         curUnwindHandler := None,
         curMethodLocalNames := localNamesBuilder(),
         curFreshScope := initFreshScope(dd.rhs),
-        curScopeId := ScopeId.TopLevel,
+        curScopeId := nir.ScopeId.TopLevel,
         curScopes := scopes
       ) {
         val sym = dd.symbol
@@ -676,7 +674,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         dd.rhs match {
           case EmptyTree =>
             Some(
-              Defn.Declare(
+              nir.Defn.Declare(
                 attrs,
                 name,
                 if (attrs.isExtern) genExternMethodSig(sym) else sig
@@ -708,12 +706,12 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                   attrs.copy(isLinktimeResolved = true)
                 else attrs
               Some(
-                new Defn.Define(
+                new nir.Defn.Define(
                   methodAttrs,
                   name,
                   sig,
                   insts = body,
-                  debugInfo = Defn.Define.DebugInfo(
+                  debugInfo = nir.Defn.Define.DebugInfo(
                     localNames = curMethodLocalNames.get.toMap,
                     lexicalScopes = scopes.toList
                   )
@@ -724,7 +722,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    protected def genLinktimeResolved(dd: DefDef, name: Global.Member)(implicit
+    protected def genLinktimeResolved(dd: DefDef, name: nir.Global.Member)(implicit
         pos: nir.Position
     ): Option[nir.Defn] = {
       if (dd.symbol.isConstant) {
@@ -742,10 +740,10 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             checkExplicitReturnTypeAnnotation(dd, "value resolved at link-time")
             genLinktimeResolvedMethod(dd, retty, name) {
               _.call(
-                Linktime.PropertyResolveFunctionTy(retty),
-                Linktime.PropertyResolveFunction(retty),
-                Val.String(propertyName) :: Nil,
-                Next.None
+                nir.Linktime.PropertyResolveFunctionTy(retty),
+                nir.Linktime.PropertyResolveFunction(retty),
+                nir.Val.String(propertyName) :: Nil,
+                nir.Next.None
               )
             }
           }
@@ -798,7 +796,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         retty: nir.Type,
         methodName: nir.Global.Member
     )(genValue: ExprBuffer => nir.Val)(implicit pos: nir.Position): nir.Defn = {
-      implicit val fresh: Fresh = Fresh()
+      implicit val fresh = nir.Fresh()
       val buf = new ExprBuffer()
 
       scoped(
@@ -808,17 +806,17 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         curMethodEnv := new MethodEnv(fresh),
         curMethodInfo := new CollectMethodInfo,
         curUnwindHandler := None,
-        curScopeId := ScopeId.TopLevel
+        curScopeId := nir.ScopeId.TopLevel
       ) {
         buf.label(fresh())
         val value = genValue(buf)
         buf.ret(value)
       }
 
-      new Defn.Define(
-        Attrs(inlineHint = Attr.AlwaysInline, isLinktimeResolved = true),
+      new nir.Defn.Define(
+        nir.Attrs(inlineHint = nir.Attr.AlwaysInline, isLinktimeResolved = true),
         methodName,
-        Type.Function(Seq.empty, retty),
+        nir.Type.Function(Seq.empty, retty),
         buf.toSeq
       )
     }
@@ -832,7 +830,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val rhs = dd.rhs
       def externMethodDecl() = {
         val externSig = genExternMethodSig(curMethodSym)
-        val externDefn = Defn.Declare(attrs, name, externSig)(rhs.pos)
+        val externDefn = nir.Defn.Declare(attrs, name, externSig)(rhs.pos)
 
         Some(externDefn)
       }
@@ -842,7 +840,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       def isExternMethodAlias(target: Symbol) =
         (name, genName(target)) match {
-          case (Global.Member(_, lsig), Global.Member(_, rsig)) => lsig == rsig
+          case (nir.Global.Member(_, lsig), nir.Global.Member(_, rsig)) => lsig == rsig
           case _                                                => false
         }
       val defaultArgs = dd.symbol.paramss.flatten.filter(_.hasDefault)
@@ -932,26 +930,26 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
 
-    def genMethodAttrs(sym: Symbol, isExtern: Boolean): Attrs = {
+    def genMethodAttrs(sym: Symbol, isExtern: Boolean): nir.Attrs = {
       val inlineAttrs =
-        if (sym.isBridge || sym.hasFlag(ACCESSOR)) Seq(Attr.AlwaysInline)
+        if (sym.isBridge || sym.hasFlag(ACCESSOR)) Seq(nir.Attr.AlwaysInline)
         else Nil
 
       val annotatedAttrs =
         sym.annotations.map(_.symbol).collect {
-          case NoInlineClass     => Attr.NoInline
-          case AlwaysInlineClass => Attr.AlwaysInline
-          case InlineClass       => Attr.InlineHint
-          case StubClass         => Attr.Stub
-          case NoOptimizeClass   => Attr.NoOpt
-          case NoSpecializeClass => Attr.NoSpecialize
+          case NoInlineClass     => nir.Attr.NoInline
+          case AlwaysInlineClass => nir.Attr.AlwaysInline
+          case InlineClass       => nir.Attr.InlineHint
+          case StubClass         => nir.Attr.Stub
+          case NoOptimizeClass   => nir.Attr.NoOpt
+          case NoSpecializeClass => nir.Attr.NoSpecialize
         }
       val externAttrs =
         if (isExtern)
-          Seq(Attr.Extern(sym.isBlocking || sym.owner.isBlocking))
+          Seq(nir.Attr.Extern(sym.isBlocking || sym.owner.isBlocking))
         else Nil
 
-      Attrs.fromSeq(inlineAttrs ++ annotatedAttrs ++ externAttrs)
+      nir.Attrs.fromSeq(inlineAttrs ++ annotatedAttrs ++ externAttrs)
     }
 
     def genMethodBody(
@@ -971,11 +969,11 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val params = paramSyms.map {
         case None =>
           val ty = genType(curClassSym.tpe)
-          Val.Local(namedId(fresh)("this"), ty)
+          nir.Val.Local(namedId(fresh)("this"), ty)
         case Some(sym) =>
           val ty = genType(sym.tpe)
           val name = genLocalName(sym)
-          val param = Val.Local(namedId(fresh)(name), ty)
+          val param = nir.Val.Local(namedId(fresh)(name), ty)
           curMethodEnv.enter(sym, param)
           param
       }
@@ -989,12 +987,12 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         vars.foreach { sym =>
           val ty = genType(sym.info)
           val name = genLocalName(sym)
-          val slot = buf.let(namedId(fresh)(name), Op.Var(ty), unwind(fresh))
+          val slot = buf.let(namedId(fresh)(name), nir.Op.Var(ty), unwind(fresh))
           curMethodEnv.enter(sym, slot)
         }
       }
 
-      def withOptSynchronized(bodyGen: ExprBuffer => Val): Val = {
+      def withOptSynchronized(bodyGen: ExprBuffer => nir.Val): nir.Val = {
         if (!isSynchronized) bodyGen(buf)
         else {
           val syncedIn = curMethodThis.getOrElse {
@@ -1006,7 +1004,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         }
       }
 
-      def genBody(): Val = bodyp match {
+      def genBody(): nir.Val = bodyp match {
         // Tailrec emits magical labeldefs that can hijack this reference is
         // current method. This requires special treatment on our side.
         case Block(
@@ -1103,9 +1101,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
    *  Precondition: `isCandidateForForwarders(sym)` is true
    */
   private def genStaticForwardersForClassOrInterface(
-      existingMembers: Seq[Defn],
+      existingMembers: Seq[nir.Defn],
       sym: Symbol
-  ): Seq[Defn.Define] = {
+  ): Seq[nir.Defn.Define] = {
     /*  Phase travel is necessary for non-top-level classes, because flatten
      *  breaks their companionModule. This is tracked upstream at
      *  https://github.com/scala/scala-dev/issues/403
@@ -1124,13 +1122,13 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
    *  Precondition: `isCandidateForForwarders(moduleClass)` is true
    */
   private def genStaticForwardersFromModuleClass(
-      existingMembers: Seq[Defn],
+      existingMembers: Seq[nir.Defn],
       moduleClass: Symbol
-  ): Seq[Defn.Define] = {
+  ): Seq[nir.Defn.Define] = {
     assert(moduleClass.isModuleClass, moduleClass)
 
     lazy val existingStaticMethodNames = existingMembers.collect {
-      case nir.Defn.Define(_, name @ Global.Member(_, sig), _, _, _)
+      case nir.Defn.Define(_, name @ nir.Global.Member(_, sig), _, _, _)
           if sig.isStatic =>
         name
     }
@@ -1172,9 +1170,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       val methodName = genMethodName(sym)
       val forwarderName = genStaticMemberName(sym, moduleClass)
-      val Type.Function(_ +: paramTypes, retType) = genMethodSig(sym)
+      val nir.Type.Function(_ +: paramTypes, retType) = genMethodSig(sym)
       val forwarderParamTypes = paramTypes
-      val forwarderType = Type.Function(forwarderParamTypes, retType)
+      val forwarderType = nir.Type.Function(forwarderParamTypes, retType)
 
       if (existingStaticMethodNames.contains(forwarderName)) {
         reporter.error(
@@ -1187,8 +1185,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         )
       }
 
-      new Defn.Define(
-        attrs = Attrs(inlineHint = nir.Attr.InlineHint),
+      new nir.Defn.Define(
+        attrs = nir.Attrs(inlineHint = nir.Attr.InlineHint),
         name = forwarderName,
         ty = forwarderType,
         insts = curStatBuffer
@@ -1197,9 +1195,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             scoped(
               curUnwindHandler := None,
               curMethodThis := None,
-              curScopeId := ScopeId.TopLevel
+              curScopeId := nir.ScopeId.TopLevel
             ) {
-              val entryParams = forwarderParamTypes.map(Val.Local(fresh(), _))
+              val entryParams = forwarderParamTypes.map(nir.Val.Local(fresh(), _))
               buf.label(fresh(), entryParams)
               val res =
                 buf.genApplyModuleMethod(
@@ -1219,8 +1217,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
   private def genStaticMethodForwarders(
       td: ClassDef,
-      existingMethods: Seq[Defn]
-  ): Seq[Defn] = {
+      existingMethods: Seq[nir.Defn]
+  ): Seq[nir.Defn] = {
     val sym = td.symbol
     if (!isCandidateForForwarders(sym)) Nil
     else if (sym.isModuleClass) Nil
@@ -1241,10 +1239,10 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       sym.isModuleClass && !sym.isNestedClass
     }
     if (isTopLevelModuleClass && sym.companionClass == NoSymbol) {
-      val classDefn = Defn.Class(
-        attrs = Attrs.None,
-        name = Global.Top(genTypeName(sym).id.stripSuffix("$")),
-        parent = Some(Rt.Object.name),
+      val classDefn = nir.Defn.Class(
+        attrs = nir.Attrs.None,
+        name = nir.Global.Top(genTypeName(sym).id.stripSuffix("$")),
+        parent = Some(nir.Rt.Object.name),
         traits = Nil
       )(cd.pos)
       generatedMirrorClasses += sym -> MirrorClass(

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenSymbols.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenSymbols.scala
@@ -1,22 +1,25 @@
 package scala.scalanative
 
-import scala.scalanative.nir.Global
-import scala.scalanative.nir.Type
-
 object NirGenSymbols {
-  val serializable = Global.Top("java.io.Serializable")
 
-  val jlClass = Global.Top("java.lang.Class")
-  val jlClassRef = Type.Ref(jlClass)
+  val serializable = nir.Global.Top("java.io.Serializable")
 
-  val jlObject = Global.Top("java.lang.Object")
-  val jlObjectRef = Type.Ref(jlObject)
+  val jlClass = nir.Global.Top("java.lang.Class")
 
-  val tuple2 = Global.Top("scala.Tuple2")
-  val tuple2Ref = Type.Ref(tuple2)
+  val jlClassRef = nir.Type.Ref(jlClass)
+
+  val jlObject = nir.Global.Top("java.lang.Object")
+
+  val jlObjectRef = nir.Type.Ref(jlObject)
+
+  val tuple2 = nir.Global.Top("scala.Tuple2")
+
+  val tuple2Ref = nir.Type.Ref(tuple2)
 
   val srAbstractFunction0 =
-    Global.Top("scala.runtime.AbstractFunction0")
+    nir.Global.Top("scala.runtime.AbstractFunction0")
+
   val srAbstractFunction1 =
-    Global.Top("scala.runtime.AbstractFunction1")
+    nir.Global.Top("scala.runtime.AbstractFunction1")
+
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -3,8 +3,6 @@ package nscplugin
 
 import scala.tools.nsc.Global
 import scala.collection.mutable
-import scala.scalanative.nir.{Fresh, LocalName, Local}
-import scala.scalanative.util.ScopedVar
 
 trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
   import global._
@@ -15,10 +13,10 @@ trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
     if (isStatic) params else None +: params
   }
 
-  protected def localNamesBuilder(): mutable.Map[Local, LocalName] =
-    mutable.Map.empty[Local, LocalName]
+  protected def localNamesBuilder(): mutable.Map[nir.Local, nir.LocalName] =
+    mutable.Map.empty[nir.Local, nir.LocalName]
 
-  def namedId(fresh: Fresh)(name: LocalName): Local = {
+  def namedId(fresh: nir.Fresh)(name: nir.LocalName): nir.Local = {
     val id = fresh()
     curMethodLocalNames.get.update(id, name)
     id
@@ -39,7 +37,7 @@ trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
       srcPosition = srcPosition
     )
 
-    ScopedVar.scoped(
+    util.ScopedVar.scoped(
       curScopeId := blockScope
     )(f(parentScope))
   }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
@@ -3,9 +3,9 @@ package scala.scalanative
 package nscplugin
 
 import scala.collection.mutable
-import scala.scalanative.nir._
 
 class ReflectiveInstantiationBuffer(val fqcn: String) {
+
   private val buf = mutable.UnrolledBuffer.empty[nir.Defn]
 
   def +=(defn: nir.Defn): Unit = {
@@ -15,9 +15,13 @@ class ReflectiveInstantiationBuffer(val fqcn: String) {
   val name = nir.Global.Top(fqcn + "$SN$ReflectivelyInstantiate$")
 
   def nonEmpty = buf.nonEmpty
+
   def toSeq = buf.toSeq
+
 }
 
 object ReflectiveInstantiationBuffer {
+
   def apply(fqcn: String) = new ReflectiveInstantiationBuffer(fqcn)
+
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -15,8 +15,10 @@ import scala.scalanative.util.ScopedVar
 
 object GenReflectiveInstantisation {
   object nirSymbols {
-    val AbstractFunction0Name = nir.Global.Top("scala.runtime.AbstractFunction0")
-    val AbstractFunction1Name = nir.Global.Top("scala.runtime.AbstractFunction1")
+    val AbstractFunction0Name =
+      nir.Global.Top("scala.runtime.AbstractFunction0")
+    val AbstractFunction1Name =
+      nir.Global.Top("scala.runtime.AbstractFunction1")
     val SerializableName = nir.Global.Top("java.io.Serializable")
     val Tuple2Name = nir.Global.Top("scala.Tuple2")
     val Tuple2Ref = nir.Type.Ref(Tuple2Name)
@@ -163,12 +165,14 @@ trait GenReflectiveInstantisation(using Context) {
     withFreshExprBuffer { buf ?=>
       val body = {
         // first argument is this
-        val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
+        val thisArg =
+          nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
         buf.label(curFresh(), Seq(thisArg))
         // call to super constructor
         buf.call(
           nir.Type.Function(Seq(nir.Type.Ref(superClass)), nir.Type.Unit),
-          nir.Val.Global(superClass.member(nir.Sig.Ctor(Seq.empty)), nir.Type.Ptr),
+          nir.Val
+            .Global(superClass.member(nir.Sig.Ctor(Seq.empty)), nir.Type.Ptr),
           Seq(thisArg),
           unwind(curFresh)
         )
@@ -179,7 +183,8 @@ trait GenReflectiveInstantisation(using Context) {
       reflInstBuffer += new nir.Defn.Define(
         nir.Attrs(),
         reflInstBuffer.name.member(nir.Sig.Ctor(Seq.empty)),
-        nir.Type.Function(Seq(nir.Type.Ref(reflInstBuffer.name)), nir.Type.Unit),
+        nir.Type
+          .Function(Seq(nir.Type.Ref(reflInstBuffer.name)), nir.Type.Unit),
         body
       )
     }
@@ -217,11 +222,13 @@ trait GenReflectiveInstantisation(using Context) {
     withFreshExprBuffer { buf ?=>
       val body = {
         // first argument is this
-        val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
+        val thisArg =
+          nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
         buf.label(curFresh(), Seq(thisArg))
 
         val module =
-          if (enclosingClass.exists && !enclosingClass.is(ModuleClass)) nir.Val.Null
+          if (enclosingClass.exists && !enclosingClass.is(ModuleClass))
+            nir.Val.Null
           else buf.module(fqSymName, unwind(curFresh))
         buf.ret(module)
         buf.toSeq
@@ -230,7 +237,8 @@ trait GenReflectiveInstantisation(using Context) {
       reflInstBuffer += new nir.Defn.Define(
         nir.Attrs(),
         reflInstBuffer.name.member(applyMethodSig),
-        nir.Type.Function(Seq(nir.Type.Ref(reflInstBuffer.name)), nir.Rt.Object),
+        nir.Type
+          .Function(Seq(nir.Type.Ref(reflInstBuffer.name)), nir.Rt.Object),
         body
       )
     }
@@ -265,7 +273,8 @@ trait GenReflectiveInstantisation(using Context) {
       fqSymName: nir.Global.Top,
       ctors: Seq[Symbol]
   )(using pos: nir.Position, buf: ExprBuffer): nir.Val = {
-    val applyMethodSig = nir.Sig.Method("apply", Seq(nir.Rt.Object, nir.Rt.Object))
+    val applyMethodSig =
+      nir.Sig.Method("apply", Seq(nir.Rt.Object, nir.Rt.Object))
 
     // Constructors info is an array of Tuple2 (tpes, inst), where:
     // - tpes is an array with the runtime classes of the constructor arguments.
@@ -293,7 +302,8 @@ trait GenReflectiveInstantisation(using Context) {
       withFreshExprBuffer { buf ?=>
         val body = {
           // first argument is this
-          val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
+          val thisArg =
+            nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
           // second argument is parameters sequence
           val argsArg = nir.Val.Local(curFresh(), nir.Type.Array(nir.Rt.Object))
           buf.label(curFresh(), Seq(thisArg, argsArg))
@@ -332,7 +342,10 @@ trait GenReflectiveInstantisation(using Context) {
           nir.Attrs.None,
           reflInstBuffer.name.member(applyMethodSig),
           nir.Type.Function(
-            Seq(nir.Type.Ref(reflInstBuffer.name), nir.Type.Array(nir.Rt.Object)),
+            Seq(
+              nir.Type.Ref(reflInstBuffer.name),
+              nir.Type.Array(nir.Rt.Object)
+            ),
             nir.Rt.Object
           ),
           body

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.nscplugin
+package scala.scalanative
+package nscplugin
 
 import scala.language.implicitConversions
 
@@ -10,18 +11,15 @@ import core.StdNames._
 import core.Flags._
 
 import scala.collection.mutable
-import scala.scalanative.nir
-import nir._
 import scala.scalanative.util.ScopedVar
-import scala.scalanative.util.ScopedVar.{scoped, toValue}
 
 object GenReflectiveInstantisation {
   object nirSymbols {
-    val AbstractFunction0Name = Global.Top("scala.runtime.AbstractFunction0")
-    val AbstractFunction1Name = Global.Top("scala.runtime.AbstractFunction1")
-    val SerializableName = Global.Top("java.io.Serializable")
-    val Tuple2Name = Global.Top("scala.Tuple2")
-    val Tuple2Ref = Type.Ref(Tuple2Name)
+    val AbstractFunction0Name = nir.Global.Top("scala.runtime.AbstractFunction0")
+    val AbstractFunction1Name = nir.Global.Top("scala.runtime.AbstractFunction1")
+    val SerializableName = nir.Global.Top("java.io.Serializable")
+    val Tuple2Name = nir.Global.Top("scala.Tuple2")
+    val Tuple2Ref = nir.Type.Ref(Tuple2Name)
   }
 }
 
@@ -52,10 +50,10 @@ trait GenReflectiveInstantisation(using Context) {
         )
 
     if (enableReflectiveInstantiation) {
-      scoped(
+      ScopedVar.scoped(
         curClassSym := sym,
-        curFresh := Fresh(),
-        curScopeId := ScopeId.TopLevel,
+        curFresh := nir.Fresh(),
+        curScopeId := nir.ScopeId.TopLevel,
         curUnwindHandler := None,
         curMethodThis := None
       ) {
@@ -82,10 +80,10 @@ trait GenReflectiveInstantisation(using Context) {
     staticInitBody
       .filter(_.nonEmpty)
       .foreach { body =>
-        generatedDefns += new Defn.Define(
-          Attrs(),
+        generatedDefns += new nir.Defn.Define(
+          nir.Attrs(),
           name,
-          nir.Type.Function(Seq.empty[nir.Type], Type.Unit),
+          nir.Type.Function(Seq.empty[nir.Type], nir.Type.Unit),
           body
         )
       }
@@ -93,11 +91,11 @@ trait GenReflectiveInstantisation(using Context) {
 
   private def registerModuleClass(
       td: TypeDef
-  ): Seq[Inst] = {
+  ): Seq[nir.Inst] = {
     val fqSymId = curClassSym.get.fullName.mangledString
-    val fqSymName = Global.Top(fqSymId)
-    val fqcnArg = Val.String(fqSymId)
-    val runtimeClassArg = Val.ClassOf(fqSymName)
+    val fqSymName = nir.Global.Top(fqSymId)
+    val fqcnArg = nir.Val.String(fqSymId)
+    val runtimeClassArg = nir.Val.ClassOf(fqSymName)
 
     given nir.Position = td.span
     given reflInstBuffer: ReflectiveInstantiationBuffer =
@@ -112,20 +110,20 @@ trait GenReflectiveInstantisation(using Context) {
         defnNir.Reflect_registerLoadableModuleClass,
         Seq(fqcnArg, runtimeClassArg, loadModuleFunArg).map(ValTree(_))
       )
-      buf.ret(Val.Unit)
+      buf.ret(nir.Val.Unit)
       buf.toSeq
     }
   }
 
   private def registerNormalClass(
       td: TypeDef
-  ): Seq[Inst] = {
+  ): Seq[nir.Inst] = {
     given nir.Position = td.span
 
     val fqSymId = curClassSym.get.fullName.mangledString
-    val fqSymName = Global.Top(fqSymId)
-    val fqcnArg = Val.String(fqSymId)
-    val runtimeClassArg = Val.ClassOf(fqSymName)
+    val fqSymName = nir.Global.Top(fqSymId)
+    val fqcnArg = nir.Val.String(fqSymId)
+    val runtimeClassArg = nir.Val.ClassOf(fqSymName)
 
     // Collect public constructors.
     val ctors =
@@ -150,7 +148,7 @@ trait GenReflectiveInstantisation(using Context) {
           Seq(fqcnArg, runtimeClassArg, instantiateClassFunArg)
             .map(ValTree(_))
         )
-        buf.ret(Val.Unit)
+        buf.ret(nir.Val.Unit)
         buf.toSeq
       }
   }
@@ -158,30 +156,30 @@ trait GenReflectiveInstantisation(using Context) {
   // Generate the constructor for the class instantiator class,
   // which is expected to extend one of scala.runtime.AbstractFunctionX.
   private def genConstructor(
-      superClass: Global.Top
+      superClass: nir.Global.Top
   )(using
       nir.Position
   )(using reflInstBuffer: ReflectiveInstantiationBuffer): Unit = {
     withFreshExprBuffer { buf ?=>
       val body = {
         // first argument is this
-        val thisArg = Val.Local(curFresh(), Type.Ref(reflInstBuffer.name))
+        val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
         buf.label(curFresh(), Seq(thisArg))
         // call to super constructor
         buf.call(
-          Type.Function(Seq(Type.Ref(superClass)), Type.Unit),
-          Val.Global(superClass.member(Sig.Ctor(Seq.empty)), Type.Ptr),
+          nir.Type.Function(Seq(nir.Type.Ref(superClass)), nir.Type.Unit),
+          nir.Val.Global(superClass.member(nir.Sig.Ctor(Seq.empty)), nir.Type.Ptr),
           Seq(thisArg),
           unwind(curFresh)
         )
-        buf.ret(Val.Unit)
+        buf.ret(nir.Val.Unit)
         buf.toSeq
       }
 
-      reflInstBuffer += new Defn.Define(
-        Attrs(),
-        reflInstBuffer.name.member(Sig.Ctor(Seq.empty)),
-        nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name)), Type.Unit),
+      reflInstBuffer += new nir.Defn.Define(
+        nir.Attrs(),
+        reflInstBuffer.name.member(nir.Sig.Ctor(Seq.empty)),
+        nir.Type.Function(Seq(nir.Type.Ref(reflInstBuffer.name)), nir.Type.Unit),
         body
       )
     }
@@ -189,14 +187,14 @@ trait GenReflectiveInstantisation(using Context) {
 
 // Allocate and construct an object, using the provided ExprBuffer.
   private def allocAndConstruct(
-      name: Global.Top,
+      name: nir.Global.Top,
       argTypes: Seq[nir.Type],
-      args: Seq[Val]
-  )(using pos: nir.Position, buf: ExprBuffer): Val = {
+      args: Seq[nir.Val]
+  )(using pos: nir.Position, buf: ExprBuffer): nir.Val = {
     val alloc = buf.classalloc(name, unwind(curFresh))
     buf.call(
-      Type.Function(Type.Ref(name) +: argTypes, Type.Unit),
-      Val.Global(name.member(Sig.Ctor(argTypes)), Type.Ptr),
+      nir.Type.Function(nir.Type.Ref(name) +: argTypes, nir.Type.Unit),
+      nir.Val.Global(name.member(nir.Sig.Ctor(argTypes)), nir.Type.Ptr),
       alloc +: args,
       unwind(curFresh)
     )
@@ -204,13 +202,13 @@ trait GenReflectiveInstantisation(using Context) {
   }
 
   private def genModuleLoader(
-      fqSymName: Global.Top
+      fqSymName: nir.Global.Top
   )(using
       pos: nir.Position,
       buf: ExprBuffer,
       reflInstBuffer: ReflectiveInstantiationBuffer
-  ): Val = {
-    val applyMethodSig = Sig.Method("apply", Seq(Rt.Object))
+  ): nir.Val = {
+    val applyMethodSig = nir.Sig.Method("apply", Seq(nir.Rt.Object))
     val enclosingClass = curClassSym.get.originalOwner
 
     // Generate the module loader class. The generated class extends
@@ -219,20 +217,20 @@ trait GenReflectiveInstantisation(using Context) {
     withFreshExprBuffer { buf ?=>
       val body = {
         // first argument is this
-        val thisArg = Val.Local(curFresh(), Type.Ref(reflInstBuffer.name))
+        val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
         buf.label(curFresh(), Seq(thisArg))
 
         val module =
-          if (enclosingClass.exists && !enclosingClass.is(ModuleClass)) Val.Null
+          if (enclosingClass.exists && !enclosingClass.is(ModuleClass)) nir.Val.Null
           else buf.module(fqSymName, unwind(curFresh))
         buf.ret(module)
         buf.toSeq
       }
 
-      reflInstBuffer += new Defn.Define(
-        Attrs(),
+      reflInstBuffer += new nir.Defn.Define(
+        nir.Attrs(),
         reflInstBuffer.name.member(applyMethodSig),
-        nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name)), Rt.Object),
+        nir.Type.Function(Seq(nir.Type.Ref(reflInstBuffer.name)), nir.Rt.Object),
         body
       )
     }
@@ -240,8 +238,8 @@ trait GenReflectiveInstantisation(using Context) {
     // Generate the module loader class constructor.
     genConstructor(nirSymbols.AbstractFunction0Name)
 
-    reflInstBuffer += Defn.Class(
-      Attrs(),
+    reflInstBuffer += nir.Defn.Class(
+      nir.Attrs(),
       reflInstBuffer.name,
       Some(nirSymbols.AbstractFunction0Name),
       Seq(nirSymbols.SerializableName)
@@ -252,30 +250,30 @@ trait GenReflectiveInstantisation(using Context) {
   }
 
   // Create a new Tuple2 and initialise it with the provided values.
-  private def createTuple(arg1: Val, arg2: Val)(using
+  private def createTuple(arg1: nir.Val, arg2: nir.Val)(using
       nir.Position,
       ExprBuffer
-  ): Val = {
+  ): nir.Val = {
     allocAndConstruct(
       nirSymbols.Tuple2Name,
-      Seq(Rt.Object, Rt.Object),
+      Seq(nir.Rt.Object, nir.Rt.Object),
       Seq(arg1, arg2)
     )
   }
 
   private def genClassConstructorsInfo(
-      fqSymName: Global.Top,
+      fqSymName: nir.Global.Top,
       ctors: Seq[Symbol]
-  )(using pos: nir.Position, buf: ExprBuffer): Val = {
-    val applyMethodSig = Sig.Method("apply", Seq(Rt.Object, Rt.Object))
+  )(using pos: nir.Position, buf: ExprBuffer): nir.Val = {
+    val applyMethodSig = nir.Sig.Method("apply", Seq(nir.Rt.Object, nir.Rt.Object))
 
     // Constructors info is an array of Tuple2 (tpes, inst), where:
     // - tpes is an array with the runtime classes of the constructor arguments.
     // - inst is a function, which accepts an array with tpes and returns a new
     //   instance of the class.
     val ctorsInfo = buf.arrayalloc(
-      Type.Array(nirSymbols.Tuple2Ref),
-      Val.Int(ctors.length),
+      nir.Type.Array(nirSymbols.Tuple2Ref),
+      nir.Val.Int(ctors.length),
       unwind(curFresh)
     )
 
@@ -295,9 +293,9 @@ trait GenReflectiveInstantisation(using Context) {
       withFreshExprBuffer { buf ?=>
         val body = {
           // first argument is this
-          val thisArg = Val.Local(curFresh(), Type.Ref(reflInstBuffer.name))
+          val thisArg = nir.Val.Local(curFresh(), nir.Type.Ref(reflInstBuffer.name))
           // second argument is parameters sequence
-          val argsArg = Val.Local(curFresh(), Type.Array(Rt.Object))
+          val argsArg = nir.Val.Local(curFresh(), nir.Type.Array(nir.Rt.Object))
           buf.label(curFresh(), Seq(thisArg, argsArg))
 
           // Extract and cast arguments to proper types.
@@ -306,14 +304,14 @@ trait GenReflectiveInstantisation(using Context) {
             yield {
               val elem =
                 buf.arrayload(
-                  Rt.Object,
+                  nir.Rt.Object,
                   argsArg,
-                  Val.Int(argIdx),
+                  nir.Val.Int(argIdx),
                   unwind(curFresh)
                 )
               // If the expected argument type can be boxed (i.e. is a primitive
               // type), then we need to unbox it before passing it to C.
-              Type.box.get(arg) match {
+              nir.Type.box.get(arg) match {
                 case Some(bt) => buf.unbox(bt, elem, unwind(curFresh))
                 case None     => buf.as(arg, elem, unwind(curFresh))
               }
@@ -330,12 +328,12 @@ trait GenReflectiveInstantisation(using Context) {
           buf.toSeq
         }
 
-        reflInstBuffer += new Defn.Define(
-          Attrs.None,
+        reflInstBuffer += new nir.Defn.Define(
+          nir.Attrs.None,
           reflInstBuffer.name.member(applyMethodSig),
           nir.Type.Function(
-            Seq(Type.Ref(reflInstBuffer.name), Type.Array(Rt.Object)),
-            Rt.Object
+            Seq(nir.Type.Ref(reflInstBuffer.name), nir.Type.Array(nir.Rt.Object)),
+            nir.Rt.Object
           ),
           body
         )
@@ -344,8 +342,8 @@ trait GenReflectiveInstantisation(using Context) {
       // Generate the class instantiator constructor.
       genConstructor(nirSymbols.AbstractFunction1Name)
 
-      reflInstBuffer += Defn.Class(
-        Attrs(),
+      reflInstBuffer += nir.Defn.Class(
+        nir.Attrs(),
         reflInstBuffer.name,
         Some(nirSymbols.AbstractFunction1Name),
         Seq(nirSymbols.SerializableName)
@@ -359,17 +357,17 @@ trait GenReflectiveInstantisation(using Context) {
       // - an array with the runtime classes of the ctor parameters.
       // - the instantiator function created above (instantiator).
       val rtClasses = buf.arrayalloc(
-        Rt.Class,
-        Val.Int(ctorSig.args.tail.length),
+        nir.Rt.Class,
+        nir.Val.Int(ctorSig.args.tail.length),
         unwind(curFresh)
       )
       for ((arg, argIdx) <- ctorSig.args.tail.zipWithIndex) {
         // Store the runtime class in the array.
         buf.arraystore(
-          Rt.Class,
+          nir.Rt.Class,
           rtClasses,
-          Val.Int(argIdx),
-          Val.ClassOf(Type.typeToName(arg)),
+          nir.Val.Int(argIdx),
+          nir.Val.ClassOf(nir.Type.typeToName(arg)),
           unwind(curFresh)
         )
       }
@@ -380,7 +378,7 @@ trait GenReflectiveInstantisation(using Context) {
       buf.arraystore(
         nirSymbols.Tuple2Ref,
         ctorsInfo,
-        Val.Int(ctorIdx),
+        nir.Val.Int(ctorIdx),
         to,
         unwind(curFresh)
       )

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package nscplugin
 
 import scala.scalanative.util
-import nir.Defn.Define.DebugInfo
+import scalanative.nir.Defn.Define.DebugInfo
 import scalanative.nir.serialization.serializeBinary
 
 import dotty.tools.dotc.{CompilationUnit, report}

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -1,7 +1,7 @@
-package scala.scalanative.nscplugin
+package scala.scalanative
+package nscplugin
 
 import scala.scalanative.util
-import scala.scalanative.nir
 import nir.Defn.Define.DebugInfo
 import scalanative.nir.serialization.serializeBinary
 
@@ -26,7 +26,6 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
     with GenReflectiveInstantisation
     with GenNativeExports:
   import tpd._
-  import nir._
 
   protected val defnNir = NirDefinitions.get
   protected val nirPrimitives = new NirPrimitives()
@@ -43,7 +42,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected val curMethodEnv = new util.ScopedVar[MethodEnv]
   protected val curMethodLabels = new util.ScopedVar[MethodLabelsEnv]
   protected val curMethodLocalNames =
-    new util.ScopedVar[mutable.Map[Local, LocalName]]
+    new util.ScopedVar[mutable.Map[nir.Local, nir.LocalName]]
   protected val curMethodThis = new util.ScopedVar[Option[nir.Val]]
   protected val curMethodIsExtern = new util.ScopedVar[Boolean]
   protected var curMethodUsesLinktimeResolvedValues = false
@@ -52,13 +51,13 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected var curScopes =
     new util.ScopedVar[mutable.Set[DebugInfo.LexicalScope]]
   protected val curFreshScope = new util.ScopedVar[nir.Fresh]
-  protected val curScopeId = new util.ScopedVar[ScopeId]
+  protected val curScopeId = new util.ScopedVar[nir.ScopeId]
   implicit protected def getScopeId: nir.ScopeId = {
     val res = curScopeId.get
-    assert(res.id >= ScopeId.TopLevel.id)
+    assert(res.id >= nir.ScopeId.TopLevel.id)
     res
   }
-  protected def initFreshScope(rhs: Tree) = Fresh(rhs match {
+  protected def initFreshScope(rhs: Tree) = nir.Fresh(rhs match {
     // Conpensate the top-level block
     case Block(stats, _) => -1L
     case _               => 0L
@@ -68,11 +67,11 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
 
   protected val lazyValsAdapter = AdaptLazyVals(defnNir)
 
-  protected def unwind(implicit fresh: Fresh): Next =
+  protected def unwind(implicit fresh: nir.Fresh): nir.Next =
     curUnwindHandler.get
-      .fold[Next](Next.None) { handler =>
-        val exc = Val.Local(fresh(), nir.Rt.Object)
-        Next.Unwind(exc, Next.Label(handler, Seq(exc)))
+      .fold[nir.Next](nir.Next.None) { handler =>
+        val exc = nir.Val.Local(fresh(), nir.Rt.Object)
+        nir.Next.Unwind(exc, nir.Next.Label(handler, Seq(exc)))
       }
 
   def run(): Unit = {
@@ -129,7 +128,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
 
       val generatedCaseInsensitiveNames =
         generatedDefns.collect {
-          case cls: Defn.Class => caseInsensitiveNameOf(cls)
+          case cls: nir.Defn.Class => caseInsensitiveNameOf(cls)
         }.toSet
 
       for ((site, staticCls) <- generatedMirrorClasses) {
@@ -169,8 +168,8 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   }
 
   class MethodLabelsEnv(val fresh: nir.Fresh) {
-    private val entries, exits = mutable.Map.empty[Symbol, Local]
-    private val exitTypes = mutable.Map.empty[Local, nir.Type]
+    private val entries, exits = mutable.Map.empty[Symbol, nir.Local]
+    private val exitTypes = mutable.Map.empty[nir.Local, nir.Type]
 
     def enterLabel(ld: Labeled): (nir.Local, nir.Local) = {
       val sym = ld.bind.symbol
@@ -201,9 +200,9 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
       local
     }
 
-    def resolve(sym: Symbol): Val = env(sym)
-    def resolveLabel(ld: Labeled): Local = {
-      val Val.Local(n, Type.Ptr) = resolve(ld.bind.symbol): @unchecked
+    def resolve(sym: Symbol): nir.Val = env(sym)
+    def resolveLabel(ld: Labeled): nir.Local = {
+      val nir.Val.Local(n, nir.Type.Ptr) = resolve(ld.bind.symbol): @unchecked
       n
     }
   }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.nscplugin
+package scala.scalanative
+package nscplugin
 
 import scala.language.implicitConversions
 import scala.annotation.{tailrec, switch}
@@ -25,9 +26,7 @@ import transform.SymUtils._
 import transform.{ValueClasses, Erasure}
 import dotty.tools.backend.jvm.DottyBackendInterface.symExtensions
 
-import scala.scalanative.nir
-import nir._
-import nir.Defn.Define.DebugInfo
+import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ScopedVar.scoped
 import scala.scalanative.util.unsupported
 import scala.scalanative.util.StringUtils
@@ -43,12 +42,12 @@ trait NirGenExpr(using Context) {
   sealed case class ValTree(value: nir.Val) extends Tree
   sealed case class ContTree(f: () => nir.Val) extends Tree
 
-  class ExprBuffer(using fresh: Fresh) extends FixupBuffer {
+  class ExprBuffer(using fresh: nir.Fresh) extends FixupBuffer {
     buf =>
 
-    def genExpr(tree: Tree): Val = {
+    def genExpr(tree: Tree): nir.Val = {
       tree match {
-        case EmptyTree      => Val.Unit
+        case EmptyTree      => nir.Val.Unit
         case ValTree(value) => value
         case ContTree(f)    => f()
         case tree: Apply =>
@@ -81,9 +80,9 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    object SafeZoneInstance extends Property.Key[Val]
+    object SafeZoneInstance extends Property.Key[nir.Val]
 
-    def genApply(app: Apply): Val = {
+    def genApply(app: Apply): nir.Val = {
       given nir.Position = app.span
       val Apply(fun, args) = app
 
@@ -95,7 +94,7 @@ trait NirGenExpr(using Context) {
 
       inline def fail(msg: String)(using Context) = {
         report.error(msg, app.srcPos)
-        Val.Null
+        nir.Val.Null
       }
       fun match {
         case _ if sym == defnNir.UnsafePackage_extern =>
@@ -134,7 +133,7 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    def genAssign(tree: Assign): Val = {
+    def genAssign(tree: Assign): nir.Val = {
       val Assign(lhsp, rhsp) = tree
       given nir.Position = tree.span
 
@@ -149,7 +148,7 @@ trait NirGenExpr(using Context) {
             val shouldIgnoreAssign =
               curMethodSym.get.isClassConstructor &&
                 rhsp.symbol == defnNir.UnsafePackage_extern
-            if (shouldIgnoreAssign) Val.Unit
+            if (shouldIgnoreAssign) nir.Val.Unit
             else {
               val externTy = genExternType(sel.tpe)
               genStoreExtern(externTy, sym, rhs)
@@ -169,7 +168,7 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    def genBlock(block: Block): Val = {
+    def genBlock(block: Block): nir.Val = {
       val Block(stats, last) = block
 
       def isCaseLabelDef(tree: Tree) =
@@ -223,7 +222,7 @@ trait NirGenExpr(using Context) {
     //   }
     //
     // Bridges might require multiple samMethod variants to be created.
-    def genClosure(tree: Closure): Val = {
+    def genClosure(tree: Closure): nir.Val = {
       given nir.Position = tree.span
       val Closure(env, fun, functionalInterface) = tree
       val treeTpe = tree.tpe.typeSymbol
@@ -231,7 +230,7 @@ trait NirGenExpr(using Context) {
       val funInterfaceSym = functionalInterface.tpe.typeSymbol
 
       val anonClassName = {
-        val Global.Top(className) = genTypeName(curClassSym)
+        val nir.Global.Top(className) = genTypeName(curClassSym)
         val suffix = "$$Lambda$" + curClassFresh.get.apply().id
         nir.Global.Top(className + suffix)
       }
@@ -265,7 +264,7 @@ trait NirGenExpr(using Context) {
           }
 
         nir.Defn.Class(
-          attrs = Attrs.None,
+          attrs = nir.Attrs.None,
           name = anonClassName,
           parent = Some(nir.Rt.Object.name),
           traits = traits
@@ -275,17 +274,17 @@ trait NirGenExpr(using Context) {
       def genCaptureFields: List[nir.Defn] = {
         for (tpe, name) <- captureTypesAndNames
         yield nir.Defn.Var(
-          attrs = Attrs.None,
+          attrs = nir.Attrs.None,
           name = name,
           ty = tpe,
-          rhs = Val.Zero(tpe)
+          rhs = nir.Val.Zero(tpe)
         )
       }
 
-      val ctorName = anonClassName.member(Sig.Ctor(captureTypes))
+      val ctorName = anonClassName.member(nir.Sig.Ctor(captureTypes))
       val ctorTy = nir.Type.Function(
-        Type.Ref(anonClassName) +: captureTypes,
-        Type.Unit
+        nir.Type.Ref(anonClassName) +: captureTypes,
+        nir.Type.Unit
       )
 
       def genAnonymousClassCtor: nir.Defn = {
@@ -293,27 +292,27 @@ trait NirGenExpr(using Context) {
           scoped(
             curScopeId := nir.ScopeId.TopLevel
           ) {
-            val fresh = Fresh()
+            val fresh = nir.Fresh()
             val buf = new nir.Buffer()(fresh)
 
-            val superTy = nir.Type.Function(Seq(Rt.Object), Type.Unit)
-            val superName = Rt.Object.name.member(Sig.Ctor(Seq.empty))
-            val superCtor = Val.Global(superName, Type.Ptr)
+            val superTy = nir.Type.Function(Seq(nir.Rt.Object), nir.Type.Unit)
+            val superName = nir.Rt.Object.name.member(nir.Sig.Ctor(Seq.empty))
+            val superCtor = nir.Val.Global(superName, nir.Type.Ptr)
 
-            val self = Val.Local(fresh(), Type.Ref(anonClassName))
-            val captureFormals = captureTypes.map(Val.Local(fresh(), _))
+            val self = nir.Val.Local(fresh(), nir.Type.Ref(anonClassName))
+            val captureFormals = captureTypes.map(nir.Val.Local(fresh(), _))
             buf.label(fresh(), self +: captureFormals)
-            buf.call(superTy, superCtor, Seq(self), Next.None)
+            buf.call(superTy, superCtor, Seq(self), nir.Next.None)
             captureNames.zip(captureFormals).foreach { (name, capture) =>
-              buf.fieldstore(capture.ty, self, name, capture, Next.None)
+              buf.fieldstore(capture.ty, self, name, capture, nir.Next.None)
             }
-            buf.ret(Val.Unit)
+            buf.ret(nir.Val.Unit)
 
             buf.toSeq
           }
         }
 
-        new nir.Defn.Define(Attrs.None, ctorName, ctorTy, body)
+        new nir.Defn.Define(nir.Attrs.None, ctorName, ctorTy, body)
       }
 
       def resolveAnonClassMethods: List[Symbol] = {
@@ -327,30 +326,30 @@ trait NirGenExpr(using Context) {
       }
 
       def genAnonClassMethod(sym: Symbol): nir.Defn = {
-        val Global.Member(_, funSig) = genName(sym): @unchecked
-        val Sig.Method(_, sigTypes :+ retType, _) = funSig.unmangled: @unchecked
+        val nir.Global.Member(_, funSig) = genName(sym): @unchecked
+        val nir.Sig.Method(_, sigTypes :+ retType, _) = funSig.unmangled: @unchecked
 
-        val selfType = Type.Ref(anonClassName)
+        val selfType = nir.Type.Ref(anonClassName)
         val methodName = anonClassName.member(funSig)
         val paramTypes = selfType +: sigTypes
         val paramSyms = funSym.paramSymss.flatten
 
         def genBody = {
-          given fresh: Fresh = Fresh()
+          given fresh: nir.Fresh = nir.Fresh()
           val freshScopes = initFreshScope(EmptyTree)
           given buf: ExprBuffer = new ExprBuffer()
           scoped(
             curFresh := fresh,
             curFreshScope := freshScopes,
-            curScopeId := ScopeId.of(freshScopes.last),
+            curScopeId := nir.ScopeId.of(freshScopes.last),
             curExprBuffer := buf,
             curMethodEnv := MethodEnv(fresh),
             curMethodLabels := MethodLabelsEnv(fresh),
             curMethodInfo := CollectMethodInfo(),
             curUnwindHandler := None
           ) {
-            val self = Val.Local(fresh(), selfType)
-            val params = sigTypes.map(Val.Local(fresh(), _))
+            val self = nir.Val.Local(fresh(), selfType)
+            val params = sigTypes.map(nir.Val.Local(fresh(), _))
 
             buf.label(fresh(), self +: params)
             // At this point, the type parameter symbols are all Objects.
@@ -400,9 +399,9 @@ trait NirGenExpr(using Context) {
         }
 
         new nir.Defn.Define(
-          Attrs.None,
+          nir.Attrs.None,
           methodName,
-          Type.Function(paramTypes, retType),
+          nir.Type.Function(paramTypes, retType),
           genBody
         )
       }
@@ -423,7 +422,7 @@ trait NirGenExpr(using Context) {
         val captures = allCaptureValues.map(genExpr)
         buf.call(
           ctorTy,
-          Val.Global(ctorName, Type.Ptr),
+          nir.Val.Global(ctorName, nir.Type.Ptr),
           alloc +: captures,
           unwind
         )
@@ -432,7 +431,7 @@ trait NirGenExpr(using Context) {
       allocateClosure()
     }
 
-    def genIdent(tree: Ident): Val =
+    def genIdent(tree: Ident): nir.Val =
       desugarIdent(tree) match {
         case Ident(_) =>
           val sym = tree.symbol
@@ -448,7 +447,7 @@ trait NirGenExpr(using Context) {
           throw FatalError(s"Unsupported desugared ident tree: $tree")
       }
 
-    def genIf(tree: If): Val = {
+    def genIf(tree: If): nir.Val = {
       given nir.Position = tree.span
       val If(cond, thenp, elsep) = tree
       val retty = genType(tree.tpe)
@@ -463,16 +462,16 @@ trait NirGenExpr(using Context) {
         ensureLinktime: Boolean = false
     )(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       val thenn, elsen, mergen = fresh()
-      val mergev = Val.Local(fresh(), retty)
+      val mergev = nir.Val.Local(fresh(), retty)
 
       locally {
         given nir.Position = condp.span
         getLinktimeCondition(condp) match {
           case Some(cond) =>
             curMethodUsesLinktimeResolvedValues = true
-            buf.branchLinktime(cond, Next(thenn), Next(elsen))
+            buf.branchLinktime(cond, nir.Next(thenn), nir.Next(elsen))
           case None =>
             if ensureLinktime then
               report.error(
@@ -480,7 +479,7 @@ trait NirGenExpr(using Context) {
                 condp.srcPos
               )
             val cond = genExpr(condp)
-            buf.branch(cond, Next(thenn), Next(elsen))(using condp.span)
+            buf.branch(cond, nir.Next(thenn), nir.Next(elsen))(using condp.span)
         }
       }
 
@@ -499,7 +498,7 @@ trait NirGenExpr(using Context) {
       buf.labelExcludeUnitValue(mergen, mergev)
     }
 
-    def genJavaSeqLiteral(tree: JavaSeqLiteral): Val = {
+    def genJavaSeqLiteral(tree: JavaSeqLiteral): nir.Val = {
       val JavaArrayType(elemTpe) = tree.tpe: @unchecked
 
       val elems = tree.elems
@@ -508,25 +507,25 @@ trait NirGenExpr(using Context) {
       given nir.Position = tree.span
 
       if (values.forall(_.isCanonical) && values.exists(v => !v.isZero))
-        buf.arrayalloc(elemty, Val.ArrayValue(elemty, values), unwind)
+        buf.arrayalloc(elemty, nir.Val.ArrayValue(elemty, values), unwind)
       else
-        val alloc = buf.arrayalloc(elemty, Val.Int(values.length), unwind)
+        val alloc = buf.arrayalloc(elemty, nir.Val.Int(values.length), unwind)
         for (v, i) <- values.zipWithIndex if !v.isZero do
           given nir.Position = elems(i).span
-          buf.arraystore(elemty, alloc, Val.Int(i), v, unwind)
+          buf.arraystore(elemty, alloc, nir.Val.Int(i), v, unwind)
         alloc
     }
 
-    def genLabelDef(label: Labeled): Val = {
+    def genLabelDef(label: Labeled): nir.Val = {
       given nir.Position = label.span
       val Labeled(bind, body) = label
       assert(bind.body == EmptyTree, "non-empty Labeled bind body")
 
       val (labelEntry, labelExit) = curMethodLabels.enterLabel(label)
-      val labelExitParam = Val.Local(fresh(), genType(bind.tpe))
+      val labelExitParam = nir.Val.Local(fresh(), genType(bind.tpe))
       curMethodLabels.enterExitType(labelExit, labelExitParam.ty)
 
-      buf.jump(Next(labelEntry))
+      buf.jump(nir.Next(labelEntry))
 
       buf.label(labelEntry, Nil)
       buf.jumpExcludeUnitValue(labelExitParam.ty)(
@@ -537,7 +536,7 @@ trait NirGenExpr(using Context) {
       buf.labelExcludeUnitValue(labelExit, labelExitParam)
     }
 
-    def genLiteral(lit: Literal): Val = {
+    def genLiteral(lit: Literal): nir.Val = {
       val value = lit.const
 
       value.tag match {
@@ -546,29 +545,29 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    private def genLiteralValue(lit: Literal): Val = {
+    private def genLiteralValue(lit: Literal): nir.Val = {
       val value = lit.const
       value.tag match {
-        case UnitTag    => Val.Unit
-        case NullTag    => Val.Null
-        case BooleanTag => if (value.booleanValue) Val.True else Val.False
-        case ByteTag    => Val.Byte(value.intValue.toByte)
-        case ShortTag   => Val.Short(value.intValue.toShort)
-        case CharTag    => Val.Char(value.intValue.toChar)
-        case IntTag     => Val.Int(value.intValue)
-        case LongTag    => Val.Long(value.longValue)
-        case FloatTag   => Val.Float(value.floatValue)
-        case DoubleTag  => Val.Double(value.doubleValue)
-        case StringTag  => Val.String(value.stringValue)
+        case UnitTag    => nir.Val.Unit
+        case NullTag    => nir.Val.Null
+        case BooleanTag => if (value.booleanValue) nir.Val.True else nir.Val.False
+        case ByteTag    => nir.Val.Byte(value.intValue.toByte)
+        case ShortTag   => nir.Val.Short(value.intValue.toShort)
+        case CharTag    => nir.Val.Char(value.intValue.toChar)
+        case IntTag     => nir.Val.Int(value.intValue)
+        case LongTag    => nir.Val.Long(value.longValue)
+        case FloatTag   => nir.Val.Float(value.floatValue)
+        case DoubleTag  => nir.Val.Double(value.doubleValue)
+        case StringTag  => nir.Val.String(value.stringValue)
       }
     }
 
-    def genMatch(m: Match): Val = {
+    def genMatch(m: Match): nir.Val = {
       given nir.Position = m.span
       val Match(scrutp, allcaseps) = m
       case class Case(
-          id: Local,
-          value: Val,
+          id: nir.Local,
+          value: nir.Val,
           tree: Tree,
           position: nir.Position
       )
@@ -579,7 +578,7 @@ trait NirGenExpr(using Context) {
           Seq.empty
         case cd @ CaseDef(pat, guard, body) =>
           assert(guard.isEmpty, "CaseDef guard was not empty")
-          val vals: Seq[Val] = pat match {
+          val vals: Seq[nir.Val] = pat match {
             case lit: Literal =>
               List(genLiteralValue(lit))
             case Alternative(alts) =>
@@ -601,12 +600,12 @@ trait NirGenExpr(using Context) {
       val scrut = genExpr(scrutp)
 
       // Generate code for the switch and its cases.
-      def genSwitch(): Val = {
+      def genSwitch(): nir.Val = {
         // Generate some more fresh names and types.
-        val casenexts = caseps.map { case Case(n, v, _, _) => Next.Case(v, n) }
-        val defaultnext = Next(fresh())
+        val casenexts = caseps.map { case Case(n, v, _, _) => nir.Next.Case(v, n) }
+        val defaultnext = nir.Next(fresh())
         val merge = fresh()
-        val mergev = Val.Local(fresh(), retty)
+        val mergev = nir.Val.Local(fresh(), retty)
 
         val defaultCasePos: nir.Position = defaultp.span
 
@@ -627,7 +626,7 @@ trait NirGenExpr(using Context) {
         buf.labelExcludeUnitValue(merge, mergev)
       }
 
-      def genIfsChain(): Val = {
+      def genIfsChain(): nir.Val = {
         /* Default label needs to be generated before any others and then added to
          * current MethodEnv. It's label might be referenced in any of them in
          * case of match with guards, eg.:
@@ -657,7 +656,7 @@ trait NirGenExpr(using Context) {
           case _              => None
         }
 
-        def loop(cases: List[Case]): Val = {
+        def loop(cases: List[Case]): nir.Val = {
           cases match {
             case Case(_, caze, body, p) :: elsep =>
               given nir.Position = p
@@ -684,14 +683,14 @@ trait NirGenExpr(using Context) {
 
       /* Since 2.13 we need to enforce that only Int switch cases reach backend
        * For all other cases we're generating If-else chain */
-      val isIntMatch = scrut.ty == Type.Int &&
-        caseps.forall(_._2.ty == Type.Int)
+      val isIntMatch = scrut.ty == nir.Type.Int &&
+        caseps.forall(_._2.ty == nir.Type.Int)
 
       if (isIntMatch) genSwitch()
       else genIfsChain()
     }
 
-    private def genMatch(prologue: List[Tree], lds: List[Labeled]): Val = {
+    private def genMatch(prologue: List[Tree], lds: List[Labeled]): nir.Val = {
       // Generate prologue expressions.
       prologue.foreach(genExpr(_))
 
@@ -699,19 +698,19 @@ trait NirGenExpr(using Context) {
       lds.foreach(curMethodLabels.enterLabel)
       val firstLd = lds.head
       given nir.Position = firstLd.span
-      buf.jump(Next(curMethodLabels.resolveEntry(firstLd)))
+      buf.jump(nir.Next(curMethodLabels.resolveEntry(firstLd)))
 
       // Generate code for all labels and return value of the last one.
       lds.map(genLabelDef(_)).last
     }
 
-    def genModule(sym: Symbol)(using nir.Position): Val = {
+    def genModule(sym: Symbol)(using nir.Position): nir.Val = {
       val moduleSym = if (sym.isTerm) sym.moduleClass else sym
       val name = genModuleName(moduleSym)
       buf.module(name, unwind)
     }
 
-    def genReturn(tree: Return): Val = {
+    def genReturn(tree: Return): nir.Val = {
       val Return(exprp, from) = tree
       given nir.Position = tree.span
       val rhs = genExpr(exprp)
@@ -722,12 +721,12 @@ trait NirGenExpr(using Context) {
       genReturn(rhs, label)
     }
 
-    def genReturn(value: Val, from: Option[Local] = None)(using
+    def genReturn(value: nir.Val, from: Option[nir.Local] = None)(using
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       val retv =
         if (curMethodIsExtern.get)
-          val Type.Function(_, retty) = genExternMethodSig(curMethodSym)
+          val nir.Type.Function(_, retty) = genExternMethodSig(curMethodSym)
           toExtern(retty, value)
         else value
 
@@ -735,13 +734,13 @@ trait NirGenExpr(using Context) {
         case Some(label) =>
           val retty = curMethodLabels.resolveExitType(label)
           buf.jumpExcludeUnitValue(retty)(label, retv)
-        case _ if retv.ty == Type.Unit => buf.ret(Val.Unit)
+        case _ if retv.ty == nir.Type.Unit => buf.ret(nir.Val.Unit)
         case _                         => buf.ret(retv)
       }
-      Val.Unit
+      nir.Val.Unit
     }
 
-    def genSelect(tree: Select): Val = {
+    def genSelect(tree: Select): nir.Val = {
       given nir.Position = tree.span
       val Select(qualp, selp) = tree
 
@@ -772,7 +771,7 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    def genThis(tree: This): Val = {
+    def genThis(tree: This): nir.Val = {
       given nir.Position = tree.span
       val sym = tree.symbol
       def currentThis = curMethodThis.get
@@ -793,10 +792,10 @@ trait NirGenExpr(using Context) {
           s"Cannot resolve `this` instance for ${tree}",
           tree.sourcePos
         )
-        Val.Zero(genType(currentClass))
+        nir.Val.Zero(genType(currentClass))
     }
 
-    def genTry(tree: Try): Val = tree match {
+    def genTry(tree: Try): nir.Val = tree match {
       case Try(expr, catches, finalizer)
           if catches.isEmpty && finalizer.isEmpty =>
         genExpr(expr)
@@ -810,11 +809,11 @@ trait NirGenExpr(using Context) {
         expr: Tree,
         catches: List[Tree],
         finallyp: Tree
-    ): Val = {
+    ): nir.Val = {
       given nir.Position = expr.span
       val handler, normaln, mergen = fresh()
-      val excv = Val.Local(fresh(), Rt.Object)
-      val mergev = Val.Local(fresh(), retty)
+      val excv = nir.Val.Local(fresh(), nir.Rt.Object)
+      val mergev = nir.Val.Local(fresh(), retty)
 
       // Nested code gen to separate out try/catch-related instructions.
       val nested = ExprBuffer()
@@ -839,17 +838,17 @@ trait NirGenExpr(using Context) {
         else genTryFinally(finallyp, nested.toSeq)
 
       // Append try/catch instructions to the outher instruction buffer.
-      buf.jump(Next(normaln))
+      buf.jump(nir.Next(normaln))
       buf ++= insts
       buf.labelExcludeUnitValue(mergen, mergev)
     }
 
     private def genTryCatch(
         retty: nir.Type,
-        exc: Val,
-        mergen: Local,
+        exc: nir.Val,
+        mergen: nir.Local,
         catches: List[Tree]
-    )(using exprPos: nir.Position): Val = {
+    )(using exprPos: nir.Position): nir.Val = {
       val cases = catches.map {
         case cd @ CaseDef(pat, _, body) =>
           val (excty, symopt) = pat match {
@@ -870,16 +869,16 @@ trait NirGenExpr(using Context) {
               val res = genExpr(body)
               buf.jumpExcludeUnitValue(retty)(mergen, res)
             }
-            Val.Unit
+            nir.Val.Unit
           }
           (excty, f, exprPos)
       }
 
-      def wrap(cases: Seq[(nir.Type, () => Val, nir.Position)]): Val =
+      def wrap(cases: Seq[(nir.Type, () => nir.Val, nir.Position)]): nir.Val =
         cases match {
           case Seq() =>
             buf.raise(exc, unwind)
-            Val.Unit
+            nir.Val.Unit
           case (excty, f, pos) +: rest =>
             val cond = buf.is(excty, exc, unwind)(pos, getScopeId)
             genIf(
@@ -896,32 +895,32 @@ trait NirGenExpr(using Context) {
     private def genTryFinally(
         finallyp: Tree,
         insts: Seq[nir.Inst]
-    ): Seq[Inst] = {
+    ): Seq[nir.Inst] = {
       val labels =
         insts.collect {
-          case Inst.Label(n, _) => n
+          case nir.Inst.Label(n, _) => n
         }.toSet
-      def internal(cf: Inst.Cf) = cf match {
-        case inst @ Inst.Jump(n) =>
+      def internal(cf: nir.Inst.Cf) = cf match {
+        case inst @ nir.Inst.Jump(n) =>
           labels.contains(n.id)
-        case inst @ Inst.If(_, n1, n2) =>
+        case inst @ nir.Inst.If(_, n1, n2) =>
           labels.contains(n1.id) && labels.contains(n2.id)
-        case inst @ Inst.LinktimeIf(_, n, n2) =>
+        case inst @ nir.Inst.LinktimeIf(_, n, n2) =>
           labels.contains(n.id) && labels.contains(n2.id)
-        case inst @ Inst.Switch(_, n, ns) =>
+        case inst @ nir.Inst.Switch(_, n, ns) =>
           labels.contains(n.id) && ns.forall(n => labels.contains(n.id))
-        case inst @ Inst.Throw(_, n) =>
-          (n ne Next.None) && labels.contains(n.id)
+        case inst @ nir.Inst.Throw(_, n) =>
+          (n ne nir.Next.None) && labels.contains(n.id)
         case _ =>
           false
       }
 
       val finalies = new ExprBuffer
       val transformed = insts.map {
-        case cf: Inst.Cf if internal(cf) =>
+        case cf: nir.Inst.Cf if internal(cf) =>
           // We don't touch control-flow within try/catch block.
           cf
-        case cf: Inst.Cf =>
+        case cf: nir.Inst.Cf =>
           // All control-flow edges that jump outside the try/catch block
           // must first go through finally block if it's present. We generate
           // a new copy of the finally handler for every edge.
@@ -932,19 +931,19 @@ trait NirGenExpr(using Context) {
           }
           finalies += cf
           // The original jump outside goes through finally block first.
-          Inst.Jump(Next(finallyn))(cf.pos)
+          nir.Inst.Jump(nir.Next(finallyn))(cf.pos)
         case inst =>
           inst
       }
       transformed ++ finalies.toSeq
     }
 
-    def genTyped(tree: Typed): Val = tree match {
+    def genTyped(tree: Typed): nir.Val = tree match {
       case Typed(Super(_, _), _) => curMethodThis.get.get
       case Typed(expr, _)        => genExpr(expr)
     }
 
-    def genTypeApply(tree: TypeApply): Val = {
+    def genTypeApply(tree: TypeApply): nir.Val = {
       given nir.Position = tree.span
       val TypeApply(fun @ Select(receiverp, _), targs) = tree: @unchecked
 
@@ -958,37 +957,37 @@ trait NirGenExpr(using Context) {
       if (funSym == defn.Any_isInstanceOf) buf.is(boxty, boxed, unwind)
       else if (funSym == defn.Any_asInstanceOf)
         (fromty, toty) match {
-          case (_: Type.PrimitiveKind, _: Type.PrimitiveKind) =>
+          case (_: nir.Type.PrimitiveKind, _: nir.Type.PrimitiveKind) =>
             genCoercion(value, fromty, toty)
           case _ if boxed.ty =?= boxty => boxed
-          case (_, Type.Nothing) =>
+          case (_, nir.Type.Nothing) =>
             val isNullL, notNullL = fresh()
-            val isNull = buf.comp(Comp.Ieq, boxed.ty, boxed, Val.Null, unwind)
-            buf.branch(isNull, Next(isNullL), Next(notNullL))
+            val isNull = buf.comp(nir.Comp.Ieq, boxed.ty, boxed, nir.Val.Null, unwind)
+            buf.branch(isNull, nir.Next(isNullL), nir.Next(notNullL))
             buf.label(isNullL)
-            buf.raise(Val.Null, unwind)
+            buf.raise(nir.Val.Null, unwind)
             buf.label(notNullL)
-            buf.as(Rt.RuntimeNothing, boxed, unwind)
+            buf.as(nir.Rt.RuntimeNothing, boxed, unwind)
             buf.unreachable(unwind)
             buf.label(fresh())
-            Val.Zero(Type.Nothing)
+            nir.Val.Zero(nir.Type.Nothing)
           case _ =>
             val cast = buf.as(boxty, boxed, unwind)
             unboxValue(tree.tpe, partial = true, cast)
         }
       else {
         report.error("Unkown case genTypeApply: " + funSym, tree.sourcePos)
-        Val.Null
+        nir.Val.Null
       }
     }
 
-    def genValDef(vd: ValDef): Val = {
+    def genValDef(vd: ValDef): nir.Val = {
       given nir.Position = vd.span
       val localNames = curMethodLocalNames.get
       val isMutable = curMethodInfo.mutableVars.contains(vd.symbol)
       def name = genLocalName(vd.symbol)
       val rhs = genExpr(vd.rhs) match {
-        case v @ Val.Local(id, _) =>
+        case v @ nir.Val.Local(id, _) =>
           if !(localNames.contains(id) || isMutable)
           then localNames.update(id, name)
           vd.rhs match {
@@ -1000,8 +999,10 @@ trait NirGenExpr(using Context) {
             case _ => ()
           }
           v
-        case Val.Unit => Val.Unit
-        case v        => buf.let(fresh.namedId(name), Op.Copy(v), unwind)
+        case nir.Val.Unit =>
+          nir.Val.Unit
+        case v =>
+          buf.let(fresh.namedId(name), nir.Op.Copy(v), unwind)
       }
 
       if (vd.symbol.isExtern)
@@ -1011,16 +1012,16 @@ trait NirGenExpr(using Context) {
         buf.varstore(slot, rhs, unwind)
       else
         curMethodEnv.enter(vd.symbol, rhs)
-        Val.Unit
+        nir.Val.Unit
     }
 
-    def genWhileDo(wd: WhileDo): Val = {
+    def genWhileDo(wd: WhileDo): nir.Val = {
       val WhileDo(cond, body) = wd
       val condLabel, bodyLabel, exitLabel = fresh()
 
       locally {
         given nir.Position = wd.span
-        buf.jump(Next(condLabel))
+        buf.jump(nir.Next(condLabel))
       }
 
       locally {
@@ -1029,7 +1030,7 @@ trait NirGenExpr(using Context) {
         val genCond =
           if (cond == EmptyTree) nir.Val.Bool(true)
           else genExpr(cond)
-        buf.branch(genCond, Next(bodyLabel), Next(exitLabel))
+        buf.branch(genCond, nir.Next(bodyLabel), nir.Next(exitLabel))
       }
 
       locally {
@@ -1042,24 +1043,24 @@ trait NirGenExpr(using Context) {
       locally {
         given nir.Position = wd.span.endPos
         buf.label(exitLabel, Seq.empty)
-        if (cond == EmptyTree) Val.Zero(genType(defn.NothingClass))
-        else Val.Unit
+        if (cond == EmptyTree) nir.Val.Zero(genType(defn.NothingClass))
+        else nir.Val.Unit
       }
     }
 
     private def genApplyBox(st: SimpleType, argp: Tree)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       val value = genExpr(argp)
       buf.box(genBoxType(st), value, unwind)
     }
 
     private def genApplyUnbox(st: SimpleType, argp: Tree)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       val value = genExpr(argp)
       value.ty match {
-        case _: scalanative.nir.Type.I | _: scalanative.nir.Type.F =>
+        case _: nir.Type.I | _: nir.Type.F =>
           // No need for unboxing, fixing some slack generated by the general
           // purpose Scala compiler.
           value
@@ -1068,7 +1069,7 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    private def genApplyPrimitive(app: Apply): Val = {
+    private def genApplyPrimitive(app: Apply): nir.Val = {
       import NirPrimitives._
       import dotty.tools.backend.ScalaPrimitivesOps._
       given nir.Position = app.span
@@ -1083,7 +1084,7 @@ trait NirGenExpr(using Context) {
         case THROW                  => genThrow(app, args)
         case CONCAT                 => genStringConcat(receiver, arg)
         case HASH                   => genHashCode(arg)
-        case BOXED_UNIT             => Val.Unit
+        case BOXED_UNIT             => nir.Val.Unit
         case SYNCHRONIZED           => genSynchronized(receiver, arg)
         case CFUNCPTR_APPLY         => genCFuncPtrApply(app)
         case CFUNCPTR_FROM_FUNCTION => genCFuncFromScalaFunction(app)
@@ -1112,12 +1113,12 @@ trait NirGenExpr(using Context) {
               s"Unknown primitive operation: ${sym.fullName}(${fun.symbol.showName})",
               app.sourcePos
             )
-            Val.Null
+            nir.Val.Null
           }
       }
     }
 
-    private def genApplyTypeApply(app: Apply): Val = {
+    private def genApplyTypeApply(app: Apply): nir.Val = {
       val Apply(tApply @ TypeApply(fun, targs), argsp) = app: @unchecked
       val Select(receiverp, _) = desugarTree(fun): @unchecked
       given nir.Position = app.span
@@ -1130,7 +1131,7 @@ trait NirGenExpr(using Context) {
       else genTypeApply(tApply)
     }
 
-    private def genApplyNew(app: Apply): Val = {
+    private def genApplyNew(app: Apply): nir.Val = {
       val Apply(fun @ Select(New(tpt), nme.CONSTRUCTOR), args) = app: @unchecked
       given nir.Position = app.span
 
@@ -1157,10 +1158,10 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    private def genApplyNewStruct(st: SimpleType, argsp: Seq[Tree]): Val = {
+    private def genApplyNewStruct(st: SimpleType, argsp: Seq[Tree]): nir.Val = {
       val ty = genType(st)
       val args = genSimpleArgs(argsp)
-      var res: Val = Val.Zero(ty)
+      var res: nir.Val = nir.Val.Zero(ty)
 
       for ((arg, argp), idx) <- args.zip(argsp).zipWithIndex
       do
@@ -1173,10 +1174,10 @@ trait NirGenExpr(using Context) {
         clssym: Symbol,
         ctorsym: Symbol,
         args: List[Tree],
-        zone: Option[Val]
+        zone: Option[nir.Val]
     )(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       val alloc = buf.classalloc(genTypeName(clssym), unwind, zone)
       genApplyMethod(ctorsym, statically = true, alloc, args)
       alloc
@@ -1188,7 +1189,7 @@ trait NirGenExpr(using Context) {
         args: Seq[Tree]
     )(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       val self = genModule(module)
       genApplyMethod(method, statically = true, self, args)
     }
@@ -1198,7 +1199,7 @@ trait NirGenExpr(using Context) {
         statically: Boolean,
         selfp: Tree,
         argsp: Seq[Tree]
-    )(using nir.Position): Val = {
+    )(using nir.Position): nir.Val = {
       if (sym.isExtern && sym.is(Accessor)) genApplyExternAccessor(sym, argsp)
       else if (sym.isStaticInNIR && !sym.isExtern)
         genApplyStaticMethod(sym, selfp.symbol, argsp)
@@ -1210,9 +1211,9 @@ trait NirGenExpr(using Context) {
     private def genApplyMethod(
         sym: Symbol,
         statically: Boolean,
-        self: Val,
+        self: nir.Val,
         argsp: Seq[Tree]
-    )(using nir.Position): Val = {
+    )(using nir.Position): nir.Val = {
       assert(!sym.isStaticMethod, sym)
       val owner = sym.owner.asClass
       val name = genMethodName(sym)
@@ -1226,9 +1227,9 @@ trait NirGenExpr(using Context) {
 
       val isStaticCall = statically || owner.isStruct || isExtern
       val method =
-        if (isStaticCall) Val.Global(name, nir.Type.Ptr)
+        if (isStaticCall) nir.Val.Global(name, nir.Type.Ptr)
         else
-          val Global.Member(_, sig) = name: @unchecked
+          val nir.Global.Member(_, sig) = name: @unchecked
           buf.method(self, sig, unwind)
       val values =
         if isExtern then args
@@ -1238,7 +1239,7 @@ trait NirGenExpr(using Context) {
 
       if !isExtern then res
       else {
-        val Type.Function(_, retty) = origSig
+        val nir.Type.Function(_, retty) = origSig
         fromExtern(retty, res)
       }
     }
@@ -1247,19 +1248,19 @@ trait NirGenExpr(using Context) {
         sym: Symbol,
         receiver: Symbol,
         argsp: Seq[Tree]
-    )(using nir.Position): Val = {
+    )(using nir.Position): nir.Val = {
       require(!sym.isExtern, sym)
 
       val sig = genMethodSig(sym)
       val args = genMethodArgs(sym, argsp)
       val methodName = genStaticMemberName(sym, receiver)
-      val method = Val.Global(methodName, nir.Type.Ptr)
+      val method = nir.Val.Global(methodName, nir.Type.Ptr)
       buf.call(sig, method, args, unwind)
     }
 
     private def genApplyExternAccessor(sym: Symbol, argsp: Seq[Tree])(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       argsp match {
         case Seq() =>
           val ty = genMethodSig(sym).ret
@@ -1272,9 +1273,9 @@ trait NirGenExpr(using Context) {
     }
 
     // Utils
-    private def boxValue(st: SimpleType, value: Val)(using
+    private def boxValue(st: SimpleType, value: nir.Val)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       if (st.sym.isUnsignedType)
         genApplyModuleMethod(
           defnNir.RuntimeBoxesModule,
@@ -1285,9 +1286,9 @@ trait NirGenExpr(using Context) {
       else genApplyBox(st, ValTree(value))
     }
 
-    private def unboxValue(st: SimpleType, partial: Boolean, value: Val)(using
+    private def unboxValue(st: SimpleType, partial: Boolean, value: nir.Val)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       if (st.sym.isUnsignedType) {
         // Results of asInstanceOfs are partially unboxed, meaning
         // that non-standard value types remain to be boxed.
@@ -1302,7 +1303,7 @@ trait NirGenExpr(using Context) {
       else genApplyUnbox(st, ValTree(value))
     }
 
-    private def genSimpleOp(app: Apply, args: List[Tree], code: Int): Val = {
+    private def genSimpleOp(app: Apply, args: List[Tree], code: Int): nir.Val = {
       given nir.Position = app.span
       val retty = genType(app.tpe)
 
@@ -1314,43 +1315,43 @@ trait NirGenExpr(using Context) {
             s"Too many arguments for primitive function: $app",
             app.sourcePos
           )
-          Val.Null
+          nir.Val.Null
       }
     }
 
-    private def negateBool(value: nir.Val)(using nir.Position): Val =
-      buf.bin(Bin.Xor, Type.Bool, Val.True, value, unwind)
+    private def negateBool(value: nir.Val)(using nir.Position): nir.Val =
+      buf.bin(nir.Bin.Xor, nir.Type.Bool, nir.Val.True, value, unwind)
 
     private def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       val right = genExpr(rightp)
       val coerced = genCoercion(right, right.ty, opty)
       val tpe = coerced.ty
 
-      def numOfType(num: Int, ty: nir.Type): Val = ty match {
-        case Type.Byte              => Val.Byte(num.toByte)
-        case Type.Short | Type.Char => Val.Short(num.toShort)
-        case Type.Int               => Val.Int(num)
-        case Type.Long              => Val.Long(num.toLong)
-        case Type.Float             => Val.Float(num.toFloat)
-        case Type.Double            => Val.Double(num.toDouble)
-        case Type.Size              => Val.Size(num.toLong)
+      def numOfType(num: Int, ty: nir.Type): nir.Val = ty match {
+        case nir.Type.Byte                  => nir.Val.Byte(num.toByte)
+        case nir.Type.Short | nir.Type.Char => nir.Val.Short(num.toShort)
+        case nir.Type.Int                   => nir.Val.Int(num)
+        case nir.Type.Long                  => nir.Val.Long(num.toLong)
+        case nir.Type.Float                 => nir.Val.Float(num.toFloat)
+        case nir.Type.Double                => nir.Val.Double(num.toDouble)
+        case nir.Type.Size                  => nir.Val.Size(num.toLong)
         case _ => unsupported(s"num = $num, ty = ${ty.show}")
       }
 
       (opty, code) match {
-        case (_: Type.I | _: Type.F, POS) => coerced
-        case (_: Type.I, NOT) =>
-          buf.bin(Bin.Xor, tpe, numOfType(-1, tpe), coerced, unwind)
-        case (_: Type.F, NEG) =>
-          buf.bin(Bin.Fmul, tpe, numOfType(-1, tpe), coerced, unwind)
-        case (_: Type.I, NEG) =>
-          buf.bin(Bin.Isub, tpe, numOfType(0, tpe), coerced, unwind)
-        case (Type.Bool, ZNOT) => negateBool(coerced)
+        case (_: nir.Type.I | _: nir.Type.F, POS) => coerced
+        case (_: nir.Type.I, NOT) =>
+          buf.bin(nir.Bin.Xor, tpe, numOfType(-1, tpe), coerced, unwind)
+        case (_: nir.Type.F, NEG) =>
+          buf.bin(nir.Bin.Fmul, tpe, numOfType(-1, tpe), coerced, unwind)
+        case (_: nir.Type.I, NEG) =>
+          buf.bin(nir.Bin.Isub, tpe, numOfType(0, tpe), coerced, unwind)
+        case (nir.Type.Bool, ZNOT) => negateBool(coerced)
         case _ =>
           report.error(s"Unknown unary operation code: $code", rightp.sourcePos)
-          Val.Null
+          nir.Val.Null
       }
     }
 
@@ -1359,7 +1360,7 @@ trait NirGenExpr(using Context) {
         left: Tree,
         right: Tree,
         retty: nir.Type
-    )(using nir.Position): Val = {
+    )(using nir.Position): nir.Val = {
       val lty = genType(left.tpe)
       val rty = genType(right.tpe)
       val opty = {
@@ -1369,7 +1370,7 @@ trait NirGenExpr(using Context) {
         else
           binaryOperationType(lty, rty)
       }
-      def genOp(op: (nir.Type, Val, Val) => Op): Val = {
+      def genOp(op: (nir.Type, nir.Val, nir.Val) => nir.Op): nir.Val = {
         val leftcoerced = genCoercion(genExpr(left), lty, opty)(using left.span)
         val rightcoerced =
           genCoercion(genExpr(right), rty, opty)(using right.span)
@@ -1380,49 +1381,49 @@ trait NirGenExpr(using Context) {
       }
 
       val binres = opty match {
-        case _: Type.F =>
+        case _: nir.Type.F =>
           code match {
-            case ADD => genOp(Op.Bin(Bin.Fadd, _, _, _))
-            case SUB => genOp(Op.Bin(Bin.Fsub, _, _, _))
-            case MUL => genOp(Op.Bin(Bin.Fmul, _, _, _))
-            case DIV => genOp(Op.Bin(Bin.Fdiv, _, _, _))
-            case MOD => genOp(Op.Bin(Bin.Frem, _, _, _))
+            case ADD => genOp(nir.Op.Bin(nir.Bin.Fadd, _, _, _))
+            case SUB => genOp(nir.Op.Bin(nir.Bin.Fsub, _, _, _))
+            case MUL => genOp(nir.Op.Bin(nir.Bin.Fmul, _, _, _))
+            case DIV => genOp(nir.Op.Bin(nir.Bin.Fdiv, _, _, _))
+            case MOD => genOp(nir.Op.Bin(nir.Bin.Frem, _, _, _))
 
-            case EQ => genOp(Op.Comp(Comp.Feq, _, _, _))
-            case NE => genOp(Op.Comp(Comp.Fne, _, _, _))
-            case LT => genOp(Op.Comp(Comp.Flt, _, _, _))
-            case LE => genOp(Op.Comp(Comp.Fle, _, _, _))
-            case GT => genOp(Op.Comp(Comp.Fgt, _, _, _))
-            case GE => genOp(Op.Comp(Comp.Fge, _, _, _))
+            case EQ => genOp(nir.Op.Comp(nir.Comp.Feq, _, _, _))
+            case NE => genOp(nir.Op.Comp(nir.Comp.Fne, _, _, _))
+            case LT => genOp(nir.Op.Comp(nir.Comp.Flt, _, _, _))
+            case LE => genOp(nir.Op.Comp(nir.Comp.Fle, _, _, _))
+            case GT => genOp(nir.Op.Comp(nir.Comp.Fgt, _, _, _))
+            case GE => genOp(nir.Op.Comp(nir.Comp.Fge, _, _, _))
 
             case _ =>
               report.error(
                 s"Unknown floating point type binary operation code: $code",
                 right.sourcePos
               )
-              Val.Null
+              nir.Val.Null
           }
-        case Type.Bool | _: Type.I =>
+        case nir.Type.Bool | _: nir.Type.I =>
           code match {
-            case ADD => genOp(Op.Bin(Bin.Iadd, _, _, _))
-            case SUB => genOp(Op.Bin(Bin.Isub, _, _, _))
-            case MUL => genOp(Op.Bin(Bin.Imul, _, _, _))
-            case DIV => genOp(Op.Bin(Bin.Sdiv, _, _, _))
-            case MOD => genOp(Op.Bin(Bin.Srem, _, _, _))
+            case ADD => genOp(nir.Op.Bin(nir.Bin.Iadd, _, _, _))
+            case SUB => genOp(nir.Op.Bin(nir.Bin.Isub, _, _, _))
+            case MUL => genOp(nir.Op.Bin(nir.Bin.Imul, _, _, _))
+            case DIV => genOp(nir.Op.Bin(nir.Bin.Sdiv, _, _, _))
+            case MOD => genOp(nir.Op.Bin(nir.Bin.Srem, _, _, _))
 
-            case OR  => genOp(Op.Bin(Bin.Or, _, _, _))
-            case XOR => genOp(Op.Bin(Bin.Xor, _, _, _))
-            case AND => genOp(Op.Bin(Bin.And, _, _, _))
-            case LSL => genOp(Op.Bin(Bin.Shl, _, _, _))
-            case LSR => genOp(Op.Bin(Bin.Lshr, _, _, _))
-            case ASR => genOp(Op.Bin(Bin.Ashr, _, _, _))
+            case OR  => genOp(nir.Op.Bin(nir.Bin.Or, _, _, _))
+            case XOR => genOp(nir.Op.Bin(nir.Bin.Xor, _, _, _))
+            case AND => genOp(nir.Op.Bin(nir.Bin.And, _, _, _))
+            case LSL => genOp(nir.Op.Bin(nir.Bin.Shl, _, _, _))
+            case LSR => genOp(nir.Op.Bin(nir.Bin.Lshr, _, _, _))
+            case ASR => genOp(nir.Op.Bin(nir.Bin.Ashr, _, _, _))
 
-            case EQ => genOp(Op.Comp(Comp.Ieq, _, _, _))
-            case NE => genOp(Op.Comp(Comp.Ine, _, _, _))
-            case LT => genOp(Op.Comp(Comp.Slt, _, _, _))
-            case LE => genOp(Op.Comp(Comp.Sle, _, _, _))
-            case GT => genOp(Op.Comp(Comp.Sgt, _, _, _))
-            case GE => genOp(Op.Comp(Comp.Sge, _, _, _))
+            case EQ => genOp(nir.Op.Comp(nir.Comp.Ieq, _, _, _))
+            case NE => genOp(nir.Op.Comp(nir.Comp.Ine, _, _, _))
+            case LT => genOp(nir.Op.Comp(nir.Comp.Slt, _, _, _))
+            case LE => genOp(nir.Op.Comp(nir.Comp.Sle, _, _, _))
+            case GT => genOp(nir.Op.Comp(nir.Comp.Sgt, _, _, _))
+            case GE => genOp(nir.Op.Comp(nir.Comp.Sge, _, _, _))
 
             case ZOR  => genIf(retty, left, Literal(Constant(true)), right)
             case ZAND => genIf(retty, left, right, Literal(Constant(false)))
@@ -1431,9 +1432,9 @@ trait NirGenExpr(using Context) {
                 s"Unknown integer type binary operation code: $code",
                 right.sourcePos
               )
-              Val.Null
+              nir.Val.Null
           }
-        case _: Type.RefKind =>
+        case _: nir.Type.RefKind =>
           def genEquals(ref: Boolean, negated: Boolean) = (left, right) match {
             // If null is present on either side, we must always
             // generate reference equality, regardless of where it
@@ -1454,19 +1455,19 @@ trait NirGenExpr(using Context) {
                 s"Unknown reference type binary operation code: $code",
                 right.sourcePos
               )
-              Val.Null
+              nir.Val.Null
           }
-        case Type.Ptr =>
+        case nir.Type.Ptr =>
           code match {
-            case EQ | ID => genOp(Op.Comp(Comp.Ieq, _, _, _))
-            case NE | NI => genOp(Op.Comp(Comp.Ine, _, _, _))
+            case EQ | ID => genOp(nir.Op.Comp(nir.Comp.Ieq, _, _, _))
+            case NE | NI => genOp(nir.Op.Comp(nir.Comp.Ine, _, _, _))
           }
         case ty =>
           report.error(
             s"Unknown binary operation type: $ty",
             right.sourcePos
           )
-          Val.Null
+          nir.Val.Null
       }
 
       genCoercion(binres, binres.ty, retty)(using right.span)
@@ -1475,7 +1476,7 @@ trait NirGenExpr(using Context) {
     private def binaryOperationType(lty: nir.Type, rty: nir.Type) =
       (lty, rty) match {
         // Bug compatibility with scala/bug/issues/11253
-        case (Type.Long, Type.Float)             => Type.Double
+        case (nir.Type.Long, nir.Type.Float)     => nir.Type.Double
         case (nir.Type.Ptr, _: nir.Type.RefKind) => lty
         case (_: nir.Type.RefKind, nir.Type.Ptr) => rty
         case (nir.Type.Bool, nir.Type.Bool)      => nir.Type.Bool
@@ -1490,13 +1491,13 @@ trait NirGenExpr(using Context) {
         case (nir.Type.F(lwidth), nir.Type.F(rwidth)) =>
           if (lwidth >= rwidth) lty
           else rty
-        case (_: nir.Type.RefKind, _: nir.Type.RefKind) => Rt.Object
+        case (_: nir.Type.RefKind, _: nir.Type.RefKind) => nir.Rt.Object
         case (ty1, ty2) if ty1 == ty2                   => ty1
-        case (Type.Nothing, ty)                         => ty
-        case (ty, Type.Nothing)                         => ty
+        case (nir.Type.Nothing, ty)                     => ty
+        case (ty, nir.Type.Nothing)                     => ty
         case _ =>
           report.error(s"can't perform binary operation between $lty and $rty")
-          Type.Nothing
+          nir.Type.Nothing
       }
 
     private def genClassEquality(
@@ -1504,20 +1505,20 @@ trait NirGenExpr(using Context) {
         rightp: Tree,
         ref: Boolean,
         negated: Boolean
-    )(using nir.Position): Val = {
+    )(using nir.Position): nir.Val = {
 
       if (ref) {
         // referencial equality
         val left = genExpr(leftp)
         val right = genExpr(rightp)
-        val comp = if (negated) Comp.Ine else Comp.Ieq
-        buf.comp(comp, Rt.Object, left, right, unwind)
+        val comp = if (negated) nir.Comp.Ine else nir.Comp.Ieq
+        buf.comp(comp, nir.Rt.Object, left, right, unwind)
       } else genClassUniversalEquality(leftp, rightp, negated)
     }
 
     private def genClassUniversalEquality(l: Tree, r: Tree, negated: Boolean)(
         using nir.Position
-    ): Val = {
+    ): nir.Val = {
 
       /* True if the equality comparison is between values that require the use of the rich equality
        * comparator (scala.runtime.BoxesRunTime.equals). This is the case when either side of the
@@ -1555,8 +1556,8 @@ trait NirGenExpr(using Context) {
       def isNonNullExpr(t: Tree): Boolean =
         t.isInstanceOf[Literal] || ((t.symbol ne null) && t.symbol.is(Module))
 
-      def comparator = if (negated) Comp.Ine else Comp.Ieq
-      def maybeNegate(v: Val): Val = if negated then negateBool(v) else v
+      def comparator = if (negated) nir.Comp.Ine else nir.Comp.Ieq
+      def maybeNegate(v: nir.Val): nir.Val = if negated then negateBool(v) else v
 
       if (mustUseAnyComparator) maybeNegate {
         val equalsMethod: Symbol = {
@@ -1572,10 +1573,10 @@ trait NirGenExpr(using Context) {
       }
       else if (isNull(l)) {
         // null == expr -> expr eq null
-        buf.comp(comparator, Rt.Object, genExpr(r), Val.Null, unwind)
+        buf.comp(comparator, nir.Rt.Object, genExpr(r), nir.Val.Null, unwind)
       } else if (isNull(r)) {
         // expr == null -> expr eq null
-        buf.comp(comparator, Rt.Object, genExpr(l), Val.Null, unwind)
+        buf.comp(comparator, nir.Rt.Object, genExpr(l), nir.Val.Null, unwind)
       } else if (isNonNullExpr(l)) maybeNegate {
         // SI-7852 Avoid null check if L is statically non-null.
         genApplyMethod(
@@ -1590,14 +1591,14 @@ trait NirGenExpr(using Context) {
         maybeNegate {
           // l == r -> if (l eq null) r eq null else l.equals(r)
           val thenn, elsen, mergen = fresh()
-          val mergev = Val.Local(fresh(), nir.Type.Bool)
+          val mergev =  nir.Val.Local(fresh(), nir.Type.Bool)
           val left = genExpr(l)
-          val isnull = buf.comp(Comp.Ieq, Rt.Object, left, Val.Null, unwind)
-          buf.branch(isnull, Next(thenn), Next(elsen))
+          val isnull = buf.comp(nir.Comp.Ieq, nir.Rt.Object, left, nir.Val.Null, unwind)
+          buf.branch(isnull, nir.Next(thenn), nir.Next(elsen))
           locally {
             buf.label(thenn)
             val right = genExpr(r)
-            val thenv = buf.comp(Comp.Ieq, Rt.Object, right, Val.Null, unwind)
+            val thenv = buf.comp(nir.Comp.Ieq, nir.Rt.Object, right, nir.Val.Null, unwind)
             buf.jump(mergen, Seq(thenv))
           }
           locally {
@@ -1615,16 +1616,16 @@ trait NirGenExpr(using Context) {
         }
     }
 
-    def genMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[Val] =
+    def genMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[nir.Val] =
       if sym.isExtern
       then genExternMethodArgs(sym, argsp)
       else genSimpleArgs(argsp)
 
-    private def genSimpleArgs(argsp: Seq[Tree]): Seq[Val] = argsp.map(genExpr)
+    private def genSimpleArgs(argsp: Seq[Tree]): Seq[nir.Val] = argsp.map(genExpr)
 
-    private def genExternMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[Val] = {
-      val res = Seq.newBuilder[Val]
-      val Type.Function(argTypes, _) = genExternMethodSig(sym)
+    private def genExternMethodArgs(sym: Symbol, argsp: Seq[Tree]): Seq[nir.Val] = {
+      val res = Seq.newBuilder[nir.Val]
+      val nir.Type.Function(argTypes, _) = genExternMethodSig(sym)
       val paramTypes = sym.paramInfo.paramInfoss.flatten
       assert(
         argTypes.size == argsp.size && argTypes.size == paramTypes.size,
@@ -1637,17 +1638,18 @@ trait NirGenExpr(using Context) {
       ): nir.Val = {
         given nir.Position = argp.span
         val externType = genExternType(paramTpe.finalResultType)
-        val value = (genExpr(argp), Type.box.get(externType)) match {
-          case (value @ Val.Null, Some(unboxedType)) =>
+        val value = (genExpr(argp), nir.Type.box.get(externType)) match {
+          case (value @ nir.Val.Null, Some(unboxedType)) =>
             externType match {
-              case Type.Ptr | _: Type.RefKind => value
+              case nir.Type.Ptr | _: nir.Type.RefKind =>
+                value
               case _ =>
                 report.warning(
                   s"Passing null as argument of type ${paramTpe.show} to the extern method is unsafe. " +
                     s"The argument would be unboxed to primitive value of type $externType.",
                   argp.srcPos
                 )
-                Val.Zero(unboxedType)
+                nir.Val.Zero(unboxedType)
             }
           case (value, _) => value
         }
@@ -1664,23 +1666,23 @@ trait NirGenExpr(using Context) {
                 do
                   given nir.Position = tree.span
                   val arg = genArg(tree, tree.tpe)
-                  def isUnsigned = Type.isUnsignedType(genType(tree.tpe))
+                  def isUnsigned = nir.Type.isUnsignedType(genType(tree.tpe))
                   // Decimal varargs needs to be promoted to at least Int, and Float needs to be promoted to Double
                   val promotedArg = arg.ty match {
-                    case Type.Float =>
-                      this.genCastOp(Type.Float, Type.Double, arg)
-                    case Type.FixedSizeI(width, _) if width < Type.Int.width =>
+                    case nir.Type.Float =>
+                      this.genCastOp(nir.Type.Float, nir.Type.Double, arg)
+                    case nir.Type.FixedSizeI(width, _) if width < nir.Type.Int.width =>
                       val conv =
                         if (isUnsigned) nir.Conv.Zext
                         else nir.Conv.Sext
-                      buf.conv(conv, Type.Int, arg, unwind)
-                    case Type.Long =>
+                      buf.conv(conv, nir.Type.Int, arg, unwind)
+                    case nir.Type.Long =>
                       // On 32-bit systems Long needs to be truncated to Int
                       // Cast it to size to make undependent from architecture
                       val conv =
                         if (isUnsigned) nir.Conv.ZSizeCast
                         else nir.Conv.SSizeCast
-                      buf.conv(conv, Type.Size, arg, unwind)
+                      buf.conv(conv, nir.Type.Size, arg, unwind)
 
                     case _ => arg
                   }
@@ -1696,12 +1698,12 @@ trait NirGenExpr(using Context) {
       res.result()
     }
 
-    private def genArrayOp(app: Apply, code: Int): Val = {
+    private def genArrayOp(app: Apply, code: Int): nir.Val = {
       import NirPrimitives._
       import dotty.tools.backend.ScalaPrimitivesOps._
 
       val Apply(Select(arrayp, _), argsp) = app: @unchecked
-      val Type.Array(elemty, _) = genType(arrayp.tpe): @unchecked
+      val nir.Type.Array(elemty, _) = genType(arrayp.tpe): @unchecked
       given nir.Position = app.span
 
       def elemcode = genArrayCode(arrayp.tpe)
@@ -1720,19 +1722,19 @@ trait NirGenExpr(using Context) {
       else buf.arraylength(array, unwind)
     }
 
-    private def genHashCode(argp: Tree)(using nir.Position): Val =
+    private def genHashCode(argp: Tree)(using nir.Position): nir.Val =
       genApplyStaticMethod(
         defn.staticsMethod(nme.anyHash),
         defn.ScalaStaticsModule,
         Seq(argp)
       )
 
-    private def genStringConcat(leftp: Tree, rightp: Tree): Val = {
-      def stringify(sym: Symbol, value: Val)(using nir.Position): Val = {
+    private def genStringConcat(leftp: Tree, rightp: Tree): nir.Val = {
+      def stringify(sym: Symbol, value: nir.Val)(using nir.Position): nir.Val = {
         val cond = ContTree { () =>
-          buf.comp(Comp.Ieq, Rt.Object, value, Val.Null, unwind)
+          buf.comp(nir.Comp.Ieq, nir.Rt.Object, value, nir.Val.Null, unwind)
         }
-        val thenp = ContTree { () => Val.String("null") }
+        val thenp = ContTree { () => nir.Val.String("null") }
         val elsep = ContTree { () =>
           if (sym == defn.StringClass) value
           else {
@@ -1740,7 +1742,7 @@ trait NirGenExpr(using Context) {
             genApplyMethod(meth, statically = false, value, Seq.empty)
           }
         }
-        genIf(Rt.String, cond, thenp, elsep)
+        genIf(nir.Rt.String, cond, thenp, elsep)
       }
 
       val left = {
@@ -1768,27 +1770,27 @@ trait NirGenExpr(using Context) {
 
     private def genStaticMember(sym: Symbol, receiver: Symbol)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       /* Actually, there is no static member in Scala Native. If we come here, that
        * is because we found the symbol in a Java-emitted .class in the
        * classpath. But the corresponding implementation in Scala Native will
        * actually be a val in the companion module.
        */
 
-      if (sym == defn.BoxedUnit_UNIT) Val.Unit
-      else if (sym == defn.BoxedUnit_TYPE) Val.Unit
+      if (sym == defn.BoxedUnit_UNIT) nir.Val.Unit
+      else if (sym == defn.BoxedUnit_TYPE) nir.Val.Unit
       else genApplyStaticMethod(sym, receiver, Seq.empty)
     }
 
     private def genSynchronized(receiverp: Tree, bodyp: Tree)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       genSynchronized(receiverp)(_.genExpr(bodyp))
     }
 
     def genSynchronized(
         receiverp: Tree
-    )(bodyGen: ExprBuffer => Val)(using nir.Position): Val = {
+    )(bodyGen: ExprBuffer => nir.Val)(using nir.Position): nir.Val = {
       // Here we wrap the synchronized call into the try-finally block
       // to ensure that monitor would be released even in case of the exception
       // or in case of non-local returns
@@ -1806,20 +1808,20 @@ trait NirGenExpr(using Context) {
         bodyGen(nested)
       }
       val retty = retValue.ty
-      val mergev = Val.Local(fresh(), retty)
+      val mergev = nir.Val.Local(fresh(), retty)
       nested.jumpExcludeUnitValue(retty)(mergen, retValue)
 
       // dummy exception handler,
       // monitorExit call would be added to it in genTryFinally transformer
       locally {
-        val excv = Val.Local(fresh(), Rt.Object)
+        val excv = nir.Val.Local(fresh(), nir.Rt.Object)
         nested.label(handler, Seq(excv))
         nested.raise(excv, unwind)
-        nested.jumpExcludeUnitValue(retty)(mergen, Val.Zero(retty))
+        nested.jumpExcludeUnitValue(retty)(mergen, nir.Val.Zero(retty))
       }
 
       // Append try/catch instructions to the outher instruction buffer.
-      buf.jump(Next(normaln))
+      buf.jump(nir.Next(normaln))
       buf ++= genTryFinally(
         // scalanative.runtime.`package`.exitMonitor(receiver)
         Apply(ref(defnNir.RuntimePackage_exitMonitor), List(receiverp)),
@@ -1828,20 +1830,20 @@ trait NirGenExpr(using Context) {
       buf.labelExcludeUnitValue(mergen, mergev)
     }
 
-    private def genThrow(tree: Tree, args: List[Tree]): Val = {
+    private def genThrow(tree: Tree, args: List[Tree]): nir.Val = {
       given nir.Position = tree.span
       val exception = args.head
       val res = genExpr(exception)
       buf.raise(res, unwind)
-      Val.Unit
+      nir.Val.Unit
     }
 
-    def genCastOp(from: nir.Type, to: nir.Type, value: Val)(using
+    def genCastOp(from: nir.Type, to: nir.Type, value: nir.Val)(using
         nir.Position
-    ): Val =
+    ): nir.Val =
       castConv(from, to).fold(value)(buf.conv(_, to, value, unwind))
 
-    private def genCoercion(app: Apply, receiver: Tree, code: Int): Val = {
+    private def genCoercion(app: Apply, receiver: Tree, code: Int): nir.Val = {
       given nir.Position = app.span
       val rec = genExpr(receiver)
       val (fromty, toty) = coercionTypes(code)
@@ -1849,45 +1851,45 @@ trait NirGenExpr(using Context) {
       genCoercion(rec, fromty, toty)
     }
 
-    private def genCoercion(value: Val, fromty: nir.Type, toty: nir.Type)(using
+    private def genCoercion(value: nir.Val, fromty: nir.Type, toty: nir.Type)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       if (fromty == toty) value
       else if (fromty == nir.Type.Nothing || toty == nir.Type.Nothing) value
       else {
         val conv = (fromty, toty) match {
-          case (nir.Type.Ptr, _: nir.Type.RefKind) => Conv.Bitcast
-          case (_: nir.Type.RefKind, nir.Type.Ptr) => Conv.Bitcast
+          case (nir.Type.Ptr, _: nir.Type.RefKind) => nir.Conv.Bitcast
+          case (_: nir.Type.RefKind, nir.Type.Ptr) => nir.Conv.Bitcast
           case (
                 nir.Type.FixedSizeI(fromw, froms),
                 nir.Type.FixedSizeI(tow, tos)
               ) =>
             if (fromw < tow)
-              if (froms) Conv.Sext
-              else Conv.Zext
-            else if (fromw > tow) Conv.Trunc
-            else Conv.Bitcast
-          case (i: nir.Type.I, _: nir.Type.F) if i.signed => Conv.Sitofp
-          case (_: nir.Type.I, _: nir.Type.F)             => Conv.Uitofp
+              if (froms) nir.Conv.Sext
+              else nir.Conv.Zext
+            else if (fromw > tow) nir.Conv.Trunc
+            else nir.Conv.Bitcast
+          case (i: nir.Type.I, _: nir.Type.F) if i.signed => nir.Conv.Sitofp
+          case (_: nir.Type.I, _: nir.Type.F)             => nir.Conv.Uitofp
           case (_: nir.Type.F, nir.Type.FixedSizeI(iwidth, true)) =>
             if (iwidth < 32) {
-              val ivalue = genCoercion(value, fromty, Type.Int)
-              return genCoercion(ivalue, Type.Int, toty)
+              val ivalue = genCoercion(value, fromty, nir.Type.Int)
+              return genCoercion(ivalue, nir.Type.Int, toty)
             }
-            Conv.Fptosi
+            nir.Conv.Fptosi
           case (_: nir.Type.F, nir.Type.FixedSizeI(iwidth, false)) =>
             if (iwidth < 32) {
-              val ivalue = genCoercion(value, fromty, Type.Int)
-              return genCoercion(ivalue, Type.Int, toty)
+              val ivalue = genCoercion(value, fromty, nir.Type.Int)
+              return genCoercion(ivalue, nir.Type.Int, toty)
             }
-            Conv.Fptoui
-          case (nir.Type.Double, nir.Type.Float) => Conv.Fptrunc
-          case (nir.Type.Float, nir.Type.Double) => Conv.Fpext
+            nir.Conv.Fptoui
+          case (nir.Type.Double, nir.Type.Float) => nir.Conv.Fptrunc
+          case (nir.Type.Float, nir.Type.Double) => nir.Conv.Fpext
           case _ =>
             report.error(
               s"Unsupported coercion types: from $fromty to $toty"
             )
-            Conv.Bitcast
+            nir.Conv.Bitcast
         }
         buf.conv(conv, toty, value, unwind)
       }
@@ -1955,20 +1957,20 @@ trait NirGenExpr(using Context) {
 
     private def castConv(fromty: nir.Type, toty: nir.Type): Option[nir.Conv] =
       (fromty, toty) match {
-        case (_: Type.I, Type.Ptr)              => Some(nir.Conv.Inttoptr)
-        case (Type.Ptr, _: Type.I)              => Some(nir.Conv.Ptrtoint)
-        case (_: Type.RefKind, Type.Ptr)        => Some(nir.Conv.Bitcast)
-        case (Type.Ptr, _: Type.RefKind)        => Some(nir.Conv.Bitcast)
-        case (_: Type.RefKind, _: Type.RefKind) => Some(nir.Conv.Bitcast)
-        case (_: Type.RefKind, _: Type.I)       => Some(nir.Conv.Ptrtoint)
-        case (_: Type.I, _: Type.RefKind)       => Some(nir.Conv.Inttoptr)
-        case (Type.FixedSizeI(w1, _), Type.F(w2)) if w1 == w2 =>
+        case (_: nir.Type.I, nir.Type.Ptr)              => Some(nir.Conv.Inttoptr)
+        case (nir.Type.Ptr, _: nir.Type.I)              => Some(nir.Conv.Ptrtoint)
+        case (_: nir.Type.RefKind, nir.Type.Ptr)        => Some(nir.Conv.Bitcast)
+        case (nir.Type.Ptr, _: nir.Type.RefKind)        => Some(nir.Conv.Bitcast)
+        case (_: nir.Type.RefKind, _: nir.Type.RefKind) => Some(nir.Conv.Bitcast)
+        case (_: nir.Type.RefKind, _: nir.Type.I)       => Some(nir.Conv.Ptrtoint)
+        case (_: nir.Type.I, _: nir.Type.RefKind)       => Some(nir.Conv.Inttoptr)
+        case (nir.Type.FixedSizeI(w1, _), nir.Type.F(w2)) if w1 == w2 =>
           Some(nir.Conv.Bitcast)
-        case (Type.F(w1), Type.FixedSizeI(w2, _)) if w1 == w2 =>
+        case (nir.Type.F(w1), nir.Type.FixedSizeI(w2, _)) if w1 == w2 =>
           Some(nir.Conv.Bitcast)
-        case _ if fromty == toty       => None
-        case (Type.Float, Type.Double) => Some(nir.Conv.Fpext)
-        case (Type.Double, Type.Float) => Some(nir.Conv.Fptrunc)
+        case _ if fromty == toty                        => None
+        case (nir.Type.Float, nir.Type.Double)          => Some(nir.Conv.Fpext)
+        case (nir.Type.Double, nir.Type.Float)          => Some(nir.Conv.Fptrunc)
         case _ => unsupported(s"cast from $fromty to $toty")
       }
 
@@ -1985,9 +1987,9 @@ trait NirGenExpr(using Context) {
      *    phase.
      */
     private def ensureBoxed(
-        value: Val,
+        value: nir.Val,
         tpeEnteringPosterasure: core.Types.Type
-    )(using buf: ExprBuffer, pos: nir.Position): Val = {
+    )(using buf: ExprBuffer, pos: nir.Position): nir.Val = {
       tpeEnteringPosterasure match {
         case tpe if tpe.isPrimitiveValueType =>
           buf.boxValue(tpe, value)
@@ -2026,17 +2028,17 @@ trait NirGenExpr(using Context) {
      *    phase.
      */
     private def ensureUnboxed(
-        value: Val,
+        value: nir.Val,
         tpeEnteringPosterasure: core.Types.Type
     )(using
         buf: ExprBuffer,
         pos: nir.Position
-    ): Val = {
+    ): nir.Val = {
       tpeEnteringPosterasure match {
         case tpe if tpe.isPrimitiveValueType =>
           val targetTpe = genType(tpeEnteringPosterasure)
           if (targetTpe == value.ty) value
-          else buf.unbox(genBoxType(tpe), value, Next.None)
+          else buf.unbox(genBoxType(tpe), value, nir.Next.None)
 
         case ErasedValueType(valueClass, _) =>
           val boxedClass = valueClass.typeSymbol.asClass
@@ -2058,17 +2060,17 @@ trait NirGenExpr(using Context) {
     }
 
     // Native specifc features
-    private def genRawPtrOp(app: Apply, code: Int): Val = {
+    private def genRawPtrOp(app: Apply, code: Int): nir.Val = {
       if (NirPrimitives.isRawPtrLoadOp(code)) genRawPtrLoadOp(app, code)
       else if (NirPrimitives.isRawPtrStoreOp(code)) genRawPtrStoreOp(app, code)
       else if (code == NirPrimitives.ELEM_RAW_PTR) genRawPtrElemOp(app)
       else {
         report.error(s"Unknown pointer operation #$code : $app", app.sourcePos)
-        Val.Null
+        nir.Val.Null
       }
     }
 
-    private def genRawPtrLoadOp(app: Apply, code: Int): Val = {
+    private def genRawPtrLoadOp(app: Apply, code: Int): nir.Val = {
       import NirPrimitives._
       given nir.Position = app.span
 
@@ -2085,14 +2087,14 @@ trait NirGenExpr(using Context) {
         case LOAD_DOUBLE   => nir.Type.Double
         case LOAD_RAW_PTR  => nir.Type.Ptr
         case LOAD_RAW_SIZE => nir.Type.Size
-        case LOAD_OBJECT   => Rt.Object
+        case LOAD_OBJECT   => nir.Rt.Object
       }
       val syncAttrs =
-        Option.when(ptrp.symbol.isVolatile)(SyncAttrs(MemoryOrder.Acquire))
+        Option.when(ptrp.symbol.isVolatile)(nir.SyncAttrs(nir.MemoryOrder.Acquire))
       buf.load(ty, ptr, unwind, syncAttrs)
     }
 
-    private def genRawPtrStoreOp(app: Apply, code: Int): Val = {
+    private def genRawPtrStoreOp(app: Apply, code: Int): nir.Val = {
       import NirPrimitives._
       given nir.Position = app.span
       val Apply(_, Seq(ptrp, valuep)) = app
@@ -2110,24 +2112,24 @@ trait NirGenExpr(using Context) {
         case STORE_DOUBLE   => nir.Type.Double
         case STORE_RAW_PTR  => nir.Type.Ptr
         case STORE_RAW_SIZE => nir.Type.Size
-        case STORE_OBJECT   => Rt.Object
+        case STORE_OBJECT   => nir.Rt.Object
       }
       val syncAttrs = Option.when(ptrp.symbol.isVolatile)(
-        SyncAttrs(MemoryOrder.Release)
+        nir.SyncAttrs(nir.MemoryOrder.Release)
       )
       buf.store(ty, ptr, value, unwind, syncAttrs)
     }
 
-    private def genRawPtrElemOp(app: Apply): Val = {
+    private def genRawPtrElemOp(app: Apply): nir.Val = {
       given nir.Position = app.span
       val Apply(_, Seq(ptrp, offsetp)) = app
 
       val ptr = genExpr(ptrp)
       val offset = genExpr(offsetp)
-      buf.elem(Type.Byte, ptr, Seq(offset), unwind)
+      buf.elem(nir.Type.Byte, ptr, Seq(offset), unwind)
     }
 
-    private def genRawPtrCastOp(app: Apply): Val = {
+    private def genRawPtrCastOp(app: Apply): nir.Val = {
       given nir.Position = app.span
       val Apply(_, Seq(argp)) = app
 
@@ -2138,24 +2140,24 @@ trait NirGenExpr(using Context) {
       genCastOp(fromty, toty, value)
     }
 
-    def genRawSizeCastOp(app: Apply, code: Int): Val = {
+    def genRawSizeCastOp(app: Apply, code: Int): nir.Val = {
       import NirPrimitives._
       given pos: nir.Position = app.span
       val Apply(_, Seq(argp)) = app
       val rec = genExpr(argp)
       val (toty, conv) = code match {
-        case CAST_RAWSIZE_TO_INT           => nir.Type.Int -> Conv.SSizeCast
-        case CAST_RAWSIZE_TO_LONG          => nir.Type.Long -> Conv.SSizeCast
-        case CAST_RAWSIZE_TO_LONG_UNSIGNED => nir.Type.Long -> Conv.ZSizeCast
-        case CAST_INT_TO_RAWSIZE           => nir.Type.Size -> Conv.SSizeCast
-        case CAST_INT_TO_RAWSIZE_UNSIGNED  => nir.Type.Size -> Conv.ZSizeCast
-        case CAST_LONG_TO_RAWSIZE          => nir.Type.Size -> Conv.SSizeCast
+        case CAST_RAWSIZE_TO_INT           => nir.Type.Int -> nir.Conv.SSizeCast
+        case CAST_RAWSIZE_TO_LONG          => nir.Type.Long -> nir.Conv.SSizeCast
+        case CAST_RAWSIZE_TO_LONG_UNSIGNED => nir.Type.Long -> nir.Conv.ZSizeCast
+        case CAST_INT_TO_RAWSIZE           => nir.Type.Size -> nir.Conv.SSizeCast
+        case CAST_INT_TO_RAWSIZE_UNSIGNED  => nir.Type.Size -> nir.Conv.ZSizeCast
+        case CAST_LONG_TO_RAWSIZE          => nir.Type.Size -> nir.Conv.SSizeCast
       }
 
       buf.conv(conv, toty, rec, unwind)
     }
 
-    private def genUnsignedOp(app: Tree, code: Int): Val = {
+    private def genUnsignedOp(app: Tree, code: Int): nir.Val = {
       given nir.Position = app.span
       import NirPrimitives._
       def castToUnsigned = code == UNSIGNED_OF
@@ -2172,13 +2174,13 @@ trait NirGenExpr(using Context) {
           val ty = genType(app.tpe)
           val arg = genExpr(argp)
 
-          buf.conv(Conv.Zext, ty, arg, unwind)
+          buf.conv(nir.Conv.Zext, ty, arg, unwind)
 
         case Apply(_, Seq(argp)) if castUnsignedToFloat =>
           val ty = genType(app.tpe)
           val arg = genExpr(argp)
 
-          buf.conv(Conv.Uitofp, ty, arg, unwind)
+          buf.conv(nir.Conv.Uitofp, ty, arg, unwind)
 
         case Apply(_, Seq(leftp, rightp)) =>
           val bin = code match {
@@ -2193,15 +2195,17 @@ trait NirGenExpr(using Context) {
       }
     }
 
-    private def getLinktimeCondition(condp: Tree): Option[LinktimeCondition] = {
+    private def getLinktimeCondition(condp: Tree): Option[nir.LinktimeCondition] = {
       import nir.LinktimeCondition._
-      def genComparsion(name: Name, value: Val): Comp = {
-        def intOrFloatComparison(onInt: Comp, onFloat: Comp) = value.ty match {
-          case _: Type.F => onFloat
-          case _         => onInt
+      def genComparsion(name: Name, value: nir.Val): nir.Comp = {
+        def intOrFloatComparison(onInt: nir.Comp, onFloat: nir.Comp) = value.ty match {
+          case _: nir.Type.F =>
+            onFloat
+          case _ =>
+            onInt
         }
 
-        import Comp._
+        import nir.Comp._
         name match {
           case nme.EQ => intOrFloatComparison(Ieq, Feq)
           case nme.NE => intOrFloatComparison(Ine, Fne)
@@ -2211,7 +2215,7 @@ trait NirGenExpr(using Context) {
           case nme.LE => intOrFloatComparison(Sle, Fle)
           case nme =>
             report.error(s"Unsupported condition '$nme'", condp.sourcePos)
-            Comp.Ine
+            nir.Comp.Ine
         }
       }
 
@@ -2221,8 +2225,8 @@ trait NirGenExpr(using Context) {
           Some {
             SimpleCondition(
               propertyName = name,
-              comparison = Comp.Ieq,
-              value = Val.True
+              comparison = nir.Comp.Ieq,
+              value = nir.Val.True
             )(using position)
           }
 
@@ -2237,8 +2241,8 @@ trait NirGenExpr(using Context) {
           Some {
             SimpleCondition(
               propertyName = name,
-              comparison = Comp.Ieq,
-              value = Val.False
+              comparison = nir.Comp.Ieq,
+              value = nir.Val.False
             )(using position)
           }
 
@@ -2282,8 +2286,8 @@ trait NirGenExpr(using Context) {
           (getLinktimeCondition(cond1), getLinktimeCondition(cond2)) match {
             case (Some(c1), Some(c2)) =>
               val bin = op match {
-                case nme.ZAND => Bin.And
-                case nme.ZOR  => Bin.Or
+                case nme.ZAND => nir.Bin.And
+                case nme.ZOR  => nir.Bin.Or
               }
               given nir.Position = condp.span
               Some(ComplexCondition(bin, c1, c2))
@@ -2320,10 +2324,10 @@ trait NirGenExpr(using Context) {
       ) ++ defnNir.Intrinsics_unsignedOfAlts ++ defnNir.RuntimePackage_toRawSizeAlts
     }
 
-    private def getUnboxedSize(sizep: Tree)(using Position): Val =
+    private def getUnboxedSize(sizep: Tree)(using nir.Position): nir.Val =
       sizep match {
         // Optimize call, strip numeric conversions
-        case Literal(Constant(size: Int)) => Val.Size(size)
+        case Literal(Constant(size: Int)) => nir.Val.Size(size)
         case Block(Nil, expr)             => getUnboxedSize(expr)
         case Apply(fun, List(arg))
             if optimizedFunctions.contains(fun.symbol) ||
@@ -2333,23 +2337,23 @@ trait NirGenExpr(using Context) {
         case _              =>
           // actual unboxing
           val size = genExpr(sizep)
-          val sizeTy = Type.normalize(size.ty)
+          val sizeTy = nir.Type.normalize(size.ty)
           val unboxed =
-            if Type.unbox.contains(sizeTy) then buf.unbox(sizeTy, size, unwind)
-            else if Type.box.contains(sizeTy) then size
+            if nir.Type.unbox.contains(sizeTy) then buf.unbox(sizeTy, size, unwind)
+            else if nir.Type.box.contains(sizeTy) then size
             else {
               report.error(
                 s"Invalid usage of Intrinsic.stackalloc, argument is not an integer type: ${sizeTy}",
                 sizep.srcPos
               )
-              Val.Size(0)
+              nir.Val.Size(0)
             }
 
           if (unboxed.ty == nir.Type.Size) unboxed
-          else buf.conv(Conv.SSizeCast, nir.Type.Size, unboxed, unwind)
+          else buf.conv(nir.Conv.SSizeCast, nir.Type.Size, unboxed, unwind)
       }
 
-    def genStackalloc(app: Apply): Val = {
+    def genStackalloc(app: Apply): nir.Val = {
       given nir.Position = app.span
       val Apply(_, args) = app
       val tpe = app
@@ -2360,11 +2364,11 @@ trait NirGenExpr(using Context) {
             "Not found type attachment for stackalloc operation, report it as a bug.",
             app.srcPos
           )
-          Type.Nothing
+          nir.Type.Nothing
         }
 
       val size = args match {
-        case Seq()         => Val.Size(1)
+        case Seq()         => nir.Val.Size(1)
         case Seq(sizep)    => getUnboxedSize(sizep)
         case Seq(_, sizep) => getUnboxedSize(sizep)
         case _             => scalanative.util.unreachable
@@ -2372,7 +2376,7 @@ trait NirGenExpr(using Context) {
       buf.stackalloc(tpe, size, unwind)
     }
 
-    def genSafeZoneAlloc(app: Apply): Val = {
+    def genSafeZoneAlloc(app: Apply): nir.Val = {
       val Apply(_, List(sz, tree)) = app
       // For new expression with a specified safe zone, e.g. `new {sz} T(...)`,
       // it's translated to `allocate(sz, new T(...))` in TyperPhase.
@@ -2395,7 +2399,7 @@ trait NirGenExpr(using Context) {
       genExpr(tree)
     }
 
-    def genCQuoteOp(app: Apply): Val = {
+    def genCQuoteOp(app: Apply): nir.Val = {
       app match {
         // case q"""
         //   scala.scalanative.unsafe.`package`.CQuote(
@@ -2421,17 +2425,17 @@ trait NirGenExpr(using Context) {
           given nir.Position = app.span
           val List(Literal(Constant(str: String))) =
             javaSeqLiteral.elems: @unchecked
-          val bytes = Val.ByteString(StringUtils.processEscapes(str))
-          val const = Val.Const(bytes)
+          val bytes = nir.Val.ByteString(StringUtils.processEscapes(str))
+          val const = nir.Val.Const(bytes)
           buf.box(nir.Rt.BoxedPtr, const, unwind)
 
         case _ =>
           report.error("Failed to interpret CQuote", app.sourcePos)
-          Val.Null
+          nir.Val.Null
       }
     }
 
-    def genClassFieldRawPtr(app: Apply): Val = {
+    def genClassFieldRawPtr(app: Apply): nir.Val = {
       given nir.Position = app.span
       val Apply(_, List(target, fieldName: Literal)) = app: @unchecked
       val fieldNameId = fieldName.const.stringValue
@@ -2468,23 +2472,23 @@ trait NirGenExpr(using Context) {
             s"${classInfoSym.show} does not contain field ${fieldNameId}",
             app.sourcePos
           )
-          Val.Int(-1)
+          nir.Val.Int(-1)
         }
     }
 
-    def genSizeOf(app: Apply): Val =
+    def genSizeOf(app: Apply): nir.Val =
       genLayoutValueOf("sizeOf", buf.sizeOf(_, unwind))(app)
-    def genAlignmentOf(app: Apply): Val =
+    def genAlignmentOf(app: Apply): nir.Val =
       genLayoutValueOf("alignmentOf", buf.alignmentOf(_, unwind))(app)
 
     private def genLayoutValueOf(
         opType: => String,
         toVal: nir.Position ?=> nir.Type => nir.Val
-    )(app: Apply): Val = {
+    )(app: Apply): nir.Val = {
       given nir.Position = app.span
       def fail(msg: => String) =
         report.error(msg, app.srcPos)
-        Val.Zero(Type.Size)
+        nir.Val.Zero(nir.Type.Size)
 
       app.getAttachment(NirDefinitions.NonErasedType) match
         case None =>
@@ -2515,12 +2519,12 @@ trait NirGenExpr(using Context) {
 
     def genLoadExtern(ty: nir.Type, externTy: nir.Type, sym: Symbol)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       assert(sym.isExtern, "loadExtern was not extern")
 
-      val name = Val.Global(genName(sym), Type.Ptr)
+      val name = nir.Val.Global(genName(sym), nir.Type.Ptr)
       val syncAttrs = Option.when(sym.isVolatile)(
-        SyncAttrs(MemoryOrder.Acquire)
+        nir.SyncAttrs(nir.MemoryOrder.Acquire)
       )
       fromExtern(
         ty,
@@ -2528,36 +2532,36 @@ trait NirGenExpr(using Context) {
       )
     }
 
-    def genStoreExtern(externTy: nir.Type, sym: Symbol, value: Val)(using
+    def genStoreExtern(externTy: nir.Type, sym: Symbol, value: nir.Val)(using
         nir.Position
-    ): Val = {
+    ): nir.Val = {
       assert(sym.isExtern, "storeExtern was not extern")
-      val name = Val.Global(genName(sym), Type.Ptr)
+      val name = nir.Val.Global(genName(sym), nir.Type.Ptr)
       val externValue = toExtern(externTy, value)
       val syncAttrs = Option.when(sym.isVolatile)(
-        SyncAttrs(MemoryOrder.Release)
+        nir.SyncAttrs(nir.MemoryOrder.Release)
       )
 
       buf.store(externTy, name, externValue, unwind, syncAttrs)
     }
 
-    def toExtern(expectedTy: nir.Type, value: Val)(using nir.Position): Val =
+    def toExtern(expectedTy: nir.Type, value: nir.Val)(using nir.Position): nir.Val =
       (expectedTy, value.ty) match {
-        case (Type.Unit, _) => Val.Unit
-        case (_, refty: Type.Ref)
-            if Type.boxClasses.contains(refty.name)
-              && Type.unbox(Type.Ref(refty.name)) == expectedTy =>
-          buf.unbox(Type.Ref(refty.name), value, unwind)
+        case (nir.Type.Unit, _) => nir.Val.Unit
+        case (_, refty: nir.Type.Ref)
+            if nir.Type.boxClasses.contains(refty.name)
+              && nir.Type.unbox(nir.Type.Ref(refty.name)) == expectedTy =>
+          buf.unbox(nir.Type.Ref(refty.name), value, unwind)
         case _ =>
           value
       }
 
-    def fromExtern(expectedTy: nir.Type, value: Val)(using nir.Position): Val =
+    def fromExtern(expectedTy: nir.Type, value: nir.Val)(using nir.Position): nir.Val =
       (expectedTy, value.ty) match {
         case (refty: nir.Type.Ref, ty)
-            if Type.boxClasses.contains(refty.name)
-              && Type.unbox(Type.Ref(refty.name)) == ty =>
-          buf.box(Type.Ref(refty.name), value, unwind)
+            if nir.Type.boxClasses.contains(refty.name)
+              && nir.Type.unbox(nir.Type.Ref(refty.name)) == ty =>
+          buf.box(nir.Type.Ref(refty.name), value, unwind)
         case _ =>
           value
       }
@@ -2568,7 +2572,7 @@ trait NirGenExpr(using Context) {
      *    - 0..N args
      *    - return type evidence
      */
-    private def genCFuncPtrApply(app: Apply): Val = {
+    private def genCFuncPtrApply(app: Apply): nir.Val = {
       given nir.Position = app.span
       val Apply(appRec @ Select(receiverp, _), aargs) = app: @unchecked
 
@@ -2582,13 +2586,13 @@ trait NirGenExpr(using Context) {
             s"Failed to generated exact NIR types for $app, something is wrong with scala-native internls.",
             app.srcPos
           )
-          return Val.Null
+          return nir.Val.Null
         case Some(paramTys) => paramTys
       }
 
       val self = genExpr(receiverp)
       val retType = genType(paramTypes.last)
-      val unboxedRetType = Type.unbox.getOrElse(retType, retType)
+      val unboxedRetType = nir.Type.unbox.getOrElse(retType, retType)
 
       val args = aargs
         .zip(paramTypes)
@@ -2602,25 +2606,25 @@ trait NirGenExpr(using Context) {
 
             /* buf.unboxValue does not handle Ref( Ptr | CArray | ... ) unboxing
              * That's why we're doing it directly */
-            if (Type.unbox.isDefinedAt(tpe)) buf.unbox(tpe, obj, unwind)
+            if (nir.Type.unbox.isDefinedAt(tpe)) buf.unbox(tpe, obj, unwind)
             else buf.unboxValue(fromType(ty), partial = false, obj)
         }
       val argTypes = args.map(_.ty)
-      val funcSig = Type.Function(argTypes, unboxedRetType)
+      val funcSig = nir.Type.Function(argTypes, unboxedRetType)
 
       val selfName = genTypeName(defnNir.CFuncPtrClass)
       val getRawPtrName = selfName
-        .member(Sig.Field("rawptr", Sig.Scope.Private(selfName)))
+        .member(nir.Sig.Field("rawptr", nir.Sig.Scope.Private(selfName)))
 
-      val target = buf.fieldload(Type.Ptr, self, getRawPtrName, unwind)
+      val target = buf.fieldload(nir.Type.Ptr, self, getRawPtrName, unwind)
       val result = buf.call(funcSig, target, args, unwind)
       if (retType != unboxedRetType) buf.box(retType, result, unwind)
       else boxValue(paramTypes.last, result)
     }
 
-    private final val ExternForwarderSig = Sig.Generated("$extern$forwarder")
+    private final val ExternForwarderSig = nir.Sig.Generated("$extern$forwarder")
 
-    private def genCFuncFromScalaFunction(app: Apply): Val = {
+    private def genCFuncFromScalaFunction(app: Apply): nir.Val = {
       given pos: nir.Position = app.span
       val paramTypes = app.getAttachment(NirDefinitions.NonErasedTypes) match
         case None =>
@@ -2635,7 +2639,7 @@ trait NirGenExpr(using Context) {
       val fn :: _ = app.args: @unchecked
 
       @tailrec
-      def resolveFunction(tree: Tree): Val = tree match {
+      def resolveFunction(tree: Tree): nir.Val = tree match {
         case Typed(expr, _) => resolveFunction(expr)
         case Block(_, expr) => resolveFunction(expr)
         case fn @ Closure(env, target, _) =>
@@ -2646,7 +2650,7 @@ trait NirGenExpr(using Context) {
             )
 
           val fnRef = genClosure(fn)
-          val Type.Ref(className, _, _) = fnRef.ty: @unchecked
+          val nir.Type.Ref(className, _, _) = fnRef.ty: @unchecked
 
           generatedDefns += genFuncExternForwarder(
             className,
@@ -2661,30 +2665,30 @@ trait NirGenExpr(using Context) {
             s"Function passed to ${app.symbol.show} needs to be inlined",
             tree.sourcePos
           )
-          Val.Null
+          nir.Val.Null
 
         case _ =>
           report.error(
             "Failed to resolve function ref for extern forwarder",
             tree.sourcePos
           )
-          Val.Null
+          nir.Val.Null
       }
 
       val fnRef = resolveFunction(fn)
       val className = genTypeName(app.tpe.sym)
 
       val ctorTy = nir.Type.Function(
-        Seq(Type.Ref(className), Type.Ptr),
-        Type.Unit
+        Seq(nir.Type.Ref(className), nir.Type.Ptr),
+        nir.Type.Unit
       )
-      val ctorName = className.member(Sig.Ctor(Seq(Type.Ptr)))
+      val ctorName = className.member(nir.Sig.Ctor(Seq(nir.Type.Ptr)))
       val rawptr = buf.method(fnRef, ExternForwarderSig, unwind)
 
       val alloc = buf.classalloc(className, unwind)
       buf.call(
         ctorTy,
-        Val.Global(ctorName, Type.Ptr),
+        nir.Val.Global(ctorName, nir.Type.Ptr),
         Seq(alloc, rawptr),
         unwind
       )
@@ -2692,12 +2696,12 @@ trait NirGenExpr(using Context) {
     }
 
     private def genFuncExternForwarder(
-        funcName: Global,
+        funcName: nir.Global,
         funSym: Symbol,
         funTree: Closure,
         evidences: List[SimpleType]
-    )(using nir.Position): Defn = {
-      val attrs = Attrs(isExtern = true)
+    )(using nir.Position): nir.Defn = {
+      val attrs = nir.Attrs(isExtern = true)
 
       // In case if passed function is adapted closure it's param types
       // would be erased, in such case we would recover original types
@@ -2706,33 +2710,33 @@ trait NirGenExpr(using Context) {
       val sig = genMethodSig(funSym)
       val externSig = genExternMethodSig(funSym)
 
-      val Type.Function(origtys, _) =
+      val nir.Type.Function(origtys, _) =
         if (!isAdapted) sig
         else {
           val params :+ retty = evidences
             .map(genType(_))
             .map(t => nir.Type.box.getOrElse(t, t)): @unchecked
-          Type.Function(params, retty)
+          nir.Type.Function(params, retty)
         }
 
-      val forwarderSig @ Type.Function(paramtys, retty) =
+      val forwarderSig @ nir.Type.Function(paramtys, retty) =
         if (!isAdapted) externSig
         else {
           val params :+ retty = evidences
             .map(genExternType)
             .map(t => nir.Type.unbox.getOrElse(t, t)): @unchecked
-          Type.Function(params, retty)
+          nir.Type.Function(params, retty)
         }
 
       val forwarderName = funcName.member(ExternForwarderSig)
       val forwarderBody = scoped(
         curUnwindHandler := None,
-        curScopeId := ScopeId.TopLevel
+        curScopeId := nir.ScopeId.TopLevel
       ) {
-        val fresh = Fresh()
+        val fresh = nir.Fresh()
         val buf = ExprBuffer(using fresh)
 
-        val params = paramtys.map(ty => Val.Local(fresh(), ty))
+        val params = paramtys.map(ty => nir.Val.Local(fresh(), ty))
         buf.label(fresh(), params)
         val origTypes =
           if (funSym.isStaticInNIR || isAdapted) origtys else origtys.tail
@@ -2762,7 +2766,7 @@ trait NirGenExpr(using Context) {
 
         buf.toSeq
       }
-      new Defn.Define(attrs, forwarderName, forwarderSig, forwarderBody)
+      new nir.Defn.Define(attrs, forwarderName, forwarderSig, forwarderBody)
     }
 
     private object WrapArray {
@@ -2789,7 +2793,7 @@ trait NirGenExpr(using Context) {
     private def genReflectiveCall(
         tree: Apply,
         isSelectDynamic: Boolean
-    ): Val = {
+    ): nir.Val = {
       given nir.Position = tree.span
       val Apply(fun @ Select(receiver, _), args) = tree: @unchecked
 
@@ -2834,7 +2838,7 @@ trait NirGenExpr(using Context) {
                       "Other uses are not supported in Scala Native.",
                     otherTree.sourcePos
                   )
-                  Rt.Object
+                  nir.Rt.Object
               }
 
               // Gen the actual args, downcasting them to the formal param types
@@ -2844,7 +2848,7 @@ trait NirGenExpr(using Context) {
                   .map { (actualArgAny, formalParamType) =>
                     val genActualArgAny = genExpr(actualArgAny)
                     (genActualArgAny.ty, formalParamType) match {
-                      case (ty: Type.Ref, formal: Type.Ref) =>
+                      case (ty: nir.Type.Ref, formal: nir.Type.Ref) =>
                         if ty.name == formal.name then genActualArgAny
                         else
                           buf.as(
@@ -2853,8 +2857,8 @@ trait NirGenExpr(using Context) {
                             unwind
                           )
 
-                      case (ty: Type.Ref, formal: Type.PrimitiveKind) =>
-                        assert(Type.Ref(ty.name) == Type.box(formal))
+                      case (ty: nir.Type.Ref, formal: nir.Type.PrimitiveKind) =>
+                        assert(nir.Type.Ref(ty.name) == nir.Type.box(formal))
                         genActualArgAny
 
                       case _ => scalanative.util.unreachable
@@ -2874,46 +2878,52 @@ trait NirGenExpr(using Context) {
 
       val dynMethod = buf.dynmethod(
         selectedValue,
-        Sig.Proxy(methodNameStr, formalParamTypeRefs),
+        nir.Sig.Proxy(methodNameStr, formalParamTypeRefs),
         unwind
       )
       // Proxies operate only on boxed types, however formal param types and name of the method
       // might contain primitive types. With current imlementation of proxies we workaround it
       // by always using boxed types in function calls
       val boxedFormalParamTypeRefs = formalParamTypeRefs.map {
-        case ty: Type.PrimitiveKind => Type.box(ty)
-        case ty                     => ty
+        case ty: nir.Type.PrimitiveKind =>
+          nir.Type.box(ty)
+        case ty =>
+          ty
       }
       buf.call(
-        Type.Function(selectedValue.ty :: boxedFormalParamTypeRefs, Rt.Object),
+        nir.Type.Function(selectedValue.ty :: boxedFormalParamTypeRefs, nir.Rt.Object),
         dynMethod,
         selectedValue :: actualArgs,
         unwind
       )
     }
 
-    private def labelExcludeUnitValue(label: Local, value: nir.Val.Local)(using
+    private def labelExcludeUnitValue(label: nir.Local, value: nir.Val.Local)(using
         nir.Position
     ): nir.Val =
       value.ty match
-        case Type.Unit => buf.label(label); Val.Unit
-        case _         => buf.label(label, Seq(value)); value
+        case nir.Type.Unit =>
+          buf.label(label); nir.Val.Unit
+        case _ =>
+          buf.label(label, Seq(value)); value
 
     private def jumpExcludeUnitValue(
         mergeType: nir.Type
-    )(label: Local, value: nir.Val)(using
+    )(label: nir.Local, value: nir.Val)(using
         nir.Position
     ): Unit =
       mergeType match
-        case Type.Unit => buf.jump(label, Nil)
-        case _         => buf.jump(label, Seq(value))
+        case nir.Type.Unit =>
+          buf.jump(label, Nil)
+        case _ =>
+          buf.jump(label, Seq(value))
 
   }
 
-  sealed class FixupBuffer(using fresh: Fresh) extends nir.Buffer {
+  sealed class FixupBuffer(using fresh: nir.Fresh) extends nir.Buffer {
     private var labeled = false
 
-    override def +=(inst: Inst): Unit = {
+    override def +=(inst: nir.Inst): Unit = {
       given nir.Position = inst.pos
       inst match {
         case inst: nir.Inst.Label =>
@@ -2929,14 +2939,14 @@ trait NirGenExpr(using Context) {
       }
       super.+=(inst)
       inst match {
-        case Inst.Let(_, op, _) if op.resty == Type.Nothing =>
+        case nir.Inst.Let(_, op, _) if op.resty == nir.Type.Nothing =>
           unreachable(unwind)
           label(fresh())
         case _ => ()
       }
     }
 
-    override def ++=(insts: Seq[Inst]): Unit =
+    override def ++=(insts: Seq[nir.Inst]): Unit =
       insts.foreach { inst => this += inst }
 
     override def ++=(other: nir.Buffer): Unit =

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.nscplugin
+package scala.scalanative
+package nscplugin
 
 import dotty.tools.dotc.ast.tpd._
 import dotty.tools.dotc.core
@@ -9,8 +10,6 @@ import core.StdNames._
 import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.backend.jvm.DottyBackendInterface.symExtensions
 import scalanative.util.unreachable
-import scala.scalanative.nir
-import scala.scalanative.nir._
 import scala.language.implicitConversions
 
 trait NirGenName(using Context) {
@@ -44,7 +43,7 @@ trait NirGenName(using Context) {
   def genModuleName(sym: Symbol): nir.Global.Top = {
     val typeName = genTypeName(sym)
     if (typeName.id.endsWith("$")) typeName
-    else Global.Top(typeName.id + "$")
+    else nir.Global.Top(typeName.id + "$")
   }
 
   def genFieldName(sym: Symbol): nir.Global.Member = {
@@ -92,7 +91,7 @@ trait NirGenName(using Context) {
       owner.member(nir.Sig.Method(id, paramTypes :+ retType, scope))
   }
 
-  def genExternSig(sym: Symbol): Sig.Extern =
+  def genExternSig(sym: Symbol): nir.Sig.Extern =
     genExternSigImpl(sym, nativeIdOf(sym))
 
   private def genExternSigImpl(sym: Symbol, id: String) =
@@ -101,7 +100,7 @@ trait NirGenName(using Context) {
       nir.Sig.Extern(id)
     else nir.Sig.Extern(id)
 
-  def genStaticMemberName(sym: Symbol, explicitOwner: Symbol): Global.Member = {
+  def genStaticMemberName(sym: Symbol, explicitOwner: Symbol): nir.Global.Member = {
     val owner = {
       // Use explicit owner in case if forwarder target was defined in the trait/interface
       // or was abstract. `sym.owner` would always point to original owner, even if it also defined
@@ -118,7 +117,7 @@ trait NirGenName(using Context) {
       val ownerIsScalaModule = ownerSym.is(Module, butNot = JavaDefined)
       def haveNoForwarders = sym.isOneOf(ExcludedForwarder, butNot = Enum)
       if (ownerIsScalaModule && haveNoForwarders) typeName
-      else Global.Top(typeName.id.stripSuffix("$"))
+      else nir.Global.Top(typeName.id.stripSuffix("$"))
     }
     val id = nativeIdOf(sym)
     val scope =

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -100,7 +100,10 @@ trait NirGenName(using Context) {
       nir.Sig.Extern(id)
     else nir.Sig.Extern(id)
 
-  def genStaticMemberName(sym: Symbol, explicitOwner: Symbol): nir.Global.Member = {
+  def genStaticMemberName(
+      sym: Symbol,
+      explicitOwner: Symbol
+  ): nir.Global.Member = {
     val owner = {
       // Use explicit owner in case if forwarder target was defined in the trait/interface
       // or was abstract. `sym.owner` would always point to original owner, even if it also defined

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -14,7 +14,6 @@ import core.Phases._
 import dotty.tools.dotc.transform.SymUtils._
 
 import scala.collection.mutable
-import scala.scalanative.nir
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.nir.Defn.Define.DebugInfo._
 import scala.scalanative.util.ScopedVar
@@ -197,7 +196,9 @@ trait NirGenStat(using Context) {
         align = getAlignmentAttr(f).orElse(classAlignment)
       )
       val ty = genType(f.info.resultType)
-      val fieldName @ nir.Global.Member(owner, sig) = genFieldName(f): @unchecked
+      val fieldName @ nir.Global.Member(owner, sig) = genFieldName(
+        f
+      ): @unchecked
       generatedDefns += nir.Defn.Var(attrs, fieldName, ty, nir.Val.Zero(ty))
 
       if (isStatic) {
@@ -573,8 +574,9 @@ trait NirGenStat(using Context) {
     }
 
     def isExternMethodAlias(target: Symbol) = (name, genName(target)) match {
-      case (nir.Global.Member(_, lsig), nir.Global.Member(_, rsig)) => lsig == rsig
-      case _                                                => false
+      case (nir.Global.Member(_, lsig), nir.Global.Member(_, rsig)) =>
+        lsig == rsig
+      case _ => false
     }
     val defaultArgs = dd.paramss.flatten.filter(_.symbol.is(HasDefault))
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.nscplugin
+package scala.scalanative
+package nscplugin
 
 import scala.language.implicitConversions
 
@@ -16,13 +17,13 @@ import scala.collection.mutable
 import scala.scalanative.nir
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.nir.Defn.Define.DebugInfo._
-import nir._
 import scala.scalanative.util.ScopedVar
 import scala.scalanative.util.ScopedVar.{scoped, toValue}
 import scala.scalanative.util.unsupported
 import dotty.tools.FatalError
 import dotty.tools.dotc.report
 import dotty.tools.dotc.core.NameKinds
+
 trait NirGenStat(using Context) {
   self: NirCodeGen =>
   import positionsConversions.fromSpan
@@ -57,9 +58,9 @@ trait NirGenStat(using Context) {
     def parent = genClassParent(sym)
     def traits = genClassInterfaces(sym)
     generatedDefns += {
-      if (sym.isStaticModule) Defn.Module(attrs, name, parent, traits)
-      else if (sym.isTraitOrInterface) Defn.Trait(attrs, name, traits)
-      else Defn.Class(attrs, name, parent, traits)
+      if (sym.isStaticModule) nir.Defn.Module(attrs, name, parent, traits)
+      else if (sym.isTraitOrInterface) nir.Defn.Trait(attrs, name, traits)
+      else nir.Defn.Class(attrs, name, parent, traits)
     }
     genClassFields(td)
     genMethods(td)
@@ -71,19 +72,19 @@ trait NirGenStat(using Context) {
     val sym = td.symbol.asClass
     val annotationAttrs = sym.annotations.collect {
       case ann if ann.symbol == defnNir.ExternClass =>
-        Attr.Extern(sym.isBlocking)
-      case ann if ann.symbol == defnNir.StubClass => Attr.Stub
+        nir.Attr.Extern(sym.isBlocking)
+      case ann if ann.symbol == defnNir.StubClass => nir.Attr.Stub
       case ann if ann.symbol == defnNir.LinkClass =>
         val Apply(_, Seq(Literal(Constant(name: String)))) =
           ann.tree: @unchecked
-        Attr.Link(name)
+        nir.Attr.Link(name)
       case ann if ann.symbol == defnNir.DefineClass =>
         val Apply(_, Seq(Literal(Constant(name: String)))) =
           ann.tree: @unchecked
-        Attr.Define(name)
+        nir.Attr.Define(name)
     }
-    val isAbstract = Option.when(sym.is(Abstract))(Attr.Abstract)
-    Attrs.fromSeq(annotationAttrs ++ isAbstract)
+    val isAbstract = Option.when(sym.is(Abstract))(nir.Attr.Abstract)
+    nir.Attrs.fromSeq(annotationAttrs ++ isAbstract)
   }
 
   private def genClassParent(sym: ClassSymbol): Option[nir.Global.Top] = {
@@ -196,23 +197,23 @@ trait NirGenStat(using Context) {
         align = getAlignmentAttr(f).orElse(classAlignment)
       )
       val ty = genType(f.info.resultType)
-      val fieldName @ Global.Member(owner, sig) = genFieldName(f): @unchecked
-      generatedDefns += Defn.Var(attrs, fieldName, ty, Val.Zero(ty))
+      val fieldName @ nir.Global.Member(owner, sig) = genFieldName(f): @unchecked
+      generatedDefns += nir.Defn.Var(attrs, fieldName, ty, nir.Val.Zero(ty))
 
       if (isStatic) {
         // Here we are generating a public static getter for the static field,
         // this is its API for other units. This is necessary for singleton
         // enum values, which are backed by static fields.
-        generatedDefns += new Defn.Define(
-          attrs = Attrs(inlineHint = nir.Attr.InlineHint),
+        generatedDefns += new nir.Defn.Define(
+          attrs = nir.Attrs(inlineHint = nir.Attr.InlineHint),
           name = genStaticMemberName(f, classSym),
-          ty = Type.Function(Nil, ty),
+          ty = nir.Type.Function(Nil, ty),
           insts = withFreshExprBuffer { buf ?=>
-            given ScopeId = ScopeId.TopLevel
+            given nir.ScopeId = nir.ScopeId.TopLevel
             val fresh = curFresh.get
             buf.label(fresh())
-            val module = buf.module(genModuleName(classSym), Next.None)
-            val value = buf.fieldload(ty, module, fieldName, Next.None)
+            val module = buf.module(genModuleName(classSym), nir.Next.None)
+            val value = buf.fieldload(ty, module, fieldName, nir.Next.None)
             buf.ret(value)
 
             buf.toSeq
@@ -241,9 +242,9 @@ trait NirGenStat(using Context) {
     generatedDefns ++= genTopLevelExports(td)
   }
 
-  private def genMethod(dd: DefDef): Option[Defn] = {
+  private def genMethod(dd: DefDef): Option[nir.Defn] = {
     implicit val pos: nir.Position = dd.span
-    val fresh = Fresh()
+    val fresh = nir.Fresh()
     val freshScope = initFreshScope(dd.rhs)
     val scopes = mutable.Set.empty[DebugInfo.LexicalScope]
     scopes += DebugInfo.LexicalScope.TopLevel(dd.rhs.span)
@@ -255,7 +256,7 @@ trait NirGenStat(using Context) {
       curMethodInfo := CollectMethodInfo().collect(dd.rhs),
       curFresh := fresh,
       curFreshScope := freshScope,
-      curScopeId := ScopeId.TopLevel,
+      curScopeId := nir.ScopeId.TopLevel,
       curScopes := scopes,
       curUnwindHandler := None,
       curMethodLocalNames := localNamesBuilder()
@@ -270,7 +271,7 @@ trait NirGenStat(using Context) {
       val sig = genMethodSig(sym)
 
       dd.rhs match {
-        case EmptyTree => Some(Defn.Declare(attrs, name, sig))
+        case EmptyTree => Some(nir.Defn.Declare(attrs, name, sig))
         case _ if sym.isConstructor && isExtern =>
           validateExternCtor(dd.rhs)
           None
@@ -295,12 +296,12 @@ trait NirGenStat(using Context) {
               if (curMethodUsesLinktimeResolvedValues)
                 attrs.copy(isLinktimeResolved = true)
               else attrs
-            val defn = Defn.Define(
+            val defn = nir.Defn.Define(
               methodAttrs,
               name,
               sig,
               insts = body,
-              debugInfo = Defn.Define.DebugInfo(
+              debugInfo = nir.Defn.Define.DebugInfo(
                 localNames = curMethodLocalNames.get.toMap,
                 lexicalScopes = scopes.toList
               )
@@ -316,23 +317,23 @@ trait NirGenStat(using Context) {
       isExtern: => Boolean
   ): nir.Attrs = {
     val inlineAttrs =
-      if (sym.is(Bridge) || sym.is(Accessor)) Seq(Attr.AlwaysInline)
+      if (sym.is(Bridge) || sym.is(Accessor)) Seq(nir.Attr.AlwaysInline)
       else Nil
 
     val annotatedAttrs =
       sym.annotations.map(_.symbol).collect {
-        case defnNir.NoInlineClass     => Attr.NoInline
-        case defnNir.AlwaysInlineClass => Attr.AlwaysInline
-        case defnNir.InlineClass       => Attr.InlineHint
-        case defnNir.NoOptimizeClass   => Attr.NoOpt
-        case defnNir.NoSpecializeClass => Attr.NoSpecialize
-        case defnNir.StubClass         => Attr.Stub
+        case defnNir.NoInlineClass     => nir.Attr.NoInline
+        case defnNir.AlwaysInlineClass => nir.Attr.AlwaysInline
+        case defnNir.InlineClass       => nir.Attr.InlineHint
+        case defnNir.NoOptimizeClass   => nir.Attr.NoOpt
+        case defnNir.NoSpecializeClass => nir.Attr.NoSpecialize
+        case defnNir.StubClass         => nir.Attr.Stub
       }
     val externAttrs = Option.when(isExtern) {
-      Attr.Extern(sym.isBlocking || sym.owner.isBlocking)
+      nir.Attr.Extern(sym.isBlocking || sym.owner.isBlocking)
     }
 
-    Attrs.fromSeq(inlineAttrs ++ annotatedAttrs ++ externAttrs)
+    nir.Attrs.fromSeq(inlineAttrs ++ annotatedAttrs ++ externAttrs)
   }
 
   protected val curExprBuffer = ScopedVar[ExprBuffer]()
@@ -356,12 +357,12 @@ trait NirGenStat(using Context) {
       val tpe = sym.info.resultType
       val ty = genType(tpe)
       val name = genLocalName(sym)
-      val param = Val.Local(fresh.namedId(genLocalName(sym)), ty)
+      val param = nir.Val.Local(fresh.namedId(genLocalName(sym)), ty)
       curMethodEnv.enter(sym, param)
       param
     }
     val thisParam = Option.unless(isStatic) {
-      Val.Local(
+      nir.Val.Local(
         fresh.namedId("this"),
         genType(curClassSym.get)
       )
@@ -377,12 +378,12 @@ trait NirGenStat(using Context) {
         .foreach { sym =>
           val ty = genType(sym.info)
           val name = genLocalName(sym)
-          val slot = buf.let(fresh.namedId(name), Op.Var(ty), unwind(fresh))
+          val slot = buf.let(fresh.namedId(name), nir.Op.Var(ty), unwind(fresh))
           curMethodEnv.enter(sym, slot)
         }
     }
 
-    def withOptSynchronized(bodyGen: ExprBuffer => Val): Val = {
+    def withOptSynchronized(bodyGen: ExprBuffer => nir.Val): nir.Val = {
       if (!isSynchronized) bodyGen(buf)
       else {
         val syncedIn = curMethodThis.getOrElse {
@@ -398,13 +399,13 @@ trait NirGenStat(using Context) {
         scoped(
           curMethodIsExtern := isExtern
         ) {
-          buf.genReturn(Val.Unit)
+          buf.genReturn(nir.Val.Unit)
         }
       else
         scoped(curMethodThis := thisParam, curMethodIsExtern := isExtern) {
           buf.genReturn(withOptSynchronized(_.genExpr(bodyp)) match {
-            case Val.Zero(_) =>
-              Val.Zero(genType(curMethodSym.get.info.resultType))
+            case nir.Val.Zero(_) =>
+              nir.Val.Zero(genType(curMethodSym.get.info.resultType))
             case v => v
           })
         }
@@ -414,7 +415,7 @@ trait NirGenStat(using Context) {
       genEntry()
       genVars()
       genBody()
-      ControlFlow.removeDeadBlocks(buf.toSeq)
+      nir.ControlFlow.removeDeadBlocks(buf.toSeq)
     }
   }
 
@@ -422,10 +423,10 @@ trait NirGenStat(using Context) {
     given nir.Position = td.span
 
     val sym = td.symbol
-    val attrs = Attrs.None
+    val attrs = nir.Attrs.None
     val name = genTypeName(sym)
 
-    generatedDefns += Defn.Class(attrs, name, None, Seq.empty)
+    generatedDefns += nir.Defn.Class(attrs, name, None, Seq.empty)
     genMethods(td)
   }
 
@@ -440,9 +441,9 @@ trait NirGenStat(using Context) {
       )
   }
 
-  protected def genLinktimeResolved(dd: DefDef, name: Global.Member)(using
+  protected def genLinktimeResolved(dd: DefDef, name: nir.Global.Member)(using
       nir.Position
-  ): Option[Defn] = {
+  ): Option[nir.Defn] = {
     if (dd.symbol.isField) {
       report.error(
         "Link-time property cannot be constant value, it would be inlined by scalac compiler",
@@ -458,10 +459,10 @@ trait NirGenStat(using Context) {
           checkExplicitReturnTypeAnnotation(dd, "value resolved at link-time")
           genLinktimeResolvedMethod(dd, retty, name) {
             _.call(
-              Linktime.PropertyResolveFunctionTy(retty),
-              Linktime.PropertyResolveFunction(retty),
-              Val.String(propertyName) :: Nil,
-              Next.None
+              nir.Linktime.PropertyResolveFunctionTy(retty),
+              nir.Linktime.PropertyResolveFunction(retty),
+              nir.Val.String(propertyName) :: Nil,
+              nir.Next.None
             )
           }
         }
@@ -500,7 +501,7 @@ trait NirGenStat(using Context) {
                       "Non-inlined terms are not allowed in linktime resolved methods",
                       expr.srcPos
                     )
-                    Val.Zero(retty)
+                    nir.Val.Zero(retty)
                   case Typed(tree, _) => resolve(tree)
                   case tree           => resolve(tree)
                 }
@@ -523,14 +524,14 @@ trait NirGenStat(using Context) {
       retty: nir.Type,
       methodName: nir.Global.Member
   )(genValue: ExprBuffer => nir.Val)(using nir.Position): nir.Defn = {
-    implicit val fresh: Fresh = Fresh()
+    implicit val fresh: nir.Fresh = nir.Fresh()
     val freshScopes = initFreshScope(dd.rhs)
     val buf = new ExprBuffer()
 
     scoped(
       curFresh := fresh,
       curFreshScope := freshScopes,
-      curScopeId := ScopeId.TopLevel,
+      curScopeId := nir.ScopeId.TopLevel,
       curMethodSym := dd.symbol,
       curMethodThis := None,
       curMethodEnv := new MethodEnv(fresh),
@@ -542,10 +543,10 @@ trait NirGenStat(using Context) {
       buf.ret(value)
     }
 
-    new Defn.Define(
-      Attrs(inlineHint = Attr.AlwaysInline, isLinktimeResolved = true),
+    new nir.Defn.Define(
+      nir.Attrs(inlineHint = nir.Attr.AlwaysInline, isLinktimeResolved = true),
       methodName,
-      Type.Function(Seq.empty, retty),
+      nir.Type.Function(Seq.empty, retty),
       buf.toSeq
     )
   }
@@ -562,17 +563,17 @@ trait NirGenStat(using Context) {
       name: nir.Global.Member,
       origSig: nir.Type,
       dd: DefDef
-  ): Option[Defn] = {
+  ): Option[nir.Defn] = {
     val rhs: Tree = dd.rhs
     given nir.Position = rhs.span
     def externMethodDecl() = {
       val externSig = genExternMethodSig(curMethodSym)
-      val externDefn = Defn.Declare(attrs, name, externSig)
+      val externDefn = nir.Defn.Declare(attrs, name, externSig)
       Some(externDefn)
     }
 
     def isExternMethodAlias(target: Symbol) = (name, genName(target)) match {
-      case (Global.Member(_, lsig), Global.Member(_, rsig)) => lsig == rsig
+      case (nir.Global.Member(_, lsig), nir.Global.Member(_, rsig)) => lsig == rsig
       case _                                                => false
     }
     val defaultArgs = dd.paramss.flatten.filter(_.symbol.is(HasDefault))
@@ -589,7 +590,7 @@ trait NirGenStat(using Context) {
 
       case Apply(target, args) if target.symbol.isExtern =>
         val sym = target.symbol
-        val Global.Member(_, selfSig) = name: @unchecked
+        val nir.Global.Member(_, selfSig) = name: @unchecked
         def isExternMethodForwarder =
           genExternSig(sym) == selfSig &&
             genExternMethodSig(sym) == origSig
@@ -708,9 +709,9 @@ trait NirGenStat(using Context) {
    *  Precondition: `isCandidateForForwarders(sym)` is true
    */
   private def genStaticForwardersForClassOrInterface(
-      existingMembers: Seq[Defn],
+      existingMembers: Seq[nir.Defn],
       sym: Symbol
-  ): Seq[Defn.Define] = {
+  ): Seq[nir.Defn.Define] = {
     val module = sym.companionModule
     if (!module.exists) Nil
     else {
@@ -724,13 +725,13 @@ trait NirGenStat(using Context) {
    *  Precondition: `isCandidateForForwarders(moduleClass)` is true
    */
   private def genStaticForwardersFromModuleClass(
-      existingMembers: Seq[Defn],
+      existingMembers: Seq[nir.Defn],
       moduleClass: Symbol
-  ): Seq[Defn.Define] = {
+  ): Seq[nir.Defn.Define] = {
     assert(moduleClass.is(ModuleClass), moduleClass)
 
-    val existingStaticMethodNames: Set[Global] = existingMembers.collect {
-      case Defn.Define(_, name @ Global.Member(_, sig), _, _, _)
+    val existingStaticMethodNames: Set[nir.Global] = existingMembers.collect {
+      case nir.Defn.Define(_, name @ nir.Global.Member(_, sig), _, _, _)
           if sig.isStatic =>
         name
     }.toSet
@@ -757,10 +758,10 @@ trait NirGenStat(using Context) {
 
       val methodName = genMethodName(sym)
       val forwarderName = genStaticMemberName(sym, moduleClass)
-      val Type.Function(_ +: paramTypes, retType) =
+      val nir.Type.Function(_ +: paramTypes, retType) =
         genMethodSig(sym): @unchecked
       val forwarderParamTypes = paramTypes
-      val forwarderType = Type.Function(forwarderParamTypes, retType)
+      val forwarderType = nir.Type.Function(forwarderParamTypes, retType)
 
       if (existingStaticMethodNames.contains(forwarderName)) {
         report.error(
@@ -773,8 +774,8 @@ trait NirGenStat(using Context) {
         )
       }
 
-      new Defn.Define(
-        attrs = Attrs(inlineHint = nir.Attr.InlineHint),
+      new nir.Defn.Define(
+        attrs = nir.Attrs(inlineHint = nir.Attr.InlineHint),
         name = forwarderName,
         ty = forwarderType,
         insts = withFreshExprBuffer { buf ?=>
@@ -782,9 +783,9 @@ trait NirGenStat(using Context) {
           scoped(
             curUnwindHandler := None,
             curMethodThis := None,
-            curScopeId := ScopeId.TopLevel
+            curScopeId := nir.ScopeId.TopLevel
           ) {
-            val entryParams = forwarderParamTypes.map(Val.Local(fresh(), _))
+            val entryParams = forwarderParamTypes.map(nir.Val.Local(fresh(), _))
             val args = entryParams.map(ValTree(_))
             buf.label(fresh(), entryParams)
             val res = buf.genApplyModuleMethod(moduleClass, sym, args)
@@ -798,8 +799,8 @@ trait NirGenStat(using Context) {
 
   private def genStaticMethodForwarders(
       td: TypeDef,
-      existingMethods: Seq[Defn]
-  ): Seq[Defn] = {
+      existingMethods: Seq[nir.Defn]
+  ): Seq[nir.Defn] = {
     val sym = td.symbol
     if !isCandidateForForwarders(sym) then Nil
     else if sym.isStaticModule then Nil
@@ -821,10 +822,10 @@ trait NirGenStat(using Context) {
         toDenot(sym).owner.is(PackageClass)
       }
     if isTopLevelModuleClass && sym.companionClass == NoSymbol then {
-      val classDefn = Defn.Class(
-        attrs = Attrs.None,
-        name = Global.Top(genTypeName(sym).id.stripSuffix("$")),
-        parent = Some(Rt.Object.name),
+      val classDefn = nir.Defn.Class(
+        attrs = nir.Attrs.None,
+        name = nir.Global.Top(genTypeName(sym).id.stripSuffix("$")),
+        parent = Some(nir.Rt.Object.name),
         traits = Nil
       )
       generatedMirrorClasses += sym -> MirrorClass(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -1,4 +1,6 @@
-package scala.scalanative.nscplugin
+package scala.scalanative
+package nscplugin
+
 import scala.language.implicitConversions
 
 import dotty.tools.dotc.ast.tpd
@@ -16,7 +18,6 @@ import dotty.tools.dotc.report
 import dotty.tools.dotc.typer.TyperPhase
 import dotty.tools.dotc.transform.SymUtils._
 
-import scala.scalanative.nir
 import scala.scalanative.util.unsupported
 
 trait NirGenType(using Context) {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.nscplugin
+package scala.scalanative
+package nscplugin
 
 import dotty.tools.dotc.ast.tpd
 import tpd._
@@ -6,9 +7,7 @@ import dotty.tools.dotc.core
 import core.Contexts._
 import core.Types._
 import scala.scalanative.util.ScopedVar
-import scalanative.nir.{Fresh, Local, LocalName}
 import scala.collection.mutable
-import scala.scalanative.nir
 
 trait NirGenUtil(using Context) { self: NirCodeGen =>
 
@@ -33,8 +32,8 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
 
   protected def withFreshExprBuffer[R](f: ExprBuffer ?=> R): R = {
     ScopedVar.scoped(
-      curFresh := Fresh(),
-      curScopeId := scala.scalanative.nir.ScopeId.TopLevel
+      curFresh := nir.Fresh(),
+      curScopeId := nir.ScopeId.TopLevel
     ) {
       val buffer = new ExprBuffer(using curFresh)
       f(using buffer)
@@ -61,11 +60,11 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
     )(f(parentScope))
   }
 
-  protected def localNamesBuilder(): mutable.Map[Local, LocalName] =
-    mutable.Map.empty[Local, LocalName]
+  protected def localNamesBuilder(): mutable.Map[nir.Local, nir.LocalName] =
+    mutable.Map.empty[nir.Local, nir.LocalName]
 
-  extension (fresh: Fresh)
-    def namedId(name: LocalName): Local = {
+  extension (fresh: nir.Fresh)
+    def namedId(name: nir.LocalName): nir.Local = {
       val id = fresh()
       curMethodLocalNames.get.update(id, name)
       id

--- a/nscplugin/src/test/scala-3/scala/scalanative/linker/StaticForwardersSuiteScala3.scala
+++ b/nscplugin/src/test/scala-3/scala/scalanative/linker/StaticForwardersSuiteScala3.scala
@@ -1,32 +1,38 @@
-package scala.scalanative.linker
+package scala.scalanative
+package linker
 
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.nir._
-
 class StaticForwardersSuiteScala3 {
 
   @Test def mainAnnotation(): Unit = {
-    val MainClass = Global.Top("myMainFunction")
-    val Package = Global.Top("Main$package")
-    val PackageModule = Global.Top("Main$package$")
+    val MainClass = nir.Global.Top("myMainFunction")
+    val Package = nir.Global.Top("Main$package")
+    val PackageModule = nir.Global.Top("Main$package$")
 
     compileAndLoad(
       "Main.scala" -> "@main def myMainFunction(): Unit = ()"
     ) { defns =>
       val expected = Seq(
         MainClass,
-        MainClass.member(Sig.Ctor(Nil)),
-        MainClass.member(Rt.ScalaMainSig),
+        MainClass.member(nir.Sig.Ctor(Nil)),
+        MainClass.member(nir.Rt.ScalaMainSig),
         Package.member(
-          Sig.Method("myMainFunction", Seq(Type.Unit), Sig.Scope.PublicStatic)
+          nir.Sig.Method(
+            "myMainFunction",
+            Seq(nir.Type.Unit),
+            nir.Sig.Scope.PublicStatic
+          )
         ),
-        PackageModule.member(Sig.Ctor(Nil)),
-        PackageModule.member(Sig.Method("myMainFunction", Seq(Type.Unit)))
+        PackageModule.member(nir.Sig.Ctor(Nil)),
+        PackageModule.member(
+          nir.Sig.Method("myMainFunction", Seq(nir.Type.Unit))
+        )
       )
       val names = defns.map(_.name)
       assertTrue(expected.diff(names).isEmpty)
     }
   }
+
 }

--- a/nscplugin/src/test/scala/scala/scalanative/linker/ExternObjectWithImplicitClass.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/ExternObjectWithImplicitClass.scala
@@ -1,9 +1,9 @@
-package scala.scalanative.linker
+package scala.scalanative
+package linker
 
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.nir._
 import scala.scalanative.util.Scope
 
 class ExternObjectWithImplicitClass {
@@ -12,29 +12,31 @@ class ExternObjectWithImplicitClass {
     compileAndLoad(
       "Test.scala" ->
         """import scala.scalanative.unsafe.extern
-          |@extern object Foo { 
-          |  implicit class Ext(v: Int) { 
+          |@extern object Foo {
+          |  implicit class Ext(v: Int) {
           |    def convert(): Long = Foo.implicitConvert(v) + Foo.doConvert(v)
-          |    def add(x: Int) = v + x 
+          |    def add(x: Int) = v + x
           |  }
           |  implicit def implicitConvert(v: Int): Long = extern
           |  def doConvert(v: Int): Long = extern
           |}
           |""".stripMargin
     ) { defns =>
-      val ExternModule = Global.Top("Foo$")
-      val ImplicitClass = Global.Top("Foo$Ext")
-      val expected: Seq[Global] = Seq(
+      val ExternModule = nir.Global.Top("Foo$")
+      val ImplicitClass = nir.Global.Top("Foo$Ext")
+      val expected: Seq[nir.Global] = Seq(
         ExternModule,
         // All ExternModule members shall be extern with exception of Ext implicit class constructor
-        ExternModule.member(Sig.Extern("doConvert")),
-        ExternModule.member(Sig.Extern("implicitConvert")),
+        ExternModule.member(nir.Sig.Extern("doConvert")),
+        ExternModule.member(nir.Sig.Extern("implicitConvert")),
         ExternModule.member(
-          Sig.Method("Ext", Seq(Type.Int, Type.Ref(ImplicitClass)))
+          nir.Sig.Method("Ext", Seq(nir.Type.Int, nir.Type.Ref(ImplicitClass)))
         ),
         ImplicitClass,
-        ImplicitClass.member(Sig.Method("convert", Seq(Type.Long))),
-        ImplicitClass.member(Sig.Method("add", Seq(Type.Int, Type.Int)))
+        ImplicitClass.member(nir.Sig.Method("convert", Seq(nir.Type.Long))),
+        ImplicitClass.member(
+          nir.Sig.Method("add", Seq(nir.Type.Int, nir.Type.Int))
+        )
       )
       assertEquals(Set.empty, expected.diff(defns.map(_.name)).toSet)
     }
@@ -44,34 +46,38 @@ class ExternObjectWithImplicitClass {
     compileAndLoad(
       "Test.scala" ->
         """import scala.scalanative.unsafe.extern
-          |@extern object Foo { 
-          |  implicit class Ext(val v: Int) extends AnyVal { 
+          |@extern object Foo {
+          |  implicit class Ext(val v: Int) extends AnyVal {
           |    def convert(): Long = Foo.implicitConvert(v) + Foo.doConvert(v)
-          |    def add(x: Int) = v + x 
+          |    def add(x: Int) = v + x
           |  }
           |  implicit def implicitConvert(v: Int): Long = extern
           |  def doConvert(v: Int): Long = extern
           |}
           |""".stripMargin
     ) { defns =>
-      val ExternModule = Global.Top("Foo$")
-      val ImplicitClass = Global.Top("Foo$Ext")
-      val ImplicitModule = Global.Top("Foo$Ext$")
-      val expected: Seq[Global] = Seq(
+      val ExternModule = nir.Global.Top("Foo$")
+      val ImplicitClass = nir.Global.Top("Foo$Ext")
+      val ImplicitModule = nir.Global.Top("Foo$Ext$")
+      val expected: Seq[nir.Global] = Seq(
         ExternModule,
         // All ExternModule members shall be extern with exception of Ext implicit class constructor
-        ExternModule.member(Sig.Extern("doConvert")),
-        ExternModule.member(Sig.Extern("implicitConvert")),
-        ExternModule.member(Sig.Method("Ext", Seq(Type.Int, Type.Int))),
+        ExternModule.member(nir.Sig.Extern("doConvert")),
+        ExternModule.member(nir.Sig.Extern("implicitConvert")),
+        ExternModule.member(
+          nir.Sig.Method("Ext", Seq(nir.Type.Int, nir.Type.Int))
+        ),
         ImplicitClass,
-        ImplicitClass.member(Sig.Method("convert", Seq(Type.Long))),
-        ImplicitClass.member(Sig.Method("add", Seq(Type.Int, Type.Int))),
+        ImplicitClass.member(nir.Sig.Method("convert", Seq(nir.Type.Long))),
+        ImplicitClass.member(
+          nir.Sig.Method("add", Seq(nir.Type.Int, nir.Type.Int))
+        ),
         ImplicitModule,
         ImplicitModule.member(
-          Sig.Method("convert$extension", Seq(Type.Int, Type.Long))
+          nir.Sig.Method("convert$extension", Seq(nir.Type.Int, nir.Type.Long))
         ),
         ImplicitModule.member(
-          Sig.Method("add$extension", Seq.fill(3)(Type.Int))
+          nir.Sig.Method("add$extension", Seq.fill(3)(nir.Type.Int))
         )
       )
       assertEquals(Set.empty, expected.diff(defns.map(_.name)).toSet)

--- a/nscplugin/src/test/scala/scala/scalanative/linker/StaticForwardersSuite.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/StaticForwardersSuite.scala
@@ -31,16 +31,20 @@ class StaticForwardersSuite {
       val expected = Seq(
         Class.member(nir.Sig.Ctor(Nil)),
         Class.member(nir.Sig.Method("foo", Seq(nir.Rt.String))),
-        Class.member(nir.Sig.Method("bar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)),
         Class.member(
-          nir.Sig.Method("fooBar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)
+          nir.Sig.Method("bar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)
+        ),
+        Class.member(
+          nir.Sig
+            .Method("fooBar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)
         ),
         Class.member(nir.Rt.ScalaMainSig),
         Module.member(nir.Sig.Ctor(Nil)),
         Module.member(nir.Sig.Method("bar", Seq(nir.Rt.String))),
         Module.member(nir.Sig.Method("fooBar", Seq(nir.Rt.String))),
         Module.member(
-          nir.Sig.Method("main", nir.Rt.ScalaMainSig.types, nir.Sig.Scope.Public)
+          nir.Sig
+            .Method("main", nir.Rt.ScalaMainSig.types, nir.Sig.Scope.Public)
         )
       )
       assertTrue(expected.diff(defns.map(_.name)).isEmpty)
@@ -64,7 +68,9 @@ class StaticForwardersSuite {
       val expected = Seq(
         Class.member(nir.Sig.Field("foo", nir.Sig.Scope.Private(Class))),
         Class.member(nir.Sig.Method("foo", Seq(nir.Rt.String))),
-        Class.member(nir.Sig.Method("bar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)),
+        Class.member(
+          nir.Sig.Method("bar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)
+        ),
         Module.member(nir.Sig.Field("bar", nir.Sig.Scope.Private(Module))),
         Module.member(nir.Sig.Method("bar", Seq(nir.Rt.String)))
       )

--- a/nscplugin/src/test/scala/scala/scalanative/linker/StaticForwardersSuite.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/StaticForwardersSuite.scala
@@ -1,9 +1,9 @@
-package scala.scalanative.linker
+package scala.scalanative
+package linker
 
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.nir._
 import scala.scalanative.util.Scope
 
 class StaticForwardersSuite {
@@ -11,7 +11,7 @@ class StaticForwardersSuite {
   @Test def generateStaticForwarders(): Unit = {
     compileAndLoad(
       "Test.scala" ->
-        """ 
+        """
           |class Foo() {
           |  def foo(): String = {
           |    Foo.bar() + Foo.fooBar
@@ -26,21 +26,21 @@ class StaticForwardersSuite {
           |}
           """.stripMargin
     ) { defns =>
-      val Class = Global.Top("Foo")
-      val Module = Global.Top("Foo$")
+      val Class = nir.Global.Top("Foo")
+      val Module = nir.Global.Top("Foo$")
       val expected = Seq(
-        Class.member(Sig.Ctor(Nil)),
-        Class.member(Sig.Method("foo", Seq(Rt.String))),
-        Class.member(Sig.Method("bar", Seq(Rt.String), Sig.Scope.PublicStatic)),
+        Class.member(nir.Sig.Ctor(Nil)),
+        Class.member(nir.Sig.Method("foo", Seq(nir.Rt.String))),
+        Class.member(nir.Sig.Method("bar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)),
         Class.member(
-          Sig.Method("fooBar", Seq(Rt.String), Sig.Scope.PublicStatic)
+          nir.Sig.Method("fooBar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)
         ),
-        Class.member(Rt.ScalaMainSig),
-        Module.member(Sig.Ctor(Nil)),
-        Module.member(Sig.Method("bar", Seq(Rt.String))),
-        Module.member(Sig.Method("fooBar", Seq(Rt.String))),
+        Class.member(nir.Rt.ScalaMainSig),
+        Module.member(nir.Sig.Ctor(Nil)),
+        Module.member(nir.Sig.Method("bar", Seq(nir.Rt.String))),
+        Module.member(nir.Sig.Method("fooBar", Seq(nir.Rt.String))),
         Module.member(
-          Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.Public)
+          nir.Sig.Method("main", nir.Rt.ScalaMainSig.types, nir.Sig.Scope.Public)
         )
       )
       assertTrue(expected.diff(defns.map(_.name)).isEmpty)
@@ -50,7 +50,7 @@ class StaticForwardersSuite {
   @Test def generateStaticAccessor(): Unit = {
     compileAndLoad(
       "Test.scala" ->
-        """ 
+        """
           |class Foo() {
           |  val foo = "foo"
           |}
@@ -59,14 +59,14 @@ class StaticForwardersSuite {
           |}
           """.stripMargin
     ) { defns =>
-      val Class = Global.Top("Foo")
-      val Module = Global.Top("Foo$")
+      val Class = nir.Global.Top("Foo")
+      val Module = nir.Global.Top("Foo$")
       val expected = Seq(
-        Class.member(Sig.Field("foo", Sig.Scope.Private(Class))),
-        Class.member(Sig.Method("foo", Seq(Rt.String))),
-        Class.member(Sig.Method("bar", Seq(Rt.String), Sig.Scope.PublicStatic)),
-        Module.member(Sig.Field("bar", Sig.Scope.Private(Module))),
-        Module.member(Sig.Method("bar", Seq(Rt.String)))
+        Class.member(nir.Sig.Field("foo", nir.Sig.Scope.Private(Class))),
+        Class.member(nir.Sig.Method("foo", Seq(nir.Rt.String))),
+        Class.member(nir.Sig.Method("bar", Seq(nir.Rt.String), nir.Sig.Scope.PublicStatic)),
+        Module.member(nir.Sig.Field("bar", nir.Sig.Scope.Private(Module))),
+        Module.member(nir.Sig.Method("bar", Seq(nir.Rt.String)))
       )
       assertTrue(expected.diff(defns.map(_.name)).isEmpty)
     }

--- a/nscplugin/src/test/scala/scala/scalanative/linker/package.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/package.scala
@@ -2,13 +2,12 @@ package scala.scalanative
 
 import java.nio.file.{Files, Path, Paths}
 import scala.scalanative.io._
-import scala.scalanative.nir.{Defn, serialization}
 import scala.scalanative.util.Scope
 
 package object linker {
   def compileAndLoad(
       sources: (String, String)*
-  )(fn: Seq[Defn] => Unit): Unit = {
+  )(fn: Seq[nir.Defn] => Unit): Unit = {
     Scope { implicit in =>
       val outDir = Files.createTempDirectory("native-test-out")
       val compiler = NIRCompiler.getCompiler(outDir)
@@ -22,7 +21,7 @@ package object linker {
         .map(outDir.relativize(_))
         .flatMap { path =>
           val buffer = dir.read(path)
-          serialization.deserializeBinary(buffer, path.toString)
+          nir.serialization.deserializeBinary(buffer, path.toString)
         }
       fn(defns)
     }

--- a/nscplugin/src/test/scala/scala/scalanative/unsafe/ExportedMembersReachabilityTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/unsafe/ExportedMembersReachabilityTest.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.unsafe
+package scala.scalanative
+package unsafe
 
 import java.nio.file.Files
 
@@ -6,11 +7,11 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.api.CompilationFailedException
-import scala.scalanative.nir._
 import scala.scalanative.linker.compileAndLoad
 
 class ExportedMembersReachabilityTest {
-  val Lib = Global.Top("lib$")
+
+  val Lib = nir.Global.Top("lib$")
 
   @Test def generateModuleExportedMethods(): Unit = {
     compileAndLoad(
@@ -23,10 +24,10 @@ class ExportedMembersReachabilityTest {
         |""".stripMargin
     ) { defns =>
       val expected = Seq(
-        Sig.Method("foo", Seq(Type.Int)),
-        Sig.Method("bar", Seq(Type.Int, Type.Long)),
-        Sig.Extern("foo"),
-        Sig.Extern("native_function")
+        nir.Sig.Method("foo", Seq(nir.Type.Int)),
+        nir.Sig.Method("bar", Seq(nir.Type.Int, nir.Type.Long)),
+        nir.Sig.Extern("foo"),
+        nir.Sig.Extern("native_function")
       ).map(Lib.member(_))
       assertTrue(expected.diff(defns.map(_.name)).isEmpty)
     }
@@ -37,21 +38,21 @@ class ExportedMembersReachabilityTest {
       "Test.scala" -> s"""
         |import scala.scalanative.unsafe._
         |object lib {
-        |  @exportAccessors 
+        |  @exportAccessors
         |  val foo: CString = c"Hello world"
-        |  
-        |  @exportAccessors("native_constant") 
+        |
+        |  @exportAccessors("native_constant")
         |  val bar: Long = 42L
         |}
         |""".stripMargin
     ) { defns =>
       val expected = Seq(
-        Sig.Field("foo", Sig.Scope.Private(Lib)),
-        Sig.Method("foo", Seq(Rt.BoxedPtr)),
-        Sig.Extern("get_foo"),
-        Sig.Field("bar", Sig.Scope.Private(Lib)),
-        Sig.Method("bar", Seq(Type.Long)),
-        Sig.Extern("native_constant")
+        nir.Sig.Field("foo", nir.Sig.Scope.Private(Lib)),
+        nir.Sig.Method("foo", Seq(nir.Rt.BoxedPtr)),
+        nir.Sig.Extern("get_foo"),
+        nir.Sig.Field("bar", nir.Sig.Scope.Private(Lib)),
+        nir.Sig.Method("bar", Seq(nir.Type.Long)),
+        nir.Sig.Extern("native_constant")
       ).map(Lib.member(_))
       assertTrue(expected.diff(defns.map(_.name)).isEmpty)
     }
@@ -62,10 +63,10 @@ class ExportedMembersReachabilityTest {
       "Test.scala" -> s"""
          |import scala.scalanative.unsafe._
          |object lib {
-         |  @exportAccessors 
+         |  @exportAccessors
          |  var foo: CString = c"Hello world"
-         |  
-         |  @exportAccessors("native_variable") 
+         |
+         |  @exportAccessors("native_variable")
          |  var bar: Long = 42L
          |
          |  @exportAccessors("native_get_baz", "native_set_baz")
@@ -75,23 +76,23 @@ class ExportedMembersReachabilityTest {
     ) { defns =>
       val expected = Seq(
         // field 1
-        Sig.Field("foo"),
-        Sig.Method("foo", Seq(Rt.BoxedPtr)),
-        Sig.Method("foo_$eq", Seq(Rt.BoxedPtr, Type.Unit)),
-        Sig.Extern("get_foo"),
-        Sig.Extern("set_foo"),
+        nir.Sig.Field("foo"),
+        nir.Sig.Method("foo", Seq(nir.Rt.BoxedPtr)),
+        nir.Sig.Method("foo_$eq", Seq(nir.Rt.BoxedPtr, nir.Type.Unit)),
+        nir.Sig.Extern("get_foo"),
+        nir.Sig.Extern("set_foo"),
         // field  2
-        Sig.Field("bar"),
-        Sig.Method("bar", Seq(Type.Long)),
-        Sig.Method("bar_$eq", Seq(Type.Long, Type.Unit)),
-        Sig.Extern("native_variable"),
-        Sig.Extern("set_bar"),
+        nir.Sig.Field("bar"),
+        nir.Sig.Method("bar", Seq(nir.Type.Long)),
+        nir.Sig.Method("bar_$eq", Seq(nir.Type.Long, nir.Type.Unit)),
+        nir.Sig.Extern("native_variable"),
+        nir.Sig.Extern("set_bar"),
         // field 3
-        Sig.Field("baz"),
-        Sig.Method("baz", Seq(Type.Byte)),
-        Sig.Method("baz_$eq", Seq(Type.Byte, Type.Unit)),
-        Sig.Extern("native_get_baz"),
-        Sig.Extern("native_set_baz")
+        nir.Sig.Field("baz"),
+        nir.Sig.Method("baz", Seq(nir.Type.Byte)),
+        nir.Sig.Method("baz_$eq", Seq(nir.Type.Byte, nir.Type.Unit)),
+        nir.Sig.Extern("native_get_baz"),
+        nir.Sig.Extern("native_set_baz")
       ).map(Lib.member(_))
       assertTrue(expected.diff(defns.map(_.name)).isEmpty)
     }

--- a/nscplugin/src/test/scala/scala/scalanative/unsafe/ExportedMembersTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/unsafe/ExportedMembersTest.scala
@@ -6,10 +6,10 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.api.CompilationFailedException
-import scala.scalanative.nir._
 import scala.scalanative.NIRCompiler
 
 class ExportedMembersTest {
+
   val NonModuleStaticError =
     "Exported members must be statically reachable, definition within class or trait is currently unsupported"
   val NonPublicMethod = "Exported members needs to be defined in public scope"
@@ -79,9 +79,9 @@ class ExportedMembersTest {
           _.compile(
             """import scala.scalanative.unsafe._
          |object lib {
-         | @exportAccessors 
+         | @exportAccessors
          | private val foo: Int = 42
-         | 
+         |
          | // Without this in Scala 3 foo would be defined as val in <init> method
          | def bar = this.foo
          |}""".stripMargin

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
@@ -4,10 +4,9 @@ package sbtplugin
 // based Scala.js sbt plugin: ScalaJSCrossVersion
 
 import sbt._
-import scala.scalanative.nir.Versions
 
 object ScalaNativeCrossVersion {
-  val currentBinaryVersion = Versions.currentBinaryVersion
+  val currentBinaryVersion = nir.Versions.currentBinaryVersion
 
   private[this] def crossVersionAddPlatformPart(
       cross: CrossVersion,
@@ -27,7 +26,10 @@ object ScalaNativeCrossVersion {
   }
 
   def scalaNativeMapped(cross: CrossVersion): CrossVersion =
-    crossVersionAddPlatformPart(cross, "native" + Versions.currentBinaryVersion)
+    crossVersionAddPlatformPart(
+      cross,
+      "native" + nir.Versions.currentBinaryVersion
+    )
 
   val binary: CrossVersion = scalaNativeMapped(CrossVersion.binary)
 

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package build
 
 import java.nio.file.{Path, Paths}
-import scala.scalanative.nir.Val
 
 /** An object describing how to configure the Scala Native toolchain. */
 sealed trait NativeConfig {
@@ -434,7 +433,7 @@ object NativeConfig {
     def isNumberOrString(value: Any) = {
       value match {
         case _: Boolean | _: Byte | _: Char | _: Short | _: Int | _: Long |
-            _: Float | _: Double | _: String | _: Val =>
+            _: Float | _: Double | _: String | _: nir.Val =>
           true
         case _ => false
       }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -8,7 +8,6 @@ import scala.scalanative.codegen.PlatformInfo
 import scala.scalanative.codegen.llvm.CodeGen
 import scala.scalanative.interflow.Interflow
 import scala.scalanative.linker.{ReachabilityAnalysis, Reach, Link}
-import scala.scalanative.nir._
 import scala.scalanative.util.Scope
 import scala.concurrent._
 import scala.util.Success
@@ -20,9 +19,9 @@ private[scalanative] object ScalaNative {
 
   /** Compute all globals that must be reachable based on given configuration.
    */
-  def entries(config: Config): Seq[Global] = {
+  def entries(config: Config): Seq[nir.Global] = {
     implicit val platform: PlatformInfo = PlatformInfo(config)
-    val entry = encodedMainClass(config).map(_.member(Rt.ScalaMainSig))
+    val entry = encodedMainClass(config).map(_.member(nir.Rt.ScalaMainSig))
     val dependencies = CodeGen.depends ++ Interflow.depends
     entry ++: dependencies
   }
@@ -30,7 +29,7 @@ private[scalanative] object ScalaNative {
   /** Given the classpath and main entry point, link under closed-world
    *  assumption.
    */
-  def link(config: Config, entries: Seq[Global])(implicit
+  def link(config: Config, entries: Seq[nir.Global])(implicit
       scope: Scope,
       ec: ExecutionContext
   ): Future[ReachabilityAnalysis.Result] = withReachabilityPostprocessing(
@@ -282,7 +281,7 @@ private[scalanative] object ScalaNative {
     log(s"\n${errors.size} errors found")
   }
 
-  def dumpDefns(config: Config, phase: String, defns: Seq[Defn]): Unit = {
+  def dumpDefns(config: Config, phase: String, defns: Seq[nir.Defn]): Unit = {
     if (config.dump) {
       config.logger.time(s"Dumping intermediate code ($phase)") {
         val path = config.workDir.resolve(phase + ".hnir")
@@ -293,11 +292,11 @@ private[scalanative] object ScalaNative {
 
   private[scalanative] def encodedMainClass(
       config: Config
-  ): Option[Global.Top] =
+  ): Option[nir.Global.Top] =
     config.mainClass.map { mainClass =>
       import scala.reflect.NameTransformer.encode
       val encoded = mainClass.split('.').map(encode).mkString(".")
-      Global.Top(encoded)
+      nir.Global.Top(encoded)
     }
 
   def genBuildInfo(

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -2,14 +2,13 @@ package scala.scalanative
 package checker
 
 import scala.collection.mutable
-import scalanative.nir._
 import scalanative.linker._
 import scalanative.util.partitionBy
 import scala.concurrent._
 
 sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
   val errors = mutable.UnrolledBuffer.empty[Check.Error]
-  var name: Global = Global.None
+  var name: nir.Global = nir.Global.None
   var ctx: List[String] = Nil
 
   def ok: Unit = ()
@@ -17,10 +16,10 @@ sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
   def error(msg: String): Unit =
     errors += Check.Error(name, ctx, msg)
 
-  def expect(expected: Type, got: Val): Unit =
+  def expect(expected: nir.Type, got: nir.Val): Unit =
     expect(expected, got.ty)
 
-  def expect(expected: Type, got: Type): Unit =
+  def expect(expected: nir.Type, got: nir.Type): Unit =
     if (!Sub.is(got, expected)) {
       error(s"expected ${expected.show}, but got ${got.show}")
     }
@@ -42,8 +41,8 @@ sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
 
   def checkMethod(meth: Method): Unit
 
-  final protected def checkFieldOp(op: Op.Field): Unit = {
-    val Op.Field(obj, name) = op
+  final protected def checkFieldOp(op: nir.Op.Field): Unit = {
+    val nir.Op.Field(obj, name) = op
     obj.ty match {
       case ScopeRef(scope) =>
         scope.implementors.foreach { cls =>
@@ -54,9 +53,9 @@ sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
     }
   }
 
-  final protected def checkMethodOp(op: Op.Method): Unit = {
-    val Op.Method(obj, sig) = op
-    expect(Rt.Object, obj)
+  final protected def checkMethodOp(op: nir.Op.Method): Unit = {
+    val nir.Op.Method(obj, sig) = op
+    expect(nir.Rt.Object, obj)
     sig match {
       case sig if sig.isMethod || sig.isCtor || sig.isGenerated => ok
       case _ => error(s"method must take a method signature, not ${sig.show}")
@@ -68,7 +67,7 @@ sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
       }
 
     obj.ty match {
-      case Type.Null => ok
+      case nir.Type.Null => ok
       case ScopeRef(info) if sig.isVirtual =>
         info.implementors.foreach(checkCallable)
       case ClassRef(info) =>
@@ -80,10 +79,10 @@ sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
 
 final class Check(implicit analysis: ReachabilityAnalysis.Result)
     extends NIRCheck {
-  val labels = mutable.Map.empty[Local, Seq[Type]]
-  val env = mutable.Map.empty[Local, Type]
+  val labels = mutable.Map.empty[nir.Local, Seq[nir.Type]]
+  val env = mutable.Map.empty[nir.Local, nir.Type]
 
-  var retty: Type = Type.Unit
+  var retty: nir.Type = nir.Type.Unit
 
   def in[T](entry: String)(f: => T): T = {
     try {
@@ -94,7 +93,7 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     }
   }
   override def checkMethod(meth: Method): Unit = {
-    val Type.Function(_, methRetty) = meth.ty
+    val nir.Type.Function(_, methRetty) = meth.ty
     retty = methRetty
 
     val insts = meth.insts
@@ -117,100 +116,100 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     labels.clear()
   }
 
-  def enterInst(inst: Inst): Unit = {
-    def enterParam(value: Val.Local) = {
-      val Val.Local(local, ty) = value
+  def enterInst(inst: nir.Inst): Unit = {
+    def enterParam(value: nir.Val.Local) = {
+      val nir.Val.Local(local, ty) = value
       env(local) = ty
     }
 
-    def enterUnwind(unwind: Next) = unwind match {
-      case Next.Unwind(param, _) =>
+    def enterUnwind(unwind: nir.Next) = unwind match {
+      case nir.Next.Unwind(param, _) =>
         enterParam(param)
       case _ =>
         ok
     }
 
     inst match {
-      case Inst.Let(n, op, unwind) =>
+      case nir.Inst.Let(n, op, unwind) =>
         env(n) = op.resty
         enterUnwind(unwind)
-      case Inst.Label(name, params) =>
+      case nir.Inst.Label(name, params) =>
         labels(name) = params.map(_.ty)
         params.foreach(enterParam)
-      case _: Inst.Ret | _: Inst.Jump | _: Inst.If | _: Inst.Switch =>
+      case _: nir.Inst.Ret | _: nir.Inst.Jump | _: nir.Inst.If | _: nir.Inst.Switch =>
         ok
-      case Inst.Throw(_, unwind) =>
+      case nir.Inst.Throw(_, unwind) =>
         enterUnwind(unwind)
-      case Inst.Unreachable(unwind) =>
+      case nir.Inst.Unreachable(unwind) =>
         enterUnwind(unwind)
-      case _: Inst.LinktimeCf => util.unreachable
+      case _: nir.Inst.LinktimeCf => util.unreachable
     }
   }
 
-  def checkInst(inst: Inst): Unit = inst match {
-    case _: Inst.Label =>
+  def checkInst(inst: nir.Inst): Unit = inst match {
+    case _: nir.Inst.Label =>
       ok
-    case Inst.Let(_, op, unwind) =>
+    case nir.Inst.Let(_, op, unwind) =>
       checkOp(op)
       in("unwind")(checkUnwind(unwind))
-    case Inst.Ret(v) =>
+    case nir.Inst.Ret(v) =>
       in("return value")(expect(retty, v))
-    case Inst.Jump(next) =>
+    case nir.Inst.Jump(next) =>
       in("jump")(checkNext(next))
-    case Inst.If(value, thenp, elsep) =>
-      in("condition")(expect(Type.Bool, value))
+    case nir.Inst.If(value, thenp, elsep) =>
+      in("condition")(expect(nir.Type.Bool, value))
       in("then")(checkNext(thenp))
       in("else")(checkNext(elsep))
-    case Inst.Switch(value, default, cases) =>
+    case nir.Inst.Switch(value, default, cases) =>
       in("default")(checkNext(default))
       cases.zipWithIndex.foreach {
         case (caseNext, idx) =>
           in("case #" + (idx + 1))(checkNext(caseNext))
       }
-    case Inst.Throw(value, unwind) =>
-      in("thrown value")(expect(Rt.Object, value))
+    case nir.Inst.Throw(value, unwind) =>
+      in("thrown value")(expect(nir.Rt.Object, value))
       in("unwind")(checkUnwind(unwind))
-    case Inst.Unreachable(unwind) =>
+    case nir.Inst.Unreachable(unwind) =>
       in("unwind")(checkUnwind(unwind))
-    case _: Inst.LinktimeCf => util.unreachable
+    case _: nir.Inst.LinktimeCf => util.unreachable
   }
 
-  def checkOp(op: Op): Unit = op match {
-    case Op.Call(ty, ptr, args) =>
-      expect(Type.Ptr, ptr)
+  def checkOp(op: nir.Op): Unit = op match {
+    case nir.Op.Call(ty, ptr, args) =>
+      expect(nir.Type.Ptr, ptr)
       checkCallArgs(ty, args)
-    case Op.Load(ty, ptr, _) =>
-      expect(Type.Ptr, ptr)
-    case Op.Store(ty, ptr, value, _) =>
-      expect(Type.Ptr, ptr)
+    case nir.Op.Load(ty, ptr, _) =>
+      expect(nir.Type.Ptr, ptr)
+    case nir.Op.Store(ty, ptr, value, _) =>
+      expect(nir.Type.Ptr, ptr)
       expect(ty, value)
-    case Op.Elem(ty, ptr, indexes) =>
-      expect(Type.Ptr, ptr)
-      checkAggregateOp(Type.ArrayValue(ty, 0), indexes, None)
-    case Op.Extract(aggr, indexes) =>
+    case nir.Op.Elem(ty, ptr, indexes) =>
+      expect(nir.Type.Ptr, ptr)
+      checkAggregateOp(nir.Type.ArrayValue(ty, 0), indexes, None)
+    case nir.Op.Extract(aggr, indexes) =>
       aggr.ty match {
-        case ty: Type.AggregateKind =>
-          checkAggregateOp(ty, indexes.map(Val.Int(_)), None)
+        case ty: nir.Type.AggregateKind =>
+          checkAggregateOp(ty, indexes.map(nir.Val.Int(_)), None)
         case _ =>
           error(s"extract is only defined on aggregate types, not ${aggr.ty}")
       }
-    case Op.Insert(aggr, value, indexes) =>
+    case nir.Op.Insert(aggr, value, indexes) =>
       aggr.ty match {
-        case ty: Type.AggregateKind =>
-          checkAggregateOp(ty, indexes.map(Val.Int(_)), Some(value.ty))
+        case ty: nir.Type.AggregateKind =>
+          checkAggregateOp(ty, indexes.map(nir.Val.Int(_)), Some(value.ty))
         case _ =>
           error(s"insert is only defined on aggregate types, not ${aggr.ty}")
       }
-    case Op.Stackalloc(ty, n) =>
+    case nir.Op.Stackalloc(ty, n) =>
       ok
-    case Op.Bin(bin, ty, l, r) =>
+    case nir.Op.Bin(bin, ty, l, r) =>
       checkBinOp(bin, ty, l, r)
-    case Op.Comp(comp, ty, l, r) =>
+    case nir.Op.Comp(comp, ty, l, r) =>
       checkCompOp(comp, ty, l, r)
-    case Op.Conv(conv, ty, value) =>
+    case nir.Op.Conv(conv, ty, value) =>
       checkConvOp(conv, ty, value)
-    case Op.Fence(_) => ok
-    case Op.Classalloc(name, zone) =>
+    case nir.Op.Fence(_) => ok
+    case nir.Op.Classalloc(name, zone) =>
       analysis.infos
         .get(name)
         .fold {
@@ -231,21 +230,21 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
         }
       zone.foreach(checkZone)
 
-    case Op.Fieldload(ty, obj, name) =>
+    case nir.Op.Fieldload(ty, obj, name) =>
       checkFieldOp(ty, obj, name, None)
-    case Op.Fieldstore(ty, obj, name, value) =>
+    case nir.Op.Fieldstore(ty, obj, name, value) =>
       checkFieldOp(ty, obj, name, Some(value))
-    case op: Op.Field  => checkFieldOp(op)
-    case op: Op.Method => checkMethodOp(op)
-    case Op.Dynmethod(obj, sig) =>
-      expect(Rt.Object, obj)
+    case op: nir.Op.Field  => checkFieldOp(op)
+    case op: nir.Op.Method => checkMethodOp(op)
+    case nir.Op.Dynmethod(obj, sig) =>
+      expect(nir.Rt.Object, obj)
       sig match {
         case sig if sig.isProxy =>
           ok
         case _ =>
           error(s"dynmethod must take a proxy signature, not ${sig.show}")
       }
-    case Op.Module(name) =>
+    case nir.Op.Module(name) =>
       analysis.infos
         .get(name)
         .fold {
@@ -264,28 +263,30 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
           case _ =>
             error(s"can't instantiate ${name.show} as a module class")
         }
-    case Op.As(ty, obj) =>
+    case nir.Op.As(ty, obj) =>
       ty match {
-        case ty: Type.RefKind =>
+        case ty: nir.Type.RefKind =>
           ok
         case ty =>
           error(s"can't cast to non-ref type ${ty.show}")
       }
-      expect(Rt.Object, obj)
-    case Op.Is(ty, obj) =>
+      expect(nir.Rt.Object, obj)
+    case nir.Op.Is(ty, obj) =>
       ty match {
-        case ty: Type.RefKind =>
+        case ty: nir.Type.RefKind =>
           ok
         case ty =>
           error(s"can't check instance of non-ref type ${ty.show}")
       }
-      expect(Rt.Object, obj)
-    case Op.Copy(value) =>
+      expect(nir.Rt.Object, obj)
+    case nir.Op.Copy(value) =>
       ok
-    case Op.SizeOf(ty) =>
+    case nir.Op.SizeOf(ty) =>
       ty match {
-        case _: Type.ValueKind                               => ok
-        case Type.Ptr | Type.Nothing | Type.Null | Type.Unit => ok
+        case _: nir.Type.ValueKind =>
+          ok
+        case nir.Type.Ptr | nir.Type.Nothing | nir.Type.Null | nir.Type.Unit =>
+          ok
         case ScopeRef(kind) =>
           kind match {
             case _: Class => ok
@@ -294,10 +295,12 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
         case _ => error(s"can't calucate size of ${ty.show}")
       }
       ok
-    case Op.AlignmentOf(ty) =>
+    case nir.Op.AlignmentOf(ty) =>
       ty match {
-        case _: Type.ValueKind                               => ok
-        case Type.Ptr | Type.Nothing | Type.Null | Type.Unit => ok
+        case _: nir.Type.ValueKind =>
+          ok
+        case nir.Type.Ptr | nir.Type.Nothing | nir.Type.Null | nir.Type.Unit =>
+          ok
         case ScopeRef(kind) =>
           kind match {
             case _: Class => ok
@@ -306,67 +309,67 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
         case _ => error(s"can't calucate alignment of ${ty.show}")
       }
       ok
-    case Op.Box(ty, value) =>
-      Type.unbox
+    case nir.Op.Box(ty, value) =>
+      nir.Type.unbox
         .get(ty)
         .fold {
           error(s"uknown box type ${ty.show}")
         } { unboxedty => expect(unboxedty, value) }
-    case Op.Unbox(ty, obj) =>
-      expect(Rt.Object, obj)
-    case Op.Var(ty) =>
+    case nir.Op.Unbox(ty, obj) =>
+      expect(nir.Rt.Object, obj)
+    case nir.Op.Var(ty) =>
       ok
-    case Op.Varload(slot) =>
+    case nir.Op.Varload(slot) =>
       slot.ty match {
-        case Type.Var(ty) =>
+        case nir.Type.Var(ty) =>
           ok
         case _ =>
           error(s"can't varload from a non-var ${slot.show}")
       }
-    case Op.Varstore(slot, value) =>
+    case nir.Op.Varstore(slot, value) =>
       slot.ty match {
-        case Type.Var(ty) =>
+        case nir.Type.Var(ty) =>
           expect(ty, value)
         case _ =>
           error(s"can't varstore into non-var ${slot.show}")
       }
-    case Op.Arrayalloc(ty, init, zone) =>
+    case nir.Op.Arrayalloc(ty, init, zone) =>
       init match {
-        case v if v.ty == Type.Int =>
+        case v if v.ty == nir.Type.Int =>
           ok
-        case Val.ArrayValue(elemty, elems) =>
+        case nir.Val.ArrayValue(elemty, elems) =>
           expect(ty, elemty)
         case _ =>
           error(s"can't initialize array with ${init.show}")
       }
       zone.foreach(checkZone)
-    case Op.Arrayload(ty, arr, idx) =>
-      val arrty = Type.Ref(Type.toArrayClass(ty))
+    case nir.Op.Arrayload(ty, arr, idx) =>
+      val arrty = nir.Type.Ref(nir.Type.toArrayClass(ty))
       expect(arrty, arr)
-      expect(Type.Int, idx)
-    case Op.Arraystore(ty, arr, idx, value) =>
-      val arrty = Type.Ref(Type.toArrayClass(ty))
+      expect(nir.Type.Int, idx)
+    case nir.Op.Arraystore(ty, arr, idx, value) =>
+      val arrty = nir.Type.Ref(nir.Type.toArrayClass(ty))
       expect(arrty, arr)
-      expect(Type.Int, idx)
+      expect(nir.Type.Int, idx)
       expect(ty, value)
-    case Op.Arraylength(arr) =>
-      expect(Rt.GenericArray, arr)
+    case nir.Op.Arraylength(arr) =>
+      expect(nir.Rt.GenericArray, arr)
   }
 
-  def checkZone(zone: Val): Unit = zone match {
-    case Val.Null | Val.Unit =>
+  def checkZone(zone: nir.Val): Unit = zone match {
+    case nir.Val.Null | nir.Val.Unit =>
       error(s"zone defined with null or unit")
     case v =>
       v.ty match {
-        case Type.Ptr | _: Type.RefKind => ()
+        case nir.Type.Ptr | _: nir.Type.RefKind => ()
         case _ => error(s"zone defind with non reference type")
       }
   }
 
   def checkAggregateOp(
-      ty: Type.AggregateKind,
-      indexes: Seq[Val],
-      stores: Option[Type]
+      ty: nir.Type.AggregateKind,
+      indexes: Seq[nir.Val],
+      stores: Option[nir.Type]
   ): Unit = {
     if (indexes.isEmpty) {
       error("index path must contain at least one index")
@@ -375,7 +378,7 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     indexes.zipWithIndex.foreach {
       case (v, idx) =>
         v.ty match {
-          case _: Type.I =>
+          case _: nir.Type.I =>
             ok
           case _ =>
             in("index #" + (idx + 1)) {
@@ -384,17 +387,17 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
         }
     }
 
-    def loop(ty: Type, indexes: Seq[Val]): Unit =
+    def loop(ty: nir.Type, indexes: Seq[nir.Val]): Unit =
       indexes match {
         case Seq() =>
           stores.foreach { v => expect(ty, v) }
         case value +: rest =>
           ty match {
-            case Type.StructValue(tys) =>
+            case nir.Type.StructValue(tys) =>
               val idx = value match {
-                case Val.Int(n) =>
+                case nir.Val.Int(n) =>
                   n
-                case Val.Long(n) =>
+                case nir.Val.Long(n) =>
                   n.toInt
                 case value =>
                   error(s"can't index into struct with ${value.show}")
@@ -405,7 +408,7 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
               } else {
                 error(s"can't index $idx into ${ty.show}")
               }
-            case Type.ArrayValue(elemty, _) =>
+            case nir.Type.ArrayValue(elemty, _) =>
               loop(elemty, rest)
             case _ =>
               error(s"can't index non-aggregate type ${ty.show}")
@@ -415,10 +418,10 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     loop(ty, indexes)
   }
 
-  def checkCallArgs(ty: Type.Function, args: Seq[Val]): Unit = {
-    def checkNoVarargs(argtys: Seq[Type]): Unit = {
+  def checkCallArgs(ty: nir.Type.Function, args: Seq[nir.Val]): Unit = {
+    def checkNoVarargs(argtys: Seq[nir.Type]): Unit = {
       argtys.zipWithIndex.foreach {
-        case (Type.Vararg, idx) =>
+        case (nir.Type.Vararg, idx) =>
           in("arg #" + (idx + 1)) {
             error("vararg type can only appear as last argumen")
           }
@@ -427,7 +430,7 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
       }
     }
 
-    def checkArgTypes(argtys: Seq[Type], args: Seq[Val]): Unit = {
+    def checkArgTypes(argtys: Seq[nir.Type], args: Seq[nir.Val]): Unit = {
       argtys.zip(args).zipWithIndex.foreach {
         case ((ty, value), idx) =>
           in("arg #" + (idx + 1))(expect(ty, value))
@@ -435,13 +438,13 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     }
 
     ty match {
-      case Type.Function(argtys :+ Type.Vararg, _) =>
+      case nir.Type.Function(argtys :+ nir.Type.Vararg, _) =>
         checkNoVarargs(argtys)
         if (args.size < argtys.size) {
           error(s"expected at least ${argtys.size} but got ${args.size}")
         }
         checkArgTypes(argtys, args.take(argtys.size))
-      case Type.Function(argtys, _) =>
+      case nir.Type.Function(argtys, _) =>
         checkNoVarargs(argtys)
         if (argtys.size != args.size) {
           error(s"expected ${argtys.size} arguments but got ${args.size}")
@@ -451,10 +454,10 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
   }
 
   def checkFieldOp(
-      ty: Type,
-      obj: Val,
-      name: Global,
-      value: Option[Val]
+      ty: nir.Type,
+      obj: nir.Val,
+      name: nir.Global,
+      value: Option[nir.Val]
   ): Unit = {
 
     obj.ty match {
@@ -482,160 +485,160 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     }
   }
 
-  def checkBinOp(bin: Bin, ty: Type, l: Val, r: Val): Unit = {
+  def checkBinOp(bin: nir.Bin, ty: nir.Type, l: nir.Val, r: nir.Val): Unit = {
     bin match {
-      case Bin.Iadd => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Fadd => checkFloatOp(bin.show, ty, l, r)
-      case Bin.Isub => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Fsub => checkFloatOp(bin.show, ty, l, r)
-      case Bin.Imul => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Fmul => checkFloatOp(bin.show, ty, l, r)
-      case Bin.Sdiv => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Udiv => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Fdiv => checkFloatOp(bin.show, ty, l, r)
-      case Bin.Srem => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Urem => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Frem => checkFloatOp(bin.show, ty, l, r)
-      case Bin.Shl  => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Lshr => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.Ashr => checkIntegerOp(bin.show, ty, l, r)
-      case Bin.And  => checkIntegerOrBoolOp(bin.show, ty, l, r)
-      case Bin.Or   => checkIntegerOrBoolOp(bin.show, ty, l, r)
-      case Bin.Xor  => checkIntegerOrBoolOp(bin.show, ty, l, r)
+      case nir.Bin.Iadd => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Fadd => checkFloatOp(bin.show, ty, l, r)
+      case nir.Bin.Isub => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Fsub => checkFloatOp(bin.show, ty, l, r)
+      case nir.Bin.Imul => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Fmul => checkFloatOp(bin.show, ty, l, r)
+      case nir.Bin.Sdiv => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Udiv => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Fdiv => checkFloatOp(bin.show, ty, l, r)
+      case nir.Bin.Srem => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Urem => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Frem => checkFloatOp(bin.show, ty, l, r)
+      case nir.Bin.Shl  => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Lshr => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.Ashr => checkIntegerOp(bin.show, ty, l, r)
+      case nir.Bin.And  => checkIntegerOrBoolOp(bin.show, ty, l, r)
+      case nir.Bin.Or   => checkIntegerOrBoolOp(bin.show, ty, l, r)
+      case nir.Bin.Xor  => checkIntegerOrBoolOp(bin.show, ty, l, r)
     }
   }
 
-  def checkCompOp(comp: Comp, ty: Type, l: Val, r: Val): Unit = comp match {
-    case Comp.Ieq => checkIntegerOrBoolOrRefOp(comp.show, ty, l, r)
-    case Comp.Ine => checkIntegerOrBoolOrRefOp(comp.show, ty, l, r)
-    case Comp.Ugt => checkIntegerOp(comp.show, ty, l, r)
-    case Comp.Uge => checkIntegerOp(comp.show, ty, l, r)
-    case Comp.Ult => checkIntegerOp(comp.show, ty, l, r)
-    case Comp.Ule => checkIntegerOp(comp.show, ty, l, r)
-    case Comp.Sgt => checkIntegerOp(comp.show, ty, l, r)
-    case Comp.Sge => checkIntegerOp(comp.show, ty, l, r)
-    case Comp.Slt => checkIntegerOp(comp.show, ty, l, r)
-    case Comp.Sle => checkIntegerOp(comp.show, ty, l, r)
-    case Comp.Feq => checkFloatOp(comp.show, ty, l, r)
-    case Comp.Fne => checkFloatOp(comp.show, ty, l, r)
-    case Comp.Fgt => checkFloatOp(comp.show, ty, l, r)
-    case Comp.Fge => checkFloatOp(comp.show, ty, l, r)
-    case Comp.Flt => checkFloatOp(comp.show, ty, l, r)
-    case Comp.Fle => checkFloatOp(comp.show, ty, l, r)
+  def checkCompOp(comp: nir.Comp, ty: nir.Type, l: nir.Val, r: nir.Val): Unit = comp match {
+    case nir.Comp.Ieq => checkIntegerOrBoolOrRefOp(comp.show, ty, l, r)
+    case nir.Comp.Ine => checkIntegerOrBoolOrRefOp(comp.show, ty, l, r)
+    case nir.Comp.Ugt => checkIntegerOp(comp.show, ty, l, r)
+    case nir.Comp.Uge => checkIntegerOp(comp.show, ty, l, r)
+    case nir.Comp.Ult => checkIntegerOp(comp.show, ty, l, r)
+    case nir.Comp.Ule => checkIntegerOp(comp.show, ty, l, r)
+    case nir.Comp.Sgt => checkIntegerOp(comp.show, ty, l, r)
+    case nir.Comp.Sge => checkIntegerOp(comp.show, ty, l, r)
+    case nir.Comp.Slt => checkIntegerOp(comp.show, ty, l, r)
+    case nir.Comp.Sle => checkIntegerOp(comp.show, ty, l, r)
+    case nir.Comp.Feq => checkFloatOp(comp.show, ty, l, r)
+    case nir.Comp.Fne => checkFloatOp(comp.show, ty, l, r)
+    case nir.Comp.Fgt => checkFloatOp(comp.show, ty, l, r)
+    case nir.Comp.Fge => checkFloatOp(comp.show, ty, l, r)
+    case nir.Comp.Flt => checkFloatOp(comp.show, ty, l, r)
+    case nir.Comp.Fle => checkFloatOp(comp.show, ty, l, r)
   }
 
-  def checkConvOp(conv: Conv, ty: Type, value: Val): Unit = conv match {
-    case Conv.ZSizeCast | Conv.SSizeCast =>
+  def checkConvOp(conv: nir.Conv, ty: nir.Type, value: nir.Val): Unit = conv match {
+    case nir.Conv.ZSizeCast | nir.Conv.SSizeCast =>
       (value.ty, ty) match {
-        case (lty: Type.FixedSizeI, Type.Size) => ok
-        case (Type.Size, rty: Type.FixedSizeI) => ok
+        case (lty: nir.Type.FixedSizeI, nir.Type.Size) => ok
+        case (nir.Type.Size, rty: nir.Type.FixedSizeI) => ok
         case _ =>
           error(
             s"can't cast size from ${value.ty.show} to ${ty.show}"
           )
       }
-    case Conv.Trunc =>
+    case nir.Conv.Trunc =>
       (value.ty, ty) match {
-        case (lty: Type.FixedSizeI, rty: Type.FixedSizeI)
+        case (lty: nir.Type.FixedSizeI, rty: nir.Type.FixedSizeI)
             if lty.width > rty.width =>
           ok
         case _ =>
           error(s"can't trunc from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Zext =>
+    case nir.Conv.Zext =>
       (value.ty, ty) match {
-        case (lty: Type.FixedSizeI, rty: Type.FixedSizeI)
+        case (lty: nir.Type.FixedSizeI, rty: nir.Type.FixedSizeI)
             if lty.width < rty.width =>
           ok
         case _ =>
           error(s"can't zext from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Sext =>
+    case nir.Conv.Sext =>
       (value.ty, ty) match {
-        case (lty: Type.FixedSizeI, rty: Type.FixedSizeI)
+        case (lty: nir.Type.FixedSizeI, rty: nir.Type.FixedSizeI)
             if lty.width < rty.width =>
           ok
         case _ =>
           error(s"can't sext from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Fptrunc =>
+    case nir.Conv.Fptrunc =>
       (value.ty, ty) match {
-        case (Type.Double, Type.Float) =>
+        case (nir.Type.Double, nir.Type.Float) =>
           ok
         case _ =>
           error(s"can't fptrunc from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Fpext =>
+    case nir.Conv.Fpext =>
       (value.ty, ty) match {
-        case (Type.Float, Type.Double) =>
+        case (nir.Type.Float, nir.Type.Double) =>
           ok
         case _ =>
           error(s"can't fpext from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Fptoui =>
+    case nir.Conv.Fptoui =>
       (value.ty, ty) match {
-        case (Type.Float | Type.Double, ity: Type.I) =>
+        case (nir.Type.Float | nir.Type.Double, ity: nir.Type.I) =>
           ok
         case _ =>
           error(s"can't fptoui from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Fptosi =>
+    case nir.Conv.Fptosi =>
       (value.ty, ty) match {
-        case (Type.Float | Type.Double, ity: Type.I) if ity.signed =>
+        case (nir.Type.Float | nir.Type.Double, ity: nir.Type.I) if ity.signed =>
           ok
         case _ =>
           error(s"can't fptosi from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Uitofp =>
+    case nir.Conv.Uitofp =>
       (value.ty, ty) match {
-        case (ity: Type.I, Type.Float | Type.Double) =>
+        case (ity: nir.Type.I, nir.Type.Float | nir.Type.Double) =>
           ok
         case _ =>
           error(s"can't uitofp from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Sitofp =>
+    case nir.Conv.Sitofp =>
       (value.ty, ty) match {
-        case (ity: Type.I, Type.Float | Type.Double) if ity.signed =>
+        case (ity: nir.Type.I, nir.Type.Float | nir.Type.Double) if ity.signed =>
           ok
         case _ =>
           error(s"can't sitofp from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Ptrtoint =>
+    case nir.Conv.Ptrtoint =>
       (value.ty, ty) match {
-        case (Type.Ptr | _: Type.RefKind, _: Type.I) =>
+        case (nir.Type.Ptr | _: nir.Type.RefKind, _: nir.Type.I) =>
           ok
         case _ =>
           error(s"can't ptrtoint from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Inttoptr =>
+    case nir.Conv.Inttoptr =>
       (value.ty, ty) match {
-        case (_: Type.I, Type.Ptr | _: Type.RefKind) =>
+        case (_: nir.Type.I, nir.Type.Ptr | _: nir.Type.RefKind) =>
           ok
         case _ =>
           error(s"can't inttoptr from ${value.ty.show} to ${ty.show}")
       }
-    case Conv.Bitcast =>
+    case nir.Conv.Bitcast =>
       def fail =
         error(s"can't bitcast from ${value.ty.show} to ${ty.show}")
       (value.ty, ty) match {
         case (lty, rty) if lty == rty =>
           ok
-        case (_: Type.I, Type.Ptr) | (Type.Ptr, _: Type.I) =>
+        case (_: nir.Type.I, nir.Type.Ptr) | (nir.Type.Ptr, _: nir.Type.I) =>
           fail
-        case (lty: Type.PrimitiveKind, rty: Type.PrimitiveKind)
+        case (lty: nir.Type.PrimitiveKind, rty: nir.Type.PrimitiveKind)
             if lty.width == rty.width =>
           ok
-        case (_: Type.RefKind, Type.Ptr) | (Type.Ptr, _: Type.RefKind) |
-            (_: Type.RefKind, _: Type.RefKind) =>
+        case (_: nir.Type.RefKind, nir.Type.Ptr) | (nir.Type.Ptr, _: nir.Type.RefKind) |
+            (_: nir.Type.RefKind, _: nir.Type.RefKind) =>
           ok
         case _ =>
           fail
       }
   }
 
-  def checkIntegerOp(op: String, ty: Type, l: Val, r: Val): Unit = {
+  def checkIntegerOp(op: String, ty: nir.Type, l: nir.Val, r: nir.Val): Unit = {
     ty match {
-      case ty: Type.I =>
+      case ty: nir.Type.I =>
         expect(ty, l)
         expect(ty, r)
       case _ =>
@@ -643,9 +646,9 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     }
   }
 
-  def checkIntegerOrBoolOp(op: String, ty: Type, l: Val, r: Val): Unit = {
+  def checkIntegerOrBoolOp(op: String, ty: nir.Type, l: nir.Val, r: nir.Val): Unit = {
     ty match {
-      case ty @ (_: Type.I | Type.Bool) =>
+      case ty @ (_: nir.Type.I | nir.Type.Bool) =>
         expect(ty, l)
         expect(ty, r)
       case _ =>
@@ -653,14 +656,14 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     }
   }
 
-  def checkIntegerOrBoolOrRefOp(op: String, ty: Type, l: Val, r: Val): Unit = {
+  def checkIntegerOrBoolOrRefOp(op: String, ty: nir.Type, l: nir.Val, r: nir.Val): Unit = {
     ty match {
-      case ty @ (_: Type.I | Type.Bool | Type.Null | Type.Ptr) =>
+      case ty @ (_: nir.Type.I | nir.Type.Bool | nir.Type.Null | nir.Type.Ptr) =>
         expect(ty, l)
         expect(ty, r)
-      case ty: Type.RefKind =>
-        expect(Rt.Object, l)
-        expect(Rt.Object, r)
+      case ty: nir.Type.RefKind =>
+        expect(nir.Rt.Object, l)
+        expect(nir.Rt.Object, r)
       case _ =>
         error(
           s"$op is only defined on integer types, bool and reference types, not ${ty.show}"
@@ -668,9 +671,9 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     }
   }
 
-  def checkFloatOp(op: String, ty: Type, l: Val, r: Val): Unit = {
+  def checkFloatOp(op: String, ty: nir.Type, l: nir.Val, r: nir.Val): Unit = {
     ty match {
-      case ty: Type.F =>
+      case ty: nir.Type.F =>
         expect(ty, l)
         expect(ty, r)
       case _ =>
@@ -678,12 +681,12 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
     }
   }
 
-  def checkUnwind(next: Next): Unit = next match {
-    case Next.None =>
+  def checkUnwind(next: nir.Next): Unit = next match {
+    case nir.Next.None =>
       ok
-    case Next.Unwind(_, next) =>
+    case nir.Next.Unwind(_, next) =>
       next match {
-        case next: Next.Label =>
+        case next: nir.Next.Label =>
           checkNext(next)
         case _ =>
           error(s"unwind's destination has to be a label, not ${next.show}")
@@ -692,14 +695,14 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
       error(s"unwind next can not be ${next.show}")
   }
 
-  def checkNext(next: Next): Unit = next match {
-    case Next.None =>
+  def checkNext(next: nir.Next): Unit = next match {
+    case nir.Next.None =>
       error("can't use none next in non-unwind context")
-    case _: Next.Unwind =>
+    case _: nir.Next.Unwind =>
       error("can't use unwind next in non-unwind context")
-    case Next.Case(_, next) =>
+    case nir.Next.Case(_, next) =>
       checkNext(next)
-    case Next.Label(name, args) =>
+    case nir.Next.Label(name, args) =>
       labels
         .get(name)
         .fold {
@@ -727,21 +730,26 @@ final class QuickCheck(implicit analysis: ReachabilityAnalysis.Result)
     meth.insts.foreach(checkInst)
   }
 
-  def checkInst(inst: Inst): Unit = inst match {
-    case Inst.Let(_, op, _) => checkOp(op)
-    case _                  => ok
+  def checkInst(inst: nir.Inst): Unit = inst match {
+    case nir.Inst.Let(_, op, _) =>
+      checkOp(op)
+    case _ =>
+      ok
   }
 
-  def checkOp(op: Op): Unit = op match {
-    case op: Op.Field  => checkFieldOp(op)
-    case op: Op.Method => checkMethodOp(op)
-    case _             => ok
+  def checkOp(op: nir.Op): Unit = op match {
+    case op: nir.Op.Field =>
+      checkFieldOp(op)
+    case op: nir.Op.Method =>
+      checkMethodOp(op)
+    case _ =>
+      ok
   }
 
 }
 
 object Check {
-  final case class Error(name: Global, ctx: List[String], msg: String)
+  final case class Error(name: nir.Global, ctx: List[String], msg: String)
 
   private def run(
       checkImpl: ReachabilityAnalysis.Result => NIRCheck

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -1,12 +1,12 @@
-package scala.scalanative.codegen
-
-import scala.scalanative.nir._
+package scala.scalanative
+package codegen
 
 class CommonMemoryLayouts(implicit meta: Metadata) {
-  sealed abstract class Layout(types: List[Type]) {
-    def this(types: Type*) = this(types.toList)
 
-    val layout: Type.StructValue = Type.StructValue(types.toList)
+  sealed abstract class Layout(types: List[nir.Type]) {
+    def this(types: nir.Type*) = this(types.toList)
+
+    val layout: nir.Type.StructValue = nir.Type.StructValue(types.toList)
     def fields: Int = layout.tys.size
   }
 
@@ -19,11 +19,11 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
 
   object Rtti
       extends Layout(
-        Type.Ptr :: // ClassRtti
+        nir.Type.Ptr :: // ClassRtti
           meta.lockWordType.toList ::: // optional, multithreading only
-          Type.Int :: // ClassId
-          Type.Int :: // Traitid
-          Type.Ptr :: // ClassName
+          nir.Type.Int :: // ClassId
+          nir.Type.Int :: // Traitid
+          nir.Type.Ptr :: // ClassName
           Nil
       ) {
     final val RttiIdx = Common.RttiIdx
@@ -42,14 +42,14 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
     // Common layout not including variable-sized virtual table
     private val baseLayout =
       Rtti.layout ::
-        Type.Int :: // class size
-        Type.Int :: // id range
+        nir.Type.Int :: // class size
+        nir.Type.Int :: // id range
         FieldLayout.referenceOffsetsTy :: // reference offsets
         dynMapType.toList
 
-    override val layout = genLayout(vtable = Type.ArrayValue(Type.Ptr, 0))
+    override val layout = genLayout(vtable = nir.Type.ArrayValue(nir.Type.Ptr, 0))
 
-    def genLayout(vtable: Type): Type.StructValue = Type.StructValue(
+    def genLayout(vtable: nir.Type): nir.Type.StructValue = nir.Type.StructValue(
       baseLayout ::: vtable :: Nil
     )
 
@@ -65,7 +65,7 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
 
   object ObjectHeader
       extends Layout(
-        Type.Ptr :: // RTTI
+        nir.Type.Ptr :: // RTTI
           meta.lockWordType.toList // optional, multithreading only
       ) {
     final val RttiIdx = Common.RttiIdx
@@ -75,7 +75,7 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
   object Object
       extends Layout(
         ObjectHeader.layout,
-        Type.ArrayValue(Type.Ptr, 0)
+        nir.Type.ArrayValue(nir.Type.Ptr, 0)
       ) {
     final val ObjectHeaderIdx = 0
     final val ValuesOffset = ObjectHeaderIdx + 1
@@ -83,10 +83,10 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
 
   object ArrayHeader
       extends Layout(
-        Type.Ptr :: // RTTI
+        nir.Type.Ptr :: // RTTI
           meta.lockWordType.toList ::: // optional, multithreading only
-          Type.Int :: // length
-          Type.Int :: // stride (used only by GC)
+          nir.Type.Int :: // length
+          nir.Type.Int :: // stride (used only by GC)
           Nil
       ) {
     final val RttiIdx = Common.RttiIdx
@@ -100,9 +100,10 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
   object Array
       extends Layout(
         ArrayHeader.layout,
-        Type.ArrayValue(Type.Nothing, 0)
+        nir.Type.ArrayValue(nir.Type.Nothing, 0)
       ) {
     final val ArrayHeaderIdx = 0
     final val ValuesIdx = ArrayHeaderIdx + 1
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -47,11 +47,13 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
         FieldLayout.referenceOffsetsTy :: // reference offsets
         dynMapType.toList
 
-    override val layout = genLayout(vtable = nir.Type.ArrayValue(nir.Type.Ptr, 0))
+    override val layout =
+      genLayout(vtable = nir.Type.ArrayValue(nir.Type.Ptr, 0))
 
-    def genLayout(vtable: nir.Type): nir.Type.StructValue = nir.Type.StructValue(
-      baseLayout ::: vtable :: Nil
-    )
+    def genLayout(vtable: nir.Type): nir.Type.StructValue =
+      nir.Type.StructValue(
+        baseLayout ::: vtable :: Nil
+      )
 
     final val RttiIdx = Common.RttiIdx
     final val SizeIdx = RttiIdx + 1

--- a/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
@@ -1,23 +1,25 @@
 package scala.scalanative
 package codegen
 
-import scalanative.nir._
 import scalanative.linker.{Class, Method}
 
 object DynamicHashMap {
-  final val ty: Type = Type.Ptr
+  final val ty: nir.Type = nir.Type.Ptr
 }
 
-class DynamicHashMap(cls: Class, proxies: Seq[Defn])(implicit meta: Metadata) {
-  val methods: Seq[Global.Member] = {
+class DynamicHashMap(cls: Class, proxies: Seq[nir.Defn])(implicit meta: Metadata) {
+
+  val methods: Seq[nir.Global.Member] = {
     val own = proxies.collect {
       case p if p.name.top == cls.name =>
-        p.name.asInstanceOf[Global.Member]
+        p.name.asInstanceOf[nir.Global.Member]
     }
     val sigs = own.map(_.sig).toSet
     cls.parent
-      .fold(Seq.empty[Global.Member])(meta.dynmap(_).methods)
+      .fold(Seq.empty[nir.Global.Member])(meta.dynmap(_).methods)
       .filterNot(m => sigs.contains(m.sig)) ++ own
   }
-  val value: Val = DynmethodPerfectHashMap(methods, meta.analysis.dynsigs)
+
+  val value: nir.Val = DynmethodPerfectHashMap(methods, meta.analysis.dynsigs)
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
@@ -7,7 +7,9 @@ object DynamicHashMap {
   final val ty: nir.Type = nir.Type.Ptr
 }
 
-class DynamicHashMap(cls: Class, proxies: Seq[nir.Defn])(implicit meta: Metadata) {
+class DynamicHashMap(cls: Class, proxies: Seq[nir.Defn])(implicit
+    meta: Metadata
+) {
 
   val methods: Seq[nir.Global.Member] = {
     val own = proxies.collect {

--- a/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
@@ -1,14 +1,16 @@
 package scala.scalanative
 package codegen
 
-import scalanative.nir._
 import scalanative.linker.{Class, Field}
 
 object FieldLayout {
-  val referenceOffsetsTy = Type.StructValue(Seq(Type.Ptr))
+
+  val referenceOffsetsTy = nir.Type.StructValue(Seq(nir.Type.Ptr))
+
 }
 
 class FieldLayout(cls: Class)(implicit meta: Metadata) {
+
   import meta.layouts.{Object, ObjectHeader}
   import meta.platform
 
@@ -35,9 +37,10 @@ class FieldLayout(cls: Class)(implicit meta: Metadata) {
     }
   }
 
-  val struct = Type.StructValue(layout.tys.map(_.ty))
+  val struct = nir.Type.StructValue(layout.tys.map(_.ty))
   val size = layout.size
-  val referenceOffsetsValue = Val.StructValue(
-    Seq(Val.Const(Val.ArrayValue(Type.Long, layout.offsetArray)))
+  val referenceOffsetsValue = nir.Val.StructValue(
+    Seq(nir.Val.Const(nir.Val.ArrayValue(nir.Type.Long, layout.offsetArray)))
   )
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -218,7 +218,11 @@ object Generate {
         ),
         nir.Inst.Let(
           ueh,
-          nir.Op.Call(JavaThreadGetUEHSig, nir.Val.Global(JavaThreadGetUEH, nir.Type.Ptr), Seq(nir.Val.Local(thread, JavaThreadRef))),
+          nir.Op.Call(
+            JavaThreadGetUEHSig,
+            nir.Val.Global(JavaThreadGetUEH, nir.Type.Ptr),
+            Seq(nir.Val.Local(thread, JavaThreadRef))
+          ),
           nir.Next.None
         ),
         nir.Inst.Let(
@@ -634,7 +638,8 @@ object Generate {
       nir.Sig.Method("getUncaughtExceptionHandler", Seq(JavaThreadUEHRef))
     )
 
-    val RuntimeExecuteUEHSig = nir.Type.Function(Seq(Runtime, JavaThreadUEHRef, JavaThreadRef, Throwable), nir.Type.Unit)
+    val RuntimeExecuteUEHSig =
+      nir.Type.Function(Seq(Runtime, JavaThreadUEHRef, JavaThreadRef, Throwable), nir.Type.Unit)
     val RuntimeExecuteUEH = Runtime.name.member(
       nir.Sig.Method("executeUncaughtExceptionHandler", Seq(JavaThreadUEHRef, JavaThreadRef, Throwable, nir.Type.Unit))
     )

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package codegen
 
 import scala.collection.mutable
-import scala.scalanative.nir._
 import scala.scalanative.linker.{
   Class,
   ScopeInfo,
@@ -15,27 +14,27 @@ import scala.scalanative.build.Logger
 object Generate {
   import Impl._
 
-  val ClassHasTraitName = Global.Member(rttiModule, Sig.Extern("__check_class_has_trait"))
-  val ClassHasTraitSig = Type.Function(Seq(Type.Int, Type.Int), Type.Bool)
+  val ClassHasTraitName = nir.Global.Member(rttiModule, nir.Sig.Extern("__check_class_has_trait"))
+  val ClassHasTraitSig = nir.Type.Function(Seq(nir.Type.Int, nir.Type.Int), nir.Type.Bool)
 
-  val TraitHasTraitName = Global.Member(rttiModule, Sig.Extern("__check_trait_has_trait"))
-  val TraitHasTraitSig = Type.Function(Seq(Type.Int, Type.Int), Type.Bool)
+  val TraitHasTraitName = nir.Global.Member(rttiModule, nir.Sig.Extern("__check_trait_has_trait"))
+  val TraitHasTraitSig = nir.Type.Function(Seq(nir.Type.Int, nir.Type.Int), nir.Type.Bool)
 
-  def apply(entry: Option[Global.Top], defns: Seq[Defn])(implicit
+  def apply(entry: Option[nir.Global.Top], defns: Seq[nir.Defn])(implicit
       meta: Metadata
-  ): Seq[Defn] =
+  ): Seq[nir.Defn] =
     (new Impl(entry, defns)).generate()
 
   implicit def reachabilityAnalysis(implicit meta: Metadata): ReachabilityAnalysis.Result = meta.analysis
-  private implicit val pos: Position = Position.NoPosition
+  private implicit val pos: nir.Position = nir.Position.NoPosition
   private implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
 
-  private class Impl(entry: Option[Global.Top], defns: Seq[Defn])(implicit
+  private class Impl(entry: Option[nir.Global.Top], defns: Seq[nir.Defn])(implicit
       meta: Metadata
   ) {
-    val buf = mutable.UnrolledBuffer.empty[Defn]
+    val buf = mutable.UnrolledBuffer.empty[nir.Defn]
 
-    def generate(): Seq[Defn] = {
+    def generate(): Seq[nir.Defn] = {
       genDefnsExcludingGenerated()
       genInjects()
       entry.fold(genLibraryInit())(genMain(_))
@@ -73,7 +72,7 @@ object Generate {
       meta.classes.foreach { cls =>
         val rtti = meta.rtti(cls)
         val pos = cls.position
-        buf += Defn.Var(Attrs.None, rtti.name, rtti.struct, rtti.value)(pos)
+        buf += nir.Defn.Var(nir.Attrs.None, rtti.name, rtti.struct, rtti.value)(pos)
       }
     }
 
@@ -102,89 +101,89 @@ object Generate {
     //   (table(bitIndex >> AddressBitsPerWord) & (1 << (bitIndex & RightBits))) != 0
     // }
     private def genHasTrait(
-        name: Global.Member,
-        sig: Type.Function,
-        tableTy: Type,
-        tableVal: Val
+        name: nir.Global.Member,
+        sig: nir.Type.Function,
+        tableTy: nir.Type,
+        tableVal: nir.Val
     ): Unit = {
-      implicit val fresh = Fresh()
-      val firstid, secondid = Val.Local(fresh(), Type.Int)
-      val row = Val.Local(fresh(), Type.Int)
-      val columns = Val.Int(meta.traits.length)
-      val bitIndex = Val.Local(fresh(), Type.Int)
-      val arrayPos = Val.Local(fresh(), Type.Int)
-      val intptr = Val.Local(fresh(), Type.Ptr)
-      val int = Val.Local(fresh(), Type.Int)
-      val toShift = Val.Local(fresh(), Type.Int)
-      val mask = Val.Local(fresh(), Type.Int)
-      val and = Val.Local(fresh(), Type.Int)
-      val result = Val.Local(fresh(), Type.Bool)
+      implicit val fresh = nir.Fresh()
+      val firstid, secondid = nir.Val.Local(fresh(), nir.Type.Int)
+      val row = nir.Val.Local(fresh(), nir.Type.Int)
+      val columns = nir.Val.Int(meta.traits.length)
+      val bitIndex = nir.Val.Local(fresh(), nir.Type.Int)
+      val arrayPos = nir.Val.Local(fresh(), nir.Type.Int)
+      val intptr = nir.Val.Local(fresh(), nir.Type.Ptr)
+      val int = nir.Val.Local(fresh(), nir.Type.Int)
+      val toShift = nir.Val.Local(fresh(), nir.Type.Int)
+      val mask = nir.Val.Local(fresh(), nir.Type.Int)
+      val and = nir.Val.Local(fresh(), nir.Type.Int)
+      val result = nir.Val.Local(fresh(), nir.Type.Bool)
 
-      def let(local: Val.Local, op: Op) = Inst.Let(local.id, op, Next.None)
+      def let(local: nir.Val.Local, op: nir.Op) = nir.Inst.Let(local.id, op, nir.Next.None)
 
-      buf += Defn.Define(
-        Attrs(inlineHint = Attr.AlwaysInline),
+      buf += nir.Defn.Define(
+        nir.Attrs(inlineHint = nir.Attr.AlwaysInline),
         name,
         sig,
         Seq(
-          Inst.Label(fresh(), Seq(firstid, secondid)),
-          let(row, Op.Bin(Bin.Imul, Type.Int, firstid, columns)),
-          let(bitIndex, Op.Bin(Bin.Iadd, Type.Int, row, secondid)),
+          nir.Inst.Label(fresh(), Seq(firstid, secondid)),
+          let(row, nir.Op.Bin(nir.Bin.Imul, nir.Type.Int, firstid, columns)),
+          let(bitIndex, nir.Op.Bin(nir.Bin.Iadd, nir.Type.Int, row, secondid)),
           let(
             arrayPos,
-            Op.Bin(
-              Bin.Ashr,
-              Type.Int,
+            nir.Op.Bin(
+              nir.Bin.Ashr,
+              nir.Type.Int,
               bitIndex,
-              Val.Int(BitMatrix.AddressBitsPerWord)
+              nir.Val.Int(BitMatrix.AddressBitsPerWord)
             )
           ),
           let(
             intptr,
-            Op.Elem(
+            nir.Op.Elem(
               tableTy,
               tableVal,
-              Seq(Val.Int(0), arrayPos)
+              Seq(nir.Val.Int(0), arrayPos)
             )
           ),
-          let(int, Op.Load(Type.Int, intptr)),
+          let(int, nir.Op.Load(nir.Type.Int, intptr)),
           let(
             toShift,
-            Op.Bin(
-              Bin.And,
-              Type.Int,
+            nir.Op.Bin(
+              nir.Bin.And,
+              nir.Type.Int,
               bitIndex,
-              Val.Int(BitMatrix.RightBits)
+              nir.Val.Int(BitMatrix.RightBits)
             )
           ),
           let(
             mask,
-            Op.Bin(
-              Bin.Shl,
-              Type.Int,
-              Val.Int(1),
+            nir.Op.Bin(
+              nir.Bin.Shl,
+              nir.Type.Int,
+              nir.Val.Int(1),
               toShift
             )
           ),
           let(
             and,
-            Op.Bin(
-              Bin.And,
-              Type.Int,
+            nir.Op.Bin(
+              nir.Bin.And,
+              nir.Type.Int,
               int,
               mask
             )
           ),
           let(
             result,
-            Op.Comp(
-              Comp.Ine,
-              Type.Int,
+            nir.Op.Comp(
+              nir.Comp.Ine,
+              nir.Type.Int,
               and,
-              Val.Int(0)
+              nir.Val.Int(0)
             )
           ),
-          Inst.Ret(result)
+          nir.Inst.Ret(result)
         )
       )
     }
@@ -193,58 +192,58 @@ object Generate {
       meta.traits.foreach { trt =>
         val rtti = meta.rtti(trt)
         val pos = trt.position
-        buf += Defn.Var(Attrs.None, rtti.name, rtti.struct, rtti.value)(pos)
+        buf += nir.Defn.Var(nir.Attrs.None, rtti.name, rtti.struct, rtti.value)(pos)
       }
     }
 
     /* Generate set of instructions using common exception handling, generate method
      * would return 0 if would execute successfully exception and 1 in otherwise */
     private def withExceptionHandler(
-        body: (() => Next.Unwind) => Seq[Inst]
-    )(implicit fresh: Fresh): Seq[Inst] = {
-      val exc = Val.Local(fresh(), Throwable)
+        body: (() => nir.Next.Unwind) => Seq[nir.Inst]
+    )(implicit fresh: nir.Fresh): Seq[nir.Inst] = {
+      val exc = nir.Val.Local(fresh(), Throwable)
       val handler, thread, ueh, uehHandler = fresh()
 
-      def unwind(): Next.Unwind = {
-        val exc = Val.Local(fresh(), nir.Rt.Object)
-        Next.Unwind(exc, Next.Label(handler, Seq(exc)))
+      def unwind(): nir.Next.Unwind = {
+        val exc = nir.Val.Local(fresh(), nir.Rt.Object)
+        nir.Next.Unwind(exc, nir.Next.Label(handler, Seq(exc)))
       }
       body(unwind) ++ Seq(
-        Inst.Ret(Val.Int(0)),
-        Inst.Label(handler, Seq(exc)),
-        Inst.Let(
+        nir.Inst.Ret(nir.Val.Int(0)),
+        nir.Inst.Label(handler, Seq(exc)),
+        nir.Inst.Let(
           thread,
-          Op.Call(JavaThreadCurrentThreadSig, Val.Global(JavaThreadCurrentThread, Type.Ptr), Seq()),
-          Next.None
+          nir.Op.Call(JavaThreadCurrentThreadSig, nir.Val.Global(JavaThreadCurrentThread, nir.Type.Ptr), Seq()),
+          nir.Next.None
         ),
-        Inst.Let(
+        nir.Inst.Let(
           ueh,
-          Op.Call(JavaThreadGetUEHSig, Val.Global(JavaThreadGetUEH, Type.Ptr), Seq(Val.Local(thread, JavaThreadRef))),
-          Next.None
+          nir.Op.Call(JavaThreadGetUEHSig, nir.Val.Global(JavaThreadGetUEH, nir.Type.Ptr), Seq(nir.Val.Local(thread, JavaThreadRef))),
+          nir.Next.None
         ),
-        Inst.Let(
+        nir.Inst.Let(
           fresh(),
-          Op.Call(
+          nir.Op.Call(
             RuntimeExecuteUEHSig,
-            Val.Global(RuntimeExecuteUEH, Type.Ptr),
-            Seq(Val.Null, Val.Local(ueh, JavaThreadUEHRef), Val.Local(thread, JavaThreadRef), exc)
+            nir.Val.Global(RuntimeExecuteUEH, nir.Type.Ptr),
+            Seq(nir.Val.Null, nir.Val.Local(ueh, JavaThreadUEHRef), nir.Val.Local(thread, JavaThreadRef), exc)
           ),
-          Next.None
+          nir.Next.None
         ),
-        Inst.Ret(Val.Int(1))
+        nir.Inst.Ret(nir.Val.Int(1))
       )
     }
 
     /* Generate class initializers to handle class instantiated using reflection */
     private def genClassInitializersCalls(
-        unwind: () => Next
-    )(implicit fresh: Fresh): Seq[Inst] = {
+        unwind: () => nir.Next
+    )(implicit fresh: nir.Fresh): Seq[nir.Inst] = {
       defns.collect {
-        case defn @ Defn.Define(_, name: Global.Member, _, _, _) if name.sig.isClinit =>
-          Inst.Let(
-            Op.Call(
-              Type.Function(Seq.empty, Type.Unit),
-              Val.Global(name, Type.Ref(name.owner)),
+        case defn @ nir.Defn.Define(_, name: nir.Global.Member, _, _, _) if name.sig.isClinit =>
+          nir.Inst.Let(
+            nir.Op.Call(
+              nir.Type.Function(Seq.empty, nir.Type.Unit),
+              nir.Val.Global(name, nir.Type.Ref(name.owner)),
               Seq.empty
             ),
             unwind()
@@ -252,95 +251,95 @@ object Generate {
       }
     }
 
-    private def genGcInit(unwindProvider: () => Next)(implicit fresh: Fresh) = {
-      def unwind: Next = unwindProvider()
-      val stackBottom = Val.Local(fresh(), Type.Ptr)
-      val StackBottomVar = Val.Global(stackBottomName, Type.Ptr)
+    private def genGcInit(unwindProvider: () => nir.Next)(implicit fresh: nir.Fresh) = {
+      def unwind: nir.Next = unwindProvider()
+      val stackBottom = nir.Val.Local(fresh(), nir.Type.Ptr)
+      val StackBottomVar = nir.Val.Global(stackBottomName, nir.Type.Ptr)
 
       Seq(
         // init __stack_bottom variable
-        Inst.Let(
+        nir.Inst.Let(
           stackBottom.id,
-          Op.Stackalloc(Type.Ptr, Val.Long(0)),
+          nir.Op.Stackalloc(nir.Type.Ptr, nir.Val.Long(0)),
           unwind
         ),
-        Inst.Let(Op.Store(Type.Ptr, StackBottomVar, stackBottom), unwind),
+        nir.Inst.Let(nir.Op.Store(nir.Type.Ptr, StackBottomVar, stackBottom), unwind),
         // Init GC
-        Inst.Let(Op.Call(InitSig, Init, Seq.empty), unwind)
+        nir.Inst.Let(nir.Op.Call(InitSig, Init, Seq.empty), unwind)
       )
     }
 
     /* Injects definition of library initializers that needs to be called, when using Scala Native as shared library.
      * Injects basic handling of exceptions, prints stack trace and returns non-zero value on exception or 0 otherwise */
     def genLibraryInit(): Unit = {
-      implicit val fresh: Fresh = Fresh()
+      implicit val fresh: nir.Fresh = nir.Fresh()
 
-      buf += Defn.Define(
-        Attrs(isExtern = true),
+      buf += nir.Defn.Define(
+        nir.Attrs(isExtern = true),
         LibraryInitName,
         LibraryInitSig,
         withExceptionHandler { unwindProvider =>
-          Seq(Inst.Label(fresh(), Nil)) ++
+          Seq(nir.Inst.Label(fresh(), Nil)) ++
             genGcInit(unwindProvider) ++
             genClassInitializersCalls(unwindProvider)
         }
       )
     }
 
-    def genMain(entry: Global.Top): Unit = {
+    def genMain(entry: nir.Global.Top): Unit = {
       validateMainEntry(entry)
 
-      implicit val fresh = Fresh()
-      buf += Defn.Define(
-        Attrs.None,
+      implicit val fresh = nir.Fresh()
+      buf += nir.Defn.Define(
+        nir.Attrs.None,
         MainName,
         MainSig,
         withExceptionHandler { unwindProvider =>
-          val entryMainTy = Type.Function(Seq(ObjectArray), Type.Unit)
+          val entryMainTy = nir.Type.Function(Seq(ObjectArray), nir.Type.Unit)
           val entryMainMethod =
-            Val.Global(entry.member(Rt.ScalaMainSig), Type.Ptr)
+            nir.Val.Global(entry.member(nir.Rt.ScalaMainSig), nir.Type.Ptr)
 
-          val argc = Val.Local(fresh(), Type.Int)
-          val argv = Val.Local(fresh(), Type.Ptr)
-          val rt = Val.Local(fresh(), Runtime)
-          val arr = Val.Local(fresh(), ObjectArray)
+          val argc = nir.Val.Local(fresh(), nir.Type.Int)
+          val argv = nir.Val.Local(fresh(), nir.Type.Ptr)
+          val rt = nir.Val.Local(fresh(), Runtime)
+          val arr = nir.Val.Local(fresh(), ObjectArray)
 
           def unwind = unwindProvider()
 
-          Seq(Inst.Label(fresh(), Seq(argc, argv))) ++
+          Seq(nir.Inst.Label(fresh(), Seq(argc, argv))) ++
             genGcInit(unwindProvider) ++
             genClassInitializersCalls(unwindProvider) ++
             Seq(
-              Inst.Let(rt.id, Op.Module(Runtime.name), unwind),
-              Inst.Let(
+              nir.Inst.Let(rt.id, nir.Op.Module(Runtime.name), unwind),
+              nir.Inst.Let(
                 arr.id,
-                Op.Call(RuntimeInitSig, RuntimeInit, Seq(rt, argc, argv)),
+                nir.Op.Call(RuntimeInitSig, RuntimeInit, Seq(rt, argc, argv)),
                 unwind
               ),
-              Inst.Let(
-                Op.Call(entryMainTy, entryMainMethod, Seq(arr)),
+              nir.Inst.Let(
+                nir.Op.Call(entryMainTy, entryMainMethod, Seq(arr)),
                 unwind
               ),
-              Inst.Let(Op.Call(RuntimeLoopSig, RuntimeLoop, Seq(rt)), unwind)
+              nir.Inst.Let(nir.Op.Call(RuntimeLoopSig, RuntimeLoop, Seq(rt)), unwind)
             )
         }
       )
     }
 
     def genStackBottom(): Unit =
-      buf += Defn.Var(Attrs.None, stackBottomName, Type.Ptr, Val.Null)
+      buf += nir.Defn.Var(nir.Attrs.None, stackBottomName, nir.Type.Ptr, nir.Val.Null)
 
     def genModuleAccessors(): Unit = {
-      val LoadModuleSig = Type.Function(
-        Seq(Type.Ptr, Type.Ptr, Type.Size, Type.Ptr),
-        Type.Ptr
+      val LoadModuleSig = nir.Type.Function(
+        Seq(nir.Type.Ptr, nir.Type.Ptr, nir.Type.Size, nir.Type.Ptr),
+        nir.Type.Ptr
       )
-      val LoadModuleDecl = Defn.Declare(
-        Attrs(isExtern = true),
+      val LoadModuleDecl = nir.Defn.Declare(
+        nir.Attrs(isExtern = true),
         extern("__scalanative_loadModule"),
         LoadModuleSig
       )
-      val LoadModule = Val.Global(LoadModuleDecl.name, Type.Ptr)
+      val LoadModule = nir.Val.Global(LoadModuleDecl.name, nir.Type.Ptr)
       val useSynchronizedAccessors = meta.config.multithreadingSupport
       if (useSynchronizedAccessors) {
         buf += LoadModuleDecl
@@ -351,26 +350,26 @@ object Generate {
           val name = cls.name
           val clsTy = cls.ty
 
-          implicit val fresh = Fresh()
+          implicit val fresh = nir.Fresh()
           implicit val pos = cls.position
 
           val entry = fresh()
           val existing = fresh()
           val initialize = fresh()
 
-          val slot = Val.Local(fresh(), Type.Ptr)
-          val self = Val.Local(fresh(), clsTy)
-          val cond = Val.Local(fresh(), Type.Bool)
-          val alloc = Val.Local(fresh(), clsTy)
+          val slot = nir.Val.Local(fresh(), nir.Type.Ptr)
+          val self = nir.Val.Local(fresh(), clsTy)
+          val cond = nir.Val.Local(fresh(), nir.Type.Bool)
+          val alloc = nir.Val.Local(fresh(), clsTy)
 
           if (cls.isConstantModule) {
-            val moduleTyName = name.member(Sig.Generated("type"))
-            val moduleTyVal = Val.Global(moduleTyName, Type.Ptr)
-            val instanceName = name.member(Sig.Generated("instance"))
-            val instanceVal = Val.StructValue(moduleTyVal :: meta.lockWordVals)
+            val moduleTyName = name.member(nir.Sig.Generated("type"))
+            val moduleTyVal = nir.Val.Global(moduleTyName, nir.Type.Ptr)
+            val instanceName = name.member(nir.Sig.Generated("instance"))
+            val instanceVal = nir.Val.StructValue(moduleTyVal :: meta.lockWordVals)
             // Needs to be defined as var, const does not allow to modify lock-word field
-            val instanceDefn = Defn.Var(
-              Attrs.None,
+            val instanceDefn = nir.Defn.Var(
+              nir.Attrs.None,
               instanceName,
               meta.layouts.ObjectHeader.layout,
               instanceVal
@@ -378,16 +377,16 @@ object Generate {
 
             buf += instanceDefn
           } else {
-            val initSig = Type.Function(Seq(clsTy), Type.Unit)
-            val init = Val.Global(name.member(Sig.Ctor(Seq.empty)), Type.Ptr)
+            val initSig = nir.Type.Function(Seq(clsTy), nir.Type.Unit)
+            val init = nir.Val.Global(name.member(nir.Sig.Ctor(Seq.empty)), nir.Type.Ptr)
 
-            val loadName = name.member(Sig.Generated("load"))
-            val loadSig = Type.Function(Seq.empty, clsTy)
+            val loadName = name.member(nir.Sig.Generated("load"))
+            val loadSig = nir.Type.Function(Seq.empty, clsTy)
 
-            val selectSlot = Op.Elem(
-              Type.Ptr,
-              Val.Global(moduleArrayName, Type.Ptr),
-              Seq(Val.Int(meta.moduleArray.index(cls)))
+            val selectSlot = nir.Op.Elem(
+              nir.Type.Ptr,
+              nir.Val.Global(moduleArrayName, nir.Type.Ptr),
+              Seq(nir.Val.Int(meta.moduleArray.index(cls)))
             )
 
             /*  singlethreaded module load
@@ -401,28 +400,28 @@ object Generate {
              *    instance
              *  }
              */
-            def loadSinglethreadImpl: Seq[Inst] = {
+            def loadSinglethreadImpl: Seq[nir.Inst] = {
               Seq(
-                Inst.Label(entry, Seq.empty),
-                Inst.Let(slot.id, selectSlot, Next.None),
-                Inst.Let(self.id, Op.Load(clsTy, slot), Next.None),
-                Inst.Let(
+                nir.Inst.Label(entry, Seq.empty),
+                nir.Inst.Let(slot.id, selectSlot, nir.Next.None),
+                nir.Inst.Let(self.id, nir.Op.Load(clsTy, slot), nir.Next.None),
+                nir.Inst.Let(
                   cond.id,
-                  Op.Comp(Comp.Ine, nir.Rt.Object, self, Val.Null),
-                  Next.None
+                  nir.Op.Comp(nir.Comp.Ine, nir.Rt.Object, self, nir.Val.Null),
+                  nir.Next.None
                 ),
-                Inst.If(cond, Next(existing), Next(initialize)),
-                Inst.Label(existing, Seq.empty),
-                Inst.Ret(self),
-                Inst.Label(initialize, Seq.empty),
-                Inst.Let(
+                nir.Inst.If(cond, nir.Next(existing), nir.Next(initialize)),
+                nir.Inst.Label(existing, Seq.empty),
+                nir.Inst.Ret(self),
+                nir.Inst.Label(initialize, Seq.empty),
+                nir.Inst.Let(
                   alloc.id,
-                  Op.Classalloc(name, zone = None),
-                  Next.None
+                  nir.Op.Classalloc(name, zone = None),
+                  nir.Next.None
                 ),
-                Inst.Let(Op.Store(clsTy, slot, alloc), Next.None),
-                Inst.Let(Op.Call(initSig, init, Seq(alloc)), Next.None),
-                Inst.Ret(alloc)
+                nir.Inst.Let(nir.Op.Store(clsTy, slot, alloc), nir.Next.None),
+                nir.Inst.Let(nir.Op.Call(initSig, init, Seq(alloc)), nir.Next.None),
+                nir.Inst.Ret(alloc)
               )
             }
 
@@ -434,30 +433,30 @@ object Generate {
              *  Safety of safe multithreaded initialization comes with the increased complexity and overhead.
              *  For single-threaded usage we use the old implementation
              */
-            def loadMultithreadingSafeImpl: Seq[Inst] = {
+            def loadMultithreadingSafeImpl: Seq[nir.Inst] = {
               val size = meta.layout(cls).size
               val rtti = meta.rtti(cls).const
 
               Seq(
-                Inst.Label(entry, Seq.empty),
-                Inst.Let(slot.id, selectSlot, Next.None),
-                Inst.Let(
+                nir.Inst.Label(entry, Seq.empty),
+                nir.Inst.Let(slot.id, selectSlot, nir.Next.None),
+                nir.Inst.Let(
                   self.id,
-                  Op.Call(
+                  nir.Op.Call(
                     LoadModuleSig,
                     LoadModule,
-                    Seq(slot, rtti, Val.Size(size), init)
+                    Seq(slot, rtti, nir.Val.Size(size), init)
                   ),
-                  Next.None
+                  nir.Next.None
                 ),
-                Inst.Ret(self)
+                nir.Inst.Ret(self)
               )
             }
 
-            val loadDefn = Defn.Define(
-              Attrs(inlineHint =
-                if (useSynchronizedAccessors) Attr.MayInline
-                else Attr.NoInline
+            val loadDefn = nir.Defn.Define(
+              nir.Attrs(inlineHint =
+                if (useSynchronizedAccessors) nir.Attr.MayInline
+                else nir.Attr.NoInline
               ),
               loadName,
               loadSig,
@@ -473,8 +472,8 @@ object Generate {
 
     def genModuleArray(): Unit =
       buf +=
-        Defn.Var(
-          Attrs.None,
+        nir.Defn.Var(
+          nir.Attrs.None,
           moduleArrayName,
           meta.moduleArray.value.ty,
           meta.moduleArray.value
@@ -482,43 +481,43 @@ object Generate {
 
     def genModuleArraySize(): Unit =
       buf +=
-        Defn.Var(
-          Attrs.None,
+        nir.Defn.Var(
+          nir.Attrs.None,
           moduleArraySizeName,
-          Type.Int,
-          Val.Int(meta.moduleArray.size)
+          nir.Type.Int,
+          nir.Val.Int(meta.moduleArray.size)
         )
 
     private def tpe2arrayId(tpe: String): Int = {
       val clazz =
         reachabilityAnalysis
-          .infos(Global.Top(s"scala.scalanative.runtime.${tpe}Array"))
+          .infos(nir.Global.Top(s"scala.scalanative.runtime.${tpe}Array"))
           .asInstanceOf[Class]
 
       meta.ids(clazz)
     }
 
     def genObjectArrayId(): Unit = {
-      buf += Defn.Var(
-        Attrs.None,
+      buf += nir.Defn.Var(
+        nir.Attrs.None,
         objectArrayIdName,
-        Type.Int,
-        Val.Int(tpe2arrayId("Object"))
+        nir.Type.Int,
+        nir.Val.Int(tpe2arrayId("Object"))
       )
     }
 
     def genWeakRefUtils(): Unit = {
-      def addToBuf(name: Global.Member, value: Int) =
+      def addToBuf(name: nir.Global.Member, value: Int) =
         buf +=
-          Defn.Var(
-            Attrs.None,
+          nir.Defn.Var(
+            nir.Attrs.None,
             name,
-            Type.Int,
-            Val.Int(value)
+            nir.Type.Int,
+            nir.Val.Int(value)
           )
 
       val (weakRefIdsMin, weakRefIdsMax, modifiedFieldOffset) = reachabilityAnalysis.infos
-        .get(Global.Top("java.lang.ref.WeakReference"))
+        .get(nir.Global.Top("java.lang.ref.WeakReference"))
         .collect { case cls: Class if cls.allocated => cls }
         .fold((-1, -1, -1)) { weakRef =>
           // if WeakReferences are being compiled and therefore supported
@@ -567,9 +566,9 @@ object Generate {
         )
       }
 
-      buf += Defn.Var(Attrs.None, arrayIdsMinName, Type.Int, Val.Int(min))
+      buf += nir.Defn.Var(nir.Attrs.None, arrayIdsMinName, nir.Type.Int, nir.Val.Int(min))
 
-      buf += Defn.Var(Attrs.None, arrayIdsMaxName, Type.Int, Val.Int(max))
+      buf += nir.Defn.Var(nir.Attrs.None, arrayIdsMaxName, nir.Type.Int, nir.Val.Int(max))
 
     }
 
@@ -579,15 +578,15 @@ object Generate {
       buf += meta.hasTraitTables.traitHasTraitDefn
     }
 
-    private def validateMainEntry(entry: Global.Top): Unit = {
+    private def validateMainEntry(entry: nir.Global.Top): Unit = {
       def fail(reason: String): Nothing =
         util.unsupported(s"Entry ${entry.id} $reason")
 
       val info = reachabilityAnalysis.infos.getOrElse(entry, fail("not linked"))
       info match {
         case cls: Class =>
-          cls.resolve(Rt.ScalaMainSig).getOrElse {
-            fail(s"does not contain ${Rt.ScalaMainSig}")
+          cls.resolve(nir.Rt.ScalaMainSig).getOrElse {
+            fail(s"does not contain ${nir.Rt.ScalaMainSig}")
           }
         case _: Unavailable => fail("unavailable")
         case _              => util.unreachable
@@ -596,53 +595,53 @@ object Generate {
   }
 
   private object Impl {
-    val rttiModule = Global.Top("java.lang.rtti$")
+    val rttiModule = nir.Global.Top("java.lang.rtti$")
 
-    val ObjectArray = Type.Ref(Global.Top("scala.scalanative.runtime.ObjectArray"))
+    val ObjectArray = nir.Type.Ref(nir.Global.Top("scala.scalanative.runtime.ObjectArray"))
 
-    val Runtime = Rt.Runtime
-    val RuntimeInitSig = Type.Function(Seq(Runtime, Type.Int, Type.Ptr), ObjectArray)
+    val Runtime = nir.Rt.Runtime
+    val RuntimeInitSig = nir.Type.Function(Seq(Runtime, nir.Type.Int, nir.Type.Ptr), ObjectArray)
     val RuntimeInitName = Runtime.name.member(
-      Sig.Method("init", Seq(Type.Int, Type.Ptr, Type.Array(Rt.String)))
+      nir.Sig.Method("init", Seq(nir.Type.Int, nir.Type.Ptr, nir.Type.Array(nir.Rt.String)))
     )
-    val RuntimeInit = Val.Global(RuntimeInitName, Type.Ptr)
-    val RuntimeLoopSig = Type.Function(Seq(Runtime), Type.Unit)
-    val RuntimeLoopName = Runtime.name.member(Sig.Method("loop", Seq(Type.Unit)))
-    val RuntimeLoop = Val.Global(RuntimeLoopName, Type.Ptr)
+    val RuntimeInit = nir.Val.Global(RuntimeInitName, nir.Type.Ptr)
+    val RuntimeLoopSig = nir.Type.Function(Seq(Runtime), nir.Type.Unit)
+    val RuntimeLoopName = Runtime.name.member(nir.Sig.Method("loop", Seq(nir.Type.Unit)))
+    val RuntimeLoop = nir.Val.Global(RuntimeLoopName, nir.Type.Ptr)
 
     val LibraryInitName = extern("ScalaNativeInit")
-    val LibraryInitSig = Type.Function(Seq.empty, Type.Int)
+    val LibraryInitSig = nir.Type.Function(Seq.empty, nir.Type.Int)
 
     val MainName = extern("main")
-    val MainSig = Type.Function(Seq(Type.Int, Type.Ptr), Type.Int)
+    val MainSig = nir.Type.Function(Seq(nir.Type.Int, nir.Type.Ptr), nir.Type.Int)
 
-    val ThrowableName = Global.Top("java.lang.Throwable")
-    val Throwable = Type.Ref(ThrowableName)
+    val ThrowableName = nir.Global.Top("java.lang.Throwable")
+    val Throwable = nir.Type.Ref(ThrowableName)
 
-    val JavaThread = Global.Top("java.lang.Thread")
-    val JavaThreadRef = Type.Ref(JavaThread)
+    val JavaThread = nir.Global.Top("java.lang.Thread")
+    val JavaThreadRef = nir.Type.Ref(JavaThread)
 
-    val JavaThreadUEH = Global.Top("java.lang.Thread$UncaughtExceptionHandler")
-    val JavaThreadUEHRef = Type.Ref(JavaThreadUEH)
+    val JavaThreadUEH = nir.Global.Top("java.lang.Thread$UncaughtExceptionHandler")
+    val JavaThreadUEHRef = nir.Type.Ref(JavaThreadUEH)
 
-    val JavaThreadCurrentThreadSig = Type.Function(Seq(), JavaThreadRef)
+    val JavaThreadCurrentThreadSig = nir.Type.Function(Seq(), JavaThreadRef)
     val JavaThreadCurrentThread = JavaThread.member(
-      Sig.Method("currentThread", Seq(JavaThreadRef), scope = Sig.Scope.PublicStatic)
+      nir.Sig.Method("currentThread", Seq(JavaThreadRef), scope = nir.Sig.Scope.PublicStatic)
     )
 
-    val JavaThreadGetUEHSig = Type.Function(Seq(JavaThreadRef), JavaThreadUEHRef)
+    val JavaThreadGetUEHSig = nir.Type.Function(Seq(JavaThreadRef), JavaThreadUEHRef)
     val JavaThreadGetUEH = JavaThread.member(
-      Sig.Method("getUncaughtExceptionHandler", Seq(JavaThreadUEHRef))
+      nir.Sig.Method("getUncaughtExceptionHandler", Seq(JavaThreadUEHRef))
     )
 
-    val RuntimeExecuteUEHSig = Type.Function(Seq(Runtime, JavaThreadUEHRef, JavaThreadRef, Throwable), Type.Unit)
+    val RuntimeExecuteUEHSig = nir.Type.Function(Seq(Runtime, JavaThreadUEHRef, JavaThreadRef, Throwable), nir.Type.Unit)
     val RuntimeExecuteUEH = Runtime.name.member(
-      Sig.Method("executeUncaughtExceptionHandler", Seq(JavaThreadUEHRef, JavaThreadRef, Throwable, Type.Unit))
+      nir.Sig.Method("executeUncaughtExceptionHandler", Seq(JavaThreadUEHRef, JavaThreadRef, Throwable, nir.Type.Unit))
     )
 
-    val InitSig = Type.Function(Seq.empty, Type.Unit)
-    val InitDecl = Defn.Declare(Attrs.None, extern("scalanative_init"), InitSig)
-    val Init = Val.Global(InitDecl.name, Type.Ptr)
+    val InitSig = nir.Type.Function(Seq.empty, nir.Type.Unit)
+    val InitDecl = nir.Defn.Declare(nir.Attrs.None, extern("scalanative_init"), InitSig)
+    val Init = nir.Val.Global(InitDecl.name, nir.Type.Ptr)
 
     val stackBottomName = extern("__stack_bottom")
     val moduleArrayName = extern("__modules")
@@ -656,11 +655,11 @@ object Generate {
     val arrayIdsMinName = extern("__array_ids_min")
     val arrayIdsMaxName = extern("__array_ids_max")
 
-    private def extern(id: String): Global.Member =
-      Global.Member(Global.Top("__"), Sig.Extern(id))
+    private def extern(id: String): nir.Global.Member =
+      nir.Global.Member(nir.Global.Top("__"), nir.Sig.Extern(id))
   }
 
-  val depends: Seq[Global] = Seq(
+  val depends: Seq[nir.Global] = Seq(
     ObjectArray.name,
     Runtime.name,
     RuntimeInit.name,

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -19,7 +19,8 @@ object GenerateReflectiveProxies {
 
     val label = genProxyLabel(proxyArgs)
     val unboxInsts = genArgUnboxes(label, defnType.args)
-    val method = nir.Inst.Let(nir.Op.Method(label.params.head, sig), nir.Next.None)
+    val method =
+      nir.Inst.Let(nir.Op.Method(label.params.head, sig), nir.Next.None)
     val call = genCall(defnType, method, label.params, unboxInsts)
     val retInsts = genRet(call.id, defnType.ret, proxyTy.ret)
 
@@ -103,20 +104,32 @@ object GenerateReflectiveProxies {
     )
   }
 
-  private def genRetValBox(callName: nir.Local, defnRetTy: nir.Type, proxyRetTy: nir.Type)(
-      implicit
+  private def genRetValBox(
+      callName: nir.Local,
+      defnRetTy: nir.Type,
+      proxyRetTy: nir.Type
+  )(implicit
       pos: nir.Position,
       fresh: nir.Fresh
   ): nir.Inst.Let =
     nir.Type.box.get(defnRetTy) match {
       case Some(boxTy) =>
-        nir.Inst.Let(nir.Op.Box(boxTy, nir.Val.Local(callName, defnRetTy)), nir.Next.None)
+        nir.Inst.Let(
+          nir.Op.Box(boxTy, nir.Val.Local(callName, defnRetTy)),
+          nir.Next.None
+        )
       case None =>
-        nir.Inst.Let(nir.Op.Copy(nir.Val.Local(callName, defnRetTy)), nir.Next.None)
+        nir.Inst.Let(
+          nir.Op.Copy(nir.Val.Local(callName, defnRetTy)),
+          nir.Next.None
+        )
     }
 
-  private def genRet(callName: nir.Local, defnRetTy: nir.Type, proxyRetTy: nir.Type)(
-      implicit
+  private def genRet(
+      callName: nir.Local,
+      defnRetTy: nir.Type,
+      proxyRetTy: nir.Type
+  )(implicit
       pos: nir.Position,
       fresh: nir.Fresh
   ): Seq[nir.Inst] = {
@@ -130,7 +143,10 @@ object GenerateReflectiveProxies {
     }
   }
 
-  def apply(dynimpls: Seq[nir.Global], defns: Seq[nir.Defn]): Seq[nir.Defn.Define] = {
+  def apply(
+      dynimpls: Seq[nir.Global],
+      defns: Seq[nir.Defn]
+  ): Seq[nir.Defn.Define] = {
 
     // filters methods with same name and args but different return type for each given type
     val toProxy =

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -1,22 +1,24 @@
 package scala.scalanative
 package codegen
 
-import scalanative.nir._
 import scalanative.linker.{Trait, Class}
 
 class HasTraitTables(meta: Metadata) {
-  private implicit val pos: Position = Position.NoPosition
-  def generated(id: String): Global.Member =
-    Global.Top("__scalanative_metadata").member(Sig.Generated(id))
+
+  private implicit val pos: nir.Position = nir.Position.NoPosition
+
+  def generated(id: String): nir.Global.Member =
+    nir.Global.Top("__scalanative_metadata").member(nir.Sig.Generated(id))
+
   private val classHasTraitName = generated("__class_has_trait")
-  val classHasTraitVal = Val.Global(classHasTraitName, Type.Ptr)
-  var classHasTraitTy: Type = _
-  var classHasTraitDefn: Defn = _
+  val classHasTraitVal = nir.Val.Global(classHasTraitName, nir.Type.Ptr)
+  var classHasTraitTy: nir.Type = _
+  var classHasTraitDefn: nir.Defn = _
 
   private val traitHasTraitName = generated("__trait_has_trait")
-  val traitHasTraitVal = Val.Global(traitHasTraitName, Type.Ptr)
-  var traitHasTraitTy: Type = _
-  var traitHasTraitDefn: Defn = _
+  val traitHasTraitVal = nir.Val.Global(traitHasTraitName, nir.Type.Ptr)
+  var traitHasTraitTy: nir.Type = _
+  var traitHasTraitDefn: nir.Defn = _
 
   initClassHasTrait()
   initTraitHasTrait()
@@ -39,10 +41,10 @@ class HasTraitTables(meta: Metadata) {
 
       row += 1
     }
-    val tableVal = Val.ArrayValue(Type.Int, matrix.toSeq.map(i => Val.Int(i)))
+    val tableVal = nir.Val.ArrayValue(nir.Type.Int, matrix.toSeq.map(i => nir.Val.Int(i)))
 
     classHasTraitDefn =
-      Defn.Const(Attrs.None, classHasTraitName, tableVal.ty, tableVal)
+      nir.Defn.Const(nir.Attrs.None, classHasTraitName, tableVal.ty, tableVal)
     classHasTraitTy = tableVal.ty
   }
 
@@ -55,10 +57,11 @@ class HasTraitTables(meta: Metadata) {
 
       row += 1
     }
-    val tableVal = Val.ArrayValue(Type.Int, matrix.toSeq.map(l => Val.Int(l)))
+    val tableVal = nir.Val.ArrayValue(nir.Type.Int, matrix.toSeq.map(l => nir.Val.Int(l)))
 
     traitHasTraitDefn =
-      Defn.Const(Attrs.None, traitHasTraitName, tableVal.ty, tableVal)
+      nir.Defn.Const(nir.Attrs.None, traitHasTraitName, tableVal.ty, tableVal)
     traitHasTraitTy = tableVal.ty
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -41,7 +41,8 @@ class HasTraitTables(meta: Metadata) {
 
       row += 1
     }
-    val tableVal = nir.Val.ArrayValue(nir.Type.Int, matrix.toSeq.map(i => nir.Val.Int(i)))
+    val tableVal =
+      nir.Val.ArrayValue(nir.Type.Int, matrix.toSeq.map(i => nir.Val.Int(i)))
 
     classHasTraitDefn =
       nir.Defn.Const(nir.Attrs.None, classHasTraitName, tableVal.ty, tableVal)
@@ -57,7 +58,8 @@ class HasTraitTables(meta: Metadata) {
 
       row += 1
     }
-    val tableVal = nir.Val.ArrayValue(nir.Type.Int, matrix.toSeq.map(l => nir.Val.Int(l)))
+    val tableVal =
+      nir.Val.ArrayValue(nir.Type.Int, matrix.toSeq.map(l => nir.Val.Int(l)))
 
     traitHasTraitDefn =
       nir.Defn.Const(nir.Attrs.None, traitHasTraitName, tableVal.ty, tableVal)

--- a/tools/src/main/scala/scala/scalanative/codegen/IncrementalCodeGenContext.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/IncrementalCodeGenContext.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.codegen
+package scala.scalanative
+package codegen
 
 import java.io.{ByteArrayOutputStream, File, ObjectOutputStream, PrintWriter}
 import java.nio.ByteBuffer
@@ -6,7 +7,6 @@ import java.nio.file.{Path, Paths, Files}
 import scala.collection.concurrent.TrieMap
 import scala.io.Source
 import scala.language.implicitConversions
-import scala.scalanative.nir.Defn
 
 class IncrementalCodeGenContext(workDir: Path) {
   private val package2hash: TrieMap[String, Long] = TrieMap[String, Long]()
@@ -30,7 +30,7 @@ class IncrementalCodeGenContext(workDir: Path) {
     }
   }
 
-  def addEntry(packageName: String, defns: Seq[Defn]): Unit = {
+  def addEntry(packageName: String, defns: Seq[nir.Defn]): Unit = {
     val hash = defns.foldLeft(0L)(_ + _.hashCode())
     val prevHash = pack2hashPrev.get(packageName)
     package2hash.put(packageName, hash)

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -3,78 +3,78 @@ package codegen
 
 import scala.collection.mutable
 import scalanative.util.{ScopedVar, unsupported}
-import scalanative.nir._
 import scalanative.linker._
 import scalanative.interflow.UseDef.eliminateDeadCode
 
 object Lower {
+
   def apply(
-      defns: Seq[Defn]
-  )(implicit meta: Metadata, logger: build.Logger): Seq[Defn] =
+      defns: Seq[nir.Defn]
+  )(implicit meta: Metadata, logger: build.Logger): Seq[nir.Defn] =
     (new Impl).onDefns(defns)
 
   private final class Impl(implicit meta: Metadata, logger: build.Logger)
-      extends Transform {
+      extends nir.Transform {
     import meta._
     import meta.config
     import meta.layouts.{Rtti, ClassRtti, ArrayHeader}
 
     implicit val analysis: ReachabilityAnalysis.Result = meta.analysis
 
-    val Object = analysis.infos(Rt.Object.name).asInstanceOf[Class]
+    val Object = analysis.infos(nir.Rt.Object.name).asInstanceOf[Class]
 
-    private val zero = Val.Int(0)
-    private val one = Val.Int(1)
-    val RttiClassIdPath = Seq(zero, Val.Int(Rtti.ClassIdIdx))
-    val RttiTraitIdPath = Seq(zero, Val.Int(Rtti.TraitIdIdx))
-    val ClassRttiDynmapPath = Seq(zero, Val.Int(ClassRtti.DynmapIdx))
-    val ClassRttiVtablePath = Seq(zero, Val.Int(ClassRtti.VtableIdx))
-    val ArrayHeaderLengthPath = Seq(zero, Val.Int(ArrayHeader.LengthIdx))
+    private val zero = nir.Val.Int(0)
+    private val one = nir.Val.Int(1)
+    val RttiClassIdPath = Seq(zero, nir.Val.Int(Rtti.ClassIdIdx))
+    val RttiTraitIdPath = Seq(zero, nir.Val.Int(Rtti.TraitIdIdx))
+    val ClassRttiDynmapPath = Seq(zero, nir.Val.Int(ClassRtti.DynmapIdx))
+    val ClassRttiVtablePath = Seq(zero, nir.Val.Int(ClassRtti.VtableIdx))
+    val ArrayHeaderLengthPath = Seq(zero, nir.Val.Int(ArrayHeader.LengthIdx))
 
     // Type of the bare runtime type information struct.
     private val classRttiType =
-      rtti(analysis.infos(Global.Top("java.lang.Object"))).struct
+      rtti(analysis.infos(nir.Global.Top("java.lang.Object"))).struct
 
     // Names of the fields of the java.lang.String in the memory layout order.
     private val stringFieldNames = {
-      val node = ClassRef.unapply(Rt.StringName).get
+      val node = ClassRef.unapply(nir.Rt.StringName).get
       val names = layout(node).entries.map(_.name)
       assert(names.length == 4, "java.lang.String is expected to have 4 fields")
       names
     }
 
-    private val fresh = new util.ScopedVar[Fresh]
-    private val unwindHandler = new util.ScopedVar[Option[Local]]
-    private val currentDefn = new util.ScopedVar[Defn.Define]
-    private val nullGuardedVals = mutable.Set.empty[Val]
+    private val fresh = new util.ScopedVar[nir.Fresh]
+    private val unwindHandler = new util.ScopedVar[Option[nir.Local]]
+    private val currentDefn = new util.ScopedVar[nir.Defn.Define]
+    private val nullGuardedVals = mutable.Set.empty[nir.Val]
     private def currentDefnRetType = {
-      val Type.Function(_, ret) = currentDefn.get.ty
+      val nir.Type.Function(_, ret) = currentDefn.get.ty
       ret
     }
 
-    private val unreachableSlowPath = mutable.Map.empty[Option[Local], Local]
-    private val nullPointerSlowPath = mutable.Map.empty[Option[Local], Local]
-    private val divisionByZeroSlowPath = mutable.Map.empty[Option[Local], Local]
-    private val classCastSlowPath = mutable.Map.empty[Option[Local], Local]
-    private val outOfBoundsSlowPath = mutable.Map.empty[Option[Local], Local]
-    private val noSuchMethodSlowPath = mutable.Map.empty[Option[Local], Local]
+    private val unreachableSlowPath = mutable.Map.empty[Option[nir.Local], nir.Local]
+    private val nullPointerSlowPath = mutable.Map.empty[Option[nir.Local], nir.Local]
+    private val divisionByZeroSlowPath = mutable.Map.empty[Option[nir.Local], nir.Local]
+    private val classCastSlowPath = mutable.Map.empty[Option[nir.Local], nir.Local]
+    private val outOfBoundsSlowPath = mutable.Map.empty[Option[nir.Local], nir.Local]
+    private val noSuchMethodSlowPath = mutable.Map.empty[Option[nir.Local], nir.Local]
 
-    private def unwind: Next =
-      unwindHandler.get.fold[Next](Next.None) { handler =>
-        val exc = Val.Local(fresh(), Rt.Object)
-        Next.Unwind(exc, Next.Label(handler, Seq(exc)))
+    private def unwind: nir.Next =
+      unwindHandler.get.fold[nir.Next](nir.Next.None) { handler =>
+        val exc = nir.Val.Local(fresh(), nir.Rt.Object)
+        nir.Next.Unwind(exc, nir.Next.Label(handler, Seq(exc)))
       }
 
-    override def onDefns(defns: Seq[Defn]): Seq[Defn] = {
-      val buf = mutable.UnrolledBuffer.empty[Defn]
+    override def onDefns(defns: Seq[nir.Defn]): Seq[nir.Defn] = {
+      val buf = mutable.UnrolledBuffer.empty[nir.Defn]
 
       defns.foreach {
-        case _: Defn.Class | _: Defn.Module | _: Defn.Trait =>
+        case _: nir.Defn.Class | _: nir.Defn.Module | _: nir.Defn.Trait =>
           ()
-        case Defn.Declare(attrs, MethodRef(_: Class | _: Trait, _), _)
+        case nir.Defn.Declare(attrs, MethodRef(_: Class | _: Trait, _), _)
             if !attrs.isExtern =>
           ()
-        case Defn.Var(attrs, FieldRef(_: Class, _), _, _) if !attrs.isExtern =>
+        case nir.Defn.Var(attrs, FieldRef(_: Class, _), _, _) if !attrs.isExtern =>
           ()
         case defn =>
           buf += onDefn(defn)
@@ -83,11 +83,11 @@ object Lower {
       buf.toSeq
     }
 
-    override def onDefn(defn: Defn): Defn = defn match {
-      case defn: Defn.Define =>
-        val Type.Function(_, ty) = defn.ty
+    override def onDefn(defn: nir.Defn): nir.Defn = defn match {
+      case defn: nir.Defn.Define =>
+        val nir.Type.Function(_, ty) = defn.ty
         ScopedVar.scoped(
-          fresh := Fresh(defn.insts),
+          fresh := nir.Fresh(defn.insts),
           currentDefn := defn
         ) {
           try super.onDefn(defn)
@@ -97,15 +97,15 @@ object Lower {
         super.onDefn(defn)
     }
 
-    override def onType(ty: Type): Type = ty
+    override def onType(ty: nir.Type): nir.Type = ty
 
-    def genNext(buf: Buffer, next: Next)(implicit pos: Position): Next = {
+    def genNext(buf: nir.Buffer, next: nir.Next)(implicit pos: nir.Position): nir.Next = {
       next match {
-        case Next.Unwind(exc, next) => Next.Unwind(exc, genNext(buf, next))
-        case Next.Case(value, next) =>
-          Next.Case(genVal(buf, value), genNext(buf, next))
-        case Next.Label(name, args) =>
-          Next.Label(name, args.map(genVal(buf, _)))
+        case nir.Next.Unwind(exc, next) => nir.Next.Unwind(exc, genNext(buf, next))
+        case nir.Next.Case(value, next) =>
+          nir.Next.Case(genVal(buf, value), genNext(buf, next))
+        case nir.Next.Label(name, args) =>
+          nir.Next.Label(name, args.map(genVal(buf, _)))
         case n => n
       }
     }
@@ -114,24 +114,24 @@ object Lower {
         pos: nir.Position
     ): nir.Val = {
       require(
-        v.ty == Type.Unit,
+        v.ty == nir.Type.Unit,
         s"Definition is expected to return Unit type, found ${v.ty}"
       )
-      if (currentDefnRetType == Type.Unit) Val.Unit
+      if (currentDefnRetType == nir.Type.Unit) nir.Val.Unit
       else unit
     }
 
-    override def onInsts(insts: Seq[Inst]): Seq[Inst] = {
+    override def onInsts(insts: Seq[nir.Inst]): Seq[nir.Inst] = {
       val buf = new nir.Buffer()(fresh)
       val handlers = new nir.Buffer()(fresh)
 
       buf += insts.head
 
-      def newUnwindHandler(next: Next)(implicit pos: Position): Option[Local] =
+      def newUnwindHandler(next: nir.Next)(implicit pos: nir.Position): Option[nir.Local] =
         next match {
-          case Next.None =>
+          case nir.Next.None =>
             None
-          case Next.Unwind(exc, next) =>
+          case nir.Next.Unwind(exc, next) =>
             val handler = fresh()
             handlers.label(handler, Seq(exc))
             handlers.jump(next)
@@ -141,14 +141,14 @@ object Lower {
         }
 
       insts.foreach {
-        case inst @ Inst.Let(n, Op.Var(ty), unwind) =>
-          buf.let(n, Op.Stackalloc(ty, one), unwind)(inst.pos, inst.scopeId)
+        case inst @ nir.Inst.Let(n, nir.Op.Var(ty), unwind) =>
+          buf.let(n, nir.Op.Stackalloc(ty, one), unwind)(inst.pos, inst.scopeId)
         case _ => ()
       }
 
-      val Inst.Label(firstLabel, _) = insts.head: @unchecked
+      val nir.Inst.Label(firstLabel, _) = insts.head: @unchecked
       val labelPositions = insts
-        .collect { case Inst.Label(id, _) => id }
+        .collect { case nir.Inst.Label(id, _) => id }
         .zipWithIndex
         .toMap
       var currentBlockPosition = labelPositions(firstLabel)
@@ -156,12 +156,12 @@ object Lower {
       genThisValueNullGuardIfUsed(
         currentDefn.get,
         buf,
-        () => newUnwindHandler(Next.None)(insts.head.pos)
+        () => newUnwindHandler(nir.Next.None)(insts.head.pos)
       )
 
-      implicit var lastScopeId: ScopeId = ScopeId.TopLevel
+      implicit var lastScopeId: nir.ScopeId = nir.ScopeId.TopLevel
       insts.tail.foreach {
-        case inst @ Inst.Let(n, op, unwind) =>
+        case inst @ nir.Inst.Let(n, op, unwind) =>
           ScopedVar.scoped(
             unwindHandler := newUnwindHandler(unwind)(inst.pos)
           ) {
@@ -169,47 +169,47 @@ object Lower {
             genLet(buf, n, op)(inst.pos, lastScopeId)
           }
 
-        case inst @ Inst.Throw(v, unwind) =>
+        case inst @ nir.Inst.Throw(v, unwind) =>
           ScopedVar.scoped(
             unwindHandler := newUnwindHandler(unwind)(inst.pos)
           ) {
             genThrow(buf, v)(inst.pos, lastScopeId)
           }
 
-        case inst @ Inst.Unreachable(unwind) =>
+        case inst @ nir.Inst.Unreachable(unwind) =>
           ScopedVar.scoped(
             unwindHandler := newUnwindHandler(unwind)(inst.pos)
           ) {
             genUnreachable(buf)(inst.pos)
           }
 
-        case inst @ Inst.Ret(v) =>
-          implicit val pos: Position = inst.pos
+        case inst @ nir.Inst.Ret(v) =>
+          implicit val pos: nir.Position = inst.pos
           currentDefn.get.name match {
-            case Global.Member(ClassRef(cls), sig)
+            case nir.Global.Member(ClassRef(cls), sig)
                 if sig.isCtor && cls.hasFinalFields =>
               // Release memory fence after initialization of constructor with final fields
-              buf.fence(MemoryOrder.Release)
+              buf.fence(nir.MemoryOrder.Release)
             case _ => ()
           }
           genGCSafepoint(buf)
           val retVal =
-            if (v.ty == Type.Unit) optionallyBoxedUnit(v)
+            if (v.ty == nir.Type.Unit) optionallyBoxedUnit(v)
             else genVal(buf, v)
-          buf += Inst.Ret(retVal)
+          buf += nir.Inst.Ret(retVal)
 
-        case inst @ Inst.Jump(next) =>
-          implicit val pos: Position = inst.pos
+        case inst @ nir.Inst.Jump(next) =>
+          implicit val pos: nir.Position = inst.pos
           // Generate safepoint before backward jumps, eg. in loops
           next match {
-            case Next.Label(target, _)
+            case nir.Next.Label(target, _)
                 if labelPositions(target) < currentBlockPosition =>
               genGCSafepoint(buf)
             case _ => ()
           }
-          buf += Inst.Jump(genNext(buf, next))
+          buf += nir.Inst.Jump(genNext(buf, next))
 
-        case inst @ Inst.Label(name, _) =>
+        case inst @ nir.Inst.Label(name, _) =>
           currentBlockPosition = labelPositions(name)
           buf += inst
 
@@ -217,7 +217,7 @@ object Lower {
           buf += inst
       }
 
-      implicit val pos: Position = Position.NoPosition
+      implicit val pos: nir.Position = nir.Position.NoPosition
       genNullPointerSlowPath(buf)
       genDivisionByZeroSlowPath(buf)
       genClassCastSlowPath(buf)
@@ -237,38 +237,45 @@ object Lower {
       eliminateDeadCode(buf.toSeq.map(onInst))
     }
 
-    override def onInst(inst: Inst): Inst = {
+    override def onInst(inst: nir.Inst): nir.Inst = {
       implicit def pos: nir.Position = inst.pos
       inst match {
-        case Inst.Ret(v) if v.ty == Type.Unit =>
-          Inst.Ret(optionallyBoxedUnit(v))
-        case _ => super.onInst(inst)
+        case nir.Inst.Ret(v) if v.ty == nir.Type.Unit =>
+          nir.Inst.Ret(optionallyBoxedUnit(v))
+        case _ =>
+          super.onInst(inst)
       }
     }
 
-    override def onVal(value: Val): Val = value match {
-      case Val.ClassOf(_) =>
+    override def onVal(value: nir.Val): nir.Val = value match {
+      case nir.Val.ClassOf(_) =>
         util.unsupported("Lowering ClassOf needs nir.Buffer")
-      case Val.Global(ScopeRef(node), _) => rtti(node).const
-      case Val.String(v)                 => genStringVal(v)
-      case Val.Unit                      => unit
-      case _                             => super.onVal(value)
+      case nir.Val.Global(ScopeRef(node), _) =>
+        rtti(node).const
+      case nir.Val.String(v) =>
+        genStringVal(v)
+      case nir.Val.Unit =>
+        unit
+      case _ =>
+        super.onVal(value)
     }
 
-    def genVal(buf: Buffer, value: Val)(implicit pos: Position): Val =
+    def genVal(buf: nir.Buffer, value: nir.Val)(implicit pos: nir.Position): nir.Val =
       value match {
-        case Val.ClassOf(ScopeRef(node)) => rtti(node).const
-        case Val.Const(v)                => Val.Const(genVal(buf, v))
-        case Val.StructValue(values) =>
-          Val.StructValue(values.map(genVal(buf, _)))
-        case Val.ArrayValue(ty, values) =>
-          Val.ArrayValue(onType(ty), values.map(genVal(buf, _)))
+        case nir.Val.ClassOf(ScopeRef(node)) =>
+          rtti(node).const
+        case nir.Val.Const(v) =>
+          nir.Val.Const(genVal(buf, v))
+        case nir.Val.StructValue(values) =>
+          nir.Val.StructValue(values.map(genVal(buf, _)))
+        case nir.Val.ArrayValue(ty, values) =>
+          nir.Val.ArrayValue(onType(ty), values.map(genVal(buf, _)))
         case _ => onVal(value)
       }
 
     def genNullPointerSlowPath(
-        buf: Buffer
-    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
+        buf: nir.Buffer
+    )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): Unit = {
       nullPointerSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
@@ -278,17 +285,17 @@ object Lower {
             buf.call(
               throwNullPointerTy,
               throwNullPointerVal,
-              Seq(Val.Null),
+              Seq(nir.Val.Null),
               unwind
             )
-            buf.unreachable(Next.None)
+            buf.unreachable(nir.Next.None)
           }
       }
     }
 
     def genDivisionByZeroSlowPath(
-        buf: Buffer
-    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
+        buf: nir.Buffer
+    )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): Unit = {
       divisionByZeroSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
@@ -298,202 +305,205 @@ object Lower {
             buf.call(
               throwDivisionByZeroTy,
               throwDivisionByZeroVal,
-              Seq(Val.Null),
+              Seq(nir.Val.Null),
               unwind
             )
-            buf.unreachable(Next.None)
+            buf.unreachable(nir.Next.None)
           }
       }
     }
 
     def genClassCastSlowPath(
-        buf: Buffer
-    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
+        buf: nir.Buffer
+    )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): Unit = {
       classCastSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
             unwindHandler := slowPathUnwindHandler
           ) {
-            val obj = Val.Local(fresh(), Type.Ptr)
-            val toty = Val.Local(fresh(), Type.Ptr)
+            val obj = nir.Val.Local(fresh(), nir.Type.Ptr)
+            val toty = nir.Val.Local(fresh(), nir.Type.Ptr)
 
             buf.label(slowPath, Seq(obj, toty))
-            val fromty = buf.let(Op.Load(Type.Ptr, obj), unwind)
+            val fromty = buf.let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
             buf.call(
               throwClassCastTy,
               throwClassCastVal,
-              Seq(Val.Null, fromty, toty),
+              Seq(nir.Val.Null, fromty, toty),
               unwind
             )
-            buf.unreachable(Next.None)
+            buf.unreachable(nir.Next.None)
           }
       }
     }
 
     def genUnreachableSlowPath(
-        buf: Buffer
-    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
+        buf: nir.Buffer
+    )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): Unit = {
       unreachableSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
             unwindHandler := slowPathUnwindHandler
           ) {
             buf.label(slowPath)
-            buf.call(throwUndefinedTy, throwUndefinedVal, Seq(Val.Null), unwind)
-            buf.unreachable(Next.None)
+            buf.call(throwUndefinedTy, throwUndefinedVal, Seq(nir.Val.Null), unwind)
+            buf.unreachable(nir.Next.None)
           }
       }
     }
 
     def genOutOfBoundsSlowPath(
-        buf: Buffer
-    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
+        buf: nir.Buffer
+    )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): Unit = {
       outOfBoundsSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
             unwindHandler := slowPathUnwindHandler
           ) {
-            val idx = Val.Local(fresh(), Type.Int)
+            val idx = nir.Val.Local(fresh(), nir.Type.Int)
 
             buf.label(slowPath, Seq(idx))
             buf.call(
               throwOutOfBoundsTy,
               throwOutOfBoundsVal,
-              Seq(Val.Null, idx),
+              Seq(nir.Val.Null, idx),
               unwind
             )
-            buf.unreachable(Next.None)
+            buf.unreachable(nir.Next.None)
           }
       }
     }
 
     def genNoSuchMethodSlowPath(
-        buf: Buffer
-    )(implicit srcPosition: Position, scopeId: ScopeId): Unit = {
+        buf: nir.Buffer
+    )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): Unit = {
       noSuchMethodSlowPath.toSeq.sortBy(_._2.id).foreach {
         case (slowPathUnwindHandler, slowPath) =>
           ScopedVar.scoped(
             unwindHandler := slowPathUnwindHandler
           ) {
-            val sig = Val.Local(fresh(), Type.Ptr)
+            val sig = nir.Val.Local(fresh(), nir.Type.Ptr)
 
             buf.label(slowPath, Seq(sig))
             buf.call(
               throwNoSuchMethodTy,
               throwNoSuchMethodVal,
-              Seq(Val.Null, sig),
+              Seq(nir.Val.Null, sig),
               unwind
             )
-            buf.unreachable(Next.None)
+            buf.unreachable(nir.Next.None)
           }
       }
     }
 
-    def genLet(buf: Buffer, n: Local, op: Op)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genLet(buf: nir.Buffer, n: nir.Local, op: nir.Op)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit =
       op.resty match {
-        case Type.Unit =>
+        case nir.Type.Unit =>
           genOp(buf, fresh(), op)
-          buf.let(n, Op.Copy(unit), unwind)
-        case Type.Nothing =>
+          buf.let(n, nir.Op.Copy(unit), unwind)
+        case nir.Type.Nothing =>
           genOp(buf, fresh(), op)
           genUnreachable(buf)
-          buf.label(fresh(), Seq(Val.Local(n, op.resty)))
+          buf.label(fresh(), Seq(nir.Val.Local(n, op.resty)))
         case _ =>
           genOp(buf, n, op)
       }
 
-    def genThrow(buf: Buffer, exc: Val)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genThrow(buf: nir.Buffer, exc: nir.Val)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ) = {
       genGuardNotNull(buf, exc)
-      genOp(buf, fresh(), Op.Call(throwSig, throw_, Seq(exc)))
-      buf.unreachable(Next.None)
+      genOp(buf, fresh(), nir.Op.Call(throwSig, throw_, Seq(exc)))
+      buf.unreachable(nir.Next.None)
     }
 
-    def genUnreachable(buf: Buffer)(implicit pos: Position) = {
+    def genUnreachable(buf: nir.Buffer)(implicit pos: nir.Position) = {
       val failL = unreachableSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
-      buf.jump(Next(failL))
+      buf.jump(nir.Next(failL))
     }
 
-    def genOp(buf: Buffer, n: Local, op: Op)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genOp(buf: nir.Buffer, n: nir.Local, op: nir.Op)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       op match {
-        case op: Op.Field =>
+        case op: nir.Op.Field =>
           genFieldOp(buf, n, op)
-        case op: Op.Fieldload =>
+        case op: nir.Op.Fieldload =>
           genFieldloadOp(buf, n, op)
-        case op: Op.Fieldstore =>
+        case op: nir.Op.Fieldstore =>
           genFieldstoreOp(buf, n, op)
-        case op: Op.Load =>
+        case op: nir.Op.Load =>
           genLoadOp(buf, n, op)
-        case op: Op.Store =>
+        case op: nir.Op.Store =>
           genStoreOp(buf, n, op)
-        case op: Op.Method =>
+        case op: nir.Op.Method =>
           genMethodOp(buf, n, op)
-        case op: Op.Dynmethod =>
+        case op: nir.Op.Dynmethod =>
           genDynmethodOp(buf, n, op)
-        case op: Op.Is =>
+        case op: nir.Op.Is =>
           genIsOp(buf, n, op)
-        case op: Op.As =>
+        case op: nir.Op.As =>
           genAsOp(buf, n, op)
-        case op: Op.SizeOf      => genSizeOfOp(buf, n, op)
-        case op: Op.AlignmentOf => genAlignmentOfOp(buf, n, op)
-        case op: Op.Classalloc =>
+        case op: nir.Op.SizeOf =>
+          genSizeOfOp(buf, n, op)
+        case op: nir.Op.AlignmentOf =>
+          genAlignmentOfOp(buf, n, op)
+        case op: nir.Op.Classalloc =>
           genClassallocOp(buf, n, op)
-        case op: Op.Conv =>
+        case op: nir.Op.Conv =>
           genConvOp(buf, n, op)
-        case op: Op.Call =>
+        case op: nir.Op.Call =>
           genCallOp(buf, n, op)
-        case op: Op.Comp =>
+        case op: nir.Op.Comp =>
           genCompOp(buf, n, op)
-        case op: Op.Bin =>
+        case op: nir.Op.Bin =>
           genBinOp(buf, n, op)
-        case op: Op.Box =>
+        case op: nir.Op.Box =>
           genBoxOp(buf, n, op)
-        case op: Op.Unbox =>
+        case op: nir.Op.Unbox =>
           genUnboxOp(buf, n, op)
-        case op: Op.Module =>
+        case op: nir.Op.Module =>
           genModuleOp(buf, n, op)
-        case Op.Var(_) => () // Already emmited
-        case Op.Varload(Val.Local(slot, Type.Var(ty))) =>
-          buf.let(n, Op.Load(ty, Val.Local(slot, Type.Ptr)), unwind)
-        case Op.Varstore(Val.Local(slot, Type.Var(ty)), value) =>
+        case nir.Op.Var(_) =>
+          () // Already emmited
+        case nir.Op.Varload(nir.Val.Local(slot, nir.Type.Var(ty))) =>
+          buf.let(n, nir.Op.Load(ty, nir.Val.Local(slot, nir.Type.Ptr)), unwind)
+        case nir.Op.Varstore(nir.Val.Local(slot, nir.Type.Var(ty)), value) =>
           buf.let(
             n,
-            Op.Store(ty, Val.Local(slot, Type.Ptr), genVal(buf, value)),
+            nir.Op.Store(ty, nir.Val.Local(slot, nir.Type.Ptr), genVal(buf, value)),
             unwind
           )
-        case op: Op.Arrayalloc =>
+        case op: nir.Op.Arrayalloc =>
           genArrayallocOp(buf, n, op)
-        case op: Op.Arrayload =>
+        case op: nir.Op.Arrayload =>
           genArrayloadOp(buf, n, op)
-        case op: Op.Arraystore =>
+        case op: nir.Op.Arraystore =>
           genArraystoreOp(buf, n, op)
-        case op: Op.Arraylength =>
+        case op: nir.Op.Arraylength =>
           genArraylengthOp(buf, n, op)
-        case op: Op.Stackalloc =>
+        case op: nir.Op.Stackalloc =>
           genStackallocOp(buf, n, op)
-        case op: Op.Copy =>
+        case op: nir.Op.Copy =>
           val v = genVal(buf, op.value)
-          buf.let(n, Op.Copy(v), unwind)
+          buf.let(n, nir.Op.Copy(v), unwind)
         case _ =>
           buf.let(n, op, unwind)
       }
     }
 
-    def genGuardNotNull(buf: Buffer, obj: Val)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genGuardNotNull(buf: nir.Buffer, obj: nir.Val)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit =
       obj.ty match {
-        case ty: Type.RefKind if !ty.isNullable =>
+        case ty: nir.Type.RefKind if !ty.isNullable =>
           ()
 
         case _ if nullGuardedVals.add(obj) =>
@@ -504,16 +514,16 @@ object Lower {
           val isNullL =
             nullPointerSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
-          val isNull = comp(Comp.Ine, v.ty, v, Val.Null, unwind)
-          branch(isNull, Next(notNullL), Next(isNullL))
+          val isNull = comp(nir.Comp.Ine, v.ty, v, nir.Val.Null, unwind)
+          branch(isNull, nir.Next(notNullL), nir.Next(isNullL))
           label(notNullL)
 
         case _ => ()
       }
 
-    def genGuardInBounds(buf: Buffer, idx: Val, len: Val)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genGuardInBounds(buf: nir.Buffer, idx: nir.Val, len: nir.Val)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       import buf._
 
@@ -521,16 +531,16 @@ object Lower {
       val outOfBoundsL =
         outOfBoundsSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
-      val gt0 = comp(Comp.Sge, Type.Int, idx, zero, unwind)
-      val ltLen = comp(Comp.Slt, Type.Int, idx, len, unwind)
-      val inBounds = bin(Bin.And, Type.Bool, gt0, ltLen, unwind)
-      branch(inBounds, Next(inBoundsL), Next.Label(outOfBoundsL, Seq(idx)))
+      val gt0 = comp(nir.Comp.Sge, nir.Type.Int, idx, zero, unwind)
+      val ltLen = comp(nir.Comp.Slt, nir.Type.Int, idx, len, unwind)
+      val inBounds = bin(nir.Bin.And, nir.Type.Bool, gt0, ltLen, unwind)
+      branch(inBounds, nir.Next(inBoundsL), nir.Next.Label(outOfBoundsL, Seq(idx)))
       label(inBoundsL)
     }
 
-    def genFieldElemOp(buf: Buffer, obj: Val, name: Global.Member)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genFieldElemOp(buf: nir.Buffer, obj: nir.Val, name: nir.Global.Member)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ) = {
       import buf._
       val v = genVal(buf, obj)
@@ -541,14 +551,14 @@ object Lower {
       val index = layout.index(fld)
 
       genGuardNotNull(buf, v)
-      elem(ty, v, Seq(zero, Val.Int(index)), unwind)
+      elem(ty, v, Seq(zero, nir.Val.Int(index)), unwind)
     }
 
-    def genFieldloadOp(buf: Buffer, n: Local, op: Op.Fieldload)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genFieldloadOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Fieldload)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ) = {
-      val Op.Fieldload(ty, obj, name) = op
+      val nir.Op.Fieldload(ty, obj, name) = op
       val field = name match {
         case FieldRef(_, field) => field
         case _ =>
@@ -556,23 +566,23 @@ object Lower {
       }
 
       val isVolatile = field.attrs.isVolatile
-      val syncAttrs = SyncAttrs(
+      val syncAttrs = nir.SyncAttrs(
         memoryOrder =
-          if (isVolatile) MemoryOrder.SeqCst
-          else if (field.attrs.isFinal) MemoryOrder.Monotonic
-          else MemoryOrder.Unordered,
+          if (isVolatile) nir.MemoryOrder.SeqCst
+          else if (field.attrs.isFinal) nir.MemoryOrder.Monotonic
+          else nir.MemoryOrder.Unordered,
         isVolatile = isVolatile
       )
 
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
-      genLoadOp(buf, n, Op.Load(ty, elem, Some(syncAttrs)))
+      genLoadOp(buf, n, nir.Op.Load(ty, elem, Some(syncAttrs)))
     }
 
-    def genFieldstoreOp(buf: Buffer, n: Local, op: Op.Fieldstore)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genFieldstoreOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Fieldstore)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ) = {
-      val Op.Fieldstore(ty, obj, name, value) = op
+      val nir.Op.Fieldstore(ty, obj, name, value) = op
       val field = name match {
         case FieldRef(_, field) => field
         case _ =>
@@ -580,113 +590,113 @@ object Lower {
       }
 
       val isVolatile = field.attrs.isVolatile
-      val syncAttrs = SyncAttrs(
+      val syncAttrs = nir.SyncAttrs(
         memoryOrder =
-          if (isVolatile) MemoryOrder.SeqCst
-          else if (field.attrs.isFinal) MemoryOrder.Monotonic
-          else MemoryOrder.Unordered,
+          if (isVolatile) nir.MemoryOrder.SeqCst
+          else if (field.attrs.isFinal) nir.MemoryOrder.Monotonic
+          else nir.MemoryOrder.Unordered,
         isVolatile = isVolatile
       )
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
-      genStoreOp(buf, n, Op.Store(ty, elem, value, Some(syncAttrs)))
+      genStoreOp(buf, n, nir.Op.Store(ty, elem, value, Some(syncAttrs)))
     }
 
-    def genFieldOp(buf: Buffer, n: Local, op: Op)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genFieldOp(buf: nir.Buffer, n: nir.Local, op: nir.Op)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ) = {
-      val Op.Field(obj, name) = op: @unchecked
+      val nir.Op.Field(obj, name) = op: @unchecked
       val elem = genFieldElemOp(buf, obj, name)
-      buf.let(n, Op.Copy(elem), unwind)
+      buf.let(n, nir.Op.Copy(elem), unwind)
     }
 
-    def genLoadOp(buf: Buffer, n: Local, op: Op.Load)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genLoadOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Load)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       op match {
         // Convert synchronized load(bool) into load(byte)
         // LLVM is not providing synchronization on booleans
-        case Op.Load(Type.Bool, ptr, syncAttrs @ Some(_)) =>
+        case nir.Op.Load(nir.Type.Bool, ptr, syncAttrs @ Some(_)) =>
           val valueAsByte = fresh()
           val asPtr =
             if (platform.useOpaquePointers) ptr
             else {
               val asPtr = fresh()
-              genConvOp(buf, asPtr, Op.Conv(Conv.Bitcast, Type.Ptr, ptr))
-              Val.Local(asPtr, Type.Ptr)
+              genConvOp(buf, asPtr, nir.Op.Conv(nir.Conv.Bitcast, nir.Type.Ptr, ptr))
+              nir.Val.Local(asPtr, nir.Type.Ptr)
             }
           genLoadOp(
             buf,
             valueAsByte,
-            Op.Load(Type.Byte, asPtr, syncAttrs)
+            nir.Op.Load(nir.Type.Byte, asPtr, syncAttrs)
           )
           genConvOp(
             buf,
             n,
-            Op.Conv(Conv.Trunc, Type.Bool, Val.Local(valueAsByte, Type.Byte))
+            nir.Op.Conv(nir.Conv.Trunc, nir.Type.Bool, nir.Val.Local(valueAsByte, nir.Type.Byte))
           )
 
-        case Op.Load(ty, ptr, syncAttrs) =>
+        case nir.Op.Load(ty, ptr, syncAttrs) =>
           buf.let(
             n,
-            Op.Load(ty, genVal(buf, ptr), syncAttrs),
+            nir.Op.Load(ty, genVal(buf, ptr), syncAttrs),
             unwind
           )
       }
     }
 
-    def genStoreOp(buf: Buffer, n: Local, op: Op.Store)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genStoreOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Store)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       op match {
         // Convert synchronized store(bool) into store(byte)
         // LLVM is not providing synchronization on booleans
-        case Op.Store(Type.Bool, ptr, value, syncAttrs @ Some(_)) =>
+        case nir.Op.Store(nir.Type.Bool, ptr, value, syncAttrs @ Some(_)) =>
           val valueAsByte = fresh()
           val asPtr =
             if (platform.useOpaquePointers) ptr
             else {
               val asPtr = fresh()
-              genConvOp(buf, asPtr, Op.Conv(Conv.Bitcast, Type.Ptr, ptr))
-              Val.Local(asPtr, Type.Ptr)
+              genConvOp(buf, asPtr, nir.Op.Conv(nir.Conv.Bitcast, nir.Type.Ptr, ptr))
+              nir.Val.Local(asPtr, nir.Type.Ptr)
             }
-          genConvOp(buf, valueAsByte, Op.Conv(Conv.Zext, Type.Byte, value))
+          genConvOp(buf, valueAsByte, nir.Op.Conv(nir.Conv.Zext, nir.Type.Byte, value))
           genStoreOp(
             buf,
             n,
-            Op.Store(
-              Type.Byte,
+            nir.Op.Store(
+              nir.Type.Byte,
               asPtr,
-              Val.Local(valueAsByte, Type.Byte),
+              nir.Val.Local(valueAsByte, nir.Type.Byte),
               syncAttrs
             )
           )
 
-        case Op.Store(ty, ptr, value, syncAttrs) =>
+        case nir.Op.Store(ty, ptr, value, syncAttrs) =>
           buf.let(
             n,
-            Op.Store(ty, genVal(buf, ptr), genVal(buf, value), syncAttrs),
+            nir.Op.Store(ty, genVal(buf, ptr), genVal(buf, value), syncAttrs),
             unwind
           )
       }
     }
 
-    def genCompOp(buf: Buffer, n: Local, op: Op.Comp)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genCompOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Comp)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Comp(comp, ty, l, r) = op
+      val nir.Op.Comp(comp, ty, l, r) = op
       val left = genVal(buf, l)
       val right = genVal(buf, r)
-      buf.let(n, Op.Comp(comp, ty, left, right), unwind)
+      buf.let(n, nir.Op.Comp(comp, ty, left, right), unwind)
     }
 
     // Cached function
     private object shouldGenerateSafepoints {
       import scalanative.build.GC._
-      private var lastDefn: Defn.Define = _
+      private var lastDefn: nir.Defn.Define = _
       private var lastResult: Boolean = false
 
       private val supportedGC = meta.config.gc match {
@@ -696,48 +706,48 @@ object Lower {
       private val multithreadingEnabled = meta.platform.isMultithreadingEnabled
       private val usesSafepoints = multithreadingEnabled && supportedGC
 
-      def apply(defn: Defn.Define): Boolean = {
+      def apply(defn: nir.Defn.Define): Boolean = {
         if (!usesSafepoints) false
         else if (defn eq lastDefn) lastResult
         else {
           lastDefn = defn
-          val Global.Member(_, sig) = defn.name
+          val nir.Global.Member(_, sig) = defn.name
           lastResult = {
             // Exclude accessors and generated methods
-            def mayContainLoops = defn.insts.exists(_.isInstanceOf[Inst.Jump])
+            def mayContainLoops = defn.insts.exists(_.isInstanceOf[nir.Inst.Jump])
             !sig.isGenerated && (defn.insts.size > 4 || mayContainLoops)
           }
           lastResult
         }
       }
     }
-    private def genGCSafepoint(buf: Buffer, genUnwind: Boolean = true)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    private def genGCSafepoint(buf: nir.Buffer, genUnwind: Boolean = true)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       if (shouldGenerateSafepoints(currentDefn.get)) {
         val handler = {
           if (genUnwind && unwindHandler.isInitialized) unwind
-          else Next.None
+          else nir.Next.None
         }
-        val syncAttrs = SyncAttrs(
-          memoryOrder = MemoryOrder.Unordered,
+        val syncAttrs = nir.SyncAttrs(
+          memoryOrder = nir.MemoryOrder.Unordered,
           isVolatile = true
         )
-        val safepointAddr = buf.load(Type.Ptr, GCSafepoint, handler)
-        buf.load(Type.Ptr, safepointAddr, handler, Some(syncAttrs))
+        val safepointAddr = buf.load(nir.Type.Ptr, GCSafepoint, handler)
+        buf.load(nir.Type.Ptr, safepointAddr, handler, Some(syncAttrs))
       }
     }
 
-    def genCallOp(buf: Buffer, n: Local, op: Op.Call)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genCallOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Call)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Call(ty, ptr, args) = op
+      val nir.Op.Call(ty, ptr, args) = op
       def genCall() = {
         buf.let(
           n,
-          Op.Call(
+          nir.Op.Call(
             ty = ty,
             ptr = genVal(buf, ptr),
             args = args.map(genVal(buf, _))
@@ -749,11 +759,11 @@ object Lower {
       def switchThreadState(managed: Boolean) = buf.call(
         GCSetMutatorThreadStateSig,
         GCSetMutatorThreadState,
-        Seq(Val.Int(if (managed) 0 else 1)),
-        if (unwindHandler.isInitialized) unwind else Next.None
+        Seq(nir.Val.Int(if (managed) 0 else 1)),
+        if (unwindHandler.isInitialized) unwind else nir.Next.None
       )
 
-      def shouldSwitchThreadState(name: Global) =
+      def shouldSwitchThreadState(name: nir.Global) =
         platform.isMultithreadingEnabled && analysis.infos.get(name).exists {
           info =>
             val attrs = info.attrs
@@ -761,7 +771,7 @@ object Lower {
         }
 
       ptr match {
-        case Val.Global(global, _) if shouldSwitchThreadState(global) =>
+        case nir.Val.Global(global, _) if shouldSwitchThreadState(global) =>
           switchThreadState(managed = false)
           genCall()
           genGCSafepoint(buf, genUnwind = false)
@@ -771,13 +781,13 @@ object Lower {
       }
     }
 
-    def genMethodOp(buf: Buffer, n: Local, op: Op.Method)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genMethodOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Method)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ) = {
       import buf._
 
-      val Op.Method(v, sig) = op
+      val nir.Op.Method(v, sig) = op
       val obj = genVal(buf, v)
 
       def genClassVirtualLookup(cls: Class): Unit = {
@@ -787,44 +797,44 @@ object Lower {
           s"The virtual table of ${cls.name} does not contain $sig"
         )
 
-        val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+        val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
         val methptrptr = let(
-          Op.Elem(
+          nir.Op.Elem(
             rtti(cls).struct,
             typeptr,
-            ClassRttiVtablePath :+ Val.Int(vindex)
+            ClassRttiVtablePath :+ nir.Val.Int(vindex)
           ),
           unwind
         )
 
-        let(n, Op.Load(Type.Ptr, methptrptr), unwind)
+        let(n, nir.Op.Load(nir.Type.Ptr, methptrptr), unwind)
       }
 
       def genTraitVirtualLookup(trt: Trait): Unit = {
         val sigid = dispatchTable.traitSigIds(sig)
-        val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+        val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
         val idptr =
-          let(Op.Elem(Rtti.layout, typeptr, RttiTraitIdPath), unwind)
-        val id = let(Op.Load(Type.Int, idptr), unwind)
+          let(nir.Op.Elem(Rtti.layout, typeptr, RttiTraitIdPath), unwind)
+        val id = let(nir.Op.Load(nir.Type.Int, idptr), unwind)
         val rowptr = let(
-          Op.Elem(
-            Type.Ptr,
+          nir.Op.Elem(
+            nir.Type.Ptr,
             dispatchTable.dispatchVal,
-            Seq(Val.Int(dispatchTable.dispatchOffset(sigid)))
+            Seq(nir.Val.Int(dispatchTable.dispatchOffset(sigid)))
           ),
           unwind
         )
         val methptrptr =
-          let(Op.Elem(Type.Ptr, rowptr, Seq(id)), unwind)
-        let(n, Op.Load(Type.Ptr, methptrptr), unwind)
+          let(nir.Op.Elem(nir.Type.Ptr, rowptr, Seq(id)), unwind)
+        let(n, nir.Op.Load(nir.Type.Ptr, methptrptr), unwind)
       }
 
       def genMethodLookup(scope: ScopeInfo): Unit = {
         scope.targets(sig).toSeq match {
           case Seq() =>
-            let(n, Op.Copy(Val.Null), unwind)
+            let(n, nir.Op.Copy(nir.Val.Null), unwind)
           case Seq(impl) =>
-            let(n, Op.Copy(Val.Global(impl, Type.Ptr)), unwind)
+            let(n, nir.Op.Copy(nir.Val.Global(impl, nir.Type.Ptr)), unwind)
           case _ =>
             obj.ty match {
               case ClassRef(cls) =>
@@ -846,24 +856,24 @@ object Lower {
               s"Did not find the signature of method $sig in ${cls.name}"
             )
           }
-        let(n, Op.Copy(Val.Global(method, Type.Ptr)), unwind)
+        let(n, nir.Op.Copy(nir.Val.Global(method, nir.Type.Ptr)), unwind)
       }
 
       def staticMethodIn(cls: Class): Boolean =
         !sig.isVirtual || !cls.calls.contains(sig)
 
       // We check type of original value, because it may change inside `genVal` transformation
-      // Eg. Val.String is transformed to Const(StructValue) which changes type from Ref to Ptr
+      // Eg. nir.Val.String is transformed to Const(StructValue) which changes type from Ref to Ptr
       v.ty match {
         // Method call with `null` ref argument might be inlined, in such case materialization of local value in Eval would
-        // result with Val.Null. We're directly throwing NPE which normally would be handled in slow path of `genGuardNotNull`
-        case Type.Null =>
+        // result with nir.Val.Null. We're directly throwing NPE which normally would be handled in slow path of `genGuardNotNull`
+        case nir.Type.Null =>
           let(
             n,
-            Op.Call(throwNullPointerTy, throwNullPointerVal, Seq(Val.Null)),
+            nir.Op.Call(throwNullPointerTy, throwNullPointerVal, Seq(nir.Val.Null)),
             unwind
           )
-          buf.unreachable(Next.None)
+          buf.unreachable(nir.Next.None)
 
         case ClassRef(cls) if staticMethodIn(cls) =>
           genStaticMethod(cls)
@@ -876,77 +886,77 @@ object Lower {
       }
     }
 
-    def genDynmethodOp(buf: Buffer, n: Local, op: Op.Dynmethod)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genDynmethodOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Dynmethod)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       import buf._
 
-      val Op.Dynmethod(v, sig) = op
+      val nir.Op.Dynmethod(v, sig) = op
       val obj = genVal(buf, v)
 
-      def throwIfNull(value: Val) = {
+      def throwIfNull(value: nir.Val) = {
         val notNullL = fresh()
         val noSuchMethodL =
           noSuchMethodSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
-        val condNull = comp(Comp.Ine, Type.Ptr, value, Val.Null, unwind)
+        val condNull = comp(nir.Comp.Ine, nir.Type.Ptr, value, nir.Val.Null, unwind)
         branch(
           condNull,
-          Next(notNullL),
-          Next.Label(noSuchMethodL, Seq(Val.String(sig.mangle)))
+          nir.Next(notNullL),
+          nir.Next.Label(noSuchMethodL, Seq(nir.Val.String(sig.mangle)))
         )
         label(notNullL)
       }
 
-      def genReflectiveLookup(): Val = {
+      def genReflectiveLookup(): nir.Val = {
         val methodIndex =
           meta.analysis.dynsigs.zipWithIndex.find(_._1 == sig).get._2
 
         // Load the type information pointer
-        val typeptr = load(Type.Ptr, obj, unwind)
+        val typeptr = load(nir.Type.Ptr, obj, unwind)
         // Load the dynamic hash map for given type, make sure it's not null
         val mapelem = elem(classRttiType, typeptr, ClassRttiDynmapPath, unwind)
-        val mapptr = load(Type.Ptr, mapelem, unwind)
+        val mapptr = load(nir.Type.Ptr, mapelem, unwind)
         // If hash map is not null, it has to contain at least one entry
         throwIfNull(mapptr)
         // Perform dynamic dispatch via dyndispatch helper
         val methptrptr = call(
           dyndispatchSig,
           dyndispatch,
-          Seq(mapptr, Val.Int(methodIndex)),
+          Seq(mapptr, nir.Val.Int(methodIndex)),
           unwind
         )
         // Hash map lookup can still not contain given signature
         throwIfNull(methptrptr)
-        let(n, Op.Load(Type.Ptr, methptrptr), unwind)
+        let(n, nir.Op.Load(nir.Type.Ptr, methptrptr), unwind)
       }
 
       genGuardNotNull(buf, obj)
       genReflectiveLookup()
     }
 
-    def genIsOp(buf: Buffer, n: Local, op: Op.Is)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genIsOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Is)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       import buf._
 
       op match {
-        case Op.Is(_, Val.Null | Val.Zero(_)) =>
-          let(n, Op.Copy(Val.False), unwind)
+        case nir.Op.Is(_, nir.Val.Null | nir.Val.Zero(_)) =>
+          let(n, nir.Op.Copy(nir.Val.False), unwind)
 
-        case Op.Is(ty, v) =>
+        case nir.Op.Is(ty, v) =>
           val obj = genVal(buf, v)
           val isNullL, checkL, resultL = fresh()
 
           // check if obj is null
-          val isNull = let(Op.Comp(Comp.Ieq, Type.Ptr, obj, Val.Null), unwind)
-          branch(isNull, Next(isNullL), Next(checkL))
+          val isNull = let(nir.Op.Comp(nir.Comp.Ieq, nir.Type.Ptr, obj, nir.Val.Null), unwind)
+          branch(isNull, nir.Next(isNullL), nir.Next(checkL))
 
           // in case it's null, result is always false
           label(isNullL)
-          jump(resultL, Seq(Val.False))
+          jump(resultL, Seq(nir.Val.False))
 
           // otherwise, do an actual instance check
           label(checkL)
@@ -954,53 +964,53 @@ object Lower {
           jump(resultL, Seq(isInstanceOf))
 
           // merge the result of two branches
-          label(resultL, Seq(Val.Local(n, op.resty)))
+          label(resultL, Seq(nir.Val.Local(n, op.resty)))
       }
     }
 
-    def genIsOp(buf: Buffer, ty: Type, v: Val)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
-    ): Val = {
+    def genIsOp(buf: nir.Buffer, ty: nir.Type, v: nir.Val)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
+    ): nir.Val = {
       import buf._
       val obj = genVal(buf, v)
 
       ty match {
         case ClassRef(cls) if meta.ranges(cls).length == 1 =>
-          val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
-          let(Op.Comp(Comp.Ieq, Type.Ptr, typeptr, rtti(cls).const), unwind)
+          val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
+          let(nir.Op.Comp(nir.Comp.Ieq, nir.Type.Ptr, typeptr, rtti(cls).const), unwind)
 
         case ClassRef(cls) =>
           val range = meta.ranges(cls)
-          val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+          val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
           val idptr =
             let(
-              Op.Elem(Rtti.layout, typeptr, RttiClassIdPath),
+              nir.Op.Elem(Rtti.layout, typeptr, RttiClassIdPath),
               unwind
             )
-          val id = let(Op.Load(Type.Int, idptr), unwind)
+          val id = let(nir.Op.Load(nir.Type.Int, idptr), unwind)
           val ge =
-            let(Op.Comp(Comp.Sle, Type.Int, Val.Int(range.start), id), unwind)
+            let(nir.Op.Comp(nir.Comp.Sle, nir.Type.Int, nir.Val.Int(range.start), id), unwind)
           val le =
-            let(Op.Comp(Comp.Sle, Type.Int, id, Val.Int(range.end)), unwind)
-          let(Op.Bin(Bin.And, Type.Bool, ge, le), unwind)
+            let(nir.Op.Comp(nir.Comp.Sle, nir.Type.Int, id, nir.Val.Int(range.end)), unwind)
+          let(nir.Op.Bin(nir.Bin.And, nir.Type.Bool, ge, le), unwind)
 
         case TraitRef(trt) =>
-          val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+          val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
           val idptr =
             let(
-              Op.Elem(Rtti.layout, typeptr, RttiClassIdPath),
+              nir.Op.Elem(Rtti.layout, typeptr, RttiClassIdPath),
               unwind
             )
-          val id = let(Op.Load(Type.Int, idptr), unwind)
+          val id = let(nir.Op.Load(nir.Type.Int, idptr), unwind)
           let(
-            Op.Call(
+            nir.Op.Call(
               Generate.ClassHasTraitSig,
-              Val.Global(
+              nir.Val.Global(
                 Generate.ClassHasTraitName,
                 Generate.ClassHasTraitSig
               ),
-              Seq(id, Val.Int(meta.ids(trt)))
+              Seq(id, nir.Val.Int(meta.ids(trt)))
             ),
             unwind
           )
@@ -1009,49 +1019,49 @@ object Lower {
       }
     }
 
-    def genAsOp(buf: Buffer, n: Local, op: Op.As)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genAsOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.As)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       import buf._
 
       op match {
-        case Op.As(ty: Type.RefKind, v) if v.ty == Type.Null =>
-          let(n, Op.Copy(Val.Null), unwind)
+        case nir.Op.As(ty: nir.Type.RefKind, v) if v.ty == nir.Type.Null =>
+          let(n, nir.Op.Copy(nir.Val.Null), unwind)
 
-        case Op.As(ty: Type.RefKind, obj)
-            if obj.ty.isInstanceOf[Type.RefKind] =>
+        case nir.Op.As(ty: nir.Type.RefKind, obj)
+            if obj.ty.isInstanceOf[nir.Type.RefKind] =>
           val v = genVal(buf, obj)
           val checkIfIsInstanceOfL, castL = fresh()
           val failL = classCastSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
-          val isNull = comp(Comp.Ieq, v.ty, v, Val.Null, unwind)
-          branch(isNull, Next(castL), Next(checkIfIsInstanceOfL))
+          val isNull = comp(nir.Comp.Ieq, v.ty, v, nir.Val.Null, unwind)
+          branch(isNull, nir.Next(castL), nir.Next(checkIfIsInstanceOfL))
 
           label(checkIfIsInstanceOfL)
           val isInstanceOf = genIsOp(buf, ty, v)
           val toTy = rtti(analysis.infos(ty.className)).const
-          branch(isInstanceOf, Next(castL), Next.Label(failL, Seq(v, toTy)))
+          branch(isInstanceOf, nir.Next(castL), nir.Next.Label(failL, Seq(v, toTy)))
 
           label(castL)
           if (platform.useOpaquePointers)
-            let(n, Op.Copy(v), unwind)
+            let(n, nir.Op.Copy(v), unwind)
           else
-            let(n, Op.Conv(Conv.Bitcast, ty, v), unwind)
+            let(n, nir.Op.Conv(nir.Conv.Bitcast, ty, v), unwind)
 
-        case Op.As(to, v) =>
+        case nir.Op.As(to, v) =>
           util.unsupported(s"can't cast from ${v.ty} to $to")
       }
     }
 
-    def genSizeOfOp(buf: Buffer, n: Local, op: Op.SizeOf)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genSizeOfOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.SizeOf)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       val size = op.ty match {
-        case ClassRef(cls) if op.ty != Type.Unit =>
+        case ClassRef(cls) if op.ty != nir.Type.Unit =>
           if (!cls.allocated) {
-            val Global.Top(clsName) = cls.name
+            val nir.Global.Top(clsName) = cls.name
             logger.warn(
               s"Referencing size of non allocated type ${clsName} in ${srcPosition.show}"
             )
@@ -1059,22 +1069,22 @@ object Lower {
           meta.layout(cls).size
         case _ => MemoryLayout.sizeOf(op.ty)
       }
-      buf.let(n, Op.Copy(Val.Size(size)), unwind)
+      buf.let(n, nir.Op.Copy(nir.Val.Size(size)), unwind)
     }
 
-    def genAlignmentOfOp(buf: Buffer, n: Local, op: Op.AlignmentOf)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genAlignmentOfOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.AlignmentOf)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       val alignment = MemoryLayout.alignmentOf(op.ty)
-      buf.let(n, Op.Copy(Val.Size(alignment)), unwind)
+      buf.let(n, nir.Op.Copy(nir.Val.Size(alignment)), unwind)
     }
 
-    def genClassallocOp(buf: Buffer, n: Local, op: Op.Classalloc)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genClassallocOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Classalloc)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Classalloc(ClassRef(cls), v) = op: @unchecked
+      val nir.Op.Classalloc(ClassRef(cls), v) = op: @unchecked
       val zone = v.map(genVal(buf, _))
 
       val size = meta.layout(cls).size
@@ -1082,18 +1092,18 @@ object Lower {
 
       zone match {
         case Some(zone) =>
-          val safeZoneAllocImplMethod = Val.Local(fresh(), Type.Ptr)
+          val safeZoneAllocImplMethod = nir.Val.Local(fresh(), nir.Type.Ptr)
           genMethodOp(
             buf,
             safeZoneAllocImplMethod.id,
-            Op.Method(zone, safeZoneAllocImpl.sig)
+            nir.Op.Method(zone, safeZoneAllocImpl.sig)
           )
           buf.let(
             n,
-            Op.Call(
+            nir.Op.Call(
               safeZoneAllocImplSig,
               safeZoneAllocImplMethod,
-              Seq(zone, rtti(cls).const, Val.Size(size.toInt))
+              Seq(zone, rtti(cls).const, nir.Val.Size(size.toInt))
             ),
             unwind
           )
@@ -1102,19 +1112,19 @@ object Lower {
             if (size < LARGE_OBJECT_MIN_SIZE) alloc else largeAlloc
           buf.let(
             n,
-            Op.Call(
+            nir.Op.Call(
               allocSig,
               allocMethod,
-              Seq(rtti(cls).const, Val.Size(size.toInt))
+              Seq(rtti(cls).const, nir.Val.Size(size.toInt))
             ),
             unwind
           )
       }
     }
 
-    def genConvOp(buf: Buffer, n: Local, op: Op.Conv)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genConvOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Conv)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       import buf._
 
@@ -1125,47 +1135,47 @@ object Lower {
         // that are numerically less than or equal to MIN_VALUE and MAX_VALUE
         // for the ones which are greate or equal to MAX_VALUE. Additionally,
         // NaNs are converted to 0.
-        case Op.Conv(Conv.Fptosi, toty, value) =>
+        case nir.Op.Conv(nir.Conv.Fptosi, toty, value) =>
           val v = genVal(buf, value)
           val (imin, imax, fmin, fmax) = toty match {
-            case Type.Int =>
+            case nir.Type.Int =>
               val min = java.lang.Integer.MIN_VALUE
               val max = java.lang.Integer.MAX_VALUE
               v.ty match {
-                case Type.Float =>
+                case nir.Type.Float =>
                   (
-                    Val.Int(min),
-                    Val.Int(max),
-                    Val.Float(min.toFloat),
-                    Val.Float(max.toFloat)
+                    nir.Val.Int(min),
+                    nir.Val.Int(max),
+                    nir.Val.Float(min.toFloat),
+                    nir.Val.Float(max.toFloat)
                   )
-                case Type.Double =>
+                case nir.Type.Double =>
                   (
-                    Val.Int(min),
-                    Val.Int(max),
-                    Val.Double(min.toDouble),
-                    Val.Double(max.toDouble)
+                    nir.Val.Int(min),
+                    nir.Val.Int(max),
+                    nir.Val.Double(min.toDouble),
+                    nir.Val.Double(max.toDouble)
                   )
                 case _ =>
                   util.unreachable
               }
-            case Type.Long =>
+            case nir.Type.Long =>
               val min = java.lang.Long.MIN_VALUE
               val max = java.lang.Long.MAX_VALUE
               v.ty match {
-                case Type.Float =>
+                case nir.Type.Float =>
                   (
-                    Val.Long(min),
-                    Val.Long(max),
-                    Val.Float(min.toFloat),
-                    Val.Float(max.toFloat)
+                    nir.Val.Long(min),
+                    nir.Val.Long(max),
+                    nir.Val.Float(min.toFloat),
+                    nir.Val.Float(max.toFloat)
                   )
-                case Type.Double =>
+                case nir.Type.Double =>
                   (
-                    Val.Long(min),
-                    Val.Long(max),
-                    Val.Double(min.toDouble),
-                    Val.Double(max.toDouble)
+                    nir.Val.Long(min),
+                    nir.Val.Long(max),
+                    nir.Val.Double(min.toDouble),
+                    nir.Val.Double(max.toDouble)
                   )
                 case _ =>
                   util.unreachable
@@ -1177,22 +1187,22 @@ object Lower {
           val isNaNL, checkLessThanMinL, lessThanMinL, checkLargerThanMaxL,
               largerThanMaxL, inBoundsL, resultL = fresh()
 
-          val isNaN = comp(Comp.Fne, v.ty, v, v, unwind)
-          branch(isNaN, Next(isNaNL), Next(checkLessThanMinL))
+          val isNaN = comp(nir.Comp.Fne, v.ty, v, v, unwind)
+          branch(isNaN, nir.Next(isNaNL), nir.Next(checkLessThanMinL))
 
           label(isNaNL)
-          jump(resultL, Seq(Val.Zero(op.resty)))
+          jump(resultL, Seq(nir.Val.Zero(op.resty)))
 
           label(checkLessThanMinL)
-          val isLessThanMin = comp(Comp.Fle, v.ty, v, fmin, unwind)
-          branch(isLessThanMin, Next(lessThanMinL), Next(checkLargerThanMaxL))
+          val isLessThanMin = comp(nir.Comp.Fle, v.ty, v, fmin, unwind)
+          branch(isLessThanMin, nir.Next(lessThanMinL), nir.Next(checkLargerThanMaxL))
 
           label(lessThanMinL)
           jump(resultL, Seq(imin))
 
           label(checkLargerThanMaxL)
-          val isLargerThanMax = comp(Comp.Fge, v.ty, v, fmax, unwind)
-          branch(isLargerThanMax, Next(largerThanMaxL), Next(inBoundsL))
+          val isLargerThanMax = comp(nir.Comp.Fge, v.ty, v, fmax, unwind)
+          branch(isLargerThanMax, nir.Next(largerThanMaxL), nir.Next(inBoundsL))
 
           label(largerThanMaxL)
           jump(resultL, Seq(imax))
@@ -1201,24 +1211,24 @@ object Lower {
           val inBoundsResult = let(op, unwind)
           jump(resultL, Seq(inBoundsResult))
 
-          label(resultL, Seq(Val.Local(n, op.resty)))
+          label(resultL, Seq(nir.Val.Local(n, op.resty)))
 
-        case Op.Conv(conv, ty, value) =>
-          let(n, Op.Conv(conv, ty, genVal(buf, value)), unwind)
+        case nir.Op.Conv(conv, ty, value) =>
+          let(n, nir.Op.Conv(conv, ty, genVal(buf, value)), unwind)
       }
     }
 
-    def genBinOp(buf: Buffer, n: Local, op: Op.Bin)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genBinOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Bin)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
       import buf._
 
       // LLVM's division by zero is undefined behaviour. We guard
       // the case when the divisor is zero and fail gracefully
       // by throwing an arithmetic exception.
-      def checkDivisionByZero(op: Op.Bin): Unit = {
-        val Op.Bin(bin, ty: Type.I, dividend, divisor) = op: @unchecked
+      def checkDivisionByZero(op: nir.Op.Bin): Unit = {
+        val nir.Op.Bin(bin, ty: nir.Type.I, dividend, divisor) = op: @unchecked
 
         val thenL, elseL = fresh()
 
@@ -1227,11 +1237,11 @@ object Lower {
           divisionByZeroSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
         val isZero =
-          comp(Comp.Ine, ty, divisor, Val.Zero(ty), unwind)
-        branch(isZero, Next(succL), Next(failL))
+          comp(nir.Comp.Ine, ty, divisor, nir.Val.Zero(ty), unwind)
+        branch(isZero, nir.Next(succL), nir.Next(failL))
 
         label(succL)
-        if (bin == Bin.Srem || bin == Bin.Sdiv) {
+        if (bin == nir.Bin.Srem || bin == nir.Bin.Sdiv) {
           checkDivisionOverflow(op)
         } else {
           let(n, op, unwind)
@@ -1250,40 +1260,51 @@ object Lower {
       // E.g. On x86_64 'srem' might get translated to 'idiv'
       // which computes both quotient and remainder at once
       // and quotient can overflow.
-      def checkDivisionOverflow(op: Op.Bin): Unit = {
-        val Op.Bin(bin, ty: Type.I, dividend, divisor) = op: @unchecked
+      def checkDivisionOverflow(op: nir.Op.Bin): Unit = {
+        val nir.Op.Bin(bin, ty: nir.Type.I, dividend, divisor) = op: @unchecked
 
         val mayOverflowL, noOverflowL, didOverflowL, resultL = fresh()
 
         val minus1 = ty match {
-          case Type.Int  => Val.Int(-1)
-          case Type.Long => Val.Long(-1L)
-          case Type.Size => Val.Size(-1L)
-          case _         => util.unreachable
+          case nir.Type.Int =>
+            nir.Val.Int(-1)
+          case nir.Type.Long =>
+            nir.Val.Long(-1L)
+          case nir.Type.Size =>
+            nir.Val.Size(-1L)
+          case _ =>
+            util.unreachable
         }
+
         val minValue = ty match {
-          case Type.Int  => Val.Int(java.lang.Integer.MIN_VALUE)
-          case Type.Long => Val.Long(java.lang.Long.MIN_VALUE)
-          case Type.Size =>
-            if (platform.is32Bit) Val.Size(java.lang.Integer.MIN_VALUE)
-            else Val.Size(java.lang.Long.MIN_VALUE)
-          case _ => util.unreachable
+          case nir.Type.Int =>
+            nir.Val.Int(java.lang.Integer.MIN_VALUE)
+          case nir.Type.Long =>
+            nir.Val.Long(java.lang.Long.MIN_VALUE)
+          case nir.Type.Size =>
+            if (platform.is32Bit) nir.Val.Size(java.lang.Integer.MIN_VALUE)
+            else nir.Val.Size(java.lang.Long.MIN_VALUE)
+          case _ =>
+            util.unreachable
         }
 
         val divisorIsMinus1 =
-          let(Op.Comp(Comp.Ieq, ty, divisor, minus1), unwind)
-        branch(divisorIsMinus1, Next(mayOverflowL), Next(noOverflowL))
+          let(nir.Op.Comp(nir.Comp.Ieq, ty, divisor, minus1), unwind)
+        branch(divisorIsMinus1, nir.Next(mayOverflowL), nir.Next(noOverflowL))
 
         label(mayOverflowL)
         val dividendIsMinValue =
-          let(Op.Comp(Comp.Ieq, ty, dividend, minValue), unwind)
-        branch(dividendIsMinValue, Next(didOverflowL), Next(noOverflowL))
+          let(nir.Op.Comp(nir.Comp.Ieq, ty, dividend, minValue), unwind)
+        branch(dividendIsMinValue, nir.Next(didOverflowL), nir.Next(noOverflowL))
 
         label(didOverflowL)
         val overflowResult = bin match {
-          case Bin.Srem => Val.Zero(ty)
-          case Bin.Sdiv => minValue
-          case _        => util.unreachable
+          case nir.Bin.Srem =>
+            nir.Val.Zero(ty)
+          case nir.Bin.Sdiv =>
+            minValue
+          case _ =>
+            util.unreachable
         }
         jump(resultL, Seq(overflowResult))
 
@@ -1291,34 +1312,37 @@ object Lower {
         val noOverflowResult = let(op, unwind)
         jump(resultL, Seq(noOverflowResult))
 
-        label(resultL, Seq(Val.Local(n, ty)))
+        label(resultL, Seq(nir.Val.Local(n, ty)))
       }
 
       // Shifts are undefined if the bits shifted by are >= bits in the type.
       // We mask the right hand side with bits in type - 1 to make it defined.
-      def maskShift(op: Op.Bin) = {
-        val Op.Bin(_, ty: Type.I, _, r) = op: @unchecked
+      def maskShift(op: nir.Op.Bin) = {
+        val nir.Op.Bin(_, ty: nir.Type.I, _, r) = op: @unchecked
         val mask = ty match {
-          case Type.Int  => Val.Int(31)
-          case Type.Long => Val.Int(63)
-          case _         => util.unreachable
+          case nir.Type.Int =>
+            nir.Val.Int(31)
+          case nir.Type.Long =>
+            nir.Val.Int(63)
+          case _ =>
+            util.unreachable
         }
-        val masked = bin(Bin.And, ty, r, mask, unwind)
+        val masked = bin(nir.Bin.And, ty, r, mask, unwind)
         let(n, op.copy(r = masked), unwind)
       }
 
       op match {
-        case op @ Op.Bin(
-              bin @ (Bin.Srem | Bin.Urem | Bin.Sdiv | Bin.Udiv),
-              ty: Type.I,
+        case op @ nir.Op.Bin(
+              bin @ (nir.Bin.Srem | nir.Bin.Urem | nir.Bin.Sdiv | nir.Bin.Udiv),
+              ty: nir.Type.I,
               l,
               r
             ) =>
           checkDivisionByZero(op)
 
-        case op @ Op.Bin(
-              bin @ (Bin.Shl | Bin.Lshr | Bin.Ashr),
-              ty: Type.I,
+        case op @ nir.Op.Bin(
+              bin @ (nir.Bin.Shl | nir.Bin.Lshr | nir.Bin.Ashr),
+              ty: nir.Type.I,
               l,
               r
             ) =>
@@ -1329,86 +1353,86 @@ object Lower {
       }
     }
 
-    def genBoxOp(buf: Buffer, n: Local, op: Op.Box)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genBoxOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Box)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Box(ty, v) = op
+      val nir.Op.Box(ty, v) = op
       val from = genVal(buf, v)
 
       val methodName = BoxTo(ty)
       val moduleName = methodName.top
 
       val boxTy =
-        Type.Function(Seq(Type.Ref(moduleName), Type.unbox(ty)), ty)
+        nir.Type.Function(Seq(nir.Type.Ref(moduleName), nir.Type.unbox(ty)), ty)
 
       buf.let(
         n,
-        Op.Call(boxTy, Val.Global(methodName, Type.Ptr), Seq(Val.Null, from)),
+        nir.Op.Call(boxTy, nir.Val.Global(methodName, nir.Type.Ptr), Seq(nir.Val.Null, from)),
         unwind
       )
     }
 
-    def genUnboxOp(buf: Buffer, n: Local, op: Op.Unbox)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genUnboxOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Unbox)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Unbox(ty, v) = op
+      val nir.Op.Unbox(ty, v) = op
       val from = genVal(buf, v)
 
       val methodName = UnboxTo(ty)
       val moduleName = methodName.top
 
       val unboxTy =
-        Type.Function(Seq(Type.Ref(moduleName), ty), Type.unbox(ty))
+        nir.Type.Function(Seq(nir.Type.Ref(moduleName), ty), nir.Type.unbox(ty))
 
       buf.let(
         n,
-        Op.Call(unboxTy, Val.Global(methodName, Type.Ptr), Seq(Val.Null, from)),
+        nir.Op.Call(unboxTy, nir.Val.Global(methodName, nir.Type.Ptr), Seq(nir.Val.Null, from)),
         unwind
       )
     }
 
-    def genModuleOp(buf: Buffer, n: Local, op: Op.Module)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genModuleOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Module)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ) = {
-      val Op.Module(name) = op
+      val nir.Op.Module(name) = op
 
       meta.analysis.infos(name) match {
         case cls: Class if cls.isConstantModule =>
-          val instance = name.member(Sig.Generated("instance"))
-          buf.let(n, Op.Copy(Val.Global(instance, Type.Ptr)), unwind)
+          val instance = name.member(nir.Sig.Generated("instance"))
+          buf.let(n, nir.Op.Copy(nir.Val.Global(instance, nir.Type.Ptr)), unwind)
 
         case _ =>
-          val loadSig = Type.Function(Seq.empty, Type.Ref(name))
-          val load = Val.Global(name.member(Sig.Generated("load")), Type.Ptr)
+          val loadSig = nir.Type.Function(Seq.empty, nir.Type.Ref(name))
+          val load = nir.Val.Global(name.member(nir.Sig.Generated("load")), nir.Type.Ptr)
 
-          buf.let(n, Op.Call(loadSig, load, Seq.empty), unwind)
+          buf.let(n, nir.Op.Call(loadSig, load, Seq.empty), unwind)
       }
     }
 
-    def genArrayallocOp(buf: Buffer, n: Local, op: Op.Arrayalloc)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genArrayallocOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Arrayalloc)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Arrayalloc(ty, v1, v2) = op
+      val nir.Op.Arrayalloc(ty, v1, v2) = op
       val init = genVal(buf, v1)
       val zone = v2.map(genVal(buf, _))
       init match {
-        case len if len.ty == Type.Int =>
+        case len if len.ty == nir.Type.Int =>
           val (arrayAlloc, arrayAllocSig) = zone match {
             case Some(_) => (arrayZoneAlloc, arrayZoneAllocSig)
             case None    => (arrayHeapAlloc, arrayHeapAllocSig)
           }
-          val sig = arrayAllocSig.getOrElse(ty, arrayAllocSig(Rt.Object))
-          val func = arrayAlloc.getOrElse(ty, arrayAlloc(Rt.Object))
-          val module = genModuleOp(buf, fresh(), Op.Module(func.owner))
+          val sig = arrayAllocSig.getOrElse(ty, arrayAllocSig(nir.Rt.Object))
+          val func = arrayAlloc.getOrElse(ty, arrayAlloc(nir.Rt.Object))
+          val module = genModuleOp(buf, fresh(), nir.Op.Module(func.owner))
           buf.let(
             n,
-            Op.Call(
+            nir.Op.Call(
               sig,
-              Val.Global(func, Type.Ptr),
+              nir.Val.Global(func, nir.Type.Ptr),
               zone match {
                 case Some(zone) => Seq(module, len, zone)
                 case None       => Seq(module, len)
@@ -1416,15 +1440,15 @@ object Lower {
             ),
             unwind
           )
-        case arrval: Val.ArrayValue =>
-          val sig = arraySnapshotSig.getOrElse(ty, arraySnapshotSig(Rt.Object))
-          val func = arraySnapshot.getOrElse(ty, arraySnapshot(Rt.Object))
-          val module = genModuleOp(buf, fresh(), Op.Module(func.owner))
-          val len = Val.Int(arrval.values.length)
-          val init = Val.Const(arrval)
+        case arrval: nir.Val.ArrayValue =>
+          val sig = arraySnapshotSig.getOrElse(ty, arraySnapshotSig(nir.Rt.Object))
+          val func = arraySnapshot.getOrElse(ty, arraySnapshot(nir.Rt.Object))
+          val module = genModuleOp(buf, fresh(), nir.Op.Module(func.owner))
+          val len = nir.Val.Int(arrval.values.length)
+          val init = nir.Val.Const(arrval)
           buf.let(
             n,
-            Op.Call(sig, Val.Global(func, Type.Ptr), Seq(module, len, init)),
+            nir.Op.Call(sig, nir.Val.Global(func, nir.Type.Ptr), Seq(module, len, init)),
             unwind
           )
         case _ => util.unreachable
@@ -1434,49 +1458,49 @@ object Lower {
     private def arrayMemoryLayout(
         ty: nir.Type,
         length: Int = 0
-    ): Type.StructValue = Type.StructValue(
-      Seq(ArrayHeader.layout, Type.ArrayValue(ty, length))
+    ): nir.Type.StructValue = nir.Type.StructValue(
+      Seq(ArrayHeader.layout, nir.Type.ArrayValue(ty, length))
     )
-    private def arrayValuePath(idx: Val) = Seq(zero, one, idx)
+    private def arrayValuePath(idx: nir.Val) = Seq(zero, one, idx)
 
-    def genArrayloadOp(buf: Buffer, n: Local, op: Op.Arrayload)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genArrayloadOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Arrayload)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Arrayload(ty, v, idx) = op
+      val nir.Op.Arrayload(ty, v, idx) = op
       val arr = genVal(buf, v)
 
       val len = fresh()
 
-      genArraylengthOp(buf, len, Op.Arraylength(arr))
-      genGuardInBounds(buf, idx, Val.Local(len, Type.Int))
+      genArraylengthOp(buf, len, nir.Op.Arraylength(arr))
+      genGuardInBounds(buf, idx, nir.Val.Local(len, nir.Type.Int))
 
       val arrTy = arrayMemoryLayout(ty)
       val elemPtr = buf.elem(arrTy, arr, arrayValuePath(idx), unwind)
-      buf.let(n, Op.Load(ty, elemPtr), unwind)
+      buf.let(n, nir.Op.Load(ty, elemPtr), unwind)
     }
 
-    def genArraystoreOp(buf: Buffer, n: Local, op: Op.Arraystore)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genArraystoreOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Arraystore)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Arraystore(ty, arr, idx, v) = op
+      val nir.Op.Arraystore(ty, arr, idx, v) = op
       val len = fresh()
       val value = genVal(buf, v)
 
-      genArraylengthOp(buf, len, Op.Arraylength(arr))
-      genGuardInBounds(buf, idx, Val.Local(len, Type.Int))
+      genArraylengthOp(buf, len, nir.Op.Arraylength(arr))
+      genGuardInBounds(buf, idx, nir.Val.Local(len, nir.Type.Int))
 
       val arrTy = arrayMemoryLayout(ty)
       val elemPtr = buf.elem(arrTy, arr, arrayValuePath(idx), unwind)
-      genStoreOp(buf, n, Op.Store(ty, elemPtr, value))
+      genStoreOp(buf, n, nir.Op.Store(ty, elemPtr, value))
     }
 
-    def genArraylengthOp(buf: Buffer, n: Local, op: Op.Arraylength)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genArraylengthOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Arraylength)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Arraylength(v) = op
+      val nir.Op.Arraylength(v) = op
       val arr = genVal(buf, v)
 
       val sig = arrayLengthSig
@@ -1485,74 +1509,79 @@ object Lower {
       genGuardNotNull(buf, arr)
       val lenPtr =
         buf.elem(ArrayHeader.layout, arr, ArrayHeaderLengthPath, unwind)
-      buf.let(n, Op.Load(Type.Int, lenPtr), unwind)
+      buf.let(n, nir.Op.Load(nir.Type.Int, lenPtr), unwind)
     }
 
-    def genStackallocOp(buf: Buffer, n: Local, op: Op.Stackalloc)(implicit
-        srcPosition: Position,
-        scopeId: ScopeId
+    def genStackallocOp(buf: nir.Buffer, n: nir.Local, op: nir.Op.Stackalloc)(implicit
+        srcPosition: nir.Position,
+        scopeId: nir.ScopeId
     ): Unit = {
-      val Op.Stackalloc(ty, size) = op
-      val initValue = Val.Zero(ty).canonicalize
+      val nir.Op.Stackalloc(ty, size) = op
+      val initValue = nir.Val.Zero(ty).canonicalize
       val pointee = buf.let(n, op, unwind)
       size match {
-        case Val.Size(1) if initValue.isCanonical =>
+        case nir.Val.Size(1) if initValue.isCanonical =>
           buf.let(
-            Op.Store(ty, pointee, initValue, None),
+            nir.Op.Store(ty, pointee, initValue, None),
             unwind
           )
         case sizeV =>
           val elemSize = MemoryLayout.sizeOf(ty)
           val size = sizeV match {
-            case Val.Size(v) => Val.Size(v * elemSize)
+            case nir.Val.Size(v) => nir.Val.Size(v * elemSize)
             case _ =>
               val asSize = sizeV.ty match {
-                case Type.FixedSizeI(width, _) =>
+                case nir.Type.FixedSizeI(width, _) =>
                   if (width == platform.sizeOfPtrBits) sizeV
                   else if (width > platform.sizeOfPtrBits)
-                    buf.conv(Conv.Trunc, Type.Size, sizeV, unwind)
+                    buf.conv(nir.Conv.Trunc, nir.Type.Size, sizeV, unwind)
                   else
-                    buf.conv(Conv.Zext, Type.Size, sizeV, unwind)
+                    buf.conv(nir.Conv.Zext, nir.Type.Size, sizeV, unwind)
 
                 case _ => sizeV
               }
               if (elemSize == 1) asSize
               else
                 buf.let(
-                  Op.Bin(Bin.Imul, Type.Size, asSize, Val.Size(elemSize)),
+                  nir.Op.Bin(nir.Bin.Imul, nir.Type.Size, asSize, nir.Val.Size(elemSize)),
                   unwind
                 )
           }
-          buf.call(memsetSig, memset, Seq(pointee, Val.Int(0), size), unwind)
+          buf.call(memsetSig, memset, Seq(pointee, nir.Val.Int(0), size), unwind)
       }
     }
 
-    def genStringVal(value: String): Val = {
-      val StringCls = ClassRef.unapply(Rt.StringName).get
+    def genStringVal(value: String): nir.Val = {
+      val StringCls = ClassRef.unapply(nir.Rt.StringName).get
       val CharArrayCls = ClassRef.unapply(CharArrayName).get
 
       val chars = value.toCharArray
-      val charsLength = Val.Int(chars.length)
-      val charsConst = Val.Const(
-        Val.StructValue(
+      val charsLength = nir.Val.Int(chars.length)
+      val charsConst = nir.Val.Const(
+        nir.Val.StructValue(
           rtti(CharArrayCls).const ::
             meta.lockWordVals :::
             charsLength ::
-            Val.Int(2) :: // stride is used only by GC
-            Val.ArrayValue(Type.Char, chars.toSeq.map(Val.Char(_))) :: Nil
+            nir.Val.Int(2) :: // stride is used only by GC
+            nir.Val.ArrayValue(nir.Type.Char, chars.toSeq.map(nir.Val.Char(_))) :: Nil
         )
       )
 
       val fieldValues = stringFieldNames.map {
-        case Rt.StringValueName          => charsConst
-        case Rt.StringOffsetName         => zero
-        case Rt.StringCountName          => charsLength
-        case Rt.StringCachedHashCodeName => Val.Int(stringHashCode(value))
-        case _                           => util.unreachable
+        case nir.Rt.StringValueName =>
+          charsConst
+        case nir.Rt.StringOffsetName =>
+          zero
+        case nir.Rt.StringCountName =>
+          charsLength
+        case nir.Rt.StringCachedHashCodeName =>
+          nir.Val.Int(stringHashCode(value))
+        case _ =>
+          util.unreachable
       }
 
-      Val.Const(
-        Val.StructValue(
+      nir.Val.Const(
+        nir.Val.StructValue(
           rtti(StringCls).const ::
             meta.lockWordVals ++
             fieldValues
@@ -1561,30 +1590,30 @@ object Lower {
     }
 
     private def genThisValueNullGuardIfUsed(
-        defn: Defn.Define,
+        defn: nir.Defn.Define,
         buf: nir.Buffer,
-        createUnwindHandler: () => Option[Local]
+        createUnwindHandler: () => Option[nir.Local]
     ) = {
-      def usesValue(expected: Val): Boolean = {
+      def usesValue(expected: nir.Val): Boolean = {
         var wasUsed = false
         import scala.util.control.Breaks._
         breakable {
-          new Traverse {
-            override def onVal(value: Val): Unit = {
+          new nir.Traverse {
+            override def onVal(value: nir.Val): Unit = {
               wasUsed = expected eq value
               if (wasUsed) break()
               else super.onVal(value)
             }
             // We're not intrested in cheecking these structures, skip them
-            override def onType(ty: Type): Unit = ()
-            override def onNext(next: Next): Unit = ()
+            override def onType(ty: nir.Type): Unit = ()
+            override def onNext(next: nir.Next): Unit = ()
           }.onDefn(defn)
         }
         wasUsed
       }
 
-      val Global.Member(_, sig) = defn.name
-      val Inst.Label(_, args) = defn.insts.head: @unchecked
+      val nir.Global.Member(_, sig) = defn.name
+      val nir.Inst.Label(_, args) = defn.insts.head: @unchecked
 
       val canHaveThisValue =
         !(sig.isStatic || sig.isClinit || sig.isExtern)
@@ -1592,9 +1621,9 @@ object Lower {
       if (canHaveThisValue) {
         args.headOption.foreach { thisValue =>
           thisValue.ty match {
-            case ref: Type.Ref if ref.isNullable && usesValue(thisValue) =>
-              implicit def pos: Position = defn.pos
-              implicit def scopeId: ScopeId = ScopeId.TopLevel
+            case ref: nir.Type.Ref if ref.isNullable && usesValue(thisValue) =>
+              implicit def pos: nir.Position = defn.pos
+              implicit def scopeId: nir.ScopeId = nir.ScopeId.TopLevel
               ScopedVar.scoped(
                 unwindHandler := createUnwindHandler()
               ) {
@@ -1624,56 +1653,56 @@ object Lower {
 
   val LARGE_OBJECT_MIN_SIZE = 8192
 
-  val allocSig = Type.Function(Seq(Type.Ptr, Type.Size), Type.Ptr)
+  val allocSig = nir.Type.Function(Seq(nir.Type.Ptr, nir.Type.Size), nir.Type.Ptr)
 
   val allocSmallName = extern("scalanative_alloc_small")
-  val alloc = Val.Global(allocSmallName, allocSig)
+  val alloc = nir.Val.Global(allocSmallName, allocSig)
 
   val largeAllocName = extern("scalanative_alloc_large")
-  val largeAlloc = Val.Global(largeAllocName, allocSig)
+  val largeAlloc = nir.Val.Global(largeAllocName, allocSig)
 
-  val SafeZone = Type.Ref(Global.Top("scala.scalanative.memory.SafeZone"))
+  val SafeZone = nir.Type.Ref(nir.Global.Top("scala.scalanative.memory.SafeZone"))
   val safeZoneAllocImplSig =
-    Type.Function(Seq(SafeZone, Type.Ptr, Type.Size), Type.Ptr)
+    nir.Type.Function(Seq(SafeZone, nir.Type.Ptr, nir.Type.Size), nir.Type.Ptr)
   val safeZoneAllocImpl = SafeZone.name.member(
-    Sig.Method("allocImpl", Seq(Type.Ptr, Type.Size, Type.Ptr))
+    nir.Sig.Method("allocImpl", Seq(nir.Type.Ptr, nir.Type.Size, nir.Type.Ptr))
   )
 
   val dyndispatchName = extern("scalanative_dyndispatch")
   val dyndispatchSig =
-    Type.Function(Seq(Type.Ptr, Type.Int), Type.Ptr)
-  val dyndispatch = Val.Global(dyndispatchName, dyndispatchSig)
+    nir.Type.Function(Seq(nir.Type.Ptr, nir.Type.Int), nir.Type.Ptr)
+  val dyndispatch = nir.Val.Global(dyndispatchName, dyndispatchSig)
 
-  val excptnGlobal = Global.Top("java.lang.NoSuchMethodException")
+  val excptnGlobal = nir.Global.Top("java.lang.NoSuchMethodException")
   val excptnInitGlobal =
-    Global.Member(excptnGlobal, Sig.Ctor(Seq(nir.Rt.String)))
+    nir.Global.Member(excptnGlobal, nir.Sig.Ctor(Seq(nir.Rt.String)))
 
-  val excInitSig = Type.Function(
-    Seq(Type.Ref(excptnGlobal), Type.Ref(Global.Top("java.lang.String"))),
-    Type.Unit
+  val excInitSig = nir.Type.Function(
+    Seq(nir.Type.Ref(excptnGlobal), nir.Type.Ref(nir.Global.Top("java.lang.String"))),
+    nir.Type.Unit
   )
-  val excInit = Val.Global(excptnInitGlobal, Type.Ptr)
+  val excInit = nir.Val.Global(excptnInitGlobal, nir.Type.Ptr)
 
   val CharArrayName =
-    Global.Top("scala.scalanative.runtime.CharArray")
+    nir.Global.Top("scala.scalanative.runtime.CharArray")
 
-  val BoxesRunTime = Global.Top("scala.runtime.BoxesRunTime$")
-  val RuntimeBoxes = Global.Top("scala.scalanative.runtime.Boxes$")
+  val BoxesRunTime = nir.Global.Top("scala.runtime.BoxesRunTime$")
+  val RuntimeBoxes = nir.Global.Top("scala.scalanative.runtime.Boxes$")
 
-  val BoxTo: Map[Type, Global] = Type.boxClasses.map { cls =>
-    val name = cls.asInstanceOf[Global.Top].id
-    val boxty = Type.Ref(Global.Top(name))
+  val BoxTo: Map[nir.Type, nir.Global] = nir.Type.boxClasses.map { cls =>
+    val name = cls.asInstanceOf[nir.Global.Top].id
+    val boxty = nir.Type.Ref(nir.Global.Top(name))
     val module = if (name.startsWith("java.")) BoxesRunTime else RuntimeBoxes
     val id = "boxTo" + name.split("\\.").last
     val tys = Seq(nir.Type.unbox(boxty), boxty)
-    val meth = module.member(Sig.Method(id, tys))
+    val meth = module.member(nir.Sig.Method(id, tys))
 
     boxty -> meth
   }.toMap
 
-  val UnboxTo: Map[Type, Global] = Type.boxClasses.map { cls =>
-    val name = cls.asInstanceOf[Global.Top].id
-    val boxty = Type.Ref(Global.Top(name))
+  val UnboxTo: Map[nir.Type, nir.Global] = nir.Type.boxClasses.map { cls =>
+    val name = cls.asInstanceOf[nir.Global.Top].id
+    val boxty = nir.Type.Ref(nir.Global.Top(name))
     val module = if (name.startsWith("java.")) BoxesRunTime else RuntimeBoxes
     val id = {
       val last = name.split("\\.").last
@@ -1684,220 +1713,220 @@ object Lower {
       "unboxTo" + suffix
     }
     val tys = Seq(nir.Rt.Object, nir.Type.unbox(boxty))
-    val meth = module.member(Sig.Method(id, tys))
+    val meth = module.member(nir.Sig.Method(id, tys))
 
     boxty -> meth
   }.toMap
 
-  private def extern(id: String): Global.Member =
-    Global.Member(Global.Top("__"), Sig.Extern(id))
+  private def extern(id: String): nir.Global.Member =
+    nir.Global.Member(nir.Global.Top("__"), nir.Sig.Extern(id))
 
-  val unitName = Global.Top("scala.scalanative.runtime.BoxedUnit$")
-  val unitInstance = unitName.member(Sig.Generated("instance"))
-  val unit = Val.Global(unitInstance, Type.Ptr)
+  val unitName = nir.Global.Top("scala.scalanative.runtime.BoxedUnit$")
+  val unitInstance = unitName.member(nir.Sig.Generated("instance"))
+  val unit = nir.Val.Global(unitInstance, nir.Type.Ptr)
 
   val throwName = extern("scalanative_throw")
-  val throwSig = Type.Function(Seq(Type.Ptr), Type.Nothing)
-  val throw_ = Val.Global(throwName, Type.Ptr)
+  val throwSig = nir.Type.Function(Seq(nir.Type.Ptr), nir.Type.Nothing)
+  val throw_ = nir.Val.Global(throwName, nir.Type.Ptr)
 
-  val arrayHeapAlloc = Type.typeToArray.map {
+  val arrayHeapAlloc = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      val Global.Top(id) = arrname
-      val arrcls = Type.Ref(arrname)
-      ty -> Global.Member(
-        Global.Top(id + "$"),
-        Sig.Method("alloc", Seq(Type.Int, arrcls))
+      val nir.Global.Top(id) = arrname
+      val arrcls = nir.Type.Ref(arrname)
+      ty -> nir.Global.Member(
+        nir.Global.Top(id + "$"),
+        nir.Sig.Method("alloc", Seq(nir.Type.Int, arrcls))
       )
   }.toMap
-  val arrayHeapAllocSig = Type.typeToArray.map {
+  val arrayHeapAllocSig = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      val Global.Top(id) = arrname
-      ty -> Type.Function(
-        Seq(Type.Ref(Global.Top(id + "$")), Type.Int),
-        Type.Ref(arrname)
+      val nir.Global.Top(id) = arrname
+      ty -> nir.Type.Function(
+        Seq(nir.Type.Ref(nir.Global.Top(id + "$")), nir.Type.Int),
+        nir.Type.Ref(arrname)
       )
   }.toMap
-  val arrayZoneAlloc = Type.typeToArray.map {
+  val arrayZoneAlloc = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      val Global.Top(id) = arrname
-      val arrcls = Type.Ref(arrname)
-      ty -> Global.Member(
-        Global.Top(id + "$"),
-        Sig.Method("alloc", Seq(Type.Int, SafeZone, arrcls))
+      val nir.Global.Top(id) = arrname
+      val arrcls = nir.Type.Ref(arrname)
+      ty -> nir.Global.Member(
+        nir.Global.Top(id + "$"),
+        nir.Sig.Method("alloc", Seq(nir.Type.Int, SafeZone, arrcls))
       )
   }.toMap
-  val arrayZoneAllocSig = Type.typeToArray.map {
+  val arrayZoneAllocSig = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      val Global.Top(id) = arrname
-      ty -> Type.Function(
-        Seq(Type.Ref(Global.Top(id + "$")), Type.Int, SafeZone),
-        Type.Ref(arrname)
+      val nir.Global.Top(id) = arrname
+      ty -> nir.Type.Function(
+        Seq(nir.Type.Ref(nir.Global.Top(id + "$")), nir.Type.Int, SafeZone),
+        nir.Type.Ref(arrname)
       )
   }.toMap
-  val arraySnapshot = Type.typeToArray.map {
+  val arraySnapshot = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      val Global.Top(id) = arrname
-      val arrcls = Type.Ref(arrname)
-      ty -> Global.Member(
-        Global.Top(id + "$"),
-        Sig.Method("snapshot", Seq(Type.Int, Type.Ptr, arrcls))
+      val nir.Global.Top(id) = arrname
+      val arrcls = nir.Type.Ref(arrname)
+      ty -> nir.Global.Member(
+        nir.Global.Top(id + "$"),
+        nir.Sig.Method("snapshot", Seq(nir.Type.Int, nir.Type.Ptr, arrcls))
       )
   }.toMap
-  val arraySnapshotSig = Type.typeToArray.map {
+  val arraySnapshotSig = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      val Global.Top(id) = arrname
-      ty -> Type.Function(
-        Seq(Type.Ref(Global.Top(id + "$")), Type.Int, Type.Ptr),
-        Type.Ref(arrname)
+      val nir.Global.Top(id) = arrname
+      ty -> nir.Type.Function(
+        Seq(nir.Type.Ref(nir.Global.Top(id + "$")), nir.Type.Int, nir.Type.Ptr),
+        nir.Type.Ref(arrname)
       )
   }.toMap
-  val arrayApplyGeneric = Type.typeToArray.map {
+  val arrayApplyGeneric = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      ty -> Global.Member(
+      ty -> nir.Global.Member(
         arrname,
-        Sig.Method("apply", Seq(Type.Int, nir.Rt.Object))
+        nir.Sig.Method("apply", Seq(nir.Type.Int, nir.Rt.Object))
       )
   }
-  val arrayApply = Type.typeToArray.map {
+  val arrayApply = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      ty -> Global.Member(arrname, Sig.Method("apply", Seq(Type.Int, ty)))
+      ty -> nir.Global.Member(arrname, nir.Sig.Method("apply", Seq(nir.Type.Int, ty)))
   }.toMap
-  val arrayApplySig = Type.typeToArray.map {
+  val arrayApplySig = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      ty -> Type.Function(Seq(Type.Ref(arrname), Type.Int), ty)
+      ty -> nir.Type.Function(Seq(nir.Type.Ref(arrname), nir.Type.Int), ty)
   }.toMap
-  val arrayUpdateGeneric = Type.typeToArray.map {
+  val arrayUpdateGeneric = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      ty -> Global.Member(
+      ty -> nir.Global.Member(
         arrname,
-        Sig.Method("update", Seq(Type.Int, nir.Rt.Object, Type.Unit))
+        nir.Sig.Method("update", Seq(nir.Type.Int, nir.Rt.Object, nir.Type.Unit))
       )
   }
-  val arrayUpdate = Type.typeToArray.map {
+  val arrayUpdate = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      ty -> Global.Member(
+      ty -> nir.Global.Member(
         arrname,
-        Sig.Method("update", Seq(Type.Int, ty, Type.Unit))
+        nir.Sig.Method("update", Seq(nir.Type.Int, ty, nir.Type.Unit))
       )
   }.toMap
-  val arrayUpdateSig = Type.typeToArray.map {
+  val arrayUpdateSig = nir.Type.typeToArray.map {
     case (ty, arrname) =>
-      ty -> Type.Function(Seq(Type.Ref(arrname), Type.Int, ty), Type.Unit)
+      ty -> nir.Type.Function(Seq(nir.Type.Ref(arrname), nir.Type.Int, ty), nir.Type.Unit)
   }.toMap
   val arrayLength =
-    Global.Member(
-      Global.Top("scala.scalanative.runtime.Array"),
-      Sig.Method("length", Seq(Type.Int))
+    nir.Global.Member(
+      nir.Global.Top("scala.scalanative.runtime.Array"),
+      nir.Sig.Method("length", Seq(nir.Type.Int))
     )
   val arrayLengthSig =
-    Type.Function(
-      Seq(Type.Ref(Global.Top("scala.scalanative.runtime.Array"))),
-      Type.Int
+    nir.Type.Function(
+      Seq(nir.Type.Ref(nir.Global.Top("scala.scalanative.runtime.Array"))),
+      nir.Type.Int
     )
 
   val throwDivisionByZeroTy =
-    Type.Function(Seq(Rt.Runtime), Type.Nothing)
+    nir.Type.Function(Seq(nir.Rt.Runtime), nir.Type.Nothing)
   val throwDivisionByZero =
-    Global.Member(
-      Rt.Runtime.name,
-      Sig.Method("throwDivisionByZero", Seq(Type.Nothing))
+    nir.Global.Member(
+      nir.Rt.Runtime.name,
+      nir.Sig.Method("throwDivisionByZero", Seq(nir.Type.Nothing))
     )
   val throwDivisionByZeroVal =
-    Val.Global(throwDivisionByZero, Type.Ptr)
+    nir.Val.Global(throwDivisionByZero, nir.Type.Ptr)
 
   val throwClassCastTy =
-    Type.Function(Seq(Rt.Runtime, Type.Ptr, Type.Ptr), Type.Nothing)
+    nir.Type.Function(Seq(nir.Rt.Runtime, nir.Type.Ptr, nir.Type.Ptr), nir.Type.Nothing)
   val throwClassCast =
-    Global.Member(
-      Rt.Runtime.name,
-      Sig.Method("throwClassCast", Seq(Type.Ptr, Type.Ptr, Type.Nothing))
+    nir.Global.Member(
+      nir.Rt.Runtime.name,
+      nir.Sig.Method("throwClassCast", Seq(nir.Type.Ptr, nir.Type.Ptr, nir.Type.Nothing))
     )
   val throwClassCastVal =
-    Val.Global(throwClassCast, Type.Ptr)
+    nir.Val.Global(throwClassCast, nir.Type.Ptr)
 
   val throwNullPointerTy =
-    Type.Function(Seq(Rt.Runtime), Type.Nothing)
+    nir.Type.Function(Seq(nir.Rt.Runtime), nir.Type.Nothing)
   val throwNullPointer =
-    Global.Member(
-      Rt.Runtime.name,
-      Sig.Method("throwNullPointer", Seq(Type.Nothing))
+    nir.Global.Member(
+      nir.Rt.Runtime.name,
+      nir.Sig.Method("throwNullPointer", Seq(nir.Type.Nothing))
     )
   val throwNullPointerVal =
-    Val.Global(throwNullPointer, Type.Ptr)
+    nir.Val.Global(throwNullPointer, nir.Type.Ptr)
 
   val throwUndefinedTy =
-    Type.Function(Seq(Type.Ptr), Type.Nothing)
+    nir.Type.Function(Seq(nir.Type.Ptr), nir.Type.Nothing)
   val throwUndefined =
-    Global.Member(
-      Rt.Runtime.name,
-      Sig.Method("throwUndefined", Seq(Type.Nothing))
+    nir.Global.Member(
+      nir.Rt.Runtime.name,
+      nir.Sig.Method("throwUndefined", Seq(nir.Type.Nothing))
     )
   val throwUndefinedVal =
-    Val.Global(throwUndefined, Type.Ptr)
+    nir.Val.Global(throwUndefined, nir.Type.Ptr)
 
   val throwOutOfBoundsTy =
-    Type.Function(Seq(Type.Ptr, Type.Int), Type.Nothing)
+    nir.Type.Function(Seq(nir.Type.Ptr, nir.Type.Int), nir.Type.Nothing)
   val throwOutOfBounds =
-    Global.Member(
-      Rt.Runtime.name,
-      Sig.Method("throwOutOfBounds", Seq(Type.Int, Type.Nothing))
+    nir.Global.Member(
+      nir.Rt.Runtime.name,
+      nir.Sig.Method("throwOutOfBounds", Seq(nir.Type.Int, nir.Type.Nothing))
     )
   val throwOutOfBoundsVal =
-    Val.Global(throwOutOfBounds, Type.Ptr)
+    nir.Val.Global(throwOutOfBounds, nir.Type.Ptr)
 
   val throwNoSuchMethodTy =
-    Type.Function(Seq(Type.Ptr, Type.Ptr), Type.Nothing)
+    nir.Type.Function(Seq(nir.Type.Ptr, nir.Type.Ptr), nir.Type.Nothing)
   val throwNoSuchMethod =
-    Global.Member(
-      Rt.Runtime.name,
-      Sig.Method("throwNoSuchMethod", Seq(Rt.String, Type.Nothing))
+    nir.Global.Member(
+      nir.Rt.Runtime.name,
+      nir.Sig.Method("throwNoSuchMethod", Seq(nir.Rt.String, nir.Type.Nothing))
     )
   val throwNoSuchMethodVal =
-    Val.Global(throwNoSuchMethod, Type.Ptr)
+    nir.Val.Global(throwNoSuchMethod, nir.Type.Ptr)
 
-  val GC = Global.Top("scala.scalanative.runtime.GC$")
-  val GCSafepointName = GC.member(Sig.Extern("scalanative_gc_safepoint"))
-  val GCSafepoint = Val.Global(GCSafepointName, Type.Ptr)
+  val GC = nir.Global.Top("scala.scalanative.runtime.GC$")
+  val GCSafepointName = GC.member(nir.Sig.Extern("scalanative_gc_safepoint"))
+  val GCSafepoint = nir.Val.Global(GCSafepointName, nir.Type.Ptr)
 
-  val GCSetMutatorThreadStateSig = Type.Function(Seq(Type.Int), Type.Unit)
-  val GCSetMutatorThreadState = Val.Global(
-    GC.member(Sig.Extern("scalanative_gc_set_mutator_thread_state")),
-    Type.Ptr
+  val GCSetMutatorThreadStateSig = nir.Type.Function(Seq(nir.Type.Int), nir.Type.Unit)
+  val GCSetMutatorThreadState = nir.Val.Global(
+    GC.member(nir.Sig.Extern("scalanative_gc_set_mutator_thread_state")),
+    nir.Type.Ptr
   )
 
   val memsetSig =
-    Type.Function(Seq(Type.Ptr, Type.Int, Type.Size), Type.Ptr)
+    nir.Type.Function(Seq(nir.Type.Ptr, nir.Type.Int, nir.Type.Size), nir.Type.Ptr)
   val memsetName = extern("memset")
-  val memset = Val.Global(memsetName, Type.Ptr)
+  val memset = nir.Val.Global(memsetName, nir.Type.Ptr)
 
-  val RuntimeNull = Type.Ref(Global.Top("scala.runtime.Null$"))
-  val RuntimeNothing = Type.Ref(Global.Top("scala.runtime.Nothing$"))
+  val RuntimeNull = nir.Type.Ref(nir.Global.Top("scala.runtime.Null$"))
+  val RuntimeNothing = nir.Type.Ref(nir.Global.Top("scala.runtime.Nothing$"))
 
-  val injects: Seq[Defn] = {
-    implicit val pos = Position.NoPosition
-    val buf = mutable.UnrolledBuffer.empty[Defn]
-    buf += Defn.Declare(Attrs.None, allocSmallName, allocSig)
-    buf += Defn.Declare(Attrs.None, largeAllocName, allocSig)
-    buf += Defn.Declare(Attrs.None, dyndispatchName, dyndispatchSig)
-    buf += Defn.Declare(Attrs.None, throwName, throwSig)
-    buf += Defn.Declare(Attrs(isExtern = true), memsetName, memsetSig)
+  val injects: Seq[nir.Defn] = {
+    implicit val pos = nir.Position.NoPosition
+    val buf = mutable.UnrolledBuffer.empty[nir.Defn]
+    buf += nir.Defn.Declare(nir.Attrs.None, allocSmallName, allocSig)
+    buf += nir.Defn.Declare(nir.Attrs.None, largeAllocName, allocSig)
+    buf += nir.Defn.Declare(nir.Attrs.None, dyndispatchName, dyndispatchSig)
+    buf += nir.Defn.Declare(nir.Attrs.None, throwName, throwSig)
+    buf += nir.Defn.Declare(nir.Attrs(isExtern = true), memsetName, memsetSig)
     buf.toSeq
   }
 
-  def depends(implicit platform: PlatformInfo): Seq[Global] = {
-    val buf = mutable.UnrolledBuffer.empty[Global]
-    buf ++= Rt.PrimitiveTypes
-    buf += Rt.ClassName
-    buf += Rt.ClassIdName
-    buf += Rt.ClassTraitIdName
-    buf += Rt.ClassNameName
-    buf += Rt.ClassSizeName
-    buf += Rt.ClassIdRangeUntilName
-    buf += Rt.StringName
-    buf += Rt.StringValueName
-    buf += Rt.StringOffsetName
-    buf += Rt.StringCountName
-    buf += Rt.StringCachedHashCodeName
+  def depends(implicit platform: PlatformInfo): Seq[nir.Global] = {
+    val buf = mutable.UnrolledBuffer.empty[nir.Global]
+    buf ++= nir.Rt.PrimitiveTypes
+    buf += nir.Rt.ClassName
+    buf += nir.Rt.ClassIdName
+    buf += nir.Rt.ClassTraitIdName
+    buf += nir.Rt.ClassNameName
+    buf += nir.Rt.ClassSizeName
+    buf += nir.Rt.ClassIdRangeUntilName
+    buf += nir.Rt.StringName
+    buf += nir.Rt.StringValueName
+    buf += nir.Rt.StringOffsetName
+    buf += nir.Rt.StringCountName
+    buf += nir.Rt.StringCachedHashCodeName
     buf += CharArrayName
     buf += BoxesRunTime
     buf += RuntimeBoxes
@@ -1926,4 +1955,5 @@ object Lower {
     }
     buf.toSeq
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -2,19 +2,18 @@ package scala.scalanative
 package codegen
 
 import scala.collection.mutable
-import scalanative.nir._
 import scalanative.linker.{Trait, Class, ReachabilityAnalysis}
 
 class Metadata(
     val analysis: ReachabilityAnalysis.Result,
     val config: build.NativeConfig,
-    proxies: Seq[Defn]
+    proxies: Seq[nir.Defn]
 )(implicit val platform: PlatformInfo) {
   implicit private def self: Metadata = this
 
   final val usesLockWords = platform.isMultithreadingEnabled
-  val lockWordType = if (usesLockWords) Some(Type.Ptr) else None
-  private[codegen] val lockWordVals = lockWordType.map(_ => Val.Null).toList
+  val lockWordType = if (usesLockWords) Some(nir.Type.Ptr) else None
+  private[codegen] val lockWordVals = lockWordType.map(_ => nir.Val.Null).toList
 
   val layouts = new CommonMemoryLayouts()
   val rtti = mutable.Map.empty[linker.Info, RuntimeTypeInformation]
@@ -76,12 +75,12 @@ class Metadata(
         topLevelSubclassOrdering = ordering
       )
 
-    Rt.PrimitiveTypes.foreach(fromRootClass(_))
+    nir.Rt.PrimitiveTypes.foreach(fromRootClass(_))
     fromRootClass(
-      Rt.Object.name,
+      nir.Rt.Object.name,
       ordering = subclasses => {
         val (arrays, other) =
-          subclasses.partition(_.name == Rt.GenericArray.name)
+          subclasses.partition(_.name == nir.Rt.GenericArray.name)
         arrays ++ other
       }
     )

--- a/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
@@ -2,10 +2,10 @@ package scala.scalanative
 package codegen
 
 import scala.collection.mutable
-import scalanative.nir._
 import scalanative.linker.Class
 
 class ModuleArray(meta: Metadata) {
+
   val index = mutable.Map.empty[Class, Int]
   val modules = mutable.UnrolledBuffer.empty[Class]
   meta.classes.foreach { cls =>
@@ -15,14 +15,15 @@ class ModuleArray(meta: Metadata) {
     }
   }
   val size: Int = modules.size
-  val value: Val =
-    Val.ArrayValue(
-      Type.Ptr,
+  val value: nir.Val =
+    nir.Val.ArrayValue(
+      nir.Type.Ptr,
       modules.toSeq.map { cls =>
         if (cls.isConstantModule(meta.analysis))
-          Val.Global(cls.name.member(Sig.Generated("instance")), Type.Ptr)
+          nir.Val.Global(cls.name.member(nir.Sig.Generated("instance")), nir.Type.Ptr)
         else
-          Val.Null
+          nir.Val.Null
       }
     )
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
@@ -20,7 +20,10 @@ class ModuleArray(meta: Metadata) {
       nir.Type.Ptr,
       modules.toSeq.map { cls =>
         if (cls.isConstantModule(meta.analysis))
-          nir.Val.Global(cls.name.member(nir.Sig.Generated("instance")), nir.Type.Ptr)
+          nir.Val.Global(
+            cls.name.member(nir.Sig.Generated("instance")),
+            nir.Type.Ptr
+          )
         else
           nir.Val.Null
       }

--- a/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
@@ -168,7 +168,10 @@ class PerfectHashMap[K, V](
 
 object DynmethodPerfectHashMap {
 
-  def apply(dynmethods: Seq[nir.Global.Member], allSignatures: Seq[nir.Sig]): nir.Val = {
+  def apply(
+      dynmethods: Seq[nir.Global.Member],
+      allSignatures: Seq[nir.Sig]
+  ): nir.Val = {
 
     val signaturesWithIndex =
       allSignatures.zipWithIndex.foldLeft(Map[nir.Sig, Int]()) {
@@ -198,7 +201,10 @@ object DynmethodPerfectHashMap {
           List(
             nir.Val.Int(perfectHashMap.size),
             nir.Val.Const(
-              nir.Val.ArrayValue(nir.Type.Int, perfectHashMap.keys.map(nir.Val.Int(_)))
+              nir.Val.ArrayValue(
+                nir.Type.Int,
+                perfectHashMap.keys.map(nir.Val.Int(_))
+              )
             ),
             nir.Val.Const(nir.Val.ArrayValue(nir.Type.Int, keys)),
             nir.Val.Const(nir.Val.ArrayValue(nir.Type.Ptr, values))

--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.codegen
+package scala.scalanative
+package codegen
 
 import java.io.File
 import java.io.IOException
@@ -18,7 +19,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.scalanative.build.Config
 import scala.scalanative.io.VirtualDirectory
-import scala.scalanative.nir._
 import scala.scalanative.util.Scope
 
 private[scalanative] object ResourceEmbedder {
@@ -31,7 +31,7 @@ private[scalanative] object ResourceEmbedder {
 
   private final val ScalaNativeExcludePattern: String = "/scala-native/**"
 
-  def apply(config: Config): Seq[Defn.Var] = Scope { implicit scope =>
+  def apply(config: Config): Seq[nir.Defn.Var] = Scope { implicit scope =>
     val classpath = config.classPath
     val fs = FileSystems.getDefault()
     val includePatterns =
@@ -42,7 +42,7 @@ private[scalanative] object ResourceEmbedder {
       (config.compilerConfig.resourceExcludePatterns :+ ScalaNativeExcludePattern)
         .map(p => fs.getPathMatcher(s"glob:$p"))
 
-    implicit val position: Position = Position.NoPosition
+    implicit val position: nir.Position = nir.Position.NoPosition
 
     val notInIncludePatterns =
       s"Not matched by any include path ${includePatterns.mkString}"
@@ -107,43 +107,43 @@ private[scalanative] object ResourceEmbedder {
 
     val pathValues = embeddedFiles.map {
       case ClasspathFile(accessPath, pathName, virtDir) =>
-        val encodedPath = pathName.toString.getBytes().map(Val.Byte(_))
-        Val.ArrayValue(Type.Byte, encodedPath.toSeq)
+        val encodedPath = pathName.toString.getBytes().map(nir.Val.Byte(_))
+        nir.Val.ArrayValue(nir.Type.Byte, encodedPath.toSeq)
     }
 
     val contentValues = embeddedFiles.map {
       case ClasspathFile(accessPath, pathName, virtDir) =>
         val fileBuffer = virtDir.read(accessPath)
-        val encodedContent = fileBuffer.array().map(Val.Byte(_))
-        Val.ArrayValue(Type.Byte, encodedContent.toSeq)
+        val encodedContent = fileBuffer.array().map(nir.Val.Byte(_))
+        nir.Val.ArrayValue(nir.Type.Byte, encodedContent.toSeq)
     }
 
-    def generateArrayVar(name: String, arrayValue: Val.ArrayValue) = {
-      Defn.Var(
-        Attrs.None,
+    def generateArrayVar(name: String, arrayValue: nir.Val.ArrayValue) = {
+      nir.Defn.Var(
+        nir.Attrs.None,
         extern(name),
-        Type.Ptr,
-        Val.Const(
+        nir.Type.Ptr,
+        nir.Val.Const(
           arrayValue
         )
       )
     }
 
-    def generateExtern2DArray(name: String, content: Seq[Val.Const]) = {
+    def generateExtern2DArray(name: String, content: Seq[nir.Val.Const]) = {
       generateArrayVar(
         name,
-        Val.ArrayValue(
-          Type.Ptr,
+        nir.Val.ArrayValue(
+          nir.Type.Ptr,
           content
         )
       )
     }
 
-    def generateExternLongArray(name: String, content: Seq[Val.Int]) = {
+    def generateExternLongArray(name: String, content: Seq[nir.Val.Int]) = {
       generateArrayVar(
         name,
-        Val.ArrayValue(
-          Type.Int,
+        nir.Val.ArrayValue(
+          nir.Type.Int,
           content
         )
       )
@@ -153,27 +153,27 @@ private[scalanative] object ResourceEmbedder {
       Seq(
         generateExtern2DArray(
           "__scala_native_resources_all_path",
-          pathValues.toIndexedSeq.map(Val.Const(_))
+          pathValues.toIndexedSeq.map(nir.Val.Const(_))
         ),
         generateExtern2DArray(
           "__scala_native_resources_all_content",
-          contentValues.toIndexedSeq.map(Val.Const(_))
+          contentValues.toIndexedSeq.map(nir.Val.Const(_))
         ),
         generateExternLongArray(
           "__scala_native_resources_all_path_lengths",
-          pathValues.toIndexedSeq.map(path => Val.Int(path.values.length))
+          pathValues.toIndexedSeq.map(path => nir.Val.Int(path.values.length))
         ),
         generateExternLongArray(
           "__scala_native_resources_all_content_lengths",
           contentValues.toIndexedSeq.map(content =>
-            Val.Int(content.values.length)
+            nir.Val.Int(content.values.length)
           )
         ),
-        Defn.Var(
-          Attrs.None,
+        nir.Defn.Var(
+          nir.Attrs.None,
           extern("__scala_native_resources_amount"),
-          Type.Ptr,
-          Val.Int(contentValues.length)
+          nir.Type.Ptr,
+          nir.Val.Int(contentValues.length)
         )
       )
 
@@ -184,8 +184,8 @@ private[scalanative] object ResourceEmbedder {
     generated
   }
 
-  private def extern(id: String): Global.Member =
-    Global.Member(Global.Top("__"), Sig.Extern(id))
+  private def extern(id: String): nir.Global.Member =
+    nir.Global.Member(nir.Global.Top("__"), nir.Sig.Extern(id))
 
   private val sourceExtensions =
     Seq(

--- a/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
@@ -54,6 +54,9 @@ class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
 object RuntimeTypeInformation {
 
   private val classConst =
-    nir.Val.Global(nir.Rt.Class.name.member(nir.Sig.Generated("type")), nir.Type.Ptr)
+    nir.Val.Global(
+      nir.Rt.Class.name.member(nir.Sig.Generated("type")),
+      nir.Type.Ptr
+    )
 
-  }
+}

--- a/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
@@ -2,31 +2,32 @@ package scala.scalanative
 package codegen
 
 import scalanative.util.unreachable
-import scalanative.nir._
 import scalanative.linker.{ScopeInfo, Class, Trait}
 
 class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
+
   import RuntimeTypeInformation._
-  val name: Global.Member = info.name.member(Sig.Generated("type"))
-  val const: Val.Global = Val.Global(name, Type.Ptr)
-  val struct: Type.StructValue = info match {
+
+  val name: nir.Global.Member = info.name.member(nir.Sig.Generated("type"))
+  val const: nir.Val.Global = nir.Val.Global(name, nir.Type.Ptr)
+  val struct: nir.Type.StructValue = info match {
     case cls: Class =>
       meta.layouts.ClassRtti.genLayout(
         vtable = meta.vtable(cls).ty
       )
     case _ => meta.layouts.Rtti.layout
   }
-  val value: Val.StructValue = {
-    val typeId = Val.Int(info match {
+  val value: nir.Val.StructValue = {
+    val typeId = nir.Val.Int(info match {
       case _: Class => meta.ids(info)
       case _: Trait => -(meta.ids(info) + 1)
     })
-    val typeStr = Val.String(info.name.asInstanceOf[Global.Top].id)
-    val traitId = Val.Int(info match {
+    val typeStr = nir.Val.String(info.name.asInstanceOf[nir.Global.Top].id)
+    val traitId = nir.Val.Int(info match {
       case info: Class => meta.dispatchTable.traitClassIds.getOrElse(info, -1)
       case _           => -1
     })
-    val base = Val.StructValue(
+    val base = nir.Val.StructValue(
       classConst :: meta.lockWordVals ::: typeId :: traitId :: typeStr :: Nil
     )
     info match {
@@ -35,10 +36,10 @@ class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
           if (!meta.layouts.ClassRtti.usesDynMap) Nil
           else List(meta.dynmap(cls).value)
         val range = meta.ranges(cls)
-        Val.StructValue(
+        nir.Val.StructValue(
           base ::
-            Val.Int(meta.layout(cls).size.toInt) ::
-            Val.Int(range.last) ::
+            nir.Val.Int(meta.layout(cls).size.toInt) ::
+            nir.Val.Int(range.last) ::
             meta.layout(cls).referenceOffsetsValue ::
             dynmap :::
             meta.vtable(cls).value ::
@@ -49,7 +50,10 @@ class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
     }
   }
 }
+
 object RuntimeTypeInformation {
+
   private val classConst =
-    Val.Global(Rt.Class.name.member(Sig.Generated("type")), Type.Ptr)
-}
+    nir.Val.Global(nir.Rt.Class.name.member(nir.Sig.Generated("type")), nir.Type.Ptr)
+
+  }

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -7,7 +7,9 @@ import scalanative.linker.{Method, Trait, Class}
 class TraitDispatchTable(meta: Metadata) {
 
   val dispatchName =
-    nir.Global.Top("__scalanative_metadata").member(nir.Sig.Generated("dispatch_table"))
+    nir.Global
+      .Top("__scalanative_metadata")
+      .member(nir.Sig.Generated("dispatch_table"))
   val dispatchVal = nir.Val.Global(dispatchName, nir.Type.Ptr)
   var dispatchTy: nir.Type = _
   var dispatchDefn: nir.Defn = _
@@ -95,7 +97,9 @@ class TraitDispatchTable(meta: Metadata) {
     dispatchOffset = offsets
     dispatchTy = nir.Type.Ptr
     dispatchDefn =
-      nir.Defn.Const(nir.Attrs.None, dispatchName, value.ty, value)(nir.Position.NoPosition)
+      nir.Defn.Const(nir.Attrs.None, dispatchName, value.ty, value)(
+        nir.Position.NoPosition
+      )
   }
 
   // Generate a compressed representation of the dispatch table

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -2,22 +2,22 @@ package scala.scalanative
 package codegen
 
 import scala.collection.mutable
-import scalanative.nir._
 import scalanative.linker.{Method, Trait, Class}
 
 class TraitDispatchTable(meta: Metadata) {
+
   val dispatchName =
-    Global.Top("__scalanative_metadata").member(Sig.Generated("dispatch_table"))
-  val dispatchVal = Val.Global(dispatchName, Type.Ptr)
-  var dispatchTy: Type = _
-  var dispatchDefn: Defn = _
+    nir.Global.Top("__scalanative_metadata").member(nir.Sig.Generated("dispatch_table"))
+  val dispatchVal = nir.Val.Global(dispatchName, nir.Type.Ptr)
+  var dispatchTy: nir.Type = _
+  var dispatchDefn: nir.Defn = _
   var dispatchOffset: mutable.Map[Int, Int] = _
 
   val traitSigIds = {
     // Collect signatures of trait methods, excluding
     // the ones defined on java.lang.Object, those always
     // go through vtable dispatch.
-    val sigs = mutable.Set.empty[Sig]
+    val sigs = mutable.Set.empty[nir.Sig]
     meta.traits.foreach { trt =>
       trt.calls.foreach { sig =>
         if (trt.targets(sig).size > 1) {
@@ -26,7 +26,7 @@ class TraitDispatchTable(meta: Metadata) {
       }
     }
 
-    val Object = meta.analysis.infos(Rt.Object.name).asInstanceOf[Class]
+    val Object = meta.analysis.infos(nir.Rt.Object.name).asInstanceOf[Class]
     sigs --= Object.calls
 
     sigs.toArray.sortBy(_.toString).zipWithIndex.toMap
@@ -62,12 +62,12 @@ class TraitDispatchTable(meta: Metadata) {
     val classes = traitClassIds
     val classesLength = traitClassIds.size
     val table =
-      Array.fill[Val](classesLength * sigsLength)(Val.Null)
+      Array.fill[nir.Val](classesLength * sigsLength)(nir.Val.Null)
     val mins = Array.fill[Int](sigsLength)(Int.MaxValue)
     val maxs = Array.fill[Int](sigsLength)(Int.MinValue)
     val sizes = Array.fill[Int](sigsLength)(0)
 
-    def put(cls: Int, meth: Int, value: Val) = {
+    def put(cls: Int, meth: Int, value: nir.Val) = {
       table(meth * classesLength + cls) = value
       mins(meth) = mins(meth) min cls
       maxs(meth) = maxs(meth) max cls
@@ -90,22 +90,22 @@ class TraitDispatchTable(meta: Metadata) {
 
     val (compressed, offsets) = compressTable(table, mins, sizes)
 
-    val value = Val.ArrayValue(Type.Ptr, compressed.toSeq)
+    val value = nir.Val.ArrayValue(nir.Type.Ptr, compressed.toSeq)
 
     dispatchOffset = offsets
-    dispatchTy = Type.Ptr
+    dispatchTy = nir.Type.Ptr
     dispatchDefn =
-      Defn.Const(Attrs.None, dispatchName, value.ty, value)(Position.NoPosition)
+      nir.Defn.Const(nir.Attrs.None, dispatchName, value.ty, value)(nir.Position.NoPosition)
   }
 
   // Generate a compressed representation of the dispatch table
   // that displaces method rows one of top of the other to miniminize
   // number of nulls in the table.
   def compressTable(
-      table: Array[Val],
+      table: Array[nir.Val],
       mins: Array[Int],
       sizes: Array[Int]
-  ): (Array[Val], mutable.Map[Int, Int]) = {
+  ): (Array[nir.Val], mutable.Map[Int, Int]) = {
     val classesLength = traitClassIds.size
     val sigsLength = traitSigIds.size
     val maxSize = sizes.max
@@ -113,7 +113,7 @@ class TraitDispatchTable(meta: Metadata) {
 
     val free = Array.fill[List[Int]](maxSize + 1)(Nil)
     val offsets = mutable.Map.empty[Int, Int]
-    val compressed = new Array[Val](totalSize)
+    val compressed = new Array[nir.Val](totalSize)
     var current = 0
 
     def updateFree(from: Int, total: Int): Unit = {
@@ -121,7 +121,7 @@ class TraitDispatchTable(meta: Metadata) {
       var size = 0
       var i = 0
       while (i < total) {
-        val isNull = compressed(from + i) eq Val.Null
+        val isNull = compressed(from + i) eq nir.Val.Null
         val inFree = start != -1
         if (inFree) {
           if (isNull) {
@@ -186,9 +186,10 @@ class TraitDispatchTable(meta: Metadata) {
         offsets(sig) = allocate(sig) - mins(sig)
     }
 
-    val result = new Array[Val](current)
+    val result = new Array[nir.Val](current)
     System.arraycopy(compressed, 0, result, 0, current)
 
     (result, offsets)
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
@@ -19,7 +19,10 @@ class VirtualTable(cls: linker.Class)(implicit meta: Metadata) {
     }
     def addImpl(sig: nir.Sig): Unit = {
       val impl =
-        cls.resolve(sig).map(nir.Val.Global(_, nir.Type.Ptr)).getOrElse(nir.Val.Null)
+        cls
+          .resolve(sig)
+          .map(nir.Val.Global(_, nir.Type.Ptr))
+          .getOrElse(nir.Val.Null)
       impls(sig) = impl
     }
     slots.foreach { sig => addImpl(sig) }

--- a/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
@@ -2,25 +2,24 @@ package scala.scalanative
 package codegen
 
 import scala.collection.mutable
-import scalanative.nir._
-import scalanative.nir.Rt._
 
 class VirtualTable(cls: linker.Class)(implicit meta: Metadata) {
-  private val slots: mutable.UnrolledBuffer[Sig] =
+
+  private val slots: mutable.UnrolledBuffer[nir.Sig] =
     cls.parent.fold {
-      mutable.UnrolledBuffer.empty[Sig]
+      mutable.UnrolledBuffer.empty[nir.Sig]
     } { parent => meta.vtable(parent).slots.clone }
-  private val impls: mutable.Map[Sig, Val] =
-    mutable.Map.empty[Sig, Val]
+  private val impls: mutable.Map[nir.Sig, nir.Val] =
+    mutable.Map.empty[nir.Sig, nir.Val]
   locally {
-    def addSlot(sig: Sig): Unit = {
+    def addSlot(sig: nir.Sig): Unit = {
       assert(!slots.contains(sig))
       val index = slots.size
       slots += sig
     }
-    def addImpl(sig: Sig): Unit = {
+    def addImpl(sig: nir.Sig): Unit = {
       val impl =
-        cls.resolve(sig).map(Val.Global(_, Type.Ptr)).getOrElse(Val.Null)
+        cls.resolve(sig).map(nir.Val.Global(_, nir.Type.Ptr)).getOrElse(nir.Val.Null)
       impls(sig) = impl
     }
     slots.foreach { sig => addImpl(sig) }
@@ -33,12 +32,13 @@ class VirtualTable(cls: linker.Class)(implicit meta: Metadata) {
       }
     }
   }
-  val value: Val =
-    Val.ArrayValue(Type.Ptr, slots.map(impls).toSeq)
+  val value: nir.Val =
+    nir.Val.ArrayValue(nir.Type.Ptr, slots.map(impls).toSeq)
   val ty =
     value.ty
-  def index(sig: Sig): Int =
+  def index(sig: nir.Sig): Int =
     slots.indexOf(sig)
-  def at(index: Int): Val =
+  def at(index: Int): nir.Val =
     impls(slots(index))
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -126,10 +126,16 @@ private[codegen] abstract class AbstractCodeGen(
       }
     }
 
-    defns.foreach { defn => if (defn.isInstanceOf[nir.Defn.Const]) onDefn(defn) }
+    defns.foreach { defn =>
+      if (defn.isInstanceOf[nir.Defn.Const]) onDefn(defn)
+    }
     defns.foreach { defn => if (defn.isInstanceOf[nir.Defn.Var]) onDefn(defn) }
-    defns.foreach { defn => if (defn.isInstanceOf[nir.Defn.Declare]) onDefn(defn) }
-    defns.foreach { defn => if (defn.isInstanceOf[nir.Defn.Define]) onDefn(defn) }
+    defns.foreach { defn =>
+      if (defn.isInstanceOf[nir.Defn.Declare]) onDefn(defn)
+    }
+    defns.foreach { defn =>
+      if (defn.isInstanceOf[nir.Defn.Define]) onDefn(defn)
+    }
 
   }
 
@@ -142,11 +148,11 @@ private[codegen] abstract class AbstractCodeGen(
     case _ =>
       touch(n)
       env(n) match {
-        case nir.Defn.Var(_, _, ty, _) => ty
-        case nir.Defn.Const(_, _, ty, _) => ty
-        case nir.Defn.Declare(_, _, sig) => sig
+        case nir.Defn.Var(_, _, ty, _)        => ty
+        case nir.Defn.Const(_, _, ty, _)      => ty
+        case nir.Defn.Declare(_, _, sig)      => sig
         case nir.Defn.Define(_, _, sig, _, _) => sig
-        case _ => unreachable
+        case _                                => unreachable
       }
   }
 
@@ -277,7 +283,7 @@ private[codegen] abstract class AbstractCodeGen(
         str(" {")
         insts.foreach {
           case nir.Inst.Let(n, nir.Op.Copy(v), _) => copies(n) = v
-          case _ => ()
+          case _                                  => ()
         }
 
         locally {
@@ -407,7 +413,8 @@ private[codegen] abstract class AbstractCodeGen(
               str(edge.from.splitCount)
             }
             def genUnwindEdge(unwind: nir.Next.Unwind): Unit = {
-              val nir.Next.Unwind(nir.Val.Local(exc, _), nir.Next.Label(_, vals)) =
+              val nir.Next
+                .Unwind(nir.Val.Local(exc, _), nir.Next.Label(_, vals)) =
                 unwind: @unchecked
               genJustVal(vals(n))
               str(", %")
@@ -470,7 +477,8 @@ private[codegen] abstract class AbstractCodeGen(
     ty match {
       case nir.Type.Vararg => str("...")
       case nir.Type.Unit   => str("void")
-      case _: nir.Type.RefKind | nir.Type.Ptr | nir.Type.Null | nir.Type.Nothing =>
+      case _: nir.Type.RefKind | nir.Type.Ptr | nir.Type.Null |
+          nir.Type.Nothing =>
         str(pointerType)
       case nir.Type.Bool          => str("i1")
       case i: nir.Type.FixedSizeI => str("i"); str(i.width)
@@ -506,7 +514,8 @@ private[codegen] abstract class AbstractCodeGen(
       v, {
         val idx = constMap.size
         val name =
-          nir.Global.Member(nir.Global.Top("__const"), nir.Sig.Generated(idx.toString))
+          nir.Global
+            .Member(nir.Global.Top("__const"), nir.Sig.Generated(idx.toString))
         constTy(name) = v.ty
         name
       }
@@ -524,7 +533,9 @@ private[codegen] abstract class AbstractCodeGen(
       v
   }
 
-  private[codegen] def genJustVal(v: nir.Val)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genJustVal(
+      v: nir.Val
+  )(implicit sb: ShowBuilder): Unit = {
     import sb._
 
     deconstify(v) match {
@@ -609,7 +620,9 @@ private[codegen] abstract class AbstractCodeGen(
     str(jl.Long.toHexString(jl.Double.doubleToRawLongBits(value)))
   }
 
-  private[codegen] def genVal(value: nir.Val)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genVal(
+      value: nir.Val
+  )(implicit sb: ShowBuilder): Unit = {
     import sb._
     if (value != nir.Val.Unit) {
       genType(value.ty)
@@ -628,7 +641,9 @@ private[codegen] abstract class AbstractCodeGen(
       "_S" + g.mangle
   }
 
-  private[codegen] def genGlobal(g: nir.Global)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genGlobal(
+      g: nir.Global
+  )(implicit sb: ShowBuilder): Unit = {
     import sb._
     str("\"")
     str(mangled(g))
@@ -769,7 +784,8 @@ private[codegen] abstract class AbstractCodeGen(
          * In this case LLVM linking would otherwise result in call arguments type mismatch.
          */
         val callDef = call.ptr match {
-          case nir.Val.Global(m @ nir.Global.Member(_, sig), valty) if sig.isExtern =>
+          case nir.Val.Global(m @ nir.Global.Member(_, sig), valty)
+              if sig.isExtern =>
             val glob = externSigMembers.getOrElseUpdate(sig, m)
             if (glob == m) call
             else call.copy(ptr = nir.Val.Global(glob, valty))
@@ -1113,7 +1129,7 @@ private[codegen] abstract class AbstractCodeGen(
           case nir.Bin.Iadd => "add"
           case nir.Bin.Isub => "sub"
           case nir.Bin.Imul => "mul"
-          case _        => opcode.toString.toLowerCase
+          case _            => opcode.toString.toLowerCase
         }
         str(bin)
         str(" ")
@@ -1174,7 +1190,9 @@ private[codegen] abstract class AbstractCodeGen(
     })
   }
 
-  private[codegen] def genNext(next: nir.Next)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genNext(
+      next: nir.Next
+  )(implicit sb: ShowBuilder): Unit = {
     import sb._
     next match {
       case nir.Next.Case(v, next) =>
@@ -1193,20 +1211,24 @@ private[codegen] abstract class AbstractCodeGen(
     }
   }
 
-  private[codegen] def genConv(conv: nir.Conv, fromType: nir.Type, toType: nir.Type)(
-      implicit sb: ShowBuilder
+  private[codegen] def genConv(
+      conv: nir.Conv,
+      fromType: nir.Type,
+      toType: nir.Type
+  )(implicit
+      sb: ShowBuilder
   ): Unit = conv match {
     case nir.Conv.ZSizeCast | nir.Conv.SSizeCast =>
       val fromSize = fromType match {
-        case nir.Type.Size => platform.sizeOfPtrBits
+        case nir.Type.Size             => platform.sizeOfPtrBits
         case nir.Type.FixedSizeI(s, _) => s
-        case o => unsupported(o)
+        case o                         => unsupported(o)
       }
 
       val toSize = toType match {
-        case nir.Type.Size => platform.sizeOfPtrBits
+        case nir.Type.Size             => platform.sizeOfPtrBits
         case nir.Type.FixedSizeI(s, _) => s
-        case o => unsupported(o)
+        case o                         => unsupported(o)
       }
 
       val castOp =

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -8,7 +8,6 @@ import scala.scalanative.build.Discover
 import scala.scalanative.codegen.llvm.compat.os.OsCompat
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir.ControlFlow.{Block, Graph => CFG}
-import scala.scalanative.nir._
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder.FileShowBuilder
 import scala.scalanative.util.{ShowBuilder, unreachable, unsupported}
@@ -25,8 +24,8 @@ import scala.scalanative.nir.Defn.Define
 import scala.scalanative.nir.Defn.Trait
 
 private[codegen] abstract class AbstractCodeGen(
-    env: Map[Global, Defn],
-    defns: Seq[Defn]
+    env: Map[nir.Global, nir.Defn],
+    defns: Seq[nir.Defn]
 )(implicit val meta: CodeGenMetadata)
     extends MetadataCodeGen {
   import meta.platform
@@ -36,13 +35,13 @@ private[codegen] abstract class AbstractCodeGen(
   val os: OsCompat
   val pointerType = if (useOpaquePointers) "ptr" else "i8*"
 
-  private var currentBlockName: Local = _
+  private var currentBlockName: nir.Local = _
   private var currentBlockSplit: Int = _
 
-  private val copies = mutable.Map.empty[Local, nir.Val]
-  private val deps = mutable.Set.empty[Global.Member]
+  private val copies = mutable.Map.empty[nir.Local, nir.Val]
+  private val deps = mutable.Set.empty[nir.Global.Member]
   private val generated = mutable.Set.empty[String]
-  private val externSigMembers = mutable.Map.empty[Sig, Global.Member]
+  private val externSigMembers = mutable.Map.empty[nir.Sig, nir.Global.Member]
 
   def gen(id: String, dir: VirtualDirectory): Path = {
     val body = Paths.get(s"$id-body.ll")
@@ -95,14 +94,14 @@ private[codegen] abstract class AbstractCodeGen(
         val defn = env(n)
         implicit val rootPos = defn.pos
         defn match {
-          case defn @ Defn.Var(attrs, _, _, _) =>
+          case defn @ nir.Defn.Var(attrs, _, _, _) =>
             defn.copy(attrs.copy(isExtern = true))
-          case defn @ Defn.Const(attrs, _, ty, _) =>
+          case defn @ nir.Defn.Const(attrs, _, ty, _) =>
             defn.copy(attrs.copy(isExtern = true))
-          case defn @ Defn.Declare(attrs, _, _) =>
+          case defn @ nir.Defn.Declare(attrs, _, _) =>
             defn.copy(attrs.copy(isExtern = true))
-          case defn @ Defn.Define(attrs, name, ty, _, _) =>
-            Defn.Declare(attrs, name, ty)
+          case defn @ nir.Defn.Define(attrs, name, ty, _, _) =>
+            nir.Defn.Declare(attrs, name, ty)
           case _ =>
             unreachable
         }
@@ -112,13 +111,13 @@ private[codegen] abstract class AbstractCodeGen(
   }
 
   private def genDefns(
-      defns: Seq[Defn]
+      defns: Seq[nir.Defn]
   )(implicit
       sb: ShowBuilder,
       metaCtx: MetadataCodeGen.Context
   ): Unit = {
     import sb._
-    def onDefn(defn: Defn): Unit = {
+    def onDefn(defn: nir.Defn): Unit = {
       val mn = mangled(defn.name)
       if (!generated.contains(mn)) {
         newline()
@@ -127,27 +126,27 @@ private[codegen] abstract class AbstractCodeGen(
       }
     }
 
-    defns.foreach { defn => if (defn.isInstanceOf[Defn.Const]) onDefn(defn) }
-    defns.foreach { defn => if (defn.isInstanceOf[Defn.Var]) onDefn(defn) }
-    defns.foreach { defn => if (defn.isInstanceOf[Defn.Declare]) onDefn(defn) }
-    defns.foreach { defn => if (defn.isInstanceOf[Defn.Define]) onDefn(defn) }
+    defns.foreach { defn => if (defn.isInstanceOf[nir.Defn.Const]) onDefn(defn) }
+    defns.foreach { defn => if (defn.isInstanceOf[nir.Defn.Var]) onDefn(defn) }
+    defns.foreach { defn => if (defn.isInstanceOf[nir.Defn.Declare]) onDefn(defn) }
+    defns.foreach { defn => if (defn.isInstanceOf[nir.Defn.Define]) onDefn(defn) }
 
   }
 
-  protected final def touch(n: Global.Member): Unit =
+  protected final def touch(n: nir.Global.Member): Unit =
     deps += n
 
-  protected final def lookup(n: Global.Member): Type = n match {
-    case Global.Member(Global.Top("__const"), _) =>
+  protected final def lookup(n: nir.Global.Member): nir.Type = n match {
+    case nir.Global.Member(nir.Global.Top("__const"), _) =>
       constTy(n)
     case _ =>
       touch(n)
       env(n) match {
-        case Defn.Var(_, _, ty, _)        => ty
-        case Defn.Const(_, _, ty, _)      => ty
-        case Defn.Declare(_, _, sig)      => sig
-        case Defn.Define(_, _, sig, _, _) => sig
-        case _                            => unreachable
+        case nir.Defn.Var(_, _, ty, _) => ty
+        case nir.Defn.Const(_, _, ty, _) => ty
+        case nir.Defn.Declare(_, _, sig) => sig
+        case nir.Defn.Define(_, _, sig, _, _) => sig
+        case _ => unreachable
       }
   }
 
@@ -179,24 +178,24 @@ private[codegen] abstract class AbstractCodeGen(
     }
   }
 
-  private def genDefn(defn: Defn)(implicit
+  private def genDefn(defn: nir.Defn)(implicit
       sb: ShowBuilder,
       metaCtx: MetadataCodeGen.Context
   ): Unit = defn match {
-    case Defn.Var(attrs, name, ty, rhs) =>
+    case nir.Defn.Var(attrs, name, ty, rhs) =>
       genGlobalDefn(attrs, name, isConst = false, ty, rhs)
-    case Defn.Const(attrs, name, ty, rhs) =>
+    case nir.Defn.Const(attrs, name, ty, rhs) =>
       genGlobalDefn(attrs, name, isConst = true, ty, rhs)
-    case Defn.Declare(attrs, name, sig) =>
-      genFunctionDefn(defn, Seq.empty, Fresh(), DebugInfo.empty)
-    case Defn.Define(attrs, name, sig, insts, debugInfo) =>
-      genFunctionDefn(defn, insts, Fresh(insts), debugInfo)
+    case nir.Defn.Declare(attrs, name, sig) =>
+      genFunctionDefn(defn, Seq.empty, nir.Fresh(), DebugInfo.empty)
+    case nir.Defn.Define(attrs, name, sig, insts, debugInfo) =>
+      genFunctionDefn(defn, insts, nir.Fresh(insts), debugInfo)
     case defn =>
       unsupported(defn)
   }
 
   private[codegen] def genGlobalDefn(
-      attrs: Attrs,
+      attrs: nir.Attrs,
       name: nir.Global,
       isConst: Boolean,
       ty: nir.Type,
@@ -218,8 +217,8 @@ private[codegen] abstract class AbstractCodeGen(
 
   private[codegen] def genFunctionDefn(
       defn: nir.Defn,
-      insts: Seq[Inst],
-      fresh: Fresh,
+      insts: Seq[nir.Inst],
+      fresh: nir.Fresh,
       debugInfo: DebugInfo
   )(implicit
       sb: ShowBuilder,
@@ -228,7 +227,7 @@ private[codegen] abstract class AbstractCodeGen(
     import sb._
     import defn.{name, attrs, pos}
 
-    val Type.Function(argtys, retty) = defn match {
+    val nir.Type.Function(argtys, retty) = defn match {
       case defn: Declare => defn.ty
       case defn: Define  => defn.ty
       case _             => unreachable
@@ -240,7 +239,7 @@ private[codegen] abstract class AbstractCodeGen(
     str(if (isDecl) "declare " else "define ")
     if (targetsWindows && !isDecl && attrs.isExtern) {
       // Generate export modifier only for extern (C-ABI compliant) signatures
-      val Global.Member(_, sig) = name: @unchecked
+      val nir.Global.Member(_, sig) = name: @unchecked
       if (sig.isExtern) str("dllexport ")
     }
     genFunctionReturnType(retty)
@@ -251,17 +250,17 @@ private[codegen] abstract class AbstractCodeGen(
       rep(argtys, sep = ", ")(genType)
     } else {
       insts.head match {
-        case Inst.Label(_, params) =>
+        case nir.Inst.Label(_, params) =>
           rep(params, sep = ", ")(genVal)
         case _ =>
           unreachable
       }
     }
     str(")")
-    if (attrs.opt eq Attr.NoOpt) {
+    if (attrs.opt eq nir.Attr.NoOpt) {
       str(" optnone noinline")
     } else {
-      if (attrs.inlineHint ne Attr.MayInline) {
+      if (attrs.inlineHint ne nir.Attr.MayInline) {
         str(" ")
         genAttr(attrs.inlineHint)
       }
@@ -277,13 +276,13 @@ private[codegen] abstract class AbstractCodeGen(
         dbg(defnScopes.getDISubprogramScope)
         str(" {")
         insts.foreach {
-          case Inst.Let(n, Op.Copy(v), _) => copies(n) = v
-          case _                          => ()
+          case nir.Inst.Let(n, nir.Op.Copy(v), _) => copies(n) = v
+          case _ => ()
         }
 
         locally {
           implicit val cfg: CFG = CFG(insts)
-          implicit val _fresh: Fresh = fresh
+          implicit val _fresh: nir.Fresh = fresh
           implicit val _debugInfo: DebugInfo = debugInfo
           cfg.all.foreach(genBlock)
           cfg.all.foreach(genBlockLandingPads)
@@ -298,9 +297,9 @@ private[codegen] abstract class AbstractCodeGen(
   }
 
   private[codegen] def genFunctionReturnType(
-      retty: Type
+      retty: nir.Type
   )(implicit sb: ShowBuilder): Unit = retty match {
-    case refty: Type.RefKind if refty != Type.Unit =>
+    case refty: nir.Type.RefKind if refty != nir.Type.Unit =>
       genReferenceTypeAttribute(refty)
       genType(retty)
     case _ =>
@@ -308,7 +307,7 @@ private[codegen] abstract class AbstractCodeGen(
   }
 
   private[codegen] def genReferenceTypeAttribute(
-      refty: Type.RefKind
+      refty: nir.Type.RefKind
   )(implicit sb: ShowBuilder): Unit = {
     import sb._
     val (nonnull, deref, size) = toDereferenceable(refty)
@@ -323,7 +322,7 @@ private[codegen] abstract class AbstractCodeGen(
   }
 
   private[codegen] def toDereferenceable(
-      refty: Type.RefKind
+      refty: nir.Type.RefKind
   ): (Boolean, String, Long) = {
     val size = meta.analysis.infos(refty.className) match {
       case info: linker.Trait =>
@@ -343,7 +342,7 @@ private[codegen] abstract class AbstractCodeGen(
 
   private[codegen] def genBlock(block: Block)(implicit
       cfg: CFG,
-      fresh: Fresh,
+      fresh: nir.Fresh,
       sb: ShowBuilder,
       debugInfo: DebugInfo,
       defnScopes: DefnScopes,
@@ -380,7 +379,7 @@ private[codegen] abstract class AbstractCodeGen(
       block: Block
   )(implicit
       cfg: CFG,
-      fresh: Fresh,
+      fresh: nir.Fresh,
       sb: ShowBuilder,
       debugInfo: DebugInfo,
       metadataCtx: MetadataCodeGen.Context,
@@ -390,8 +389,8 @@ private[codegen] abstract class AbstractCodeGen(
     val params = block.params.zipWithIndex
     if (!block.isEntry) {
       params.foreach {
-        case (Val.Local(_, Type.Unit), n) => () // skip
-        case (Val.Local(id, ty), n) =>
+        case (nir.Val.Local(_, nir.Type.Unit), n) => () // skip
+        case (nir.Val.Local(id, ty), n) =>
           newline()
           str("%")
           genLocal(id)
@@ -399,16 +398,16 @@ private[codegen] abstract class AbstractCodeGen(
           genType(ty)
           str(" ")
           rep(block.inEdges.toSeq, sep = ", ") { edge =>
-            def genRegularEdge(next: Next.Label): Unit = {
-              val Next.Label(_, vals) = next
+            def genRegularEdge(next: nir.Next.Label): Unit = {
+              val nir.Next.Label(_, vals) = next
               genJustVal(vals(n))
               str(", %")
               genLocal(edge.from.id)
               str(".")
               str(edge.from.splitCount)
             }
-            def genUnwindEdge(unwind: Next.Unwind): Unit = {
-              val Next.Unwind(Val.Local(exc, _), Next.Label(_, vals)) =
+            def genUnwindEdge(unwind: nir.Next.Unwind): Unit = {
+              val nir.Next.Unwind(nir.Val.Local(exc, _), nir.Next.Label(_, vals)) =
                 unwind: @unchecked
               genJustVal(vals(n))
               str(", %")
@@ -418,11 +417,11 @@ private[codegen] abstract class AbstractCodeGen(
 
             str("[")
             edge.next match {
-              case n: Next.Label =>
+              case n: nir.Next.Label =>
                 genRegularEdge(n)
-              case Next.Case(_, n: Next.Label) =>
+              case nir.Next.Case(_, n: nir.Next.Label) =>
                 genRegularEdge(n)
-              case n: Next.Unwind =>
+              case n: nir.Next.Unwind =>
                 genUnwindEdge(n)
               case _ =>
                 unreachable
@@ -436,10 +435,10 @@ private[codegen] abstract class AbstractCodeGen(
         if (block.isEntry) nir.ScopeId.TopLevel
         else
           block.insts
-            .collectFirst { case let: Inst.Let => let.scopeId }
+            .collectFirst { case let: nir.Inst.Let => let.scopeId }
             .getOrElse(nir.ScopeId.TopLevel)
       params.foreach {
-        case (Val.Local(id, ty), idx) =>
+        case (nir.Val.Local(id, ty), idx) =>
           // arg should be non-zero value
           val argIdx = if (block.isEntry) Some(idx + 1) else None
           dbgLocalValue(id, ty, argIdx)(
@@ -452,45 +451,45 @@ private[codegen] abstract class AbstractCodeGen(
 
   private[codegen] def genBlockLandingPads(block: Block)(implicit
       cfg: CFG,
-      fresh: Fresh,
+      fresh: nir.Fresh,
       sb: ShowBuilder,
       debugInfo: DebugInfo,
       metaCtx: MetadataCodeGen.Context,
       defnScoeps: this.DefnScopes
   ): Unit = {
     block.insts.foreach {
-      case inst @ Inst.Let(_, _, unwind: Next.Unwind) =>
+      case inst @ nir.Inst.Let(_, _, unwind: nir.Next.Unwind) =>
         import inst.pos
         os.genLandingPad(unwind)
       case _ => ()
     }
   }
 
-  private[codegen] def genType(ty: Type)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genType(ty: nir.Type)(implicit sb: ShowBuilder): Unit = {
     import sb._
     ty match {
-      case Type.Vararg => str("...")
-      case Type.Unit   => str("void")
-      case _: Type.RefKind | Type.Ptr | Type.Null | Type.Nothing =>
+      case nir.Type.Vararg => str("...")
+      case nir.Type.Unit   => str("void")
+      case _: nir.Type.RefKind | nir.Type.Ptr | nir.Type.Null | nir.Type.Nothing =>
         str(pointerType)
-      case Type.Bool          => str("i1")
-      case i: Type.FixedSizeI => str("i"); str(i.width)
-      case Type.Size =>
+      case nir.Type.Bool          => str("i1")
+      case i: nir.Type.FixedSizeI => str("i"); str(i.width)
+      case nir.Type.Size =>
         str("i")
         str(platform.sizeOfPtrBits)
-      case Type.Float  => str("float")
-      case Type.Double => str("double")
-      case Type.ArrayValue(ty, n) =>
+      case nir.Type.Float  => str("float")
+      case nir.Type.Double => str("double")
+      case nir.Type.ArrayValue(ty, n) =>
         str("[")
         str(n)
         str(" x ")
         genType(ty)
         str("]")
-      case Type.StructValue(tys) =>
+      case nir.Type.StructValue(tys) =>
         str("{ ")
         rep(tys, sep = ", ")(genType)
         str(" }")
-      case Type.Function(args, ret) =>
+      case nir.Type.Function(args, ret) =>
         genType(ret)
         str(" (")
         rep(args, sep = ", ")(genType)
@@ -500,65 +499,65 @@ private[codegen] abstract class AbstractCodeGen(
     }
   }
 
-  private val constMap = mutable.Map.empty[Val, Global.Member]
-  private val constTy = mutable.Map.empty[Global.Member, Type]
-  private[codegen] def constFor(v: Val): Global.Member =
+  private val constMap = mutable.Map.empty[nir.Val, nir.Global.Member]
+  private val constTy = mutable.Map.empty[nir.Global.Member, nir.Type]
+  private[codegen] def constFor(v: nir.Val): nir.Global.Member =
     constMap.getOrElseUpdate(
       v, {
         val idx = constMap.size
         val name =
-          Global.Member(Global.Top("__const"), Sig.Generated(idx.toString))
+          nir.Global.Member(nir.Global.Top("__const"), nir.Sig.Generated(idx.toString))
         constTy(name) = v.ty
         name
       }
     )
-  private[codegen] def deconstify(v: Val): Val = v match {
-    case Val.Local(local, _) if copies.contains(local) =>
+  private[codegen] def deconstify(v: nir.Val): nir.Val = v match {
+    case nir.Val.Local(local, _) if copies.contains(local) =>
       deconstify(copies(local))
-    case Val.StructValue(vals) =>
-      Val.StructValue(vals.map(deconstify))
-    case Val.ArrayValue(elemty, vals) =>
-      Val.ArrayValue(elemty, vals.map(deconstify))
-    case Val.Const(value) =>
-      Val.Global(constFor(deconstify(value)), Type.Ptr)
+    case nir.Val.StructValue(vals) =>
+      nir.Val.StructValue(vals.map(deconstify))
+    case nir.Val.ArrayValue(elemty, vals) =>
+      nir.Val.ArrayValue(elemty, vals.map(deconstify))
+    case nir.Val.Const(value) =>
+      nir.Val.Global(constFor(deconstify(value)), nir.Type.Ptr)
     case _ =>
       v
   }
 
-  private[codegen] def genJustVal(v: Val)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genJustVal(v: nir.Val)(implicit sb: ShowBuilder): Unit = {
     import sb._
 
     deconstify(v) match {
-      case Val.True     => str("true")
-      case Val.False    => str("false")
-      case Val.Null     => str("null")
-      case Val.Unit     => str("void")
-      case Val.Zero(ty) => str("zeroinitializer")
-      case Val.Byte(v)  => str(v)
-      case Val.Size(v) =>
+      case nir.Val.True     => str("true")
+      case nir.Val.False    => str("false")
+      case nir.Val.Null     => str("null")
+      case nir.Val.Unit     => str("void")
+      case nir.Val.Zero(ty) => str("zeroinitializer")
+      case nir.Val.Byte(v)  => str(v)
+      case nir.Val.Size(v) =>
         if (!platform.is32Bit) str(v)
         else if (v.toInt == v) str(v.toInt)
         else unsupported("Emitting size values that exceed the platform bounds")
-      case Val.Char(v)   => str(v.toInt)
-      case Val.Short(v)  => str(v)
-      case Val.Int(v)    => str(v)
-      case Val.Long(v)   => str(v)
-      case Val.Float(v)  => genFloatHex(v)
-      case Val.Double(v) => genDoubleHex(v)
-      case Val.StructValue(vs) =>
+      case nir.Val.Char(v)   => str(v.toInt)
+      case nir.Val.Short(v)  => str(v)
+      case nir.Val.Int(v)    => str(v)
+      case nir.Val.Long(v)   => str(v)
+      case nir.Val.Float(v)  => genFloatHex(v)
+      case nir.Val.Double(v) => genDoubleHex(v)
+      case nir.Val.StructValue(vs) =>
         str("{ ")
         rep(vs, sep = ", ")(genVal)
         str(" }")
-      case Val.ArrayValue(_, vs) =>
+      case nir.Val.ArrayValue(_, vs) =>
         str("[ ")
         rep(vs, sep = ", ")(genVal)
         str(" ]")
-      case Val.ByteString(v) =>
+      case nir.Val.ByteString(v) =>
         genByteString(v)
-      case Val.Local(n, ty) =>
+      case nir.Val.Local(n, ty) =>
         str("%")
         genLocal(n)
-      case Val.Global(n: Global.Member, ty) =>
+      case nir.Val.Global(n: nir.Global.Member, ty) =>
         if (useOpaquePointers) {
           lookup(n)
           str("@")
@@ -610,26 +609,26 @@ private[codegen] abstract class AbstractCodeGen(
     str(jl.Long.toHexString(jl.Double.doubleToRawLongBits(value)))
   }
 
-  private[codegen] def genVal(value: Val)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genVal(value: nir.Val)(implicit sb: ShowBuilder): Unit = {
     import sb._
-    if (value != Val.Unit) {
+    if (value != nir.Val.Unit) {
       genType(value.ty)
       str(" ")
     }
     genJustVal(value)
   }
 
-  private[codegen] def mangled(g: Global): String = g match {
-    case Global.None =>
+  private[codegen] def mangled(g: nir.Global): String = g match {
+    case nir.Global.None =>
       unsupported(g)
-    case Global.Member(_, sig) if sig.isExtern =>
-      val Sig.Extern(id) = sig.unmangled: @unchecked
+    case nir.Global.Member(_, sig) if sig.isExtern =>
+      val nir.Sig.Extern(id) = sig.unmangled: @unchecked
       id
     case _ =>
       "_S" + g.mangle
   }
 
-  private[codegen] def genGlobal(g: Global)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genGlobal(g: nir.Global)(implicit sb: ShowBuilder): Unit = {
     import sb._
     str("\"")
     str(mangled(g))
@@ -637,18 +636,18 @@ private[codegen] abstract class AbstractCodeGen(
   }
 
   private[codegen] def genLocal(
-      local: Local
+      local: nir.Local
   )(implicit sb: ShowBuilder): Unit = {
     import sb._
     local match {
-      case Local(id) =>
+      case nir.Local(id) =>
         str("_")
         str(id)
     }
   }
 
-  private[codegen] def genInst(inst: Inst)(implicit
-      fresh: Fresh,
+  private[codegen] def genInst(inst: nir.Inst)(implicit
+      fresh: nir.Fresh,
       sb: ShowBuilder,
       debugInfo: DebugInfo,
       defnScopes: DefnScopes,
@@ -656,20 +655,20 @@ private[codegen] abstract class AbstractCodeGen(
   ): Unit = {
     import sb._
     inst match {
-      case inst: Inst.Let =>
+      case inst: nir.Inst.Let =>
         genLet(inst)
 
-      case Inst.Unreachable(unwind) =>
-        assert(unwind eq Next.None)
+      case nir.Inst.Unreachable(unwind) =>
+        assert(unwind eq nir.Next.None)
         newline()
         str("unreachable")
 
-      case Inst.Ret(value) =>
+      case nir.Inst.Ret(value) =>
         newline()
         str("ret ")
         genVal(value)
 
-      case Inst.Jump(next) =>
+      case nir.Inst.Jump(next) =>
         newline()
         str("br ")
         genNext(next)
@@ -677,13 +676,13 @@ private[codegen] abstract class AbstractCodeGen(
       // LLVM Phis can not express two different if branches pointing at the
       // same target basic block. In those cases we replace branching with
       // select instruction.
-      case Inst.If(
+      case nir.Inst.If(
             cond,
-            thenNext @ Next.Label(thenId, thenArgs),
-            elseNext @ Next.Label(elseId, elseArgs)
+            thenNext @ nir.Next.Label(thenId, thenArgs),
+            elseNext @ nir.Next.Label(elseId, elseArgs)
           ) if thenId == elseId =>
         if (thenArgs == elseArgs) {
-          genInst(Inst.Jump(thenNext)(inst.pos))
+          genInst(nir.Inst.Jump(thenNext)(inst.pos))
         } else {
           val args = thenArgs.zip(elseArgs).map {
             case (thenV, elseV) =>
@@ -697,12 +696,12 @@ private[codegen] abstract class AbstractCodeGen(
               genVal(thenV)
               str(", ")
               genVal(elseV)
-              Val.Local(id, thenV.ty)
+              nir.Val.Local(id, thenV.ty)
           }
-          genInst(Inst.Jump(Next.Label(thenId, args))(inst.pos))
+          genInst(nir.Inst.Jump(nir.Next.Label(thenId, args))(inst.pos))
         }
 
-      case Inst.If(cond, thenp, elsep) =>
+      case nir.Inst.If(cond, thenp, elsep) =>
         newline()
         str("br ")
         genVal(cond)
@@ -711,7 +710,7 @@ private[codegen] abstract class AbstractCodeGen(
         str(", ")
         genNext(elsep)
 
-      case Inst.Switch(scrut, default, cases) =>
+      case nir.Inst.Switch(scrut, default, cases) =>
         newline()
         str("switch ")
         genVal(scrut)
@@ -732,16 +731,16 @@ private[codegen] abstract class AbstractCodeGen(
     }
   }
 
-  private[codegen] def genLet(inst: Inst.Let)(implicit
-      fresh: Fresh,
+  private[codegen] def genLet(inst: nir.Inst.Let)(implicit
+      fresh: nir.Fresh,
       sb: ShowBuilder,
       debugInfo: DebugInfo,
       defnScopes: DefnScopes,
       metaCtx: MetadataCodeGen.Context
   ): Unit = {
     import sb._
-    def isVoid(ty: Type): Boolean =
-      ty == Type.Unit || ty == Type.Nothing
+    def isVoid(ty: nir.Type): Boolean =
+      ty == nir.Type.Unit || ty == nir.Type.Nothing
 
     val op = inst.op
     val id = inst.id
@@ -757,10 +756,10 @@ private[codegen] abstract class AbstractCodeGen(
       }
 
     op match {
-      case _: Op.Copy =>
+      case _: nir.Op.Copy =>
         ()
 
-      case call: Op.Call =>
+      case call: nir.Op.Call =>
         /* When a call points to an extern method with same mangled Sig as some already defined call
          * in another extern object we need to manually enforce getting into second case of `genCall`
          * (when lookup(pointee) != call.ty). By replacing `call.ptr` with the ptr of that already
@@ -770,16 +769,16 @@ private[codegen] abstract class AbstractCodeGen(
          * In this case LLVM linking would otherwise result in call arguments type mismatch.
          */
         val callDef = call.ptr match {
-          case Val.Global(m @ Global.Member(_, sig), valty) if sig.isExtern =>
+          case nir.Val.Global(m @ nir.Global.Member(_, sig), valty) if sig.isExtern =>
             val glob = externSigMembers.getOrElseUpdate(sig, m)
             if (glob == m) call
-            else call.copy(ptr = Val.Global(glob, valty))
+            else call.copy(ptr = nir.Val.Global(glob, valty))
           case _ => call
         }
         genCall(genBind, callDef, unwind, inst.pos, inst.scopeId)
         dbgLocalValue(id, ty)(inst.pos, inst.scopeId)
 
-      case Op.Load(ty, ptr, syncAttrs) =>
+      case nir.Op.Load(ty, ptr, syncAttrs) =>
         val pointee = fresh()
         val isAtomic = isMultithreadingEnabled && syncAttrs.isDefined
         val isVolatile =
@@ -816,7 +815,7 @@ private[codegen] abstract class AbstractCodeGen(
           str(MemoryLayout.alignmentOf(ty))
         } else {
           ty match {
-            case refty: Type.RefKind =>
+            case refty: nir.Type.RefKind =>
               val (nonnull, deref, size) = toDereferenceable(refty)
               if (nonnull) {
                 str(", !nonnull !{}")
@@ -832,7 +831,7 @@ private[codegen] abstract class AbstractCodeGen(
           dbgLocalValue(id, ty)(inst.pos, inst.scopeId)
         }
 
-      case Op.Store(ty, ptr, value, syncAttrs) =>
+      case nir.Op.Store(ty, ptr, value, syncAttrs) =>
         val pointee = fresh()
         val isAtomic = isMultithreadingEnabled && syncAttrs.isDefined
         val isVolatile =
@@ -871,7 +870,7 @@ private[codegen] abstract class AbstractCodeGen(
         str(", align ")
         str(MemoryLayout.alignmentOf(ty))
 
-      case Op.Elem(ty, ptr, indexes) =>
+      case nir.Op.Elem(ty, ptr, indexes) =>
         val pointee = fresh()
         val derived = fresh()
 
@@ -896,7 +895,7 @@ private[codegen] abstract class AbstractCodeGen(
         str("getelementptr ")
         genType(ty)
         str(", ")
-        if (ty.isInstanceOf[Type.AggregateKind] || !useOpaquePointers) {
+        if (ty.isInstanceOf[nir.Type.AggregateKind] || !useOpaquePointers) {
           genType(ty)
           str("*")
         } else str(pointerType)
@@ -918,9 +917,9 @@ private[codegen] abstract class AbstractCodeGen(
           genLocal(derived)
           str(" to i8*")
         }
-        dbgLocalValue(id, Type.Ptr)(inst.pos, inst.scopeId)
+        dbgLocalValue(id, nir.Type.Ptr)(inst.pos, inst.scopeId)
 
-      case Op.Stackalloc(ty, n) =>
+      case nir.Op.Stackalloc(ty, n) =>
         val pointee = fresh()
 
         newline()
@@ -946,7 +945,7 @@ private[codegen] abstract class AbstractCodeGen(
           genLocal(pointee)
           str(" to i8*")
         }
-        dbgLocalVariable(inst.id, Type.Ptr)(inst.pos, inst.scopeId)
+        dbgLocalVariable(inst.id, nir.Type.Ptr)(inst.pos, inst.scopeId)
 
       case _ =>
         newline()
@@ -960,12 +959,12 @@ private[codegen] abstract class AbstractCodeGen(
 
   private[codegen] def genCall(
       genBind: () => Unit,
-      call: Op.Call,
-      unwind: Next,
-      srcPos: Position,
-      scopeId: ScopeId
+      call: nir.Op.Call,
+      unwind: nir.Next,
+      srcPos: nir.Position,
+      scopeId: nir.ScopeId
   )(implicit
-      fresh: Fresh,
+      fresh: nir.Fresh,
       sb: ShowBuilder,
       metaCtx: MetadataCodeGen.Context,
       defnScopes: DefnScopes
@@ -980,21 +979,21 @@ private[codegen] abstract class AbstractCodeGen(
     def genDbgPosition() = dbg(",", dbgPosition)
 
     call match {
-      case Op.Call(ty, Val.Global(pointee: Global.Member, _), args)
+      case nir.Op.Call(ty, nir.Val.Global(pointee: nir.Global.Member, _), args)
           if lookup(pointee) == ty =>
-        val Type.Function(argtys, _) = ty
+        val nir.Type.Function(argtys, _) = ty
         touch(pointee)
 
         newline()
         genBind()
-        str(if (unwind ne Next.None) "invoke " else "call ")
+        str(if (unwind ne nir.Next.None) "invoke " else "call ")
         genCallFunctionType(ty)
         str(" @")
         genGlobal(pointee)
         str("(")
         rep(args, sep = ", ")(genCallArgument)
         str(")")
-        if (unwind eq Next.None) genDbgPosition()
+        if (unwind eq nir.Next.None) genDbgPosition()
         else {
           str(" to label %")
           currentBlockSplit += 1
@@ -1008,8 +1007,8 @@ private[codegen] abstract class AbstractCodeGen(
           indent()
         }
 
-      case Op.Call(ty, ptr, args) =>
-        val Type.Function(_, resty) = ty
+      case nir.Op.Call(ty, ptr, args) =>
+        val nir.Type.Function(_, resty) = ty
 
         val pointee = fresh()
 
@@ -1026,7 +1025,7 @@ private[codegen] abstract class AbstractCodeGen(
 
         newline()
         genBind()
-        str(if (unwind ne Next.None) "invoke " else "call ")
+        str(if (unwind ne nir.Next.None) "invoke " else "call ")
         genCallFunctionType(ty)
         str(" ")
         if (useOpaquePointers) genJustVal(ptr)
@@ -1037,7 +1036,7 @@ private[codegen] abstract class AbstractCodeGen(
         str("(")
         rep(args, sep = ", ")(genCallArgument)
         str(")")
-        if (unwind eq Next.None) genDbgPosition()
+        if (unwind eq nir.Next.None) genDbgPosition()
         else {
           str(" to label %")
           currentBlockSplit += 1
@@ -1054,11 +1053,11 @@ private[codegen] abstract class AbstractCodeGen(
   }
 
   private[codegen] def genCallFunctionType(
-      ty: Type
+      ty: nir.Type
   )(implicit sb: ShowBuilder): Unit = {
     ty match {
-      case Type.Function(argtys, retty) =>
-        val hasVarArgs = argtys.contains(Type.Vararg)
+      case nir.Type.Function(argtys, retty) =>
+        val hasVarArgs = argtys.contains(nir.Type.Vararg)
         if (hasVarArgs) {
           genType(ty)
         } else {
@@ -1070,14 +1069,14 @@ private[codegen] abstract class AbstractCodeGen(
   }
 
   private[codegen] def genCallArgument(
-      v: Val
+      v: nir.Val
   )(implicit sb: ShowBuilder): Unit = {
     import sb._
     v match {
-      case Val.Local(_, refty: Type.RefKind) =>
+      case nir.Val.Local(_, refty: nir.Type.RefKind) =>
         val (nonnull, deref, size) = toDereferenceable(refty)
         // Primitive unit value cannot be passed as argument, probably BoxedUnit is expected
-        if (refty == Type.Unit) genType(Type.Ptr)
+        if (refty == nir.Type.Unit) genType(nir.Type.Ptr)
         else genType(refty)
         if (nonnull) {
           str(" nonnull")
@@ -1094,26 +1093,26 @@ private[codegen] abstract class AbstractCodeGen(
     }
   }
 
-  private[codegen] def genOp(op: Op)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genOp(op: nir.Op)(implicit sb: ShowBuilder): Unit = {
     import sb._
     op match {
-      case Op.Extract(aggr, indexes) =>
+      case nir.Op.Extract(aggr, indexes) =>
         str("extractvalue ")
         genVal(aggr)
         str(", ")
         rep(indexes, sep = ", ")(str)
-      case Op.Insert(aggr, value, indexes) =>
+      case nir.Op.Insert(aggr, value, indexes) =>
         str("insertvalue ")
         genVal(aggr)
         str(", ")
         genVal(value)
         str(", ")
         rep(indexes, sep = ", ")(str)
-      case Op.Bin(opcode, ty, l, r) =>
+      case nir.Op.Bin(opcode, ty, l, r) =>
         val bin = opcode match {
-          case Bin.Iadd => "add"
-          case Bin.Isub => "sub"
-          case Bin.Imul => "mul"
+          case nir.Bin.Iadd => "add"
+          case nir.Bin.Isub => "sub"
+          case nir.Bin.Imul => "mul"
           case _        => opcode.toString.toLowerCase
         }
         str(bin)
@@ -1121,37 +1120,37 @@ private[codegen] abstract class AbstractCodeGen(
         genVal(l)
         str(", ")
         genJustVal(r)
-      case Op.Comp(opcode, ty, l, r) =>
+      case nir.Op.Comp(opcode, ty, l, r) =>
         val cmp = opcode match {
-          case Comp.Ieq => "icmp eq"
-          case Comp.Ine => "icmp ne"
-          case Comp.Ult => "icmp ult"
-          case Comp.Ule => "icmp ule"
-          case Comp.Ugt => "icmp ugt"
-          case Comp.Uge => "icmp uge"
-          case Comp.Slt => "icmp slt"
-          case Comp.Sle => "icmp sle"
-          case Comp.Sgt => "icmp sgt"
-          case Comp.Sge => "icmp sge"
-          case Comp.Feq => "fcmp oeq"
-          case Comp.Fne => "fcmp une"
-          case Comp.Flt => "fcmp olt"
-          case Comp.Fle => "fcmp ole"
-          case Comp.Fgt => "fcmp ogt"
-          case Comp.Fge => "fcmp oge"
+          case nir.Comp.Ieq => "icmp eq"
+          case nir.Comp.Ine => "icmp ne"
+          case nir.Comp.Ult => "icmp ult"
+          case nir.Comp.Ule => "icmp ule"
+          case nir.Comp.Ugt => "icmp ugt"
+          case nir.Comp.Uge => "icmp uge"
+          case nir.Comp.Slt => "icmp slt"
+          case nir.Comp.Sle => "icmp sle"
+          case nir.Comp.Sgt => "icmp sgt"
+          case nir.Comp.Sge => "icmp sge"
+          case nir.Comp.Feq => "fcmp oeq"
+          case nir.Comp.Fne => "fcmp une"
+          case nir.Comp.Flt => "fcmp olt"
+          case nir.Comp.Fle => "fcmp ole"
+          case nir.Comp.Fgt => "fcmp ogt"
+          case nir.Comp.Fge => "fcmp oge"
         }
         str(cmp)
         str(" ")
         genVal(l)
         str(", ")
         genJustVal(r)
-      case Op.Conv(conv, ty, v) =>
+      case nir.Op.Conv(conv, ty, v) =>
         genConv(conv, v.ty, ty)
         str(" ")
         genVal(v)
         str(" to ")
         genType(ty)
-      case Op.Fence(syncAttrs) =>
+      case nir.Op.Fence(syncAttrs) =>
         str("fence ")
         genSyncAttrs(syncAttrs)
 
@@ -1161,29 +1160,29 @@ private[codegen] abstract class AbstractCodeGen(
   }
 
   private def genSyncAttrs(
-      attrs: SyncAttrs
+      attrs: nir.SyncAttrs
   )(implicit sb: ShowBuilder): Unit = {
     import sb._
-    val SyncAttrs(memoryOrder, _) = attrs
+    val nir.SyncAttrs(memoryOrder, _) = attrs
     str(memoryOrder match {
-      case MemoryOrder.Unordered => "unordered"
-      case MemoryOrder.Monotonic => "monotonic"
-      case MemoryOrder.Acquire   => "acquire"
-      case MemoryOrder.Release   => "release"
-      case MemoryOrder.AcqRel    => "acq_rel"
-      case MemoryOrder.SeqCst    => "seq_cst"
+      case nir.MemoryOrder.Unordered => "unordered"
+      case nir.MemoryOrder.Monotonic => "monotonic"
+      case nir.MemoryOrder.Acquire   => "acquire"
+      case nir.MemoryOrder.Release   => "release"
+      case nir.MemoryOrder.AcqRel    => "acq_rel"
+      case nir.MemoryOrder.SeqCst    => "seq_cst"
     })
   }
 
-  private[codegen] def genNext(next: Next)(implicit sb: ShowBuilder): Unit = {
+  private[codegen] def genNext(next: nir.Next)(implicit sb: ShowBuilder): Unit = {
     import sb._
     next match {
-      case Next.Case(v, next) =>
+      case nir.Next.Case(v, next) =>
         genVal(v)
         str(", label %")
         genLocal(next.id)
         str(".0")
-      case Next.Unwind(Val.Local(exc, _), _) =>
+      case nir.Next.Unwind(nir.Val.Local(exc, _), _) =>
         str("label %_")
         str(exc.id)
         str(".landingpad")
@@ -1194,26 +1193,26 @@ private[codegen] abstract class AbstractCodeGen(
     }
   }
 
-  private[codegen] def genConv(conv: Conv, fromType: Type, toType: Type)(
+  private[codegen] def genConv(conv: nir.Conv, fromType: nir.Type, toType: nir.Type)(
       implicit sb: ShowBuilder
   ): Unit = conv match {
-    case Conv.ZSizeCast | Conv.SSizeCast =>
+    case nir.Conv.ZSizeCast | nir.Conv.SSizeCast =>
       val fromSize = fromType match {
-        case Type.Size             => platform.sizeOfPtrBits
-        case Type.FixedSizeI(s, _) => s
-        case o                     => unsupported(o)
+        case nir.Type.Size => platform.sizeOfPtrBits
+        case nir.Type.FixedSizeI(s, _) => s
+        case o => unsupported(o)
       }
 
       val toSize = toType match {
-        case Type.Size             => platform.sizeOfPtrBits
-        case Type.FixedSizeI(s, _) => s
-        case o                     => unsupported(o)
+        case nir.Type.Size => platform.sizeOfPtrBits
+        case nir.Type.FixedSizeI(s, _) => s
+        case o => unsupported(o)
       }
 
       val castOp =
         if (fromSize == toSize) "bitcast"
         else if (fromSize > toSize) "trunc"
-        else if (conv == Conv.ZSizeCast) "zext"
+        else if (conv == nir.Conv.ZSizeCast) "zext"
         else "sext"
 
       sb.str(castOp)
@@ -1221,7 +1220,7 @@ private[codegen] abstract class AbstractCodeGen(
     case o => sb.str(o.show)
   }
 
-  private[codegen] def genAttr(attr: Attr)(implicit sb: ShowBuilder): Unit =
+  private[codegen] def genAttr(attr: nir.Attr)(implicit sb: ShowBuilder): Unit =
     sb.str(attr.show)
 
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
@@ -1,14 +1,14 @@
-package scala.scalanative.codegen
+package scala.scalanative
+package codegen
 package llvm
 
-import scala.scalanative.nir.Val
 import scala.language.implicitConversions
 
 sealed trait Metadata
 object Metadata {
   case class Str(value: String) extends Metadata
   case class Const(value: String) extends Metadata
-  case class Value(value: Val) extends Metadata
+  case class Value(value: nir.Val) extends Metadata
   sealed trait Node extends Metadata {
     def distinct: Boolean = false
   }
@@ -97,7 +97,7 @@ object Metadata {
     object UnsignedChar extends DW_ATE("DW_ATE_unsigned_char")
   }
 
-  sealed class ModFlagBehavior(tag: Int) extends Value(Val.Int(tag))
+  sealed class ModFlagBehavior(tag: Int) extends Value(nir.Val.Int(tag))
   object ModFlagBehavior {
     object Error extends ModFlagBehavior(1)
     object Warning extends ModFlagBehavior(2)
@@ -120,7 +120,8 @@ object Metadata {
 
   object conversions {
     def tuple(values: Metadata*) = Metadata.Tuple(values)
-    implicit def intToValue(v: Int): Metadata.Value = Metadata.Value(Val.Int(v))
+    implicit def intToValue(v: Int): Metadata.Value =
+      Metadata.Value(nir.Val.Int(v))
     implicit def stringToStr(v: String): Metadata.Str = Metadata.Str(v)
     implicit class StringOps(val v: String) extends AnyVal {
       def string: Metadata.Str = Metadata.Str(v)

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -1,8 +1,7 @@
-package scala.scalanative.codegen
+package scala.scalanative
+package codegen
 package llvm
 
-import scala.scalanative.nir
-import scala.scalanative.nir.{Position, Fresh, Val, Local}
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 import scala.collection.mutable
@@ -10,8 +9,6 @@ import scala.scalanative.util.unsupported
 
 import scala.language.implicitConversions
 import scala.scalanative.codegen.llvm.MetadataCodeGen.Writer.Specialized
-import scala.scalanative.nir.Unmangle
-import scala.scalanative.nir.Sig.Method
 import scala.scalanative.util.unreachable
 
 // scalafmt: { maxColumn = 100}
@@ -62,7 +59,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
     case _                                => true
   }
 
-  def dbgLocalValue(id: Local, ty: nir.Type, argIdx: Option[Int] = None)(
+  def dbgLocalValue(id: nir.Local, ty: nir.Type, argIdx: Option[Int] = None)(
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
   )(implicit
@@ -74,7 +71,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
     if (generateDebugMetadata && canHaveDebugValue(ty)) {
       debugInfo.localNames.get(id).foreach { localName =>
         `llvm.dbg.value`(
-          address = Metadata.Value(Val.Local(id, ty)),
+          address = Metadata.Value(nir.Val.Local(id, ty)),
           description = Metadata.DILocalVariable(
             name = localName,
             arg = argIdx,
@@ -88,7 +85,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
       }
     }
 
-  def dbgLocalVariable(id: Local, ty: nir.Type)(
+  def dbgLocalVariable(id: nir.Local, ty: nir.Type)(
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
   )(implicit
@@ -100,7 +97,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
     if (generateDebugMetadata && canHaveDebugValue(ty)) {
       debugInfo.localNames.get(id).foreach { localName =>
         `llvm.dbg.declare`(
-          address = Metadata.Value(Val.Local(id, ty)),
+          address = Metadata.Value(nir.Val.Local(id, ty)),
           description = Metadata.DILocalVariable(
             name = localName,
             arg = None,
@@ -138,7 +135,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
       address: Metadata.Value,
       description: DILocalVariable,
       expr: Metadata.DIExpression
-  )(pos: Position, scopeId: nir.ScopeId)(implicit
+  )(pos: nir.Position, scopeId: nir.ScopeId)(implicit
       ctx: Context,
       sb: ShowBuilder,
       defnScopes: DefnScopes
@@ -160,7 +157,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
       .map(_.keySet.toSeq.asInstanceOf[Seq[DICompileUnit]])
       .getOrElse(Nil)
 
-  def toDIFile(pos: Position): DIFile = {
+  def toDIFile(pos: nir.Position): DIFile = {
     pos.filename
       .zip(pos.dir)
       .headOption
@@ -195,11 +192,11 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
       val linkageName = mangled(defn.name)
       val defnName = if (linkageName.startsWith("_S")) linkageName.drop(2) else linkageName
       val unmangledName = if (defnName.startsWith("M")) { // subprogram should be a member
-        Unmangle.unmangleGlobal(defnName) match {
+        nir.Unmangle.unmangleGlobal(defnName) match {
           case nir.Global.Member(owner, sig) =>
-            Unmangle.unmangleSig(sig.mangle) match {
-              case Method(id, _, _) => Some(id)
-              case _                => None
+            nir.Unmangle.unmangleSig(sig.mangle) match {
+              case nir.Sig.Method(id, _, _) => Some(id)
+              case _                        => None
             }
           case _ => None
         }
@@ -309,7 +306,7 @@ object MetadataCodeGen {
 
     private[MetadataCodeGen] val specializedBuilder: Specialized.Builder[_] =
       new Specialized.Builder[Any]()(this)
-    private[MetadataCodeGen] val fresh: Fresh = Fresh()
+    private[MetadataCodeGen] val fresh: nir.Fresh = nir.Fresh()
   }
 
   class MetadataId(val value: Int) extends AnyVal {

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -2,7 +2,7 @@ package scala.scalanative.codegen
 package llvm
 
 import scala.scalanative.nir
-import scala.scalanative.nir.{Position, Global, Fresh, Val, Local}
+import scala.scalanative.nir.{Position, Fresh, Val, Local}
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 import scala.collection.mutable
@@ -11,7 +11,6 @@ import scala.scalanative.util.unsupported
 import scala.language.implicitConversions
 import scala.scalanative.codegen.llvm.MetadataCodeGen.Writer.Specialized
 import scala.scalanative.nir.Unmangle
-import scala.scalanative.nir.Global.Member
 import scala.scalanative.nir.Sig.Method
 import scala.scalanative.util.unreachable
 
@@ -197,7 +196,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
       val defnName = if (linkageName.startsWith("_S")) linkageName.drop(2) else linkageName
       val unmangledName = if (defnName.startsWith("M")) { // subprogram should be a member
         Unmangle.unmangleGlobal(defnName) match {
-          case Member(owner, sig) =>
+          case nir.Global.Member(owner, sig) =>
             Unmangle.unmangleSig(sig.mangle) match {
               case Method(id, _, _) => Some(id)
               case _                => None

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
@@ -1,30 +1,33 @@
-package scala.scalanative.codegen
+package scala.scalanative
+package codegen
 package llvm
 package compat.os
 
-import scala.scalanative.nir.ControlFlow.Block
 import scala.scalanative.nir.Defn.Define.DebugInfo
-import scala.scalanative.nir.{Fresh, Next, Position}
 import scala.scalanative.util.ShowBuilder
 
 private[codegen] abstract class OsCompat(
     protected val codegen: AbstractCodeGen
 ) {
+
   protected def osPersonalityType: String
 
   def useOpaquePointers = codegen.meta.platform.useOpaquePointers
 
   def genPrelude()(implicit sb: ShowBuilder): Unit
   def genLandingPad(
-      unwind: Next.Unwind
+      unwind: nir.Next.Unwind
   )(implicit
-      fresh: Fresh,
-      pos: Position,
+      fresh: nir.Fresh,
+      pos: nir.Position,
       sb: ShowBuilder
   ): Unit
-  def genBlockAlloca(block: Block)(implicit sb: ShowBuilder): Unit
+  def genBlockAlloca(block: nir.ControlFlow.Block)(implicit
+      sb: ShowBuilder
+  ): Unit
 
   final lazy val gxxPersonality =
     if (useOpaquePointers) s"personality ptr $osPersonalityType"
     else s"personality i8* bitcast (i32 (...)* $osPersonalityType to i8*)"
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -1,15 +1,17 @@
-package scala.scalanative.codegen.llvm
+package scala.scalanative
+package codegen.llvm
 package compat.os
 
 import scala.scalanative.codegen.llvm.AbstractCodeGen
 import scala.scalanative.nir.ControlFlow.Block
-import scala.scalanative.nir._
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 
 private[codegen] class UnixCompat(codegen: AbstractCodeGen)
     extends OsCompat(codegen) {
+
   import codegen.{pointerType => ptrT}
+
   val ehWrapperTy = "@_ZTIN11scalanative16ExceptionWrapperE"
   val excRecTy = s"{ $ptrT, i32 }"
   val beginCatch = "@__cxa_begin_catch"
@@ -28,14 +30,14 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
     ()
 
   def genLandingPad(
-      unwind: Next.Unwind
+      unwind: nir.Next.Unwind
   )(implicit
-      fresh: Fresh,
-      pos: Position,
+      fresh: nir.Fresh,
+      pos: nir.Position,
       sb: ShowBuilder
   ): Unit = {
     import sb._
-    val Next.Unwind(Val.Local(excname, _), next) = unwind
+    val nir.Next.Unwind(nir.Val.Local(excname, _), next) = unwind
 
     val excpad = "_" + excname.id + ".landingpad"
     val excsucc = excpad + ".succ"
@@ -87,4 +89,5 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
     line(s"declare void $endCatch()")
     line(s"$ehWrapperTy = external constant { $ptrT, $ptrT, $ptrT }")
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -3,7 +3,6 @@ package codegen.llvm
 package compat.os
 
 import scala.scalanative.codegen.llvm.AbstractCodeGen
-import scala.scalanative.nir.ControlFlow.Block
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 
@@ -26,7 +25,9 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
 
   protected val osPersonalityType: String = "@__gxx_personality_v0"
 
-  override def genBlockAlloca(block: Block)(implicit sb: ShowBuilder): Unit =
+  override def genBlockAlloca(block: nir.ControlFlow.Block)(implicit
+      sb: ShowBuilder
+  ): Unit =
     ()
 
   def genLandingPad(

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
@@ -1,15 +1,16 @@
-package scala.scalanative.codegen.llvm
+package scala.scalanative
+package codegen.llvm
 package compat.os
 
 import scala.scalanative.codegen.llvm.AbstractCodeGen
-import scala.scalanative.nir.ControlFlow.Block
-import scala.scalanative.nir.{Fresh, Next, Position, Val}
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
 
 private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
     extends OsCompat(codegen) {
+
   import codegen.{pointerType => ptrT}
+
   val ehWrapperTy = "\"??_R0?AVExceptionWrapper@scalanative@@@8\""
   val ehWrapperName = "c\".?AVExceptionWrapper@scalanative@@\\00\""
   val ehClass = "%\"class.scalanative::ExceptionWrapper\""
@@ -21,7 +22,9 @@ private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
 
   override protected val osPersonalityType: String = "@__CxxFrameHandler3"
 
-  override def genBlockAlloca(block: Block)(implicit sb: ShowBuilder): Unit = {
+  override def genBlockAlloca(
+      block: nir.ControlFlow.Block
+  )(implicit sb: ShowBuilder): Unit = {
     import sb._
     if (block.pred.isEmpty) {
       newline()
@@ -49,15 +52,15 @@ private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
   }
 
   override def genLandingPad(
-      unwind: Next.Unwind
+      unwind: nir.Next.Unwind
   )(implicit
-      fresh: Fresh,
-      pos: Position,
+      fresh: nir.Fresh,
+      pos: nir.Position,
       sb: ShowBuilder
   ): Unit = {
     import codegen._
     import sb._
-    val Next.Unwind(Val.Local(excname, _), next) = unwind
+    val nir.Next.Unwind(nir.Val.Local(excname, _), next) = unwind
 
     val excpad = s"_${excname.id}.landingpad"
     val excsucc = excpad + ".succ"
@@ -96,4 +99,5 @@ private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
     genNext(next)
     unindent()
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Allowlist.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Allowlist.scala
@@ -2,61 +2,63 @@ package scala.scalanative
 package interflow
 
 import scala.collection.mutable
-import scalanative.nir._
 import scalanative.codegen.Lower
 
 object Allowlist {
+
   val constantModules = {
-    val out = collection.mutable.Set.empty[Global]
-    out += Global.Top("scala.scalanative.runtime.BoxedUnit$")
-    out += Global.Top("scala.scalanative.runtime.LazyVals$")
-    out += Global.Top("scala.scalanative.runtime.MemoryLayout$")
-    out += Global.Top("scala.scalanative.runtime.MemoryLayout$Array$")
-    out += Global.Top("scala.scalanative.runtime.MemoryLayout$Object$")
-    out += Global.Top("scala.scalanative.runtime.MemoryLayout$Rtti$")
-    out += Global.Top("scala.scalanative.runtime.monitor.BasicMonitor$")
-    out += Global.Top("scala.scalanative.runtime.monitor.package$LockWord")
-    out += Global.Top("scala.scalanative.runtime.monitor.package$LockWord$")
-    out += Global.Top("scala.scalanative.runtime.monitor.package$LockWord32$")
-    out += Global.Top("scala.scalanative.runtime.monitor.package$LockType$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Unit$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Boolean$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Char$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Byte$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$UByte$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Short$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$UShort$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Int$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$UInt$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Long$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$ULong$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Float$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Double$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Size$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$USize$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat0$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat1$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat2$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat3$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat4$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat5$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat6$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat7$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat8$")
-    out += Global.Top("scala.scalanative.unsafe.Tag$Nat9$")
-    out += Global.Top("java.lang.Math$")
+    val out = collection.mutable.Set.empty[nir.Global]
+    out += nir.Global.Top("scala.scalanative.runtime.BoxedUnit$")
+    out += nir.Global.Top("scala.scalanative.runtime.LazyVals$")
+    out += nir.Global.Top("scala.scalanative.runtime.MemoryLayout$")
+    out += nir.Global.Top("scala.scalanative.runtime.MemoryLayout$Array$")
+    out += nir.Global.Top("scala.scalanative.runtime.MemoryLayout$Object$")
+    out += nir.Global.Top("scala.scalanative.runtime.MemoryLayout$Rtti$")
+    out += nir.Global.Top("scala.scalanative.runtime.monitor.BasicMonitor$")
+    out += nir.Global.Top("scala.scalanative.runtime.monitor.package$LockWord")
+    out += nir.Global.Top("scala.scalanative.runtime.monitor.package$LockWord$")
+    out += nir.Global.Top(
+      "scala.scalanative.runtime.monitor.package$LockWord32$"
+    )
+    out += nir.Global.Top("scala.scalanative.runtime.monitor.package$LockType$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Unit$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Boolean$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Char$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Byte$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$UByte$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Short$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$UShort$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Int$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$UInt$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Long$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$ULong$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Float$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Double$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Size$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$USize$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat0$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat1$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat2$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat3$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat4$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat5$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat6$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat7$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat8$")
+    out += nir.Global.Top("scala.scalanative.unsafe.Tag$Nat9$")
+    out += nir.Global.Top("java.lang.Math$")
     out
   }
 
   val pure = {
-    val out = mutable.Set.empty[Global]
-    out += Global.Top("scala.Predef$")
-    out += Global.Top("scala.runtime.BoxesRunTime$")
-    out += Global.Top("scala.scalanative.runtime.Boxes$")
-    out += Global.Top("scala.scalanative.runtime.package$")
-    out += Global.Top("scala.scalanative.unsafe.package$")
-    out += Global.Top("scala.collection.immutable.Range$")
+    val out = mutable.Set.empty[nir.Global]
+    out += nir.Global.Top("scala.Predef$")
+    out += nir.Global.Top("scala.runtime.BoxesRunTime$")
+    out += nir.Global.Top("scala.scalanative.runtime.Boxes$")
+    out += nir.Global.Top("scala.scalanative.runtime.package$")
+    out += nir.Global.Top("scala.scalanative.unsafe.package$")
+    out += nir.Global.Top("scala.collection.immutable.Range$")
     out ++= Lower.BoxTo.values
     out ++= constantModules
     out

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -114,9 +114,19 @@ trait Combine { self: Interflow =>
 
           // x * 2^n ==> x << n
           case (lhs, nir.Val.Int(v)) if isPowerOfTwoOrMinValue(v) =>
-            combine(Shl, ty, lhs, nir.Val.Int(jl.Integer.numberOfTrailingZeros(v)))
+            combine(
+              Shl,
+              ty,
+              lhs,
+              nir.Val.Int(jl.Integer.numberOfTrailingZeros(v))
+            )
           case (lhs, nir.Val.Long(v)) if isPowerOfTwoOrMinValue(v) =>
-            combine(Shl, ty, lhs, nir.Val.Long(jl.Long.numberOfTrailingZeros(v)))
+            combine(
+              Shl,
+              ty,
+              lhs,
+              nir.Val.Long(jl.Long.numberOfTrailingZeros(v))
+            )
 
           // (x * b) * a ==> x * (a * b)
           case (BinRef(Imul, x, nir.Val.Int(b)), nir.Val.Int(a)) =>
@@ -150,9 +160,19 @@ trait Combine { self: Interflow =>
 
           // x unsigned_/ 2^n ==> x >> n
           case (lhs, nir.Val.Int(v)) if isPowerOfTwoOrMinValue(v) =>
-            combine(Lshr, ty, lhs, nir.Val.Int(jl.Integer.numberOfTrailingZeros(v)))
+            combine(
+              Lshr,
+              ty,
+              lhs,
+              nir.Val.Int(jl.Integer.numberOfTrailingZeros(v))
+            )
           case (lhs, nir.Val.Long(v)) if isPowerOfTwoOrMinValue(v) =>
-            combine(Lshr, ty, lhs, nir.Val.Long(jl.Long.numberOfTrailingZeros(v)))
+            combine(
+              Lshr,
+              ty,
+              lhs,
+              nir.Val.Long(jl.Long.numberOfTrailingZeros(v))
+            )
 
           case _ =>
             fallback
@@ -422,23 +442,31 @@ trait Combine { self: Interflow =>
 
       // Comparing non-nullable value with null will always
       // yield the same result.
-      case (Ieq, v @ nir.Of(ty: nir.Type.RefKind), nir.Val.Null) if !ty.isNullable =>
+      case (Ieq, v @ nir.Of(ty: nir.Type.RefKind), nir.Val.Null)
+          if !ty.isNullable =>
         nir.Val.False
-      case (Ieq, nir.Val.Null, v @ nir.Of(ty: nir.Type.RefKind)) if !ty.isNullable =>
+      case (Ieq, nir.Val.Null, v @ nir.Of(ty: nir.Type.RefKind))
+          if !ty.isNullable =>
         nir.Val.False
-      case (Ine, v @ nir.Of(ty: nir.Type.RefKind), nir.Val.Null) if !ty.isNullable =>
+      case (Ine, v @ nir.Of(ty: nir.Type.RefKind), nir.Val.Null)
+          if !ty.isNullable =>
         nir.Val.True
-      case (Ine, nir.Val.Null, v @ nir.Of(ty: nir.Type.RefKind)) if !ty.isNullable =>
+      case (Ine, nir.Val.Null, v @ nir.Of(ty: nir.Type.RefKind))
+          if !ty.isNullable =>
         nir.Val.True
 
       // Ptr boxes are null if underlying pointer is null.
-      case (Ieq, DelayedRef(nir.Op.Box(ty, x)), nir.Val.Null) if nir.Type.isPtrBox(ty) =>
+      case (Ieq, DelayedRef(nir.Op.Box(ty, x)), nir.Val.Null)
+          if nir.Type.isPtrBox(ty) =>
         combine(Ieq, nir.Type.Ptr, x, nir.Val.Null)
-      case (Ieq, nir.Val.Null, DelayedRef(nir.Op.Box(ty, x))) if nir.Type.isPtrBox(ty) =>
+      case (Ieq, nir.Val.Null, DelayedRef(nir.Op.Box(ty, x)))
+          if nir.Type.isPtrBox(ty) =>
         combine(Ieq, nir.Type.Ptr, x, nir.Val.Null)
-      case (Ine, DelayedRef(nir.Op.Box(ty, x)), nir.Val.Null) if nir.Type.isPtrBox(ty) =>
+      case (Ine, DelayedRef(nir.Op.Box(ty, x)), nir.Val.Null)
+          if nir.Type.isPtrBox(ty) =>
         combine(Ine, nir.Type.Ptr, x, nir.Val.Null)
-      case (Ine, nir.Val.Null, DelayedRef(nir.Op.Box(ty, x))) if nir.Type.isPtrBox(ty) =>
+      case (Ine, nir.Val.Null, DelayedRef(nir.Op.Box(ty, x)))
+          if nir.Type.isPtrBox(ty) =>
         combine(Ine, nir.Type.Ptr, x, nir.Val.Null)
 
       // Comparing two non-null module references will

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package interflow
 
 import java.{lang => jl}
-import scalanative.nir._
 import scalanative.linker._
 import scalanative.util.{unreachable, And}
 import nir.Bin.{And => Iand, _}
@@ -11,18 +10,18 @@ import nir.Conv._
 
 trait Combine { self: Interflow =>
 
-  def combine(bin: Bin, ty: Type, l: Val, r: Val)(implicit
+  def combine(bin: nir.Bin, ty: nir.Type, l: nir.Val, r: nir.Val)(implicit
       state: State,
-      srcPosition: Position,
-      scopeId: ScopeId
-  ): Val = {
+      srcPosition: nir.Position,
+      scopeId: nir.ScopeId
+  ): nir.Val = {
     import state.{materialize, delay, emit}
 
     def fallback = {
-      if (Op.Bin(bin, ty, l, r).isPure) {
-        delay(Op.Bin(bin, ty, l, r))
+      if (nir.Op.Bin(bin, ty, l, r).isPure) {
+        delay(nir.Op.Bin(bin, ty, l, r))
       } else {
-        emit(Op.Bin(bin, ty, materialize(l), materialize(r)))
+        emit(nir.Op.Bin(bin, ty, materialize(l), materialize(r)))
       }
     }
 
@@ -34,16 +33,16 @@ trait Combine { self: Interflow =>
             x
 
           // (x + b) + a ==> x + (a + b)
-          case (BinRef(Iadd, x, Val.Int(b)), Val.Int(a)) =>
-            combine(Iadd, ty, x, Val.Int(a + b))
-          case (BinRef(Iadd, x, Val.Long(b)), Val.Long(a)) =>
-            combine(Iadd, ty, x, Val.Long(a + b))
+          case (BinRef(Iadd, x, nir.Val.Int(b)), nir.Val.Int(a)) =>
+            combine(Iadd, ty, x, nir.Val.Int(a + b))
+          case (BinRef(Iadd, x, nir.Val.Long(b)), nir.Val.Long(a)) =>
+            combine(Iadd, ty, x, nir.Val.Long(a + b))
 
           // (x - b) + a ==> x + (a - b)
-          case (BinRef(Isub, x, Val.Int(b)), Val.Int(a)) =>
-            combine(Iadd, ty, x, Val.Int(a - b))
-          case (BinRef(Isub, x, Val.Long(b)), Val.Long(a)) =>
-            combine(Iadd, ty, x, Val.Long(a - b))
+          case (BinRef(Isub, x, nir.Val.Int(b)), nir.Val.Int(a)) =>
+            combine(Iadd, ty, x, nir.Val.Int(a - b))
+          case (BinRef(Isub, x, nir.Val.Long(b)), nir.Val.Long(a)) =>
+            combine(Iadd, ty, x, nir.Val.Long(a - b))
 
           // x + (0 - y) ==> x - y
           case (x, BinRef(Isub, v, y)) if v.isZero =>
@@ -72,16 +71,16 @@ trait Combine { self: Interflow =>
             zero(ty)
 
           // (x - b) - a ==> x - (a + b)
-          case (BinRef(Isub, x, Val.Int(b)), Val.Int(a)) =>
-            combine(Isub, ty, x, Val.Int(a + b))
-          case (BinRef(Isub, x, Val.Long(b)), Val.Long(a)) =>
-            combine(Isub, ty, x, Val.Long(a + b))
+          case (BinRef(Isub, x, nir.Val.Int(b)), nir.Val.Int(a)) =>
+            combine(Isub, ty, x, nir.Val.Int(a + b))
+          case (BinRef(Isub, x, nir.Val.Long(b)), nir.Val.Long(a)) =>
+            combine(Isub, ty, x, nir.Val.Long(a + b))
 
           // (x + b) - a ==> x - (a - b)
-          case (BinRef(Iadd, x, Val.Int(b)), Val.Int(a)) =>
-            combine(Isub, ty, x, Val.Int(a - b))
-          case (BinRef(Iadd, x, Val.Long(b)), Val.Long(a)) =>
-            combine(Isub, ty, x, Val.Long(a - b))
+          case (BinRef(Iadd, x, nir.Val.Int(b)), nir.Val.Int(a)) =>
+            combine(Isub, ty, x, nir.Val.Int(a - b))
+          case (BinRef(Iadd, x, nir.Val.Long(b)), nir.Val.Long(a)) =>
+            combine(Isub, ty, x, nir.Val.Long(a - b))
 
           // x - (0 - y) ==> x + y
           case (x, BinRef(Isub, v, y)) if v.isZero =>
@@ -114,16 +113,16 @@ trait Combine { self: Interflow =>
             combine(Isub, ty, zero(ty), lhs)
 
           // x * 2^n ==> x << n
-          case (lhs, Val.Int(v)) if isPowerOfTwoOrMinValue(v) =>
-            combine(Shl, ty, lhs, Val.Int(jl.Integer.numberOfTrailingZeros(v)))
-          case (lhs, Val.Long(v)) if isPowerOfTwoOrMinValue(v) =>
-            combine(Shl, ty, lhs, Val.Long(jl.Long.numberOfTrailingZeros(v)))
+          case (lhs, nir.Val.Int(v)) if isPowerOfTwoOrMinValue(v) =>
+            combine(Shl, ty, lhs, nir.Val.Int(jl.Integer.numberOfTrailingZeros(v)))
+          case (lhs, nir.Val.Long(v)) if isPowerOfTwoOrMinValue(v) =>
+            combine(Shl, ty, lhs, nir.Val.Long(jl.Long.numberOfTrailingZeros(v)))
 
           // (x * b) * a ==> x * (a * b)
-          case (BinRef(Imul, x, Val.Int(b)), Val.Int(a)) =>
-            combine(Imul, ty, x, Val.Int(b * a))
-          case (BinRef(Imul, x, Val.Long(b)), Val.Long(a)) =>
-            combine(Imul, ty, x, Val.Long(b * a))
+          case (BinRef(Imul, x, nir.Val.Int(b)), nir.Val.Int(a)) =>
+            combine(Imul, ty, x, nir.Val.Int(b * a))
+          case (BinRef(Imul, x, nir.Val.Long(b)), nir.Val.Long(a)) =>
+            combine(Imul, ty, x, nir.Val.Long(b * a))
 
           case _ =>
             fallback
@@ -150,10 +149,10 @@ trait Combine { self: Interflow =>
             lhs
 
           // x unsigned_/ 2^n ==> x >> n
-          case (lhs, Val.Int(v)) if isPowerOfTwoOrMinValue(v) =>
-            combine(Lshr, ty, lhs, Val.Int(jl.Integer.numberOfTrailingZeros(v)))
-          case (lhs, Val.Long(v)) if isPowerOfTwoOrMinValue(v) =>
-            combine(Lshr, ty, lhs, Val.Long(jl.Long.numberOfTrailingZeros(v)))
+          case (lhs, nir.Val.Int(v)) if isPowerOfTwoOrMinValue(v) =>
+            combine(Lshr, ty, lhs, nir.Val.Int(jl.Integer.numberOfTrailingZeros(v)))
+          case (lhs, nir.Val.Long(v)) if isPowerOfTwoOrMinValue(v) =>
+            combine(Lshr, ty, lhs, nir.Val.Long(jl.Long.numberOfTrailingZeros(v)))
 
           case _ =>
             fallback
@@ -186,9 +185,9 @@ trait Combine { self: Interflow =>
       case Shl =>
         (l, r) match {
           // x << v ==> x if v & bitsize(x) - 1 == 0
-          case (lhs, Val.Int(v)) if (v & 31) == 0 =>
+          case (lhs, nir.Val.Int(v)) if (v & 31) == 0 =>
             lhs
-          case (lhs, Val.Long(v)) if (v & 63) == 0 =>
+          case (lhs, nir.Val.Long(v)) if (v & 63) == 0 =>
             lhs
 
           // 0 << x ==> 0
@@ -196,19 +195,19 @@ trait Combine { self: Interflow =>
             zero(ty)
 
           // (x << a) << b ==> x << (a + b)
-          case (BinRef(Shl, x, Val.Int(a)), Val.Int(b)) =>
+          case (BinRef(Shl, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
             val dist = (a & 31) + (b & 31)
             if (dist >= 32) {
-              Val.Int(0)
+              nir.Val.Int(0)
             } else {
-              combine(Shl, ty, x, Val.Int(dist))
+              combine(Shl, ty, x, nir.Val.Int(dist))
             }
-          case (BinRef(Shl, x, Val.Long(a)), Val.Long(b)) =>
+          case (BinRef(Shl, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
             val dist = (a & 63) + (b & 63)
             if (dist >= 64) {
-              Val.Long(0)
+              nir.Val.Long(0)
             } else {
-              combine(Shl, ty, x, Val.Long(dist))
+              combine(Shl, ty, x, nir.Val.Long(dist))
             }
 
           case _ =>
@@ -218,9 +217,9 @@ trait Combine { self: Interflow =>
       case Lshr =>
         (l, r) match {
           // x >>> v ==> x if v & bitsize(x) - 1 == 0
-          case (lhs, Val.Int(v)) if (v & 31) == 0 =>
+          case (lhs, nir.Val.Int(v)) if (v & 31) == 0 =>
             lhs
-          case (lhs, Val.Long(v)) if (v & 63) == 0 =>
+          case (lhs, nir.Val.Long(v)) if (v & 63) == 0 =>
             lhs
 
           // 0 >>> x ==> 0
@@ -228,19 +227,19 @@ trait Combine { self: Interflow =>
             zero(ty)
 
           // (x >>> a) >>> b ==> x >>> (a + b)
-          case (BinRef(Lshr, x, Val.Int(a)), Val.Int(b)) =>
+          case (BinRef(Lshr, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
             val dist = (a & 31) + (b & 31)
             if (dist >= 32) {
-              Val.Int(0)
+              nir.Val.Int(0)
             } else {
-              combine(Lshr, ty, x, Val.Int(dist))
+              combine(Lshr, ty, x, nir.Val.Int(dist))
             }
-          case (BinRef(Lshr, x, Val.Long(a)), Val.Long(b)) =>
+          case (BinRef(Lshr, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
             val dist = (a & 63) + (b & 63)
             if (dist >= 64) {
-              Val.Int(0)
+              nir.Val.Int(0)
             } else {
-              combine(Lshr, ty, x, Val.Long(dist))
+              combine(Lshr, ty, x, nir.Val.Long(dist))
             }
 
           case _ =>
@@ -250,9 +249,9 @@ trait Combine { self: Interflow =>
       case Ashr =>
         (l, r) match {
           // x >> v ==> x if v & bitsize(x) - 1 == 0
-          case (lhs, Val.Int(a)) if (a & 31) == 0 =>
+          case (lhs, nir.Val.Int(a)) if (a & 31) == 0 =>
             lhs
-          case (lhs, Val.Long(v)) if (v & 63) == 0 =>
+          case (lhs, nir.Val.Long(v)) if (v & 63) == 0 =>
             lhs
 
           // 0 >> x ==> 0
@@ -264,12 +263,12 @@ trait Combine { self: Interflow =>
             minusOne(ty)
 
           // (x >> a) >> b ==> x >> (a + b)
-          case (BinRef(Ashr, x, Val.Int(a)), Val.Int(b)) =>
+          case (BinRef(Ashr, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
             val dist = Math.min((a & 31) + (b & 31), 31)
-            combine(Ashr, ty, x, Val.Int(dist))
-          case (BinRef(Ashr, x, Val.Long(a)), Val.Long(b)) =>
+            combine(Ashr, ty, x, nir.Val.Int(dist))
+          case (BinRef(Ashr, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
             val dist = Math.min((a & 63) + (b & 63), 63)
-            combine(Ashr, ty, x, Val.Long(dist))
+            combine(Ashr, ty, x, nir.Val.Long(dist))
 
           case _ =>
             fallback
@@ -290,10 +289,10 @@ trait Combine { self: Interflow =>
             lhs
 
           // (x & a) & b ==> x & (a & b)
-          case (BinRef(Iand, x, Val.Int(a)), Val.Int(b)) =>
-            combine(Iand, ty, x, Val.Int(a & b))
-          case (BinRef(Iand, x, Val.Long(a)), Val.Long(b)) =>
-            combine(Iand, ty, x, Val.Long(a & b))
+          case (BinRef(Iand, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
+            combine(Iand, ty, x, nir.Val.Int(a & b))
+          case (BinRef(Iand, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
+            combine(Iand, ty, x, nir.Val.Long(a & b))
 
           // (x >= y) & (x <= y) ==> (x == y)
           case (CompRef(Sge, ty1, x1, y1), CompRef(Sle, _, x2, y2))
@@ -322,10 +321,10 @@ trait Combine { self: Interflow =>
             minusOne(ty)
 
           // (x or a) or b ==> x or (a or b)
-          case (BinRef(Or, x, Val.Int(a)), Val.Int(b)) =>
-            combine(Or, ty, x, Val.Int(a | b))
-          case (BinRef(Or, x, Val.Long(a)), Val.Long(b)) =>
-            combine(Or, ty, x, Val.Long(a | b))
+          case (BinRef(Or, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
+            combine(Or, ty, x, nir.Val.Int(a | b))
+          case (BinRef(Or, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
+            combine(Or, ty, x, nir.Val.Long(a | b))
 
           // (x > y) | (x == y) ==> (x >= y)
           case (CompRef(Sgt, ty1, x1, y1), CompRef(Ieq, _, x2, y2))
@@ -374,10 +373,10 @@ trait Combine { self: Interflow =>
             lhs
 
           // (x ^ a) ^ b ==> x ^ (a ^ b)
-          case (BinRef(Xor, x, Val.Int(a)), Val.Int(b)) =>
-            combine(Xor, ty, x, Val.Int(a ^ b))
-          case (BinRef(Xor, x, Val.Long(a)), Val.Long(b)) =>
-            combine(Xor, ty, x, Val.Long(a ^ b))
+          case (BinRef(Xor, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
+            combine(Xor, ty, x, nir.Val.Int(a ^ b))
+          case (BinRef(Xor, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
+            combine(Xor, ty, x, nir.Val.Long(a ^ b))
 
           case _ =>
             fallback
@@ -388,22 +387,22 @@ trait Combine { self: Interflow =>
     }
   }
 
-  def combine(comp: Comp, ty: Type, l: Val, r: Val)(implicit
+  def combine(comp: nir.Comp, ty: nir.Type, l: nir.Val, r: nir.Val)(implicit
       state: State,
-      srcPosition: Position,
-      scopeId: ScopeId
-  ): Val = {
+      srcPosition: nir.Position,
+      scopeId: nir.ScopeId
+  ): nir.Val = {
     import state.{materialize, delay, emit}
 
     (comp, l, r) match {
       // Two virtual allocations will compare equal if
       // and only if they have the same virtual address.
-      case (Ieq, Val.Virtual(l), Val.Virtual(r))
+      case (Ieq, nir.Val.Virtual(l), nir.Val.Virtual(r))
           if state.isVirtual(l) && state.isVirtual(r) =>
-        Val.Bool(l == r)
-      case (Ine, Val.Virtual(l), Val.Virtual(r))
+        nir.Val.Bool(l == r)
+      case (Ine, nir.Val.Virtual(l), nir.Val.Virtual(r))
           if state.isVirtual(l) && state.isVirtual(r) =>
-        Val.Bool(l != r)
+        nir.Val.Bool(l != r)
 
       // Not-yet-materialized virtual allocation will never be
       // the same as already existing allocation (be it null
@@ -413,83 +412,83 @@ trait Combine { self: Interflow =>
       // they may be interned and the virtual allocation may
       // alias pre-existing materialized allocation.
       case (Ieq, VirtualRef(ClassKind | ArrayKind, _, _), r) =>
-        Val.False
+        nir.Val.False
       case (Ieq, l, VirtualRef(ClassKind | ArrayKind, _, _)) =>
-        Val.False
+        nir.Val.False
       case (Ine, VirtualRef(ClassKind | ArrayKind, _, _), r) =>
-        Val.True
+        nir.Val.True
       case (Ine, l, VirtualRef(ClassKind | ArrayKind, _, _)) =>
-        Val.True
+        nir.Val.True
 
       // Comparing non-nullable value with null will always
       // yield the same result.
-      case (Ieq, v @ Of(ty: Type.RefKind), Val.Null) if !ty.isNullable =>
-        Val.False
-      case (Ieq, Val.Null, v @ Of(ty: Type.RefKind)) if !ty.isNullable =>
-        Val.False
-      case (Ine, v @ Of(ty: Type.RefKind), Val.Null) if !ty.isNullable =>
-        Val.True
-      case (Ine, Val.Null, v @ Of(ty: Type.RefKind)) if !ty.isNullable =>
-        Val.True
+      case (Ieq, v @ nir.Of(ty: nir.Type.RefKind), nir.Val.Null) if !ty.isNullable =>
+        nir.Val.False
+      case (Ieq, nir.Val.Null, v @ nir.Of(ty: nir.Type.RefKind)) if !ty.isNullable =>
+        nir.Val.False
+      case (Ine, v @ nir.Of(ty: nir.Type.RefKind), nir.Val.Null) if !ty.isNullable =>
+        nir.Val.True
+      case (Ine, nir.Val.Null, v @ nir.Of(ty: nir.Type.RefKind)) if !ty.isNullable =>
+        nir.Val.True
 
       // Ptr boxes are null if underlying pointer is null.
-      case (Ieq, DelayedRef(Op.Box(ty, x)), Val.Null) if Type.isPtrBox(ty) =>
-        combine(Ieq, Type.Ptr, x, Val.Null)
-      case (Ieq, Val.Null, DelayedRef(Op.Box(ty, x))) if Type.isPtrBox(ty) =>
-        combine(Ieq, Type.Ptr, x, Val.Null)
-      case (Ine, DelayedRef(Op.Box(ty, x)), Val.Null) if Type.isPtrBox(ty) =>
-        combine(Ine, Type.Ptr, x, Val.Null)
-      case (Ine, Val.Null, DelayedRef(Op.Box(ty, x))) if Type.isPtrBox(ty) =>
-        combine(Ine, Type.Ptr, x, Val.Null)
+      case (Ieq, DelayedRef(nir.Op.Box(ty, x)), nir.Val.Null) if nir.Type.isPtrBox(ty) =>
+        combine(Ieq, nir.Type.Ptr, x, nir.Val.Null)
+      case (Ieq, nir.Val.Null, DelayedRef(nir.Op.Box(ty, x))) if nir.Type.isPtrBox(ty) =>
+        combine(Ieq, nir.Type.Ptr, x, nir.Val.Null)
+      case (Ine, DelayedRef(nir.Op.Box(ty, x)), nir.Val.Null) if nir.Type.isPtrBox(ty) =>
+        combine(Ine, nir.Type.Ptr, x, nir.Val.Null)
+      case (Ine, nir.Val.Null, DelayedRef(nir.Op.Box(ty, x))) if nir.Type.isPtrBox(ty) =>
+        combine(Ine, nir.Type.Ptr, x, nir.Val.Null)
 
       // Comparing two non-null module references will
       // yield true only if it's the same module.
       case (
             Ieq,
-            l @ Of(And(lty: Type.RefKind, ClassRef(lcls))),
-            r @ Of(And(rty: Type.RefKind, ClassRef(rcls)))
+            l @ nir.Of(And(lty: nir.Type.RefKind, ClassRef(lcls))),
+            r @ nir.Of(And(rty: nir.Type.RefKind, ClassRef(rcls)))
           )
           if !lty.isNullable && lty.isExact && lcls.isModule
             && !rty.isNullable && rty.isExact && rcls.isModule =>
-        Val.Bool(lcls.name == rcls.name)
+        nir.Val.Bool(lcls.name == rcls.name)
       case (
             Ine,
-            l @ Of(And(lty: Type.RefKind, ClassRef(lcls))),
-            r @ Of(And(rty: Type.RefKind, ClassRef(rcls)))
+            l @ nir.Of(And(lty: nir.Type.RefKind, ClassRef(lcls))),
+            r @ nir.Of(And(rty: nir.Type.RefKind, ClassRef(rcls)))
           )
           if !lty.isNullable && lty.isExact && lcls.isModule
             && !rty.isNullable && rty.isExact && rcls.isModule =>
-        Val.Bool(lcls.name != rcls.name)
+        nir.Val.Bool(lcls.name != rcls.name)
 
       // Comparisons against the same SSA value or
       // against true/false are statically known.
       case (Ieq, lhs, rhs) if (lhs == rhs) =>
-        Val.True
-      case (Ieq, lhs, Val.True) =>
+        nir.Val.True
+      case (Ieq, lhs, nir.Val.True) =>
         lhs
       case (Ine, lhs, rhs) if (lhs == rhs) =>
-        Val.False
-      case (Ine, lhs, Val.False) =>
+        nir.Val.False
+      case (Ine, lhs, nir.Val.False) =>
         lhs
 
       // Integer comparisons against corresponding
       // min/max value are often statically known.
       case (Ugt, lhs, v) if v.isUnsignedMaxValue =>
-        Val.False
+        nir.Val.False
       case (Uge, lhs, v) if v.isUnsignedMinValue =>
-        Val.True
+        nir.Val.True
       case (Ult, lhs, v) if v.isUnsignedMinValue =>
-        Val.False
+        nir.Val.False
       case (Ule, lhs, v) if v.isUnsignedMaxValue =>
-        Val.True
+        nir.Val.True
       case (Sgt, lhs, v) if v.isSignedMaxValue(platform.is32Bit) =>
-        Val.False
+        nir.Val.False
       case (Sge, lhs, v) if v.isSignedMinValue(platform.is32Bit) =>
-        Val.True
+        nir.Val.True
       case (Slt, lhs, v) if v.isSignedMinValue(platform.is32Bit) =>
-        Val.False
+        nir.Val.False
       case (Sle, lhs, v) if v.isSignedMaxValue(platform.is32Bit) =>
-        Val.True
+        nir.Val.True
 
       // ((x xor y) == 0) ==> (x == y)
       case (Ieq, BinRef(Xor, x, y), v) if v.isZero =>
@@ -500,104 +499,104 @@ trait Combine { self: Interflow =>
         combine(Ine, ty, x, y)
 
       // ((x + a) == b) ==> (x == (b - a))
-      case (Ieq, BinRef(Iadd, x, Val.Char(a)), Val.Char(b)) =>
-        combine(Ieq, ty, x, Val.Char((b - a).toChar))
-      case (Ieq, BinRef(Iadd, x, Val.Byte(a)), Val.Byte(b)) =>
-        combine(Ieq, ty, x, Val.Byte((b - a).toByte))
-      case (Ieq, BinRef(Iadd, x, Val.Short(a)), Val.Short(b)) =>
-        combine(Ieq, ty, x, Val.Short((b - a).toShort))
-      case (Ieq, BinRef(Iadd, x, Val.Int(a)), Val.Int(b)) =>
-        combine(Ieq, ty, x, Val.Int(b - a))
-      case (Ieq, BinRef(Iadd, x, Val.Long(a)), Val.Long(b)) =>
-        combine(Ieq, ty, x, Val.Long(b - a))
+      case (Ieq, BinRef(Iadd, x, nir.Val.Char(a)), nir.Val.Char(b)) =>
+        combine(Ieq, ty, x, nir.Val.Char((b - a).toChar))
+      case (Ieq, BinRef(Iadd, x, nir.Val.Byte(a)), nir.Val.Byte(b)) =>
+        combine(Ieq, ty, x, nir.Val.Byte((b - a).toByte))
+      case (Ieq, BinRef(Iadd, x, nir.Val.Short(a)), nir.Val.Short(b)) =>
+        combine(Ieq, ty, x, nir.Val.Short((b - a).toShort))
+      case (Ieq, BinRef(Iadd, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
+        combine(Ieq, ty, x, nir.Val.Int(b - a))
+      case (Ieq, BinRef(Iadd, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
+        combine(Ieq, ty, x, nir.Val.Long(b - a))
 
       // ((x - a) == b) ==> (x == (a + b))
-      case (Ieq, BinRef(Isub, x, Val.Char(a)), Val.Char(b)) =>
-        combine(Ieq, ty, x, Val.Char((a + b).toChar))
-      case (Ieq, BinRef(Isub, x, Val.Byte(a)), Val.Byte(b)) =>
-        combine(Ieq, ty, x, Val.Byte((a + b).toByte))
-      case (Ieq, BinRef(Isub, x, Val.Short(a)), Val.Short(b)) =>
-        combine(Ieq, ty, x, Val.Short((a + b).toShort))
-      case (Ieq, BinRef(Isub, x, Val.Int(a)), Val.Int(b)) =>
-        combine(Ieq, ty, x, Val.Int(a + b))
-      case (Ieq, BinRef(Isub, x, Val.Long(a)), Val.Long(b)) =>
-        combine(Ieq, ty, x, Val.Long(a + b))
+      case (Ieq, BinRef(Isub, x, nir.Val.Char(a)), nir.Val.Char(b)) =>
+        combine(Ieq, ty, x, nir.Val.Char((a + b).toChar))
+      case (Ieq, BinRef(Isub, x, nir.Val.Byte(a)), nir.Val.Byte(b)) =>
+        combine(Ieq, ty, x, nir.Val.Byte((a + b).toByte))
+      case (Ieq, BinRef(Isub, x, nir.Val.Short(a)), nir.Val.Short(b)) =>
+        combine(Ieq, ty, x, nir.Val.Short((a + b).toShort))
+      case (Ieq, BinRef(Isub, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
+        combine(Ieq, ty, x, nir.Val.Int(a + b))
+      case (Ieq, BinRef(Isub, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
+        combine(Ieq, ty, x, nir.Val.Long(a + b))
 
       // ((a - x) == b) ==> (x == (a - b))
-      case (Ieq, BinRef(Isub, Val.Char(a), x), Val.Char(b)) =>
-        combine(Ieq, ty, x, Val.Char((a - b).toChar))
-      case (Ieq, BinRef(Isub, Val.Byte(a), x), Val.Byte(b)) =>
-        combine(Ieq, ty, x, Val.Byte((a - b).toByte))
-      case (Ieq, BinRef(Isub, Val.Short(a), x), Val.Short(b)) =>
-        combine(Ieq, ty, x, Val.Short((a - b).toShort))
-      case (Ieq, BinRef(Isub, Val.Int(a), x), Val.Int(b)) =>
-        combine(Ieq, ty, x, Val.Int(a - b))
-      case (Ieq, BinRef(Isub, Val.Long(a), x), Val.Long(b)) =>
-        combine(Ieq, ty, x, Val.Long(a - b))
+      case (Ieq, BinRef(Isub, nir.Val.Char(a), x), nir.Val.Char(b)) =>
+        combine(Ieq, ty, x, nir.Val.Char((a - b).toChar))
+      case (Ieq, BinRef(Isub, nir.Val.Byte(a), x), nir.Val.Byte(b)) =>
+        combine(Ieq, ty, x, nir.Val.Byte((a - b).toByte))
+      case (Ieq, BinRef(Isub, nir.Val.Short(a), x), nir.Val.Short(b)) =>
+        combine(Ieq, ty, x, nir.Val.Short((a - b).toShort))
+      case (Ieq, BinRef(Isub, nir.Val.Int(a), x), nir.Val.Int(b)) =>
+        combine(Ieq, ty, x, nir.Val.Int(a - b))
+      case (Ieq, BinRef(Isub, nir.Val.Long(a), x), nir.Val.Long(b)) =>
+        combine(Ieq, ty, x, nir.Val.Long(a - b))
 
       // ((x xor a) == b) ==> (x == (a xor b))
-      case (Ieq, BinRef(Xor, x, Val.Char(a)), Val.Char(b)) =>
-        combine(Ieq, ty, x, Val.Char((a ^ b).toChar))
-      case (Ieq, BinRef(Xor, x, Val.Byte(a)), Val.Byte(b)) =>
-        combine(Ieq, ty, x, Val.Byte((a ^ b).toByte))
-      case (Ieq, BinRef(Xor, x, Val.Short(a)), Val.Short(b)) =>
-        combine(Ieq, ty, x, Val.Short((a ^ b).toShort))
-      case (Ieq, BinRef(Xor, x, Val.Int(a)), Val.Int(b)) =>
-        combine(Ieq, ty, x, Val.Int(a ^ b))
-      case (Ieq, BinRef(Xor, x, Val.Long(a)), Val.Long(b)) =>
-        combine(Ieq, ty, x, Val.Long(a ^ b))
+      case (Ieq, BinRef(Xor, x, nir.Val.Char(a)), nir.Val.Char(b)) =>
+        combine(Ieq, ty, x, nir.Val.Char((a ^ b).toChar))
+      case (Ieq, BinRef(Xor, x, nir.Val.Byte(a)), nir.Val.Byte(b)) =>
+        combine(Ieq, ty, x, nir.Val.Byte((a ^ b).toByte))
+      case (Ieq, BinRef(Xor, x, nir.Val.Short(a)), nir.Val.Short(b)) =>
+        combine(Ieq, ty, x, nir.Val.Short((a ^ b).toShort))
+      case (Ieq, BinRef(Xor, x, nir.Val.Int(a)), nir.Val.Int(b)) =>
+        combine(Ieq, ty, x, nir.Val.Int(a ^ b))
+      case (Ieq, BinRef(Xor, x, nir.Val.Long(a)), nir.Val.Long(b)) =>
+        combine(Ieq, ty, x, nir.Val.Long(a ^ b))
 
       // ((x xor true) == y) ==> (x != y)
-      case (Ieq, BinRef(Xor, x, Val.True), y) =>
+      case (Ieq, BinRef(Xor, x, nir.Val.True), y) =>
         combine(Ine, ty, x, y)
 
       // (x == (y xor true)) ==> (x != y)
-      case (Ieq, x, BinRef(Xor, y, Val.True)) =>
+      case (Ieq, x, BinRef(Xor, y, nir.Val.True)) =>
         combine(Ine, ty, x, y)
 
       case (_, l, r) =>
-        delay(Op.Comp(comp, ty, r, l))
+        delay(nir.Op.Comp(comp, ty, r, l))
     }
   }
 
-  def combine(conv: Conv, ty: Type, value: Val)(implicit
+  def combine(conv: nir.Conv, ty: nir.Type, value: nir.Val)(implicit
       state: State,
-      srcPosition: Position,
-      scopeId: ScopeId
-  ): Val = {
+      srcPosition: nir.Position,
+      scopeId: nir.ScopeId
+  ): nir.Val = {
     import state.{materialize, delay, emit}
 
     (conv, ty, value) match {
       // trunc[iN] (trunc[iM] x) ==> trunc[iN] x if N < M
       case (
             Trunc,
-            Type.FixedSizeI(n, _),
-            ConvRef(Trunc, Type.FixedSizeI(m, _), x)
+            nir.Type.FixedSizeI(n, _),
+            ConvRef(Trunc, nir.Type.FixedSizeI(m, _), x)
           ) if n < m =>
         combine(Trunc, ty, x)
 
       // sext[iN] (sext[iM] x) ==> sext[iN] x if N > M
       case (
             Sext,
-            Type.FixedSizeI(n, _),
-            ConvRef(Sext, Type.FixedSizeI(m, _), x)
+            nir.Type.FixedSizeI(n, _),
+            ConvRef(Sext, nir.Type.FixedSizeI(m, _), x)
           ) if n > m =>
         combine(Sext, ty, x)
 
       // zext[iN] (zext[iM] x) ==> zext[iN] x if N > M
       case (
             Zext,
-            Type.FixedSizeI(n, _),
-            ConvRef(Zext, Type.FixedSizeI(m, _), x)
+            nir.Type.FixedSizeI(n, _),
+            ConvRef(Zext, nir.Type.FixedSizeI(m, _), x)
           ) if n > m =>
         combine(Zext, ty, x)
 
       // ptrtoint[long] (inttoptr[long] x) ==> x
-      case (Ptrtoint, Type.Long, ConvRef(Inttoptr, Type.Long, x)) =>
+      case (Ptrtoint, nir.Type.Long, ConvRef(Inttoptr, nir.Type.Long, x)) =>
         x
 
       // inttoptr[long] (ptrtoint[long] x) ==> x
-      case (Inttoptr, Type.Long, ConvRef(Ptrtoint, Type.Long, x)) =>
+      case (Inttoptr, nir.Type.Long, ConvRef(Ptrtoint, nir.Type.Long, x)) =>
         x
 
       // bitcast[ty1] (bitcast[ty2] x) ==> bitcast[ty1] x
@@ -609,21 +608,28 @@ trait Combine { self: Interflow =>
         x
 
       case _ =>
-        delay(Op.Conv(conv, ty, value))
+        delay(nir.Op.Conv(conv, ty, value))
     }
   }
 
-  private def zero(ty: Type): Val =
-    Val.Zero(ty).canonicalize
+  private def zero(ty: nir.Type): nir.Val =
+    nir.Val.Zero(ty).canonicalize
 
-  private def minusOne(ty: Type): Val = ty match {
-    case Type.Byte   => Val.Byte(-1)
-    case Type.Short  => Val.Short(-1)
-    case Type.Int    => Val.Int(-1)
-    case Type.Long   => Val.Long(-1)
-    case Type.Float  => Val.Float(-1)
-    case Type.Double => Val.Double(-1)
-    case _           => unreachable
+  private def minusOne(ty: nir.Type): nir.Val = ty match {
+    case nir.Type.Byte =>
+      nir.Val.Byte(-1)
+    case nir.Type.Short =>
+      nir.Val.Short(-1)
+    case nir.Type.Int =>
+      nir.Val.Int(-1)
+    case nir.Type.Long =>
+      nir.Val.Long(-1)
+    case nir.Type.Float =>
+      nir.Val.Float(-1)
+    case nir.Type.Double =>
+      nir.Val.Double(-1)
+    case _ =>
+      unreachable
   }
 
   private def isPowerOfTwoOrMinValue(x: Int): Boolean =
@@ -631,4 +637,5 @@ trait Combine { self: Interflow =>
 
   private def isPowerOfTwoOrMinValue(x: Long): Boolean =
     (x & (x - 1)) == 0
+
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -107,8 +107,10 @@ trait Eval { self: Interflow =>
             case value if value.isCanonical =>
               val next = cases
                 .collectFirst {
-                  case nir.Next.Case(caseValue, nir.Next.Label(caseTarget, caseArgs))
-                      if caseValue == value =>
+                  case nir.Next.Case(
+                        caseValue,
+                        nir.Next.Label(caseTarget, caseArgs)
+                      ) if caseValue == value =>
                     val evalArgs = caseArgs.map(eval)
                     val next = nir.Next.Label(caseTarget, evalArgs)
                     next
@@ -162,7 +164,9 @@ trait Eval { self: Interflow =>
           val (dsig, dtarget) = emeth match {
             case nir.Val.Global(name: nir.Global.Member, _) =>
               visitDuplicate(name, argtys)
-                .map { defn => (defn.ty, nir.Val.Global(defn.name, nir.Type.Ptr)) }
+                .map { defn =>
+                  (defn.ty, nir.Val.Global(defn.name, nir.Type.Ptr))
+                }
                 .getOrElse {
                   visitRoot(name)
                   (sig, emeth)
@@ -351,7 +355,7 @@ trait Eval { self: Interflow =>
       case nir.Op.As(ty, rawObj) =>
         val refty = ty match {
           case ty: nir.Type.RefKind => ty
-          case _                => bailOut
+          case _                    => bailOut
         }
         val obj = eval(rawObj)
         def fallback =
@@ -373,7 +377,7 @@ trait Eval { self: Interflow =>
       case nir.Op.Is(ty, rawObj) =>
         val refty = ty match {
           case ty: nir.Type.RefKind => ty
-          case _                => bailOut
+          case _                    => bailOut
         }
         val obj = eval(rawObj)
         def fallback =
@@ -517,39 +521,39 @@ trait Eval { self: Interflow =>
     bin match {
       case nir.Bin.Iadd =>
         (l, r) match {
-          case (nir.Val.Int(l), nir.Val.Int(r)) => nir.Val.Int(l + r)
+          case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l + r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l + r)
-          case _ => bailOut
+          case _                                  => bailOut
         }
       case nir.Bin.Fadd =>
         (l, r) match {
-          case (nir.Val.Float(l), nir.Val.Float(r)) => nir.Val.Float(l + r)
+          case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Float(l + r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Double(l + r)
-          case _ => bailOut
+          case _                                      => bailOut
         }
       case nir.Bin.Isub =>
         (l, r) match {
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l - r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l - r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Bin.Fsub =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Float(l - r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Double(l - r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Bin.Imul =>
         (l, r) match {
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l * r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l * r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Bin.Fmul =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Float(l * r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Double(l * r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Bin.Sdiv =>
         (l, r) match {
@@ -589,7 +593,7 @@ trait Eval { self: Interflow =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Float(l / r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Double(l / r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Bin.Srem =>
         (l, r) match {
@@ -629,51 +633,53 @@ trait Eval { self: Interflow =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Float(l % r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Double(l % r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Bin.Shl =>
         (l, r) match {
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l << r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l << r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Bin.Lshr =>
         (l, r) match {
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l >>> r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l >>> r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Bin.Ashr =>
         (l, r) match {
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l >> r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l >> r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Bin.And =>
         (l, r) match {
           case (nir.Val.Bool(l), nir.Val.Bool(r)) => nir.Val.Bool(l & r)
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l & r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l & r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Bin.Or =>
         (l, r) match {
           case (nir.Val.Bool(l), nir.Val.Bool(r)) => nir.Val.Bool(l | r)
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l | r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l | r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Bin.Xor =>
         (l, r) match {
           case (nir.Val.Bool(l), nir.Val.Bool(r)) => nir.Val.Bool(l ^ r)
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Int(l ^ r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Long(l ^ r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
     }
   }
 
-  def eval(comp: nir.Comp, ty: nir.Type, l: nir.Val, r: nir.Val)(implicit state: State): nir.Val = {
+  def eval(comp: nir.Comp, ty: nir.Type, l: nir.Val, r: nir.Val)(implicit
+      state: State
+  ): nir.Val = {
     def bailOut =
       throw BailOut(
         s"can't eval comp op: $comp[${ty.show}] ${l.show}, ${r.show}"
@@ -681,25 +687,35 @@ trait Eval { self: Interflow =>
     comp match {
       case nir.Comp.Ieq =>
         (l, r) match {
-          case (nir.Val.Bool(l), nir.Val.Bool(r))           => nir.Val.Bool(l == r)
-          case (nir.Val.Int(l), nir.Val.Int(r))             => nir.Val.Bool(l == r)
-          case (nir.Val.Long(l), nir.Val.Long(r))           => nir.Val.Bool(l == r)
-          case (nir.Val.Size(l), nir.Val.Size(r))           => nir.Val.Bool(l == r)
-          case (nir.Val.Null, nir.Val.Null)                 => nir.Val.True
-          case (nir.Val.Global(l, _), nir.Val.Global(r, _)) => nir.Val.Bool(l == r)
-          case (nir.Val.Null | _: nir.Val.Global, nir.Val.Null | _: nir.Val.Global) => nir.Val.False
-          case _                                                    => bailOut
+          case (nir.Val.Bool(l), nir.Val.Bool(r)) => nir.Val.Bool(l == r)
+          case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Bool(l == r)
+          case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Bool(l == r)
+          case (nir.Val.Size(l), nir.Val.Size(r)) => nir.Val.Bool(l == r)
+          case (nir.Val.Null, nir.Val.Null)       => nir.Val.True
+          case (nir.Val.Global(l, _), nir.Val.Global(r, _)) =>
+            nir.Val.Bool(l == r)
+          case (
+                nir.Val.Null | _: nir.Val.Global,
+                nir.Val.Null | _: nir.Val.Global
+              ) =>
+            nir.Val.False
+          case _ => bailOut
         }
       case nir.Comp.Ine =>
         (l, r) match {
-          case (nir.Val.Bool(l), nir.Val.Bool(r))           => nir.Val.Bool(l != r)
-          case (nir.Val.Int(l), nir.Val.Int(r))             => nir.Val.Bool(l != r)
-          case (nir.Val.Long(l), nir.Val.Long(r))           => nir.Val.Bool(l != r)
-          case (nir.Val.Size(l), nir.Val.Size(r))           => nir.Val.Bool(l != r)
-          case (nir.Val.Null, nir.Val.Null)                 => nir.Val.False
-          case (nir.Val.Global(l, _), nir.Val.Global(r, _)) => nir.Val.Bool(l != r)
-          case (nir.Val.Null | _: nir.Val.Global, nir.Val.Null | _: nir.Val.Global) => nir.Val.True
-          case _                                                    => bailOut
+          case (nir.Val.Bool(l), nir.Val.Bool(r)) => nir.Val.Bool(l != r)
+          case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Bool(l != r)
+          case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Bool(l != r)
+          case (nir.Val.Size(l), nir.Val.Size(r)) => nir.Val.Bool(l != r)
+          case (nir.Val.Null, nir.Val.Null)       => nir.Val.False
+          case (nir.Val.Global(l, _), nir.Val.Global(r, _)) =>
+            nir.Val.Bool(l != r)
+          case (
+                nir.Val.Null | _: nir.Val.Global,
+                nir.Val.Null | _: nir.Val.Global
+              ) =>
+            nir.Val.True
+          case _ => bailOut
         }
       case nir.Comp.Ugt =>
         (l, r) match {
@@ -750,69 +766,71 @@ trait Eval { self: Interflow =>
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Bool(l > r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Bool(l > r)
           case (nir.Val.Size(l), nir.Val.Size(r)) => nir.Val.Bool(l > r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Comp.Sge =>
         (l, r) match {
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Bool(l >= r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Bool(l >= r)
           case (nir.Val.Size(l), nir.Val.Size(r)) => nir.Val.Bool(l >= r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Comp.Slt =>
         (l, r) match {
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Bool(l < r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Bool(l < r)
           case (nir.Val.Size(l), nir.Val.Size(r)) => nir.Val.Bool(l < r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Comp.Sle =>
         (l, r) match {
           case (nir.Val.Int(l), nir.Val.Int(r))   => nir.Val.Bool(l <= r)
           case (nir.Val.Long(l), nir.Val.Long(r)) => nir.Val.Bool(l <= r)
           case (nir.Val.Size(l), nir.Val.Size(r)) => nir.Val.Bool(l <= r)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Comp.Feq =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Bool(l == r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Bool(l == r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Comp.Fne =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Bool(l != r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Bool(l != r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Comp.Fgt =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Bool(l > r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Bool(l > r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Comp.Fge =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Bool(l >= r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Bool(l >= r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Comp.Flt =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Bool(l < r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Bool(l < r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
       case nir.Comp.Fle =>
         (l, r) match {
           case (nir.Val.Float(l), nir.Val.Float(r))   => nir.Val.Bool(l <= r)
           case (nir.Val.Double(l), nir.Val.Double(r)) => nir.Val.Bool(l <= r)
-          case _                              => bailOut
+          case _                                      => bailOut
         }
     }
   }
 
-  def eval(conv: nir.Conv, ty: nir.Type, value: nir.Val)(implicit state: State): nir.Val = {
+  def eval(conv: nir.Conv, ty: nir.Type, value: nir.Val)(implicit
+      state: State
+  ): nir.Val = {
     def bailOut =
       throw BailOut(s"can't eval conv op: $conv[${ty.show}] ${value.show}")
     conv match {
@@ -847,9 +865,10 @@ trait Eval { self: Interflow =>
           case (nir.Val.Long(v), nir.Type.Char)  => nir.Val.Char(v.toChar)
           case (nir.Val.Size(v), nir.Type.Byte)  => nir.Val.Byte(v.toByte)
           case (nir.Val.Size(v), nir.Type.Short) => nir.Val.Short(v.toShort)
-          case (nir.Val.Size(v), nir.Type.Int) if !platform.is32Bit => nir.Val.Int(v.toInt)
+          case (nir.Val.Size(v), nir.Type.Int) if !platform.is32Bit =>
+            nir.Val.Int(v.toInt)
           case (nir.Val.Size(v), nir.Type.Char) => nir.Val.Char(v.toChar)
-          case _                        => bailOut
+          case _                                => bailOut
         }
       case nir.Conv.Zext =>
         (value, ty) match {
@@ -888,18 +907,18 @@ trait Eval { self: Interflow =>
       case nir.Conv.Fptrunc =>
         (value, ty) match {
           case (nir.Val.Double(v), nir.Type.Float) => nir.Val.Float(v.toFloat)
-          case _                           => bailOut
+          case _                                   => bailOut
         }
       case nir.Conv.Fpext =>
         (value, ty) match {
           case (nir.Val.Float(v), nir.Type.Double) => nir.Val.Double(v.toDouble)
-          case _                           => bailOut
+          case _                                   => bailOut
         }
       case nir.Conv.Fptoui =>
         (value, ty) match {
           case (nir.Val.Float(v), nir.Type.Char)  => nir.Val.Char(v.toChar)
           case (nir.Val.Double(v), nir.Type.Char) => nir.Val.Char(v.toChar)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Conv.Fptosi =>
         (value, ty) match {
@@ -907,13 +926,15 @@ trait Eval { self: Interflow =>
           case (nir.Val.Double(v), nir.Type.Int)  => nir.Val.Int(v.toInt)
           case (nir.Val.Float(v), nir.Type.Long)  => nir.Val.Long(v.toLong)
           case (nir.Val.Double(v), nir.Type.Long) => nir.Val.Long(v.toLong)
-          case _                          => bailOut
+          case _                                  => bailOut
         }
       case nir.Conv.Uitofp =>
         (value, ty) match {
-          case (nir.Val.Char(v), nir.Type.Float)  => nir.Val.Float(v.toInt.toFloat)
-          case (nir.Val.Char(v), nir.Type.Double) => nir.Val.Double(v.toInt.toFloat)
-          case _                          => bailOut
+          case (nir.Val.Char(v), nir.Type.Float) =>
+            nir.Val.Float(v.toInt.toFloat)
+          case (nir.Val.Char(v), nir.Type.Double) =>
+            nir.Val.Double(v.toInt.toFloat)
+          case _ => bailOut
         }
       case nir.Conv.Sitofp =>
         (value, ty) match {
@@ -927,21 +948,21 @@ trait Eval { self: Interflow =>
           case (nir.Val.Long(v), nir.Type.Double)  => nir.Val.Double(v.toDouble)
           case (nir.Val.Size(v), nir.Type.Float)   => nir.Val.Float(v.toFloat)
           case (nir.Val.Size(v), nir.Type.Double)  => nir.Val.Double(v.toDouble)
-          case _                           => bailOut
+          case _                                   => bailOut
         }
       case nir.Conv.Ptrtoint =>
         (value, ty) match {
           case (nir.Val.Null, nir.Type.Long) => nir.Val.Long(0L)
           case (nir.Val.Null, nir.Type.Int)  => nir.Val.Int(0)
           case (nir.Val.Null, nir.Type.Size) => nir.Val.Size(0)
-          case _                     => bailOut
+          case _                             => bailOut
         }
       case nir.Conv.Inttoptr =>
         (value, ty) match {
           case (nir.Val.Long(0L), nir.Type.Ptr) => nir.Val.Null
           case (nir.Val.Int(0L), nir.Type.Ptr)  => nir.Val.Null
           case (nir.Val.Size(0L), nir.Type.Ptr) => nir.Val.Null
-          case _                        => bailOut
+          case _                                => bailOut
         }
       case nir.Conv.Bitcast =>
         (value, ty) match {
@@ -984,7 +1005,7 @@ trait Eval { self: Interflow =>
       case nir.Val.Local(local, _) if local.id >= 0 =>
         state.loadLocal(local) match {
           case value: nir.Val.Virtual => eval(value)
-          case value              => value
+          case value                  => value
         }
       case nir.Val.Virtual(addr) if state.hasEscaped(addr) =>
         state.derefEscaped(addr).escapedValue
@@ -1033,7 +1054,8 @@ trait Eval { self: Interflow =>
     }
 
     def isPureModuleCtor(defn: nir.Defn.Define): Boolean = {
-      val nir.Inst.Label(_, nir.Val.Local(self, _) +: _) = defn.insts.head: @unchecked
+      val nir.Inst.Label(_, nir.Val.Local(self, _) +: _) =
+        defn.insts.head: @unchecked
 
       val canStoreTo = mutable.Set(self)
       val arrayLength = mutable.Map.empty[nir.Local, Int]
@@ -1049,17 +1071,21 @@ trait Eval { self: Interflow =>
             case _ =>
               ()
           }
-        case nir.Inst.Let(n, _: nir.Op.Classalloc | _: nir.Op.Box | _: nir.Op.Module, _) =>
+        case nir.Inst.Let(
+              n,
+              _: nir.Op.Classalloc | _: nir.Op.Box | _: nir.Op.Module,
+              _
+            ) =>
           canStoreTo += n
         case _ =>
           ()
       }
 
       def canStoreValue(v: nir.Val): Boolean = v match {
-        case _ if v.isCanonical => true
+        case _ if v.isCanonical  => true
         case nir.Val.Local(n, _) => canStoreTo.contains(n)
-        case _: nir.Val.String => true
-        case _ => false
+        case _: nir.Val.String   => true
+        case _                   => false
       }
 
       defn.insts.forall {
@@ -1071,7 +1097,11 @@ trait Eval { self: Interflow =>
           true
         case nir.Inst.Let(_, op, _) if op.isPure =>
           true
-        case nir.Inst.Let(_, _: nir.Op.Classalloc | _: nir.Op.Arrayalloc | _: nir.Op.Box, _) =>
+        case nir.Inst.Let(
+              _,
+              _: nir.Op.Classalloc | _: nir.Op.Arrayalloc | _: nir.Op.Box,
+              _
+            ) =>
           true
         case inst @ nir.Inst.Let(_, nir.Op.Module(name), _) =>
           if (!visiting.contains(name)) {
@@ -1082,16 +1112,28 @@ trait Eval { self: Interflow =>
         case nir.Inst.Let(_, nir.Op.Fieldload(_, nir.Val.Local(to, _), _), _)
             if canStoreTo.contains(to) =>
           true
-        case inst @ nir.Inst.Let(_, nir.Op.Fieldstore(_, nir.Val.Local(to, _), _, value), _)
-            if canStoreTo.contains(to) =>
+        case inst @ nir.Inst.Let(
+              _,
+              nir.Op.Fieldstore(_, nir.Val.Local(to, _), _, value),
+              _
+            ) if canStoreTo.contains(to) =>
           canStoreValue(value)
-        case nir.Inst.Let(_, nir.Op.Arrayload(_, nir.Val.Local(to, _), nir.Val.Int(idx)), _)
+        case nir.Inst.Let(
+              _,
+              nir.Op.Arrayload(_, nir.Val.Local(to, _), nir.Val.Int(idx)),
+              _
+            )
             if canStoreTo.contains(to)
               && inBounds(arrayLength.getOrElse(to, -1), idx) =>
           true
         case nir.Inst.Let(
               _,
-              nir.Op.Arraystore(_, nir.Val.Local(to, _), nir.Val.Int(idx), value),
+              nir.Op.Arraystore(
+                _,
+                nir.Val.Local(to, _),
+                nir.Val.Int(idx),
+                value
+              ),
               _
             )
             if canStoreTo.contains(to)

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -1,7 +1,6 @@
 package scala.scalanative
 package interflow
 
-import scala.scalanative.nir._
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.linker._
 import scala.scalanative.util.unreachable
@@ -17,7 +16,7 @@ trait Inline { self: Interflow =>
   private val maxInlineDepth =
     config.compilerConfig.optimizerConfig.maxInlineDepth
 
-  def shallInline(name: Global.Member, args: Seq[Val])(implicit
+  def shallInline(name: nir.Global.Member, args: Seq[nir.Val])(implicit
       state: State,
       analysis: ReachabilityAnalysis.Result
   ): Boolean = {
@@ -33,7 +32,7 @@ trait Inline { self: Interflow =>
         false
       } { defn =>
         def isCtor = originalName(name) match {
-          case Global.Member(_, sig) if sig.isCtor =>
+          case nir.Global.Member(_, sig) if sig.isCtor =>
             true
           case _ =>
             false
@@ -43,15 +42,15 @@ trait Inline { self: Interflow =>
         val isExtern =
           defn.attrs.isExtern
         def hasVirtualArgs =
-          args.exists(_.isInstanceOf[Val.Virtual])
+          args.exists(_.isInstanceOf[nir.Val.Virtual])
         val noOpt =
-          defn.attrs.opt == Attr.NoOpt
+          defn.attrs.opt == nir.Attr.NoOpt
         val noInline =
-          defn.attrs.inlineHint == Attr.NoInline
+          defn.attrs.inlineHint == nir.Attr.NoInline
         val alwaysInline =
-          defn.attrs.inlineHint == Attr.AlwaysInline
+          defn.attrs.inlineHint == nir.Attr.AlwaysInline
         val hintInline =
-          defn.attrs.inlineHint == Attr.InlineHint
+          defn.attrs.inlineHint == nir.Attr.InlineHint
         def isRecursive =
           hasContext(s"inlining ${name.show}")
         def isDenylisted =
@@ -64,10 +63,14 @@ trait Inline { self: Interflow =>
           maxInlineDepth.exists(_ > state.inlineDepth)
 
         def hasUnwind = defn.insts.exists {
-          case Inst.Let(_, _, unwind)   => unwind ne Next.None
-          case Inst.Throw(_, unwind)    => unwind ne Next.None
-          case Inst.Unreachable(unwind) => unwind ne Next.None
-          case _                        => false
+          case nir.Inst.Let(_, _, unwind) =>
+            unwind ne nir.Next.None
+          case nir.Inst.Throw(_, unwind) =>
+            unwind ne nir.Next.None
+          case nir.Inst.Unreachable(unwind) =>
+            unwind ne nir.Next.None
+          case _ =>
+            false
         }
 
         val shall = mode match {
@@ -115,59 +118,59 @@ trait Inline { self: Interflow =>
       }
   }
 
-  def adapt(value: Val, ty: Type)(implicit
+  def adapt(value: nir.Val, ty: nir.Type)(implicit
       state: State,
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
-  ): Val = {
+  ): nir.Val = {
     val valuety = value match {
       case InstanceRef(ty) => ty
       case _               => value.ty
     }
     if (!Sub.is(valuety, ty)) {
-      combine(Conv.Bitcast, ty, value)
+      combine(nir.Conv.Bitcast, ty, value)
     } else {
       value
     }
   }
 
-  def adapt(args: Seq[Val], sig: Type.Function)(implicit
+  def adapt(args: Seq[nir.Val], sig: nir.Type.Function)(implicit
       state: State,
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
-  ): Seq[Val] = {
-    val Type.Function(argtys, _) = sig
+  ): Seq[nir.Val] = {
+    val nir.Type.Function(argtys, _) = sig
 
     // Varargs signature might appear to have less
     // argument types than arguments at the call site.
     val expected = argtys match {
-      case inittys :+ Type.Vararg =>
+      case inittys :+ nir.Type.Vararg =>
         val nonvarargs = args.take(inittys.size).zip(inittys)
-        val varargs = args.drop(inittys.size).map { arg => (arg, Type.Vararg) }
+        val varargs = args.drop(inittys.size).map { arg => (arg, nir.Type.Vararg) }
         nonvarargs ++ varargs
       case _ =>
         args.zip(argtys)
     }
 
     expected.map {
-      case (value, Type.Vararg) =>
+      case (value, nir.Type.Vararg) =>
         value
       case (value, argty) =>
         adapt(value, argty)
     }
   }
 
-  def `inline`(name: Global.Member, args: Seq[Val])(implicit
+  def `inline`(name: nir.Global.Member, args: Seq[nir.Val])(implicit
       state: State,
       analysis: ReachabilityAnalysis.Result,
-      parentScopeId: ScopeId
-  ): Val =
+      parentScopeId: nir.ScopeId
+  ): nir.Val =
     in(s"inlining ${name.show}") {
       val defn = mode match {
-        case build.Mode.Debug      => getOriginal(name)
+        case build.Mode.Debug => getOriginal(name)
         case _: build.Mode.Release => getDone(name)
       }
-      val Type.Function(_, origRetTy) = defn.ty
+      val nir.Type.Function(_, origRetTy) = defn.ty
 
       implicit val srcPosition: nir.Position = defn.pos
       val blocks = process(
@@ -184,7 +187,7 @@ trait Inline { self: Interflow =>
 
       def nothing = {
         emit.label(state.fresh(), Seq.empty)
-        Val.Zero(Type.Nothing)
+        nir.Val.Zero(nir.Type.Nothing)
       }
 
       val (res, endState) = blocks match {
@@ -193,15 +196,15 @@ trait Inline { self: Interflow =>
 
         case Seq(block) =>
           block.cf match {
-            case Inst.Ret(value) =>
+            case nir.Inst.Ret(value) =>
               emit ++= block.end.emit
               (value, block.end)
-            case Inst.Throw(value, unwind) =>
+            case nir.Inst.Throw(value, unwind) =>
               val excv = block.end.materialize(value)
               emit ++= block.end.emit
               emit.raise(excv, unwind)
               (nothing, block.end)
-            case Inst.Unreachable(unwind) =>
+            case nir.Inst.Unreachable(unwind) =>
               emit ++= block.end.emit
               emit.unreachable(unwind)
               (nothing, block.end)
@@ -214,9 +217,9 @@ trait Inline { self: Interflow =>
 
           rest.foreach { block =>
             block.cf match {
-              case _: Inst.Ret =>
+              case _: nir.Inst.Ret =>
                 ()
-              case Inst.Throw(value, unwind) =>
+              case nir.Inst.Throw(value, unwind) =>
                 val excv = block.end.materialize(value)
                 emit ++= block.toInsts().init
                 emit.raise(excv, unwind)
@@ -227,8 +230,8 @@ trait Inline { self: Interflow =>
 
           rest
             .collectFirst {
-              case block if block.cf.isInstanceOf[Inst.Ret] =>
-                val Inst.Ret(value) = block.cf: @unchecked
+              case block if block.cf.isInstanceOf[nir.Inst.Ret] =>
+                val nir.Inst.Ret(value) = block.cf: @unchecked
                 emit ++= block.toInsts().init
                 (value, block.end)
             }
@@ -245,9 +248,9 @@ trait Inline { self: Interflow =>
         // Adapt result of inlined call
         // Replace the calle scopeId with the scopeId of caller function, to represent that result of this call is available in parent
         res match {
-          case Val.Local(id, _) =>
+          case nir.Val.Local(id, _) =>
             emit.updateLetInst(id)(i => i.copy()(i.pos, parentScopeId))
-          case Val.Virtual(addr) =>
+          case nir.Val.Virtual(addr) =>
             endState.heap(addr) = endState.deref(addr) match {
               case inst: EscapedInstance =>
                 inst.copy()(inst.srcPosition, parentScopeId)
@@ -263,7 +266,7 @@ trait Inline { self: Interflow =>
       state.emit ++= emit
       state.inherit(endState, res +: args)
 
-      val Type.Function(_, retty) = defn.ty
+      val nir.Type.Function(_, retty) = defn.ty
       adapt(res, retty)
     }
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -146,7 +146,8 @@ trait Inline { self: Interflow =>
     val expected = argtys match {
       case inittys :+ nir.Type.Vararg =>
         val nonvarargs = args.take(inittys.size).zip(inittys)
-        val varargs = args.drop(inittys.size).map { arg => (arg, nir.Type.Vararg) }
+        val varargs =
+          args.drop(inittys.size).map { arg => (arg, nir.Type.Vararg) }
         nonvarargs ++ varargs
       case _ =>
         args.zip(argtys)
@@ -167,7 +168,7 @@ trait Inline { self: Interflow =>
   ): nir.Val =
     in(s"inlining ${name.show}") {
       val defn = mode match {
-        case build.Mode.Debug => getOriginal(name)
+        case build.Mode.Debug      => getOriginal(name)
         case _: build.Mode.Release => getDone(name)
       }
       val nir.Type.Function(_, origRetTy) = defn.ty

--- a/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
@@ -2,20 +2,19 @@ package scala.scalanative
 package interflow
 
 import java.util.Arrays
-import scalanative.nir.{Type, Val, Op}
 import scalanative.linker.Class
 
 sealed abstract class Instance(implicit
     val srcPosition: nir.Position,
     val scopeId: nir.ScopeId
 ) extends Cloneable {
-  def ty: Type = this match {
+  def ty: nir.Type = this match {
     case EscapedInstance(value) =>
       value.ty
     case DelayedInstance(op) =>
       op.resty
     case VirtualInstance(_, cls, _, _) =>
-      Type.Ref(cls.name, exact = true, nullable = false)
+      nir.Type.Ref(cls.name, exact = true, nullable = false)
   }
 
   override def clone(): Instance = this match {
@@ -35,15 +34,15 @@ sealed abstract class Instance(implicit
   }
 }
 
-final case class EscapedInstance(val escapedValue: Val)(implicit
+final case class EscapedInstance(val escapedValue: nir.Val)(implicit
     srcPosition: nir.Position,
     scopeId: nir.ScopeId
 ) extends Instance {
-  def this(escapedValue: Val, instance: Instance) =
+  def this(escapedValue: nir.Val, instance: Instance) =
     this(escapedValue)(instance.srcPosition, instance.scopeId)
 }
 
-final case class DelayedInstance(val delayedOp: Op)(implicit
+final case class DelayedInstance(val delayedOp: nir.Op)(implicit
     srcPosition: nir.Position,
     scopeId: nir.ScopeId
 ) extends Instance
@@ -51,8 +50,8 @@ final case class DelayedInstance(val delayedOp: Op)(implicit
 final case class VirtualInstance(
     kind: Kind,
     cls: Class,
-    values: Array[Val],
-    zone: Option[Val]
+    values: Array[nir.Val],
+    zone: Option[nir.Val]
 )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId)
     extends Instance {
 

--- a/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
@@ -1,30 +1,35 @@
 package scala.scalanative
 package interflow
 
-import scalanative.nir._
 import scalanative.linker._
 
 object InstanceRef {
-  def unapply(addr: Addr)(implicit state: State): Option[Type] =
-    unapply(Val.Virtual(addr))
-  def unapply(value: Val)(implicit state: State): Option[Type] = value match {
-    case Val.Virtual(addr) =>
+
+  def unapply(addr: Addr)(implicit state: State): Option[nir.Type] =
+    unapply(nir.Val.Virtual(addr))
+
+  def unapply(value: nir.Val)(implicit state: State): Option[nir.Type] = value match {
+    case nir.Val.Virtual(addr) =>
       Some(state.deref(addr).ty)
     case _ =>
       None
   }
+
 }
 
 object VirtualRef {
-  type VirtulRefExtract = (Kind, Class, Array[Val])
+
+  type Extract = (Kind, Class, Array[nir.Val])
+
   def unapply(addr: Addr)(implicit
       state: State
-  ): Option[VirtulRefExtract] =
-    unapply(Val.Virtual(addr))
+  ): Option[Extract] =
+    unapply(nir.Val.Virtual(addr))
+
   def unapply(
-      value: Val
-  )(implicit state: State): Option[VirtulRefExtract] = value match {
-    case Val.Virtual(addr) =>
+      value: nir.Val
+  )(implicit state: State): Option[Extract] = value match {
+    case nir.Val.Virtual(addr) =>
       state.deref(addr) match {
         case VirtualInstance(kind, cls, values, _) =>
           Some((kind, cls, values))
@@ -34,13 +39,16 @@ object VirtualRef {
     case _ =>
       None
   }
+
 }
 
 object DelayedRef {
-  def unapply(addr: Addr)(implicit state: State): Option[Op] =
-    unapply(Val.Virtual(addr))
-  def unapply(value: Val)(implicit state: State): Option[Op] = value match {
-    case Val.Virtual(addr) =>
+
+  def unapply(addr: Addr)(implicit state: State): Option[nir.Op] =
+    unapply(nir.Val.Virtual(addr))
+
+  def unapply(value: nir.Val)(implicit state: State): Option[nir.Op] = value match {
+    case nir.Val.Virtual(addr) =>
       state.deref(addr) match {
         case DelayedInstance(op) =>
           Some(op)
@@ -50,16 +58,21 @@ object DelayedRef {
     case _ =>
       None
   }
+
 }
 
 object BinRef {
-  def unapply(addr: Addr)(implicit state: State): Option[(Bin, Val, Val)] =
-    unapply(Val.Virtual(addr))
-  def unapply(value: Val)(implicit state: State): Option[(Bin, Val, Val)] =
+
+  type Extract = (nir.Bin, nir.Val, nir.Val)
+
+  def unapply(addr: Addr)(implicit state: State): Option[Extract] =
+    unapply(nir.Val.Virtual(addr))
+
+  def unapply(value: nir.Val)(implicit state: State): Option[Extract] =
     value match {
-      case Val.Virtual(addr) =>
+      case nir.Val.Virtual(addr) =>
         state.deref(addr) match {
-          case DelayedInstance(Op.Bin(bin, _, l, r)) =>
+          case DelayedInstance(nir.Op.Bin(bin, _, l, r)) =>
             Some((bin, l, r))
           case _ =>
             None
@@ -67,16 +80,21 @@ object BinRef {
       case _ =>
         None
     }
+
 }
 
 object ConvRef {
-  def unapply(addr: Addr)(implicit state: State): Option[(Conv, Type, Val)] =
-    unapply(Val.Virtual(addr))
-  def unapply(value: Val)(implicit state: State): Option[(Conv, Type, Val)] =
+
+  type Extract = (nir.Conv, nir.Type, nir.Val)
+
+  def unapply(addr: Addr)(implicit state: State): Option[Extract] =
+    unapply(nir.Val.Virtual(addr))
+
+  def unapply(value: nir.Val)(implicit state: State): Option[Extract] =
     value match {
-      case Val.Virtual(addr) =>
+      case nir.Val.Virtual(addr) =>
         state.deref(addr) match {
-          case DelayedInstance(Op.Conv(conv, ty, v)) =>
+          case DelayedInstance(nir.Op.Conv(conv, ty, v)) =>
             Some((conv, ty, v))
           case _ =>
             None
@@ -84,20 +102,25 @@ object ConvRef {
       case _ =>
         None
     }
-}
+
+  }
 
 object CompRef {
+
+  type Extract = (nir.Comp, nir.Type, nir.Val, nir.Val)
+
   def unapply(addr: Addr)(implicit
       state: State
-  ): Option[(Comp, Type, Val, Val)] =
-    unapply(Val.Virtual(addr))
+  ): Option[Extract] =
+    unapply(nir.Val.Virtual(addr))
+
   def unapply(
-      value: Val
-  )(implicit state: State): Option[(Comp, Type, Val, Val)] =
+      value: nir.Val
+  )(implicit state: State): Option[Extract] =
     value match {
-      case Val.Virtual(addr) =>
+      case nir.Val.Virtual(addr) =>
         state.deref(addr) match {
-          case DelayedInstance(Op.Comp(comp, ty, v1, v2)) =>
+          case DelayedInstance(nir.Op.Comp(comp, ty, v1, v2)) =>
             Some((comp, ty, v1, v2))
           case _ =>
             None
@@ -105,13 +128,16 @@ object CompRef {
       case _ =>
         None
     }
-}
+
+  }
 
 object EscapedRef {
-  def unapply(addr: Addr)(implicit state: State): Option[Val] =
-    unapply(Val.Virtual(addr))
-  def unapply(value: Val)(implicit state: State): Option[Val] = value match {
-    case Val.Virtual(addr) =>
+
+  def unapply(addr: Addr)(implicit state: State): Option[nir.Val] =
+    unapply(nir.Val.Virtual(addr))
+
+  def unapply(value: nir.Val)(implicit state: State): Option[nir.Val] = value match {
+    case nir.Val.Virtual(addr) =>
       state.deref(addr) match {
         case EscapedInstance(value) =>
           Some(value)
@@ -121,4 +147,5 @@ object EscapedRef {
     case _ =>
       None
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
@@ -8,12 +8,13 @@ object InstanceRef {
   def unapply(addr: Addr)(implicit state: State): Option[nir.Type] =
     unapply(nir.Val.Virtual(addr))
 
-  def unapply(value: nir.Val)(implicit state: State): Option[nir.Type] = value match {
-    case nir.Val.Virtual(addr) =>
-      Some(state.deref(addr).ty)
-    case _ =>
-      None
-  }
+  def unapply(value: nir.Val)(implicit state: State): Option[nir.Type] =
+    value match {
+      case nir.Val.Virtual(addr) =>
+        Some(state.deref(addr).ty)
+      case _ =>
+        None
+    }
 
 }
 
@@ -47,17 +48,18 @@ object DelayedRef {
   def unapply(addr: Addr)(implicit state: State): Option[nir.Op] =
     unapply(nir.Val.Virtual(addr))
 
-  def unapply(value: nir.Val)(implicit state: State): Option[nir.Op] = value match {
-    case nir.Val.Virtual(addr) =>
-      state.deref(addr) match {
-        case DelayedInstance(op) =>
-          Some(op)
-        case _ =>
-          None
-      }
-    case _ =>
-      None
-  }
+  def unapply(value: nir.Val)(implicit state: State): Option[nir.Op] =
+    value match {
+      case nir.Val.Virtual(addr) =>
+        state.deref(addr) match {
+          case DelayedInstance(op) =>
+            Some(op)
+          case _ =>
+            None
+        }
+      case _ =>
+        None
+    }
 
 }
 
@@ -103,7 +105,7 @@ object ConvRef {
         None
     }
 
-  }
+}
 
 object CompRef {
 
@@ -129,23 +131,24 @@ object CompRef {
         None
     }
 
-  }
+}
 
 object EscapedRef {
 
   def unapply(addr: Addr)(implicit state: State): Option[nir.Val] =
     unapply(nir.Val.Virtual(addr))
 
-  def unapply(value: nir.Val)(implicit state: State): Option[nir.Val] = value match {
-    case nir.Val.Virtual(addr) =>
-      state.deref(addr) match {
-        case EscapedInstance(value) =>
-          Some(value)
-        case _ =>
-          None
-      }
-    case _ =>
-      None
-  }
+  def unapply(value: nir.Val)(implicit state: State): Option[nir.Val] =
+    value match {
+      case nir.Val.Virtual(addr) =>
+        state.deref(addr) match {
+          case EscapedInstance(value) =>
+            Some(value)
+          case _ =>
+            None
+        }
+      case _ =>
+        None
+    }
 
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -173,7 +173,8 @@ object Interflow {
 
   object LLVMIntrinsics {
     private val externAttrs = nir.Attrs(isExtern = true)
-    private val LLVMI = nir.Global.Top("scala.scalanative.runtime.LLVMIntrinsics$")
+    private val LLVMI =
+      nir.Global.Top("scala.scalanative.runtime.LLVMIntrinsics$")
     private def llvmIntrinsic(id: String) =
       nir.Val.Global(LLVMI.member(nir.Sig.Extern(id)), nir.Type.Ptr)
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -3,7 +3,6 @@ package interflow
 
 import scala.collection.mutable
 import scala.scalanative.codegen.PlatformInfo
-import scala.scalanative.nir._
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.linker._
 import scala.scalanative.util.ScopedVar
@@ -24,21 +23,21 @@ class Interflow(val config: build.Config)(implicit
   implicit val platform: PlatformInfo = PlatformInfo(config)
 
   private val originals = {
-    val out = mutable.Map.empty[Global, Defn]
+    val out = mutable.Map.empty[nir.Global, nir.Defn]
     analysis.defns.foreach { defn => out(defn.name) = defn }
     out
   }
 
-  private val todo = mutable.Queue.empty[Global.Member]
-  private val done = mutable.Map.empty[Global.Member, Defn.Define]
-  private val started = mutable.Set.empty[Global.Member]
-  private val denylist = mutable.Set.empty[Global.Member]
-  private val reached = mutable.HashSet.empty[Global.Member]
-  private val modulePurity = mutable.Map.empty[Global.Top, Boolean]
+  private val todo = mutable.Queue.empty[nir.Global.Member]
+  private val done = mutable.Map.empty[nir.Global.Member, nir.Defn.Define]
+  private val started = mutable.Set.empty[nir.Global.Member]
+  private val denylist = mutable.Set.empty[nir.Global.Member]
+  private val reached = mutable.HashSet.empty[nir.Global.Member]
+  private val modulePurity = mutable.Map.empty[nir.Global.Top, Boolean]
 
   def currentFreshScope = freshScopeTl.get()
   private val freshScopeTl =
-    ThreadLocal.withInitial(() => new ScopedVar[Fresh])
+    ThreadLocal.withInitial(() => new ScopedVar[nir.Fresh])
 
   def currentLexicalScopes = lexicalScopesTl.get()
   private val lexicalScopesTl = ThreadLocal.withInitial(() =>
@@ -50,79 +49,79 @@ class Interflow(val config: build.Config)(implicit
   private val mergeProcessorTl =
     ThreadLocal.withInitial(() => List.empty[MergeProcessor])
   private val blockFreshTl =
-    ThreadLocal.withInitial(() => List.empty[Fresh])
+    ThreadLocal.withInitial(() => List.empty[nir.Fresh])
 
-  def hasOriginal(name: Global.Member): Boolean =
-    originals.contains(name) && originals(name).isInstanceOf[Defn.Define]
-  def getOriginal(name: Global.Member): Defn.Define =
-    originals(name).asInstanceOf[Defn.Define]
-  def maybeOriginal(name: Global.Member): Option[Defn.Define] =
-    originals.get(name).collect { case defn: Defn.Define => defn }
+  def hasOriginal(name: nir.Global.Member): Boolean =
+    originals.contains(name) && originals(name).isInstanceOf[nir.Defn.Define]
+  def getOriginal(name: nir.Global.Member): nir.Defn.Define =
+    originals(name).asInstanceOf[nir.Defn.Define]
+  def maybeOriginal(name: nir.Global.Member): Option[nir.Defn.Define] =
+    originals.get(name).collect { case defn: nir.Defn.Define => defn }
 
-  def popTodo(): Global =
+  def popTodo(): nir.Global =
     todo.synchronized {
       if (todo.isEmpty) {
-        Global.None
+        nir.Global.None
       } else {
         todo.dequeue()
       }
     }
-  def pushTodo(name: Global.Member): Unit =
+  def pushTodo(name: nir.Global.Member): Unit =
     todo.synchronized {
       if (!reached.contains(name)) {
         todo.enqueue(name)
         reached += name
       }
     }
-  def allTodo(): Seq[Global.Member] =
+  def allTodo(): Seq[nir.Global.Member] =
     todo.synchronized {
       todo.toSeq
     }
 
-  def isDone(name: Global.Member): Boolean =
+  def isDone(name: nir.Global.Member): Boolean =
     done.synchronized {
       done.contains(name)
     }
-  def setDone(name: Global.Member, value: Defn.Define) =
+  def setDone(name: nir.Global.Member, value: nir.Defn.Define) =
     done.synchronized {
       done(name) = value
     }
-  def getDone(name: Global.Member): Defn.Define =
+  def getDone(name: nir.Global.Member): nir.Defn.Define =
     done.synchronized {
       done(name)
     }
-  def maybeDone(name: Global.Member): Option[Defn.Define] =
+  def maybeDone(name: nir.Global.Member): Option[nir.Defn.Define] =
     done.synchronized {
       done.get(name)
     }
 
-  def hasStarted(name: Global.Member): Boolean =
+  def hasStarted(name: nir.Global.Member): Boolean =
     started.synchronized {
       started.contains(name)
     }
-  def markStarted(name: Global.Member): Unit =
+  def markStarted(name: nir.Global.Member): Unit =
     started.synchronized {
       started += name
     }
 
-  def isDenylisted(name: Global.Member): Boolean =
+  def isDenylisted(name: nir.Global.Member): Boolean =
     denylist.synchronized {
       denylist.contains(name)
     }
-  def markDenylisted(name: Global.Member): Unit =
+  def markDenylisted(name: nir.Global.Member): Unit =
     denylist.synchronized {
       denylist += name
     }
 
-  def hasModulePurity(name: Global.Top): Boolean =
+  def hasModulePurity(name: nir.Global.Top): Boolean =
     modulePurity.synchronized {
       modulePurity.contains(name)
     }
-  def setModulePurity(name: Global.Top, value: Boolean): Unit =
+  def setModulePurity(name: nir.Global.Top, value: Boolean): Unit =
     modulePurity.synchronized {
       modulePurity(name) = value
     }
-  def getModulePurity(name: Global.Top): Boolean =
+  def getModulePurity(name: nir.Global.Top): Boolean =
     modulePurity.synchronized {
       modulePurity(name)
     }
@@ -143,26 +142,28 @@ class Interflow(val config: build.Config)(implicit
   def popMergeProcessor(): Unit =
     mergeProcessorTl.set(mergeProcessorTl.get.tail)
 
-  def blockFresh: Fresh =
+  def blockFresh: nir.Fresh =
     blockFreshTl.get.head
-  def pushBlockFresh(value: Fresh): Unit =
+  def pushBlockFresh(value: nir.Fresh): Unit =
     blockFreshTl.set(value :: blockFreshTl.get)
   def popBlockFresh(): Unit =
     blockFreshTl.set(blockFreshTl.get.tail)
 
-  def result(): Seq[Defn] = {
+  def result(): Seq[nir.Defn] = {
     val optimized = originals.clone()
     optimized ++= done
     optimized.values.toSeq
   }
 
   protected def mode: build.Mode = config.compilerConfig.mode
+
 }
 
 object Interflow {
+
   def optimize(config: build.Config, analysis: ReachabilityAnalysis.Result)(
       implicit ec: ExecutionContext
-  ): Future[Seq[Defn]] = {
+  ): Future[Seq[nir.Defn]] = {
     val interflow = new Interflow(config)(analysis)
     interflow.visitEntries()
     interflow
@@ -171,20 +172,21 @@ object Interflow {
   }
 
   object LLVMIntrinsics {
-    private val externAttrs = Attrs(isExtern = true)
-    private val LLVMI = Global.Top("scala.scalanative.runtime.LLVMIntrinsics$")
+    private val externAttrs = nir.Attrs(isExtern = true)
+    private val LLVMI = nir.Global.Top("scala.scalanative.runtime.LLVMIntrinsics$")
     private def llvmIntrinsic(id: String) =
-      Val.Global(LLVMI.member(Sig.Extern(id)), Type.Ptr)
+      nir.Val.Global(LLVMI.member(nir.Sig.Extern(id)), nir.Type.Ptr)
 
     val StackSave = llvmIntrinsic("llvm.stacksave")
-    val StackSaveSig = Type.Function(Nil, Type.Ptr)
+    val StackSaveSig = nir.Type.Function(Nil, nir.Type.Ptr)
 
     val StackRestore = llvmIntrinsic("llvm.stackrestore")
-    val StackRestoreSig = Type.Function(Seq(Type.Ptr), Type.Unit)
+    val StackRestoreSig = nir.Type.Function(Seq(nir.Type.Ptr), nir.Type.Unit)
   }
 
-  val depends: Seq[Global] = Seq(
+  val depends: Seq[nir.Global] = Seq(
     LLVMIntrinsics.StackSave.name,
     LLVMIntrinsics.StackRestore.name
   )
+
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
@@ -4,164 +4,179 @@ package interflow
 import scalanative.codegen.Lower
 
 import java.util.Arrays
-import scalanative.nir._
 import scalanative.linker._
 
 trait Intrinsics { self: Interflow =>
-  val arrayApplyIntrinsics = Lower.arrayApply.values.toSet[Global]
-  val arrayUpdateIntrinsics = Lower.arrayUpdate.values.toSet[Global]
+
+  val arrayApplyIntrinsics = Lower.arrayApply.values.toSet[nir.Global]
+  val arrayUpdateIntrinsics = Lower.arrayUpdate.values.toSet[nir.Global]
   val arrayLengthIntrinsic = Lower.arrayLength
   val arrayIntrinsics =
     arrayApplyIntrinsics ++ arrayUpdateIntrinsics + arrayLengthIntrinsic
 
-  val intrinsics = Set[Global](
-    Global.Member(Global.Top("java.lang.Object"), Rt.GetClassSig),
-    Global.Member(Global.Top("java.lang.Class"), Rt.IsArraySig),
-    Global.Member(Global.Top("java.lang.Class"), Rt.IsAssignableFromSig),
-    Global.Member(Global.Top("java.lang.Class"), Rt.GetNameSig),
-    Global.Member(Global.Top("java.lang.Integer$"), Rt.BitCountSig),
-    Global.Member(Global.Top("java.lang.Integer$"), Rt.ReverseBytesSig),
-    Global.Member(Global.Top("java.lang.Integer$"), Rt.NumberOfLeadingZerosSig),
-    Global.Member(Global.Top("java.lang.Math$"), Rt.CosSig),
-    Global.Member(Global.Top("java.lang.Math$"), Rt.SinSig),
-    Global.Member(Global.Top("java.lang.Math$"), Rt.PowSig),
-    Global.Member(Global.Top("java.lang.Math$"), Rt.MaxSig),
-    Global.Member(Global.Top("java.lang.Math$"), Rt.SqrtSig),
-    Global.Member(Rt.Runtime.name, Rt.FromRawPtrSig),
-    Global.Member(Rt.Runtime.name, Rt.ToRawPtrSig)
+  val intrinsics = Set[nir.Global](
+    nir.Global.Member(nir.Global.Top("java.lang.Object"), nir.Rt.GetClassSig),
+    nir.Global.Member(nir.Global.Top("java.lang.Class"), nir.Rt.IsArraySig),
+    nir.Global
+      .Member(nir.Global.Top("java.lang.Class"), nir.Rt.IsAssignableFromSig),
+    nir.Global.Member(nir.Global.Top("java.lang.Class"), nir.Rt.GetNameSig),
+    nir.Global.Member(nir.Global.Top("java.lang.Integer$"), nir.Rt.BitCountSig),
+    nir.Global
+      .Member(nir.Global.Top("java.lang.Integer$"), nir.Rt.ReverseBytesSig),
+    nir.Global.Member(
+      nir.Global.Top("java.lang.Integer$"),
+      nir.Rt.NumberOfLeadingZerosSig
+    ),
+    nir.Global.Member(nir.Global.Top("java.lang.Math$"), nir.Rt.CosSig),
+    nir.Global.Member(nir.Global.Top("java.lang.Math$"), nir.Rt.SinSig),
+    nir.Global.Member(nir.Global.Top("java.lang.Math$"), nir.Rt.PowSig),
+    nir.Global.Member(nir.Global.Top("java.lang.Math$"), nir.Rt.MaxSig),
+    nir.Global.Member(nir.Global.Top("java.lang.Math$"), nir.Rt.SqrtSig),
+    nir.Global.Member(nir.Rt.Runtime.name, nir.Rt.FromRawPtrSig),
+    nir.Global.Member(nir.Rt.Runtime.name, nir.Rt.ToRawPtrSig)
   ) ++ arrayIntrinsics
 
-  def intrinsic(ty: Type.Function, name: Global.Member, rawArgs: Seq[Val])(
-      implicit
+  def intrinsic(
+      ty: nir.Type.Function,
+      name: nir.Global.Member,
+      rawArgs: Seq[nir.Val]
+  )(implicit
       state: State,
-      srcPosition: Position,
-      scopeId: ScopeId
-  ): Option[Val] = {
-    val Global.Member(_, sig) = name
+      srcPosition: nir.Position,
+      scopeId: nir.ScopeId
+  ): Option[nir.Val] = {
+    val nir.Global.Member(_, sig) = name
 
     val args = rawArgs.map(eval)
 
     def emit =
       state.emit(
-        Op.Call(ty, Val.Global(name, Type.Ptr), args.map(state.materialize(_)))
+        nir.Op.Call(
+          ty,
+          nir.Val.Global(name, nir.Type.Ptr),
+          args.map(state.materialize(_))
+        )
       )
 
     sig match {
-      case Rt.GetClassSig =>
+      case nir.Rt.GetClassSig =>
         args match {
           case Seq(VirtualRef(_, cls, _)) =>
-            Some(Val.Global(cls.name, Rt.Class))
+            Some(nir.Val.Global(cls.name, nir.Rt.Class))
           case Seq(value) =>
             val ty = value match {
               case InstanceRef(ty) => ty
               case _               => value.ty
             }
             ty match {
-              case refty: Type.RefKind if refty.isExact =>
-                Some(Val.Global(refty.className, Rt.Class))
+              case refty: nir.Type.RefKind if refty.isExact =>
+                Some(nir.Val.Global(refty.className, nir.Rt.Class))
               case _ =>
                 Some(emit)
             }
           case _ =>
             Some(emit)
         }
-      case Rt.IsArraySig =>
+      case nir.Rt.IsArraySig =>
         args match {
-          case Seq(Val.Global(clsName: Global.Top, ty)) if ty == Rt.Class =>
-            Some(Val.Bool(Type.isArray(clsName)))
+          case Seq(nir.Val.Global(clsName: nir.Global.Top, ty))
+              if ty == nir.Rt.Class =>
+            Some(nir.Val.Bool(nir.Type.isArray(clsName)))
           case _ =>
             None
         }
-      case Rt.IsAssignableFromSig =>
+      case nir.Rt.IsAssignableFromSig =>
         args match {
           case Seq(
-                Val.Global(ScopeRef(linfo), lty),
-                Val.Global(ScopeRef(rinfo), rty)
-              ) if lty == Rt.Class && rty == Rt.Class =>
-            Some(Val.Bool(rinfo.is(linfo)))
+                nir.Val.Global(ScopeRef(linfo), lty),
+                nir.Val.Global(ScopeRef(rinfo), rty)
+              ) if lty == nir.Rt.Class && rty == nir.Rt.Class =>
+            Some(nir.Val.Bool(rinfo.is(linfo)))
           case _ =>
             None
         }
-      case Rt.GetNameSig =>
+      case nir.Rt.GetNameSig =>
         args match {
-          case Seq(Val.Global(name: Global.Top, ty)) if ty == Rt.Class =>
-            Some(eval(Val.String(name.id)))
+          case Seq(nir.Val.Global(name: nir.Global.Top, ty))
+              if ty == nir.Rt.Class =>
+            Some(eval(nir.Val.String(name.id)))
           case _ =>
             None
         }
-      case Rt.BitCountSig =>
+      case nir.Rt.BitCountSig =>
         args match {
-          case Seq(_, Val.Int(v)) =>
-            Some(Val.Int(java.lang.Integer.bitCount(v)))
+          case Seq(_, nir.Val.Int(v)) =>
+            Some(nir.Val.Int(java.lang.Integer.bitCount(v)))
           case _ =>
             None
         }
-      case Rt.ReverseBytesSig =>
+      case nir.Rt.ReverseBytesSig =>
         args match {
-          case Seq(_, Val.Int(v)) =>
-            Some(Val.Int(java.lang.Integer.reverseBytes(v)))
+          case Seq(_, nir.Val.Int(v)) =>
+            Some(nir.Val.Int(java.lang.Integer.reverseBytes(v)))
           case _ =>
             None
         }
-      case Rt.NumberOfLeadingZerosSig =>
+      case nir.Rt.NumberOfLeadingZerosSig =>
         args match {
-          case Seq(_, Val.Int(v)) =>
-            Some(Val.Int(java.lang.Integer.numberOfLeadingZeros(v)))
+          case Seq(_, nir.Val.Int(v)) =>
+            Some(nir.Val.Int(java.lang.Integer.numberOfLeadingZeros(v)))
           case _ =>
             None
         }
-      case Rt.CosSig =>
+      case nir.Rt.CosSig =>
         args match {
-          case Seq(_, Val.Double(v)) =>
-            Some(Val.Double(java.lang.Math.cos(v)))
+          case Seq(_, nir.Val.Double(v)) =>
+            Some(nir.Val.Double(java.lang.Math.cos(v)))
           case _ =>
             None
         }
-      case Rt.SinSig =>
+      case nir.Rt.SinSig =>
         args match {
-          case Seq(_, Val.Double(v)) =>
-            Some(Val.Double(java.lang.Math.sin(v)))
+          case Seq(_, nir.Val.Double(v)) =>
+            Some(nir.Val.Double(java.lang.Math.sin(v)))
           case _ =>
             None
         }
-      case Rt.PowSig =>
+      case nir.Rt.PowSig =>
         args match {
-          case Seq(_, Val.Double(v1), Val.Double(v2)) =>
-            Some(Val.Double(java.lang.Math.pow(v1, v2)))
+          case Seq(_, nir.Val.Double(v1), nir.Val.Double(v2)) =>
+            Some(nir.Val.Double(java.lang.Math.pow(v1, v2)))
           case _ =>
             None
         }
-      case Rt.SqrtSig =>
+      case nir.Rt.SqrtSig =>
         args match {
-          case Seq(_, Val.Double(v)) =>
-            Some(Val.Double(java.lang.Math.sqrt(v)))
+          case Seq(_, nir.Val.Double(v)) =>
+            Some(nir.Val.Double(java.lang.Math.sqrt(v)))
           case _ =>
             None
         }
-      case Rt.MaxSig =>
+      case nir.Rt.MaxSig =>
         args match {
-          case Seq(_, Val.Double(v1), Val.Double(v2)) =>
-            Some(Val.Double(java.lang.Math.max(v1, v2)))
+          case Seq(_, nir.Val.Double(v1), nir.Val.Double(v2)) =>
+            Some(nir.Val.Double(java.lang.Math.max(v1, v2)))
           case _ =>
             None
         }
       case _ if arrayApplyIntrinsics.contains(name) =>
         val Seq(arr, idx) = rawArgs
-        val Type.Function(_, elemty) = ty
-        Some(eval(Op.Arrayload(elemty, arr, idx)))
+        val nir.Type.Function(_, elemty) = ty
+        Some(eval(nir.Op.Arrayload(elemty, arr, idx)))
       case _ if arrayUpdateIntrinsics.contains(name) =>
         val Seq(arr, idx, value) = rawArgs
-        val Type.Function(Seq(_, _, elemty), _) = ty: @unchecked
-        Some(eval(Op.Arraystore(elemty, arr, idx, value)))
+        val nir.Type.Function(Seq(_, _, elemty), _) = ty: @unchecked
+        Some(eval(nir.Op.Arraystore(elemty, arr, idx, value)))
       case _ if name == arrayLengthIntrinsic =>
         val Seq(arr) = rawArgs
-        Some(eval(Op.Arraylength(arr)))
-      case Rt.FromRawPtrSig =>
+        Some(eval(nir.Op.Arraylength(arr)))
+      case nir.Rt.FromRawPtrSig =>
         val Seq(_, value) = rawArgs
-        Some(eval(Op.Box(Rt.BoxedPtr, value)))
-      case Rt.ToRawPtrSig =>
+        Some(eval(nir.Op.Box(nir.Rt.BoxedPtr, value)))
+      case nir.Rt.ToRawPtrSig =>
         val Seq(_, value) = rawArgs
-        Some(eval(Op.Unbox(Rt.BoxedPtr, value)))
+        Some(eval(nir.Op.Unbox(nir.Rt.BoxedPtr, value)))
     }
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/MergePhi.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergePhi.scala
@@ -1,6 +1,7 @@
 package scala.scalanative
 package interflow
 
-import scalanative.nir._
-
-final case class MergePhi(param: Val.Local, incoming: Seq[(Local, Val)])
+final case class MergePhi(
+    param: nir.Val.Local,
+    incoming: Seq[(nir.Local, nir.Val)]
+)

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -1,7 +1,6 @@
 package scala.scalanative
 package interflow
 
-import scala.scalanative.nir._
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.linker._
 import scala.collection.mutable
@@ -9,151 +8,164 @@ import scala.scalanative.util.ScopedVar.scoped
 
 trait Opt { self: Interflow =>
 
-  def shallOpt(name: Global.Member): Boolean = {
+  def shallOpt(name: nir.Global.Member): Boolean = {
     val defn =
       getOriginal(originalName(name))
     val noUnwind = defn.insts.forall {
-      case Inst.Let(_, _, unwind)   => unwind == Next.None
-      case Inst.Throw(_, unwind)    => unwind == Next.None
-      case Inst.Unreachable(unwind) => unwind == Next.None
-      case _                        => true
+      case nir.Inst.Let(_, _, unwind) =>
+        unwind == nir.Next.None
+      case nir.Inst.Throw(_, unwind) =>
+        unwind == nir.Next.None
+      case nir.Inst.Unreachable(unwind) =>
+        unwind == nir.Next.None
+      case _ =>
+        true
     }
 
-    defn.attrs.opt != Attr.NoOpt && noUnwind
+    defn.attrs.opt != nir.Attr.NoOpt && noUnwind
   }
 
-  def opt(name: Global.Member): Defn.Define = in(s"visit ${name.show}") {
-    val orig = originalName(name)
-    val origtys = argumentTypes(orig)
-    val origdefn = getOriginal(orig)
-    val argtys = argumentTypes(name)
-    val Inst.Label(_, origargs) = origdefn.insts.head: @unchecked
-    implicit val pos = origdefn.pos
-    // Wrap up the result.
-    def result(retty: Type, rawInsts: Seq[Inst], debugInfo: DebugInfo) = {
-      val insts = ControlFlow.removeDeadBlocks(rawInsts)
-      // TODO: filter-out unreachable scopes
-      val scopes = debugInfo.lexicalScopes.sorted
-      origdefn.copy(
-        name = name,
-        attrs = origdefn.attrs.copy(opt = Attr.DidOpt),
-        ty = Type.Function(argtys, retty),
-        insts = insts,
-        debugInfo = debugInfo.copy(lexicalScopes = scopes)
-      )(origdefn.pos)
-    }
-
-    // Create new fresh and state for the first basic block.
-    val fresh = Fresh(0)
-    val state = new State(Local(0))(preserveDebugInfo)
-
-    // Interflow usually infers better types on our erased type system
-    // than scalac, yet we live it as a benefit of the doubt and make sure
-    // that if original return type is more specific, we keep it as is.
-    val Type.Function(_, origRetTy) = origdefn.ty
-
-    // Compute opaque fresh locals for the arguments. Argument types
-    // are always a subtype of the original declared type, but in
-    // some cases they might not be obviously related, despite
-    // having the same concrete allocated class inhabitants.
-    val args = argtys.zip(origtys).zip(origargs).map {
-      case ((argty, origty), origarg) =>
-        val ty = if (!Sub.is(argty, origty)) {
-          log(
-            s"using original argument type ${origty.show} instead of ${argty.show}"
-          )
-          origty
-        } else argty
-
-        val id = fresh()
-        if (preserveDebugInfo) {
-          origdefn.debugInfo.localNames
-            .get(origarg.id)
-            .foreach(state.localNames.update(id, _))
-        }
-        Val.Local(id, ty)
-    }
-
-    // If any of the argument types is nothing, this method
-    // is never going to be called, so we don't have to visit it.
-    if (args.exists(_.ty == Type.Nothing)) {
-      val insts = Seq(Inst.Label(Local(0), args), Inst.Unreachable(Next.None))
-      result(Type.Nothing, insts, DebugInfo.empty)
-    } else
-      scoped(
-        currentFreshScope := Fresh(0L),
-        currentLexicalScopes := mutable.UnrolledBuffer.empty
-      ) {
-        // Run a merge processor starting from the entry basic block.
-        val blocks =
-          try {
-            pushBlockFresh(fresh)
-            process(
-              origdefn.insts.toArray,
-              debugInfo = origdefn.debugInfo,
-              args = args,
-              state = state,
-              doInline = false,
-              retTy = origRetTy,
-              parentScopeId = ScopeId.TopLevel
-            )
-          } finally {
-            popBlockFresh()
-          }
-
-        // Collect instructions, materialize all returned values
-        // and compute the result type.
-        val insts = blocks.flatMap { block =>
-          block.cf = block.cf match {
-            case inst @ Inst.Ret(retv) =>
-              Inst.Ret(block.end.materialize(retv))(inst.pos)
-            case inst @ Inst.Throw(excv, unwind) =>
-              Inst.Throw(block.end.materialize(excv), unwind)(inst.pos)
-            case cf =>
-              cf
-          }
-          block.toInsts()
-        }
-        val debugInfo: DebugInfo = if (preserveDebugInfo) {
-          val localNames = mutable.OpenHashMap.empty[Local, LocalName]
-          for {
-            block <- blocks
-            state = block.end
-          } {
-            localNames.addMissing(block.end.localNames)
-          }
-          DebugInfo(
-            localNames = localNames.toMap,
-            lexicalScopes = currentLexicalScopes.get.toSeq
-          )
-        } else DebugInfo.empty
-
-        val rets = insts.collect {
-          case Inst.Ret(v) => v.ty
-        }
-
-        val retty0 = rets match {
-          case Seq()   => Type.Nothing
-          case Seq(ty) => ty
-          case tys     => Sub.lub(tys, Some(origRetTy))
-        }
-        // Make sure to not override expected BoxedUnit with primitive Unit
-        val retty =
-          if (retty0 == Type.Unit && origRetTy.isInstanceOf[Type.Ref]) origRetTy
-          else retty0
-
-        result(retty, insts, debugInfo)
+  def opt(name: nir.Global.Member): nir.Defn.Define =
+    in(s"visit ${name.show}") {
+      val orig = originalName(name)
+      val origtys = argumentTypes(orig)
+      val origdefn = getOriginal(orig)
+      val argtys = argumentTypes(name)
+      val nir.Inst.Label(_, origargs) = origdefn.insts.head: @unchecked
+      implicit val pos = origdefn.pos
+      // Wrap up the result.
+      def result(
+          retty: nir.Type,
+          rawInsts: Seq[nir.Inst],
+          debugInfo: DebugInfo
+      ) = {
+        val insts = nir.ControlFlow.removeDeadBlocks(rawInsts)
+        // TODO: filter-out unreachable scopes
+        val scopes = debugInfo.lexicalScopes.sorted
+        origdefn.copy(
+          name = name,
+          attrs = origdefn.attrs.copy(opt = nir.Attr.DidOpt),
+          ty = nir.Type.Function(argtys, retty),
+          insts = insts,
+          debugInfo = debugInfo.copy(lexicalScopes = scopes)
+        )(origdefn.pos)
       }
-  }
+
+      // Create new fresh and state for the first basic block.
+      val fresh = nir.Fresh(0)
+      val state = new State(nir.Local(0))(preserveDebugInfo)
+
+      // Interflow usually infers better types on our erased type system
+      // than scalac, yet we live it as a benefit of the doubt and make sure
+      // that if original return type is more specific, we keep it as is.
+      val nir.Type.Function(_, origRetTy) = origdefn.ty
+
+      // Compute opaque fresh locals for the arguments. Argument types
+      // are always a subtype of the original declared type, but in
+      // some cases they might not be obviously related, despite
+      // having the same concrete allocated class inhabitants.
+      val args = argtys.zip(origtys).zip(origargs).map {
+        case ((argty, origty), origarg) =>
+          val ty = if (!Sub.is(argty, origty)) {
+            log(
+              s"using original argument type ${origty.show} instead of ${argty.show}"
+            )
+            origty
+          } else argty
+
+          val id = fresh()
+          if (preserveDebugInfo) {
+            origdefn.debugInfo.localNames
+              .get(origarg.id)
+              .foreach(state.localNames.update(id, _))
+          }
+          nir.Val.Local(id, ty)
+      }
+
+      // If any of the argument types is nothing, this method
+      // is never going to be called, so we don't have to visit it.
+      if (args.exists(_.ty == nir.Type.Nothing)) {
+        val insts = Seq(
+          nir.Inst.Label(nir.Local(0), args),
+          nir.Inst.Unreachable(nir.Next.None)
+        )
+        result(nir.Type.Nothing, insts, DebugInfo.empty)
+      } else
+        scoped(
+          currentFreshScope := nir.Fresh(0L),
+          currentLexicalScopes := mutable.UnrolledBuffer.empty
+        ) {
+          // Run a merge processor starting from the entry basic block.
+          val blocks =
+            try {
+              pushBlockFresh(fresh)
+              process(
+                origdefn.insts.toArray,
+                debugInfo = origdefn.debugInfo,
+                args = args,
+                state = state,
+                doInline = false,
+                retTy = origRetTy,
+                parentScopeId = nir.ScopeId.TopLevel
+              )
+            } finally {
+              popBlockFresh()
+            }
+
+          // Collect instructions, materialize all returned values
+          // and compute the result type.
+          val insts = blocks.flatMap { block =>
+            block.cf = block.cf match {
+              case inst @ nir.Inst.Ret(retv) =>
+                nir.Inst.Ret(block.end.materialize(retv))(inst.pos)
+              case inst @ nir.Inst.Throw(excv, unwind) =>
+                nir.Inst.Throw(block.end.materialize(excv), unwind)(inst.pos)
+              case cf =>
+                cf
+            }
+            block.toInsts()
+          }
+          val debugInfo: DebugInfo = if (preserveDebugInfo) {
+            val localNames = mutable.OpenHashMap.empty[nir.Local, nir.LocalName]
+            for {
+              block <- blocks
+              state = block.end
+            } {
+              localNames.addMissing(block.end.localNames)
+            }
+            DebugInfo(
+              localNames = localNames.toMap,
+              lexicalScopes = currentLexicalScopes.get.toSeq
+            )
+          } else DebugInfo.empty
+
+          val rets = insts.collect {
+            case nir.Inst.Ret(v) => v.ty
+          }
+
+          val retty0 = rets match {
+            case Seq()   => nir.Type.Nothing
+            case Seq(ty) => ty
+            case tys     => Sub.lub(tys, Some(origRetTy))
+          }
+          // Make sure to not override expected BoxedUnit with primitive Unit
+          val retty =
+            if (retty0 == nir.Type.Unit && origRetTy.isInstanceOf[nir.Type.Ref])
+              origRetTy
+            else retty0
+
+          result(retty, insts, debugInfo)
+        }
+    }
 
   def process(
-      insts: Array[Inst],
+      insts: Array[nir.Inst],
       debugInfo: DebugInfo,
-      args: Seq[Val],
+      args: Seq[nir.Val],
       state: State,
       doInline: Boolean,
-      retTy: Type,
-      parentScopeId: ScopeId
+      retTy: nir.Type,
+      parentScopeId: nir.ScopeId
   ): Seq[MergeBlock] = {
     val processor =
       MergeProcessor.fromEntry(

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -3,58 +3,58 @@ package interflow
 
 import scala.collection.mutable
 import scalanative.util.unreachable
-import scalanative.nir._
 import scalanative.linker._
 import scalanative.codegen.Lower
 
-final class State(block: Local)(preserveDebugInfo: Boolean) {
-  var fresh = Fresh(block.id)
-  /* Performance Note: OpenHashMap/LongMap/AnyRefMap have a faster clone()
+final class State(block: nir.Local)(preserveDebugInfo: Boolean) {
+
+  var fresh = nir.Fresh(block.id)
+  /* Performance Note: nir.OpenHashMap/LongMap/AnyRefMap have a faster clone()
    * operation. This really makes a difference on fullClone() */
   var heap = mutable.LongMap.empty[Instance]
-  var locals = mutable.OpenHashMap.empty[Local, Val]
-  var delayed = mutable.AnyRefMap.empty[Op, Val]
-  var emitted = mutable.AnyRefMap.empty[Op, Val.Local]
+  var locals = mutable.OpenHashMap.empty[nir.Local, nir.Val]
+  var delayed = mutable.AnyRefMap.empty[nir.Op, nir.Val]
+  var emitted = mutable.AnyRefMap.empty[nir.Op, nir.Val.Local]
   var emit = new nir.Buffer()(fresh)
   var inlineDepth = 0
 
   // Delayed init
-  var localNames: mutable.OpenHashMap[Local, String] = _
+  var localNames: mutable.OpenHashMap[nir.Local, String] = _
   var virtualNames: mutable.LongMap[String] = _
 
   if (preserveDebugInfo) {
-    localNames = mutable.OpenHashMap.empty[Local, String]
+    localNames = mutable.OpenHashMap.empty[nir.Local, String]
     virtualNames = mutable.LongMap.empty[String]
   }
 
   private def alloc(
       kind: Kind,
       cls: Class,
-      values: Array[Val],
-      zone: Option[Val]
+      values: Array[nir.Val],
+      zone: Option[nir.Val]
   )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): Addr = {
     val addr = fresh().id
     heap(addr) = VirtualInstance(kind, cls, values, zone)
     addr
   }
-  def allocClass(cls: Class, zone: Option[Val])(implicit
+  def allocClass(cls: Class, zone: Option[nir.Val])(implicit
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
   ): Addr = {
-    val fields = cls.fields.map(fld => Val.Zero(fld.ty).canonicalize)
-    alloc(ClassKind, cls, fields.toArray[Val], zone)
+    val fields = cls.fields.map(fld => nir.Val.Zero(fld.ty).canonicalize)
+    alloc(ClassKind, cls, fields.toArray[nir.Val], zone)
   }
-  def allocArray(elemty: Type, count: Int, zone: Option[Val])(implicit
+  def allocArray(elemty: nir.Type, count: Int, zone: Option[nir.Val])(implicit
       analysis: ReachabilityAnalysis.Result,
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
   ): Addr = {
-    val zero = Val.Zero(elemty).canonicalize
-    val values = Array.fill[Val](count)(zero)
-    val cls = analysis.infos(Type.toArrayClass(elemty)).asInstanceOf[Class]
+    val zero = nir.Val.Zero(elemty).canonicalize
+    val values = Array.fill[nir.Val](count)(zero)
+    val cls = analysis.infos(nir.Type.toArrayClass(elemty)).asInstanceOf[Class]
     alloc(ArrayKind, cls, values, zone)
   }
-  def allocBox(boxname: Global, value: Val)(implicit
+  def allocBox(boxname: nir.Global, value: nir.Val)(implicit
       analysis: ReachabilityAnalysis.Result,
       srcPosition: nir.Position,
       scopeId: nir.ScopeId
@@ -68,49 +68,49 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
       scopeId: nir.ScopeId
   ): Addr = {
     val charsArray = value.toArray
-    val charsAddr = allocArray(Type.Char, charsArray.length, zone = None)
+    val charsAddr = allocArray(nir.Type.Char, charsArray.length, zone = None)
     val chars = derefVirtual(charsAddr)
     charsArray.zipWithIndex.foreach {
       case (value, idx) =>
-        chars.values(idx) = Val.Char(value)
+        chars.values(idx) = nir.Val.Char(value)
     }
-    val values = new Array[Val](4)
-    values(analysis.StringValueField.index) = Val.Virtual(charsAddr)
-    values(analysis.StringOffsetField.index) = Val.Int(0)
-    values(analysis.StringCountField.index) = Val.Int(charsArray.length)
+    val values = new Array[nir.Val](4)
+    values(analysis.StringValueField.index) = nir.Val.Virtual(charsAddr)
+    values(analysis.StringOffsetField.index) = nir.Val.Int(0)
+    values(analysis.StringCountField.index) = nir.Val.Int(charsArray.length)
     values(analysis.StringCachedHashCodeField.index) =
-      Val.Int(Lower.stringHashCode(value))
+      nir.Val.Int(Lower.stringHashCode(value))
     alloc(StringKind, analysis.StringClass, values, zone = None)
   }
   def delay(
-      op: Op
-  )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): Val = {
+      op: nir.Op
+  )(implicit srcPosition: nir.Position, scopeId: nir.ScopeId): nir.Val = {
     delayed.getOrElseUpdate(
       op, {
         val addr = fresh().id
         heap(addr) = DelayedInstance(op)
-        Val.Virtual(addr)
+        nir.Val.Virtual(addr)
       }
     )
   }
-  def emit(op: Op, idempotent: Boolean = false)(implicit
-      srcPosition: Position,
-      scopeId: ScopeId
-  ): Val.Local = {
+  def emit(op: nir.Op, idempotent: Boolean = false)(implicit
+      srcPosition: nir.Position,
+      scopeId: nir.ScopeId
+  ): nir.Val.Local = {
     if (op.isIdempotent || idempotent) {
       if (emitted.contains(op)) {
         emitted(op)
       } else {
-        val value = emit.let(op, Next.None)
+        val value = emit.let(op, nir.Next.None)
         emitted(op) = value
         value
       }
-    } else emit.let(op, Next.None)
+    } else emit.let(op, nir.Next.None)
   }
 
   def emitVirtual(
       addr: Addr
-  )(op: Op, idempotent: Boolean = false): Val.Local = {
+  )(op: nir.Op, idempotent: Boolean = false): nir.Val.Local = {
     val instance = heap(addr)
     import instance.{srcPosition, scopeId}
 
@@ -118,7 +118,7 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
     // there might cases when virtualName for given addres might be assigned to two different instances
     // It can happend when we deal with partially-evaluated instances, eg. arrayalloc + arraystore
     // Don't emit local names for ops returing unit value
-    if (preserveDebugInfo && op.resty != Type.Unit) {
+    if (preserveDebugInfo && op.resty != nir.Type.Unit) {
       virtualNames.get(addr).foreach { name =>
         this.localNames += value.id -> name
       }
@@ -141,44 +141,50 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
   def isVirtual(addr: Addr): Boolean = {
     heap(addr).isInstanceOf[VirtualInstance]
   }
-  def isVirtual(value: Val): Boolean = value match {
-    case Val.Virtual(addr) => isVirtual(addr)
-    case _                 => false
+  def isVirtual(value: nir.Val): Boolean = value match {
+    case nir.Val.Virtual(addr) =>
+      isVirtual(addr)
+    case _ =>
+      false
   }
   def isDelayed(addr: Addr): Boolean = {
     heap(addr).isInstanceOf[DelayedInstance]
   }
-  def isDelayed(value: Val): Boolean = value match {
-    case Val.Virtual(addr) => isDelayed(addr)
-    case _                 => false
+  def isDelayed(value: nir.Val): Boolean = value match {
+    case nir.Val.Virtual(addr) =>
+      isDelayed(addr)
+    case _ =>
+      false
   }
   def hasEscaped(addr: Addr): Boolean = {
     heap(addr).isInstanceOf[EscapedInstance]
   }
-  def hasEscaped(value: Val): Boolean = value match {
-    case Val.Virtual(addr) => hasEscaped(addr)
-    case _                 => false
+  def hasEscaped(value: nir.Val): Boolean = value match {
+    case nir.Val.Virtual(addr) =>
+      hasEscaped(addr)
+    case _ =>
+      false
   }
-  def loadLocal(local: Local): Val = {
+  def loadLocal(local: nir.Local): nir.Val = {
     locals(local)
   }
-  def storeLocal(local: Local, value: Val): Unit = {
+  def storeLocal(local: nir.Local, value: nir.Val): Unit = {
     locals(local) = value
   }
-  def newVar(ty: Type): Local = {
-    val local = Local(-fresh().id)
-    locals(local) = Val.Zero(ty).canonicalize
+  def newVar(ty: nir.Type): nir.Local = {
+    val local = nir.Local(-fresh().id)
+    locals(local) = nir.Val.Zero(ty).canonicalize
     local
   }
-  def loadVar(local: Local): Val = {
+  def loadVar(local: nir.Local): nir.Val = {
     assert(local.id < 0)
     locals(local)
   }
-  def storeVar(local: Local, value: Val): Unit = {
+  def storeVar(local: nir.Local, value: nir.Val): Unit = {
     assert(local.id < 0)
     locals(local) = value
   }
-  def inherit(other: State, roots: Seq[Val]): Unit = {
+  def inherit(other: State, roots: Seq[nir.Val]): Unit = {
     val closure = heapClosure(roots) ++ other.heapClosure(roots)
 
     for {
@@ -188,8 +194,10 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
     } {
       val clone = obj.clone()
       clone match {
-        case DelayedInstance(op) => delayed(op) = Val.Virtual(addr)
-        case _                   => ()
+        case DelayedInstance(op) =>
+          delayed(op) = nir.Val.Virtual(addr)
+        case _ =>
+          ()
       }
       heap(addr) = clone
     }
@@ -200,7 +208,7 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
       virtualNames.addMissing(other.virtualNames)
     }
   }
-  def heapClosure(roots: Seq[Val]): mutable.Set[Addr] = {
+  def heapClosure(roots: Seq[nir.Val]): mutable.Set[Addr] = {
     val reachable = mutable.Set.empty[Addr]
 
     def reachAddr(addr: Addr): Unit = {
@@ -218,55 +226,59 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
       }
     }
 
-    def reachVal(v: Val): Unit = v match {
-      case Val.Virtual(addr)       => reachAddr(addr)
-      case Val.ArrayValue(_, vals) => vals.foreach(reachVal)
-      case Val.StructValue(vals)   => vals.foreach(reachVal)
-      case _                       => ()
+    def reachVal(v: nir.Val): Unit = v match {
+      case nir.Val.Virtual(addr) =>
+        reachAddr(addr)
+      case nir.Val.ArrayValue(_, vals) =>
+        vals.foreach(reachVal)
+      case nir.Val.StructValue(vals) =>
+        vals.foreach(reachVal)
+      case _ =>
+        ()
     }
 
-    def reachOp(op: Op): Unit = op match {
-      case Op.Call(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
-      case Op.Load(_, v, _)       => reachVal(v)
-      case Op.Store(_, v1, v2, _) => reachVal(v1); reachVal(v2)
-      case Op.Elem(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
-      case Op.Extract(v, _)       => reachVal(v)
-      case Op.Insert(v1, v2, _)   => reachVal(v1); reachVal(v2)
-      case Op.Stackalloc(_, v)    => reachVal(v)
-      case Op.Bin(_, _, v1, v2)   => reachVal(v1); reachVal(v2)
-      case Op.Comp(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
-      case Op.Conv(_, _, v)       => reachVal(v)
-      case Op.Fence(_)            => ()
+    def reachOp(op: nir.Op): Unit = op match {
+      case nir.Op.Call(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case nir.Op.Load(_, v, _)       => reachVal(v)
+      case nir.Op.Store(_, v1, v2, _) => reachVal(v1); reachVal(v2)
+      case nir.Op.Elem(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case nir.Op.Extract(v, _)       => reachVal(v)
+      case nir.Op.Insert(v1, v2, _)   => reachVal(v1); reachVal(v2)
+      case nir.Op.Stackalloc(_, v)    => reachVal(v)
+      case nir.Op.Bin(_, _, v1, v2)   => reachVal(v1); reachVal(v2)
+      case nir.Op.Comp(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
+      case nir.Op.Conv(_, _, v)       => reachVal(v)
+      case nir.Op.Fence(_)            => ()
 
-      case Op.Classalloc(_, zh)        => zh.foreach(reachVal)
-      case Op.Fieldload(_, v, _)       => reachVal(v)
-      case Op.Fieldstore(_, v1, _, v2) => reachVal(v1); reachVal(v2)
-      case Op.Field(v, _)              => reachVal(v)
-      case Op.Method(v, _)             => reachVal(v)
-      case Op.Dynmethod(v, _)          => reachVal(v)
-      case _: Op.Module                => ()
-      case Op.As(_, v)                 => reachVal(v)
-      case Op.Is(_, v)                 => reachVal(v)
-      case Op.Copy(v)                  => reachVal(v)
-      case _: Op.SizeOf                => ()
-      case _: Op.AlignmentOf           => ()
-      case Op.Box(_, v)                => reachVal(v)
-      case Op.Unbox(_, v)              => reachVal(v)
-      case _: Op.Var                   => ()
-      case Op.Varload(v)               => reachVal(v)
-      case Op.Varstore(v1, v2)         => reachVal(v1); reachVal(v2)
-      case Op.Arrayalloc(_, v1, zh)    => reachVal(v1); zh.foreach(reachVal)
-      case Op.Arrayload(_, v1, v2)     => reachVal(v1); reachVal(v2)
-      case Op.Arraystore(_, v1, v2, v3) =>
+      case nir.Op.Classalloc(_, zh)        => zh.foreach(reachVal)
+      case nir.Op.Fieldload(_, v, _)       => reachVal(v)
+      case nir.Op.Fieldstore(_, v1, _, v2) => reachVal(v1); reachVal(v2)
+      case nir.Op.Field(v, _)              => reachVal(v)
+      case nir.Op.Method(v, _)             => reachVal(v)
+      case nir.Op.Dynmethod(v, _)          => reachVal(v)
+      case _: nir.Op.Module                => ()
+      case nir.Op.As(_, v)                 => reachVal(v)
+      case nir.Op.Is(_, v)                 => reachVal(v)
+      case nir.Op.Copy(v)                  => reachVal(v)
+      case _: nir.Op.SizeOf                => ()
+      case _: nir.Op.AlignmentOf           => ()
+      case nir.Op.Box(_, v)                => reachVal(v)
+      case nir.Op.Unbox(_, v)              => reachVal(v)
+      case _: nir.Op.Var                   => ()
+      case nir.Op.Varload(v)               => reachVal(v)
+      case nir.Op.Varstore(v1, v2)         => reachVal(v1); reachVal(v2)
+      case nir.Op.Arrayalloc(_, v1, zh)    => reachVal(v1); zh.foreach(reachVal)
+      case nir.Op.Arrayload(_, v1, v2)     => reachVal(v1); reachVal(v2)
+      case nir.Op.Arraystore(_, v1, v2, v3) =>
         reachVal(v1); reachVal(v2); reachVal(v3)
-      case Op.Arraylength(v) => reachVal(v)
+      case nir.Op.Arraylength(v) => reachVal(v)
     }
 
     roots.foreach(reachVal)
 
     reachable
   }
-  def fullClone(block: Local): State = {
+  def fullClone(block: nir.Local): State = {
     val newstate = new State(block)(preserveDebugInfo)
     newstate.heap = heap.mapValuesNow(_.clone())
     newstate.locals = locals.clone()
@@ -286,9 +298,9 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
       false
   }
   def materialize(
-      rootValue: Val
-  )(implicit analysis: ReachabilityAnalysis.Result): Val = {
-    val locals = mutable.Map.empty[Addr, Val]
+      rootValue: nir.Val
+  )(implicit analysis: ReachabilityAnalysis.Result): nir.Val = {
+    val locals = mutable.Map.empty[Addr, nir.Val]
     def reachAddr(addr: Addr): Unit = {
       if (!locals.contains(addr)) {
         val local = reachAlloc(addr)
@@ -299,43 +311,43 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
       }
     }
 
-    def reachAlloc(addr: Addr): Val = heap(addr) match {
+    def reachAlloc(addr: Addr): nir.Val = heap(addr) match {
       case VirtualInstance(ArrayKind, cls, values, zone) =>
         val ArrayRef(elemty, _) = cls.ty: @unchecked
         val canConstantInit =
-          (!elemty.isInstanceOf[Type.RefKind]
+          (!elemty.isInstanceOf[nir.Type.RefKind]
             && values.forall(_.isCanonical)
             && values.exists(v => !v.isZero))
         val init =
           if (canConstantInit) {
-            Val.ArrayValue(elemty, values.toSeq)
+            nir.Val.ArrayValue(elemty, values.toSeq)
           } else {
-            Val.Int(values.length)
+            nir.Val.Int(values.length)
           }
         emitVirtual(addr)(
-          Op.Arrayalloc(elemty, init, zone.map(escapedVal))
+          nir.Op.Arrayalloc(elemty, init, zone.map(escapedVal))
         )
       case VirtualInstance(BoxKind, cls, Array(value), zone) =>
         reachVal(value)
         zone.foreach(reachVal)
         emitVirtual(addr)(
-          Op.Box(Type.Ref(cls.name), escapedVal(value))
+          nir.Op.Box(nir.Type.Ref(cls.name), escapedVal(value))
         )
       case VirtualInstance(StringKind, _, values, zone)
           if !hasEscaped(values(analysis.StringValueField.index)) =>
-        val Val.Virtual(charsAddr) = values(
+        val nir.Val.Virtual(charsAddr) = values(
           analysis.StringValueField.index
         ): @unchecked
         val chars = derefVirtual(charsAddr).values
           .map {
-            case Val.Char(v) => v
-            case _           => unreachable
+            case nir.Val.Char(v) => v
+            case _               => unreachable
           }
           .toArray[Char]
-        Val.String(new java.lang.String(chars))
+        nir.Val.String(new java.lang.String(chars))
       case VirtualInstance(_, cls, values, zone) =>
         emitVirtual(addr)(
-          Op.Classalloc(cls.name, zone.map(escapedVal))
+          nir.Op.Classalloc(cls.name, zone.map(escapedVal))
         )
       case DelayedInstance(op) =>
         reachOp(op)
@@ -348,11 +360,11 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
         escapedVal(value)
     }
 
-    def reachInit(local: Val, addr: Addr): Unit = heap(addr) match {
+    def reachInit(local: nir.Val, addr: Addr): Unit = heap(addr) match {
       case VirtualInstance(ArrayKind, cls, values, zone) =>
         val ArrayRef(elemty, _) = cls.ty: @unchecked
         val canConstantInit =
-          (!elemty.isInstanceOf[Type.RefKind]
+          (!elemty.isInstanceOf[nir.Type.RefKind]
             && values.forall(_.isCanonical)
             && values.exists(v => !v.isZero))
         if (!canConstantInit) {
@@ -362,10 +374,10 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
                 reachVal(value)
                 zone.foreach(reachVal)
                 emitVirtual(addr)(
-                  Op.Arraystore(
+                  nir.Op.Arraystore(
                     ty = elemty,
                     arr = local,
-                    idx = Val.Int(idx),
+                    idx = nir.Val.Int(idx),
                     value = escapedVal(value)
                   )
                 )
@@ -384,7 +396,7 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
               reachVal(value)
               zone.foreach(reachVal)
               emitVirtual(addr)(
-                Op.Fieldstore(
+                nir.Op.Fieldstore(
                   ty = fld.ty,
                   obj = local,
                   name = fld.name,
@@ -397,121 +409,128 @@ final class State(block: Local)(preserveDebugInfo: Boolean) {
       case EscapedInstance(value) => ()
     }
 
-    def reachVal(v: Val): Unit = v match {
-      case Val.Virtual(addr)       => reachAddr(addr)
-      case Val.ArrayValue(_, vals) => vals.foreach(reachVal)
-      case Val.StructValue(vals)   => vals.foreach(reachVal)
-      case _                       => ()
+    def reachVal(v: nir.Val): Unit = v match {
+      case nir.Val.Virtual(addr) =>
+        reachAddr(addr)
+      case nir.Val.ArrayValue(_, vals) =>
+        vals.foreach(reachVal)
+      case nir.Val.StructValue(vals) =>
+        vals.foreach(reachVal)
+      case _ =>
+        ()
     }
 
-    def reachOp(op: Op): Unit = op match {
-      case Op.Call(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
-      case Op.Load(_, v, _)       => reachVal(v)
-      case Op.Store(_, v1, v2, _) => reachVal(v1); reachVal(v2)
-      case Op.Elem(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
-      case Op.Extract(v, _)       => reachVal(v)
-      case Op.Insert(v1, v2, _)   => reachVal(v1); reachVal(v2)
-      case Op.Stackalloc(_, v)    => reachVal(v)
-      case Op.Bin(_, _, v1, v2)   => reachVal(v1); reachVal(v2)
-      case Op.Comp(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
-      case Op.Conv(_, _, v)       => reachVal(v)
-      case Op.Fence(_)            => ()
+    def reachOp(op: nir.Op): Unit = op match {
+      case nir.Op.Call(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case nir.Op.Load(_, v, _)       => reachVal(v)
+      case nir.Op.Store(_, v1, v2, _) => reachVal(v1); reachVal(v2)
+      case nir.Op.Elem(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case nir.Op.Extract(v, _)       => reachVal(v)
+      case nir.Op.Insert(v1, v2, _)   => reachVal(v1); reachVal(v2)
+      case nir.Op.Stackalloc(_, v)    => reachVal(v)
+      case nir.Op.Bin(_, _, v1, v2)   => reachVal(v1); reachVal(v2)
+      case nir.Op.Comp(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
+      case nir.Op.Conv(_, _, v)       => reachVal(v)
+      case nir.Op.Fence(_)            => ()
 
-      case Op.Classalloc(_, zh)        => zh.foreach(reachVal)
-      case Op.Fieldload(_, v, _)       => reachVal(v)
-      case Op.Fieldstore(_, v1, _, v2) => reachVal(v1); reachVal(v2)
-      case Op.Field(v, _)              => reachVal(v)
-      case Op.Method(v, _)             => reachVal(v)
-      case Op.Dynmethod(v, _)          => reachVal(v)
-      case _: Op.Module                => ()
-      case Op.As(_, v)                 => reachVal(v)
-      case Op.Is(_, v)                 => reachVal(v)
-      case Op.Copy(v)                  => reachVal(v)
-      case _: Op.SizeOf                => ()
-      case _: Op.AlignmentOf           => ()
-      case Op.Box(_, v)                => reachVal(v)
-      case Op.Unbox(_, v)              => reachVal(v)
-      case _: Op.Var                   => ()
-      case Op.Varload(v)               => reachVal(v)
-      case Op.Varstore(v1, v2)         => reachVal(v1); reachVal(v2)
-      case Op.Arrayalloc(_, v1, zh)    => reachVal(v1); zh.foreach(reachVal)
-      case Op.Arrayload(_, v1, v2)     => reachVal(v1); reachVal(v2)
-      case Op.Arraystore(_, v1, v2, v3) =>
+      case nir.Op.Classalloc(_, zh)        => zh.foreach(reachVal)
+      case nir.Op.Fieldload(_, v, _)       => reachVal(v)
+      case nir.Op.Fieldstore(_, v1, _, v2) => reachVal(v1); reachVal(v2)
+      case nir.Op.Field(v, _)              => reachVal(v)
+      case nir.Op.Method(v, _)             => reachVal(v)
+      case nir.Op.Dynmethod(v, _)          => reachVal(v)
+      case _: nir.Op.Module                => ()
+      case nir.Op.As(_, v)                 => reachVal(v)
+      case nir.Op.Is(_, v)                 => reachVal(v)
+      case nir.Op.Copy(v)                  => reachVal(v)
+      case _: nir.Op.SizeOf                => ()
+      case _: nir.Op.AlignmentOf           => ()
+      case nir.Op.Box(_, v)                => reachVal(v)
+      case nir.Op.Unbox(_, v)              => reachVal(v)
+      case _: nir.Op.Var                   => ()
+      case nir.Op.Varload(v)               => reachVal(v)
+      case nir.Op.Varstore(v1, v2)         => reachVal(v1); reachVal(v2)
+      case nir.Op.Arrayalloc(_, v1, zh)    => reachVal(v1); zh.foreach(reachVal)
+      case nir.Op.Arrayload(_, v1, v2)     => reachVal(v1); reachVal(v2)
+      case nir.Op.Arraystore(_, v1, v2, v3) =>
         reachVal(v1); reachVal(v2); reachVal(v3)
-      case Op.Arraylength(v) => reachVal(v)
+      case nir.Op.Arraylength(v) => reachVal(v)
     }
 
-    def escapedVal(v: Val): Val = v match {
-      case Val.Virtual(addr) => locals(addr)
-      case _                 => v
+    def escapedVal(v: nir.Val): nir.Val = v match {
+      case nir.Val.Virtual(addr) =>
+        locals(addr)
+      case _ =>
+        v
     }
 
-    def escapedOp(op: Op): Op = op match {
-      case Op.Call(ty, v, vs) =>
-        Op.Call(ty, escapedVal(v), vs.map(escapedVal))
-      case op @ Op.Load(_, v, _) =>
+    def escapedOp(op: nir.Op): nir.Op = op match {
+      case nir.Op.Call(ty, v, vs) =>
+        nir.Op.Call(ty, escapedVal(v), vs.map(escapedVal))
+      case op @ nir.Op.Load(_, v, _) =>
         op.copy(ptr = escapedVal(v))
-      case op @ Op.Store(_, v1, v2, _) =>
+      case op @ nir.Op.Store(_, v1, v2, _) =>
         op.copy(ptr = escapedVal(v1), value = escapedVal(v2))
-      case Op.Elem(ty, v, vs) =>
-        Op.Elem(ty, escapedVal(v), vs.map(escapedVal))
-      case Op.Extract(v, idxs) =>
-        Op.Extract(escapedVal(v), idxs)
-      case Op.Insert(v1, v2, idxs) =>
-        Op.Insert(escapedVal(v1), escapedVal(v2), idxs)
-      case Op.Stackalloc(ty, v) =>
-        Op.Stackalloc(ty, escapedVal(v))
-      case Op.Bin(bin, ty, v1, v2) =>
-        Op.Bin(bin, ty, escapedVal(v1), escapedVal(v2))
-      case Op.Comp(comp, ty, v1, v2) =>
-        Op.Comp(comp, ty, escapedVal(v1), escapedVal(v2))
-      case Op.Conv(conv, ty, v) =>
-        Op.Conv(conv, ty, escapedVal(v))
-      case Op.Fence(_) => op
+      case nir.Op.Elem(ty, v, vs) =>
+        nir.Op.Elem(ty, escapedVal(v), vs.map(escapedVal))
+      case nir.Op.Extract(v, idxs) =>
+        nir.Op.Extract(escapedVal(v), idxs)
+      case nir.Op.Insert(v1, v2, idxs) =>
+        nir.Op.Insert(escapedVal(v1), escapedVal(v2), idxs)
+      case nir.Op.Stackalloc(ty, v) =>
+        nir.Op.Stackalloc(ty, escapedVal(v))
+      case nir.Op.Bin(bin, ty, v1, v2) =>
+        nir.Op.Bin(bin, ty, escapedVal(v1), escapedVal(v2))
+      case nir.Op.Comp(comp, ty, v1, v2) =>
+        nir.Op.Comp(comp, ty, escapedVal(v1), escapedVal(v2))
+      case nir.Op.Conv(conv, ty, v) =>
+        nir.Op.Conv(conv, ty, escapedVal(v))
+      case nir.Op.Fence(_) => op
 
-      case op: Op.Classalloc =>
+      case op: nir.Op.Classalloc =>
         op
-      case Op.Fieldload(ty, v, n) =>
-        Op.Fieldload(ty, escapedVal(v), n)
-      case Op.Fieldstore(ty, v1, n, v2) =>
-        Op.Fieldstore(ty, escapedVal(v1), n, escapedVal(v2))
-      case Op.Field(v, n) =>
-        Op.Field(escapedVal(v), n)
-      case Op.Method(v, n) =>
-        Op.Method(escapedVal(v), n)
-      case Op.Dynmethod(v, n) =>
-        Op.Dynmethod(escapedVal(v), n)
-      case op: Op.Module =>
+      case nir.Op.Fieldload(ty, v, n) =>
+        nir.Op.Fieldload(ty, escapedVal(v), n)
+      case nir.Op.Fieldstore(ty, v1, n, v2) =>
+        nir.Op.Fieldstore(ty, escapedVal(v1), n, escapedVal(v2))
+      case nir.Op.Field(v, n) =>
+        nir.Op.Field(escapedVal(v), n)
+      case nir.Op.Method(v, n) =>
+        nir.Op.Method(escapedVal(v), n)
+      case nir.Op.Dynmethod(v, n) =>
+        nir.Op.Dynmethod(escapedVal(v), n)
+      case op: nir.Op.Module =>
         op
-      case Op.As(ty, v) =>
-        Op.As(ty, escapedVal(v))
-      case Op.Is(ty, v) =>
-        Op.Is(ty, escapedVal(v))
-      case Op.Copy(v) =>
-        Op.Copy(escapedVal(v))
-      case op: Op.SizeOf      => op
-      case op: Op.AlignmentOf => op
-      case Op.Box(ty, v) =>
-        Op.Box(ty, escapedVal(v))
-      case Op.Unbox(ty, v) =>
-        Op.Unbox(ty, escapedVal(v))
-      case op: Op.Var =>
+      case nir.Op.As(ty, v) =>
+        nir.Op.As(ty, escapedVal(v))
+      case nir.Op.Is(ty, v) =>
+        nir.Op.Is(ty, escapedVal(v))
+      case nir.Op.Copy(v) =>
+        nir.Op.Copy(escapedVal(v))
+      case op: nir.Op.SizeOf      => op
+      case op: nir.Op.AlignmentOf => op
+      case nir.Op.Box(ty, v) =>
+        nir.Op.Box(ty, escapedVal(v))
+      case nir.Op.Unbox(ty, v) =>
+        nir.Op.Unbox(ty, escapedVal(v))
+      case op: nir.Op.Var =>
         op
-      case Op.Varload(v) =>
-        Op.Varload(escapedVal(v))
-      case Op.Varstore(v1, v2) =>
-        Op.Varstore(escapedVal(v1), escapedVal(v2))
-      case Op.Arrayalloc(ty, v1, zh) =>
-        Op.Arrayalloc(ty, escapedVal(v1), zh.map(escapedVal))
-      case Op.Arrayload(ty, v1, v2) =>
-        Op.Arrayload(ty, escapedVal(v1), escapedVal(v2))
-      case Op.Arraystore(ty, v1, v2, v3) =>
-        Op.Arraystore(ty, escapedVal(v1), escapedVal(v2), escapedVal(v3))
-      case Op.Arraylength(v) =>
-        Op.Arraylength(escapedVal(v))
+      case nir.Op.Varload(v) =>
+        nir.Op.Varload(escapedVal(v))
+      case nir.Op.Varstore(v1, v2) =>
+        nir.Op.Varstore(escapedVal(v1), escapedVal(v2))
+      case nir.Op.Arrayalloc(ty, v1, zh) =>
+        nir.Op.Arrayalloc(ty, escapedVal(v1), zh.map(escapedVal))
+      case nir.Op.Arrayload(ty, v1, v2) =>
+        nir.Op.Arrayload(ty, escapedVal(v1), escapedVal(v2))
+      case nir.Op.Arraystore(ty, v1, v2, v3) =>
+        nir.Op.Arraystore(ty, escapedVal(v1), escapedVal(v2), escapedVal(v3))
+      case nir.Op.Arraylength(v) =>
+        nir.Op.Arraylength(escapedVal(v))
     }
 
     reachVal(rootValue)
     escapedVal(rootValue)
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/package.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/package.scala
@@ -1,9 +1,9 @@
 package scala.scalanative
 
-import scalanative.nir._
 import scala.collection.mutable
 
 package object interflow {
+
   type Addr = Long
 
   implicit class MutMapOps[K, V](val map: mutable.Map[K, V]) extends AnyVal {
@@ -11,4 +11,5 @@ package object interflow {
       case (key, value) => map.getOrElseUpdate(key, value)
     }
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -6,7 +6,6 @@ import java.nio.file.Path
 import scala.collection.mutable
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir.serialization.deserializeBinary
-import scala.scalanative.nir.{Defn}
 import scala.scalanative.nir.serialization.{Prelude => NirPrelude}
 
 sealed trait ClassPath {
@@ -15,7 +14,7 @@ sealed trait ClassPath {
   private[scalanative] def contains(name: nir.Global): Boolean
 
   /** Load given global and info about its dependencies. */
-  private[scalanative] def load(name: nir.Global): Option[Seq[Defn]]
+  private[scalanative] def load(name: nir.Global): Option[Seq[nir.Defn]]
 
   private[scalanative] def classesWithEntryPoints: Iterable[nir.Global.Top]
 
@@ -43,7 +42,7 @@ object ClassPath {
         .toMap
 
     private val cache =
-      mutable.Map.empty[nir.Global, Option[Seq[Defn]]]
+      mutable.Map.empty[nir.Global, Option[Seq[nir.Defn]]]
 
     def contains(name: nir.Global) =
       files.contains(name.top)
@@ -53,7 +52,7 @@ object ClassPath {
         .resolve(new java.net.URI(file.getFileName().toString))
         .toString
 
-    def load(name: nir.Global): Option[Seq[Defn]] =
+    def load(name: nir.Global): Option[Seq[nir.Defn]] =
       cache.getOrElseUpdate(
         name, {
           files.get(name.top).map { file =>

--- a/tools/src/main/scala/scala/scalanative/linker/Link.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Link.scala
@@ -1,13 +1,12 @@
 package scala.scalanative
 package linker
 
-import scalanative.nir._
 import scalanative.util.Scope
 
 object Link {
 
   /** Load all clases and methods reachable from the entry points. */
-  def apply(config: build.Config, entries: Seq[Global])(implicit
+  def apply(config: build.Config, entries: Seq[nir.Global])(implicit
       scope: Scope
   ): ReachabilityAnalysis =
     Reach(config, entries, ClassLoader.fromDisk(config))
@@ -15,8 +14,9 @@ object Link {
   /** Run reachability analysis on already loaded methods. */
   def apply(
       config: build.Config,
-      entries: Seq[Global],
-      defns: Seq[Defn]
+      entries: Seq[nir.Global],
+      defns: Seq[nir.Defn]
   ): ReachabilityAnalysis =
     Reach(config, entries, ClassLoader.fromMemory(defns))
+
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package linker
 
 import scala.collection.mutable
-import scalanative.nir._
 import scalanative.util.unreachable
 
 /** Our subtyping can be described by a following diagram:
@@ -34,17 +33,17 @@ import scalanative.util.unreachable
  */
 object Sub {
 
-  def is(l: Type, r: Type)(implicit
+  def is(l: nir.Type, r: nir.Type)(implicit
       analysis: ReachabilityAnalysis.Result
   ): Boolean = {
     (l, r) match {
       case (l, r) if l == r =>
         true
-      case (Type.Null, (Type.Ptr | _: Type.RefKind)) =>
+      case (nir.Type.Null, (nir.Type.Ptr | _: nir.Type.RefKind)) =>
         true
-      case (Type.Nothing, (_: Type.ValueKind | _: Type.RefKind)) =>
+      case (nir.Type.Nothing, (_: nir.Type.ValueKind | _: nir.Type.RefKind)) =>
         true
-      case (_: Type.RefKind, Rt.Object) =>
+      case (_: nir.Type.RefKind, nir.Rt.Object) =>
         true
       case (ScopeRef(linfo), ScopeRef(rinfo)) =>
         linfo.is(rinfo)
@@ -53,7 +52,7 @@ object Sub {
     }
   }
 
-  def is(info: ScopeInfo, ty: Type.RefKind)(implicit
+  def is(info: ScopeInfo, ty: nir.Type.RefKind)(implicit
       analysis: ReachabilityAnalysis.Result
   ): Boolean = {
     ty match {
@@ -64,36 +63,36 @@ object Sub {
     }
   }
 
-  def lub(tys: Seq[Type], bound: Option[Type])(implicit
+  def lub(tys: Seq[nir.Type], bound: Option[nir.Type])(implicit
       analysis: ReachabilityAnalysis.Result
-  ): Type = {
+  ): nir.Type = {
     tys match {
       case Seq() =>
         unreachable
       case head +: tail =>
-        tail.foldLeft[Type](head)(lub(_, _, bound))
+        tail.foldLeft[nir.Type](head)(lub(_, _, bound))
     }
   }
 
-  def lub(lty: Type, rty: Type, bound: Option[Type])(implicit
+  def lub(lty: nir.Type, rty: nir.Type, bound: Option[nir.Type])(implicit
       analysis: ReachabilityAnalysis.Result
-  ): Type = {
+  ): nir.Type = {
     (lty, rty) match {
       case _ if lty == rty =>
         lty
-      case (ty, Type.Nothing) =>
+      case (ty, nir.Type.Nothing) =>
         ty
-      case (Type.Nothing, ty) =>
+      case (nir.Type.Nothing, ty) =>
         ty
-      case (Type.Ptr, Type.Null) =>
-        Type.Ptr
-      case (Type.Null, Type.Ptr) =>
-        Type.Ptr
-      case (refty: Type.RefKind, Type.Null) =>
-        Type.Ref(refty.className, refty.isExact, nullable = true)
-      case (Type.Null, refty: Type.RefKind) =>
-        Type.Ref(refty.className, refty.isExact, nullable = true)
-      case (lty: Type.RefKind, rty: Type.RefKind) =>
+      case (nir.Type.Ptr, nir.Type.Null) =>
+        nir.Type.Ptr
+      case (nir.Type.Null, nir.Type.Ptr) =>
+        nir.Type.Ptr
+      case (refty: nir.Type.RefKind, nir.Type.Null) =>
+        nir.Type.Ref(refty.className, refty.isExact, nullable = true)
+      case (nir.Type.Null, refty: nir.Type.RefKind) =>
+        nir.Type.Ref(refty.className, refty.isExact, nullable = true)
+      case (lty: nir.Type.RefKind, rty: nir.Type.RefKind) =>
         val ScopeRef(linfo) = lty: @unchecked
         val ScopeRef(rinfo) = rty: @unchecked
         val binfo = bound.flatMap(ScopeRef.unapply)
@@ -103,7 +102,7 @@ object Sub {
             lubinfo.name == linfo.name && lty.isExact
         val nullable =
           lty.isNullable || rty.isNullable
-        Type.Ref(lubinfo.name, exact, nullable)
+        nir.Type.Ref(lubinfo.name, exact, nullable)
       case _ =>
         util.unsupported(s"lub(${lty.show}, ${rty.show})")
     }
@@ -133,7 +132,7 @@ object Sub {
 
       candidates match {
         case Seq() =>
-          analysis.infos(Rt.Object.name).asInstanceOf[ScopeInfo]
+          analysis.infos(nir.Rt.Object.name).asInstanceOf[ScopeInfo]
         case Seq(cand) =>
           cand
         case _ =>
@@ -148,7 +147,7 @@ object Sub {
           }
 
           minimums.headOption.getOrElse {
-            analysis.infos(Rt.Object.name).asInstanceOf[ScopeInfo]
+            analysis.infos(nir.Rt.Object.name).asInstanceOf[ScopeInfo]
           }
       }
     }

--- a/tools/src/test/scala-2/scala/scalanative/IdentifiersSuite.scala
+++ b/tools/src/test/scala-2/scala/scalanative/IdentifiersSuite.scala
@@ -1,7 +1,5 @@
-package scala.scalanative.linker
-
-import scala.scalanative.nir
-import scala.scalanative.nir.{Rt, Sig, Type}
+package scala.scalanative
+package linker
 
 class IdentifiersSuite extends ReachabilitySuite {
 
@@ -42,33 +40,37 @@ class IdentifiersSuite extends ReachabilitySuite {
     val Main = nir.Global.Top("Main")
     val MainModule = nir.Global.Top("Main$")
 
-    val entry = Main.member(Rt.ScalaMainSig)
-    val privateFooBar = Sig.Scope.Private(FooBar)
+    val entry = Main.member(nir.Rt.ScalaMainSig)
+    val privateFooBar = nir.Sig.Scope.Private(FooBar)
 
     val reachable = Seq(
-      Rt.Object.name,
-      Rt.Object.name.member(Sig.Ctor(Seq.empty)),
+      nir.Rt.Object.name,
+      nir.Rt.Object.name.member(nir.Sig.Ctor(Seq.empty)),
       Main,
-      Main.member(Rt.ScalaMainSig),
+      Main.member(nir.Rt.ScalaMainSig),
       MainModule,
-      MainModule.member(Sig.Ctor(Seq.empty)),
+      MainModule.member(nir.Sig.Ctor(Seq.empty)),
       MainModule.member(
-        Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.Public)
+        nir.Sig.Method("main", nir.Rt.ScalaMainSig.types, nir.Sig.Scope.Public)
       ),
       FooBar,
-      FooBar.member(Sig.Ctor(Seq.empty)),
+      FooBar.member(nir.Sig.Ctor(Seq.empty)),
       // fields
-      FooBar.member(Sig.Field("x", privateFooBar)),
-      FooBar.member(Sig.Field("$u0022x$u0022", privateFooBar)),
-      FooBar.member(Sig.Field("$u0022x$u0022x$u0022", privateFooBar)),
+      FooBar.member(nir.Sig.Field("x", privateFooBar)),
+      FooBar.member(nir.Sig.Field("$u0022x$u0022", privateFooBar)),
+      FooBar.member(nir.Sig.Field("$u0022x$u0022x$u0022", privateFooBar)),
       // accessors
-      FooBar.member(Sig.Method("x", Seq(Type.Ref(FooBar)))),
-      FooBar.member(Sig.Method("$u0022x$u0022", Seq(Type.Ref(FooBar)))),
-      FooBar.member(Sig.Method("$u0022x$u0022x$u0022", Seq(Type.Ref(FooBar)))),
+      FooBar.member(nir.Sig.Method("x", Seq(nir.Type.Ref(FooBar)))),
+      FooBar.member(nir.Sig.Method("$u0022x$u0022", Seq(nir.Type.Ref(FooBar)))),
+      FooBar.member(
+        nir.Sig.Method("$u0022x$u0022x$u0022", Seq(nir.Type.Ref(FooBar)))
+      ),
       // methods
-      FooBar.member(Sig.Method("y", Seq(Type.Ref(FooBar)))),
-      FooBar.member(Sig.Method("$u0022y$u0022", Seq(Type.Ref(FooBar)))),
-      FooBar.member(Sig.Method("$u0022y$u0022y$u0022", Seq(Type.Ref(FooBar))))
+      FooBar.member(nir.Sig.Method("y", Seq(Type.Ref(FooBar)))),
+      FooBar.member(nir.Sig.Method("$u0022y$u0022", Seq(nir.Type.Ref(FooBar)))),
+      FooBar.member(
+        nir.Sig.Method("$u0022y$u0022y$u0022", Seq(nir.Type.Ref(FooBar)))
+      )
     )
     (source, entry, reachable)
   }

--- a/tools/src/test/scala-2/scala/scalanative/IdentifiersSuite.scala
+++ b/tools/src/test/scala-2/scala/scalanative/IdentifiersSuite.scala
@@ -1,6 +1,7 @@
 package scala.scalanative.linker
 
-import scala.scalanative.nir.{Global, Rt, Sig, Type}
+import scala.scalanative.nir
+import scala.scalanative.nir.{Rt, Sig, Type}
 
 class IdentifiersSuite extends ReachabilitySuite {
 
@@ -10,7 +11,7 @@ class IdentifiersSuite extends ReachabilitySuite {
         |  val x: `"Foo"Bar"`.type       = this
         |  val `"x"`: `"Foo"Bar"`.type   = this
         |  val `"x"x"`: `"Foo"Bar"`.type = this
-        |  
+        |
         |  def y(): `"Foo"Bar"`.type     = this
         |  def `"y"`(): `"Foo"Bar"`.type   = this
         |  def `"y"y"`(): `"Foo"Bar"`.type = this
@@ -37,9 +38,9 @@ class IdentifiersSuite extends ReachabilitySuite {
         |}
         |""".stripMargin
 
-    val FooBar = Global.Top("$u0022Foo$u0022Bar$u0022$")
-    val Main = Global.Top("Main")
-    val MainModule = Global.Top("Main$")
+    val FooBar = nir.Global.Top("$u0022Foo$u0022Bar$u0022$")
+    val Main = nir.Global.Top("Main")
+    val MainModule = nir.Global.Top("Main$")
 
     val entry = Main.member(Rt.ScalaMainSig)
     val privateFooBar = Sig.Scope.Private(FooBar)

--- a/tools/src/test/scala-3/scala/scalanative/IdentifiersSuite.scala
+++ b/tools/src/test/scala-3/scala/scalanative/IdentifiersSuite.scala
@@ -58,11 +58,15 @@ class IdentifiersSuite extends ReachabilitySuite {
       // accessors
       FooBar.member(nir.Sig.Method("x", Seq(nir.Type.Ref(FooBar)))),
       FooBar.member(nir.Sig.Method("$u0022x$u0022", Seq(nir.Type.Ref(FooBar)))),
-      FooBar.member(nir.Sig.Method("$u0022x$u0022x$u0022", Seq(nir.Type.Ref(FooBar)))),
+      FooBar.member(
+        nir.Sig.Method("$u0022x$u0022x$u0022", Seq(nir.Type.Ref(FooBar)))
+      ),
       // methods
       FooBar.member(nir.Sig.Method("y", Seq(nir.Type.Ref(FooBar)))),
       FooBar.member(nir.Sig.Method("$u0022y$u0022", Seq(nir.Type.Ref(FooBar)))),
-      FooBar.member(nir.Sig.Method("$u0022y$u0022y$u0022", Seq(nir.Type.Ref(FooBar))))
+      FooBar.member(
+        nir.Sig.Method("$u0022y$u0022y$u0022", Seq(nir.Type.Ref(FooBar)))
+      )
     )
     (source, entry, reachable)
   }

--- a/tools/src/test/scala-3/scala/scalanative/IdentifiersSuite.scala
+++ b/tools/src/test/scala-3/scala/scalanative/IdentifiersSuite.scala
@@ -1,8 +1,7 @@
-package scala.scalanative.linker
+package scala.scalanative
+package linker
 
 import org.junit._
-
-import scala.scalanative.nir.{Global, Rt, Sig, Type}
 
 class IdentifiersSuite extends ReachabilitySuite {
 
@@ -12,7 +11,7 @@ class IdentifiersSuite extends ReachabilitySuite {
         |  val x: `"Foo"Bar"`.type       = this
         |  val `"x"`: `"Foo"Bar"`.type   = this
         |  val `"x"x"`: `"Foo"Bar"`.type = this
-        |  
+        |
         |  def y(): `"Foo"Bar"`.type     = this
         |  def `"y"`(): `"Foo"Bar"`.type   = this
         |  def `"y"y"`(): `"Foo"Bar"`.type = this
@@ -33,37 +32,37 @@ class IdentifiersSuite extends ReachabilitySuite {
         |}
         |""".stripMargin
 
-    val FooBar = Global.Top("$u0022Foo$u0022Bar$u0022$")
-    val Main = Global.Top("Main")
-    val MainModule = Global.Top("Main$")
+    val FooBar = nir.Global.Top("$u0022Foo$u0022Bar$u0022$")
+    val Main = nir.Global.Top("Main")
+    val MainModule = nir.Global.Top("Main$")
 
-    val entry = Main.member(Rt.ScalaMainSig)
-    val privateFooBar = Sig.Scope.Private(FooBar)
+    val entry = Main.member(nir.Rt.ScalaMainSig)
+    val privateFooBar = nir.Sig.Scope.Private(FooBar)
 
     val reachable = Seq(
-      Rt.Object.name,
-      Rt.Object.name.member(Sig.Ctor(Seq.empty)),
+      nir.Rt.Object.name,
+      nir.Rt.Object.name.member(nir.Sig.Ctor(Seq.empty)),
       Main,
-      Main.member(Rt.ScalaMainSig),
+      Main.member(nir.Rt.ScalaMainSig),
       MainModule,
-      MainModule.member(Sig.Ctor(Seq.empty)),
+      MainModule.member(nir.Sig.Ctor(Seq.empty)),
       MainModule.member(
-        Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.Public)
+        nir.Sig.Method("main", nir.Rt.ScalaMainSig.types, nir.Sig.Scope.Public)
       ),
       FooBar,
-      FooBar.member(Sig.Ctor(Seq.empty)),
+      FooBar.member(nir.Sig.Ctor(Seq.empty)),
       // fields
-      FooBar.member(Sig.Field("x", privateFooBar)),
-      FooBar.member(Sig.Field("$u0022x$u0022", privateFooBar)),
-      FooBar.member(Sig.Field("$u0022x$u0022x$u0022", privateFooBar)),
+      FooBar.member(nir.Sig.Field("x", privateFooBar)),
+      FooBar.member(nir.Sig.Field("$u0022x$u0022", privateFooBar)),
+      FooBar.member(nir.Sig.Field("$u0022x$u0022x$u0022", privateFooBar)),
       // accessors
-      FooBar.member(Sig.Method("x", Seq(Type.Ref(FooBar)))),
-      FooBar.member(Sig.Method("$u0022x$u0022", Seq(Type.Ref(FooBar)))),
-      FooBar.member(Sig.Method("$u0022x$u0022x$u0022", Seq(Type.Ref(FooBar)))),
+      FooBar.member(nir.Sig.Method("x", Seq(nir.Type.Ref(FooBar)))),
+      FooBar.member(nir.Sig.Method("$u0022x$u0022", Seq(nir.Type.Ref(FooBar)))),
+      FooBar.member(nir.Sig.Method("$u0022x$u0022x$u0022", Seq(nir.Type.Ref(FooBar)))),
       // methods
-      FooBar.member(Sig.Method("y", Seq(Type.Ref(FooBar)))),
-      FooBar.member(Sig.Method("$u0022y$u0022", Seq(Type.Ref(FooBar)))),
-      FooBar.member(Sig.Method("$u0022y$u0022y$u0022", Seq(Type.Ref(FooBar))))
+      FooBar.member(nir.Sig.Method("y", Seq(nir.Type.Ref(FooBar)))),
+      FooBar.member(nir.Sig.Method("$u0022y$u0022", Seq(nir.Type.Ref(FooBar)))),
+      FooBar.member(nir.Sig.Method("$u0022y$u0022y$u0022", Seq(nir.Type.Ref(FooBar))))
     )
     (source, entry, reachable)
   }

--- a/tools/src/test/scala/scala/scalanative/linker/ClassReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ClassReachabilitySuite.scala
@@ -1,6 +1,5 @@
-package scala.scalanative.linker
-
-import scalanative.nir.{Sig, Type, Rt}
+package scala.scalanative
+package linker
 
 import org.junit.Test
 import org.junit.Assert._
@@ -12,28 +11,34 @@ class ClassReachabilitySuite extends ReachabilitySuite {
   val ParentClsName = "Parent"
   val ObjectClsName = "java.lang.Object"
   val ScalaMainNonStaticSig =
-    Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.Public)
+    nir.Sig.Method("main", nir.Rt.ScalaMainSig.types, nir.Sig.Scope.Public)
 
   val Parent = g(ParentClsName)
-  val ParentInit = g(ParentClsName, Sig.Ctor(Seq.empty))
-  val ParentFoo = g(ParentClsName, Sig.Method("foo", Seq(Type.Unit)))
-  val ParentBar = g(ParentClsName, Sig.Field("bar"))
+  val ParentInit = g(ParentClsName, nir.Sig.Ctor(Seq.empty))
+  val ParentFoo = g(ParentClsName, nir.Sig.Method("foo", Seq(nir.Type.Unit)))
+  val ParentBar = g(ParentClsName, nir.Sig.Field("bar"))
   val ParentBarSet =
-    g(ParentClsName, Sig.Method("bar_$eq", Seq(Type.Int, Type.Unit)))
-  val ParentBarGet = g(ParentClsName, Sig.Method("bar", Seq(Type.Int)))
+    g(
+      ParentClsName,
+      nir.Sig.Method("bar_$eq", Seq(nir.Type.Int, nir.Type.Unit))
+    )
+  val ParentBarGet = g(ParentClsName, nir.Sig.Method("bar", Seq(nir.Type.Int)))
   val ParentMain = g(ParentClsName, ScalaMainNonStaticSig)
   val Child = g(ChildClsName)
-  val ChildInit = g(ChildClsName, Sig.Ctor(Seq.empty))
-  val ChildFoo = g(ChildClsName, Sig.Method("foo", Seq(Type.Unit)))
+  val ChildInit = g(ChildClsName, nir.Sig.Ctor(Seq.empty))
+  val ChildFoo = g(ChildClsName, nir.Sig.Method("foo", Seq(nir.Type.Unit)))
   val Object = g(ObjectClsName)
-  val ObjectInit = g(ObjectClsName, Sig.Ctor(Seq.empty))
+  val ObjectInit = g(ObjectClsName, nir.Sig.Ctor(Seq.empty))
   val Test = g(TestClsName)
   val TestModule = g(TestModuleName)
-  val TestInit = g(TestModuleName, Sig.Ctor(Seq.empty))
-  val TestMain = g(TestClsName, Rt.ScalaMainSig)
+  val TestInit = g(TestModuleName, nir.Sig.Ctor(Seq.empty))
+  val TestMain = g(TestClsName, nir.Rt.ScalaMainSig)
   val TestModuleMain = g(TestModuleName, ScalaMainNonStaticSig)
   val TestCallFoo =
-    g(TestModuleName, Sig.Method("callFoo", Seq(Type.Ref(Parent), Type.Unit)))
+    g(
+      TestModuleName,
+      nir.Sig.Method("callFoo", Seq(nir.Type.Ref(Parent), nir.Type.Unit))
+    )
 
   val commonReachable =
     Seq(Test, TestModule, TestInit, TestMain, TestModuleMain)

--- a/tools/src/test/scala/scala/scalanative/linker/ClassReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ClassReachabilitySuite.scala
@@ -1,6 +1,6 @@
 package scala.scalanative.linker
 
-import scalanative.nir.{Sig, Type, Global, Rt}
+import scalanative.nir.{Sig, Type, Rt}
 
 import org.junit.Test
 import org.junit.Assert._

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.linker
+package scala.scalanative
+package linker
 
 import scala.scalanative.LinkerSpec
 
@@ -6,8 +7,6 @@ import org.junit.Test
 import org.junit.Assert._
 import scala.scalanative.build.{NativeConfig, Config}
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo
-
-import scala.scalanative.nir._
 
 /** Tests minimal number of NIR symbols required when linking minimal
  *  application based on the predefined hard limits. In the future we shall try
@@ -119,11 +118,11 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       s"{types=$types, members=$members, total=${total}}"
   }
   object SymbolsCount {
-    def apply(defns: Seq[Defn]): SymbolsCount = {
+    def apply(defns: Seq[nir.Defn]): SymbolsCount = {
       val names = defns.map(_.name)
       SymbolsCount(
-        types = names.count(_.isInstanceOf[Global.Top]),
-        members = names.count(_.isInstanceOf[Global.Member])
+        types = names.count(_.isInstanceOf[nir.Global.Top]),
+        members = names.count(_.isInstanceOf[nir.Global.Member])
       )
     }
   }

--- a/tools/src/test/scala/scala/scalanative/linker/MissingSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MissingSymbolsTest.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.linker
+package scala.scalanative
+package linker
 
 import scala.scalanative.checker.Check
 import scala.scalanative.LinkerSpec
@@ -6,7 +7,6 @@ import scala.scalanative.LinkerSpec
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.nir._
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -14,6 +14,7 @@ import scala.scalanative.optimizer.assertContainsAll
 import java.sql.Time
 
 class MissingSymbolsTest extends LinkerSpec {
+
   private val mainClass = "Test"
   private val sourceFile = "Test.scala"
 
@@ -53,13 +54,13 @@ class MissingSymbolsTest extends LinkerSpec {
             .map(_.symbol)
             .map(v => (v.kind, v.name, v.argTypes))
         )
-        val TimeType = Global.Top("java.sql.Time")
-        val TimeCtor = TimeType.member(Sig.Ctor(Seq(Type.Long)))
+        val TimeType = nir.Global.Top("java.sql.Time")
+        val TimeCtor = TimeType.member(nir.Sig.Ctor(Seq(nir.Type.Long)))
         val TimeValueOf = TimeType.member(
-          Sig.Method(
+          nir.Sig.Method(
             "valueOf",
-            Seq(Rt.String, Type.Ref(TimeType)),
-            Sig.Scope.PublicStatic
+            Seq(nir.Rt.String, nir.Type.Ref(TimeType)),
+            nir.Sig.Scope.PublicStatic
           )
         )
         assertContainsAll(

--- a/tools/src/test/scala/scala/scalanative/linker/ModuleReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ModuleReachabilitySuite.scala
@@ -1,11 +1,11 @@
-package scala.scalanative.linker
+package scala.scalanative
+package linker
 
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.nir.{Sig, Type, Rt}
-
 class ModuleReachabilitySuite extends ReachabilitySuite {
+
   val sources = Seq("""
     object Module {
       def meth: Unit = ()
@@ -18,26 +18,29 @@ class ModuleReachabilitySuite extends ReachabilitySuite {
   val ParentClsName = "Parent"
   val ObjectClsName = "java.lang.Object"
   val ScalaMainNonStaticSig =
-    Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.Public)
+    nir.Sig.Method("main", nir.Rt.ScalaMainSig.types, nir.Sig.Scope.Public)
 
   val Test = g(TestClsName)
   val TestModule = g(TestModuleName)
-  val TestInit = g(TestModuleName, Sig.Ctor(Seq.empty))
-  val TestMain = g(TestClsName, Rt.ScalaMainSig)
+  val TestInit = g(TestModuleName, nir.Sig.Ctor(Seq.empty))
+  val TestMain = g(TestClsName, nir.Rt.ScalaMainSig)
   val TestModuleMain = g(TestModuleName, ScalaMainNonStaticSig)
   val Module = g(ModuleClsName)
-  val ModuleInit = g(ModuleClsName, Sig.Ctor(Seq.empty))
-  val ModuleFoo = g(ModuleClsName, Sig.Method("foo", Seq(Type.Unit)))
-  val ModuleBar = g(ModuleClsName, Sig.Field("bar"))
+  val ModuleInit = g(ModuleClsName, nir.Sig.Ctor(Seq.empty))
+  val ModuleFoo = g(ModuleClsName, nir.Sig.Method("foo", Seq(nir.Type.Unit)))
+  val ModuleBar = g(ModuleClsName, nir.Sig.Field("bar"))
   val ModuleBarSet =
-    g(ModuleClsName, Sig.Method("bar_$eq", Seq(Type.Int, Type.Unit)))
-  val ModuleBarGet = g(ModuleClsName, Sig.Method("bar", Seq(Type.Int)))
+    g(
+      ModuleClsName,
+      nir.Sig.Method("bar_$eq", Seq(nir.Type.Int, nir.Type.Unit))
+    )
+  val ModuleBarGet = g(ModuleClsName, nir.Sig.Method("bar", Seq(nir.Type.Int)))
   val Parent = g(ParentClsName)
-  val ParentInit = g(ParentClsName, Sig.Ctor(Seq.empty))
-  val ParentFoo = g(ParentClsName, Sig.Method("foo", Seq(Type.Unit)))
+  val ParentInit = g(ParentClsName, nir.Sig.Ctor(Seq.empty))
+  val ParentFoo = g(ParentClsName, nir.Sig.Method("foo", Seq(nir.Type.Unit)))
   val Trait = g("Trait")
   val Object = g(ObjectClsName)
-  val ObjectInit = g(ObjectClsName, Sig.Ctor(Seq.empty))
+  val ObjectInit = g(ObjectClsName, nir.Sig.Ctor(Seq.empty))
 
   val commonReachable =
     Seq(Test, TestModule, TestInit, TestMain, TestModuleMain)
@@ -235,4 +238,5 @@ class ModuleReachabilitySuite extends ReachabilitySuite {
     )
     (source, entry, commonReachable ++ reachable)
   }
+
 }

--- a/tools/src/test/scala/scala/scalanative/linker/ModuleReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ModuleReachabilitySuite.scala
@@ -3,7 +3,7 @@ package scala.scalanative.linker
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.nir.{Sig, Type, Global, Rt}
+import scalanative.nir.{Sig, Type, Rt}
 
 class ModuleReachabilitySuite extends ReachabilitySuite {
   val sources = Seq("""

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scalanative.util.Scope
-import scalanative.nir.{Sig, Global}
+import scalanative.nir.{Sig}
 import scalanative.build.{ScalaNative, Logger, Discover}
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -16,23 +16,23 @@ import scala.scalanative.buildinfo.ScalaNativeBuildInfo
 
 trait ReachabilitySuite {
 
-  def g(top: String): Global.Top =
-    Global.Top(top)
+  def g(top: String): nir.Global.Top =
+    nir.Global.Top(top)
 
-  def g(top: String, sig: Sig): Global.Member =
-    Global.Member(Global.Top(top), sig)
+  def g(top: String, sig: Sig): nir.Global.Member =
+    nir.Global.Member(nir.Global.Top(top), sig)
 
   private val MainMethodDependencies = Set(
-    Global.Top("java.lang.String"),
-    Global.Top("java.lang.CharSequence"),
-    Global.Top("java.lang.Comparable"),
-    Global.Top("java.io.Serializable"),
-    Global.Top("java.lang.constant.Constable"),
-    Global.Top("java.lang.constant.ConstantDesc")
+    nir.Global.Top("java.lang.String"),
+    nir.Global.Top("java.lang.CharSequence"),
+    nir.Global.Top("java.lang.Comparable"),
+    nir.Global.Top("java.io.Serializable"),
+    nir.Global.Top("java.lang.constant.Constable"),
+    nir.Global.Top("java.lang.constant.ConstantDesc")
   )
 
   def testReachable(includeMainDeps: Boolean = true)(
-      f: => (String, Global, Seq[Global])
+      f: => (String, nir.Global, Seq[nir.Global])
   ) = {
     val (source, entry, expected) = f
     // When running reachability tests disable loading static constructors
@@ -74,7 +74,7 @@ trait ReachabilitySuite {
    *    The result of applying `fn` to the resulting definitions.
    */
   def link[T](
-      entries: Seq[Global],
+      entries: Seq[nir.Global],
       sources: Seq[String],
       mainClass: String
   )(f: ReachabilityAnalysis => T): T =

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -7,7 +7,6 @@ import org.junit.Assert._
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scalanative.util.Scope
-import scalanative.nir.{Sig}
 import scalanative.build.{ScalaNative, Logger, Discover}
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -19,7 +18,7 @@ trait ReachabilitySuite {
   def g(top: String): nir.Global.Top =
     nir.Global.Top(top)
 
-  def g(top: String, sig: Sig): nir.Global.Member =
+  def g(top: String, sig: nir.Sig): nir.Global.Member =
     nir.Global.Member(nir.Global.Top(top), sig)
 
   private val MainMethodDependencies = Set(

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package linker
 
-import nir.{Sig, Type, Global}
+import nir.{Sig, Type}
 
 import org.junit.Test
 import org.junit.Assert._
@@ -33,7 +33,7 @@ class StubSpec extends LinkerSpec {
         assertTrue(!cfg.linkStubs)
         assertTrue(result.unreachable.length == 1)
         assertEquals(
-          Global
+          nir.Global
             .Top("Main$")
             .member(Sig.Method("stubMethod", Seq(Type.Int))),
           result.unreachable.head.name
@@ -53,7 +53,7 @@ class StubSpec extends LinkerSpec {
       (cfg, result: ReachabilityAnalysis.Failure) =>
         assertTrue(!cfg.linkStubs)
         assertTrue(result.unreachable.length == 1)
-        assertTrue(result.unreachable.head.name == Global.Top("StubClass"))
+        assertTrue(result.unreachable.head.name == nir.Global.Top("StubClass"))
     }
   }
 
@@ -69,7 +69,7 @@ class StubSpec extends LinkerSpec {
       case (cfg, result) =>
         assertTrue(!cfg.linkStubs)
         assertTrue(result.unreachable.length == 1)
-        assertTrue(result.unreachable.head.name == Global.Top("StubModule$"))
+        assertTrue(result.unreachable.head.name == nir.Global.Top("StubModule$"))
     }
   }
 

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package linker
 
-import nir.{Sig, Type}
-
 import org.junit.Test
 import org.junit.Assert._
 
@@ -35,7 +33,7 @@ class StubSpec extends LinkerSpec {
         assertEquals(
           nir.Global
             .Top("Main$")
-            .member(Sig.Method("stubMethod", Seq(Type.Int))),
+            .member(nir.Sig.Method("stubMethod", Seq(nir.Type.Int))),
           result.unreachable.head.name
         )
     }
@@ -69,7 +67,9 @@ class StubSpec extends LinkerSpec {
       case (cfg, result) =>
         assertTrue(!cfg.linkStubs)
         assertTrue(result.unreachable.length == 1)
-        assertTrue(result.unreachable.head.name == nir.Global.Top("StubModule$"))
+        assertTrue(
+          result.unreachable.head.name == nir.Global.Top("StubModule$")
+        )
     }
   }
 

--- a/tools/src/test/scala/scala/scalanative/linker/SubSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/SubSuite.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package linker
 
-import scalanative.nir._
-
 import org.junit.Test
 import org.junit.Assert._
 
@@ -23,7 +21,8 @@ class SubSuite extends ReachabilitySuite {
   """
 
   val MainClass = "Main"
-  val entry: Global.Member = Global.Top(MainClass).member(Rt.ScalaMainSig)
+  val entry: nir.Global.Member =
+    nir.Global.Top(MainClass).member(nir.Rt.ScalaMainSig)
 
   implicit val analysis: ReachabilityAnalysis.Result =
     link(Seq(entry), Seq(source), MainClass) {
@@ -32,36 +31,36 @@ class SubSuite extends ReachabilitySuite {
     }
 
   val primitiveTypes = Seq(
-    Type.Bool,
-    Type.Ptr,
-    Type.Char,
-    Type.Byte,
-    Type.Short,
-    Type.Int,
-    Type.Long,
-    Type.Float,
-    Type.Double
+    nir.Type.Bool,
+    nir.Type.Ptr,
+    nir.Type.Char,
+    nir.Type.Byte,
+    nir.Type.Short,
+    nir.Type.Int,
+    nir.Type.Long,
+    nir.Type.Float,
+    nir.Type.Double
   )
 
   val aggregateTypes = Seq(
-    Type.StructValue(Seq(Type.Bool, Type.Int)),
-    Type.ArrayValue(Type.Byte, 32)
+    nir.Type.StructValue(Seq(nir.Type.Bool, nir.Type.Int)),
+    nir.Type.ArrayValue(nir.Type.Byte, 32)
   )
 
   val valueTypes =
     primitiveTypes ++ aggregateTypes
 
-  val A = Type.Ref(Global.Top("A"))
-  val B = Type.Ref(Global.Top("B"))
-  val C = Type.Ref(Global.Top("C"))
-  val T1 = Type.Ref(Global.Top("T1"))
-  val T2 = Type.Ref(Global.Top("T2"))
-  val T3 = Type.Ref(Global.Top("T3"))
+  val A = nir.Type.Ref(nir.Global.Top("A"))
+  val B = nir.Type.Ref(nir.Global.Top("B"))
+  val C = nir.Type.Ref(nir.Global.Top("C"))
+  val T1 = nir.Type.Ref(nir.Global.Top("T1"))
+  val T2 = nir.Type.Ref(nir.Global.Top("T2"))
+  val T3 = nir.Type.Ref(nir.Global.Top("T3"))
 
   val referenceTypes = Seq(
-    Type.Null,
-    Type.Unit,
-    Type.Array(Type.Int),
+    nir.Type.Null,
+    nir.Type.Unit,
+    nir.Type.Array(nir.Type.Int),
     A,
     B,
     C,
@@ -73,10 +72,10 @@ class SubSuite extends ReachabilitySuite {
   val types =
     valueTypes ++ referenceTypes
 
-  def testIs(l: Type, r: Type) =
+  def testIs(l: nir.Type, r: nir.Type) =
     assertTrue(s"${l.show} is ${r.show}", Sub.is(l, r))
 
-  def testIsNot(l: Type, r: Type) =
+  def testIsNot(l: nir.Type, r: nir.Type) =
     assertTrue(s"${l.show} is not ${r.show}", !Sub.is(l, r))
 
   @Test def valueTypeWithvalueTypes(): Unit = {
@@ -93,7 +92,7 @@ class SubSuite extends ReachabilitySuite {
 
   @Test def valueTypeWitRefTypes(): Unit = {
     valueTypes.foreach { vty =>
-      referenceTypes.filter(_ != Type.Null).foreach { rty =>
+      referenceTypes.filter(_ != nir.Type.Null).foreach { rty =>
         testIsNot(vty, rty)
         testIsNot(rty, vty)
       }
@@ -101,14 +100,14 @@ class SubSuite extends ReachabilitySuite {
   }
 
   @Test def nullTypes(): Unit =
-    referenceTypes.foreach { rty => testIs(Type.Null, rty) }
+    referenceTypes.foreach { rty => testIs(nir.Type.Null, rty) }
 
   @Test def nothingType(): Unit =
-    types.foreach { ty => testIs(Type.Nothing, ty) }
+    types.foreach { ty => testIs(nir.Type.Nothing, ty) }
 
   @Test def referenceObjectTypes(): Unit =
     referenceTypes.foreach { rty =>
-      testIs(rty, Type.Ref(Global.Top("java.lang.Object")))
+      testIs(rty, nir.Type.Ref(nir.Global.Top("java.lang.Object")))
     }
 
   @Test def inheritence(): Unit = {
@@ -154,4 +153,5 @@ class SubSuite extends ReachabilitySuite {
     testIsNot(T3, T2)
     testIs(T3, T3)
   }
+
 }

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package linker
 
 import scala.scalanative.NativePlatform
-import scala.scalanative.nir.{Global, Sig, Type, Rt}
+import scala.scalanative.nir.{Sig, Type, Rt}
 
 import org.junit.Test
 import org.junit.Assert._
@@ -18,28 +18,28 @@ class TraitReachabilitySuite extends ReachabilitySuite {
   val ScalaMainNonStaticSig =
     Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.Public)
 
-  val Parent: Global.Top = g(ParentClsName)
+  val Parent: nir.Global.Top = g(ParentClsName)
   // Scala 2.12.x
-  val ParentInit: Global =
+  val ParentInit: nir.Global =
     g(ParentClsName, Sig.Method("$init$", Seq(Type.Unit)))
-  val ParentMain: Global = g(ParentClsName, ScalaMainNonStaticSig)
-  val ParentFoo: Global = g(ParentClsName, Sig.Method("foo", Seq(Type.Unit)))
+  val ParentMain: nir.Global = g(ParentClsName, ScalaMainNonStaticSig)
+  val ParentFoo: nir.Global = g(ParentClsName, Sig.Method("foo", Seq(Type.Unit)))
 
-  val Child: Global = g(ChildClsName)
-  val ChildInit: Global = g(ChildClsName, Sig.Ctor(Seq.empty))
-  val ChildFoo: Global = g(ChildClsName, Sig.Method("foo", Seq(Type.Unit)))
-  val GrandChild: Global = g(GrandChildClsName)
-  val GrandChildInit: Global = g(GrandChildClsName, Sig.Ctor(Seq.empty))
-  val GrandChildFoo: Global =
+  val Child: nir.Global = g(ChildClsName)
+  val ChildInit: nir.Global = g(ChildClsName, Sig.Ctor(Seq.empty))
+  val ChildFoo: nir.Global = g(ChildClsName, Sig.Method("foo", Seq(Type.Unit)))
+  val GrandChild: nir.Global = g(GrandChildClsName)
+  val GrandChildInit: nir.Global = g(GrandChildClsName, Sig.Ctor(Seq.empty))
+  val GrandChildFoo: nir.Global =
     g(GrandChildClsName, Sig.Method("foo", Seq(Type.Unit)))
-  val Object: Global = g(ObjectClsName)
-  val ObjectInit: Global = g(ObjectClsName, Sig.Ctor(Seq.empty))
-  val Test: Global = g(TestClsName)
-  val TestModule: Global = g(TestModuleName)
-  val TestInit: Global = g(TestModuleName, Sig.Ctor(Seq.empty))
-  val TestMain: Global = g(TestClsName, Rt.ScalaMainSig)
-  val TestModuleMain: Global = g(TestModuleName, ScalaMainNonStaticSig)
-  val TestCallFoo: Global =
+  val Object: nir.Global = g(ObjectClsName)
+  val ObjectInit: nir.Global = g(ObjectClsName, Sig.Ctor(Seq.empty))
+  val Test: nir.Global = g(TestClsName)
+  val TestModule: nir.Global = g(TestModuleName)
+  val TestInit: nir.Global = g(TestModuleName, Sig.Ctor(Seq.empty))
+  val TestMain: nir.Global = g(TestClsName, Rt.ScalaMainSig)
+  val TestModuleMain: nir.Global = g(TestModuleName, ScalaMainNonStaticSig)
+  val TestCallFoo: nir.Global =
     g(TestModuleName, Sig.Method("callFoo", Seq(Type.Ref(Parent), Type.Unit)))
   val commonReachable =
     Seq(Test, TestModule, TestInit, TestMain, TestModuleMain)

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package linker
 
 import scala.scalanative.NativePlatform
-import scala.scalanative.nir.{Sig, Type, Rt}
 
 import org.junit.Test
 import org.junit.Assert._
@@ -16,31 +15,36 @@ class TraitReachabilitySuite extends ReachabilitySuite {
   val ParentClassClsName = "Parent$class"
   val ObjectClsName = "java.lang.Object"
   val ScalaMainNonStaticSig =
-    Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.Public)
+    nir.Sig.Method("main", nir.Rt.ScalaMainSig.types, nir.Sig.Scope.Public)
 
   val Parent: nir.Global.Top = g(ParentClsName)
   // Scala 2.12.x
   val ParentInit: nir.Global =
-    g(ParentClsName, Sig.Method("$init$", Seq(Type.Unit)))
+    g(ParentClsName, nir.Sig.Method("$init$", Seq(nir.Type.Unit)))
   val ParentMain: nir.Global = g(ParentClsName, ScalaMainNonStaticSig)
-  val ParentFoo: nir.Global = g(ParentClsName, Sig.Method("foo", Seq(Type.Unit)))
+  val ParentFoo: nir.Global =
+    g(ParentClsName, nir.Sig.Method("foo", Seq(nir.Type.Unit)))
 
   val Child: nir.Global = g(ChildClsName)
-  val ChildInit: nir.Global = g(ChildClsName, Sig.Ctor(Seq.empty))
-  val ChildFoo: nir.Global = g(ChildClsName, Sig.Method("foo", Seq(Type.Unit)))
+  val ChildInit: nir.Global = g(ChildClsName, nir.Sig.Ctor(Seq.empty))
+  val ChildFoo: nir.Global =
+    g(ChildClsName, nir.Sig.Method("foo", Seq(nir.Type.Unit)))
   val GrandChild: nir.Global = g(GrandChildClsName)
-  val GrandChildInit: nir.Global = g(GrandChildClsName, Sig.Ctor(Seq.empty))
+  val GrandChildInit: nir.Global = g(GrandChildClsName, nir.Sig.Ctor(Seq.empty))
   val GrandChildFoo: nir.Global =
-    g(GrandChildClsName, Sig.Method("foo", Seq(Type.Unit)))
+    g(GrandChildClsName, nir.Sig.Method("foo", Seq(nir.Type.Unit)))
   val Object: nir.Global = g(ObjectClsName)
-  val ObjectInit: nir.Global = g(ObjectClsName, Sig.Ctor(Seq.empty))
+  val ObjectInit: nir.Global = g(ObjectClsName, nir.Sig.Ctor(Seq.empty))
   val Test: nir.Global = g(TestClsName)
   val TestModule: nir.Global = g(TestModuleName)
-  val TestInit: nir.Global = g(TestModuleName, Sig.Ctor(Seq.empty))
-  val TestMain: nir.Global = g(TestClsName, Rt.ScalaMainSig)
+  val TestInit: nir.Global = g(TestModuleName, nir.Sig.Ctor(Seq.empty))
+  val TestMain: nir.Global = g(TestClsName, nir.Rt.ScalaMainSig)
   val TestModuleMain: nir.Global = g(TestModuleName, ScalaMainNonStaticSig)
   val TestCallFoo: nir.Global =
-    g(TestModuleName, Sig.Method("callFoo", Seq(Type.Ref(Parent), Type.Unit)))
+    g(
+      TestModuleName,
+      nir.Sig.Method("callFoo", Seq(nir.Type.Ref(Parent), nir.Type.Unit))
+    )
   val commonReachable =
     Seq(Test, TestModule, TestInit, TestMain, TestModuleMain)
 
@@ -248,4 +252,5 @@ class TraitReachabilitySuite extends ReachabilitySuite {
       }
     (source, entry, commonReachable.diff(Seq(TestModuleMain)) ++ reachable)
   }
+
 }

--- a/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
@@ -10,7 +10,6 @@ import scala.scalanative.linker.ReachabilityAnalysis
 import scala.scalanative.nir.Defn.Define.DebugInfo.LexicalScope
 
 class LexicalScopesTest extends OptimizerSpec {
-  import nir._
 
   override def optimize[T](
       entry: String,
@@ -27,10 +26,10 @@ class LexicalScopesTest extends OptimizerSpec {
       }.andThen(setupConfig)
     )(fn)
 
-  def scopeOf(localName: LocalName)(implicit defn: Defn.Define) =
+  def scopeOf(localName: nir.LocalName)(implicit defn: nir.Defn.Define) =
     namedLets(defn)
       .collectFirst {
-        case (let @ Inst.Let(id, _, _), `localName`) => let.scopeId
+        case (let @ nir.Inst.Let(id, _, _), `localName`) => let.scopeId
       }
       .orElse { fail(s"Not found a local named: ${localName}"); None }
       .flatMap(id => defn.debugInfo.lexicalScopeOf.get(id))
@@ -39,10 +38,10 @@ class LexicalScopesTest extends OptimizerSpec {
 
   def scopeParents(
       scope: LexicalScope
-  )(implicit defn: Defn.Define): List[ScopeId] = {
+  )(implicit defn: nir.Defn.Define): List[nir.ScopeId] = {
     if (scope.isTopLevel) Nil
     else {
-      val stack = List.newBuilder[ScopeId]
+      val stack = List.newBuilder[nir.ScopeId]
       var current = scope
       while ({
         val parent = defn.debugInfo.lexicalScopeOf(current.parent)
@@ -80,7 +79,7 @@ class LexicalScopesTest extends OptimizerSpec {
     setupConfig = _.withMode(build.Mode.debug)
   ) {
     case (config, result) =>
-      def test(defns: Seq[Defn]): Unit = findEntry(defns).foreach {
+      def test(defns: Seq[nir.Defn]): Unit = findEntry(defns).foreach {
         implicit defn =>
           assertContainsAll(
             "named vals",
@@ -140,7 +139,7 @@ class LexicalScopesTest extends OptimizerSpec {
   ) {
     case (config, result) =>
       assertEquals(config.compilerConfig.mode, build.Mode.releaseFull)
-      def test(defns: Seq[Defn]): Unit = findEntry(defns).foreach {
+      def test(defns: Seq[nir.Defn]): Unit = findEntry(defns).foreach {
         implicit defn =>
           assertContainsAll(
             "named vals",
@@ -212,7 +211,7 @@ class LexicalScopesTest extends OptimizerSpec {
         )
         // a and b can move moved to seperate scopes in transofrmation, but shall still have common parent
         val a = scopeOf("a")
-        assertEquals("a-parent", a.id, ScopeId.TopLevel)
+        assertEquals("a-parent", a.id, nir.ScopeId.TopLevel)
 
         val myMin = scopeOf("myMin")
         assertNotEquals("myMin-scope", a.id, myMin.id)

--- a/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
@@ -8,7 +8,6 @@ import scala.collection.mutable
 
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
 import scala.reflect.ClassTag
-import scala.scalanative.nir.Global.Member
 import scala.scalanative.linker.ReachabilityAnalysis
 
 class LocalNamesTest extends OptimizerSpec {

--- a/tools/src/test/scala/scala/scalanative/optimizer/StackallocStateRestoreTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/StackallocStateRestoreTest.scala
@@ -1,8 +1,8 @@
-package scala.scalanative.optimizer
+package scala.scalanative
+package optimizer
 
 import scala.scalanative.OptimizerSpec
 import scala.scalanative.interflow.Interflow.LLVMIntrinsics._
-import scala.scalanative.nir._
 
 import org.junit._
 import org.junit.Assert._
@@ -48,16 +48,16 @@ class StackallocStateRestoreTest extends OptimizerSpec {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
           val stackallocId = defn.insts.collectFirst {
-            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Stackalloc(_, _), _) => id
           }
           assertTrue("No stackalloc op", stackallocId.isDefined)
 
           val saveIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackSave, _), _) => id
           }
           assertTrue("No StackSave ops", saveIds.isEmpty)
           val restoreIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackRestore, _), _) => id
           }
           assertTrue("No StackRestore ops", restoreIds.isEmpty)
         }
@@ -101,17 +101,17 @@ class StackallocStateRestoreTest extends OptimizerSpec {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
           val stackallocId = defn.insts.collectFirst {
-            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Stackalloc(_, _), _) => id
           }
           assertTrue("No stackalloc op", stackallocId.isDefined)
 
           val saveIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackSave, _), _) => id
           }
           assertTrue("No StackSave ops", saveIds.nonEmpty)
           assertEquals("StackSave ammount", 1, saveIds.size)
           val restoreIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackRestore, _), _) => id
           }
           assertTrue("No StackRestore ops", restoreIds.nonEmpty)
           assertEquals("StackRestore ammount", 1, restoreIds.size)
@@ -151,18 +151,18 @@ class StackallocStateRestoreTest extends OptimizerSpec {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
           val stackallocId = defn.insts.collectFirst {
-            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Stackalloc(_, _), _) => id
           }
           assertTrue("No stackalloc op", stackallocId.isDefined)
 
           val saveIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackSave, _), _) => id
           }
           assertTrue("No StackSave ops", saveIds.nonEmpty)
           assertEquals("StackSave ammount", 1, saveIds.size)
 
           val restoreIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackRestore, _), _) => id
           }
           assertTrue("No StackRestore ops", restoreIds.nonEmpty)
           assertEquals("StackRestore ammount", 1, restoreIds.size)
@@ -203,18 +203,18 @@ class StackallocStateRestoreTest extends OptimizerSpec {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
           val stackallocId = defn.insts.collectFirst {
-            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Stackalloc(_, _), _) => id
           }
           assertTrue("No stackalloc op", stackallocId.isDefined)
 
           val saveIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackSave, _), _) => id
           }
           assertTrue("No StackSave ops", saveIds.nonEmpty)
           assertEquals("StackSave ammount", 3, saveIds.size)
 
           val restoreIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackRestore, _), _) => id
           }
           assertTrue("No StackRestore ops", restoreIds.nonEmpty)
           assertEquals("StackRestore ammount", 3, restoreIds.size)
@@ -257,18 +257,18 @@ class StackallocStateRestoreTest extends OptimizerSpec {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
           val stackallocId = defn.insts.collectFirst {
-            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Stackalloc(_, _), _) => id
           }
           assertTrue("No stackalloc op", stackallocId.isDefined)
 
           val saveIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackSave, _), _) => id
           }
           assertTrue("No StackSave ops", saveIds.nonEmpty)
           assertEquals("StackSave ammount", 3, saveIds.size)
 
           val restoreIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackRestore, _), _) => id
           }
           assertTrue("No StackRestore ops", restoreIds.nonEmpty)
           assertEquals("StackRestore ammount", 3, restoreIds.size)
@@ -317,12 +317,12 @@ class StackallocStateRestoreTest extends OptimizerSpec {
         findEntry(result.defns).foreach { defn =>
 
           val stackallocId = defn.insts.collectFirst {
-            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Stackalloc(_, _), _) => id
           }
           assertTrue("No stackalloc op", stackallocId.nonEmpty)
 
           val saveIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackSave, _), _) => id
           }
           assertTrue("No StackSave ops", saveIds.isEmpty)
         }
@@ -373,18 +373,18 @@ class StackallocStateRestoreTest extends OptimizerSpec {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
           val stackallocId = defn.insts.collectFirst {
-            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Stackalloc(_, _), _) => id
           }
           assertTrue("No stackalloc op", stackallocId.isDefined)
 
           val saveIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackSave, _), _) => id
           }
           assertTrue("No StackSave ops", saveIds.nonEmpty)
           assertEquals("StackSave ammount", 1, saveIds.size)
 
           val restoreIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackRestore, _), _) => id
           }
           assertTrue("No StackRestore ops", restoreIds.nonEmpty)
           assertEquals("StackRestore ammount", 1, restoreIds.size)
@@ -436,18 +436,18 @@ class StackallocStateRestoreTest extends OptimizerSpec {
       case (_, result) =>
         findEntry(result.defns).foreach { defn =>
           val stackallocId = defn.insts.collectFirst {
-            case Inst.Let(id, Op.Stackalloc(_, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Stackalloc(_, _), _) => id
           }
           assertTrue("No stackalloc op", stackallocId.isDefined)
 
           val saveIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackSave, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackSave, _), _) => id
           }
           assertTrue("No StackSave ops", saveIds.nonEmpty)
           assertEquals("StackSave ammount", 1, saveIds.size)
 
           val restoreIds = defn.insts.collect {
-            case Inst.Let(id, Op.Call(_, StackRestore, _), _) => id
+            case nir.Inst.Let(id, nir.Op.Call(_, StackRestore, _), _) => id
           }
           assertTrue("No StackRestore ops", restoreIds.nonEmpty)
           assertEquals("StackRestore ammount", 1, restoreIds.size)


### PR DESCRIPTION
This PR uniformize the way `nir` symbols are qualified (e.g., `Type` => `nir.Type`).