### PR TITLE
Fix #3657: Remove a number of java.net defects

### DIFF
--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -142,7 +142,7 @@ object Inet6Address {
     new Inet6Address(addr, host, false, 0, null)
   }
 
-  private final val hexCharacters = "0123456789abcdef"
+  private final val HexCharacters = "0123456789abcdef"
 
   private[net] def formatInet6Address(in6Addr: Inet6Address): String = {
     /* ScalaJVM expects the long form of, say "0:0:0:0:0:0:0:1"
@@ -172,12 +172,12 @@ object Inet6Address {
 
       var j = (ia6ByteArray(i) & 0xf0) >>> 4
       if (j != 0 || !isFirst) {
-        buffer.append(hexCharacters.charAt(j))
+        buffer.append(HexCharacters.charAt(j))
         isFirst = false
       }
       j = ia6ByteArray(i) & 0x0f
       if (j != 0 || !isFirst) {
-        buffer.append(hexCharacters.charAt(j))
+        buffer.append(HexCharacters.charAt(j))
         isFirst = false
       }
       if ((i & 1) != 0 && (i + 1) < ia6ByteArray.length) {

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -43,13 +43,13 @@ final class Inet6Address private (
     else nif.getIndex()
 
   override def hashCode(): Int = {
-    val base = ju.Arrays.hashCode(ipAddress)
-      + host.hashCode()
-      + useScopeId.hashCode()
-      + scopeId.hashCode()
-
-    val hash = if (nif == null) base else (base + nif.hashCode())
-    hash
+    var res = 1
+    res = 31 * res + ju.Arrays.hashCode(ipAddress)
+    res = 31 * res + host.hashCode()
+    res = 31 * res + useScopeId.hashCode()
+    res = 31 * res + scopeId.hashCode()
+    res = if (nif != null) (res = 31 * res + nif.hashCode())
+    res
   }
 
   override def isLinkLocalAddress(): Boolean =

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -1,9 +1,11 @@
 package java.net
 
-// Ported from Apache Harmony
+// Ported from Apache Harmony & extensively re-worked for Scala Native.
 
 import scalanative.unsafe._
 import scalanative.unsigned._
+
+import java.{util => ju}
 
 import scala.scalanative.posix.net.`if`._
 import scala.scalanative.posix.stddef
@@ -11,17 +13,42 @@ import scala.scalanative.posix.stddef
 final class Inet6Address private (
     ipAddress: Array[Byte],
     host: String,
+    useScopeId: Boolean, // true when this created with explicit, valid scopeId
     scopeId: Int,
-    val zoneIdent: String
+    nif: NetworkInterface
 ) extends InetAddress(ipAddress, host) {
 
-  private[net] def this(ipAddress: Array[Byte], host: String, scope: Int) =
-    this(ipAddress, host, scope, "")
+  /* Note on scopeId constructor argument:
+   *
+   *   For most intents and purposes a Java scopeId is a NetworkInterface index
+   *   equivalent to a C or IETF (Internet Engineering Task Force) sin6_scope_id.
+   *   IETF discussions sometimes call it a 'zoneId'.
+   *
+   *   See the "Design Note_2" in NetworkInterface.scala for a description of
+   *   a case where Java and C practice differ.
+   */
 
-  private[net] def this(ipAddress: Array[Byte], host: String) =
-    this(ipAddress, host, 0)
+  override def equals(that: Any): Boolean = that match {
+    case that: Inet6Address => this.hashCode() == that.hashCode()
+    case _                  => false
+  }
 
-  def getScopeId(): Int = scopeId
+  def getScopedInterface(): NetworkInterface = nif
+
+  def getScopeId(): Int =
+    if (useScopeId) scopeId
+    else if (nif == null) 0
+    else nif.getIndex()
+
+  override def hashCode(): Int = {
+    val base = ju.Arrays.hashCode(ipAddress)
+      + host.hashCode()
+      + useScopeId.hashCode()
+      + scopeId.hashCode()
+
+    val hash = if (nif == null) base else (base + nif.hashCode())
+    hash
+  }
 
   override def isLinkLocalAddress(): Boolean =
     (ipAddress(0) == -2) && ((ipAddress(1) & 255) >>> 6) == 2
@@ -57,6 +84,16 @@ final class Inet6Address private (
 
   def isIPv4CompatibleAddress(): Boolean = ipAddress.take(12).forall(_ == 0)
 
+  private def formatScopeId(): String = {
+    if (nif != null)
+      nif.getDisplayName()
+    else if (useScopeId) {
+      val netIf = NetworkInterface.getByIndex(scopeId)
+      if (netIf == null) String.valueOf(scopeId)
+      else netIf.getDisplayName()
+    } else ""
+  }
+
 }
 
 object Inet6Address {
@@ -64,24 +101,45 @@ object Inet6Address {
   def getByAddress(
       host: String,
       addr: Array[Byte],
-      scope_id: Int
+      scopeId: Int
   ): Inet6Address = {
     if (addr == null || addr.length != 16)
       throw new UnknownHostException("Illegal IPv6 address")
 
-    new Inet6Address(addr, host, Math.max(0, scope_id))
+    /* JVM treats negative scopeId as having being not supplied.
+     * Explicitly specified 0 scopeIds are considered supplied.
+     * Elsewhere implicit 0 scopeIds, say from a sin6_scope_id, are not.
+     */
+    if (scopeId < 0)
+      Inet6Address(addr, host)
+    else
+      new Inet6Address(addr, host, true, scopeId, null)
+  }
+
+  def getByAddress(
+      host: String,
+      addr: Array[Byte],
+      nif: NetworkInterface
+  ): Inet6Address = {
+    if (addr == null || addr.length != 16)
+      throw new UnknownHostException("Illegal IPv6 address")
+
+    /* match JVM
+     * Do not throw on null nif but fail late with obscure/wrong/unexpected
+     * scopeId of 0.
+     */
+
+    new Inet6Address(addr, host, false, 0, nif)
   }
 
   private[net] def apply(
-      ipAddress: Array[Byte],
-      host: String,
-      scopeId: Int,
-      zone: String
+      addr: Array[Byte],
+      host: String
   ): Inet6Address = {
-    new Inet6Address(ipAddress, host, scopeId, zone)
+    new Inet6Address(addr, host, false, 0, null)
   }
 
-  private val hexCharacters = "0123456789abcdef"
+  private final val hexCharacters = "0123456789abcdef"
 
   private[net] def formatInet6Address(in6Addr: Inet6Address): String = {
     /* ScalaJVM expects the long form of, say "0:0:0:0:0:0:0:1"
@@ -92,7 +150,16 @@ object Inet6Address {
 
     val ia6ByteArray = in6Addr.getAddress()
 
-    val buffer = new StringBuilder()
+    /* The magic number 64 is used to construct the StringBuffer with a large
+     * enough size that it should not have pay the cost of expanding.
+     * The largest IPv6 address, proper, is 39 ((sizeof("fe80:") * 7) plus 4).
+     * Memory blocks tend to be allocated in powers of two.
+     * Round up to the next higher power of two which will also cover a
+     * possible interface identifier ("%bridge0").
+     * The math need not be exact, the buffer will grow if we guess wrong.
+     */
+
+    val buffer = new StringBuilder(64)
     var isFirst = true
     for (i <- 0 until ia6ByteArray.length) {
       if ((i & 1) == 0)
@@ -118,20 +185,10 @@ object Inet6Address {
       }
     }
 
-    if (!in6Addr.zoneIdent.isEmpty) {
-      val zi = in6Addr.zoneIdent
-      val suffix =
-        try {
-          val ifIndex = Integer.parseInt(zi)
-          val ifName = stackalloc[Byte](IF_NAMESIZE)
-          if (if_indextoname(ifIndex.toUInt, ifName) == stddef.NULL) zi
-          else fromCString(ifName)
-        } catch {
-          case e: NumberFormatException => zi
-        }
+    val suffix = in6Addr.formatScopeId()
 
+    if (!suffix.isEmpty())
       buffer.append('%').append(suffix)
-    }
 
     buffer.toString
   }

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -48,7 +48,8 @@ final class Inet6Address private (
     res = 31 * res + host.hashCode()
     res = 31 * res + useScopeId.hashCode()
     res = 31 * res + scopeId.hashCode()
-    res = if (nif != null) (res = 31 * res + nif.hashCode())
+    if (nif != null)
+      res = 31 * res + nif.hashCode()
     res
   }
 

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -21,7 +21,9 @@ final class Inet6Address private (
   /* Note on scopeId constructor argument:
    *
    *   For most intents and purposes a Java scopeId is a NetworkInterface index
-   *   equivalent to a C or IETF (Internet Engineering Task Force) sin6_scope_id.
+   *   equivalent to a C or IETF (Internet Engineering Task Force)
+   *   sin6_scope_id.
+   *
    *   IETF discussions sometimes call it a 'zoneId'.
    *
    *   See the "Design Note_2" in NetworkInterface.scala for a description of

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -161,7 +161,9 @@ object Inet6Address {
 
     val buffer = new StringBuilder(64)
     var isFirst = true
-    for (i <- 0 until ia6ByteArray.length) {
+
+    // IPv6 binary addresses are defined as 16 bytes, so loop count is known.
+    for (i <- 0 until 16) {
       if ((i & 1) == 0)
         isFirst = true
 

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -487,8 +487,12 @@ object InetAddress {
       // By contract the 'sockaddr' argument passed in is cleared/all_zeros.
       if (ipBA.length == 16) {
         val v6addr = addr.asInstanceOf[Ptr[sockaddr_in6]]
+        /* No need to set other sin6 fields, particularly sin6_scope_id
+         * and sin6_flowinfo. v6addr is later passed to getnameinfo() which
+         * is likely to ignore, reject, or get confused by non-zero values
+         * in those fields.
+         */
         v6addr.sin6_family = AF_INET6.toUShort
-        // because the FQDN scope is Global, no need to set sin6_scope_id
         val dst = v6addr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
         memcpy(dst, from, 16.toUInt)
       } else if (ipBA.length == 4) {

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -116,8 +116,6 @@ class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
       | ((bytes(start) & 255) << 24))
   }
 
-  protected def getZoneIdent(): String = "" // Ease Inet6Address declaration
-
   override def hashCode(): Int =
     if (ipAddress.length == 4) bytesToInt(ipAddress, 0) // too scared to change
     else ju.Arrays.hashCode(ipAddress)
@@ -212,30 +210,61 @@ object InetAddress {
      * to leave the host field blank/empty.
      */
     val effectiveHost = if (isNumeric) null else host
-    val ipAddress = SocketHelpers.sockaddrToByteArray(addrinfoP.ai_addr)
-    if (ipAddress.length == 4) {
-      new Inet4Address(ipAddress, effectiveHost)
-    } else {
+
+    if (addrinfoP.ai_family == AF_INET) {
+      new Inet4Address(addrinfoToByteArray(addrinfoP), effectiveHost)
+    } else if (addrinfoP.ai_family == AF_INET6) {
       val addr = addrinfoP.ai_addr.asInstanceOf[Ptr[sockaddr_in6]]
-      /* Yes, Java specifies Int for scope_id in a way which disallows
-       * some values POSIX/IEEE/IETF allows.
-       */
-      val scope_id = addr.sin6_scope_id.toInt
+      val addrBytes = addr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
 
-      val zoneIdent = {
-        val ifIndex = host.indexOf('%')
-        val ifNameStart = ifIndex + 1
-        if ((ifIndex < 0) || (ifNameStart >= host.length)) ""
-        else host.substring(ifNameStart)
+      // Scala JVM down-converts even when preferIPv6Addresses is "true"
+      if (isIPv4MappedAddress(addrBytes)) {
+        new Inet4Address(extractIP4Bytes(addrBytes), effectiveHost)
+      } else {
+        /* Yes, Java specifies Int for scope_id in a way which disallows
+         * some values POSIX/IEEE/IETF allows.
+         */
+
+        val scope_id = addr.sin6_scope_id.toInt
+
+        /* Be aware some trickiness here.
+         * Java treats a 0 scope_id (qua NetworkInterface index)
+         * as having been not supplied.
+         * Exactly the same 0 scope_id explicitly passed to
+         * Inet6Address.getByAddress() is considered supplied and
+         * displayed as such.
+         */
+
+        if (scope_id == 0)
+          Inet6Address(addrinfoToByteArray(addrinfoP), effectiveHost)
+        else
+          Inet6Address.getByAddress(
+            effectiveHost,
+            addrinfoToByteArray(addrinfoP),
+            scope_id
+          )
       }
-
-      Inet6Address(
-        ipAddress,
-        effectiveHost,
-        scope_id,
-        zoneIdent
+    } else {
+      val af = addrinfoP.ai_family
+      throw new IOException(
+        s"The requested address family is not supported: ${af}."
       )
     }
+  }
+
+  private def addrinfoToByteArray(
+      addrinfoP: Ptr[addrinfo]
+  ): Array[Byte] = {
+    SocketHelpers.sockaddrToByteArray(addrinfoP.ai_addr)
+  }
+
+  private def extractIP4Bytes(pb: Ptr[Byte]): Array[Byte] = {
+    val buf = new Array[Byte](4)
+    buf(0) = pb(12)
+    buf(1) = pb(13)
+    buf(2) = pb(14)
+    buf(3) = pb(15)
+    buf
   }
 
   private def formatIn4Addr(pb: Ptr[Byte]): String = {
@@ -312,6 +341,15 @@ object InetAddress {
         }
   }
 
+  private def vetScopeText(host: String): Unit = { // callers have handled null
+    // Fail on either numeric %-2 and non-numeric (text) %-abc
+    val idx = host.indexOf("%-")
+    if (idx >= 0) {
+      val invalidIf = host.substring(idx + 1)
+      throw new UnknownHostException(s"no such interface: ${invalidIf}")
+    }
+  }
+
   private def getByNonNumericName(host: String): InetAddress = Zone {
     implicit z =>
       /* Design Note:
@@ -379,6 +417,8 @@ object InetAddress {
           }
         }
       }
+
+      vetScopeText(host)
 
       val hints = stackalloc[addrinfo]() // stackalloc clears its memory
       val addrinfo = stackalloc[Ptr[addrinfo]]()
@@ -592,6 +632,12 @@ object InetAddress {
       retArray.toArray
     }
 
+  private def isIPv4MappedAddress(pb: Ptr[Byte]): Boolean = {
+    val ptrInt = pb.asInstanceOf[Ptr[Int]]
+    val ptrLong = pb.asInstanceOf[Ptr[Long]]
+    (ptrInt(2) == 0xffff0000) && (ptrLong(0) == 0x0L)
+  }
+
   private def mapGaiStatus(gaiStatus: Int): Int = {
     /* This is where some arcane Operating System specific behavior
      * comes to puddle and pool. This method is not for small children
@@ -638,10 +684,12 @@ object InetAddress {
       val ia = if (lbBytes.length == 4) {
         new Inet4Address(lbBytes, "localhost")
       } else {
-        new Inet6Address(lbBytes, "localhost")
+        Inet6Address(lbBytes, "localhost")
       }
       Array[InetAddress](ia)
     } else {
+      vetScopeText(host)
+
       val ips = InetAddress.hostToInetAddressArray(host)
       if (ips.isEmpty) {
         throw new UnknownHostException(host + ": Name or service not known")
@@ -660,7 +708,7 @@ object InetAddress {
     if (addr.length == 4) {
       new Inet4Address(addr.clone, host)
     } else if (addr.length == 16) {
-      new Inet6Address(addr.clone, host)
+      Inet6Address(addr.clone, host)
     } else {
       throw new UnknownHostException(
         s"addr is of illegal length: ${addr.length}"

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -116,9 +116,13 @@ class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
       | ((bytes(start) & 255) << 24))
   }
 
-  override def hashCode(): Int =
-    if (ipAddress.length == 4) bytesToInt(ipAddress, 0) // too scared to change
-    else ju.Arrays.hashCode(ipAddress)
+  override def hashCode(): Int = {
+    ju.Arrays.hashCode(ipAddress)
+    var res = 1
+    res = 31 * res + ju.Arrays.hashCode(ipAddress)
+    res = if (originalHost != null) (res = 31 * res + originalHost.hashCode())
+    res
+  }
 
   def isLinkLocalAddress(): Boolean = false
 

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -120,7 +120,8 @@ class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
     ju.Arrays.hashCode(ipAddress)
     var res = 1
     res = 31 * res + ju.Arrays.hashCode(ipAddress)
-    res = if (originalHost != null) (res = 31 * res + originalHost.hashCode())
+    if (originalHost != null)
+      res = 31 * res + originalHost.hashCode()
     res
   }
 

--- a/javalib/src/main/scala/java/net/InetSocketAddress.scala
+++ b/javalib/src/main/scala/java/net/InetSocketAddress.scala
@@ -64,10 +64,12 @@ class InetSocketAddress private[net] (
   final def isUnresolved: Boolean = !isResolved
 
   override final def hashCode: Int = {
-    if (addr == null)
-      hostName.hashCode + port
-    else
-      addr.hashCode + port
+    var res = 1
+    res = if (addr != null) (res = 31 * res + addr.hashCode())
+    res = 31 * res + port.hashCode()
+    res = if (hostname != null) (res = 31 * res + hostname.hashCode())
+    res = 31 * res + needsResolving.hashCode()
+    res
   }
 
   override def equals(obj: Any): Boolean = {

--- a/javalib/src/main/scala/java/net/InetSocketAddress.scala
+++ b/javalib/src/main/scala/java/net/InetSocketAddress.scala
@@ -68,8 +68,8 @@ class InetSocketAddress private[net] (
     if (addr != null)
       res = 31 * res + addr.hashCode()
     res = 31 * res + port.hashCode()
-    if (hostname != null)
-      res = 31 * res + hostname.hashCode()
+    if (hostName != null)
+      res = 31 * res + hostName.hashCode()
     res = 31 * res + needsResolving.hashCode()
     res
   }

--- a/javalib/src/main/scala/java/net/InetSocketAddress.scala
+++ b/javalib/src/main/scala/java/net/InetSocketAddress.scala
@@ -65,9 +65,11 @@ class InetSocketAddress private[net] (
 
   override final def hashCode: Int = {
     var res = 1
-    res = if (addr != null) (res = 31 * res + addr.hashCode())
+    if (addr != null)
+      res = 31 * res + addr.hashCode()
     res = 31 * res + port.hashCode()
-    res = if (hostname != null) (res = 31 * res + hostname.hashCode())
+    if (hostname != null)
+      res = 31 * res + hostname.hashCode()
     res = 31 * res + needsResolving.hashCode()
     res
   }

--- a/javalib/src/main/scala/java/net/InterfaceAddress.scala
+++ b/javalib/src/main/scala/java/net/InterfaceAddress.scala
@@ -24,8 +24,13 @@ class InterfaceAddress private[net] (
 
   /** This hashCode is not intended or guaranteed to match Java.
    */
-  override def hashCode(): Int =
-    inetAddr.hashCode() + broadcastAddr.hashCode() + prefixLength
+  override def hashCode(): Int = {
+    var res = 1
+    res = 31 * res + inetAddr.hashCode()
+    res = 31 * res + broadcastAddr.hashCode()
+    res = 31 * res + prefixLength
+    res
+  }
 
   override def toString(): String = {
     val iaPart = inetAddr.getHostAddress()

--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -184,7 +184,7 @@ class NetworkInterface private (ifName: String) {
   // relies upon convention that Virtual or sub-interfaces have colon in name.
   def isVirtual(): Boolean = ifName.indexOf(':') >= 0 // a best guess
 
-  override def hashCode(): Int = ifName.hashCode()
+  override def hashCode(): Int = 31 * ifName.hashCode()
 
   def subInterfaces(): Stream[NetworkInterface] = {
     val allIfs = NetworkInterface.networkInterfaces()

--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -63,6 +63,14 @@ import macOsIfDl._
  *   They are only set to the actual, non-zero, interface for link-local
  *   and other non-global addresses.
  *
+ *   IETF RFC (Internet Engineering Task Force, Request for Comments)
+ *   2553 (https://datatracker.ietf.org/doc/html/rfc2553) states:
+ *       "The sin6_scope_id field is a 32-bit integer that identifies a set of
+ *        interfaces as appropriate for the scope of the address carried in the
+ *        sin6_addr field.  For a link scope sin6_addr sin6_scope_id would be
+ *        an interface index.  For a site scope sin6_addr, sin6_scope_id would
+ *        be a site identifier."
+ *
  *   This file explicitly sets the network index (Java scopeId) and does
  *   not rely upon the possibly zero contents of sin6_scope_id.
  */

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/net/NetworkInterfaceTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/net/NetworkInterfaceTestOnJDK9.scala
@@ -55,10 +55,12 @@ class NetworkInterfaceTestOnJDK9 {
       })
       .count
 
-    /* Linux tends to have two addresses, one IPv4 & one IPv6.
+    /* Out-of-the-box Linux tends to have two addresses, one IPv4 & one IPv6.
      * macOS has three. It adds a link local (fe80) address.
+     * Of course, a user may configure their system differently and
+     * break this test.
      */
-    assertTrue("count > 0", count > 2)
+    assertTrue("count ${count} not >= 2", count >= 2)
   }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/InetAddressTest.scala
@@ -77,6 +77,16 @@ class InetAddressTest {
     assertEquals("a6.1", 1, list.length)
   }
 
+  // Issue 3657
+  @Test def getAllByNameWithInvalidScopeId(): Unit = {
+    val nameWithInvalidScopeId = "::1%-2"
+    assertThrows(
+      s"getAllByName(${nameWithInvalidScopeId})",
+      classOf[java.net.UnknownHostException],
+      InetAddress.getAllByName(nameWithInvalidScopeId)
+    )
+  }
+
   @Test def getByName(): Unit = {
     val ia = InetAddress.getByName("127.0.0.1") // numeric lookup path
 


### PR DESCRIPTION
Fix #3657

A number of  defects in javalib  java.net were removed. See referenced Issue for details.

In particular, `InterfaceAddress` and `InetAddress` instances returned by `NetworkInterface`
should handle the network interface index as they are handled in the JVM. A number of
other changes are internal and not user-facing.

Since `NetworkInterface` was not, for good reasons, ported to SN 0.4.n, this PR is __not__ a 
candidate for backporting.