### PR TITLE
javalib: Format IPv4-mapped IPv6 addresses as IPv6

### DIFF
--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -88,11 +88,7 @@ class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
     if (ipAddress.length == 4) {
       formatIn4Addr(bytes)
     } else if (ipAddress.length == 16) {
-      if (isIPv4MappedAddress(bytes)) {
-        formatIn4Addr(extractIP4Bytes(bytes).at(0))
-      } else {
-        Inet6Address.formatInet6Address(this.asInstanceOf[Inet6Address])
-      }
+      Inet6Address.formatInet6Address(this.asInstanceOf[Inet6Address])
     } else {
       "<unknown>"
     }


### PR DESCRIPTION
Whilst working on PR #3614 contributor RustedBones noticed that IPv4-mapped IPv6 addresses were
being formatted as IPv4 addresses.  

RustedBones also suggested a correction. This PR implements that suggestion so that PR #3614 can
stay focused on Datagrams (UDP).

All credit to RustedBones, I am merely the clerk, and generator of bugs, here.

Wrong: Address /0:0:0:0:7f7f:7f7f:7f00:1 formatting as 127.0.0.1
Correct: Address /0:0:0:0:7f7f:7f7f:7f00:1 formatting as /0:0:0:0:7f7f:7f7f:7f00:1