### PR TITLE
improvement: Use` java.lang.StringBuilder` for optimized concatation of Strings in NIR CodeGen

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -345,6 +345,21 @@ trait NirDefinitions {
     lazy val JavaProperties = getRequiredClass("java.util.Properties")
 
     lazy val StringConcatMethod = getMember(StringClass, TermName("concat"))
+    lazy val String_valueOf_Object =
+      getMember(StringModule, nme.valueOf).filter(sym =>
+        sym.info.paramTypes match {
+          case List(pt) => pt.typeSymbol == ObjectClass
+          case _        => false
+        }
+      )
+    lazy val jlStringBuilderRef = getRequiredClass("java.lang.StringBuilder")
+    lazy val jlStringBuilderType = jlStringBuilderRef.toType
+    lazy val jlStringBuilderAppendAlts =
+      getMemberMethod(jlStringBuilderRef, TermName("append")).alternatives
+    lazy val jlStringBufferRef = getRequiredClass("java.lang.StringBuffer")
+    lazy val jlStringBufferType = jlStringBufferRef.toType
+    lazy val jlCharSequenceRef = getRequiredClass("java.lang.CharSequence")
+    lazy val jlCharSequenceType = jlCharSequenceRef.toType
 
     lazy val BoxMethod = Map[Char, Symbol](
       'B' -> getDecl(BoxesRunTimeModule, TermName("boxToBoolean")),

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -260,4 +260,19 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
       }
     }
   }
+
+  lazy val jlStringBuilderAppendForSymbol =
+    nirDefinitions.jlStringBuilderAppendAlts.flatMap { sym =>
+      val sig = genMethodSig(sym)
+      def name = genMethodName(sym)
+      sig match {
+        case nir.Type.Function(Seq(_, arg), _)
+            if sym.owner == nirDefinitions.jlStringBuilderRef =>
+          Some(
+            nir.Type.normalize(arg) -> (nir.Val.Global(name, nir.Type.Ptr), sig)
+          )
+        case _ => None
+      }
+    }.toMap
+
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -279,6 +279,18 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val JavaUtilServiceLoaderLoad = JavaUtilServiceLoader.alternatives("load")
   @tu lazy val JavaUtilServiceLoaderLoadInstalled = JavaUtilServiceLoader.requiredMethod("loadInstalled")
   @tu lazy val LinktimeIntrinsics = JavaUtilServiceLoaderLoad ++ Seq(JavaUtilServiceLoaderLoadInstalled)
+
+  @tu lazy val jlStringBuilderRef = requiredClass("java.lang.StringBuilder")
+  @tu lazy val jlStringBuilderType = jlStringBuilderRef.typeRef
+  @tu lazy val jlStringBuilderAppendAlts = jlStringBuilderRef.info
+    .decl(termName("append"))
+    .alternatives
+    .map(_.symbol)
+  @tu lazy val jlStringBufferRef = requiredClass("java.lang.StringBuffer")
+  @tu lazy val jlStringBufferType = jlStringBufferRef.typeRef
+  @tu lazy val jlCharSequenceRef = requiredClass("java.lang.CharSequence")
+  @tu lazy val jlCharSequenceType = jlCharSequenceRef.typeRef
+
   // Scala library & runtime
   @tu lazy val InlineClass = requiredClass("scala.inline")
   @tu lazy val NoInlineClass = requiredClass("scala.noinline")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -148,6 +148,19 @@ trait NirGenType(using Context) {
     defn.DoubleClass -> genType(defn.BoxedDoubleClass)
   )
 
+  lazy val jlStringBuilderAppendForSymbol = defnNir.jlStringBuilderAppendAlts
+    .flatMap(sym =>
+      val sig = genMethodSig(sym)
+      def name = genMethodName(sym)
+      sig match
+        case nir.Type.Function(Seq(_, arg), _) =>
+          Some(
+            nir.Type.normalize(arg) -> (nir.Val.Global(name, nir.Type.Ptr), sig)
+          )
+        case _ => None
+    )
+    .toMap
+
   def genExternType(st: SimpleType): nir.Type = {
     if (st.sym.isCFuncPtrClass)
       nir.Type.Ptr

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -8,6 +8,8 @@ import core.Contexts._
 import core.Types._
 import scala.scalanative.util.ScopedVar
 import scala.collection.mutable
+import dotty.tools.dotc.core.Names.Name
+import dotty.tools.dotc.report
 
 trait NirGenUtil(using Context) { self: NirCodeGen =>
 
@@ -69,6 +71,58 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
       curMethodLocalNames.get.update(id, name)
       id
     }
+
+  // Backend utils ported from Dotty JVM backend
+  // https://github.com/lampepfl/dotty/blob/938d405f05e3b47eb18183a6d6330b6324505cdf/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+  private val desugared = new java.util.IdentityHashMap[Type, tpd.Select]
+
+  private def cachedDesugarIdent(i: Ident): Option[tpd.Select] = {
+    var found = desugared.get(i.tpe)
+    if (found == null) {
+      tpd.desugarIdent(i) match {
+        case sel: tpd.Select =>
+          desugared.put(i.tpe, sel)
+          found = sel
+        case _ =>
+      }
+    }
+    if (found == null) None else Some(found)
+  }
+
+  object DesugaredSelect extends DeconstructorCommon[tpd.Tree] {
+    var desugared: tpd.Select = null
+
+    override def isEmpty: Boolean =
+      desugared eq null
+
+    def _1: Tree = desugared.qualifier
+    def _2: Name = desugared.name
+
+    override def unapply(s: tpd.Tree): this.type = {
+      s match {
+        case t: tpd.Select => desugared = t
+        case t: Ident =>
+          cachedDesugarIdent(t) match {
+            case Some(t) => desugared = t
+            case None    => desugared = null
+          }
+        case _ => desugared = null
+      }
+
+      this
+    }
+  }
+
+  abstract class DeconstructorCommon[T >: Null <: AnyRef] {
+    var field: T = null
+    def get: this.type = this
+    def isEmpty: Boolean = field eq null
+    def isDefined = !isEmpty
+    def unapply(s: T): this.type = {
+      field = s
+      this
+    }
+  }
 }
 
 object NirGenUtil {


### PR DESCRIPTION
Previously always String concatation was using `String.concat` which was in-optimal when used in String interpolators. One of Scala 2 partests was generating way too large files becouse of that: https://github.com/scala/scala/blob/e09bfc87119d5152c131e0c98757d5b9e48a794b/test/files/run/t11665.scala In case of this file size of generated NIR has dropped from over 1MB leading to BufferOverflowException in serializer, to ~150kb, which shall be similar with the size of generated TASTy for this file.