### PR TITLE
Add dependabot for CI updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
This creates a `dependabot.yml` file for automatically creating a PR for updating `actions` and can be modified to support other updates as needed.

Settings would need to be updated to enable the `dependabot`.