### PR TITLE
Exlcude internal part of stacktraces from JUnit error reports

### DIFF
--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
@@ -171,18 +171,20 @@ private[junit] final class Reporter(
     else Ansi.filterAnsi(s)
 
   private def logTrace(t: Throwable): Unit = {
-    val trace = t.getStackTrace.dropWhile { p =>
-      p.getFileName != null && {
-        p.getFileName.contains("StackTrace.scala") ||
-        p.getFileName.contains("Throwables.scala")
+    val trace = t.getStackTrace
+      .dropWhile { p =>
+        p.getClassName() != null && {
+          p.getClassName().startsWith("java.lang.StackTrace") ||
+          p.getClassName().startsWith("java.lang.Throwable")
+        }
       }
-    }
     val testFileName = {
       if (settings.color) findTestFileName(trace)
       else null
     }
     val i = trace.indexWhere { p =>
-      p.getFileName != null && p.getFileName.contains("JUnitExecuteTest.scala")
+      p.getClassName() != null &&
+      p.getClassName().startsWith("scala.scalanative.junit.")
     } - 1
     val m = if (i > 0) i else trace.length - 1
     logStackTracePart(trace, m, trace.length - m - 1, t, testFileName)


### PR DESCRIPTION
This PR fixes the JUnit runtime to not show stacktraces of internal runtime methods when tests fails due to assertions. 

Now:
```scala
[error] Test FailingTest.fail failed: java.lang.AssertionError: expected:<0> but was:<1>, took 0.759 sec
[error]     at FailingTest.fail(SimpleTest.scala:11)
[error]     at FailingTest$scalanative$junit$bootstrapper$.invokeTest(SimpleTest.scala:10)
[error]     ... 44 more
```

Previously:
```scala
[error] Test FailingTest.fail failed: java.lang.AssertionError: expected:<0> but was:<1>, took 0.755 sec
[error]     at FailingTest.fail(SimpleTest.scala:11)
[error]     at FailingTest$scalanative$junit$bootstrapper$.invokeTest(SimpleTest.scala:25)
[error]     at scala.scalanative.junit.JUnitTask.$anonfun$9$$anonfun$1$$anonfun$1(JUnitTask.scala:108)
[error]     at scala.scalanative.junit.JUnitTask$$Lambda$19.apply(JUnitTask.scala:108)
[error]     at scala.scalanative.junit.JUnitTask.catchAll(JUnitTask.scala:235)
[error]     at scala.scalanative.junit.JUnitTask.$anonfun$9$$anonfun$1(JUnitTask.scala:107)
[error]     at scala.scalanative.junit.JUnitTask$$Lambda$20.apply(JUnitTask.scala:112)
[error]     at scala.scalanative.junit.JUnitTask.handleExpected(JUnitTask.scala:175)
[error]     at scala.scalanative.junit.JUnitTask.$anonfun$9(JUnitTask.scala:106)
[error]     at scala.scalanative.junit.JUnitTask$$Lambda$9.apply(JUnitTask.scala:112)
[error]     at scala.scalanative.junit.JUnitTask.runTestLifecycle(JUnitTask.scala:207)
[error]     at scala.scalanative.junit.JUnitTask.executeTestMethod(JUnitTask.scala:97)
[error]     at scala.scalanative.junit.JUnitTask.runTests$1(JUnitTask.scala:43)
[error]     at scala.scalanative.junit.JUnitTask.$anonfun$4(JUnitTask.scala:73)
[error]     at scala.scalanative.junit.JUnitTask$$Lambda$4.apply(JUnitTask.scala:74)
[error]     at scala.scalanative.junit.JUnitTask.runTestLifecycle(JUnitTask.scala:207)
[error]     at scala.scalanative.junit.JUnitTask.executeTests(JUnitTask.scala:32)
[error]     at scala.scalanative.junit.JUnitTask.execute$$anonfun$1(JUnitTask.scala:25)
[error]     at scala.scalanative.junit.JUnitTask$$Lambda$1.applyVoid(JUnitTask.scala:26)
[error]     at scala.runtime.function.JProcedure1.apply(JProcedure.scala:28)
[error]     at scala.Option.foreach(Option.scala:437)
[error]     at scala.scalanative.junit.JUnitTask.execute(JUnitTask.scala:19)
[error]     at scala.scalanative.testinterface.TestAdapterBridge.executeFun$$anonfun$1(TestAdapterBridge.scala:85)
[error]     at scala.scalanative.testinterface.TestAdapterBridge$$Lambda$4.apply(TestAdapterBridge.scala:94)
[error]     at scala.scalanative.testinterface.common.RunMuxRPC.attach$$anonfun$2$$anonfun$1(RunMuxRPC.scala:48)
[error]     at scala.scalanative.testinterface.common.RunMuxRPC$$Lambda$8.apply(RunMuxRPC.scala:48)
[error]     at scala.util.Try$.apply(Try.scala:210)
[error]     at scala.scalanative.testinterface.common.RunMuxRPC.attach$$anonfun$2(RunMuxRPC.scala:48)
[error]     at scala.scalanative.testinterface.common.RunMuxRPC$$Lambda$2.apply(RunMuxRPC.scala:48)
[error]     at scala.scalanative.testinterface.common.RunMuxRPC.newDispatchMap$1$$anonfun$1$$anonfun$2(RunMuxRPC.scala:70)
[error]     at scala.scalanative.testinterface.common.RunMuxRPC$$Lambda$10.apply(RunMuxRPC.scala:70)
[error]     at scala.Option.fold(Option.scala:263)
[error]     at scala.scalanative.testinterface.common.RunMuxRPC.newDispatchMap$1$$anonfun$1(RunMuxRPC.scala:67)
[error]     at scala.scalanative.testinterface.common.RunMuxRPC$$Lambda$11.apply(RunMuxRPC.scala:70)
[error]     at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:455)
[error]     at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.scala:714)
[error]     at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.scala:104)
[error]     at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.scala:1787)
[error]     at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.scala:343)
[error]     at java.util.concurrent.ForkJoinPool.tryScan$1(ForkJoinPool.scala:323)
[error]     at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.scala:317)
[error]     at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.scala:55)
[error]     at scala.scalanative.runtime.NativeThread$.threadEntryPoint(NativeThread.scala:126)
[error]     at scala.scalanative.runtime.NativeThread$.threadRoutine$$anonfun$1(NativeThread.scala:119)
[error]     at <none>._SM49scala.scalanative.runtime.NativeThread$$$Lambda$1G17$extern$forwarder(NativeThread.scala:118)
[error]     at <none>.ProxyThreadStartRoutine(/Users/wmazur/projects/scala-native/sandbox/.3/target/scala-3.3.1/native-test/dependencies/nativelib_native0.5.0-SNAPSHOT_3-0.5.0-SNAPSHOT-0/scala-native/gc/immix/ImmixGC.c:105)
[error]     at <none>._pthread_start(Unknown Source)
```