### PR TITLE
feature: Add `BlobArray` - a variant of `Array[Byte]` which can be scanned by GC.

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
@@ -1,7 +1,6 @@
+#if defined(SCALANATIVE_GC_COMMIX)
 #include "shared/GCTypes.h"
 #include <stdint.h>
-#if defined(SCALANATIVE_GC_COMMIX)
-
 #include <stdio.h>
 #include <setjmp.h>
 #include "Marker.h"

--- a/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
@@ -280,7 +280,7 @@ static int Marker_markBlobArray(Heap *heap, Stats *stats, Object *object,
                                 GreyPacket **outHolder,
                                 GreyPacket **outWeakRefHolder) {
     ArrayHeader *arrayHeader = (ArrayHeader *)object;
-    size_t bytesLength = arrayHeader->length;
+    size_t bytesLength = BlobArray_ScannableLimit(arrayHeader);
     size_t objectsLength = bytesLength / sizeof(word_t);
     word_t **blobStart = (word_t **)(arrayHeader + 1);
     int objectsTraced;

--- a/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
@@ -1,3 +1,5 @@
+#include "shared/GCTypes.h"
+#include <stdint.h>
 #if defined(SCALANATIVE_GC_COMMIX)
 
 #include <stdio.h>
@@ -256,9 +258,9 @@ int Marker_splitObjectArray(Heap *heap, Stats *stats, GreyPacket **outHolder,
     return objectsTraced;
 }
 
-int Marker_markObjectArray(Heap *heap, Stats *stats, Object *object,
-                           GreyPacket **outHolder,
-                           GreyPacket **outWeakRefHolder, Bytemap *bytemap) {
+static int Marker_markObjectArray(Heap *heap, Stats *stats, Object *object,
+                                  GreyPacket **outHolder,
+                                  GreyPacket **outWeakRefHolder) {
     ArrayHeader *arrayHeader = (ArrayHeader *)object;
     size_t length = arrayHeader->length;
     word_t **fields = (word_t **)(arrayHeader + 1);
@@ -271,6 +273,27 @@ int Marker_markObjectArray(Heap *heap, Stats *stats, Object *object,
         // to handle
         objectsTraced = Marker_splitObjectArray(
             heap, stats, outHolder, outWeakRefHolder, fields, length);
+    }
+    return objectsTraced;
+}
+
+static int Marker_markBlobArray(Heap *heap, Stats *stats, Object *object,
+                                GreyPacket **outHolder,
+                                GreyPacket **outWeakRefHolder) {
+    ArrayHeader *arrayHeader = (ArrayHeader *)object;
+    size_t bytesLength = arrayHeader->length;
+    size_t objectsLength = bytesLength / sizeof(word_t);
+    word_t **blobStart = (word_t **)(arrayHeader + 1);
+    int objectsTraced;
+    // From that point we can treat it similary as object array
+    if (objectsLength <= ARRAY_SPLIT_THRESHOLD) {
+        objectsTraced = Marker_markRange(
+            heap, stats, outHolder, outWeakRefHolder, blobStart, objectsLength);
+    } else {
+        // object array is two large, split it into pieces for multiple threads
+        // to handle
+        objectsTraced = Marker_splitObjectArray(
+            heap, stats, outHolder, outWeakRefHolder, blobStart, objectsLength);
     }
     return objectsTraced;
 }
@@ -304,9 +327,13 @@ void Marker_markPacket(Heap *heap, Stats *stats, GreyPacket *in,
     while (!GreyPacket_IsEmpty(in)) {
         Object *object = GreyPacket_Pop(in);
         if (Object_IsArray(object)) {
-            if (object->rtti->rt.id == __object_array_id) {
+            const int arrayId = object->rtti->rt.id;
+            if (arrayId == __object_array_id) {
                 objectsTraced += Marker_markObjectArray(
-                    heap, stats, object, outHolder, outWeakRefHolder, bytemap);
+                    heap, stats, object, outHolder, outWeakRefHolder);
+            } else if (arrayId == __blob_array_id) {
+                objectsTraced += Marker_markBlobArray(
+                    heap, stats, object, outHolder, outWeakRefHolder);
             }
             // non-object arrays do not contain pointers
         } else {

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -99,10 +99,9 @@ void Marker_Mark(Heap *heap, Stack *stack) {
                     Marker_markField(heap, stack, fields[i]);
                 }
             } else if (arrayId == __blob_array_id) {
-                int8_t **blobStart = (int8_t **)(arrayHeader + 1);
-                int8_t **blobEnd = blobStart + length;
-                Marker_markRange(heap, stack, (word_t **)blobStart,
-                                 (word_t **)blobEnd);
+                int8_t *start = (int8_t *)(arrayHeader + 1);
+                int8_t *end = start + BlobArray_ScannableLimit(arrayHeader);
+                Marker_markRange(heap, stack, (word_t **)start, (word_t **)end);
             }
             // non-object arrays do not contain pointers
         } else {

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -1,6 +1,5 @@
-#include <stdint.h>
 #if defined(SCALANATIVE_GC_IMMIX)
-
+#include <stdint.h>
 #include <stdio.h>
 #include <setjmp.h>
 #include "Marker.h"

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #if defined(SCALANATIVE_GC_IMMIX)
 
 #include <stdio.h>
@@ -21,6 +22,8 @@ extern int __modules_size;
 
 static inline void Marker_markLockWords(Heap *heap, Stack *stack,
                                         Object *object);
+static void Marker_markRange(Heap *heap, Stack *stack, word_t **from,
+                             word_t **to);
 
 void Marker_markObject(Heap *heap, Stack *stack, Bytemap *bytemap,
                        Object *object, ObjectMeta *objectMeta) {
@@ -87,13 +90,20 @@ void Marker_Mark(Heap *heap, Stack *stack) {
     while (!Stack_IsEmpty(stack)) {
         Object *object = Stack_Pop(stack);
         if (Object_IsArray(object)) {
-            if (object->rtti->rt.id == __object_array_id) {
-                ArrayHeader *arrayHeader = (ArrayHeader *)object;
-                size_t length = arrayHeader->length;
+            ArrayHeader *arrayHeader = (ArrayHeader *)object;
+            const int arrayId = object->rtti->rt.id;
+            const size_t length = arrayHeader->length;
+
+            if (arrayId == __object_array_id) {
                 word_t **fields = (word_t **)(arrayHeader + 1);
                 for (int i = 0; i < length; i++) {
                     Marker_markField(heap, stack, fields[i]);
                 }
+            } else if (arrayId == __blob_array_id) {
+                int8_t **blobStart = (int8_t **)(arrayHeader + 1);
+                int8_t **blobEnd = blobStart + length;
+                Marker_markRange(heap, stack, (word_t **)blobStart,
+                                 (word_t **)blobEnd);
             }
             // non-object arrays do not contain pointers
         } else {
@@ -107,8 +117,8 @@ void Marker_Mark(Heap *heap, Stack *stack) {
     }
 }
 
-NO_SANITIZE void Marker_markRange(Heap *heap, Stack *stack, word_t **from,
-                                  word_t **to) {
+NO_SANITIZE static void Marker_markRange(Heap *heap, Stack *stack,
+                                         word_t **from, word_t **to) {
     assert(from != NULL);
     assert(to != NULL);
     for (word_t **current = from; current <= to; current += 1) {

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
@@ -10,12 +10,13 @@
 #include "immix_commix/utils/MathUtils.h"
 #include "shared/GCTypes.h"
 
-extern int __object_array_id;
-extern int __weak_ref_ids_min;
-extern int __weak_ref_ids_max;
-extern int __weak_ref_field_offset;
-extern int __array_ids_min;
-extern int __array_ids_max;
+extern const int __object_array_id;
+extern const int __blob_array_id;
+extern const int __weak_ref_ids_min;
+extern const int __weak_ref_ids_max;
+extern const int __weak_ref_field_offset;
+extern const int __array_ids_min;
+extern const int __array_ids_max;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #define USES_LOCKWORD 1

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
@@ -92,18 +92,16 @@ object Continuations:
    *  `ObjectArray` to simulate just that.
    */
   private[Continuations] class Continuation[-R, +T] extends (R => T):
-    private[Continuations] var inner: Impl.Continuation = fromRawPtr(
-      castIntToRawPtr(0)
-    ) // null
-    private val allocas = mutable.ArrayBuffer[ObjectArray]()
+    private[Continuations] var inner: Impl.Continuation = _
+    private val allocas = mutable.ArrayBuffer[BlobArray]()
 
     def apply(x: R): T =
       resume(inner, x).get
 
     private[Continuations] def alloc(size: CUnsignedLong): Ptr[Byte] =
-      val obj = ObjectArray.alloc(size.toInt) // round up the blob size
+      val obj = BlobArray.alloc(size.toInt) // round up the blob size
       allocas += obj
-      obj.at(0).asInstanceOf[Ptr[Byte]]
+      obj.atUnsafe(0)
   end Continuation
 
   // STATIC FUNCTIONS THAT CALL PASSED-IN FUNCTION OBJECTS

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -784,13 +784,11 @@ final class BlobArray private () extends Array[Byte] {
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def scannableLimit_=(v: Int): Unit = {
     if(v < 0 || v > length) throwOutOfBounds(v, length)
-    else storeInt(limitPtr, -v)
+    else setScannableLimitUnsafe(limitPtr, v)
   }
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array. This version of scannableLimit setter is not checking the bound of argument. */
-  @inline def setScannableLimitUnsafe(v: Int): Unit = {
-    if(v < 0 || v > length) throwOutOfBounds(v, length)
-    else storeInt(limitPtr, -v)
-  }
+  @inline def setScannableLimitUnsafe(v: Int): Unit = storeInt(limitPtr, -v)
+
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def withScannableLimit(v: Int): this.type = {
     scannableLimit = v

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -29,6 +29,7 @@ package runtime
 
 import scalanative.unsafe._
 import scalanative.unsigned._
+import scalanative.annotation.alwaysinline
 import scala.scalanative.memory.SafeZone
 import scalanative.runtime.Intrinsics._
 
@@ -209,8 +210,8 @@ object BooleanArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[BooleanArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 1 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 1 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 1)
     castRawPtrToObject(arr).asInstanceOf[BooleanArray]
@@ -277,8 +278,8 @@ object CharArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[CharArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 2 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 2 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 2)
     castRawPtrToObject(arr).asInstanceOf[CharArray]
@@ -345,8 +346,8 @@ object ByteArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[ByteArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 1 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 1 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 1)
     castRawPtrToObject(arr).asInstanceOf[ByteArray]
@@ -413,8 +414,8 @@ object ShortArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[ShortArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 2 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 2 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 2)
     castRawPtrToObject(arr).asInstanceOf[ShortArray]
@@ -481,8 +482,8 @@ object IntArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[IntArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 4 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 4 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 4)
     castRawPtrToObject(arr).asInstanceOf[IntArray]
@@ -549,8 +550,8 @@ object LongArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[LongArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 8 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 8 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 8)
     castRawPtrToObject(arr).asInstanceOf[LongArray]
@@ -617,8 +618,8 @@ object FloatArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[FloatArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 4 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 4 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 4)
     castRawPtrToObject(arr).asInstanceOf[FloatArray]
@@ -685,8 +686,8 @@ object DoubleArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[DoubleArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 8 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 8 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 8)
     castRawPtrToObject(arr).asInstanceOf[DoubleArray]
@@ -753,8 +754,8 @@ object ObjectArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[ObjectArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + castRawSizeToInt(Intrinsics.sizeOf[RawPtr]) * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + castRawSizeToInt(Intrinsics.sizeOf[RawPtr]) * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), castRawSizeToInt(Intrinsics.sizeOf[RawPtr]))
     castRawPtrToObject(arr).asInstanceOf[ObjectArray]
@@ -772,7 +773,24 @@ object ObjectArray {
   }
 }
 
+/** Implementation of [[Array[Byte]]] potentially containing pointers to other GC allocated objects. Unlike [[ByteArray]] it is conservatively scanned. When running with Immix or Commix GC allows to set [[scannableLimit]] of maximal number of bytes to scan.  */
 final class BlobArray private () extends Array[Byte] {
+  @alwaysinline private def limitPtr: RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, MemoryLayout.Array.StrideOffset)
+  }
+  /** Maximal number of elements to scan by the garbage collector (best effort) */
+  @inline def scannableLimit: Int = loadInt(limitPtr)
+  /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
+  @inline def scannableLimit_=(v: Int): Unit = {
+    if(v < 0 || v > length) throwOutOfBounds(v, length)
+    else storeInt(limitPtr, v)
+  }
+  /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
+  @inline def withScannableLimit(v: Int): this.type = {
+    scannableLimit = v
+    this
+  }
 
   @inline def stride: Int = 1
 
@@ -812,7 +830,7 @@ object BlobArray {
     val arrsize = MemoryLayout.Array.ValuesOffset + 1 * length
     val arr = GC.alloc(arrcls, arrsize) 
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
-    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 1)
+    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), length)
     castRawPtrToObject(arr).asInstanceOf[BlobArray]
   }
 
@@ -821,10 +839,10 @@ object BlobArray {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[BlobArray]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 1 * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 1 * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
-    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), 1)
+    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), length)
     castRawPtrToObject(arr).asInstanceOf[BlobArray]
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -773,7 +773,7 @@ object ObjectArray {
   }
 }
 
-/** Implementation of [[Array[Byte]]] potentially containing pointers to other GC allocated objects. Unlike [[ByteArray]] it is conservatively scanned. When running with Immix or Commix GC allows to set [[scannableLimit]] of maximal number of bytes to scan.  */
+/** Implementation of Array[Byte] potentially containing pointers to other GC allocated objects. Unlike [[ByteArray]] it is conservatively scanned. When running with Immix or Commix GC allows to set [[scannableLimit]] of maximal number of bytes to scan.  */
 final class BlobArray private () extends Array[Byte] {
   @alwaysinline private def limitPtr: RawPtr = {
     val rawptr = castObjectToRawPtr(this)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -780,11 +780,16 @@ final class BlobArray private () extends Array[Byte] {
     elemRawPtr(rawptr, MemoryLayout.Array.StrideOffset)
   }
   /** Maximal number of elements to scan by the garbage collector (best effort) */
-  @inline def scannableLimit: Int = loadInt(limitPtr)
+  @inline def scannableLimit: Int = -loadInt(limitPtr)
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def scannableLimit_=(v: Int): Unit = {
     if(v < 0 || v > length) throwOutOfBounds(v, length)
-    else storeInt(limitPtr, v)
+    else storeInt(limitPtr, -v)
+  }
+  /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array. This version of scannableLimit setter is not checking the bound of argument. */
+  @inline def setScannableLimitUnsafe(v: Int): Unit = {
+    if(v < 0 || v > length) throwOutOfBounds(v, length)
+    else storeInt(limitPtr, -v)
   }
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def withScannableLimit(v: Int): this.type = {
@@ -830,7 +835,7 @@ object BlobArray {
     val arrsize = MemoryLayout.Array.ValuesOffset + 1 * length
     val arr = GC.alloc(arrcls, arrsize) 
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
-    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), length)
+    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), -length)
     castRawPtrToObject(arr).asInstanceOf[BlobArray]
   }
 
@@ -842,7 +847,7 @@ object BlobArray {
     val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + 1 * length)
     val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
-    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), length)
+    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), -length)
     castRawPtrToObject(arr).asInstanceOf[BlobArray]
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -784,7 +784,7 @@ final class BlobArray private () extends Array[Byte] {
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def scannableLimit_=(v: Int): Unit = {
     if(v < 0 || v > length) throwOutOfBounds(v, length)
-    else setScannableLimitUnsafe(limitPtr, v)
+    else setScannableLimitUnsafe(v)
   }
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array. This version of scannableLimit setter is not checking the bound of argument. */
   @inline def setScannableLimitUnsafe(v: Int): Unit = storeInt(limitPtr, -v)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -182,7 +182,7 @@ object Array {
 }%
 
 % if T == 'Blob':
-/** Implementation of [[Array[Byte]]] potentially containing pointers to other GC allocated objects. Unlike [[ByteArray]] it is conservatively scanned. When running with Immix or Commix GC allows to set [[scannableLimit]] of maximal number of bytes to scan.  */
+/** Implementation of Array[Byte] potentially containing pointers to other GC allocated objects. Unlike [[ByteArray]] it is conservatively scanned. When running with Immix or Commix GC allows to set [[scannableLimit]] of maximal number of bytes to scan.  */
 % end 
 final class ${T}Array private () extends Array[${Repr}] {
 % if T == 'Blob':

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -195,13 +195,11 @@ final class ${T}Array private () extends Array[${Repr}] {
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def scannableLimit_=(v: Int): Unit = {
     if(v < 0 || v > length) throwOutOfBounds(v, length)
-    else storeInt(limitPtr, -v)
+    else setScannableLimitUnsafe(limitPtr, v)
   }
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array. This version of scannableLimit setter is not checking the bound of argument. */
-  @inline def setScannableLimitUnsafe(v: Int): Unit = {
-    if(v < 0 || v > length) throwOutOfBounds(v, length)
-    else storeInt(limitPtr, -v)
-  }
+  @inline def setScannableLimitUnsafe(v: Int): Unit = storeInt(limitPtr, -v)
+
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def withScannableLimit(v: Int): this.type = {
     scannableLimit = v

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -191,11 +191,16 @@ final class ${T}Array private () extends Array[${Repr}] {
     elemRawPtr(rawptr, MemoryLayout.Array.StrideOffset)
   }
   /** Maximal number of elements to scan by the garbage collector (best effort) */
-  @inline def scannableLimit: Int = loadInt(limitPtr)
+  @inline def scannableLimit: Int = -loadInt(limitPtr)
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def scannableLimit_=(v: Int): Unit = {
     if(v < 0 || v > length) throwOutOfBounds(v, length)
-    else storeInt(limitPtr, v)
+    else storeInt(limitPtr, -v)
+  }
+  /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array. This version of scannableLimit setter is not checking the bound of argument. */
+  @inline def setScannableLimitUnsafe(v: Int): Unit = {
+    if(v < 0 || v > length) throwOutOfBounds(v, length)
+    else storeInt(limitPtr, -v)
   }
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def withScannableLimit(v: Int): this.type = {
@@ -243,7 +248,7 @@ object ${T}Array {
     val arr = ${allocGC}(arrcls, arrsize) 
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
   % if T == 'Blob':
-    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), length)
+    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), -length)
   % else:
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), ${sizeT})
   % end
@@ -259,7 +264,7 @@ object ${T}Array {
     val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
   % if T == 'Blob':
-    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), length)
+    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), -length)
   % else:
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), ${sizeT})
   % end

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -195,7 +195,7 @@ final class ${T}Array private () extends Array[${Repr}] {
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
   @inline def scannableLimit_=(v: Int): Unit = {
     if(v < 0 || v > length) throwOutOfBounds(v, length)
-    else setScannableLimitUnsafe(limitPtr, v)
+    else setScannableLimitUnsafe(v)
   }
   /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array. This version of scannableLimit setter is not checking the bound of argument. */
   @inline def setScannableLimitUnsafe(v: Int): Unit = storeInt(limitPtr, -v)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -161,7 +161,10 @@ object Array {
 
 %{
    types = {'Boolean': 1, 'Char': 2, 'Byte': 1, 'Short': 2,
-            'Int': 4, 'Long': 8, 'Float': 4, 'Double': 8, 'Object': 'castRawSizeToInt(Intrinsics.sizeOf[RawPtr])'}
+            'Int': 4, 'Long': 8, 'Float': 4, 'Double': 8, 
+            'Object': 'castRawSizeToInt(Intrinsics.sizeOf[RawPtr])',
+            'Blob': 1 # Array[Byte] but scanned
+          }
 }%
 % # BEWARE: Order of iteration of the dictionary depends on version of Python
 % #         used to run this script.
@@ -173,10 +176,11 @@ object Array {
 % #         used to run this script.
 % for T, sizeT in types.items():
 %{
-   allocGC = 'GC.alloc_atomic' if T != 'Object' else 'GC.alloc'
+   Repr = 'Byte' if T == 'Blob' else T
+   allocGC = 'GC.alloc' if T == 'Object' else 'GC.alloc' if T == 'Blob' else 'GC.alloc_atomic'
 }%
 
-final class ${T}Array private () extends Array[${T}] {
+final class ${T}Array private () extends Array[${Repr}] {
 
   @inline def stride: Int = ${sizeT}
 
@@ -192,9 +196,9 @@ final class ${T}Array private () extends Array[${T}] {
     elemRawPtr(rawptr, MemoryLayout.Array.ValuesOffset + ${sizeT} * i)
   }
 
-  @inline def apply(i: Int): ${T} = load${T}(atRaw(i))
+  @inline def apply(i: Int): ${Repr} = load${Repr}(atRaw(i))
 
-  @inline def update(i: Int, value: ${T}): Unit = store${T}(atRaw(i), value)
+  @inline def update(i: Int, value: ${Repr}): Unit = store${Repr}(atRaw(i), value)
 
   @inline override def clone(): ${T}Array = {
     val arrcls  = classOf[${T}Array]

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -29,6 +29,7 @@ package runtime
 
 import scalanative.unsafe._
 import scalanative.unsigned._
+import scalanative.annotation.alwaysinline
 import scala.scalanative.memory.SafeZone
 import scalanative.runtime.Intrinsics._
 
@@ -180,7 +181,28 @@ object Array {
    allocGC = 'GC.alloc' if T == 'Object' else 'GC.alloc' if T == 'Blob' else 'GC.alloc_atomic'
 }%
 
+% if T == 'Blob':
+/** Implementation of [[Array[Byte]]] potentially containing pointers to other GC allocated objects. Unlike [[ByteArray]] it is conservatively scanned. When running with Immix or Commix GC allows to set [[scannableLimit]] of maximal number of bytes to scan.  */
+% end 
 final class ${T}Array private () extends Array[${Repr}] {
+% if T == 'Blob':
+  @alwaysinline private def limitPtr: RawPtr = {
+    val rawptr = castObjectToRawPtr(this)
+    elemRawPtr(rawptr, MemoryLayout.Array.StrideOffset)
+  }
+  /** Maximal number of elements to scan by the garbage collector (best effort) */
+  @inline def scannableLimit: Int = loadInt(limitPtr)
+  /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
+  @inline def scannableLimit_=(v: Int): Unit = {
+    if(v < 0 || v > length) throwOutOfBounds(v, length)
+    else storeInt(limitPtr, v)
+  }
+  /** Set maximal number of elements to scan by the garbage collector (best effort), new limit needs to smaller or equal to length of array  */
+  @inline def withScannableLimit(v: Int): this.type = {
+    scannableLimit = v
+    this
+  }
+% end
 
   @inline def stride: Int = ${sizeT}
 
@@ -220,7 +242,11 @@ object ${T}Array {
     val arrsize = MemoryLayout.Array.ValuesOffset + ${sizeT} * length
     val arr = ${allocGC}(arrcls, arrsize) 
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
+  % if T == 'Blob':
+    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), length)
+  % else:
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), ${sizeT})
+  % end
     castRawPtrToObject(arr).asInstanceOf[${T}Array]
   }
 
@@ -229,10 +255,14 @@ object ${T}Array {
       throw new NegativeArraySizeException
     }
     val arrcls  = classOf[${T}Array]
-    val arrsize = Intrinsics.castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + ${sizeT} * length)
-    val arr = zone.allocImpl(Intrinsics.castObjectToRawPtr(arrcls), arrsize)
+    val arrsize = castIntToRawSizeUnsigned(MemoryLayout.Array.ValuesOffset + ${sizeT} * length)
+    val arr = zone.allocImpl(castObjectToRawPtr(arrcls), arrsize)
     storeInt(elemRawPtr(arr, MemoryLayout.Array.LengthOffset), length)
+  % if T == 'Blob':
+    storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), length)
+  % else:
     storeInt(elemRawPtr(arr, MemoryLayout.Array.StrideOffset), ${sizeT})
+  % end
     castRawPtrToObject(arr).asInstanceOf[${T}Array]
   }
 

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -71,7 +71,8 @@ object Rt {
     "LongArray",
     "FloatArray",
     "DoubleArray",
-    "ObjectArray"
+    "ObjectArray",
+    "BlobArray"
   ).map { arr =>
     val cls = Global.Top("scala.scalanative.runtime." + arr)
     val sig = Sig.Method("alloc", Seq(Int, Ref(cls))).mangled

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -216,9 +216,9 @@ class Reach(
         reachDeclare(defn)
       case defn: nir.Defn.Define =>
         val nir.Global.Member(_, sig) = defn.name
-        if (nir.Rt.arrayAlloc.contains(sig)) {
-          classInfo(nir.Rt.arrayAlloc(sig)).foreach(reachAllocation)
-        }
+        nir.Rt.arrayAlloc
+          .get(sig)
+          .foreach { classInfo(_).foreach(reachAllocation) }
         reachDefine(defn)
       case defn: nir.Defn.Trait =>
         reachTrait(defn)


### PR DESCRIPTION
Resolves #3312

Add BlobArray - a variant of Array[Byte] which can be scanned by GC. 
Use it store continuations state - current usage of `ObjectArray` was leading to invalid state - it could treat primitive values living at continuation stack as objects leading to undefined behaviour. 