### PR TITLE
fix: Fix handling of erased extern calls with variadic arguments

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -144,6 +144,14 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
             )
           tree.updateAttachment(NonErasedType(tpe))
 
+        case Apply(fun, args)
+            if isExternType(fun.symbol.owner) &&
+              fun.tpe.paramss.exists(isScalaVarArgs(_)) =>
+          args.foreach { arg =>
+            arg.updateAttachment(NonErasedType(widenDealiasType(arg.tpe)))
+          }
+          tree
+
         // Catch the definition of scala.Enumeration itself
         case cldef: ClassDef if cldef.symbol == EnumerationClass =>
           enterOwner(OwnerKind.EnumImpl) { super.transform(cldef) }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NativeInteropUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NativeInteropUtil.scala
@@ -4,6 +4,14 @@ import dotty.tools.dotc.plugins.PluginPhase
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Contexts.ctx
 import dotty.tools.dotc.core.Definitions
+import dotty.tools.dotc.core.Symbols
+import dotty.tools.dotc.core.Flags._
+import scala.scalanative.nscplugin.CompilerCompat.SymUtilsCompat.*
+import dotty.tools.dotc.ast.tpd._
+import dotty.tools.dotc.core.Names._
+import dotty.tools.dotc.core.Types._
+import dotty.tools.dotc.core.Flags._
+import NirGenUtil.ContextCached
 
 trait NativeInteropUtil { self: PluginPhase =>
 
@@ -12,5 +20,47 @@ trait NativeInteropUtil { self: PluginPhase =>
 
   /** Returns the Native IR definitions in the current context. */
   protected def defnNir(using Context): NirDefinitions = NirDefinitions.get
+
+  /** `true` iff `dd` is a toplevel declaration that is defined externally. */
+  def isTopLevelExtern(dd: ValOrDefDef)(using Context) = {
+    dd.rhs.symbol == defnNir.UnsafePackage_extern &&
+    dd.symbol.isWrappedToplevelDef
+  }
+
+  extension (sym: Symbols.Symbol)
+    /** `true` iff `sym` a trait or Java interface declaration. */
+    def isTraitOrInterface(using Context): Boolean =
+      sym.is(Trait) || sym.isAllOf(JavaInterface)
+
+    /** `true` iff `sym` is a scala module. */
+    def isScalaModule(using Context): Boolean =
+      sym.is(ModuleClass, butNot = Lifted)
+
+    /** `true` iff `sym` is a C-bridged type or a declaration defined
+     *  externally.
+     */
+    def isExtern(using Context): Boolean = sym.exists && {
+      sym.owner.isExternType ||
+      sym.hasAnnotation(defnNir.ExternClass) ||
+      (sym.is(Accessor) && sym.field.isExtern)
+    }
+
+    /** `true` iff `sym` is a C-bridged type (e.g., `unsafe.CSize`). */
+    def isExternType(using Context): Boolean =
+      (isScalaModule || sym.isTraitOrInterface) &&
+        sym.hasAnnotation(defnNir.ExternClass)
+
+    /** `true` iff `sym` is an exported definition. */
+    def isExported(using Context) =
+      sym.hasAnnotation(defnNir.ExportedClass) ||
+        sym.hasAnnotation(defnNir.ExportAccessorsClass)
+
+    /** `true` iff `sym` uses variadic arguments. */
+    def usesVariadicArgs(using Context) = sym.paramInfo.stripPoly match {
+      case MethodTpe(_, paramTypes, _) =>
+        paramTypes.exists(param => param.isRepeatedParam)
+      case t => t.isVarArgsMethod
+    }
+  end extension
 
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -29,48 +29,6 @@ class PrepNativeInterop extends PluginPhase with NativeInteropUtil {
   val phaseName = PrepNativeInterop.name
   override def description: String = "prepare ASTs for Native interop"
 
-  /** `true` iff `dd` is a toplevel declaration that is defined externally. */
-  private def isTopLevelExtern(dd: ValOrDefDef)(using Context) = {
-    dd.rhs.symbol == defnNir.UnsafePackage_extern &&
-    dd.symbol.isWrappedToplevelDef
-  }
-
-  extension (sym: Symbol)
-    /** `true` iff `sym` a trait or Java interface declaration. */
-    def isTraitOrInterface(using Context): Boolean =
-      sym.is(Trait) || sym.isAllOf(JavaInterface)
-
-    /** `true` iff `sym` is a scala module. */
-    def isScalaModule(using Context): Boolean =
-      sym.is(ModuleClass, butNot = Lifted)
-
-    /** `true` iff `sym` is a C-bridged type or a declaration defined
-     *  externally.
-     */
-    def isExtern(using Context): Boolean = sym.exists && {
-      sym.owner.isExternType ||
-      sym.hasAnnotation(defnNir.ExternClass) ||
-      (sym.is(Accessor) && sym.field.isExtern)
-    }
-
-    /** `true` iff `sym` is a C-bridged type (e.g., `unsafe.CSize`). */
-    def isExternType(using Context): Boolean =
-      (isScalaModule || sym.isTraitOrInterface) &&
-        sym.hasAnnotation(defnNir.ExternClass)
-
-    /** `true` iff `sym` is an exported definition. */
-    def isExported(using Context) =
-      sym.hasAnnotation(defnNir.ExportedClass) ||
-        sym.hasAnnotation(defnNir.ExportAccessorsClass)
-
-    /** `true` iff `sym` uses variadic arguments. */
-    def usesVariadicArgs(using Context) = sym.paramInfo.stripPoly match {
-      case MethodTpe(_, paramTypes, _) =>
-        paramTypes.exists(param => param.isRepeatedParam)
-      case t => t.isVarArgsMethod
-    }
-  end extension
-
   private val exportTargets = collection.mutable.Map.empty[Symbol, Symbol]
   override def runOn(
       units: List[CompilationUnit]

--- a/nscplugin/src/test/scala/scala/scalanative/linker/ExternVarArgsTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/linker/ExternVarArgsTest.scala
@@ -1,0 +1,65 @@
+package scala.scalanative
+package linker
+
+import org.junit.Test
+import org.junit.Assert._
+
+class ExternVarArgsTest {
+
+  @Test def unboxesVarArgs(): Unit = {
+    compileAndLoad(
+      "Test.scala" ->
+        """import scala.scalanative.unsafe._
+          | 
+          |@extern object FFI {
+          |  def printf(format: CString, args: Any*): Unit = extern
+          |}
+          |
+          |object Test{
+          |  def main(): Unit = {
+          |    def string: Ptr[Byte] = ???
+          |    def size: Ptr[Size] = ???
+          |    def long: Ptr[Long] = ???
+          |    def float: Ptr[Float] = ???
+          |    FFI.printf(c"", !(string + 1), string, !size, !long, long, !float)
+          |  }
+          |}
+          |""".stripMargin
+    ) { defns =>
+      val TestModule = nir.Global.Top("Test$")
+      val MainMethod =
+        TestModule.member(nir.Sig.Method("main", Seq(nir.Type.Unit)))
+      val FFIModule = nir.Global.Top("FFI$")
+      val PrintfMethod = FFIModule.member(nir.Sig.Extern("printf"))
+      val callArgs: Seq[nir.Val] = defns
+        .collectFirst {
+          case nir.Defn.Define(_, MainMethod, _, insts, _) => insts
+        }
+        .flatMap {
+          _.collectFirst {
+            case nir.Inst.Let(
+                  _,
+                  nir.Op.Call(_, nir.Val.Global(PrintfMethod, _), args),
+                  _
+                ) =>
+              args
+          }
+        }
+        .headOption
+        .getOrElse {
+          fail("Not found either tested method or the extern calls"); ???
+        }
+      val expectedCallArgs = Seq(
+        nir.Type.Ptr, // format CString
+        nir.Type.Int, // byte extended to Int
+        nir.Type.Ptr, // Ptr[Byte]
+        nir.Type.Size, // size,
+        nir.Type.Long, // long
+        nir.Type.Ptr, // Ptr[Long]
+        nir.Type.Double // float extended to double
+      )
+
+      assertEquals(expectedCallArgs.toList, callArgs.map(_.ty).toList)
+    }
+  }
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgTest.scala
@@ -18,7 +18,7 @@ class CVarArgTest {
     val buff: Ptr[CChar] = stackalloc[CChar](1024)
     generator(buff, cstr)
     val got = fromCString(buff)
-    assertEquals(got, output)
+    assertEquals(output, got)
   }
 
   @Test def empty(): Unit =
@@ -250,11 +250,11 @@ class CVarArgTest {
     )
 
   @Test def longValue0(): Unit =
-    vatest(c"%d", "0")(stdio.sprintf(_, _, 0L))
+    vatest(c"%lld", "0")(stdio.sprintf(_, _, 0L))
   @Test def longValue1(): Unit =
-    vatest(c"%d", "1")(stdio.sprintf(_, _, 1L))
+    vatest(c"%lld", "1")(stdio.sprintf(_, _, 1L))
   @Test def longValueMinus1(): Unit =
-    vatest(c"%d", "-1")(stdio.sprintf(_, _, -1L))
+    vatest(c"%lld", "-1")(stdio.sprintf(_, _, -1L))
   @Test def longValueMin(): Unit = {
     assumeNot32Bit()
     vatest(c"%lld", "-9223372036854775808")(
@@ -268,31 +268,36 @@ class CVarArgTest {
     )
   }
   @Test def longArgs1(): Unit =
-    vatest(c"%d", "1")(stdio.sprintf(_, _, 1L))
+    vatest(c"%lld", "1")(stdio.sprintf(_, _, 1L))
   @Test def longArgs2(): Unit =
-    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1L, 2L))
+    vatest(c"%lld %lld", "1 2")(stdio.sprintf(_, _, 1L, 2L))
   @Test def longArgs3(): Unit =
-    vatest(c"%d %d %d", "1 2 3")(stdio.sprintf(_, _, 1L, 2L, 3L))
+    vatest(c"%lld %lld %lld", "1 2 3")(stdio.sprintf(_, _, 1L, 2L, 3L))
   @Test def longArgs4(): Unit =
-    vatest(c"%d %d %d %d", "1 2 3 4")(stdio.sprintf(_, _, 1L, 2L, 3L, 4L))
+    vatest(c"%lld %lld %lld %lld", "1 2 3 4")(
+      stdio.sprintf(_, _, 1L, 2L, 3L, 4L)
+    )
   @Test def longArgs5(): Unit =
-    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+    vatest(c"%lld %lld %lld %lld %lld", "1 2 3 4 5")(
       stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L)
     )
   @Test def longArgs6(): Unit =
-    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+    vatest(c"%lld %lld %lld %lld %lld %lld", "1 2 3 4 5 6")(
       stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L, 6L)
     )
   @Test def longArgs7(): Unit =
-    vatest(c"%d %d %d %d %d %d %d", "1 2 3 4 5 6 7")(
+    vatest(c"%lld %lld %lld %lld %lld %lld %lld", "1 2 3 4 5 6 7")(
       stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L, 6L, 7L)
     )
   @Test def longArgs8(): Unit =
-    vatest(c"%d %d %d %d %d %d %d %d", "1 2 3 4 5 6 7 8")(
+    vatest(c"%lld %lld %lld %lld %lld %lld %lld %lld", "1 2 3 4 5 6 7 8")(
       stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L)
     )
   @Test def longArgs9(): Unit =
-    vatest(c"%d %d %d %d %d %d %d %d %d", "1 2 3 4 5 6 7 8 9")(
+    vatest(
+      c"%lld %lld %lld %lld %lld %lld %lld %lld %lld",
+      "1 2 3 4 5 6 7 8 9"
+    )(
       stdio.sprintf(_, _, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
     )
 
@@ -577,23 +582,23 @@ class CVarArgTest {
     vatest(c"%llu", "18446744073709551615")(stdio.sprintf(_, _, ULong.MaxValue))
   }
   @Test def ulongArgs1(): Unit =
-    vatest(c"%d", "1")(stdio.sprintf(_, _, 1.toULong))
+    vatest(c"%llu", "1")(stdio.sprintf(_, _, 1.toULong))
   @Test def ulongArgs2(): Unit =
-    vatest(c"%d %d", "1 2")(stdio.sprintf(_, _, 1.toULong, 2.toULong))
+    vatest(c"%llu %llu", "1 2")(stdio.sprintf(_, _, 1.toULong, 2.toULong))
   @Test def ulongArgs3(): Unit =
-    vatest(c"%d %d %d", "1 2 3")(
+    vatest(c"%llu %llu %llu", "1 2 3")(
       stdio.sprintf(_, _, 1.toULong, 2.toULong, 3.toULong)
     )
   @Test def ulongArgs4(): Unit =
-    vatest(c"%d %d %d %d", "1 2 3 4")(
+    vatest(c"%llu %llu %llu %llu", "1 2 3 4")(
       stdio.sprintf(_, _, 1.toULong, 2.toULong, 3.toULong, 4.toULong)
     )
   @Test def ulongArgs5(): Unit =
-    vatest(c"%d %d %d %d %d", "1 2 3 4 5")(
+    vatest(c"%llu %llu %llu %llu %llu", "1 2 3 4 5")(
       stdio.sprintf(_, _, 1.toULong, 2.toULong, 3.toULong, 4.toULong, 5.toULong)
     )
   @Test def ulongArgs6(): Unit =
-    vatest(c"%d %d %d %d %d %d", "1 2 3 4 5 6")(
+    vatest(c"%llu %llu %llu %llu %llu %llu", "1 2 3 4 5 6")(
       stdio.sprintf(
         _,
         _,
@@ -607,7 +612,7 @@ class CVarArgTest {
     )
   @Test def ulongArgs7(): Unit =
     vatest(
-      c"%d %d %d %d %d %d %d",
+      c"%llu %llu %llu %llu %llu %llu %llu",
       "1 2 3 4 5 6 7"
     )(
       stdio.sprintf(
@@ -624,7 +629,7 @@ class CVarArgTest {
     )
   @Test def ulongArgs8(): Unit =
     vatest(
-      c"%d %d %d %d %d %d %d %d",
+      c"%llu %llu %llu %llu %llu %llu %llu %llu",
       "1 2 3 4 5 6 7 8"
     )(
       stdio.sprintf(
@@ -642,7 +647,7 @@ class CVarArgTest {
     )
   @Test def ulongArgs9(): Unit =
     vatest(
-      c"%d %d %d %d %d %d %d %d %d",
+      c"%llu %llu %llu %llu %llu %llu %llu %llu %llu",
       "1 2 3 4 5 6 7 8 9"
     )(
       stdio.sprintf(


### PR DESCRIPTION
Fixes #3668 
- Fix handling of erased extern calls with variadic arguments
- Fix a bug leading to truncation of Long to Size on 32-bit systems
- Share parts of common symbol utils betwen prepNativeInterop phases