### PR TITLE
chore: Update nightly version of compiler and fix new deprecation warnings

### DIFF
--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -718,9 +718,9 @@ object Arrays {
       from: Int,
       to: Int
   ): Array[T] = {
-    copyOfRangeImpl[T](original, from, to)(
-      ClassTag(original.getClass.getComponentType)
-    ).asInstanceOf[Array[T]]
+    implicit def tag: ClassTag[T] = ClassTag(original.getClass.getComponentType)
+    copyOfRangeImpl[T](original, from, to)
+      .asInstanceOf[Array[T]]
   }
 
   @noinline
@@ -730,9 +730,9 @@ object Arrays {
       to: Int,
       newType: Class[_ <: Array[T]]
   ): Array[T] = {
-    copyOfRangeImpl[AnyRef](original.asInstanceOf[Array[AnyRef]], from, to)(
-      ClassTag(newType.getComponentType)
-    ).asInstanceOf[Array[T]]
+    implicit def tag: ClassTag[T] = ClassTag(original.getClass.getComponentType)
+    copyOfRangeImpl[AnyRef](original.asInstanceOf[Array[AnyRef]], from, to)
+      .asInstanceOf[Array[T]]
   }
 
   @noinline

--- a/nativelib/src/main/scala-next/scala/scalanative/memory/SafeZone.scala
+++ b/nativelib/src/main/scala-next/scala/scalanative/memory/SafeZone.scala
@@ -42,7 +42,7 @@ trait SafeZone {
 
 object SafeZone {
   /** Run given function with a fresh zone and destroy it afterwards. */
-  final def apply[sealed T](f: (SafeZone^) ?=> T): T = {
+  final def apply[T](f: (SafeZone^) ?=> T): T = {
     val sz: SafeZone^ = new MemorySafeZone(SafeZoneAllocator.Impl.open())
     try f(using sz)
     finally sz.close()

--- a/nscplugin/src/test/scala-next/scala/scalanative/memory/SafeZoneTest.scala
+++ b/nscplugin/src/test/scala-next/scala/scalanative/memory/SafeZoneTest.scala
@@ -54,7 +54,10 @@ class SafeZoneTest {
         |}
         |""".stripMargin))
     )
-    assertTrue(err.getMessage.contains("Sealed type variable T cannot  be instantiated to box A^"))
+    assertTrue(
+      "Got:" + err.getMessage,
+     err.getMessage.contains("local reference sz1 leaks into outer capture set of type parameter T of method apply")
+     )
   }
 
   @Test def typeCheckCapturedZone(): Unit = nativeCompilation(

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -38,7 +38,7 @@ object ScalaVersions {
   val scala3PublishVersion = "3.1.3"
 
   // List of nightly version can be found here: https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/
-  lazy val scala3Nightly = "3.3.2-RC1-bin-20230601-8814760-NIGHTLY"
+  val scala3Nightly = "3.4.0-RC1-bin-20240114-bfabc31-NIGHTLY"
 
   // minimum version rationale:
   //   1.5 is required for Scala 3 and

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -194,7 +194,7 @@ object Build {
       analysis: ReachabilityAnalysis.Result
   ): (Config, Boolean) = {
     var currentConfig = config
-    var needsToReload = true
+    var needsToReload = false
 
     // Each block can modify currentConfig stat,
     // modification should be lazy to not reconstruct object when not required

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -860,7 +860,10 @@ object MetadataCodeGen {
           implicit val DISizeField: FieldWriter[DISize] = (ctx: Context, value: DISize) =>
             ctx.sb.str(value.sizeOfBits)
           implicit def MetadataNodeField[T <: Metadata.Node: InternedWriter]: FieldWriter[T] =
-            (ctx: Context, value: T) => writeInterned(value)(implicitly, ctx)
+            (ctx: Context, value: T) => {
+              implicit def _ctx: Context = ctx
+              writeInterned(value)
+            }
           implicit def MetadataField[T <: Metadata: Writer]: FieldWriter[T] =
             (ctx: Context, value: T) => implicitly[Writer[T]].write(value)(ctx)
           implicit val ofDIFlags: FieldWriter[DIFlags] = (ctx: Context, value: DIFlags) =>


### PR DESCRIPTION
Updated nightly version of compiler to test if issue blocking 3.4.0-RC1 was fixed