### PR TITLE
Mutate socket localAddr only on successful bind

### DIFF
--- a/javalib/src/main/scala/java/net/Socket.scala
+++ b/javalib/src/main/scala/java/net/Socket.scala
@@ -130,8 +130,7 @@ class Socket protected (
   def bind(bindpoint: SocketAddress): Unit = {
     if (bindpoint != null && !bindpoint.isInstanceOf[InetSocketAddress]) {
       throw new IllegalArgumentException(
-        "Endpoint is of unsupported " +
-          "SocketAddress subclass"
+        "Endpoint SocketAddress subclass is not supported"
       )
     }
 
@@ -145,8 +144,8 @@ class Socket protected (
 
     checkClosedAndCreate()
 
+    impl.bind(addr.getAddress, addr.getPort)
     this.localAddr = addr.getAddress
-    impl.bind(this.localAddr, addr.getPort)
     this.localPort = impl.localport
     bound = true
   }


### PR DESCRIPTION
Extracted from #2279 

- Boy-scout update bind exception message
- Only mutate `localAddr` if bind was successful. In case of recovered exception, calling `getLocalAddress` on the socket should return the original value.