### PR TITLE
Refactor and document NIR type definitions

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -88,20 +88,18 @@ object Mangle {
     }
 
     def mangleType(ty: Type): Unit = ty match {
-      case Type.Vararg               => str("v")
-      case Type.Ptr                  => str("R_")
-      case Type.Bool                 => str("z")
-      case Type.Char                 => str("c")
-      case Type.FixedSizeI(8, true)  => str("b")
-      case Type.FixedSizeI(16, true) => str("s")
-      case Type.FixedSizeI(32, true) => str("i")
-      case Type.FixedSizeI(64, true) => str("j")
-      case Type.Size                 => str("w")
-      case Type.Float                => str("f")
-      case Type.Double               => str("d")
-      case Type.Null                 => str("l")
-      case Type.Nothing              => str("n")
-      case Type.Unit                 => str("u")
+      case Type.Vararg => str("v")
+      case Type.Ptr    => str("R_")
+      case Type.Bool   => str("z")
+      case Type.Char   => str("c")
+      case i: Type.FixedSizeI =>
+        mangleFixedSizeIntegerType(i)
+      case Type.Size    => str("w")
+      case Type.Float   => str("f")
+      case Type.Double  => str("d")
+      case Type.Null    => str("l")
+      case Type.Nothing => str("n")
+      case Type.Unit    => str("u")
       case Type.ArrayValue(ty, n) =>
         str("A")
         mangleType(ty)
@@ -134,6 +132,18 @@ object Mangle {
         mangleIdent(id)
       case _ =>
         util.unreachable
+    }
+
+    /** Appends the mangled representation of `ty` to `this.sb`. */
+    def mangleFixedSizeIntegerType(ty: Type.FixedSizeI): Unit = {
+      assert(ty.signed, "unsupported unsigned fixed-size integer")
+      ty.width match {
+        case 8  => str("b")
+        case 16 => str("s")
+        case 32 => str("i")
+        case 64 => str("j")
+        case _  => util.unreachable
+      }
     }
 
     def mangleIdent(id: String): Unit = {

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -124,7 +124,13 @@ object Type {
       case r: Type.Ref   => r.name
     }
 
-    /** TODO */
+    /** `true` iff the referenced type is exactly the type denoted by `this`.
+     *
+     *  Given an instance `r` of `RefKind` denoting a reference to some time
+     *  `T`, `r.isExact` holds iff the referenced type is exactly `T` and not a
+     *  subtype thereof. The optimizer may be able to compute the exact variant
+     *  of an arbitrary reference after it has replaced a virtual call.
+     */
     final def isExact: Boolean = this match {
       case Type.Null     => true
       case Type.Unit     => true
@@ -150,7 +156,9 @@ object Type {
 
   /** The type of an array reference.
    *
-   *  TODO: Explain the difference with `ArrayValue`.
+   *  An `Array` is a reference to `scala.Array[T]`. It contains a header
+   *  followed by a tail allocated buffer, which typically sit on the heap. That
+   *  is unlike `ArrayValue`, which corresponds to LLVM's fixed-size array type.
    */
   final case class Array(ty: Type, nullable: Boolean = true) extends RefKind
 

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -26,73 +26,135 @@ sealed abstract class Type {
     case _                      => true
   }
 
+  /** A textual representation of `this`. */
   final def show: String = nir.Show(this)
+
+  /** The mangled representation of `this`. */
   final def mangle: String = nir.Mangle(this)
+
 }
 
 object Type {
 
-  /** Value types are either primitive or aggregate. */
+  /** The type of an aggregate or primitive value. */
   sealed abstract class ValueKind extends Type
 
-  /** Primitive value types. */
+  /** A primitive value type.
+   *
+   *  @param width
+   *    The bit width of the type's instances.
+   */
   sealed abstract class PrimitiveKind(val width: Int) extends ValueKind
-  case object Bool extends PrimitiveKind(1)
-  case object Ptr extends ValueKind
 
+  /** The type of an integer. */
   sealed trait I extends ValueKind {
+
+    /** `true` iff instances of this type are signed. */
     val signed: Boolean
+
   }
 
+  /** The type of a fixed-size integer.
+   *
+   *  @param width
+   *    The bit width of the type's instances.
+   *  @param signed
+   *    `true` iff the type's instances are signed.
+   */
   sealed abstract class FixedSizeI(width: Int, val signed: Boolean)
       extends PrimitiveKind(width)
       with I
-  object FixedSizeI {
-    def unapply(i: FixedSizeI): Some[(Int, Boolean)] = Some((i.width, i.signed))
+
+  /** The type of a floating-point number.
+   *
+   *  @param width
+   *    The bit width of the type's instances.
+   */
+  sealed abstract class F(width: Int) extends PrimitiveKind(width)
+
+  /** The type of pointers. */
+  case object Ptr extends ValueKind
+
+  /** The type of Boolean values. */
+  case object Bool extends PrimitiveKind(1)
+
+  /** The type of a value suitable to represent the size of a container. */
+  case object Size extends ValueKind with I {
+    val signed = true
   }
-  case object Size extends I {
-    val signed = true;
-  }
+
+  /** The type of a 16-bit unsigned integer. */
   case object Char extends FixedSizeI(16, signed = false)
+
+  /** The type of a 8-bit signed integer. */
   case object Byte extends FixedSizeI(8, signed = true)
+
+  /** The type of a 16-bit signed integer. */
   case object Short extends FixedSizeI(16, signed = true)
+
+  /** The type of a 32-bit signed integer. */
   case object Int extends FixedSizeI(32, signed = true)
+
+  /** The type of a 64-bit signed integer. */
   case object Long extends FixedSizeI(64, signed = true)
 
-  sealed abstract class F(width: Int) extends PrimitiveKind(width)
-  object F { def unapply(f: F): Some[Int] = Some(f.width) }
+  /** The type of a 32-bit IEEE 754 single-precision float. */
   case object Float extends F(32)
+
+  /** The type of a 64-bit IEEE 754 single-precision float. */
   case object Double extends F(64)
 
-  /** Aggregate value types. */
+  /** The type of an aggregate. */
   sealed abstract class AggregateKind extends ValueKind
+
+  /** The type of a homogeneous collection of data members. */
   final case class ArrayValue(ty: Type, n: Int) extends AggregateKind
+
+  /** The type of a heterogeneous collection of data members. */
   final case class StructValue(tys: Seq[Type]) extends AggregateKind
 
-  /** Reference types. */
+  /** A reference type. */
   sealed abstract class RefKind extends Type {
+
+    /** The identifier of the class corresponding to this type. */
     final def className: Global.Top = this match {
-      case Type.Null            => Rt.BoxedNull.name
-      case Type.Unit            => Rt.BoxedUnit.name
-      case Type.Array(ty, _)    => toArrayClass(ty)
-      case Type.Ref(name, _, _) => name
+      case Type.Null     => Rt.BoxedNull.name
+      case Type.Unit     => Rt.BoxedUnit.name
+      case a: Type.Array => toArrayClass(a.ty)
+      case r: Type.Ref   => r.name
     }
+
+    /** TODO */
     final def isExact: Boolean = this match {
-      case Type.Null         => true
-      case Type.Unit         => true
-      case _: Type.Array     => true
-      case Type.Ref(_, e, _) => e
+      case Type.Null     => true
+      case Type.Unit     => true
+      case _: Type.Array => true
+      case r: Type.Ref   => r.exact
     }
+
+    /** `true` iff instances of this type are nullable. */
     final def isNullable: Boolean = this match {
-      case Type.Null         => true
-      case Type.Unit         => false
-      case Type.Array(_, n)  => n
-      case Type.Ref(_, _, n) => n
+      case Type.Null     => true
+      case Type.Unit     => false
+      case a: Type.Array => a.nullable
+      case r: Type.Ref   => r.nullable
     }
+
   }
+
+  /** The null reference type. */
   case object Null extends RefKind
+
+  /** The unit type. */
   case object Unit extends RefKind
+
+  /** The type of an array reference.
+   *
+   *  TODO: Explain the difference with `ArrayValue`.
+   */
   final case class Array(ty: Type, nullable: Boolean = true) extends RefKind
+
+  /** The type of a reference. */
   final case class Ref(
       name: Global.Top,
       exact: Boolean = false,
@@ -216,4 +278,5 @@ object Type {
     case _ =>
       throw new Exception(s"typeToName: unexpected type ${tpe.show}")
   }
+
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1749,29 +1749,45 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       // Bug compatibility with scala/bug/issues/11253
       case (nir.Type.Long, nir.Type.Float) =>
         nir.Type.Double
+
       case (nir.Type.Ptr, _: nir.Type.RefKind) =>
         lty
+
       case (_: nir.Type.RefKind, nir.Type.Ptr) =>
         rty
+
       case (nir.Type.Bool, nir.Type.Bool) =>
         nir.Type.Bool
-      case (nir.Type.FixedSizeI(lwidth, _), nir.Type.FixedSizeI(rwidth, _))
-          if lwidth < 32 && rwidth < 32 =>
-        nir.Type.Int
-      case (nir.Type.FixedSizeI(lwidth, _), nir.Type.FixedSizeI(rwidth, _)) =>
-        if (lwidth >= rwidth) lty else rty
-      case (nir.Type.FixedSizeI(_, _), nir.Type.F(_)) =>
+
+      case (lhs: nir.Type.FixedSizeI, rhs: nir.Type.FixedSizeI) =>
+        if (lhs.width < 32 && rhs.width < 32) {
+          nir.Type.Int
+        } else if (lhs.width >= rhs.width) {
+          lhs
+        } else {
+          rhs
+        }
+
+      case (_: nir.Type.FixedSizeI, _: nir.Type.F) =>
         rty
-      case (nir.Type.F(_), nir.Type.FixedSizeI(_, _)) =>
+
+      case (_: nir.Type.F, _: nir.Type.FixedSizeI) =>
         lty
-      case (nir.Type.F(lwidth), nir.Type.F(rwidth)) =>
-        if (lwidth >= rwidth) lty else rty
+
+      case (lhs: nir.Type.F, rhs: nir.Type.F) =>
+        if (lhs.width >= rhs.width) lhs else rhs
+
       case (_: nir.Type.RefKind, _: nir.Type.RefKind) =>
         nir.Rt.Object
+
       case (ty1, ty2) if ty1 == ty2 =>
         ty1
-      case (nir.Type.Nothing, ty) => ty
-      case (ty, nir.Type.Nothing) => ty
+
+      case (nir.Type.Nothing, ty) =>
+        ty
+
+      case (ty, nir.Type.Nothing) =>
+        ty
 
       case _ =>
         abort(s"can't perform binary operation between $lty and $rty")
@@ -2009,9 +2025,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           Some(nir.Conv.Bitcast)
         case (_: nir.Type.RefKind, _: nir.Type.I) => Some(nir.Conv.Ptrtoint)
         case (_: nir.Type.I, _: nir.Type.RefKind) => Some(nir.Conv.Inttoptr)
-        case (nir.Type.FixedSizeI(w1, _), nir.Type.F(w2)) if w1 == w2 =>
+        case (l: nir.Type.FixedSizeI, r: nir.Type.F) if l.width == r.width =>
           Some(nir.Conv.Bitcast)
-        case (nir.Type.F(w1), nir.Type.FixedSizeI(w2, _)) if w1 == w2 =>
+        case (l: nir.Type.F, r: nir.Type.FixedSizeI) if l.width == r.width =>
           Some(nir.Conv.Bitcast)
         case _ if fromty == toty               => None
         case (nir.Type.Float, nir.Type.Double) => Some(nir.Conv.Fpext)
@@ -2391,17 +2407,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             nir.Conv.Bitcast
           case (_: nir.Type.RefKind, nir.Type.Ptr) =>
             nir.Conv.Bitcast
-          case (
-                nir.Type.FixedSizeI(fromw, froms),
-                nir.Type.FixedSizeI(tow, tos)
-              ) =>
-            if (fromw < tow) {
-              if (froms) {
+          case (l: nir.Type.FixedSizeI, r: nir.Type.FixedSizeI) =>
+            if (l.width < r.width) {
+              if (l.signed) {
                 nir.Conv.Sext
               } else {
                 nir.Conv.Zext
               }
-            } else if (fromw > tow) {
+            } else if (l.width > r.width) {
               nir.Conv.Trunc
             } else {
               nir.Conv.Bitcast
@@ -2410,14 +2423,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             nir.Conv.Sitofp
           case (i: nir.Type.I, _: nir.Type.F) if !i.signed =>
             nir.Conv.Uitofp
-          case (_: nir.Type.F, nir.Type.FixedSizeI(iwidth, true)) =>
-            if (iwidth < 32) {
+          case (_: nir.Type.F, i: nir.Type.FixedSizeI) if i.signed =>
+            if (i.width < 32) {
               val ivalue = genCoercion(value, fromty, nir.Type.Int)
               return genCoercion(ivalue, nir.Type.Int, toty)
             }
             nir.Conv.Fptosi
-          case (_: nir.Type.F, nir.Type.FixedSizeI(iwidth, false)) =>
-            if (iwidth < 32) {
+          case (_: nir.Type.F, i: nir.Type.FixedSizeI) if !i.signed =>
+            if (i.width < 32) {
               val ivalue = genCoercion(value, fromty, nir.Type.Int)
               return genCoercion(ivalue, nir.Type.Int, toty)
             }
@@ -2785,8 +2798,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                   val promotedArg = arg.ty match {
                     case nir.Type.Float =>
                       this.genCastOp(nir.Type.Float, nir.Type.Double, arg)
-                    case nir.Type.FixedSizeI(width, _)
-                        if width < nir.Type.Int.width =>
+                    case i: nir.Type.FixedSizeI
+                        if i.width < nir.Type.Int.width =>
                       val conv =
                         if (isUnsigned) nir.Conv.Zext
                         else nir.Conv.Sext

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1485,25 +1485,48 @@ trait NirGenExpr(using Context) {
     private def binaryOperationType(lty: nir.Type, rty: nir.Type) =
       (lty, rty) match {
         // Bug compatibility with scala/bug/issues/11253
-        case (nir.Type.Long, nir.Type.Float)     => nir.Type.Double
-        case (nir.Type.Ptr, _: nir.Type.RefKind) => lty
-        case (_: nir.Type.RefKind, nir.Type.Ptr) => rty
-        case (nir.Type.Bool, nir.Type.Bool)      => nir.Type.Bool
-        case (nir.Type.FixedSizeI(lwidth, _), nir.Type.FixedSizeI(rwidth, _))
-            if lwidth < 32 && rwidth < 32 =>
-          nir.Type.Int
-        case (nir.Type.FixedSizeI(lwidth, _), nir.Type.FixedSizeI(rwidth, _)) =>
-          if (lwidth >= rwidth) lty
-          else rty
-        case (nir.Type.FixedSizeI(_, _), nir.Type.F(_)) => rty
-        case (nir.Type.F(_), nir.Type.FixedSizeI(_, _)) => lty
-        case (nir.Type.F(lwidth), nir.Type.F(rwidth)) =>
-          if (lwidth >= rwidth) lty
-          else rty
-        case (_: nir.Type.RefKind, _: nir.Type.RefKind) => nir.Rt.Object
-        case (ty1, ty2) if ty1 == ty2                   => ty1
-        case (nir.Type.Nothing, ty)                     => ty
-        case (ty, nir.Type.Nothing)                     => ty
+        case (nir.Type.Long, nir.Type.Float) =>
+          nir.Type.Double
+
+        case (nir.Type.Ptr, _: nir.Type.RefKind) =>
+          lty
+
+        case (_: nir.Type.RefKind, nir.Type.Ptr) =>
+          rty
+
+        case (nir.Type.Bool, nir.Type.Bool) =>
+          nir.Type.Bool
+
+        case (lhs: nir.Type.FixedSizeI, rhs: nir.Type.FixedSizeI) =>
+          if (lhs.width < 32 && rhs.width < 32) {
+            nir.Type.Int
+          } else if (lhs.width >= rhs.width) {
+            lhs
+          } else {
+            rhs
+          }
+
+        case (_: nir.Type.FixedSizeI, _: nir.Type.F) =>
+          rty
+
+        case (_: nir.Type.F, _: nir.Type.FixedSizeI) =>
+          lty
+
+        case (lhs: nir.Type.F, rhs: nir.Type.F) =>
+          if (lhs.width >= rhs.width) lhs else rhs
+
+        case (_: nir.Type.RefKind, _: nir.Type.RefKind) =>
+          nir.Rt.Object
+
+        case (ty1, ty2) if ty1 == ty2 =>
+          ty1
+
+        case (nir.Type.Nothing, ty) =>
+          ty
+
+        case (ty, nir.Type.Nothing) =>
+          ty
+
         case _ =>
           report.error(s"can't perform binary operation between $lty and $rty")
           nir.Type.Nothing
@@ -1687,8 +1710,8 @@ trait NirGenExpr(using Context) {
                   val promotedArg = arg.ty match {
                     case nir.Type.Float =>
                       this.genCastOp(nir.Type.Float, nir.Type.Double, arg)
-                    case nir.Type.FixedSizeI(width, _)
-                        if width < nir.Type.Int.width =>
+                    case i: nir.Type.FixedSizeI
+                        if i.width < nir.Type.Int.width =>
                       val conv =
                         if (isUnsigned) nir.Conv.Zext
                         else nir.Conv.Sext
@@ -1879,25 +1902,22 @@ trait NirGenExpr(using Context) {
         val conv = (fromty, toty) match {
           case (nir.Type.Ptr, _: nir.Type.RefKind) => nir.Conv.Bitcast
           case (_: nir.Type.RefKind, nir.Type.Ptr) => nir.Conv.Bitcast
-          case (
-                nir.Type.FixedSizeI(fromw, froms),
-                nir.Type.FixedSizeI(tow, tos)
-              ) =>
-            if (fromw < tow)
-              if (froms) nir.Conv.Sext
+          case (l: nir.Type.FixedSizeI, r: nir.Type.FixedSizeI) =>
+            if (l.width < r.width)
+              if (l.signed) nir.Conv.Sext
               else nir.Conv.Zext
-            else if (fromw > tow) nir.Conv.Trunc
+            else if (l.width > r.width) nir.Conv.Trunc
             else nir.Conv.Bitcast
           case (i: nir.Type.I, _: nir.Type.F) if i.signed => nir.Conv.Sitofp
           case (_: nir.Type.I, _: nir.Type.F)             => nir.Conv.Uitofp
-          case (_: nir.Type.F, nir.Type.FixedSizeI(iwidth, true)) =>
-            if (iwidth < 32) {
+          case (_: nir.Type.F, i: nir.Type.FixedSizeI) if i.signed =>
+            if (i.width < 32) {
               val ivalue = genCoercion(value, fromty, nir.Type.Int)
               return genCoercion(ivalue, nir.Type.Int, toty)
             }
             nir.Conv.Fptosi
-          case (_: nir.Type.F, nir.Type.FixedSizeI(iwidth, false)) =>
-            if (iwidth < 32) {
+          case (_: nir.Type.F, i: nir.Type.FixedSizeI) if !i.signed =>
+            if (i.width < 32) {
               val ivalue = genCoercion(value, fromty, nir.Type.Int)
               return genCoercion(ivalue, nir.Type.Int, toty)
             }
@@ -1984,9 +2004,9 @@ trait NirGenExpr(using Context) {
           Some(nir.Conv.Bitcast)
         case (_: nir.Type.RefKind, _: nir.Type.I) => Some(nir.Conv.Ptrtoint)
         case (_: nir.Type.I, _: nir.Type.RefKind) => Some(nir.Conv.Inttoptr)
-        case (nir.Type.FixedSizeI(w1, _), nir.Type.F(w2)) if w1 == w2 =>
+        case (l: nir.Type.FixedSizeI, r: nir.Type.F) if l.width == r.width =>
           Some(nir.Conv.Bitcast)
-        case (nir.Type.F(w1), nir.Type.FixedSizeI(w2, _)) if w1 == w2 =>
+        case (l: nir.Type.F, r: nir.Type.FixedSizeI) if l.width == r.width =>
           Some(nir.Conv.Bitcast)
         case _ if fromty == toty               => None
         case (nir.Type.Float, nir.Type.Double) => Some(nir.Conv.Fpext)

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1630,9 +1630,9 @@ object Lower {
             case nir.Val.Size(v) => nir.Val.Size(v * elemSize)
             case _ =>
               val asSize = sizeV.ty match {
-                case nir.Type.FixedSizeI(width, _) =>
-                  if (width == platform.sizeOfPtrBits) sizeV
-                  else if (width > platform.sizeOfPtrBits)
+                case i: nir.Type.FixedSizeI =>
+                  if (i.width == platform.sizeOfPtrBits) sizeV
+                  else if (i.width > platform.sizeOfPtrBits)
                     buf.conv(nir.Conv.Trunc, nir.Type.Size, sizeV, unwind)
                   else
                     buf.conv(nir.Conv.Zext, nir.Type.Size, sizeV, unwind)

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -1220,15 +1220,21 @@ private[codegen] abstract class AbstractCodeGen(
   ): Unit = conv match {
     case nir.Conv.ZSizeCast | nir.Conv.SSizeCast =>
       val fromSize = fromType match {
-        case nir.Type.Size             => platform.sizeOfPtrBits
-        case nir.Type.FixedSizeI(s, _) => s
-        case o                         => unsupported(o)
+        case nir.Type.Size =>
+          platform.sizeOfPtrBits
+        case i: nir.Type.FixedSizeI =>
+          i.width
+        case o =>
+          unsupported(o)
       }
 
       val toSize = toType match {
-        case nir.Type.Size             => platform.sizeOfPtrBits
-        case nir.Type.FixedSizeI(s, _) => s
-        case o                         => unsupported(o)
+        case nir.Type.Size =>
+          platform.sizeOfPtrBits
+        case i: nir.Type.FixedSizeI =>
+          i.width
+        case o =>
+          unsupported(o)
       }
 
       val castOp =

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -598,25 +598,25 @@ trait Combine { self: Interflow =>
       // trunc[iN] (trunc[iM] x) ==> trunc[iN] x if N < M
       case (
             Trunc,
-            nir.Type.FixedSizeI(n, _),
-            ConvRef(Trunc, nir.Type.FixedSizeI(m, _), x)
-          ) if n < m =>
+            n: nir.Type.FixedSizeI,
+            ConvRef(Trunc, m: nir.Type.FixedSizeI, x)
+          ) if n.width < m.width =>
         combine(Trunc, ty, x)
 
       // sext[iN] (sext[iM] x) ==> sext[iN] x if N > M
       case (
             Sext,
-            nir.Type.FixedSizeI(n, _),
-            ConvRef(Sext, nir.Type.FixedSizeI(m, _), x)
-          ) if n > m =>
+            n: nir.Type.FixedSizeI,
+            ConvRef(Sext, m: nir.Type.FixedSizeI, x)
+          ) if n.width > m.width =>
         combine(Sext, ty, x)
 
       // zext[iN] (zext[iM] x) ==> zext[iN] x if N > M
       case (
             Zext,
-            nir.Type.FixedSizeI(n, _),
-            ConvRef(Zext, nir.Type.FixedSizeI(m, _), x)
-          ) if n > m =>
+            n: nir.Type.FixedSizeI,
+            ConvRef(Zext, m: nir.Type.FixedSizeI, x)
+          ) if n.width > m.width =>
         combine(Zext, ty, x)
 
       // ptrtoint[long] (inttoptr[long] x) ==> x

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -839,8 +839,8 @@ trait Eval { self: Interflow =>
         def size(ty: nir.Type) = ty match {
           case nir.Type.Size =>
             if (platform.is32Bit) 32 else 64
-          case nir.Type.FixedSizeI(s, _) =>
-            s
+          case i: nir.Type.FixedSizeI =>
+            i.width
           case o =>
             bailOut
         }


### PR DESCRIPTION
This PR simplifies the class/trait hierarchy surrounding NIR type definitions and document them.

One opinionated change is to prefer the use of nominal types over case class destructuring in pattern matches. Destructuring is quite brittle. Any change to the case class definition can break existing patterns. Even more concerning, some changes may silently change the semantics of a pattern! In contrast, matching over a type lets us reuse the names of case class fields, which are resilient to structural changes.

The PR is not ready to be merged yet. Some type definitions are still undocumented because I wasn't sure about their roles.