### PR TITLE
bugfix: Fix writing NIR files exceeded 1MB of size 

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -277,7 +277,7 @@ final class BinarySerializer(channel: WritableByteChannel) {
     }
   }
 
-  private object Insts extends NIRSectionWriter with Common {
+  private object Insts extends NIRSectionWriter(1024 * 1024) with Common {
     private def putBin(bin: Bin) = bin match {
       case Bin.Iadd => putTag(T.IaddBin)
       case Bin.Isub => putTag(T.IsubBin)
@@ -636,7 +636,7 @@ final class BinarySerializer(channel: WritableByteChannel) {
 
 }
 
-sealed abstract class NIRSectionWriter(initialBufferSize: Int = 1024 * 1024) {
+sealed abstract class NIRSectionWriter(initialBufferSize: Int = 64 * 1024) {
   private val baos = new ByteArrayOutputStream(initialBufferSize)
   private val output = new DataOutputStream(baos)
 


### PR DESCRIPTION
Use automatically resizable `ByteArrayOutputStream` instead of fixed indirect `ByteBuffer` in `BinarySerializer`. Currently it would fail with exception when size of NIR file would exceed 1MB of size. As an alternative we could have used direct byte buffer with large, initially un-commited, chunk of memory, but it seems to be unnecessary. 
Additionally we reduce default initial size of output stream to 64kb (for positions, defns, offsets, etc) and keep initial 1MB for instructions