### PR TITLE
fix: Thread safe custom roots modification and stability fixes

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -50,6 +50,7 @@ NOINLINE void scalanative_GC_init() {
 #endif
     MutatorThreads_init();
     MutatorThread_init((word_t **)&dummy); // approximate stack bottom
+    customRoots = GC_Roots_Init();
 #ifdef ENABLE_GC_STATS
     atexit(scalanative_afterexit);
 #endif
@@ -120,12 +121,12 @@ size_t scalanative_GC_get_max_heapsize() {
 
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {
     AddressRange range = {addr_low, addr_high};
-    GC_Roots_Add(&roots, range);
+    GC_Roots_Add(customRoots, range);
 }
 
 void scalanative_GC_remove_roots(void *addr_low, void *addr_high) {
     AddressRange range = {addr_low, addr_high};
-    GC_Roots_RemoveByRange(&roots, range);
+    GC_Roots_RemoveByRange(customRoots, range);
 }
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED

--- a/nativelib/src/main/resources/scala-native/gc/commix/State.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/State.c
@@ -7,7 +7,7 @@ BlockAllocator blockAllocator = {};
 _Atomic(MutatorThreads) mutatorThreads = NULL;
 atomic_int_fast32_t mutatorThreadsCount = 0;
 thread_local MutatorThread *currentMutatorThread = NULL;
-GC_Roots *roots = NULL;
+GC_Roots *customRoots = NULL;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 struct GCWeakRefsHandlerThread *weakRefsHandlerThread = NULL;

--- a/nativelib/src/main/resources/scala-native/gc/commix/State.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/State.h
@@ -12,7 +12,7 @@ extern BlockAllocator blockAllocator;
 extern _Atomic(MutatorThreads) mutatorThreads;
 extern atomic_int_fast32_t mutatorThreadsCount;
 extern thread_local MutatorThread *currentMutatorThread;
-extern GC_Roots *roots;
+extern GC_Roots *customRoots;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #include "GCThread.h"

--- a/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
@@ -37,6 +37,7 @@ NOINLINE void scalanative_GC_init() {
 #endif
     MutatorThreads_init();
     MutatorThread_init((word_t **)&dummy); // approximate stack bottom
+    customRoots = GC_Roots_Init();
     atexit(scalanative_afterexit);
 }
 
@@ -153,11 +154,11 @@ void scalanative_GC_yield() {
 
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {
     AddressRange range = {addr_low, addr_high};
-    GC_Roots_Add(&roots, range);
+    GC_Roots_Add(customRoots, range);
 }
 
 void scalanative_GC_remove_roots(void *addr_low, void *addr_high) {
     AddressRange range = {addr_low, addr_high};
-    GC_Roots_RemoveByRange(&roots, range);
+    GC_Roots_RemoveByRange(customRoots, range);
 }
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/immix/State.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/State.c
@@ -8,7 +8,7 @@ Stack weakRefStack = {};
 BlockAllocator blockAllocator = {};
 _Atomic(MutatorThreads) mutatorThreads = NULL;
 thread_local MutatorThread *currentMutatorThread = NULL;
-GC_Roots *roots = NULL;
+GC_Roots *customRoots = NULL;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 struct GCWeakRefsHandlerThread *weakRefsHandlerThread = NULL;

--- a/nativelib/src/main/resources/scala-native/gc/immix/State.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/State.h
@@ -13,7 +13,7 @@ extern Stack weakRefStack;
 extern BlockAllocator blockAllocator;
 extern _Atomic(MutatorThreads) mutatorThreads;
 extern thread_local MutatorThread *currentMutatorThread;
-extern GC_Roots *roots;
+extern GC_Roots *customRoots;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #include "GCThreads.h"

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/GCRoots.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/GCRoots.c
@@ -1,49 +1,58 @@
+#if defined(SCALANATIVE_GC_IMMIX) || defined(SCALANATIVE_GC_COMMIX)
+
 #include "immix_commix/GCRoots.h"
 
 #include <stdio.h>
 #include <assert.h>
+#include <stdlib.h>
+#include <stdatomic.h>
+#include "shared/ThreadUtil.h"
 
-void GC_Roots_Add(GC_Roots **head, AddressRange range) {
-    // Prepend the node with given range to the head of linked list of GC roots
-    GC_Roots *node = (GC_Roots *)malloc(sizeof(GC_Roots));
-    node->range = range;
-    node->next = NULL;
-    GC_Roots *currentHead = *head;
-
-    do {
-        node->next = currentHead;
-    } while (!atomic_compare_exchange_strong((_Atomic(GC_Roots *) *)head,
-                                             &currentHead, node));
+GC_Roots *GC_Roots_Init() {
+    GC_Roots *roots = (GC_Roots *)malloc(sizeof(GC_Roots));
+    roots->head = ATOMIC_VAR_INIT(NULL);
+    mutex_init(&roots->modificationLock);
+    return roots;
 }
 
-void GC_Roots_Add_Range_Except(GC_Roots **head, AddressRange range,
+void GC_Roots_Add(GC_Roots *roots, AddressRange range) {
+    // Prepend the node with given range to the head of linked list of GC roots
+    GC_Root *node = (GC_Root *)malloc(sizeof(GC_Root));
+    node->range = range;
+    mutex_lock(&roots->modificationLock);
+    node->next = roots->head;
+    roots->head = node;
+    mutex_unlock(&roots->modificationLock);
+}
+
+void GC_Roots_Add_Range_Except(GC_Roots *roots, AddressRange range,
                                AddressRange except) {
     assert(AddressRange_Contains(range, except));
     if (range.address_low < except.address_low) {
-        GC_Roots_Add(head,
+        GC_Roots_Add(roots,
                      (AddressRange){range.address_low, except.address_low});
     }
     if (range.address_high > except.address_high) {
-        GC_Roots_Add(head,
+        GC_Roots_Add(roots,
                      (AddressRange){except.address_high, range.address_high});
     }
 }
 
-void GC_Roots_RemoveByRange(GC_Roots **head, AddressRange range) {
-    GC_Roots *current = *head;
-    GC_Roots *prev = NULL;
+void GC_Roots_RemoveByRange(GC_Roots *roots, AddressRange range) {
+    mutex_lock(&roots->modificationLock);
+    GC_Root *current = roots->head;
+    GC_Root *prev = NULL;
     while (current != NULL) {
         if (AddressRange_Contains(range, current->range)) {
             AddressRange current_range = current->range;
-            bool detached = false;
-            if (prev == NULL) {
-                *head = current->next;
-            } else {
+            if (prev == NULL)
+                roots->head = current->next;
+            else
                 prev->next = current->next;
-            }
-            GC_Roots_Add_Range_Except(head, current_range, range);
+            GC_Roots_Add_Range_Except(roots, current_range, range);
+
             prev = current;
-            GC_Roots *next = current->next;
+            GC_Root *next = current->next;
             free(current);
             current = next;
         } else {
@@ -51,4 +60,6 @@ void GC_Roots_RemoveByRange(GC_Roots **head, AddressRange range) {
             current = current->next;
         }
     }
+    mutex_unlock(&roots->modificationLock);
 }
+#endif

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/GCRoots.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/GCRoots.h
@@ -1,21 +1,24 @@
 #ifndef GC_ROOTS_H
 #define GC_ROOTS_H
 
-#include <stdatomic.h>
-#include <stdlib.h>
 #include <stdbool.h>
 #include "shared/GCTypes.h"
+#include "shared/ThreadUtil.h"
 
 typedef struct AddressRange {
-    word_t *address_low;
-    word_t *address_high;
+    const word_t *address_low;
+    const word_t *address_high;
 } AddressRange;
 
-struct GC_Roots {
+typedef struct GC_Root {
     AddressRange range;
-    _Atomic(struct GC_Roots *) next;
-};
-typedef struct GC_Roots GC_Roots;
+    struct GC_Root *next;
+} GC_Root;
+
+typedef struct GC_Roots {
+    GC_Root *head;
+    mutex_t modificationLock;
+} GC_Roots;
 
 INLINE static bool AddressRange_Contains(AddressRange self,
                                          AddressRange other) {
@@ -23,10 +26,11 @@ INLINE static bool AddressRange_Contains(AddressRange self,
             other.address_high <= self.address_high);
 }
 
+GC_Roots *GC_Roots_Init();
 /* Add given memory address range to the head of linked list of GC roots*/
-void GC_Roots_Add(GC_Roots **head, AddressRange range);
+void GC_Roots_Add(GC_Roots *roots, AddressRange range);
 /* Remove GC roots nodes for which memory adress range is fully contained within
  * range passed as an argument to this method*/
-void GC_Roots_RemoveByRange(GC_Roots **head, AddressRange range);
+void GC_Roots_RemoveByRange(GC_Roots *roots, AddressRange range);
 
 #endif


### PR DESCRIPTION
This PR cherry-picks some of the safer changes made in #3658 - the original branch seems to frequently fail in CI
Cherry-picked: 
* Fixes #3334 - make modification of custom roots list thread safe 
* Move prefetching debug symbols after creating connection with TestRunner to prevent timeouts 
* Make ObjectMonitorTest more deterministic