### PR TITLE
ci: Set a fixed timeout for runtime tests

### DIFF
--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -116,6 +116,7 @@ jobs:
         with:
           scala-version: ${{matrix.scala}}
       - name: Run tests
+        timeout-minutes: 45
         env:
           SCALANATIVE_GC: ${{ matrix.gc }}
           SCALANATIVE_TEST_PREFETCH_DEBUG_INFO: 1
@@ -166,6 +167,7 @@ jobs:
           scala-version: ${{matrix.scala}}
 
       - name: Run tests
+        timeout-minutes: 45
         env:
           SCALANATIVE_MODE: ${{ matrix.build-mode }}
           SCALANATIVE_GC: ${{ matrix.gc }}
@@ -196,6 +198,7 @@ jobs:
           scala-version: ${{matrix.scala}}
 
       - name: Run tests
+        timeout-minutes: 45
         env:
           SCALANATIVE_MODE: ${{ matrix.build-mode }}
           SCALANATIVE_GC: immix
@@ -245,6 +248,7 @@ jobs:
           java-version: 8
 
       - name: Run tests
+        timeout-minutes: 45
         env:
           SCALANATIVE_MODE: release-fast
           SCALANATIVE_LTO: thin

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Test partests infrastructure
         # No partests support for Scala 3
         if: ${{ !startsWith(matrix.scala, '3') }}
+        timeout-minutes: 45
         run: >
           sbt "scalaPartestTests${{env.project-version}}/testOnly -- --showDiff neg/abstract.scala pos/abstract.scala run/Course-2002-01.scala"
 
@@ -97,6 +98,7 @@ jobs:
           echo set-native-config=${SetConfigTemplate} >> $GITHUB_ENV
 
       - name: Run tests
+        timeout-minutes: 45
         env:
           SCALANATIVE_MODE: ${{ matrix.build-mode }}
           SCALANATIVE_GC: ${{ matrix.gc }}
@@ -157,6 +159,7 @@ jobs:
           java-version: 8
 
       - name: Run tests
+        timeout-minutes: 45
         # env:
         #   SCALANATIVE_MODE: release-fast
         #   SCALANATIVE_LTO: thin

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -42,6 +42,7 @@ jobs:
       # Execution with enabled multithreading increases memory usage, run only minimal tests
       - name: Test runtime None GC
         if: matrix.gc == 'none'
+        timeout-minutes: 45
         run: >
           set SCALANATIVE_GC=${{matrix.gc}}&
           set SCALANATIVE_INCLUDE_DIRS=${{steps.setup.outputs.vcpkg-dir}}\include&
@@ -56,6 +57,7 @@ jobs:
 
       - name: Test runtime
         if: matrix.gc != 'none'
+        timeout-minutes: 45
         run: >
           set SCALANATIVE_GC=${{matrix.gc}}&
           set SCALANATIVE_INCLUDE_DIRS=${{steps.setup.outputs.vcpkg-dir}}\include&
@@ -131,6 +133,7 @@ jobs:
           scala-version: ${{matrix.scala}}
 
       - name: Run tests
+        timeout-minutes: 45
         run: >
           set SCALANATIVE_GC=${{matrix.gc}}&
           set SCALANATIVE_MODE=${{matrix.build-mode}}&
@@ -164,6 +167,7 @@ jobs:
 
       - name: Run tests
         shell: cmd
+        timeout-minutes: 45
         run: >
           set SCALANATIVE_INCLUDE_DIRS=${{steps.setup.outputs.vcpkg-dir}}\include&
           set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&


### PR DESCRIPTION
Set a fixed timeout for runtime tests due to deadlocks when executing tests leading to CI jobs running for max allowed time