### PR TITLE
improvement: Microoptimizations to toolchains and runtime

### DIFF
--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdatomic.h>
+#include "gc/shared/ThreadUtil.h"
 
 // Defined symbols here:
 // - ASM_JMPBUF_SIZE: The size of the jmpbuf, should be a constant defined in
@@ -105,7 +106,7 @@ typedef struct Handlers {
  * function is suspended and resumed on different threads, a cached thread-local
  * address might wreck havoc on its users.
  */
-static _Thread_local Handlers *__handlers = NULL;
+static SN_ThreadLocal Handlers *__handlers = NULL;
 
 static void print_handlers(Handlers *hs) {
     while (hs != NULL) {

--- a/nativelib/src/main/resources/scala-native/gc/commix/State.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/State.c
@@ -6,7 +6,7 @@ Heap heap = {};
 BlockAllocator blockAllocator = {};
 _Atomic(MutatorThreads) mutatorThreads = NULL;
 atomic_int_fast32_t mutatorThreadsCount = 0;
-thread_local MutatorThread *currentMutatorThread = NULL;
+SN_ThreadLocal MutatorThread *currentMutatorThread = NULL;
 GC_Roots *customRoots = NULL;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED

--- a/nativelib/src/main/resources/scala-native/gc/commix/State.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/State.h
@@ -11,7 +11,7 @@ extern Heap heap;
 extern BlockAllocator blockAllocator;
 extern _Atomic(MutatorThreads) mutatorThreads;
 extern atomic_int_fast32_t mutatorThreadsCount;
-extern thread_local MutatorThread *currentMutatorThread;
+extern SN_ThreadLocal MutatorThread *currentMutatorThread;
 extern GC_Roots *customRoots;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED

--- a/nativelib/src/main/resources/scala-native/gc/immix/State.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/State.c
@@ -7,7 +7,7 @@ Stack stack = {};
 Stack weakRefStack = {};
 BlockAllocator blockAllocator = {};
 _Atomic(MutatorThreads) mutatorThreads = NULL;
-thread_local MutatorThread *currentMutatorThread = NULL;
+SN_ThreadLocal MutatorThread *currentMutatorThread = NULL;
 GC_Roots *customRoots = NULL;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED

--- a/nativelib/src/main/resources/scala-native/gc/immix/State.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/State.h
@@ -12,7 +12,7 @@ extern Stack stack;
 extern Stack weakRefStack;
 extern BlockAllocator blockAllocator;
 extern _Atomic(MutatorThreads) mutatorThreads;
-extern thread_local MutatorThread *currentMutatorThread;
+extern SN_ThreadLocal MutatorThread *currentMutatorThread;
 extern GC_Roots *customRoots;
 
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -30,8 +30,8 @@
 #endif
 #endif
 
-thread_local void *current = 0;
-thread_local void *end = 0;
+SN_ThreadLocal void *current = 0;
+SN_ThreadLocal void *end = 0;
 
 static size_t DEFAULT_CHUNK;
 static size_t PREALLOC_CHUNK;

--- a/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
@@ -31,7 +31,8 @@
 #else
 #error "Cannot define thread_local"
 #endif
-#endif
+#endif // thread_local
+#define SN_ThreadLocal __attribute__((tls_model("local-exec"))) __attribute__((visibility("hidden"))) thread_local
 #endif
 
 typedef void *(*routine_fn)(void *);

--- a/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
@@ -18,6 +18,7 @@
 #ifndef SCALANATIVE_MULTITHREADING_ENABLED
 #undef thread_local
 #define thread_local
+#define SN_ThreadLocal
 #else
 #ifndef thread_local
 #if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
@@ -31,8 +32,8 @@
 #else
 #error "Cannot define thread_local"
 #endif
+#define SN_ThreadLocal __attribute__((tls_model("local-exec"))) thread_local
 #endif // thread_local
-#define SN_ThreadLocal __attribute__((tls_model("local-exec"))) __attribute__((visibility("hidden"))) thread_local
 #endif
 
 typedef void *(*routine_fn)(void *);

--- a/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
@@ -18,13 +18,14 @@
 #ifndef SCALANATIVE_MULTITHREADING_ENABLED
 #define SN_ThreadLocal
 #else
-#define TLS_MODEL_ATTR __attribute__((tls_model("local-exec")))
 #if __STDC_VERSION__ >= 201112L
-#define SN_ThreadLocal TLS_MODEL_ATTR _Thread_local
+// TODO Use tls_model hints when building application, but not when creating
+// library #define TLS_MODEL_ATTR __attribute__((tls_model("local-exec")))
+#define SN_ThreadLocal _Thread_local
 #elif defined(_MSC_VER)
 #define SN_ThreadLocal __declspec(thread)
 #elif defined(__GNUC__) || defined(__clang__)
-#define SN_ThreadLocal TLS_MODEL_ATTR __thread
+#define SN_ThreadLocal __thread
 #else
 #error Unable to create thread local storage
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
@@ -16,24 +16,17 @@
 #endif
 
 #ifndef SCALANATIVE_MULTITHREADING_ENABLED
-#undef thread_local
-#define thread_local
 #define SN_ThreadLocal
 #else
-#ifndef thread_local
-#if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
-#define thread_local _Thread_local
-#elif defined _WIN32 && (defined _MSC_VER || defined __ICL ||                  \
-                         defined __DMC__ || defined __BORLANDC__)
-#define thread_local __declspec(thread)
-/* note that ICC (linux) and Clang are covered by __GNUC__ */
-#elif defined __GNUC__ || defined __SUNPRO_C || defined __xlC__
-#define thread_local __thread
+#define TLS_MODEL_ATTR __attribute__((tls_model("local-exec")))
+#if __STDC_VERSION__ >= 201112L
+#define SN_ThreadLocal TLS_MODEL_ATTR _Thread_local
+#elif defined(_MSC_VER)
+#define SN_ThreadLocal __declspec(thread)
+#elif defined(__GNUC__) || defined(__clang__)
+#define SN_ThreadLocal TLS_MODEL_ATTR __thread
 #else
-#error "Cannot define thread_local"
-#endif
-#define SN_ThreadLocal __attribute__((tls_model("local-exec"))) thread_local
-#endif // thread_local
+#error Unable to create thread local storage
 #endif
 
 typedef void *(*routine_fn)(void *);

--- a/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ThreadUtil.h
@@ -28,6 +28,7 @@
 #else
 #error Unable to create thread local storage
 #endif
+#endif // SCALANATIVE_MULTITHREADING_ENABLED
 
 typedef void *(*routine_fn)(void *);
 #ifdef _WIN32

--- a/nativelib/src/main/resources/scala-native/nativeThreadTLS.c
+++ b/nativelib/src/main/resources/scala-native/nativeThreadTLS.c
@@ -1,7 +1,8 @@
 #include "nativeThreadTLS.h"
+#include "gc/shared/ThreadUtil.h"
 
-thread_local JavaThread currentThread = NULL;
-thread_local NativeThread currentNativeThread = NULL;
+SN_ThreadLocal JavaThread currentThread = NULL;
+SN_ThreadLocal NativeThread currentNativeThread = NULL;
 
 void scalanative_assignCurrentThread(JavaThread thread,
                                      NativeThread nativeThread) {

--- a/nativelib/src/main/resources/scala-native/nativeThreadTLS.h
+++ b/nativelib/src/main/resources/scala-native/nativeThreadTLS.h
@@ -1,31 +1,10 @@
 #ifndef NATIVE_THREAD_TLS_H
 #define NATIVE_THREAD_TLS_H
-#include <stddef.h>
 
-#ifndef SCALANATIVE_MULTITHREADING_ENABLED
-#undef thread_local
-#define thread_local
-#else
-#ifndef thread_local
-#if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
-#define thread_local _Thread_local
-#elif defined _WIN32 && (defined _MSC_VER || defined __ICL ||                  \
-                         defined __DMC__ || defined __BORLANDC__)
-#define thread_local __declspec(thread)
-/* note that ICC (linux) and Clang are covered by __GNUC__ */
-#elif defined __GNUC__ || defined __SUNPRO_C || defined __xlC__
-#define thread_local __thread
-#else
-#error "Cannot define thread_local"
-#endif
-#endif
-#endif
+#include "gc/shared/ThreadUtil.h"
 
 typedef void *JavaThread;
 typedef void *NativeThread;
-
-extern thread_local JavaThread currentThread;
-extern thread_local NativeThread currentNativeThread;
 
 void scalanative_assignCurrentThread(JavaThread thread,
                                      NativeThread nativeThread);

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -7,6 +7,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 import scala.collection.mutable
+import scala.collection.immutable
 import scala.util.control.NonFatal
 
 import scala.scalanative.nir.serialization.{Tags => T}
@@ -159,7 +160,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, nirSource: NIRSource) {
   }
 
   private def getSeq[T](getT: => T): Seq[T] =
-    Seq.fill(getLebUnsignedInt())(getT)
+    Vector.fill(getLebUnsignedInt())(getT)
   private def getOpt[T](getT: => T): Option[T] =
     if (get == 0) None
     else Some(getT)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -12,8 +12,10 @@ import scala.util.control.NonFatal
 
 import scala.scalanative.nir.serialization.{Tags => T}
 import scala.scalanative.util.TypeOps.TypeNarrowing
+import scala.scalanative.util.ScalaStdlibCompat.ArraySeqCompat
 
 import scala.annotation.{tailrec, switch}
+import scala.reflect.ClassTag
 
 class DeserializationException(
     global: nir.Global,
@@ -159,8 +161,8 @@ final class BinaryDeserializer(buffer: ByteBuffer, nirSource: NIRSource) {
     result
   }
 
-  private def getSeq[T](getT: => T): Seq[T] =
-    Vector.fill(getLebUnsignedInt())(getT)
+  private def getSeq[T: ClassTag](getT: => T): Seq[T] =
+    ArraySeqCompat.fill(getLebUnsignedInt())(getT)
   private def getOpt[T](getT: => T): Option[T] =
     if (get == 0) None
     else Some(getT)

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -151,7 +151,7 @@ final class MergeProcessor(
           def escapes(addr: Addr): Boolean =
             states.exists(_.hasEscaped(addr))
 
-          states.head.heap.keys.iterator
+          states.head.heap.keysIterator
             .filter(includeAddr)
             .foreach { addr =>
               val headInstance = states.head.deref(addr)

--- a/util/src/main/scala/scala/scalanative/util/ScalaStdlibCompat.scala
+++ b/util/src/main/scala/scala/scalanative/util/ScalaStdlibCompat.scala
@@ -1,0 +1,20 @@
+package scala.scalanative.util
+
+object ScalaStdlibCompat {
+  private[scalanative] object ArraySeqCompatDef {
+    val ArraySeq = scala.collection.immutable.Vector
+    type ArraySeq[T] = scala.collection.immutable.Vector[T]
+  }
+
+  private[scalanative] object ArraySeqCompatSelect {
+    import ArraySeqCompatDef._
+    object Inner {
+      import scala.collection.immutable._
+      val ArraySeqAlias = ArraySeq
+      type ArraySeqAlias[T] = ArraySeq[T]
+    }
+  }
+  // Vector in Scala 2.12, ArraySeq otherwise
+  val ArraySeqCompat = ArraySeqCompatSelect.Inner.ArraySeqAlias
+  type ArraySeqCompat[T] = ArraySeqCompatSelect.Inner.ArraySeqAlias[T]
+}

--- a/util/src/main/scala/scala/scalanative/util/ScopedVar.scala
+++ b/util/src/main/scala/scala/scalanative/util/ScopedVar.scala
@@ -47,4 +47,11 @@ object ScopedVar {
     try body
     finally stack.reverse.foreach(_.pop())
   }
+  @nowarn("msg=`_` is deprecated for wildcard arguments of types")
+  def scopedPushIf[T](
+      shouldPushAssignments: Boolean
+  )(lazyAssignments: => Seq[Assignment[_]])(body: => T): T = {
+    if (shouldPushAssignments) scoped(lazyAssignments:_*)(body)
+    else body
+  }
 }

--- a/util/src/main/scala/scala/scalanative/util/ScopedVar.scala
+++ b/util/src/main/scala/scala/scalanative/util/ScopedVar.scala
@@ -51,7 +51,7 @@ object ScopedVar {
   def scopedPushIf[T](
       shouldPushAssignments: Boolean
   )(lazyAssignments: => Seq[Assignment[_]])(body: => T): T = {
-    if (shouldPushAssignments) scoped(lazyAssignments:_*)(body)
+    if (shouldPushAssignments) scoped(lazyAssignments: _*)(body)
     else body
   }
 }


### PR DESCRIPTION
- Use ArraySeq as default when deserializing NIR sequences
- Disable some computions in optimizers when source level dubbing is disabled
- Use common thread_local implementation hinting usage of local-exec TLS mode. 