### PR TITLE
Make module loader in multithreading mode be more aware when init fails

### DIFF
--- a/nativelib/src/main/resources/scala-native/eh.cpp
+++ b/nativelib/src/main/resources/scala-native/eh.cpp
@@ -1,4 +1,5 @@
 #include <exception>
+#include "eh.h"
 
 // Scala Native compiles Scala's exception in C++-compatible
 // manner under the hood. Every exception thrown on the Scala
@@ -6,14 +7,6 @@
 // ExceptionWrapper-based exceptions can be caught by
 // Scala code. We currently do not support catching arbitrary
 // C++ exceptions.
-
-namespace scalanative {
-class ExceptionWrapper : public std::exception {
-  public:
-    ExceptionWrapper(void *_obj) : obj(_obj) {}
-    void *obj;
-};
-} // namespace scalanative
 
 extern "C" {
 void scalanative_throw(void *obj) { throw scalanative::ExceptionWrapper(obj); }

--- a/nativelib/src/main/resources/scala-native/eh.h
+++ b/nativelib/src/main/resources/scala-native/eh.h
@@ -1,0 +1,9 @@
+#include <exception>
+
+namespace scalanative {
+class ExceptionWrapper : public std::exception {
+  public:
+    ExceptionWrapper(void *_obj) : obj(_obj) {}
+    void *obj;
+};
+}

--- a/nativelib/src/main/resources/scala-native/module.h
+++ b/nativelib/src/main/resources/scala-native/module.h
@@ -1,0 +1,4 @@
+#include <stdatomic.h>
+typedef _Atomic(void **) ModuleRef;
+typedef ModuleRef *ModuleSlot;
+typedef void (*ModuleCtor)(ModuleRef);

--- a/sandbox/src/main/scala/Test.scala
+++ b/sandbox/src/main/scala/Test.scala
@@ -1,5 +1,25 @@
+object Deadlocking {
+  val init = {
+    println(s"start init by ${Thread.currentThread()}")
+    Thread.sleep(1000)
+    throw new RuntimeException()
+    println("init done")
+    42
+  }
+}
+
 object Test {
   def main(args: Array[String]): Unit = {
-    println("Hello, World!")
+    List.tabulate(8) { n =>
+        val t = new Thread(() => {
+          println(s"start thread $n")
+          println(s"thread $n, result=${Deadlocking.init}")
+          println(s"thread done $n")
+        })
+        t.setName(s"thread-$n")
+        t
+      }
+      .tapEach(_.start())
+      .foreach(_.join())
   }
 }


### PR DESCRIPTION
https://github.com/scala-native/scala-native/issues/3591

- [x] Catch an exception thrown in `ctor(instance)` (in `module_load.cpp`)
- [x] Store the thrown exception somehow and notify to other threads that module initialization is failed
  - Through `InitializationContext`
  - Waiting (for module initialization) threads will know when the initialization is failed in a thread via `InitializationContext`.
- [ ] Show meaningful error/stacktrace to users
  - Currently, we just re-throw the C++ exception, and die with `libc++abi: terminating due to uncaught exception of type void*`.
  - Maybe we need to store the thrown exception into pointer, and re-throw in Scala world? Potentially related "We potentially can provide a CFuncPtr to the native code which would be used to wrap the exception thrown by the ctor into the ExceptionInInitializerError, which later can be thrown using the scalanative_throw" https://github.com/scala-native/scala-native/issues/3591#issuecomment-1790987537
  - Or, maybe we can somehow pretty-print the error message and stacktrace of the Throwable object underlying of the `ExceptionWrapper` in C++?

```
libc++abi: terminating due to uncaught exception of type void*
[error] java.lang.RuntimeException: Nonzero exit code: 134
[error]         at scala.sys.package$.error(package.scala:30)
[error]         at scala.scalanative.sbtplugin.ScalaNativePluginInternal$.$anonfun$scalaNativeConfigSettings$18(ScalaNativePluginInternal.scala:276)
[error]         at scala.Option.foreach(Option.scala:407)
[error]         at scala.scalanative.sbtplugin.ScalaNativePluginInternal$.$anonfun$scalaNativeConfigSettings$16(ScalaNativePluginInternal.scala:276)
[error]         at scala.scalanative.sbtplugin.ScalaNativePluginInternal$.$anonfun$scalaNativeConfigSettings$16$adapted(ScalaNativePluginInternal.scala:253)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] stack trace is suppressed; run last sandbox3 / Compile / run for the full output
[error] (sandbox3 / Compile / run) Nonzero exit code: 134
[error] Total time: 8 s, completed Nov 6, 2023, 5:12:09 PM
```