### PR TITLE
improve: Use only `Charset` instances in javalib instead of encoding strings

### DIFF
--- a/javalib/src/main/scala/java/net/URIEncoderDecoder.scala
+++ b/javalib/src/main/scala/java/net/URIEncoderDecoder.scala
@@ -1,12 +1,14 @@
 package java.net
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets
 
-object URIEncoderDecoder {
+// ScalaNative specific
+private[net] object URIEncoderDecoder {
 
   val digits: String = "0123456789ABCDEF"
 
-  val encoding: String = "UTF8"
+  val encoding = StandardCharsets.UTF_8
 
   def validate(s: String, legal: String): Unit = {
     var i: Int = 0


### PR DESCRIPTION
This allows to skip usage of ServiceProvider lookup for charsets