### PR TITLE
Fix #3648: Ensure default Linux stacks are not executable

### DIFF
--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd32.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd32.S
@@ -3,7 +3,7 @@
 /* ----------------------------------------------------------------------------
 // Copyright (c) 2016, 2017 Microsoft Research, Daan Leijen
 // This is free software// you can redistribute it and/or modify it under the
-// terms of the Apache License, Version 2.0. 
+// terms of the Apache License, Version 2.0.
 // -----------------------------------------------------------------------------
 
 // -------------------------------------------------------
@@ -95,7 +95,7 @@ ok:
    f
    old_esp+8 -- new esp = old esp - 12
 */
-_lh_boundary_entry: 
+_lh_boundary_entry:
 __lh_boundary_entry:
   /* copy arguments */
   movl    4 (%esp), %edx /* f */
@@ -134,5 +134,14 @@ _lh_get_sp:
 __lh_get_sp:
   leal   4 (%esp), %eax
   ret
+
+#endif
+
+#if defined(__linux__) && defined(__ELF__)
+/* Reference:
+ *   https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
+ */
+
+.section .note.GNU-stack,"",%progbits
 
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
@@ -1,4 +1,3 @@
-
 #if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
 
 /* ----------------------------------------------------------------------------
@@ -112,5 +111,14 @@ __lh_get_sp:
   movq %rsp, %rax
   addq $8, %rax
   ret
+
+#endif
+
+#if defined(__linux__) && defined(__ELF__)
+/* Reference:
+ *   https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
+ */
+
+.section .note.GNU-stack,"",%progbits
 
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_arm64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_arm64.S
@@ -128,4 +128,14 @@ _lh_resume_entry: /* x0 = cont_size, x1 = cont, x2 = arg */
 _lh_get_sp:
     mov  x0, sp
     ret
+
+#endif
+
+#if defined(__linux__) && defined(__ELF__)
+/* Reference:
+ *   https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
+ */
+
+.section .note.GNU-stack,"",%progbits
+
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
@@ -144,4 +144,14 @@ __lh_get_sp:
   movq %rsp, %rax
   addq $8, %rax
   ret
+
+#endif
+
+#if defined(__linux__) && defined(__ELF__)
+/* Reference:
+ *   https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
+ */
+
+.section .note.GNU-stack,"",%progbits
+
 #endif

--- a/unit-tests/native/src/test/scala-3/scala/scala/scalanative/runtime/ContinuationsTest.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalanative/runtime/ContinuationsTest.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 import Continuations._
 import scala.scalanative.meta.LinktimeInfo.{isWindows, is32BitPlatform}
 
-class ContinuationsTestScala3:
+class ContinuationsTest:
   @Test def canBoundaryNoSuspend() =
     if !isWindows then
       val res = boundary[Int] {
@@ -99,4 +99,4 @@ class ContinuationsTestScala3:
         case End(v) =>
           assert(false)
   }
-end ContinuationsTestScala3
+end ContinuationsTest

--- a/unit-tests/native/src/test/scala-3/scala/scala/scalanative/runtime/ContinuationsTestScala3.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalanative/runtime/ContinuationsTestScala3.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 import Continuations._
 import scala.scalanative.meta.LinktimeInfo.{isWindows, is32BitPlatform}
 
-class Scala3ContinuationsTests:
+class ContinuationsTestScala3:
   @Test def canBoundaryNoSuspend() =
     if !isWindows then
       val res = boundary[Int] {
@@ -99,4 +99,4 @@ class Scala3ContinuationsTests:
         case End(v) =>
           assert(false)
   }
-end Scala3ContinuationsTests
+end ContinuationsTestScala3


### PR DESCRIPTION
Fix #3648 

Ensure that Linux applications are linked with the default ld.bfd linker have non-executable stacks
unless specified otherwise by Clang or linker options.

That is, non-executable stacks are the desirable & "normal" condition across contemporary operating systems.
On Linux, an unfortunate interaction between Clang, ld.bfd, and the ".S" assembler files
added in SN 0.5.0 can all too easily generate executable stacks. See referenced issue for
gory details.

Of course, if an executable stack is necessary and intended, one can still use SN link options to specify that
as before.
