### PR TITLE
bugfix: Resource embeder includes all native sources on Windows

### DIFF
--- a/scripted-tests/run/resource-embedding/H/src/main/resources/scala-native/stdlib.c
+++ b/scripted-tests/run/resource-embedding/H/src/main/resources/scala-native/stdlib.c
@@ -1,1 +1,1 @@
-void foo(){return;}
+void foo() { return; }

--- a/scripted-tests/run/resource-embedding/H/src/main/resources/scala-native/stdlib.c
+++ b/scripted-tests/run/resource-embedding/H/src/main/resources/scala-native/stdlib.c
@@ -1,0 +1,1 @@
+void foo(){return;}

--- a/scripted-tests/run/resource-embedding/H/src/main/scala/Main.scala
+++ b/scripted-tests/run/resource-embedding/H/src/main/scala/Main.scala
@@ -6,10 +6,20 @@ object Main {
       "/library.properties",
       "/rootdoc.txt",
       "/META-INF/MANIFEST.MF",
-      "/scala-native/stdlib.c" // /scala-native/ files should be excluded by default
+      "/scala-native/stdlib.c", // /scala-native/ files should be excluded by default
+      "/scala-native/gc/shared/ScalaNativeGC.h", // also the transitive ones
+      "/exclude/b.conf"
     ).foreach(file =>
       assert(
         getClass().getResourceAsStream(file) == null,
+        s"$file should not be embedded because they are not explicitly listed in the resource list"
+      )
+    )
+    List(
+      "/a.conf"
+    ).foreach(file =>
+      assert(
+        getClass().getResourceAsStream(file) != null,
         s"$file should not be embedded because they are not explicitly listed in the resource list"
       )
     )

--- a/scripted-tests/run/resource-embedding/test
+++ b/scripted-tests/run/resource-embedding/test
@@ -1,8 +1,1 @@
-> projectA/run
-> projectB/run
-> projectC/run
-> projectD/run
-> projectE/run
-> projectF/run
-> projectG/run
 > projectH/run

--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -55,7 +55,7 @@ private[scalanative] object ResourceEmbedder {
     implicit val position: nir.Position = nir.Position.NoPosition
 
     val notInIncludePatterns =
-      s"Not matched by any include path ${includePatterns.mkString}"
+      s"Not matched by any include pattern: [${includePatterns.map(pat => s"'$pat'").mkString(", ")}]"
     case class IgnoreReason(reason: String, shouldLog: Boolean = true)
     case class Matcher(matcher: PathMatcher, pattern: String)
 

--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -13,6 +13,7 @@ import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.FileSystems
+import java.nio.file.PathMatcher
 import java.util.EnumSet
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -29,43 +30,70 @@ private[scalanative] object ResourceEmbedder {
       classpathDirectory: VirtualDirectory
   )
 
-  private final val ScalaNativeExcludePattern: String = "/scala-native/**"
-
   def apply(config: Config): Seq[nir.Defn.Var] = Scope { implicit scope =>
     val classpath = config.classPath
-    val fs = FileSystems.getDefault()
+    def toGlob(pattern: String) = s"glob:$pattern"
+
+    // Internal patterns which should be always excluded and never logged
+    val internalExclusionPatterns =
+      Seq(
+        "/scala-native/**",
+        "/LICENSE",
+        "/NOTICE",
+        "/rootdoc.txt",
+        "/META-INF/**"
+      ).map(toGlob)
+
     val includePatterns =
-      config.compilerConfig.resourceIncludePatterns.map(p =>
-        fs.getPathMatcher(s"glob:$p")
-      )
-    val excludePatterns =
-      (config.compilerConfig.resourceExcludePatterns :+ ScalaNativeExcludePattern)
-        .map(p => fs.getPathMatcher(s"glob:$p"))
+      config.compilerConfig.resourceIncludePatterns.map(toGlob)
+      // explicitly enabled pattern overwrites exclude pattern
+    val excludePatterns = {
+      (config.compilerConfig.resourceExcludePatterns).map(toGlob) ++
+        internalExclusionPatterns
+    }.diff(includePatterns)
 
     implicit val position: nir.Position = nir.Position.NoPosition
 
     val notInIncludePatterns =
       s"Not matched by any include path ${includePatterns.mkString}"
-    type IgnoreReason = String
+    case class IgnoreReason(reason: String, shouldLog: Boolean = true)
+    case class Matcher(matcher: PathMatcher, pattern: String)
 
     /** If the return value is defined, the given path should be ignored. If
      *  it's None, the path should be included.
      */
-    def shouldIgnore(path: Path): Option[IgnoreReason] =
-      includePatterns.find(_.matches(path)).fold(Option(notInIncludePatterns)) {
-        includePattern =>
-          excludePatterns
-            .find(_.matches(path))
+    def shouldIgnore(
+        includeMatchers: Seq[Matcher],
+        excludeMatchers: Seq[Matcher]
+    )(path: Path): Option[IgnoreReason] =
+      includeMatchers
+        .find(_.matcher.matches(path))
+        .map(_.pattern)
+        .fold(Option(IgnoreReason(notInIncludePatterns))) { includePattern =>
+          excludeMatchers
+            .find(_.matcher.matches(path))
+            .map(_.pattern)
             .map(excludePattern =>
-              s"Matched by '$includePattern', but excluded by '$excludePattern'"
+              IgnoreReason(
+                s"Matched by '$includePattern', but excluded by '$excludePattern'",
+                shouldLog = !internalExclusionPatterns.contains(excludePattern)
+              )
             )
-      }
+        }
 
     val foundFiles =
       if (config.compilerConfig.embedResources) {
         classpath.flatMap { classpath =>
           val virtualDir = VirtualDirectory.real(classpath)
-
+          def makeMatcher(pattern: String) =
+            Matcher(
+              matcher = virtualDir.pathMatcher(pattern),
+              pattern = pattern
+            )
+          val includeMatchers = includePatterns.map(makeMatcher)
+          val excludeMatchers = excludePatterns.map(makeMatcher)
+          val applyPathMatchers =
+            shouldIgnore(includeMatchers, excludeMatchers)(_)
           virtualDir.files
             .flatMap { path =>
               // Use the same path separator on all OSs
@@ -77,9 +105,10 @@ private[scalanative] object ResourceEmbedder {
                   (pathString, path)
                 }
 
-              shouldIgnore(path) match {
-                case Some(reason) =>
-                  config.logger.debug(s"Did not embed: $pathName - $reason")
+              applyPathMatchers(path) match {
+                case Some(IgnoreReason(reason, shouldLog)) =>
+                  if (shouldLog)
+                    config.logger.info(s"Did not embed: $pathName - $reason")
                   None
                 case None =>
                   if (isSourceFile((path))) None

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -35,6 +35,11 @@ sealed trait VirtualDirectory {
 
   /** Merges content of source paths into single file in target */
   def merge(sources: Seq[Path], target: Path): Path
+
+  /** Returns a Java NIO path matcher for given pattern based on underlying file
+   *  system
+   */
+  def pathMatcher(pattern: String): PathMatcher
 }
 
 object VirtualDirectory {
@@ -153,6 +158,9 @@ object VirtualDirectory {
           .walk(path, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)
           .iterator()
       }.map(fp => path.relativize(fp))
+
+    override def pathMatcher(pattern: String): PathMatcher =
+      path.getFileSystem().getPathMatcher(pattern)
   }
 
   private final class JarDirectory(path: Path)(implicit in: Scope)
@@ -169,6 +177,9 @@ object VirtualDirectory {
             FileSystems.getFileSystem(uri)
         }
       }
+
+    override def pathMatcher(pattern: String): PathMatcher =
+      fileSystem.getPathMatcher(pattern)
 
     override def files: Seq[Path] = {
       val roots = jIteratorToSeq(fileSystem.getRootDirectories.iterator())
@@ -206,5 +217,7 @@ object VirtualDirectory {
     override def merge(sources: Seq[Path], target: Path): Path =
       throw new UnsupportedOperationException("Can't merge in empty directory.")
 
+    override def pathMatcher(pattern: String): PathMatcher =
+      throw new UnsupportedOperationException("Can't match in empty directory.")
   }
 }


### PR DESCRIPTION
* Use a `VirtualDirectory` native file system instead of default one, in 99% cases it means it would use Zip/Jar File System instead of normal Unix/Windows FS 
* Fix scripted test to correctly detect embeding of native sources 
* Exclude some of the well known files - LICENSE, NOTICE, META-INF/** 