### PR TITLE
Prevent crashes in `test-interface`

### DIFF
--- a/test-interface-common/src/main/scala/scala/scalanative/testinterface/common/RPCCore.scala
+++ b/test-interface-common/src/main/scala/scala/scalanative/testinterface/common/RPCCore.scala
@@ -115,6 +115,9 @@ private[testinterface] abstract class RPCCore()(implicit ec: ExecutionContext) {
     }
   }
 
+  /** Has connection channel been closed */
+  private[testinterface] def isClosed: Boolean = closeReason != null
+
   /** Subclass needs to implement message sending. */
   protected def send(msg: String): Unit
 

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
@@ -9,6 +9,7 @@ import signalhandling.SignalConfig
 import scalanative.posix.sys.socket._
 import scalanative.posix.netinet.in
 import scalanative.posix.unistd
+import scala.concurrent.ExecutionContext
 
 object TestMain {
 
@@ -104,7 +105,7 @@ object TestMain {
       else getFreeBSDLoopbackAddr()
     val serverPort = args(0).toInt
     val clientSocket = new Socket(serverAddr, serverPort)
-    val nativeRPC = new NativeRPC(clientSocket)
+    val nativeRPC = new NativeRPC(clientSocket)(ExecutionContext.global)
     val bridge = new TestAdapterBridge(nativeRPC)
 
     bridge.start()

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
@@ -22,8 +22,6 @@ private[testinterface] object SignalConfig {
    * async-signal-safe methods the way POSIX does.
    */
   private def asyncSafePrintStackTrace(sig: CInt): Unit = {
-    val errorTag = c"[\u001b[0;31merror\u001b[0;0m]"
-
     def printError(str: CString): Unit =
       if (isWindows) {
         val written = stackalloc[DWord]()
@@ -70,7 +68,6 @@ private[testinterface] object SignalConfig {
       }
 
     val stackTraceHeader: Ptr[CChar] = stackalloc[CChar](100)
-    strcat(stackTraceHeader, errorTag)
     strcat(stackTraceHeader, c" Fatal signal ")
     strcat(stackTraceHeader, signalNumberStr)
     strcat(stackTraceHeader, c" caught\n")
@@ -101,7 +98,6 @@ private[testinterface] object SignalConfig {
 
         val formattedSymbol: Ptr[CChar] = stackalloc[CChar](1100)
         formattedSymbol(0) = 0.toByte
-        strcat(formattedSymbol, errorTag)
         strcat(formattedSymbol, c"   at ")
         strcat(formattedSymbol, className)
         strcat(formattedSymbol, c".")

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
@@ -19,7 +19,8 @@ private[testinterface] class ComRunner(
     serverSocket: ServerSocket,
     logger: Logger,
     handleMessage: String => Unit
-)(implicit ec: ExecutionContext) extends AutoCloseable {
+)(implicit ec: ExecutionContext)
+    extends AutoCloseable {
   import ComRunner._
 
   processRunner.future.onComplete {

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
@@ -19,9 +19,8 @@ private[testinterface] class ComRunner(
     serverSocket: ServerSocket,
     logger: Logger,
     handleMessage: String => Unit
-) extends AutoCloseable {
+)(implicit ec: ExecutionContext) extends AutoCloseable {
   import ComRunner._
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   processRunner.future.onComplete {
     case Failure(exception) => forceClose(exception)

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/adapter/TestAdapter.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/adapter/TestAdapter.scala
@@ -74,7 +74,7 @@ final class TestAdapter(config: TestAdapter.Config) {
    *  on an async operation to complete.
    */
   private def reportFailure(cause: Throwable): Unit = {
-    val msg = "Failure in async execution. Aborting all test runs."
+    val msg = "Fatal failure in tests execution. Aborting all test runs."
     val error = new AssertionError(msg, cause)
     config.logger.error(msg)
     config.logger.trace(error)


### PR DESCRIPTION
Calling `done()` RPC command on crashed (e.g. due to SegFault) runner lead to throw unhandled exception in `sbt`. Instead skip sending `done()` to crashed workers/controllers. This allows to gather information about crashed tests. 

```scala
[error] Error: Total 5, Failed 1, Errors 1, Passed 3
[error] Failed tests:
[error]         FailingTest
[error] Error during tests:
[error]         CrashingTest
[error] (sandbox2_13 / Test / test) sbt.TestsFailedException: Tests unsuccessful
```
Here `FailingTest` failed due to assertion and `CrashingTest` crashed via segfault. Previously the unhandled `RPCCore.ClosedException` would bubble up to the sbt tests implementation leading to failure without context.