### PR TITLE
improvement: Use debug metadata to create stacktraces on Windows when LTO enabled

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -142,7 +142,6 @@ jobs:
           set SCALANATIVE_LTO=${{matrix.lto}}&
           set SCALANATIVE_INCLUDE_DIRS=${{steps.setup.outputs.vcpkg-dir}}\include&
           set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&
-          set SCALANATIVE_CI_NO_DEBUG_SYMBOLS=true&
           set SCALANATIVE_TEST_PREFETCH_DEBUG_INFO=1&
           set SCALANATIVE &
           sbt "test-runtime ${{matrix.scala}}"
@@ -173,6 +172,5 @@ jobs:
         run: >
           set SCALANATIVE_INCLUDE_DIRS=${{steps.setup.outputs.vcpkg-dir}}\include&
           set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&
-          set SCALANATIVE_CI_NO_DEBUG_SYMBOLS=true&
           set SCALANATIVE &
           sbt "show tests3/nativeConfig" "test-runtime ${{matrix.scala}}"

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -65,12 +65,11 @@ private[lang] object StackTraceElement {
       fileNameOut = fileName,
       lineOut = lineOut
     )
-
     val filename =
-      if (position.filename.nonEmpty) position.filename
+      if (position.filename != null || fileName == null) position.filename
       else fromCString(fileName)
     val line =
-      if (position.line > 0 || fileName == null) position.line
+      if (position.line > 0 || filename == null) position.line
       else !lineOut
 
     new StackTraceElement(

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -25,7 +25,7 @@ final class StackTraceElement(
 
   override def toString: String = {
     val (file, line) =
-      if (getFileName == null) ("Unknown Source", "")
+      if (getFileName == null || getFileName.isEmpty()) ("Unknown Source", "")
       else if (getLineNumber <= 0) (getFileName, "")
       else (getFileName, ":" + getLineNumber)
     s"$getClassName.$getMethodName($file$line)"

--- a/nativelib/src/main/scala/scala/scalanative/runtime/SymbolFormatter.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/SymbolFormatter.scala
@@ -1,6 +1,6 @@
 package scala.scalanative.runtime
 
-import scala.scalanative.meta.LinktimeInfo.isWindows
+import scala.scalanative.meta.LinktimeInfo.{isWindows, sourceLevelDebuging}
 import scalanative.unsigned._
 import scala.scalanative.unsafe._
 import scala.scalanative.runtime.libc._
@@ -13,17 +13,13 @@ object SymbolFormatter {
   def asyncSafeFromSymbol(
       sym: CString,
       classNameOut: CString,
-      methodNameOut: CString
+      methodNameOut: CString,
+      fileNameOut: CString, // Windows only
+      lineOut: Ptr[Int] // Windows only
   ): Unit = {
 
     val len = strlen(sym)
     var pos = 0
-    val ident =
-      fromRawPtr[CChar](
-        Intrinsics.stackalloc[CChar](
-          Intrinsics.castIntToRawSizeUnsigned(1024)
-        )
-      )
     classNameOut(0) = 0.toByte
     methodNameOut(0) = 0.toByte
 
@@ -31,34 +27,23 @@ object SymbolFormatter {
       // On Windows symbol names are different then on Unix platforms.
       // Due to differences in implementation between WinDbg and libUnwind used
       // on each platform, symbols on Windows do not contain '_' prefix.
-      if (!isWindows) {
-        if (read() != '_') {
-          false
-        } else if (read() != 'S') {
-          false
-        } else {
-          readGlobal()
-        }
-      } else {
-        if (read() != 'S') {
-          false
-        } else {
-          readGlobal()
-        }
-      }
+      // When debug metadata is generated and there is no symbols (LTO) then
+      // returned sybmols have form `fqcn.methodName:(file:line)` (linkage name from MetadataCodeGen)
+      def mayHaveLinkageSymbol =
+        isWindows && sourceLevelDebuging.generateFunctionSourcePositions
+      // If symbol is not linkage symbol when it would skip Windows specific prefix allowing to continue unix-like reading
+      val head = read()
+      // unlikekly that package name would start with upper case 'S'
+      if (mayHaveLinkageSymbol && head != 'S')
+        readLinkageSymbol()
+      else if (head == 'S') readGlobal() // Windows
+      else if (head == '_' && read() == 'S') readGlobal() // Unix
+      else false
     }
 
     def readGlobal(): Boolean = read() match {
-      case 'M' =>
-        readIdent()
-        if (strlen(ident) == 0) {
-          false
-        } else {
-          strcpy(classNameOut, ident)
-          readSig()
-        }
-      case _ =>
-        false
+      case 'M' => readIdent(classNameOut) && readSig()
+      case _   => false
     }
 
     def readSig(): Boolean = read() match {
@@ -66,33 +51,19 @@ object SymbolFormatter {
         strcpy(methodNameOut, c"<init>")
         true
       case 'D' | 'P' | 'C' | 'G' =>
-        readIdent()
-        if (strlen(ident) == 0) {
-          false
-        } else {
-          strcpy(methodNameOut, ident)
-          true
-        }
+        readIdent(methodNameOut)
       case 'K' =>
         readSig()
       case _ =>
         false
     }
 
-    def readIdent(): Unit = {
+    def readIdent(output: CString): Boolean = {
       val n = readNumber()
-      if (n <= 0) {
-        ident(0) = 0.toByte
-      } else if (!inBounds(pos) || !inBounds(pos + n)) {
-        ident(0) = 0.toByte
-      } else {
-        var i = 0
-        while (i < n) {
-          ident(i) = sym(pos + i)
-          i += 1
-        }
-        ident(i) = 0.toByte
+      (n > 0 && inBounds(pos) && inBounds(pos + n)) && {
+        strncpy(output, sym + pos, Intrinsics.castIntToRawSize(n))
         pos += n
+        true
       }
     }
 
@@ -130,6 +101,55 @@ object SymbolFormatter {
 
     def inBounds(pos: Int) =
       pos >= 0 && pos < len.toLong
+
+    // Windows only
+    def readLinkageSymbol(): Boolean = {
+      fileNameOut(0) = 0.toByte
+      val location = strchr(sym, ':')
+      if (location == null) {
+        // No location part, simplifield
+        val methodNamePos = strrchr(sym, '.')
+        if (methodNamePos != null) {
+          strncpy(classNameOut, sym, toRawSize(methodNamePos - sym))
+          strcpy(methodNameOut, methodNamePos + 1)
+          true
+        } else false
+      } else {
+        val lineSeperator = strrchr(location, ':')
+        val filenameOffset = 2
+        if (lineSeperator != null) {
+          // skip ':(', take until line number ':num)'
+          strncpy(
+            fileNameOut,
+            location + filenameOffset,
+            toRawSize(
+              strlen(location) - strlen(lineSeperator) - filenameOffset.toUSize
+            )
+          )
+          pos = (lineSeperator - sym).toInt + 1
+          !lineOut = readNumber()
+        } else strcpy(fileNameOut, location + filenameOffset)
+
+        // Find methodStart, we cannot use strrchr becouse there is no last index limitter and filename would contain extension
+        var methodStart = sym
+        while ({
+          val nextDot = strchr(methodStart, '.')
+          val isBeforeLocation =
+            nextDot != null && (nextDot.toLong < location.toLong)
+          if (isBeforeLocation) methodStart = nextDot + 1
+          isBeforeLocation
+        }) ()
+        if (methodStart != null && methodStart != sym) {
+          strncpy(
+            methodNameOut,
+            methodStart + 1,
+            toRawSize(location - methodStart)
+          )
+          strncpy(classNameOut, sym, toRawSize(methodStart - sym))
+          true
+        } else false
+      }
+    }
 
     if (!readSymbol()) {
       strcpy(classNameOut, c"<none>")

--- a/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
@@ -14,7 +14,10 @@ object libc {
   def free(ptr: RawPtr): Unit = extern
   def free(ptr: Ptr[_]): Unit = extern
   def strlen(str: CString): CSize = extern
+  def strchr(str: CString, ch: CInt): CString = extern
+  def strrchr(str: CString, ch: CInt): CString = extern
   def wcslen(str: CWideString): CSize = extern
+  def strncpy(dest: CString, src: CString, count: RawSize): CString = extern
   def strcpy(dest: CString, src: CString): CString = extern
   def strcat(dest: CString, src: CString): CString = extern
   def memcpy(dst: Ptr[_], src: Ptr[_], count: CSize): RawPtr = extern

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
@@ -101,7 +101,7 @@ private[testinterface] object SignalConfig {
           className,
           methodName,
           fileName,
-          lineOut
+          unused
         )
 
         val formattedSymbol: Ptr[CChar] = stackalloc[CChar](750)


### PR DESCRIPTION
Under LTO Windows would try to provide is with linkage names for stacktraces instead of missing symbol names. We can use them to implement stacktraces 

Also: 
* fixes MetadataCodeGen to use correct Constructor/Class Constructor names