### PR TITLE
Fix typo on VEOL @name annotation in termios module

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/termios.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/termios.scala
@@ -58,7 +58,7 @@ object termios {
 
   @name("scalanative_termios_veof")
   def VEOF: CInt = extern
-  @name("scalanative_termios_veof")
+  @name("scalanative_termios_veol")
   def VEOL: CInt = extern
   @name("scalanative_termios_verase")
   def VERASE: CInt = extern


### PR DESCRIPTION
The spelling is correct in `termios.c` so there is a mismatch. (See here: [termios.c](https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/resources/scala-native/termios.c#L16) )