### PR TITLE
fix: Fix accessing mapped byte buffers if offset is not page size alligned

### DIFF
--- a/javalib/src/main/scala/java/nio/Buffer.scala
+++ b/javalib/src/main/scala/java/nio/Buffer.scala
@@ -214,11 +214,11 @@ abstract class Buffer private[nio] (val _capacity: Int) {
       s"Index $index out of bounds for length ${limit()}"
     )
   private def throwBufferUnderflow(index: Int): Nothing =
-    throw new BufferOverflowException(
+    throw new BufferUnderflowException(
       s"Access at index $index underflows buffer of length ${limit()}"
     )
   private def throwBufferOverflow(index: Int): Nothing =
-    throw new BufferUnderflowException(
+    throw new BufferOverflowException(
       s"Access at index $index overflows buffer of length ${limit()}"
     )
 }

--- a/javalib/src/main/scala/java/nio/BufferOverflowException.scala
+++ b/javalib/src/main/scala/java/nio/BufferOverflowException.scala
@@ -1,3 +1,6 @@
 package java.nio
 
-class BufferOverflowException extends RuntimeException
+class BufferOverflowException private[java] (msg: String)
+    extends RuntimeException(msg) {
+  def this() = this(null)
+}

--- a/javalib/src/main/scala/java/nio/BufferUnderflowException.scala
+++ b/javalib/src/main/scala/java/nio/BufferUnderflowException.scala
@@ -1,3 +1,6 @@
 package java.nio
 
-class BufferUnderflowException extends RuntimeException
+class BufferUnderflowException private[java] (message: String)
+    extends RuntimeException(message) {
+  def this() = this(null)
+}

--- a/javalib/src/main/scala/java/nio/GenMappedBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenMappedBuffer.scala
@@ -113,7 +113,7 @@ private[nio] final class GenMappedBuffer[B <: Buffer](val self: B)
       ()
     } else {
       val dstPtr = dst.asInstanceOf[ByteArray].at(0) + offset
-      val srcPtr = _mappedData.ptr + startIndex
+      val srcPtr = _mappedData.data + startIndex
       string.memcpy(dstPtr, srcPtr, length.toUInt)
     }
   }
@@ -135,7 +135,7 @@ private[nio] final class GenMappedBuffer[B <: Buffer](val self: B)
       ()
     } else {
       val srcPtr = src.asInstanceOf[ByteArray].at(0) + offset
-      val dstPtr = _mappedData.ptr + startIndex
+      val dstPtr = _mappedData.data + startIndex
       string.memcpy(dstPtr, srcPtr, length.toUInt)
     }
   }

--- a/javalib/src/main/scala/java/nio/GenMappedBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenMappedBufferView.scala
@@ -118,7 +118,7 @@ private[nio] final class GenMappedBufferView[B <: Buffer](val self: B)
       newMappedBufferView: NewThisMappedBufferView
   ): ByteArrayBits = {
     ByteArrayBits(
-      _mappedData.ptr,
+      _mappedData.data,
       _offset,
       isBigEndian,
       newMappedBufferView.bytesPerElem

--- a/javalib/src/main/scala/java/nio/charset/CoderResult.scala
+++ b/javalib/src/main/scala/java/nio/charset/CoderResult.scala
@@ -24,8 +24,8 @@ class CoderResult private (kind: Int, _length: Int) {
   }
 
   def throwException(): Unit = (kind: @switch) match {
-    case Overflow   => throw new BufferOverflowException
-    case Underflow  => throw new BufferUnderflowException
+    case Overflow   => throw new BufferOverflowException()
+    case Underflow  => throw new BufferUnderflowException()
     case Malformed  => throw new MalformedInputException(_length)
     case Unmappable => throw new UnmappableCharacterException(_length)
   }

--- a/windowslib/src/main/scala/scala/scalanative/windows/ErrorHandlingApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ErrorHandlingApi.scala
@@ -10,7 +10,7 @@ object ErrorHandlingApi {
 }
 
 object ErrorHandlingApiOps {
-  def errorMessage(errCode: DWord): String = Zone { implicit z =>
+  def errorMessage(errCode: DWord): String = {
     import WinBaseApi._
     import WinBaseApiExt._
 


### PR DESCRIPTION
Opening MappedByteBuffer with a position offset not being page size alligned would lead to failure in creating mapping using mmap or it's Windows counterpart. This PR fixes that and ensure we use correct page size alligned values. Also improves context of buffer exceptions for out of bounds and under/overflow exceptions. Additionally fixes usage of "empty" MappedByteBufferData, previous usage was only defining local methods which were never used, now we create an overriden instance. 