### PR TITLE
feature: Disable unused multithreading to improve performance

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -7,7 +7,6 @@
 #include <gc/gc.h>
 #include "shared/ScalaNativeGC.h"
 #include <stdlib.h>
-#include <errno.h>
 #include <string.h>
 #include "shared/Parsing.h"
 
@@ -58,6 +57,7 @@ void scalanative_GC_collect() { GC_gcollect(); }
 
 void scalanative_GC_register_weak_reference_handler(void *handler) {}
 
+#ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #ifdef _WIN32
 HANDLE scalanative_GC_CreateThread(LPSECURITY_ATTRIBUTES threadAttributes,
                                    SIZE_T stackSize, ThreadStartRoutine routine,
@@ -73,6 +73,7 @@ int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
     return GC_pthread_create(thread, attr, routine, args);
 }
 #endif
+#endif // SCALANATIVE_MULTITHREADING_ENABLED
 
 // ScalaNativeGC interface stubs. Boehm GC relies on STW using signal handlers
 void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused){};

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -63,25 +63,14 @@ HANDLE scalanative_GC_CreateThread(LPSECURITY_ATTRIBUTES threadAttributes,
                                    SIZE_T stackSize, ThreadStartRoutine routine,
                                    RoutineArgs args, DWORD creationFlags,
                                    DWORD *threadId) {
-#ifdef SCALANATIVE_MULTITHREADING_ENABLED
-
     return GC_CreateThread(threadAttributes, stackSize, routine, args,
                            creationFlags, threadId);
-#endif
-    // We can end up here only if we started build with enabled multihreading
-    // but it was disabled, becouse it was unused
-    return NULL;
 }
 #else
 int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
                                   ThreadStartRoutine routine,
                                   RoutineArgs args) {
-#ifdef SCALANATIVE_MULTITHREADING_ENABLED
     return GC_pthread_create(thread, attr, routine, args);
-#endif
-    // We can end up here only if we started build with enabled multihreading
-    // but it was disabled, becouse it was unused
-    return EAGAIN;
 }
 #endif
 

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -128,7 +128,6 @@ void scalanative_GC_remove_roots(void *addr_low, void *addr_high) {
     GC_Roots_RemoveByRange(customRoots, range);
 }
 
-#ifdef SCALANATIVE_MULTITHREADING_ENABLED
 typedef void *RoutineArgs;
 typedef struct {
     ThreadStartRoutine fn;
@@ -183,8 +182,10 @@ void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState state) {
     MutatorThread_switchState(currentMutatorThread, state);
 }
 void scalanative_GC_yield() {
+#ifdef SCALANATIVE_MULTITHREADING_ENABLED
     if (atomic_load_explicit(&Synchronizer_stopThreads, memory_order_relaxed))
         Synchronizer_yield();
-}
-#endif // SCALANATIVE_MULTITHREADING_ENABLED
 #endif
+}
+
+#endif // defined(SCALANATIVE_GC_COMMIX)

--- a/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
@@ -91,7 +91,6 @@ size_t scalanative_GC_get_max_heapsize() {
     return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
 }
 
-#ifdef SCALANATIVE_MULTITHREADING_ENABLED
 typedef void *RoutineArgs;
 typedef struct {
     ThreadStartRoutine fn;
@@ -147,10 +146,11 @@ void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState state) {
 }
 
 void scalanative_GC_yield() {
+#ifdef SCALANATIVE_MULTITHREADING_ENABLED
     if (atomic_load_explicit(&Synchronizer_stopThreads, memory_order_relaxed))
         Synchronizer_yield();
+#endif
 }
-#endif // SCALANATIVE_MULTITHREADING_ENABLED
 
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {
     AddressRange range = {addr_low, addr_high};

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -136,7 +136,6 @@ void scalanative_GC_collect() {}
 
 void scalanative_GC_register_weak_reference_handler(void *handler) {}
 
-#ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #ifdef _WIN32
 HANDLE scalanative_GC_CreateThread(LPSECURITY_ATTRIBUTES threadAttributes,
                                    SIZE_T stackSize, ThreadStartRoutine routine,
@@ -152,7 +151,6 @@ int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
     return pthread_create(thread, attr, routine, args);
 }
 #endif
-#endif // SCALANATIVE_MULTITHREADING_ENABLED
 
 // ScalaNativeGC interface stubs. None GC does not need STW
 void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused){};

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -212,7 +212,7 @@ object Build {
         if (!usesSystemThreads) {
           config.logger.info(
             "Detected enabled multithreading, but not found any usage of system threads. " +
-              "Multihreading would be disabled to improve performance. " +
+              "Multihreading will be disabled to improve performance. " +
               s"This behavior can be disabled by setting enviornment variable $envFlag=0."
           )
           currentConfig = currentConfig.withCompilerConfig(

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -104,11 +104,15 @@ object Build {
       checkWorkdirExists(initialConfig)
 
       // validate Config
-      val config = Validator.validate(initialConfig)
+      var config = Validator.validate(initialConfig)
       config.logger.debug(config.toString())
 
       ScalaNative
         .link(config, entries(config))
+        .map { linkerResult =>
+          config = postRechabilityAnalysisConfigUpdate(config, linkerResult)
+          linkerResult
+        }
         .flatMap(optimize(config, _))
         .flatMap(linkerResult =>
           codegen(config, linkerResult)
@@ -177,6 +181,42 @@ object Build {
     s"Linking native code (${config.gc.name} gc, ${config.LTO.name} lto)"
   ) {
     LLVM.link(config, analysis, compiled)
+  }
+
+  /** Based on reachability analysis check if config can be tuned for better
+   *  performance
+   */
+  private def postRechabilityAnalysisConfigUpdate(
+      config: Config,
+      analysis: ReachabilityAnalysis.Result
+  ): Config = {
+    var currentConfig = config
+    // Each block can modify currentConfig stat,
+    // modification should be lazy to not reconstruct object when not required
+    locally { // disable unused mulithreading
+      val envFlag = "SCALANATIVE_DISABLE_UNUSED_MULTITHREADING"
+      val suppressDisablingThreads = sys.env.get(envFlag).contains("0")
+      if (!suppressDisablingThreads && config.compilerConfig.multithreadingSupport) {
+        // format: off
+        val jlThread = nir.Global.Top("java.lang.Thread")
+        val jlThreadStart = jlThread.member(nir.Sig.Method("start", Seq(nir.Type.Unit)))
+        val jlPlatformContext = nir.Global.Top("java.lang.PlatformThreadContext")
+        val jlPlatformContextStart = jlPlatformContext.member(nir.Sig.Method("start", Seq(nir.Type.Ref(jlThread), nir.Type.Unit)))
+        val usesSystemThreads = analysis.infos.contains(jlThreadStart) && analysis.infos.contains(jlPlatformContextStart)
+        // format: on
+        if (!usesSystemThreads) {
+          config.logger.info(
+            "Detected enabled multithreading, but not found any usage of system threads. " +
+              "Multihreading would be disabled to improve performance. " +
+              s"This behavior can be disabled by setting enviornment variable $envFlag=0."
+          )
+          currentConfig = currentConfig.withCompilerConfig(
+            _.withMultithreadingSupport(false)
+          )
+        }
+      }
+    }
+    currentConfig
   }
 
   /** Links the DWARF debug information found in the object files. */


### PR DESCRIPTION
Enabled multithreading does impose additional runtime overhead. Following Java Memory Model can cost up to 20% of execution time - in one of benchmarks singlethreaded app finished in 1,8s with multihreading 2,4s. Lost of small scripts might not require MT support, detect and disable it to improve performance. 