### PR TITLE
Integrate with AsyncProfiler

### DIFF
--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -82,7 +82,9 @@ object MyScalaNativePlugin extends AutoPlugin {
       typ <- OutputType.fromString(input)
     } yield typ) match {
       case Left(ex) =>
-        logger.warn(s"${ex.getMessage()}, using default output type: `flamegraph`")
+        logger.warn(
+          s"${ex.getMessage()}, using default output type: `flamegraph`"
+        )
         OutputType.Flamegraph
       case Right(value) => value
     }
@@ -100,7 +102,8 @@ object MyScalaNativePlugin extends AutoPlugin {
       }
 
       val module = moduleName.value
-      val out = (crossTarget.value / s"$module-profile.${outputType.extension}").toString
+      val out =
+        (crossTarget.value / s"$module-profile.${outputType.extension}").toString
       profilerOpt match {
         case Some(profiler) =>
           logger.info(s"[async-profiler] starting profiler: $profiler")
@@ -155,10 +158,10 @@ object MyScalaNativePlugin extends AutoPlugin {
 
 sealed abstract class OutputType(val name: String) {
   def extension: String = this match {
-    case Text => "txt"
-    case Collapsed => "csv"
+    case Text       => "txt"
+    case Collapsed  => "csv"
     case Flamegraph => "html"
-    case Tree => "html"
+    case Tree       => "html"
   }
 }
 object OutputType {

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -23,6 +23,7 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.4")
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "5.10.0.202012080955-r"
+libraryDependencies += "me.bechberger" % "ap-loader-all" % "2.9-7"
 
 // scalacOptions used to bootstrap to sbt prompt.
 // In particular, no "-Xfatal-warnings"

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -24,6 +24,8 @@ import scala.scalanative.build.Platform
 import sjsonnew.BasicJsonProtocol._
 import java.nio.file.{Files, Path}
 
+import one.profiler.AsyncProfilerLoader
+
 /** ScalaNativePlugin delegates to this object
  *
  *  Note: All logic should be in the Config, NativeConfig, or the build itself.
@@ -167,11 +169,25 @@ object ScalaNativePluginInternal {
         .withCompilerConfig(nativeConfig)
 
     interceptBuildException {
-      await(sbtLogger) { implicit ec: ExecutionContext =>
-        implicit def scope: Scope = sharedScope
-        Build
-          .buildCached(config)
-          .map(_.toFile())
+      val profiler =
+        if (AsyncProfilerLoader.isSupported())
+          Some(AsyncProfilerLoader.load())
+        else None
+      try {
+        config.logger.info(s"[async-profiler] starting profiler: $profiler")
+        profiler.foreach(_.execute("start,event=cpu,interval=100000"))
+        await(sbtLogger) { implicit ec: ExecutionContext =>
+          implicit def scope: Scope = sharedScope
+          Build
+            .buildCached(config)
+            .map(_.toFile())
+        }
+      } finally {
+        profiler.foreach { p =>
+          config.logger.info("[async-profiler] stop profiler")
+          p.execute("stop")
+          p.execute("flamegraph,file=profile.html")
+        }
       }
     }
   }


### PR DESCRIPTION
https://github.com/scala-native/scala-native/issues/3597

This PR will add `nativeLinkProfiling <output-type>` task to `MyScalaNativePlugin` that is a wrapper for `nativeLink` with an [async-profiler](https://github.com/async-profiler/async-profiler) using [ap-loader](https://github.com/jvm-profiling-tools/ap-loader)

While this will generate a bit biased profiling result (because it doesn't warm up JVM for benchmark/profile as JMH does), but still we'll have something useful :)

TODO (which might we should work on in another PR)
- [x] Enable to pass more arguments to profiler
  - ~Currently, we can configure the output-type of the async-profiler while other options are hard-coded or default.~
  - ~It would be nice if we can pass more configuration to async-profiler~
  - We can pass the arguments to async-profiler e.g. `nativeLinkProfiling events=cpu,interval=10000000,threads flamegraph`
  - see: https://github.com/tanishiking/scala-native/blob/03fb96a1743dce6f9b64188a74e8e0ac1150e594/project/MyScalaNativePlugin.scala#L78-L83
- **Better argument parser?**
  - current implementation doesn't have fancy argument parser, it just passes the given arguments to async-profiler. This is because this implementation is just only for the internal (scala-native/scala-native) use, and I didn't see it worth implementing a nicer argument parser for that.
  - If we'd like to have better argument parser, I'd like to parse it using `scopt` or something, but leaving it for now.
- [x] (optional) Better profiler state management
  - I found we hit this path https://github.com/jvm-profiling-tools/ap-loader/blob/c1c2d917c4368008230ad962089c72484ad1cc67/src/main/java/one/profiler/AsyncProfilerLoader.java#L716-L727 when we run `nativeLinkProfiling' reload` and re-run `nativeLinkProfiling`
  - This is because there's the restriction that a native library can only be loaded in one class loader. It seems old sbt session doesn't free the old classloader 🤔 Workaround is to restart sbt.
  - Maybe we can workaround it in better way, but I'm leaving it to just warn `please restart sbt` since I couldn't find a way + it's a lower priority it seems.