### PR TITLE
Fix #3631: Regex now handles OR alternatives with more than two clauses

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -702,6 +702,13 @@ class Parser(wholeRegexp: String, _flags: Int) {
           val old = re
           re = re.subs(0)
           this.reuse(old)
+
+        /* Scala Native Issue #3631
+         * This Scala Native port must follow the Java switch
+         * statement semantics used in the RE2J original code.
+         * That is, return the now shortened re if there is no explicit case.
+         */
+        case _ =>
       }
       re
     } else {

--- a/unit-tests/shared/src/test/scala-3/scala/issues/RegexIssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/RegexIssuesTest.scala
@@ -1,0 +1,33 @@
+package scala.issues
+
+import org.junit.Test
+import org.junit.Assert._
+
+class RegexIssuesTest:
+
+  /* Issue 3631 describes a parse failue in a complicated regex.
+   * To increase confidence, the Test should stay as close as feasible
+   * to the original report.
+   *
+   * The complication is that Scala 2.12 regex class does not have
+   * the "matches" method used in the Issue. That method was introduced
+   * in Scala 2.13.
+   *
+   * To reduce duplication & confusion, this Test is run only on Scala 3.
+   *
+   * This test should be run on both Scala and JVM to ensure that the regex
+   * from the Issue continues to parse on the latter.
+   */
+
+  @Test def test_Issue3631(): Unit = {
+    // Use the full regex from the Issue, which is _not_ the minimal reproducer.
+    val pattern = "^(\\-|\\+)?(0\\.[0-9]+|[1-9][0-9]*\\.[0-9]+|[1-9][0-9]*|0)$"
+    val expected = "1"
+
+    assertTrue(
+      s"regex '${pattern}' does not match '${expected}'",
+      pattern.r.matches(expected)
+    )
+  }
+
+end RegexIssuesTest


### PR DESCRIPTION
The complicated regex expression described in Issue #3631 is now handled correctly.