### PR TITLE
fix: Make a list of linked libraries distinct sequence

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -198,7 +198,7 @@ private[scalanative] object LLVM {
         if (config.targetsWindows) Seq("Dbghelp")
         else Seq("pthread", "dl")
       platformsLinks ++ srclinks ++ gclinks
-    }
+    }.distinct
     config.logger.info(s"Linking with [${links.mkString(", ")}]")
     val linkopts = config.linkingOptions ++ links.map("-l" + _)
 


### PR DESCRIPTION
Fixes #3677 
Fixes #3552

The order of linked libraries comming from `@link` annotations is mostly random. It should not harm us to make this list distinct. For any additional libraries for which order matters the linking options appended to the end of clang options lists would fix any other possible issues.