### PR TITLE
Exclude `scala.collection.convert.MapWrapperTest` from scalaPartestJunitTest

### DIFF
--- a/scala-partest-junit-tests/src/test/resources/2.13.10/DenylistedTests.txt
+++ b/scala-partest-junit-tests/src/test/resources/2.13.10/DenylistedTests.txt
@@ -227,3 +227,6 @@ scala/util/TryTest.scala
 scala/math/BigIntTest.scala
 ### deadlocks maybe needs j.u.c.ConcurrentLinkedQueue
 scala/concurrent/impl/DefaultPromiseTest.scala
+
+# Object monitors locking issue #3594
+scala/collection/convert/MapWrapperTest.scala

--- a/scala-partest-junit-tests/src/test/resources/2.13.11/DenylistedTests.txt
+++ b/scala-partest-junit-tests/src/test/resources/2.13.11/DenylistedTests.txt
@@ -229,3 +229,6 @@ scala/util/TryTest.scala
 scala/math/BigIntTest.scala
 ### deadlocks maybe needs j.u.c.ConcurrentLinkedQueue
 scala/concurrent/impl/DefaultPromiseTest.scala
+
+# Object monitors locking issue #3594
+scala/collection/convert/MapWrapperTest.scala

--- a/scala-partest-junit-tests/src/test/resources/2.13.12/DenylistedTests.txt
+++ b/scala-partest-junit-tests/src/test/resources/2.13.12/DenylistedTests.txt
@@ -243,3 +243,6 @@ scala/util/TryTest.scala
 scala/math/BigIntTest.scala
 ### deadlocks maybe needs j.u.c.ConcurrentLinkedQueue
 scala/concurrent/impl/DefaultPromiseTest.scala
+
+# Object monitors locking issue #3594
+scala/collection/convert/MapWrapperTest.scala


### PR DESCRIPTION
These are failing due to reasons described in #3594. These can be restored when the underlying issue is fixed