### PR TITLE
bugfix: Invalid LLVM IR generated for ServiceProvider loaders in unoptimized builds 

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -218,10 +218,12 @@ object BooleanArray {
 
   @inline def snapshot(length: Int, data: RawPtr): BooleanArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(1 * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(1 * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }
@@ -284,10 +286,12 @@ object CharArray {
 
   @inline def snapshot(length: Int, data: RawPtr): CharArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(2 * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(2 * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }
@@ -350,10 +354,12 @@ object ByteArray {
 
   @inline def snapshot(length: Int, data: RawPtr): ByteArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(1 * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(1 * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }
@@ -416,10 +422,12 @@ object ShortArray {
 
   @inline def snapshot(length: Int, data: RawPtr): ShortArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(2 * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(2 * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }
@@ -482,10 +490,12 @@ object IntArray {
 
   @inline def snapshot(length: Int, data: RawPtr): IntArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(4 * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(4 * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }
@@ -548,10 +558,12 @@ object LongArray {
 
   @inline def snapshot(length: Int, data: RawPtr): LongArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(8 * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(8 * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }
@@ -614,10 +626,12 @@ object FloatArray {
 
   @inline def snapshot(length: Int, data: RawPtr): FloatArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(4 * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(4 * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }
@@ -680,10 +694,12 @@ object DoubleArray {
 
   @inline def snapshot(length: Int, data: RawPtr): DoubleArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(8 * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(8 * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }
@@ -746,10 +762,12 @@ object ObjectArray {
 
   @inline def snapshot(length: Int, data: RawPtr): ObjectArray = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(castRawSizeToInt(Intrinsics.sizeOf[RawPtr]) * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(castRawSizeToInt(Intrinsics.sizeOf[RawPtr]) * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -234,10 +234,12 @@ object ${T}Array {
 
   @inline def snapshot(length: Int, data: RawPtr): ${T}Array = {
     val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = castIntToRawSizeUnsigned(${sizeT} * length)
-    libc.memcpy(dst, src, size)
+    if(length > 0) {
+      val dst  = arr.atRawUnsafe(0)
+      val src  = data
+      val size = castIntToRawSizeUnsigned(${sizeT} * length)
+      libc.memcpy(dst, src, size)
+    }
     arr
   }
 }

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
@@ -290,8 +290,8 @@ trait LinktimeIntrinsicCallsResolver { self: Reach =>
         }
       }
     val providersArray = buf.arrayalloc(
-      ty = Type.Array(ServiceLoaderProviderRef),
-      init = Val.ArrayValue(Type.Array(ServiceLoaderProviderRef), serviceProviders),
+      ty = ServiceLoaderProviderRef,
+      init = Val.ArrayValue(ServiceLoaderProviderRef, serviceProviders),
       unwind = let.unwind
     )
 


### PR DESCRIPTION
* Use correct signatures for ServiceProviders instancences array alloc 
* Allow 0-length Array.snapshots 
* Handle ArrayAlloc with non-canonical init value