### PR TITLE
Handle negative stride before casting into `size_t`

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
@@ -78,8 +78,8 @@ static inline bool Object_IsArray(const Object *object) {
 static inline size_t Array_Stride(const ArrayHeader *header) {
     // clang would optimize it to llvm.max(stride, 1)
     // negative stride is used only for blob array
-    size_t stride = (size_t)header->stride;
-    return (stride > 0) ? stride : 1;
+    int32_t stride = header->stride;
+    return (stride > 0) ? (size_t)stride : 1;
 }
 
 static inline size_t BlobArray_ScannableLimit(const ArrayHeader *header) {


### PR DESCRIPTION
We would otherwise never hit the "not `stride > 0`" case (unless stride is 0), since we casted it to unsigned
before checking.
