### PR TITLE
Fix compilation on FreeBSD.

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -93,15 +93,20 @@ installation of Arch Linux.
     $ sudo dnf groupinstall "Development Tools"
     $ sudo dnf install gc-devel zlib-devel # both optional
 
-**FreeBSD 12.2 and later**
+**FreeBSD 12.4 and later**
 
 .. code-block:: shell
 
-    $ pkg install llvm10
+    $ pkg install llvm # optional
     $ pkg install boehm-gc # optional
 
-*Note:* A version of zlib that is sufficiently recent comes with the
+*Note 1:* Sufficiently recent versions of llvm and zlib come with the
 installation of FreeBSD.
+
+*Note 2:* Only AMD64 and ARM64 architectures are supported.
+
+*Note 3:* Using the boehm GC with multi-threaded binaries doesn't work
+out-of-the-box yet.
 
 **Nix/NixOS**
 

--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -95,15 +95,14 @@ installation of Arch Linux.
 
 **FreeBSD 12.4 and later**
 
-.. code-block:: shell
+*Note 1:* Only AMD64 and ARM64 architectures are supported.
 
-    $ pkg install llvm # optional
-    $ pkg install boehm-gc # optional
-
-*Note 1:* Sufficiently recent versions of llvm and zlib come with the
+*Note 2:* Sufficiently recent versions of llvm and zlib come with the
 installation of FreeBSD.
 
-*Note 2:* Only AMD64 and ARM64 architectures are supported.
+.. code-block:: shell
+
+    $ pkg install boehm-gc # optional
 
 *Note 3:* Using the boehm GC with multi-threaded binaries doesn't work
 out-of-the-box yet.

--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -107,6 +107,11 @@ installation of FreeBSD.
 *Note 3:* Using the boehm GC with multi-threaded binaries doesn't work
 out-of-the-box yet.
 
+*Note 4:* A number of tests, primarily unit-tests, are known to fail
+or not terminate on FreeBSD. It is believed that the code-under-test
+is correct and that the defect is in the test itself.
+Work is underway to fix these tests.
+
 **Nix/NixOS**
 
 .. code-block:: shell

--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -15,16 +15,18 @@
 #define ASM_JMPBUF_SIZE 192
 #define JMPBUF_STACK_POINTER_OFFSET (104 / 8)
 #elif defined(__x86_64__) &&                                                   \
-    (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)) // x86-64 linux, macOS and FreeBSD
+    (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
 #define ASM_JMPBUF_SIZE 72
 #define JMPBUF_STACK_POINTER_OFFSET (16 / 8)
 #elif defined(__i386__) &&                                                     \
-    (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)) // x86 linux, macOS and FreeBSD
+    (defined(__linux__) || defined(__APPLE__)) // x86 linux and macOS
 #define ASM_JMPBUF_SIZE 32
 #define JMPBUF_STACK_POINTER_OFFSET (16 / 4)
 #elif defined(__x86_64__) && defined(_WIN64) // x86-64 Windows
 #define ASM_JMPBUF_SIZE 256
 #define JMPBUF_STACK_POINTER_OFFSET (16 / 8)
+#else
+#error "Unsupported platform"
 #endif
 
 #ifdef DELIMCC_DEBUG

--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -15,11 +15,11 @@
 #define ASM_JMPBUF_SIZE 192
 #define JMPBUF_STACK_POINTER_OFFSET (104 / 8)
 #elif defined(__x86_64__) &&                                                   \
-    (defined(__linux__) || defined(__APPLE__)) // x86-64 linux and macOS
+    (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)) // x86-64 linux, macOS and FreeBSD
 #define ASM_JMPBUF_SIZE 72
 #define JMPBUF_STACK_POINTER_OFFSET (16 / 8)
 #elif defined(__i386__) &&                                                     \
-    (defined(__linux__) || defined(__APPLE__)) // x86 linux and macOS
+    (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)) // x86 linux, macOS and FreeBSD
 #define ASM_JMPBUF_SIZE 32
 #define JMPBUF_STACK_POINTER_OFFSET (16 / 4)
 #elif defined(__x86_64__) && defined(_WIN64) // x86-64 Windows
@@ -57,7 +57,9 @@
 #define __externc extern
 #define __noreturn __attribute__((noreturn))
 #define __returnstwice __attribute__((returns_twice))
+#ifndef __noinline
 #define __noinline __attribute__((noinline))
+#endif
 // define the lh_jmp_buf in terms of `void*` elements to have natural alignment
 typedef void *lh_jmp_buf[ASM_JMPBUF_SIZE / sizeof(void *)];
 // Non-standard setjmp.

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
@@ -1,5 +1,5 @@
 
-#if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__))
+#if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
 
 /* ----------------------------------------------------------------------------
   Copyright (c) 2016, Microsoft Research, Daan Leijen

--- a/nativelib/src/main/resources/scala-native/gc/shared/Safepoint.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Safepoint.c
@@ -12,7 +12,7 @@
 #include <windows.h>
 #else // Unix
 #include <sys/mman.h>
-#ifndef MAP_NORESERVE
+#if defined(__FreeBSD__) && !defined(MAP_NORESERVE)
 #define MAP_NORESERVE 0
 #endif
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/Safepoint.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Safepoint.c
@@ -12,6 +12,9 @@
 #include <windows.h>
 #else // Unix
 #include <sys/mman.h>
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0
+#endif
 #endif
 
 #if defined(__APPLE__)

--- a/scripts/scalafmt
+++ b/scripts/scalafmt
@@ -3,7 +3,7 @@
 set -e
 
 HERE="`dirname $0`"
-VERSION=$(sed -nre "s#version[^0-9]+([0-9.]+)#\1#p" $HERE/../.scalafmt.conf)
+VERSION=$(sed -nre "s#[[:space:]]*version[^0-9]+([0-9.]+)#\1#p" $HERE/../.scalafmt.conf)
 COURSIER="$HERE/.coursier"
 SCALAFMT="$HERE/.scalafmt-$VERSION"
 

--- a/scripts/scalafmt
+++ b/scripts/scalafmt
@@ -3,7 +3,7 @@
 set -e
 
 HERE="`dirname $0`"
-VERSION=$(sed -nre "s#\s*version[^0-9]+([0-9.]+)#\1#p" $HERE/../.scalafmt.conf)
+VERSION=$(sed -nre "s#version[^0-9]+([0-9.]+)#\1#p" $HERE/../.scalafmt.conf)
 COURSIER="$HERE/.coursier"
 SCALAFMT="$HERE/.scalafmt-$VERSION"
 

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
@@ -28,27 +28,23 @@ object TestMain {
       |""".stripMargin
   }
 
-  final val iPv4Loopback = "127.0.0.1"
-  final val iPv6Loopback = "::1"
-
   private def setFreeBSDWorkaround(): Unit = {
     /* Standard out-of-the-box FreeBSD differs from Linux & macOS in
-     * not allowing IPv4 mapped IPv6 addresses, such as :FFFF:127.0.0.1
-     * or ::ffff:7f00:1.  These can be enabled at runtime by running
-     *
-     *   sysctl net.inet6.ip6.v6only=0
-     *
-     * To make it persistent on reboot it is possible to set the line
-     * ipv6_ipv4mapping="YES" in /etc/rc.conf.
+     * not allowing IPv4-mapped IPv6 addresses, such as :FFFF:127.0.0.1
+     * or ::ffff:7f00:1.
      *
      * Another difference is that Java versions >= 11 on FreeBSD set
      * java.net.preferIPv4Stack=true by default, so the sbt server
      * listens only on a tcp4 socket.
      *
-     * The easiest way to make TestMain to work on most FreeBSD machines
-     * with different Java versions without changing system defaults is
-     * to set java.net.preferIPv4Stack=true in Scala Native in order to
-     * always use AF_INET IPv4 socket.
+     * Even if IPv4-mapped IPv6 addresses can be enabled (via the
+     * net.inet6.ip6.v6only=0 sysctl and/or via the ipv6_ipv4mapping="YES"
+     * rc.conf variable) and sbt can be instructed to listen on an IPv6
+     * socket (via the java.net.preferIPv4Stack=false system property),
+     * the easiest way to make TestMain to work on most FreeBSD machines,
+     * with different Java versions, is to set
+     * java.net.preferIPv4Stack=true in Scala Native, before the first
+     * Java network call, in order to always use an AF_INET IPv4 socket.
      */
 
     System.setProperty("java.net.preferIPv4Stack", "true")
@@ -75,9 +71,8 @@ object TestMain {
     }
 
     if (LinktimeInfo.isFreeBSD) setFreeBSDWorkaround()
-    val serverAddr = iPv4Loopback
     val serverPort = args(0).toInt
-    val clientSocket = new Socket(serverAddr, serverPort)
+    val clientSocket = new Socket("127.0.0.1", serverPort)
     val nativeRPC = new NativeRPC(clientSocket)(ExecutionContext.global)
     val bridge = new TestAdapterBridge(nativeRPC)
 

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
@@ -31,53 +31,27 @@ object TestMain {
   final val iPv4Loopback = "127.0.0.1"
   final val iPv6Loopback = "::1"
 
-  private def getFreeBSDLoopbackAddr(): String = {
+  private def setFreeBSDWorkaround(): Unit = {
     /* Standard out-of-the-box FreeBSD differs from Linux & macOS in
      * not allowing IPv4 mapped IPv6 addresses, such as :FFFF:127.0.0.1
-     * or ::ffff:7f00:1.  These can be enabled by setting the line
-     * ipv6_ipv4mapping="YES" in /etc/rc.conf (and rebooting).
+     * or ::ffff:7f00:1.  These can be enabled at runtime by running
      *
-     * FreeBSD TestMain initial connections should succeed on both IPv4
-     * and IPv6 systems without requiring arcane and non-standard system
-     * configuration.  This method checks the protocol that Java connect()
-     * is likely used and returns the corresponding loopback address.
-     * Tests which use IPv4 addresses, either through hard-coding or
-     * bind resolution, on IPv6 systems will still fail. This allows to
-     * run the vast majority of tests which do not have this characteristic.
+     *   sysctl net.inet6.ip6.v6only=0
      *
-     * Networking is complex, especially on j-random systems: full of
-     * joy & lamentation.
+     * To make it persistent on reboot it is possible to set the line
+     * ipv6_ipv4mapping="YES" in /etc/rc.conf.
+     *
+     * Another difference is that Java versions >= 11 on FreeBSD set
+     * java.net.preferIPv4Stack=true by default, so the sbt server
+     * listens only on a tcp4 socket.
+     *
+     * The easiest way to make TestMain to work on most FreeBSD machines
+     * with different Java versions without changing system defaults is
+     * to set java.net.preferIPv4Stack=true in Scala Native in order to
+     * always use AF_INET IPv4 socket.
      */
 
-    if (!LinktimeInfo.isFreeBSD) iPv4Loopback // should never happen
-    else {
-      // These are the effective imports
-      import scalanative.posix.sys.socket._
-      import scalanative.posix.netinet.in
-      import scalanative.posix.unistd
-
-      /* These are to get this code to compile on Windows.
-       * Including all of them is cargo cult programming. Someone
-       * more patient or more knowledgeable about Windows may
-       * be able to reduce the set.
-       */
-      import scala.scalanative.windows._
-      import scala.scalanative.windows.WinSocketApi._
-      import scala.scalanative.windows.WinSocketApiExt._
-      import scala.scalanative.windows.WinSocketApiOps._
-      import scala.scalanative.windows.ErrorHandlingApi._
-
-      /* The keen observer will note that this scheme could be used
-       * for Linux and macOS. That change is not introduced at this time
-       * in order to preserve historical behavior.
-       */
-      val sd = socket(AF_INET6, SOCK_STREAM, in.IPPROTO_TCP)
-      if (sd == -1) iPv4Loopback
-      else {
-        unistd.close(sd)
-        iPv6Loopback
-      }
-    }
+    System.setProperty("java.net.preferIPv4Stack", "true")
   }
 
   /** Main method of the test runner. */
@@ -100,9 +74,8 @@ object TestMain {
         new RuntimeException().fillInStackTrace().ensuring(_ != null)
     }
 
-    val serverAddr =
-      if (!LinktimeInfo.isFreeBSD) iPv4Loopback
-      else getFreeBSDLoopbackAddr()
+    if (LinktimeInfo.isFreeBSD) setFreeBSDWorkaround()
+    val serverAddr = iPv4Loopback
     val serverPort = args(0).toInt
     val clientSocket = new Socket(serverAddr, serverPort)
     val nativeRPC = new NativeRPC(clientSocket)(ExecutionContext.global)


### PR DESCRIPTION
This patch allows to successfully run `sandbox3/run` on FreeBSD.

This is not enough to have a fully working scala-native setup, but many applications will work.

There are at least a couple of additional issues that I've found:
- when the boehm GC is used with multithreading, FreeBSD requires linking with `gc-threaded` instead of just `gc`. I'm not sure how to change that. Moreover, the documentation should be updated unconditionally to require the `boehm-gc-threaded` package instead of `boehm-gc` (regardless the runtime use of multithreading)
- any jdk >= 11 on FreeBSD has the system param `java.net.preferIPv4Stack` set to `true` by default, and the IPv4-mapped IPv6 addresses are disabled by default. Many tests won't work unless the `net.inet6.ip6.v6only` sysctl is set to zero and `java.net.preferIPv4Stack` is set to `false`