### PR TITLE
Build: *DO NOT* Update sbt to 1.9.8

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -45,7 +45,7 @@ object ScalaVersions {
   //   1.9.4 fixes (Common Vulnerabilities and Exposures) CVE-2022-46751
   //   1.9.7 fixes sbt IO.unzip vulnerability described in sbt release notes.
 
-  val sbt10Version: String = "1.9.7"
+  val sbt10Version: String = "1.9.8"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.7
+sbt.version = 1.9.8


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.9.8.

The build failure looks like an SBT 1.9.8 [issue/bug](https://github.com/sbt/sbt/issues/7463).

Abend this PR by converting to Draft. Leave Draft as a tombstone in case anybody else gets
the idea to upgrade  to sbt 1.9.8.

Remove this tombstone once sbt is fixed and SN is upgraded.
