### PR TITLE
improvement/GC: Create a dedicated thread to invoke registered `WeakReference` handlers

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -49,6 +49,7 @@ NOINLINE void scalanative_init() {
     Heap_Init(&heap, Settings_MinHeapSize(), Settings_MaxHeapSize());
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
     Synchronizer_init();
+    weakRefsHandlerThread = GCThread_WeakThreadsHandler_Start();
 #endif
     MutatorThreads_init();
     MutatorThread_init(__stack_bottom);

--- a/nativelib/src/main/resources/scala-native/gc/commix/GCThread.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/GCThread.c
@@ -284,7 +284,7 @@ static void *GCThread_WeakThreadsHandlerLoop(void *arg) {
     while (true) {
         // Wait for dispatch
 #ifdef _WIN32
-        while (!atomic_load(self->isActive)) {
+        while (!atomic_load(&self->isActive)) {
             WaitForSingleObject(self->resumeEvent, INFINITE);
             ResetEvent(self->resumeEvent);
         }

--- a/nativelib/src/main/resources/scala-native/gc/commix/GCThread.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/GCThread.c
@@ -251,4 +251,81 @@ void GCThread_ScaleMarkerThreads(Heap *heap, uint32_t remainingFullPackets) {
     }
 }
 
+static void
+GCThread_WeakThreadsHandler_init(struct GCWeakRefsHandlerThread *self) {
+    MutatorThread_init((word_t **)&self);
+    MutatorThread_switchState(currentMutatorThread,
+                              MutatorThreadState_Unmanaged);
+#ifdef _WIN32
+    self->resumeEvent = CreateEvent(NULL, true, false, NULL);
+    if (self->resumeEvent == NULL) {
+        fprintf(stderr,
+                "Failed to setup GC weak refs threads event: errno=%lu\n",
+                GetLastError());
+        exit(1);
+    }
+#else
+    if (pthread_mutex_init(&self->resumeEvent.lock, NULL) != 0 ||
+        pthread_cond_init(&self->resumeEvent.cond, NULL) != 0) {
+        perror("Failed to setup GC weak refs thread");
+        exit(1);
+    }
+#endif
+}
+
+// ----------------
+// Weak Refs handler
+// -----------------
+static void *GCThread_WeakThreadsHandlerLoop(void *arg) {
+    struct GCWeakRefsHandlerThread *self =
+        (struct GCWeakRefsHandlerThread *)arg;
+    GCThread_WeakThreadsHandler_init(self);
+    // main loop
+    while (true) {
+        // Wait for dispatch
+#ifdef _WIN32
+        while (!atomic_load(self->isActive)) {
+            WaitForSingleObject(self->resumeEvent, INFINITE);
+            ResetEvent(self->resumeEvent);
+        }
+#else
+        pthread_mutex_lock(&self->resumeEvent.lock);
+        while (!atomic_load(&self->isActive)) {
+            pthread_cond_wait(&self->resumeEvent.cond, &self->resumeEvent.lock);
+        }
+        pthread_mutex_unlock(&self->resumeEvent.lock);
+#endif
+        MutatorThread_switchState(currentMutatorThread,
+                                  MutatorThreadState_Managed);
+        WeakRefGreyList_CallHandlers();
+        MutatorThread_switchState(currentMutatorThread,
+                                  MutatorThreadState_Unmanaged);
+        atomic_store(&self->isActive, false);
+    }
+    free(self);
+}
+
+struct GCWeakRefsHandlerThread *GCThread_WeakThreadsHandler_Start() {
+    struct GCWeakRefsHandlerThread *thread =
+        (struct GCWeakRefsHandlerThread *)malloc(
+            sizeof(struct GCWeakRefsHandlerThread));
+    thread_create(&thread->handle, GCThread_WeakThreadsHandlerLoop,
+                  (void *)thread);
+    return thread;
+}
+
+void GCThread_WeakThreadsHandler_Resume(
+    struct GCWeakRefsHandlerThread *thread) {
+    bool expected = false;
+    if (atomic_compare_exchange_weak(&thread->isActive, &expected, true)) {
+#ifdef _WIN32
+        SetEvent(thread->resumeEvent);
+#else
+        pthread_mutex_lock(&thread->resumeEvent.lock);
+        pthread_cond_signal(&thread->resumeEvent.cond);
+        pthread_mutex_unlock(&thread->resumeEvent.lock);
+#endif
+    }
+}
+
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/commix/GCThread.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/GCThread.h
@@ -26,4 +26,20 @@ void GCThread_WakeMaster(Heap *heap);
 void GCThread_WakeWorkers(Heap *heap, int toWake);
 void GCThread_ScaleMarkerThreads(Heap *heap, uint32_t remainingFullPackets);
 
+struct GCWeakRefsHandlerThread {
+    thread_t handle;
+    atomic_bool isActive;
+#ifdef _WIN32
+    HANDLE resumeEvent;
+#else
+    struct {
+        pthread_mutex_t lock;
+        pthread_cond_t cond;
+    } resumeEvent;
+#endif
+};
+
+struct GCWeakRefsHandlerThread *GCThread_WeakThreadsHandler_Start();
+void GCThread_WeakThreadsHandler_Resume(struct GCWeakRefsHandlerThread *);
+
 #endif // IMMIX_GCTHREAD_H

--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
@@ -245,13 +245,12 @@ void Heap_Collect(Heap *heap) {
     Phase_StartSweep(heap);
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
     Synchronizer_release();
+    GCThread_WeakThreadsHandler_Resume(weakRefsHandlerThread);
+
 #else
     MutatorThread_switchState(currentMutatorThread, MutatorThreadState_Managed);
-#endif
-    // Skip calling WeakRef handlers on thread which is being initialized
-    // If the current block is set to null it means it failed to allocate
-    // memory for allocator and forced GC
     WeakRefGreyList_CallHandlers();
+#endif
 }
 
 bool Heap_shouldGrow(Heap *heap) {

--- a/nativelib/src/main/resources/scala-native/gc/commix/State.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/State.c
@@ -9,4 +9,8 @@ atomic_int_fast32_t mutatorThreadsCount = 0;
 thread_local MutatorThread *currentMutatorThread = NULL;
 GC_Roots *roots = NULL;
 
+#ifdef SCALANATIVE_MULTITHREADING_ENABLED
+struct GCWeakRefsHandlerThread *weakRefsHandlerThread = NULL;
+#endif
+
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/commix/State.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/State.h
@@ -14,4 +14,9 @@ extern atomic_int_fast32_t mutatorThreadsCount;
 extern thread_local MutatorThread *currentMutatorThread;
 extern GC_Roots *roots;
 
+#ifdef SCALANATIVE_MULTITHREADING_ENABLED
+#include "GCThread.h"
+extern struct GCWeakRefsHandlerThread *weakRefsHandlerThread;
+#endif
+
 #endif // IMMIX_STATE_H

--- a/nativelib/src/main/resources/scala-native/gc/immix/GCThreads.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/GCThreads.c
@@ -38,7 +38,7 @@ static void *GCThread_WeakThreadsHandlerLoop(void *arg) {
     while (true) {
         // Wait for dispatch
 #ifdef _WIN32
-        while (!atomic_load(self->isActive)) {
+        while (!atomic_load(&self->isActive)) {
             WaitForSingleObject(self->resumeEvent, INFINITE);
             ResetEvent(self->resumeEvent);
         }

--- a/nativelib/src/main/resources/scala-native/gc/immix/GCThreads.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/GCThreads.c
@@ -1,0 +1,85 @@
+#include "immix/State.h"
+#include "shared/ScalaNativeGC.h"
+#ifdef SCALANATIVE_GC_IMMIX
+#include "GCThreads.h"
+#include "MutatorThread.h"
+#include "WeakRefStack.h"
+#include <stdlib.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+static void
+GCThread_WeakThreadsHandler_init(struct GCWeakRefsHandlerThread *self) {
+    MutatorThread_init((word_t **)&self);
+    MutatorThread_switchState(currentMutatorThread,
+                              MutatorThreadState_Unmanaged);
+#ifdef _WIN32
+    self->resumeEvent = CreateEvent(NULL, true, false, NULL);
+    if (self->resumeEvent == NULL) {
+        fprintf(stderr,
+                "Failed to setup GC weak refs threads event: errno=%lu\n",
+                GetLastError());
+        exit(1);
+    }
+#else
+    if (pthread_mutex_init(&self->resumeEvent.lock, NULL) != 0 ||
+        pthread_cond_init(&self->resumeEvent.cond, NULL) != 0) {
+        perror("Failed to setup GC weak refs thread");
+        exit(1);
+    }
+#endif
+}
+
+static void *GCThread_WeakThreadsHandlerLoop(void *arg) {
+    struct GCWeakRefsHandlerThread *self =
+        (struct GCWeakRefsHandlerThread *)arg;
+    GCThread_WeakThreadsHandler_init(self);
+    // main loop
+    while (true) {
+        // Wait for dispatch
+#ifdef _WIN32
+        while (!atomic_load(self->isActive)) {
+            WaitForSingleObject(self->resumeEvent, INFINITE);
+            ResetEvent(self->resumeEvent);
+        }
+#else
+        pthread_mutex_lock(&self->resumeEvent.lock);
+        while (!atomic_load(&self->isActive)) {
+            pthread_cond_wait(&self->resumeEvent.cond, &self->resumeEvent.lock);
+        }
+        pthread_mutex_unlock(&self->resumeEvent.lock);
+#endif
+        MutatorThread_switchState(currentMutatorThread,
+                                  MutatorThreadState_Managed);
+        WeakRefStack_CallHandlers();
+        MutatorThread_switchState(currentMutatorThread,
+                                  MutatorThreadState_Unmanaged);
+        atomic_store(&self->isActive, false);
+    }
+    free(self);
+}
+
+struct GCWeakRefsHandlerThread *GCThread_WeakThreadsHandler_Start() {
+    struct GCWeakRefsHandlerThread *thread =
+        (struct GCWeakRefsHandlerThread *)malloc(
+            sizeof(struct GCWeakRefsHandlerThread));
+    thread_create(&thread->handle, GCThread_WeakThreadsHandlerLoop,
+                  (void *)thread);
+    return thread;
+}
+
+void GCThread_WeakThreadsHandler_Resume(
+    struct GCWeakRefsHandlerThread *thread) {
+    bool expected = false;
+    if (atomic_compare_exchange_weak(&thread->isActive, &expected, true)) {
+#ifdef _WIN32
+        SetEvent(thread->resumeEvent);
+#else
+        pthread_mutex_lock(&thread->resumeEvent.lock);
+        pthread_cond_signal(&thread->resumeEvent.cond);
+        pthread_mutex_unlock(&thread->resumeEvent.lock);
+#endif
+    }
+}
+
+#endif

--- a/nativelib/src/main/resources/scala-native/gc/immix/GCThreads.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/GCThreads.h
@@ -1,0 +1,25 @@
+#ifdef SCALANATIVE_GC_IMMIX
+#ifndef GC_THREADS_H
+#define GC_THREADS_H
+
+#include <stdatomic.h>
+#include "shared/ThreadUtil.h"
+
+struct GCWeakRefsHandlerThread {
+    thread_t handle;
+    atomic_bool isActive;
+#ifdef _WIN32
+    HANDLE resumeEvent;
+#else
+    struct {
+        pthread_mutex_t lock;
+        pthread_cond_t cond;
+    } resumeEvent;
+#endif
+};
+
+struct GCWeakRefsHandlerThread *GCThread_WeakThreadsHandler_Start();
+void GCThread_WeakThreadsHandler_Resume(struct GCWeakRefsHandlerThread *);
+
+#endif
+#endif

--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
@@ -299,14 +299,11 @@ void Heap_Collect(Heap *heap, Stack *stack) {
     }
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
     Synchronizer_release();
+    GCThread_WeakThreadsHandler_Resume(weakRefsHandlerThread);
 #else
     MutatorThread_switchState(currentMutatorThread, MutatorThreadState_Managed);
+    WeakRefStack_CallHandlers();
 #endif
-    // Skip calling WeakRef handlers on thread which is being initialized
-    // If the current block is set to null it means it failed to allocate
-    // memory for allocator and forced GC
-    if (currentMutatorThread->allocator.block)
-        WeakRefStack_CallHandlers();
 #ifdef DEBUG_PRINT
     printf("End collect\n");
     fflush(stdout);

--- a/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
@@ -18,6 +18,7 @@
 #include "shared/Parsing.h"
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #include "Synchronizer.h"
+#include "GCThreads.h"
 #endif
 #include "MutatorThread.h"
 #include <stdatomic.h>
@@ -35,6 +36,7 @@ NOINLINE void scalanative_init() {
     Stack_Init(&weakRefStack, INITIAL_STACK_SIZE);
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
     Synchronizer_init();
+    weakRefsHandlerThread = GCThread_WeakThreadsHandler_Start();
 #endif
     MutatorThreads_init();
     MutatorThread_init(__stack_bottom);

--- a/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.h
@@ -2,9 +2,7 @@
 #include "shared/GCTypes.h"
 #include "Allocator.h"
 #include "LargeAllocator.h"
-#include "State.h"
 #include <stdatomic.h>
-#include "shared/ThreadUtil.h"
 #include <setjmp.h>
 
 #ifndef MUTATOR_THREAD_H

--- a/nativelib/src/main/resources/scala-native/gc/immix/State.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/State.c
@@ -10,4 +10,8 @@ _Atomic(MutatorThreads) mutatorThreads = NULL;
 thread_local MutatorThread *currentMutatorThread = NULL;
 GC_Roots *roots = NULL;
 
+#ifdef SCALANATIVE_MULTITHREADING_ENABLED
+struct GCWeakRefsHandlerThread *weakRefsHandlerThread = NULL;
+#endif
+
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/immix/State.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/State.h
@@ -15,4 +15,9 @@ extern _Atomic(MutatorThreads) mutatorThreads;
 extern thread_local MutatorThread *currentMutatorThread;
 extern GC_Roots *roots;
 
+#ifdef SCALANATIVE_MULTITHREADING_ENABLED
+#include "GCThreads.h"
+extern struct GCWeakRefsHandlerThread *weakRefsHandlerThread;
+#endif
+
 #endif // IMMIX_STATE_H

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/ref/WeakReferenceTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/ref/WeakReferenceTest.scala
@@ -61,6 +61,12 @@ class WeakReferenceTest {
     ): Unit = {
       ref.get() match {
         case null =>
+          val waitForEnqueue = 0
+            .until(10)
+            .iterator
+            .map(_ => Thread.sleep(100))
+            .takeWhile(_ => !ref.isEnqueued())
+            .foreach(_ => ())
           assertTrue("collected but not enqueued", ref.isEnqueued())
         case v =>
           if (System.currentTimeMillis() < deadline) {


### PR DESCRIPTION
Create a dedicated thread to invoke registered `WeakReference` handlers instead of running them on thread invoking GC collection