### PR TITLE
Add test for Visual Studio toolchain target triple

### DIFF
--- a/tools/src/test/scala/scala/scalanative/build/TargetTripleTest.scala
+++ b/tools/src/test/scala/scala/scalanative/build/TargetTripleTest.scala
@@ -22,6 +22,8 @@ class TargetTripleTest {
       TargetTriple("x86_64", "pc", "linux", "gnu"),
     "x86_64-pc-windows-msvc" ->
       TargetTriple("x86_64", "pc", "windows", "msvc"),
+    "i686-pc-windows-msvc" ->
+      TargetTriple("i386", "pc", "windows", "msvc"),
     "x86_64-portbld-freebsd13.1" ->
       TargetTriple("x86_64", "unknown", "freebsd", "unknown")
   )


### PR DESCRIPTION
Sanity check for using Windows toolchain default (32 bit build) - I have not succeeded but this causes no harm for people who may want to try.