### PR TITLE
Make java.net.Inet6Address constructor arguments more consistent

### DIFF
--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -8,11 +8,11 @@ import scalanative.unsigned._
 import scala.scalanative.posix.net.`if`._
 import scala.scalanative.posix.stddef
 
-final class Inet6Address private (
-    val ipAddress: Array[Byte],
+final class Inet6Address(
+    ipAddress: Array[Byte],
     host: String,
-    scopeId: Int,
-    val zoneIdent: String
+    private val scopeId: Int,
+    private val zoneIdent: String
 ) extends InetAddress(ipAddress, host) {
 
   def this(ipAddress: Array[Byte], host: String, scope: Int) =
@@ -92,7 +92,7 @@ object Inet6Address {
      * Translate by hand as before but avoid non-local returns.
      */
 
-    val ia6ByteArray = in6Addr.ipAddress
+    val ia6ByteArray = in6Addr.getAddress()
 
     val buffer = new StringBuilder()
     var isFirst = true
@@ -120,8 +120,11 @@ object Inet6Address {
       }
     }
 
-    if (!in6Addr.zoneIdent.isEmpty) {
-      val zi = in6Addr.zoneIdent
+//    if (!in6Addr.zoneIdent.isEmpty) {
+//      val zi = in6Addr.zoneIdent
+
+    val zi = in6Addr.zoneIdent
+    if (!zi.isEmpty) {
       val suffix =
         try {
           val ifIndex = Integer.parseInt(zi)

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -120,9 +120,6 @@ object Inet6Address {
       }
     }
 
-//    if (!in6Addr.zoneIdent.isEmpty) {
-//      val zi = in6Addr.zoneIdent
-
     val zi = in6Addr.zoneIdent
     if (!zi.isEmpty) {
       val suffix =

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -8,11 +8,11 @@ import scalanative.unsigned._
 import scala.scalanative.posix.net.`if`._
 import scala.scalanative.posix.stddef
 
-final class Inet6Address(
+final class Inet6Address private (
     ipAddress: Array[Byte],
     host: String,
-    private val scopeId: Int,
-    private val zoneIdent: String
+    scopeId: Int,
+    val zoneIdent: String
 ) extends InetAddress(ipAddress, host) {
 
   def this(ipAddress: Array[Byte], host: String, scope: Int) =
@@ -120,8 +120,8 @@ object Inet6Address {
       }
     }
 
-    val zi = in6Addr.zoneIdent
-    if (!zi.isEmpty) {
+    if (!in6Addr.zoneIdent.isEmpty) {
+      val zi = in6Addr.zoneIdent
       val suffix =
         try {
           val ifIndex = Integer.parseInt(zi)

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -15,13 +15,11 @@ final class Inet6Address private (
     val zoneIdent: String
 ) extends InetAddress(ipAddress, host) {
 
-  def this(ipAddress: Array[Byte], host: String, scope: Int) =
+  private[net] def this(ipAddress: Array[Byte], host: String, scope: Int) =
     this(ipAddress, host, scope, "")
 
-  def this(ipAddress: Array[Byte], host: String) =
+  private[net] def this(ipAddress: Array[Byte], host: String) =
     this(ipAddress, host, 0)
-
-  def this(ipAddress: Array[Byte]) = this(ipAddress, null)
 
   def getScopeId(): Int = scopeId
 


### PR DESCRIPTION
Whilst adding javalib Datagram support (PR #3614) new contributor RustedBones noticed that the
constructor arguments for class `Inet6Address` were slightly inconsistent with those for `Inet4Address`.
This inconsistency added unnecessary complexity to an already complex trace of the code.   

Future maintainer time should not be spent/wasted on things which can be corrected today.

This PR isolates & implements recommended changes to `Inet6Address` constructor parameters
so that the parameters common to the `InetAddress` parent class and its two subclasses, `Inet4Address`
& `Inet6Address` are now have an identical declaration.

Thank you, RustedBones, for discovering this situation.