### PR TITLE
bugfix: Try to fix GC overrides of objects allocated just before collection

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/Allocator.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Allocator.c
@@ -142,8 +142,10 @@ bool Allocator_getNextLine(Allocator *allocator) {
 
     allocator->cursor = line;
     FreeLineMeta *lineMeta = (FreeLineMeta *)line;
-    BlockMeta_SetFirstFreeLine(block, lineMeta->next);
     uint16_t size = lineMeta->size;
+    if (size == 0)
+        return Allocator_newBlock(allocator);
+    BlockMeta_SetFirstFreeLine(block, lineMeta->next);
     allocator->limit = line + (size * WORDS_IN_LINE);
     assert(allocator->limit <= Block_GetBlockEnd(blockStart));
 

--- a/nativelib/src/main/resources/scala-native/gc/commix/MutatorThread.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/MutatorThread.c
@@ -36,11 +36,15 @@ void MutatorThread_delete(MutatorThread *self) {
     free(self);
 }
 
-typedef word_t **volatile stackptr_t;
+typedef word_t **stackptr_t;
 
 NOINLINE static stackptr_t MutatorThread_approximateStackTop() {
     volatile word_t sp;
+#if GNUC_PREREQ(4, 0)
+    sp = (word_t)__builtin_frame_address(0);
+#else
     sp = (word_t)&sp;
+#endif
     /* Also force stack to grow if necessary. Otherwise the later accesses might
      * cause the kernel to think we're doing something wrong. */
     return (stackptr_t)sp;

--- a/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
@@ -51,7 +51,7 @@ static void Synchronizer_SuspendThreads() {
 }
 
 static void Synchronizer_WakeupThreads() {
-    assert(Synchronizer_stopThreads == FALSE);
+    assert(Synchronizer_stopThreads == false);
 #ifdef _WIN32
     SetEvent(threadSuspensionEvent);
 #else

--- a/nativelib/src/main/resources/scala-native/gc/immix/Allocator.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Allocator.c
@@ -136,8 +136,11 @@ bool Allocator_getNextLine(Allocator *allocator) {
 
     allocator->cursor = line;
     FreeLineMeta *lineMeta = (FreeLineMeta *)line;
-    BlockMeta_SetFirstFreeLine(block, lineMeta->next);
     uint16_t size = lineMeta->size;
+    if (size == 0) {
+        return Allocator_newBlock(allocator);
+    }
+    BlockMeta_SetFirstFreeLine(block, lineMeta->next);
     allocator->limit = line + (size * WORDS_IN_LINE);
     assert(allocator->limit <= Block_GetBlockEnd(blockStart));
 

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -1,4 +1,3 @@
-#include "shared/GCTypes.h"
 #if defined(SCALANATIVE_GC_IMMIX)
 
 #include <stdio.h>
@@ -11,6 +10,7 @@
 #include "immix_commix/headers/ObjectHeader.h"
 #include "Block.h"
 #include "WeakRefStack.h"
+#include "shared/GCTypes.h"
 #include <stdatomic.h>
 
 extern word_t *__modules;

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -1,3 +1,4 @@
+#include "shared/GCTypes.h"
 #if defined(SCALANATIVE_GC_IMMIX)
 
 #include <stdio.h>
@@ -117,10 +118,14 @@ NO_SANITIZE void Marker_markRange(Heap *heap, Stack *stack, word_t **from,
     }
 }
 
-void Marker_markProgramStack(MutatorThread *thread, Heap *heap, Stack *stack) {
+NO_SANITIZE void Marker_markProgramStack(MutatorThread *thread, Heap *heap,
+                                         Stack *stack) {
     word_t **stackBottom = thread->stackBottom;
     word_t **stackTop = (word_t **)atomic_load(&thread->stackTop);
-
+    // Extend scanning slightly over the approximated stack top
+    // In the past we were frequently missing objects allocated just before GC
+    // (mostly under LTO enabled)
+    stackTop -= 8;
     Marker_markRange(heap, stack, stackTop, stackBottom);
 
     // Mark last context of execution
@@ -143,15 +148,8 @@ void Marker_markModules(Heap *heap, Stack *stack) {
 void Marker_markCustomRoots(Heap *heap, Stack *stack, GC_Roots *roots) {
     GC_Roots *it = roots;
     while (it != NULL) {
-        word_t **current = (word_t **)it->range.address_low;
-        word_t **limit = (word_t **)it->range.address_high;
-        while (current < limit) {
-            word_t *object = *current;
-            if (Heap_IsWordInHeap(heap, object)) {
-                Marker_markConservative(heap, stack, object);
-            }
-            current += 1;
-        }
+        Marker_markRange(heap, stack, (word_t **)it->range.address_low,
+                         (word_t **)it->range.address_high);
         it = it->next;
     }
 }

--- a/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.c
@@ -40,11 +40,15 @@ void MutatorThread_delete(MutatorThread *self) {
     free(self);
 }
 
-typedef word_t **volatile stackptr_t;
+typedef word_t **stackptr_t;
 
 NOINLINE static stackptr_t MutatorThread_approximateStackTop() {
     volatile word_t sp;
+#if GNUC_PREREQ(4, 0)
+    sp = (word_t)__builtin_frame_address(0);
+#else
     sp = (word_t)&sp;
+#endif
     /* Also force stack to grow if necessary. Otherwise the later accesses might
      * cause the kernel to think we're doing something wrong. */
     return (stackptr_t)sp;

--- a/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
@@ -51,7 +51,7 @@ static void Synchronizer_SuspendThreads() {
 }
 
 static void Synchronizer_WakeupThreads() {
-    assert(Synchronizer_stopThreads == FALSE);
+    assert(Synchronizer_stopThreads == false);
 #ifdef _WIN32
     SetEvent(threadSuspensionEvent);
 #else

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/Log.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/Log.h
@@ -1,12 +1,12 @@
 #ifndef IMMIX_LOG_H
 #define IMMIX_LOG_H
 
-#ifndef DEBUG_ASSERT
-
+#ifdef DEBUG_ASSERT
+#undef NDEBUG
+#else
 #ifndef NDEBUG
 #define NDEBUG
 #endif // NDEBUG
-
 #endif // DEBUG_ASSERT
 
 #include <assert.h>

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/UInt24.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/UInt24.h
@@ -11,11 +11,24 @@ typedef union {
     uint32_t bits : 24;
 } UInt24Bits;
 
+static inline UInt24Bits UInt24Bits_fromUInt32(uint32_t value) {
+    UInt24Bits result;
+    result.bits =
+        value & 0xFFFFFF; // mask to ensure only lower 24 bits are taken
+    return result;
+}
+
+static inline UInt24Bits UInt24Bits_fromUInt24(UInt24 v) {
+    UInt24Bits result;
+    result.value = v;
+    return result;
+}
+
 static inline UInt24 UInt24_fromUInt32(uint32_t value) {
-    return ((UInt24Bits)(value)).value;
+    return UInt24Bits_fromUInt32(value).value;
 }
 static inline uint32_t UInt24_toUInt32(UInt24 v) {
-    return ((UInt24Bits)(v)).bits;
+    return UInt24Bits_fromUInt24(v).bits;
 }
 
 static inline UInt24 UInt24_plus(UInt24 value, int32_t arg) {

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
@@ -18,7 +18,7 @@ extern int __array_ids_min;
 extern int __array_ids_max;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
-#define USES_LOCKWORD = 1
+#define USES_LOCKWORD 1
 
 // Inflation mark and object monitor are complementary
 #define MONITOR_INFLATION_MARK_MASK ((word_t)1)
@@ -68,12 +68,12 @@ struct Chunk {
     Chunk *next;
 };
 
-static inline bool Object_IsArray(Object *object) {
+static inline bool Object_IsArray(const Object *object) {
     int32_t id = object->rtti->rt.id;
     return __array_ids_min <= id && id <= __array_ids_max;
 }
 
-static inline size_t Object_Size(Object *object) {
+static inline size_t Object_Size(const Object *object) {
     if (Object_IsArray(object)) {
         ArrayHeader *arrayHeader = (ArrayHeader *)object;
         return MathUtils_RoundToNextMultiple(
@@ -86,23 +86,23 @@ static inline size_t Object_Size(Object *object) {
     }
 }
 
-static inline bool Object_IsWeakReference(Object *object) {
+static inline bool Object_IsWeakReference(const Object *object) {
     int32_t id = object->rtti->rt.id;
     return __weak_ref_ids_min <= id && id <= __weak_ref_ids_max;
 }
 
-static inline bool Object_IsReferantOfWeakReference(Object *object,
+static inline bool Object_IsReferantOfWeakReference(const Object *object,
                                                     int fieldOffset) {
     return Object_IsWeakReference(object) &&
            fieldOffset == __weak_ref_field_offset;
 }
 
 #ifdef USES_LOCKWORD
-static inline bool Field_isInflatedLock(Field_t field) {
+static inline bool Field_isInflatedLock(const Field_t field) {
     return (word_t)field & MONITOR_INFLATION_MARK_MASK;
 }
 
-static inline Field_t Field_allignedLockRef(Field_t field) {
+static inline Field_t Field_allignedLockRef(const Field_t field) {
     return (Field_t)((word_t)field & MONITOR_OBJECT_MASK);
 }
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/GCTypes.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/GCTypes.h
@@ -8,12 +8,22 @@
 
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
-#define NO_SANITIZE __attribute__((no_sanitize("address")))
+// NO_SANITIZE annotation might be skipped if function is inlined, prohibit
+// inlining instead
+#define NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address"))) NOINLINE
 #endif
+#if __has_feature(thread_sanitizer)
+#define NO_SANITIZE_THREAD __attribute__((no_sanitize("thread"))) NOINLINE
 #endif
+#if defined(NO_SANITIZE_ADDRESS) || defined(NO_SANITIZE_THREAD)
+#define NO_SANITIZE __attribute__((disable_sanitizer_instrumentation)) NOINLINE
+#endif
+#endif // has_feature
 
 #ifndef NO_SANITIZE
 #define NO_SANITIZE
+#define NO_SANITIZE_ADDRESS
+#define NO_SANITIZE_THREAD
 #endif
 
 #define UNLIKELY(b) __builtin_expect((b), 0)
@@ -21,5 +31,13 @@
 
 typedef uintptr_t word_t;
 typedef uint8_t ubyte_t;
+
+/* Convenient internal macro to test version of gcc.    */
+#if defined(__GNUC__) && defined(__GNUC_MINOR__)
+#define GNUC_PREREQ(major, minor)                                              \
+    ((__GNUC__ << 8) + __GNUC_MINOR__ >= ((major) << 8) + (minor))
+#else
+#define GNUC_PREREQ(major, minor) 0 /* FALSE */
+#endif
 
 #endif // GC_TYPES_H

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/HeapSizeTest.scala.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/HeapSizeTest.scala.scala
@@ -10,12 +10,12 @@ class HeapSizeTest {
   @Before
   val conversionFactor = (1024 * 1024 * 1024).toULong
   val lowerBound: ULong = 0.toULong
-  val higherBound: ULong = 32.toULong * conversionFactor
+  val higherBound: ULong = 128.toULong * conversionFactor
 
   @Test def checkInitHeapSize(): Unit = {
     val initHeapSz = GC.getInitHeapSize()
     assertTrue(
-      s"0 <= ${initHeapSz / conversionFactor}GB < 32GB",
+      s"0 <= ${initHeapSz / conversionFactor}GB < 128GB",
       initHeapSz >= lowerBound && initHeapSz < higherBound
     )
   }
@@ -23,7 +23,7 @@ class HeapSizeTest {
   @Test def checkMaxHeapSize(): Unit = {
     val maxHeapSize = GC.getMaxHeapSize()
     assertTrue(
-      s"0 < ${maxHeapSize / conversionFactor}GB <= 32GB",
+      s"0 < ${maxHeapSize / conversionFactor}GB <= 128GB",
       maxHeapSize > lowerBound && maxHeapSize <= higherBound
     )
   }


### PR DESCRIPTION
When running under LTO=thin we could have observed a frequent CI failures in `junitOutputsTests` - these are allocating lots of arrays. During debugging I've found out that object that was allocated just before the `GC_collect` might be skipped when scanning. Typically it should not happen, since the approximated stack top address should point further then last local variable containing allocated object, but it seems that under some circumstances it might not be fulfilled. Because of that we might skip scanning freshly allocated object leading to it's retention and an override by different thread leading to undefined behaviour