### PR TITLE
WIP Fix #3648: Ensure default Linux stacks are not executable

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -90,11 +90,8 @@ object Discover {
       (libDirs ++ llvmLibDir).map(s => s"-L$s")
     }
 
-    val opts =
-      if (!Platform.isLinux) libs
-      else libs ++ Seq("-z", "noexecstack") // Issue #3648, .S files
-
-    opts
+    if (!Platform.isLinux) libs
+    else libs ++ Seq("-z", "noexecstack") // Issue #3648, .S files
   }
 
   private case class ClangInfo(

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -89,7 +89,12 @@ object Discover {
 
       (libDirs ++ llvmLibDir).map(s => s"-L$s")
     }
-    libs
+
+    val opts =
+      if (!Platform.isLinux) libs
+      else libs ++ Seq("-z", "noexecstack") // Issue #3648, .S files
+
+    opts
   }
 
   private case class ClangInfo(

--- a/unit-tests/native/src/test/scala-3/scala/scala/scalanative/runtime/ContinuationsTestScala3.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalanative/runtime/ContinuationsTestScala3.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 import Continuations._
 import scala.scalanative.meta.LinktimeInfo.{isWindows, is32BitPlatform}
 
-class Scala3ContinuationsTests:
+class ContinuationsTestScala3:
   @Test def canBoundaryNoSuspend() =
     if !isWindows then
       val res = boundary[Int] {
@@ -99,4 +99,4 @@ class Scala3ContinuationsTests:
         case End(v) =>
           assert(false)
   }
-end Scala3ContinuationsTests
+end ContinuationsTestScala3


### PR DESCRIPTION
 Fix #3648

Ensure that Linux applications are linked with the default ld.bfd linker are, have non-executable stacks
unless specified otherwise by Clang or linker options.

That is, non-executable stacks are the desirable & "normal" condition across operating systems.
On Linux, an unfortunate interaction between Clang, ld.bfd, and the ".S" assembler files
added in SN 0.5.0 can all too easily generate executable stacks. See referenced issue for
gory details.

Of course, if an executable stack is necessary, one can use SN link options to specify that. 
Hint: add the `Seq("-z", "execstack")` to the __right__ of existing link options so that it is considered
after the "noexecstack" SN now supplies on Linux.  