### PR TITLE
improvement: Make `ArrayIndexOutBoundsExceptions` compliant with JVM 8+ -

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -101,9 +101,9 @@ object Array {
     } else if (len < 0) {
       throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (fromPos < 0 || fromPos + len > from.length) {
-      throwOutOfBounds(fromPos)
+      throwOutOfBounds(fromPos, from.length)
     } else if (toPos < 0 || toPos + len > to.length) {
-      throwOutOfBounds(toPos)
+      throwOutOfBounds(toPos, to.length)
     } else if (len == 0) {
       ()
     } else {
@@ -146,9 +146,9 @@ object Array {
     } else if (len < 0) {
       throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (leftPos < 0 || leftPos + len > left.length) {
-      throwOutOfBounds(leftPos)
+      throwOutOfBounds(leftPos, left.length)
     } else if (rightPos < 0 || rightPos + len > right.length) {
-      throwOutOfBounds(rightPos)
+      throwOutOfBounds(rightPos, right.length)
     } else if (len == 0) {
       0
     } else {
@@ -166,7 +166,7 @@ final class BooleanArray private () extends Array[Boolean] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }
@@ -232,7 +232,7 @@ final class CharArray private () extends Array[Char] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }
@@ -298,7 +298,7 @@ final class ByteArray private () extends Array[Byte] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }
@@ -364,7 +364,7 @@ final class ShortArray private () extends Array[Short] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }
@@ -430,7 +430,7 @@ final class IntArray private () extends Array[Int] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }
@@ -496,7 +496,7 @@ final class LongArray private () extends Array[Long] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }
@@ -562,7 +562,7 @@ final class FloatArray private () extends Array[Float] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }
@@ -628,7 +628,7 @@ final class DoubleArray private () extends Array[Double] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }
@@ -694,7 +694,7 @@ final class ObjectArray private () extends Array[Object] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -101,9 +101,9 @@ object Array {
     } else if (len < 0) {
       throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (fromPos < 0 || fromPos + len > from.length) {
-      throwOutOfBounds(fromPos)
+      throwOutOfBounds(fromPos, from.length)
     } else if (toPos < 0 || toPos + len > to.length) {
-      throwOutOfBounds(toPos)
+      throwOutOfBounds(toPos, to.length)
     } else if (len == 0) {
       ()
     } else {
@@ -146,9 +146,9 @@ object Array {
     } else if (len < 0) {
       throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (leftPos < 0 || leftPos + len > left.length) {
-      throwOutOfBounds(leftPos)
+      throwOutOfBounds(leftPos, left.length)
     } else if (rightPos < 0 || rightPos + len > right.length) {
-      throwOutOfBounds(rightPos)
+      throwOutOfBounds(rightPos, right.length)
     } else if (len == 0) {
       0
     } else {
@@ -182,7 +182,7 @@ final class ${T}Array private () extends Array[${T}] {
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
+      throwOutOfBounds(i, length)
     } else {
       atRawUnsafe(i)
     }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -148,9 +148,10 @@ package object runtime {
     throw new UndefinedBehaviorError
 
   /** Called by the generated code in case of out of bounds on array access. */
-  @noinline
-  private[scalanative] def throwOutOfBounds(i: Int): Nothing =
-    throw new ArrayIndexOutOfBoundsException(i.toString)
+  private[scalanative] def throwOutOfBounds(i: Int, length: Int): Nothing =
+    throw new ArrayIndexOutOfBoundsException(
+      s"Index $i out of bounds for length $length"
+    )
 
   /** Called by the generated code in case of missing method on reflective call.
    */

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -382,12 +382,13 @@ object Lower {
             unwindHandler := slowPathUnwindHandler
           ) {
             val idx = nir.Val.Local(fresh(), nir.Type.Int)
+            val len = nir.Val.Local(fresh(), nir.Type.Int)
 
-            buf.label(slowPath, Seq(idx))
+            buf.label(slowPath, Seq(idx, len))
             buf.call(
               throwOutOfBoundsTy,
               throwOutOfBoundsVal,
-              Seq(nir.Val.Null, idx),
+              Seq(nir.Val.Null, idx, len),
               unwind
             )
             buf.unreachable(nir.Next.None)
@@ -559,7 +560,7 @@ object Lower {
       branch(
         inBounds,
         nir.Next(inBoundsL),
-        nir.Next.Label(outOfBoundsL, Seq(idx))
+        nir.Next.Label(outOfBoundsL, Seq(idx, len))
       )
       label(inBoundsL)
     }
@@ -1986,11 +1987,17 @@ object Lower {
     nir.Val.Global(throwUndefined, nir.Type.Ptr)
 
   val throwOutOfBoundsTy =
-    nir.Type.Function(Seq(nir.Type.Ptr, nir.Type.Int), nir.Type.Nothing)
+    nir.Type.Function(
+      Seq(nir.Type.Ptr, nir.Type.Int, nir.Type.Int),
+      nir.Type.Nothing
+    )
   val throwOutOfBounds =
     nir.Global.Member(
       nir.Rt.Runtime.name,
-      nir.Sig.Method("throwOutOfBounds", Seq(nir.Type.Int, nir.Type.Nothing))
+      nir.Sig.Method(
+        "throwOutOfBounds",
+        Seq(nir.Type.Int, nir.Type.Int, nir.Type.Nothing)
+      )
     )
   val throwOutOfBoundsVal =
     nir.Val.Global(throwOutOfBounds, nir.Type.Ptr)


### PR DESCRIPTION
Inform about bounds in exception message, eg: 
`java.lang.ArrayIndexOutOfBoundsException: Index -5 out of bounds for length 10` 
instead of 
`java.lang.ArrayIndexOutOfBoundsException: -5`
