### PR TITLE
bugfix: Use load:acquire and store:plain for final fields

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -593,7 +593,7 @@ object Lower {
 
       val memoryOrder =
         if (field.attrs.isVolatile) nir.MemoryOrder.SeqCst
-        else if (field.attrs.isFinal) nir.MemoryOrder.Monotonic
+        else if (field.attrs.isFinal) nir.MemoryOrder.Acquire
         else nir.MemoryOrder.Unordered
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
       genLoadOp(buf, n, nir.Op.Load(ty, elem, Some(memoryOrder)))
@@ -611,9 +611,10 @@ object Lower {
           throw new LinkingException(s"Metadata for field '$name' not found")
       }
 
+      // No explicit memory order for store of final field, 
+      // all final fields are published with release fence when existing the constructor
       val memoryOrder =
         if (field.attrs.isVolatile) nir.MemoryOrder.SeqCst
-        else if (field.attrs.isFinal) nir.MemoryOrder.Monotonic
         else nir.MemoryOrder.Unordered
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
       genStoreOp(buf, n, nir.Op.Store(ty, elem, value, Some(memoryOrder)))

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -611,7 +611,7 @@ object Lower {
           throw new LinkingException(s"Metadata for field '$name' not found")
       }
 
-      // No explicit memory order for store of final field, 
+      // No explicit memory order for store of final field,
       // all final fields are published with release fence when existing the constructor
       val memoryOrder =
         if (field.attrs.isVolatile) nir.MemoryOrder.SeqCst


### PR DESCRIPTION
As discussed in #3610 we fix the how load/store operatation are generated for the final fields. We use a plain store when followed by release fence at the end of constructor and loadAcquire for subsequent loads