### PR TITLE
refactor: Remove `mapSourceURI`, always use local copy of sources when debugging

### DIFF
--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -28,7 +28,7 @@ private[lang] object StackTrace {
     // behavior is not defined for non-zero-terminated strings.
     name(nameMax - 1) = 0.toByte
     val position =
-      if (LinktimeInfo.isMac && LinktimeInfo.hasDebugMetadata)
+      if (LinktimeInfo.isMac && LinktimeInfo.sourceLevelDebuging.generateFunctionSourcePositions)
         Backtrace.decodePosition(ip.toLong)
       else Backtrace.Position.empty
     try StackTraceElement(name, position)

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -6,8 +6,6 @@ import scala.scalanative.unsafe._
  *  discard some parts of NIR instructions when linking
  */
 object LinktimeInfo {
-  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.hasDebugMetadata")
-  def hasDebugMetadata: Boolean = resolved
 
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.debugMode")
   def debugMode: Boolean = resolved
@@ -58,5 +56,18 @@ object LinktimeInfo {
     def os: String = resolved
     @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.target.env")
     def env: String = resolved
+  }
+
+  object sourceLevelDebuging {
+    @resolvedAtLinktime(
+      "scala.scalanative.meta.linktimeinfo.debugMetadata.enabled"
+    )
+    def enabled: Boolean = resolved
+
+    @resolvedAtLinktime(
+      "scala.scalanative.meta.linktimeinfo.debugMetadata.generateFunctionSourcePositions"
+    )
+    def generateFunctionSourcePositions: Boolean = resolved
+
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -73,11 +73,16 @@ final class BinarySerializer(channel: WritableByteChannel) {
     }
   }
 
-  private object Positions extends InternedBinarySectionWriter[Position] with Common {
-    override def internDeps(pos: Position): Unit = ()
+  private object Positions extends InternedBinarySectionWriter[nir.Position] with Common {
+    override def internDeps(pos: nir.Position): Unit = ()
 
-    override def put(pos: Position): Unit = {
-      putString(pos.source.toString) // interned
+    override def put(pos: nir.Position): Unit = {
+      putString {
+        pos.source match { // interned
+          case nir.SourceFile.Virtual                        => ""
+          case nir.SourceFile.SourceRootRelative(pathString) => pathString
+        }
+      }
       putLebUnsignedInt(pos.line)
       putLebUnsignedInt(pos.column)
     }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Prelude.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Prelude.scala
@@ -26,7 +26,7 @@ object Prelude {
       insts: Int
   )
 
-  def readFrom(buffer: ByteBuffer, fileName: String): Prelude = {
+  def readFrom(buffer: ByteBuffer, fileName: => String): Prelude = {
     buffer.position(0)
     val magic = buffer.getInt()
     val compat = buffer.getInt()

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
@@ -3,7 +3,9 @@ package nir
 
 import java.io.OutputStream
 import java.nio._
+import java.nio.file.Path
 import java.nio.channels.WritableByteChannel
+import scala.scalanative.io.VirtualDirectory
 
 package object serialization {
   @inline
@@ -18,8 +20,13 @@ package object serialization {
     new BinarySerializer(channel).serialize(defns)
   }
 
-  def deserializeBinary(buffer: ByteBuffer, fileName: String): Seq[Defn] =
+  def deserializeBinary(directory: VirtualDirectory, path: Path): Seq[Defn] = {
+    val buffer = directory.read(path)
     withBigEndian(buffer) {
-      new BinaryDeserializer(_, fileName).deserialize()
+      new BinaryDeserializer(
+        _,
+        new NIRSource(directory.path, path)
+      ).deserialize()
     }
+  }
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
@@ -8,6 +8,7 @@ import java.net.URI
  *  options.
  */
 trait ScalaNativeOptions {
+
   /** Should static forwarders be emitted for non-top-level objects.
    *
    *  Scala/JVM does not do that and, we do not do it by default either, but

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
@@ -8,8 +8,6 @@ import java.net.URI
  *  options.
  */
 trait ScalaNativeOptions {
-  import ScalaNativeOptions._
-
   /** Should static forwarders be emitted for non-top-level objects.
    *
    *  Scala/JVM does not do that and, we do not do it by default either, but
@@ -17,13 +15,4 @@ trait ScalaNativeOptions {
    *  of JDK classes.
    */
   def genStaticForwardersForNonTopLevelObjects: Boolean
-
-  /** Which source locations in source maps should be relativized (or where
-   *  should they be mapped to)?
-   */
-  def sourceURIMaps: List[URIMap]
-}
-
-object ScalaNativeOptions {
-  case class URIMap(from: URI, to: Option[URI])
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -49,7 +49,10 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
       case "genStaticForwardersForNonTopLevelObjects" =>
         genStaticForwardersForNonTopLevelObjects = true
       case opt if opt.startsWith("mapSourceURI:") =>
-        global.reporter.warning(global.NoPosition,"'mapSourceURI' is deprecated, it is ignored")
+        global.reporter.warning(
+          global.NoPosition,
+          "'mapSourceURI' is deprecated, it is ignored"
+        )
       case option =>
         error("Option not understood: " + option)
     }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -24,11 +24,7 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
   object nirAddons extends NirGlobalAddonsEarlyInit[global.type](global)
 
   object scalaNativeOpts extends ScalaNativeOptions {
-    import ScalaNativeOptions.URIMap
-
     var genStaticForwardersForNonTopLevelObjects: Boolean = false
-    lazy val sourceURIMaps: List[URIMap] = _sourceURIMaps.reverse
-    var _sourceURIMaps: List[URIMap] = Nil
   }
 
   object prepNativeInterop extends PrepNativeInterop[global.type](global) {
@@ -49,25 +45,11 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
 
   override def init(options: List[String], error: String => Unit): Boolean = {
     import scalaNativeOpts._
-    import ScalaNativeOptions.URIMap
     options.foreach {
       case "genStaticForwardersForNonTopLevelObjects" =>
         genStaticForwardersForNonTopLevelObjects = true
       case opt if opt.startsWith("mapSourceURI:") =>
-        val uris = opt.stripPrefix("mapSourceURI:").split("->")
-        if (uris.length != 1 && uris.length != 2) {
-          error("mapSourceURI needs one or two URIs as argument.")
-        } else {
-          try {
-            val from = new URI(uris.head)
-            val to = uris.lift(1).map(str => new URI(str))
-            _sourceURIMaps ::= URIMap(from, to)
-          } catch {
-            case e: URISyntaxException =>
-              error(s"${e.getInput} is not a valid URI")
-          }
-        }
-
+        global.reporter.warning(global.NoPosition,"'mapSourceURI' is deprecated, it is ignored")
       case option =>
         error("Option not understood: " + option)
     }
@@ -76,11 +58,6 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
   }
 
   override val optionsHelp: Option[String] = Some(s"""
-      |  -P:$name:mapSourceURI:FROM_URI[->TO_URI]
-      |     Change the location the source URIs in the emitted IR point to
-      |     - strips away the prefix FROM_URI (if it matches)
-      |     - optionally prefixes the TO_URI, where stripping has been performed
-      |     - any number of occurrences are allowed. Processing is done on a first match basis.
       |  -P:$name:genStaticForwardersForNonTopLevelObjects
       |     Generate static forwarders for non-top-level objects.
       |     This option should be used by codebases that implement JDK classes.

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
@@ -28,6 +28,6 @@ object GenNIR {
        *  this option can be used to opt in. This is necessary for
        *  implementations of JDK classes.
        */
-      genStaticForwardersForNonTopLevelObjects: Boolean = false,
+      genStaticForwardersForNonTopLevelObjects: Boolean = false
   )
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
@@ -29,11 +29,5 @@ object GenNIR {
        *  implementations of JDK classes.
        */
       genStaticForwardersForNonTopLevelObjects: Boolean = false,
-      /** Which source locations in source maps should be relativized (or where
-       *  should they be mapped to)?
-       */
-      sourceURIMaps: List[URIMap] = Nil
   )
-  case class URIMap(from: URI, to: Option[URI])
-
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -29,7 +29,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
 
   protected val defnNir = NirDefinitions.get
   protected val nirPrimitives = new NirPrimitives()
-  protected val positionsConversions = new NirPositions(settings.sourceURIMaps)
+  protected val positionsConversions = new NirPositions()
   protected val cachedMethodSig =
     collection.mutable.Map.empty[(Symbol, Boolean), nir.Type.Function]
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPositions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPositions.scala
@@ -5,10 +5,9 @@ import Contexts._
 
 import dotty.tools.dotc.util.{SourceFile, SourcePosition}
 import dotty.tools.dotc.util.Spans.Span
-import GenNIR.URIMap
 import scalanative.nir
 
-class NirPositions(sourceURIMaps: List[GenNIR.URIMap])(using Context) {
+class NirPositions()(using Context) {
   given fromSourcePosition: Conversion[SourcePosition, nir.Position] = {
     sourcePos =>
       sourceAndSpanToNirPos(sourcePos.source, sourcePos.span)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -13,11 +13,6 @@ class ScalaNativePlugin extends StandardPlugin:
 
   override val optionsHelp: Option[String] =
     Some(s"""
-      |  -P:$name:mapSourceURI:FROM_URI[->TO_URI]
-      |     Change the location the source URIs in the emitted IR point to
-      |     - strips away the prefix FROM_URI (if it matches)
-      |     - optionally prefixes the TO_URI, where stripping has been performed
-      |     - any number of occurrences are allowed. Processing is done on a first match basis.
       |  -P:$name:genStaticForwardersForNonTopLevelObjects
       |     Generate static forwarders for non-top-level objects.
       |     This option should be used by codebases that implement JDK classes.
@@ -31,24 +26,8 @@ class ScalaNativePlugin extends StandardPlugin:
           config.copy(genStaticForwardersForNonTopLevelObjects = true)
         case (config, s"mapSourceURI:${mapping}") =>
           given Context = NoContext
-          val uris = mapping.split("->")
-          if uris.length != 1 && uris.length != 2
-          then
-            report.error(
-              s"mapSourceUri needs one or two URIs as argument, got '$mapping'"
-            )
-            config
-          else {
-            try
-              val from = new URI(uris.head)
-              val to = uris.lift(1).map(str => new URI(str))
-              val sourceMaps = config.sourceURIMaps :+ GenNIR.URIMap(from, to)
-              config.copy(sourceURIMaps = sourceMaps)
-            catch
-              case e: URISyntaxException =>
-                report.error(s"${e.getInput} is not a valid URI")
-                config
-          }
+          report.warning("'mapSourceURI' is deprecated, it's ignored.")
+          config
         case (config, _) => config
       }
     List(PrepNativeInterop(), PostInlineNativeInterop(), GenNIR(genNirSettings))

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/PositionsTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/PositionsTest.scala
@@ -64,7 +64,7 @@ class PositionsTest {
       def checkPos(line: Int, column: Int)(pos: nir.Position) = {
         val clue =
           s"${defn.name} - expected=$line:$column, actual=${pos.line}:${pos.column}"
-        assertTrue(clue, pos.source.getPath().endsWith(sourceFile))
+        assertTrue(clue, pos.source.filename.contains(sourceFile))
         assertEquals(clue, line, pos.line)
         assertEquals(clue, column, pos.column)
       }
@@ -72,12 +72,12 @@ class PositionsTest {
           positions: Iterable[nir.Position]
       ): Unit = {
         positions.foreach { pos =>
-          assertTrue(s"${defn.name}", pos.source.getPath().endsWith(sourceFile))
+          assertTrue(s"${defn.name}", pos.source.filename.contains(sourceFile))
           assertTrue(s"${defn.name}", range.contains(pos.line))
         }
       }
       val pos = defn.pos
-      assertTrue(pos.source.getPath().endsWith(sourceFile))
+      assertTrue(pos.source.filename.contains(sourceFile))
       defn match {
         case nir.Defn.Class(_, TopLevel, _, _) =>
           checkPos(0, 6)(pos)

--- a/nscplugin/src/test/scala/scala/scalanative/linker/package.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/package.scala
@@ -20,8 +20,7 @@ package object linker {
         .filter(_.toString.endsWith(".nir"))
         .map(outDir.relativize(_))
         .flatMap { path =>
-          val buffer = dir.read(path)
-          nir.serialization.deserializeBinary(buffer, path.toString)
+          nir.serialization.deserializeBinary(dir, path)
         }
       fn(defns)
     }

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -155,16 +155,6 @@ object MyScalaNativePlugin extends AutoPlugin {
             .getOrElse(nc.multithreadingSupport)
         )
     },
-    scalacOptions ++= {
-      // Link source maps to GitHub sources
-      val isSnapshot = nativeVersion.endsWith("-SNAPSHOT")
-      if (isSnapshot) Nil
-      else
-        Settings.scalaNativeMapSourceURIOption(
-          (LocalProject("scala-native") / baseDirectory).value,
-          s"https://raw.githubusercontent.com/scala-native/scala-native/v$nativeVersion/"
-        )
-    },
     inConfig(Compile) {
       nativeLinkProfiling := nativeLinkProfilingImpl
         .tag(NativeTags.Link)

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -149,7 +149,7 @@ object MyScalaNativePlugin extends AutoPlugin {
       nc.withCheck(true)
         .withCheckFatalWarnings(true)
         .withDump(true)
-        .withDebugMetadata(true)
+        .withSourceLevelDebuggingConfig(_.enableAll)
         .withMultithreadingSupport(
           multithreadingEnabledBySbtSysProps()
             .getOrElse(nc.multithreadingSupport)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -685,7 +685,7 @@ object Settings {
       scalacOptions ++= Seq(
         // Create nir.SourceFile relative to Scala sources dir instead of root dir
         // It should use -sourcepath for both, but it fails to compile under Scala 2
-        if(scalaVersion.value.startsWith("2.")) "-rootdir" else "-sourcepath",
+        if (scalaVersion.value.startsWith("2.")) "-rootdir" else "-sourcepath",
         (fetchScalaSource / artifactPath).value.toString
       ),
       // Scala.js original comment modified to clarify issue is Scala.js.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -682,23 +682,12 @@ object Settings {
       libraryDependencies += "org.scala-lang" % libraryName % scalaVersion.value,
       fetchScalaSource / artifactPath :=
         baseDirectory.value.getParentFile / "target" / "scalaSources" / scalaVersion.value,
-      /* Link source maps to the GitHub sources of the original scalalib
-       * This must come *before* the option added by MyScalaJSPlugin
-       * because mapSourceURI works on a first-match basis.
-       */
-      scalacOptions := {
-        val prev = scalacOptions.value
-        val scalaVersion = Keys.scalaVersion.value
-        val option = scalaNativeMapSourceURIOption(
-          baseDir = (fetchScalaSource / artifactPath).value,
-          targetURI =
-            if (scalaVersion.startsWith("3."))
-              s"https://raw.githubusercontent.com/lampepfl/dotty/${scalaVersion}/library/src/"
-            else
-              s"https://raw.githubusercontent.com/scala/scala/v${scalaVersion}/src/library/"
-        )
-        option ++ prev
-      },
+      scalacOptions ++= Seq(
+        // Create nir.SourceFile relative to Scala sources dir instead of root dir
+        // It should use -sourcepath for both, but it fails to compile under Scala 2
+        if(scalaVersion.value.startsWith("2.")) "-rootdir" else "-sourcepath",
+        (fetchScalaSource / artifactPath).value.toString
+      ),
       // Scala.js original comment modified to clarify issue is Scala.js.
       /* Work around for https://github.com/scala-js/scala-js/issues/2649
        * We would like to always use `update`, but
@@ -924,23 +913,6 @@ object Settings {
   def scalaNativeCompilerOptions(options: String*): Seq[String] = {
     if (isGeneratingForIDE) Nil
     else options.map(opt => s"-P:scalanative:$opt")
-  }
-
-  def scalaNativeMapSourceURIOption(
-      baseDir: File,
-      targetURI: String
-  ): Seq[String] = {
-    /* Ensure that there is a trailing '/', otherwise we can get no '/'
-     * before the first compilation (because the directory does not exist yet)
-     * but a '/' after the first compilation, causing a full recompilation on
-     * the *second* run after 'clean' (but not third and following).
-     */
-    val baseDirURI0 = baseDir.toURI.toString
-    val baseDirURI =
-      if (baseDirURI0.endsWith("/")) baseDirURI0
-      else baseDirURI0 + "/"
-
-    scalaNativeCompilerOptions(s"mapSourceURI:$baseDirURI->$targetURI")
   }
 
   def scalaVersionsDependendent[T](scalaVersion: String)(default: T)(

--- a/scripted-tests/run/backtrace/build.sbt
+++ b/scripted-tests/run/backtrace/build.sbt
@@ -15,6 +15,6 @@ scalaVersion := {
 }
 
 nativeConfig ~= { c =>
-  c.withDebugMetadata(true)
+  c.withSourceLevelDebuggingConfig(_.enableAll)
     .withMode(Mode.debug) // otherwise, clang O2 inlines the call stack in Linux
 }

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
@@ -61,7 +61,7 @@ object TestMain {
 
     // Loading debug metadata can take up to few seconds which might mess up timeout specific tests
     // Prefetch the debug metadata before the actual tests do start
-    if (LinktimeInfo.hasDebugMetadata) {
+    if (LinktimeInfo.sourceLevelDebuging.generateFunctionSourcePositions) {
       val shouldPrefetch =
         sys.env
           .get("SCALANATIVE_TEST_PREFETCH_DEBUG_INFO")

--- a/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/testinterface/CodeGenBench.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/testinterface/CodeGenBench.scala
@@ -76,6 +76,6 @@ class CodeGenWithMultithreading
 
 class CodeGenWithDebugMetadata
     extends CodeGenBench(
-      nativeConfig = _.withDebugMetadata(true)
+      nativeConfig = _.withSourceLevelDebuggingConfig(_.enableAll)
         .withIncrementalCompilation(false)
     )

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -182,7 +182,7 @@ object Build {
   /** Links the DWARF debug information found in the object files. */
   private def postProcess(config: Config, artifact: Path): Path =
     config.logger.time("Postprocessing") {
-      if (Platform.isMac && config.compilerConfig.debugMetadata) {
+      if (Platform.isMac && config.compilerConfig.sourceLevelDebuggingConfig.generateFunctionSourcePositions) {
         LLVM.dsymutil(config, artifact)
       }
       artifact

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -62,6 +62,11 @@ sealed trait Config {
   /** Sequence of all NIR locations. */
   def classPath: Seq[Path]
 
+  /** Sequence of all Scala sources locations used when mapping binary symbols
+   *  with original sources.
+   */
+  def sourcesClassPath: Seq[Path]
+
   /** The logger used by the toolchain. */
   def logger: Logger
 
@@ -90,6 +95,9 @@ sealed trait Config {
 
   /** Create a new config with given nir paths. */
   def withClassPath(value: Seq[Path]): Config
+
+  /** Create a new config with given Scala sources paths. */
+  def withSourcesClassPath(value: Seq[Path]): Config
 
   /** Create a new config with the given logger. */
   def withLogger(value: Logger): Config
@@ -180,6 +188,7 @@ object Config {
       moduleName = "",
       mainClass = None,
       classPath = Seq.empty,
+      sourcesClassPath = Seq.empty,
       compilerConfig = NativeConfig.empty
     )(Logger.default)
 
@@ -189,6 +198,7 @@ object Config {
       moduleName: String,
       mainClass: Option[String],
       classPath: Seq[Path],
+      sourcesClassPath: Seq[Path],
       compilerConfig: NativeConfig
   )(implicit
       val logger: Logger // Exclude logger from hashCode calculation https://stackoverflow.com/questions/10373715/scala-ignore-case-class-field-for-equals-hascode
@@ -208,6 +218,9 @@ object Config {
 
     def withClassPath(value: Seq[Path]): Config =
       copy(classPath = value)
+
+    def withSourcesClassPath(value: Seq[Path]): Config =
+      copy(sourcesClassPath = value)
 
     override def withCompilerConfig(value: NativeConfig): Config =
       copy(compilerConfig = value)
@@ -261,20 +274,22 @@ object Config {
     }
 
     override def toString: String = {
-      val classPathFormat =
-        classPath.mkString("List(", "\n".padTo(22, ' '), ")")
+      def formatClassPath(cp: Seq[Path]) =
+        cp.mkString("List(", "\n".padTo(22, ' '), ")")
+
       s"""Config(
-        | - baseDir:        $baseDir
-        | - testConfig:     $testConfig
-        | - workDir:        $workDir
-        | - moduleName:     $moduleName
-        | - baseName:       $baseName
-        | - artifactName:   $artifactName
-        | - artifactPath:   $artifactPath
-        | - buildPath:      $buildPath
-        | - mainClass:      $mainClass
-        | - classPath:      $classPathFormat
-        | - compilerConfig: $compilerConfig
+        | - baseDir:          $baseDir
+        | - testConfig:       $testConfig
+        | - workDir:          $workDir
+        | - moduleName:       $moduleName
+        | - baseName:         $baseName
+        | - artifactName:     $artifactName
+        | - artifactPath:     $artifactPath
+        | - buildPath:        $buildPath
+        | - mainClass:        $mainClass
+        | - classPath:        ${formatClassPath(classPath)}
+        | - sourcesClasspath: ${formatClassPath(sourcesClassPath)} 
+        | - compilerConfig:   $compilerConfig
         |)""".stripMargin
     }
 

--- a/tools/src/main/scala/scala/scalanative/build/IO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/IO.scala
@@ -78,7 +78,7 @@ private[scalanative] object IO {
   /** Does a `pattern` match starting at base */
   def existsInDir(base: Path, pattern: String): Boolean = {
     var out = false
-    val matcher = FileSystems.getDefault.getPathMatcher(pattern)
+    val matcher = base.getFileSystem.getPathMatcher(pattern)
     val visitor = new SimpleFileVisitor[Path] {
       override def preVisitDirectory(
           directory: Path,

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -89,7 +89,7 @@ private[scalanative] object LLVM {
     }
     // Always generate debug metadata on Windows, it's required for stack traces to work
     val debugFlags =
-      if (config.compilerConfig.debugMetadata || config.targetsWindows)
+      if (config.compilerConfig.sourceLevelDebuggingConfig.enabled || config.targetsWindows)
         Seq("-g")
       else Nil
 
@@ -203,7 +203,7 @@ private[scalanative] object LLVM {
 
     val flags = {
       val debugFlags =
-        if (config.compilerConfig.debugMetadata || config.targetsWindows)
+        if (config.compilerConfig.sourceLevelDebuggingConfig.enabled || config.targetsWindows)
           Seq("-g")
         else Nil
 

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -197,7 +197,8 @@ private[scalanative] object ScalaNative {
       ec: ExecutionContext
   ): Future[Seq[Path]] = {
     val withMetadata =
-      if (config.compilerConfig.debugMetadata) " (with debug metadata)"
+      if (config.compilerConfig.sourceLevelDebuggingConfig.enabled)
+        " (with debug metadata)"
       else ""
 
     config.logger.timeAsync(s"Generating intermediate code$withMetadata") {

--- a/tools/src/main/scala/scala/scalanative/build/SourceLevelDebugingConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/SourceLevelDebugingConfig.scala
@@ -1,0 +1,95 @@
+package scala.scalanative.build
+
+import java.nio.file.Path
+
+sealed trait SourceLevelDebuggingConfig {
+
+  /** Shall toolchain enable mechanism for generation for source level debugging
+   *  metadata.
+   */
+  def enabled: Boolean
+  def enabled(state: Boolean): SourceLevelDebuggingConfig
+
+  def enableAll: SourceLevelDebuggingConfig
+  def disableAll: SourceLevelDebuggingConfig
+
+  /** Shall function contain additional information about source definition.
+   *  Enables source positions in stacktraces, but introduces a runtime penalty
+   *  for symbols deserialization
+   */
+  def generateFunctionSourcePositions: Boolean
+  def generateFunctionSourcePositions(
+      state: Boolean
+  ): SourceLevelDebuggingConfig
+
+  /** Shall generate a metadata for local variables, allows to check state of
+   *  local variables in debugger. Recommended usage of LLDB with disabled
+   *  optimizations.
+   */
+  def generateLocalVariables: Boolean
+  def generateLocalVariables(state: Boolean): SourceLevelDebuggingConfig
+
+  /** List of custom source roots used to map symbols find in binary file (NIR)
+   *  with orignal Scala sources
+   */
+  def customSourceRoots: Seq[Path]
+  def withCustomSourceRoots(paths: Seq[Path]): SourceLevelDebuggingConfig
+
+  private[scalanative] def show(indent: String): String
+
+}
+
+object SourceLevelDebuggingConfig {
+  def disabled: SourceLevelDebuggingConfig = Impl(false, false, false, Nil)
+  def enabled: SourceLevelDebuggingConfig = Impl(true, true, true, Nil)
+
+  private final case class Impl(
+      enabled: Boolean,
+      private val genFunctionSourcePositions: Boolean,
+      private val genLocalVariables: Boolean,
+      customSourceRoots: Seq[Path]
+  ) extends SourceLevelDebuggingConfig {
+    override def enabled(state: Boolean): SourceLevelDebuggingConfig =
+      copy(enabled = state)
+    override def enableAll: SourceLevelDebuggingConfig = copy(
+      enabled = true,
+      genFunctionSourcePositions = true,
+      genLocalVariables = true
+    )
+    override def disableAll: SourceLevelDebuggingConfig =
+      copy(
+        enabled = false,
+        genFunctionSourcePositions = false,
+        genLocalVariables = false
+      )
+
+    override def generateFunctionSourcePositions: Boolean =
+      enabled && genFunctionSourcePositions
+    override def generateFunctionSourcePositions(
+        state: Boolean
+    ): SourceLevelDebuggingConfig =
+      copy(genFunctionSourcePositions = state)
+
+    override def generateLocalVariables: Boolean = enabled && genLocalVariables
+    override def generateLocalVariables(
+        state: Boolean
+    ): SourceLevelDebuggingConfig =
+      copy(genLocalVariables = state)
+
+    override def withCustomSourceRoots(
+        paths: Seq[Path]
+    ): SourceLevelDebuggingConfig =
+      copy(customSourceRoots = paths)
+
+    override def toString: String = show(indent = " ")
+    override private[scalanative] def show(indent: String): String = {
+      val state = if (enabled) "Enabled" else "Disabled"
+      val sourceRoots = customSourceRoots.mkString("[", ", ", "]")
+      s"""SourceLevelDebuggingConfig[${state}]
+        |$indent- customSourceRoots:       ${sourceRoots}
+        |$indent- generateFunctionSourcePositions: $generateFunctionSourcePositions
+        |$indent- generateLocalVariables:  $generateLocalVariables
+        |$indent)""".stripMargin
+    }
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -12,6 +12,8 @@ import scala.scalanative.build.Logger
 
 // scalafmt: { maxColumn = 120}
 object Generate {
+  private implicit val pos: nir.Position = nir.Position.NoPosition
+  private implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
   import Impl._
 
   val ClassHasTraitName = nir.Global.Member(rttiModule, nir.Sig.Extern("__check_class_has_trait"))
@@ -26,8 +28,6 @@ object Generate {
     (new Impl(entry, defns)).generate()
 
   implicit def reachabilityAnalysis(implicit meta: Metadata): ReachabilityAnalysis.Result = meta.analysis
-  private implicit val pos: nir.Position = nir.Position.NoPosition
-  private implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
 
   private class Impl(entry: Option[nir.Global.Top], defns: Seq[nir.Defn])(implicit
       meta: Metadata

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -229,13 +229,15 @@ object Lower {
           buf += inst
       }
 
-      implicit val pos: nir.Position = nir.Position.NoPosition
-      genNullPointerSlowPath(buf)
-      genDivisionByZeroSlowPath(buf)
-      genClassCastSlowPath(buf)
-      genUnreachableSlowPath(buf)
-      genOutOfBoundsSlowPath(buf)
-      genNoSuchMethodSlowPath(buf)
+      locally {
+        implicit val pos: nir.Position = nir.Position.NoPosition
+        genNullPointerSlowPath(buf)
+        genDivisionByZeroSlowPath(buf)
+        genClassCastSlowPath(buf)
+        genUnreachableSlowPath(buf)
+        genOutOfBoundsSlowPath(buf)
+        genNoSuchMethodSlowPath(buf)
+      }
 
       nullPointerSlowPath.clear()
       divisionByZeroSlowPath.clear()

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -6,9 +6,10 @@ import scalanative.linker.{Trait, Class, ReachabilityAnalysis}
 
 class Metadata(
     val analysis: ReachabilityAnalysis.Result,
-    val config: build.NativeConfig,
+    val buildConfig: build.Config,
     proxies: Seq[nir.Defn]
 )(implicit val platform: PlatformInfo) {
+  def config: build.NativeConfig = buildConfig.compilerConfig
   implicit private def self: Metadata = this
 
   final val usesLockWords = platform.isMultithreadingEnabled

--- a/tools/src/main/scala/scala/scalanative/codegen/SourceCodeCache.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/SourceCodeCache.scala
@@ -46,7 +46,14 @@ class SourceCodeCache(config: build.Config) {
       source: nir.SourceFile.SourceRootRelative,
       pos: nir.Position
   ): Option[Path] = {
-    assert(pos.source eq source)
+    assert(
+      config.compilerConfig.sourceLevelDebuggingConfig.enabled,
+      "Sources shall not be reoslved in source level debuging is disabled"
+    )
+    assert(
+      pos.source eq source,
+      "invalid usage, `pos.source` shall eq `source`"
+    )
     cache.getOrElseUpdate(
       pos.source, {
         // NIR sources are always put in the package name similarry to sources in jar

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -760,7 +760,7 @@ private[codegen] abstract class AbstractCodeGen(
     val id = inst.id
     val unwind = inst.unwind
     val ty = inst.op.resty
-    val scope = defnScopes.toDIScope(inst.scopeId)
+    lazy val scope = defnScopes.toDIScope(inst.scopeId)
 
     def genBind() =
       if (!isVoid(ty)) {
@@ -984,7 +984,7 @@ private[codegen] abstract class AbstractCodeGen(
      *  situations where a null check is generated (and the function call is
      *  throwNullPointer) in this case we can only use NoPosition
      */
-    val dbgPosition = toDILocation(srcPos, scopeId)
+    lazy val dbgPosition = toDILocation(srcPos, scopeId)
     def genDbgPosition() = dbg(",", dbgPosition)
 
     call match {

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -279,9 +279,9 @@ private[codegen] abstract class AbstractCodeGen(
         implicit val cfg: CFG = CFG(insts)
         implicit val _fresh: nir.Fresh = fresh
         implicit val _debugInfo: DebugInfo = debugInfo
+        str(" ")
+        str(os.gxxPersonality)
         def genBody() = {
-          str(" ")
-          str(os.gxxPersonality)
           str(" {")
           cfg.all.foreach(genBlock)
           cfg.all.foreach(genBlockLandingPads)

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -161,7 +161,7 @@ private[codegen] abstract class AbstractCodeGen(
       newline()
     }
     os.genPrelude()
-    if (config.debugMetadata) {
+    if (config.sourceLevelDebuggingConfig.generateLocalVariables) {
       newline()
       line("declare void @llvm.dbg.declare(metadata, metadata, metadata)")
       line("declare void @llvm.dbg.value(metadata, metadata, metadata)")
@@ -434,7 +434,7 @@ private[codegen] abstract class AbstractCodeGen(
           }
       }
     }
-    if (generateDebugMetadata) {
+    if (generateLocalVariables) {
       lazy val scopeId =
         if (block.isEntry) nir.ScopeId.TopLevel
         else

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -10,7 +10,7 @@ import scala.scalanative.util.{unreachable, And}
 trait Eval { self: Interflow =>
   def interflow: Interflow = self
   final val preserveDebugInfo: Boolean =
-    self.config.compilerConfig.debugMetadata
+    self.config.compilerConfig.sourceLevelDebuggingConfig.generateLocalVariables
 
   def run(
       insts: Array[nir.Inst],

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -14,17 +14,13 @@ sealed trait ClassPath {
   private[scalanative] def contains(name: nir.Global): Boolean
 
   /** Load given global and info about its dependencies. */
-  private[scalanative] def load(name: nir.Global): Option[Seq[nir.Defn]]
+  private[scalanative] def load(name: nir.Global.Top): Option[Seq[nir.Defn]]
 
   private[scalanative] def classesWithEntryPoints: Iterable[nir.Global.Top]
 
 }
 
 object ClassPath {
-
-  /** Create classpath based on the directory. */
-  def apply(directory: Path): ClassPath =
-    new Impl(VirtualDirectory.local(directory))
 
   /** Create classpath based on the virtual directory. */
   private[scalanative] def apply(directory: VirtualDirectory): ClassPath =
@@ -42,7 +38,7 @@ object ClassPath {
         .toMap
 
     private val cache =
-      mutable.Map.empty[nir.Global, Option[Seq[nir.Defn]]]
+      mutable.Map.empty[nir.Global.Top, Option[Seq[nir.Defn]]]
 
     def contains(name: nir.Global) =
       files.contains(name.top)
@@ -52,14 +48,11 @@ object ClassPath {
         .resolve(new java.net.URI(file.getFileName().toString))
         .toString
 
-    def load(name: nir.Global): Option[Seq[nir.Defn]] =
+    def load(name: nir.Global.Top): Option[Seq[nir.Defn]] =
       cache.getOrElseUpdate(
         name, {
           files.get(name.top).map { file =>
-            deserializeBinary(
-              directory.read(file),
-              makeBufferName(directory, file)
-            )
+            deserializeBinary(directory, file)
           }
         }
       )

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -18,7 +18,8 @@ trait LinktimeValueResolver { self: Reach =>
     val conf = config.compilerConfig
     val triple = conf.configuredOrDetectedTriple
     val predefined: NativeConfig.LinktimeProperites = Map(
-      s"$linktimeInfo.hasDebugMetadata" -> conf.debugMetadata,
+      s"$linktimeInfo.debugMetadata.enabled" -> conf.sourceLevelDebuggingConfig.enabled,
+      s"$linktimeInfo.debugMetadata.generateFunctionSourcePositions" -> conf.sourceLevelDebuggingConfig.generateFunctionSourcePositions,
       s"$linktimeInfo.debugMode" -> (conf.mode == Mode.debug),
       s"$linktimeInfo.releaseMode" -> (conf.mode == Mode.releaseFast || conf.mode == Mode.releaseFull || conf.mode == Mode.releaseSize),
       s"$linktimeInfo.isMultithreadingEnabled" -> conf.multithreadingSupport,

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -1016,7 +1016,7 @@ class Reach(
       val current = from.getOrElse(name, ReferencedFrom.Root)
       if (current == ReferencedFrom.Root) buf.result()
       else {
-        val file = current.srcPosition.filename.getOrElse("unknown")
+        val file = current.srcPosition.source.filename.getOrElse("unknown")
         val line = current.srcPosition.line
         buf += BackTraceElement(
           name = current.referencedBy,

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -56,14 +56,16 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withMultithreading: Boolean = false,
       withTargetTriple: String = "x86_64-unknown-unknown"
   )(expected: SymbolsCount) = usingMinimalApp(
-    _.withDebugMetadata(withDebugMetadata)
+    _.withSourceLevelDebuggingConfig(conf =>
+      if (withDebugMetadata) conf.enableAll else conf.disableAll
+    )
       .withMultithreadingSupport(withMultithreading)
       .withTargetTriple(withTargetTriple)
   ) { (config: Config, result: ReachabilityAnalysis.Result) =>
     assertEquals(
       "debugMetadata",
       withDebugMetadata,
-      config.compilerConfig.debugMetadata
+      config.compilerConfig.sourceLevelDebuggingConfig.enabled
     )
     assertEquals(
       "multithreading",

--- a/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
@@ -21,7 +21,7 @@ class LexicalScopesTest extends OptimizerSpec {
       sources,
       { (config: NativeConfig) =>
         config
-          .withDebugMetadata(true)
+          .withSourceLevelDebuggingConfig(_.enableAll)
           .withMode(build.Mode.releaseFull)
       }.andThen(setupConfig)
     )(fn)

--- a/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
@@ -21,7 +21,7 @@ class LocalNamesTest extends OptimizerSpec {
       entry,
       sources,
       setupConfig.andThen(
-        _.withDebugMetadata(true)
+        _.withSourceLevelDebuggingConfig(_.enableAll)
           .withMode(build.Mode.releaseFull)
       )
     )(fn)
@@ -43,7 +43,7 @@ class LocalNamesTest extends OptimizerSpec {
     |  }
     |}
     """.stripMargin),
-    setupConfig = _.withDebugMetadata(true)
+    setupConfig = _.withSourceLevelDebuggingConfig(_.enableAll)
   ) {
     case (config, result) =>
       def checkLocalNames(defns: Seq[nir.Defn]) =

--- a/tools/src/test/scala/scala/scalanative/optimizer/package.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/package.scala
@@ -88,7 +88,7 @@ package object optimizer {
     implicit def logger: build.Logger = config.logger
     implicit val platform: PlatformInfo = PlatformInfo(config)
     implicit val meta: Metadata =
-      new Metadata(optimized, config.compilerConfig, Nil)
+      new Metadata(optimized, config, Nil)
     val lowered = llvm.CodeGen.lower(defns)
     Await.result(lowered.map(fn), duration.Duration.Inf)
   }

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -14,6 +14,9 @@ sealed trait VirtualDirectory {
   /** A unique identifier for this directory */
   def uri: URI
 
+  /** Java NIO Path pointing to underlying directory */
+  def path: Path
+
   /** Check if file with given path is in the directory. */
   def contains(path: Path): Boolean =
     files.contains(path)
@@ -145,7 +148,8 @@ object VirtualDirectory {
     }
   }
 
-  private final class LocalDirectory(path: Path) extends NioDirectory {
+  private final class LocalDirectory(override val path: Path)
+      extends NioDirectory {
 
     def uri: URI = path.toUri
 
@@ -163,7 +167,7 @@ object VirtualDirectory {
       path.getFileSystem().getPathMatcher(pattern)
   }
 
-  private final class JarDirectory(path: Path)(implicit in: Scope)
+  private final class JarDirectory(override val path: Path)(implicit in: Scope)
       extends NioDirectory {
     def uri: URI = URI.create(s"jar:${path.toUri}")
     private val fileSystem: FileSystem =
@@ -196,7 +200,7 @@ object VirtualDirectory {
   }
 
   private object EmptyDirectory extends VirtualDirectory {
-
+    override def path: Path = Paths.get("")
     val uri: URI = URI.create("")
 
     override def files = Seq.empty


### PR DESCRIPTION
When generating DWARF metadata all the paths need to be an absolute paths to local files. Becouse of that we cannot use remote sources in debuggers. This limitation made Scala.js based `mapSourceURI` settings obsolete, they might be only useful for Web WASM embeddings, however we should be able to replace them with DWARF metadata as well.  
In this PR we remove `mapSourceURI` (compiler plugin gives a warning and ignores it) and change informations about paths to allow for better local discovery of local sources. When linking the source path would contain both source root relative path to original source (same as in TASTy) generated by scalac compiler and a coordinates to directory (or JAR) for classpath entry and it's relative path to actual NIR file containing given definitions.
We introduce a `SourceCodeCache` which is responsbile for finding either required files of current project or extern dependenices sources based on relative paths or jar sources. Custom roots can be configured in refactored `SourceLevelDebugingConfig` which replaced as single `debugMetadata` flag.  

We introduce a new entry in `build.Config::sourcesClassPath` which might be used by build-tools integrators to pass resolved paths to JARs containing sources of external dependencies. Reference implementation was added to `ScalaNativePluginInternal`