### PR TITLE
Skip addr memcmp if getifaddrs returns a null ifa_addr pointer

### DIFF
--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -316,19 +316,22 @@ object NetworkInterface {
   private def unixGetByInetAddress(addr: InetAddress): NetworkInterface = {
 
     def found(addr: Array[Byte], addrLen: Int, sa: Ptr[sockaddr]): Boolean = {
-      val sa_family = sa.sa_family.toInt
-      if (sa_family == AF_INET6) {
-        if (addrLen != 16) false
-        else {
-          val sa6 = sa.asInstanceOf[Ptr[sockaddr_in6]]
-          val sin6Addr = sa6.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
-          memcmp(addr.at(0), sin6Addr, addrLen.toUInt) == 0
-        }
-      } else if (sa_family == AF_INET) {
-        val sa4 = sa.asInstanceOf[Ptr[sockaddr_in]]
-        val sin4Addr = sa4.sin_addr.at1.asInstanceOf[Ptr[Byte]]
-        memcmp(addr.at(0), sin4Addr, addrLen.toUInt) == 0
-      } else false
+      if (sa == null) false
+      else {
+        val sa_family = sa.sa_family.toInt
+        if (sa_family == AF_INET6) {
+          if (addrLen != 16) false
+          else {
+            val sa6 = sa.asInstanceOf[Ptr[sockaddr_in6]]
+            val sin6Addr = sa6.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
+            memcmp(addr.at(0), sin6Addr, addrLen.toUInt) == 0
+          }
+        } else if (sa_family == AF_INET) {
+          val sa4 = sa.asInstanceOf[Ptr[sockaddr_in]]
+          val sin4Addr = sa4.sin_addr.at1.asInstanceOf[Ptr[Byte]]
+          memcmp(addr.at(0), sin4Addr, addrLen.toUInt) == 0
+        } else false
+      }
     }
 
     @tailrec
@@ -344,7 +347,7 @@ object NetworkInterface {
         findIfInetAddress(
           ipAddress,
           addrLen,
-          ifa.ifa_next.asInstanceOf[Ptr[ifaddrs]]
+          ifa.ifa_next
         )
     }
 


### PR DESCRIPTION
According to the `getifaddrs` man [page](https://www.man7.org/linux/man-pages/man3/getifaddrs.3.html), the `ifa_addr` contained in the `ifaddrs` struct can be a null pointer.

When running the `org.scalanative.testsuite.javalib.net.NetworkInterfaceTest` unit-test on my machine, I have the following error

```
Unexpected signal 11 when accessing memory at address (nil)
  | => tat _SM36scala.scalanative.unsafe.Tag$UShort$D4loadR_L16java.lang.ObjectEO
        at _SM50scala.scalanative.posix.sys.socketOps$sockaddrOps$D19sa_family$extensionL28scala.scalanative.unsafe.PtrL33scala.scalanative.unsigned.UShortEO
        at _SM26java.net.NetworkInterface$D7found$1LAb_iL28scala.scalanative.unsafe.PtrzEPT26java.net.NetworkInterface$
        ...
```

Adding null check so `found` returns `false` and lookup continues to next `ifaddrs` record.