### PR TITLE
improvement: Better source positions relativization

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Position.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Position.scala
@@ -45,12 +45,12 @@ object Position {
 sealed trait SourceFile {
   def filename: Option[String] = this match {
     case SourceFile.Virtual => None
-    case source: SourceFile.SourceRootRelative =>
+    case source: SourceFile.Relative =>
       Option(source.path.getFileName()).map(_.toString())
   }
   def directory: Option[String] = this match {
     case SourceFile.Virtual => None
-    case source: SourceFile.SourceRootRelative =>
+    case source: SourceFile.Relative =>
       Option(source.path.getParent()).map(_.toString())
   }
 }
@@ -65,7 +65,7 @@ object SourceFile {
    *    path relative to `-sourceroot` setting defined when compiling source -
    *    typically it's root directory of workspace
    */
-  case class SourceRootRelative(pathString: String) extends SourceFile {
+  case class Relative(pathString: String) extends SourceFile {
     lazy val path: Path = Paths.get(pathString)
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -489,7 +489,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, nirSource: NIRSource) {
   def getPosition(): nir.Position = in(prelude.sections.positions) {
     val file = getString() match {
       case ""   => nir.SourceFile.Virtual
-      case path => nir.SourceFile.SourceRootRelative(path)
+      case path => nir.SourceFile.Relative(path)
     }
     val line = getLebUnsignedInt()
     val column = getLebUnsignedInt()

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -81,8 +81,8 @@ final class BinarySerializer(channel: WritableByteChannel) {
     override def put(pos: nir.Position): Unit = {
       putString {
         pos.source match { // interned
-          case nir.SourceFile.Virtual                        => ""
-          case nir.SourceFile.SourceRootRelative(pathString) => pathString
+          case nir.SourceFile.Virtual              => ""
+          case nir.SourceFile.Relative(pathString) => pathString
         }
       }
       putLebUnsignedInt(pos.line)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -486,11 +486,11 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         // initialising and returning an instance of the class, using C.
         for ((ctor, ctorIdx) <- ctors.zipWithIndex) {
           val ctorSig = genMethodSig(ctor)
-          val ctorArgsSig = ctorSig.args.map(_.mangle).mkString
+          val ctorSuffix = if (ctorIdx == 0) "" else s"$$$ctorIdx"
           implicit val pos: nir.Position = ctor.pos
 
           reflectiveInstantiationInfo += ReflectiveInstantiationBuffer(
-            fqSymId + ctorArgsSig
+            fqSymId + ctorSuffix
           )
           val reflInstBuffer = reflectiveInstantiationInfo.last
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
@@ -1,6 +1,6 @@
 package scala.scalanative.nscplugin
 
-import java.net.URI
+import java.nio.file.Path
 
 /** This trait allows to query all options to the ScalaNative Plugin
  *
@@ -16,4 +16,7 @@ trait ScalaNativeOptions {
    *  of JDK classes.
    */
   def genStaticForwardersForNonTopLevelObjects: Boolean
+
+  /** List of paths usd for relativization of source file positions */
+  def positionRelativizationPaths: Seq[Path]
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
@@ -7,6 +7,7 @@ import core._
 import Contexts._
 
 import java.net.URI
+import java.nio.file.Path
 
 class GenNIR(settings: GenNIR.Settings) extends PluginPhase {
   val phaseName = GenNIR.name
@@ -28,6 +29,10 @@ object GenNIR {
        *  this option can be used to opt in. This is necessary for
        *  implementations of JDK classes.
        */
-      genStaticForwardersForNonTopLevelObjects: Boolean = false
+      genStaticForwardersForNonTopLevelObjects: Boolean = false,
+
+      /** List of paths usd for relativization of source file positions
+       */
+      positionRelativizationPaths: Seq[Path] = Nil
   )
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -290,10 +290,10 @@ trait GenReflectiveInstantisation(using Context) {
     // initialising and returning an instance of the class, using C.
     for ((ctor, ctorIdx) <- ctors.zipWithIndex) {
       val ctorSig = genMethodSig(ctor)
-      val ctorArgsSig = ctorSig.args.map(_.mangle).mkString
       given nir.Position = ctor.span
+      val ctorSuffix = if (ctorIdx == 0) "" else s"$$$ctorIdx"
       given reflInstBuffer: ReflectiveInstantiationBuffer =
-        ReflectiveInstantiationBuffer(fqSymName.id + ctorArgsSig)
+        ReflectiveInstantiationBuffer(fqSymName.id + ctorSuffix)
 
       // Lambda generation consists of generating a class which extends
       // scala.runtime.AbstractFunction1, with an apply method that accepts

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -29,7 +29,9 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
 
   protected val defnNir = NirDefinitions.get
   protected val nirPrimitives = new NirPrimitives()
-  protected val positionsConversions = new NirPositions()
+  protected val positionsConversions = new NirPositions(
+    settings.positionRelativizationPaths
+  )
   protected val cachedMethodSig =
     collection.mutable.Map.empty[(Symbol, Boolean), nir.Type.Function]
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -720,12 +720,12 @@ object Settings {
       libraryDependencies += "org.scala-lang" % libraryName % scalaVersion.value,
       fetchScalaSource / artifactPath :=
         baseDirectory.value.getParentFile / "target" / "scalaSources" / scalaVersion.value,
-      scalacOptions ++= Seq(
-        // Create nir.SourceFile relative to Scala sources dir instead of root dir
-        // It should use -sourcepath for both, but it fails to compile under Scala 2
-        if (scalaVersion.value.startsWith("2.")) "-rootdir" else "-sourcepath",
-        (fetchScalaSource / artifactPath).value.toString
-      ),
+      // Create nir.SourceFile relative to Scala sources dir instead of root dir
+      // It should use -sourcepath for both, but it fails to compile under Scala 2
+      scalacOptions ++=
+        scalaNativeCompilerOptions(
+          s"positionRelativizationPaths:${crossTarget.value / "patched"};${(fetchScalaSource / artifactPath).value}"
+        ),
       // Scala.js original comment modified to clarify issue is Scala.js.
       /* Work around for https://github.com/scala-js/scala-js/issues/2649
        * We would like to always use `update`, but

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -188,6 +188,9 @@ object ScalaNativePluginInternal {
    *  times per project.
    */
   def scalaNativeConfigSettings(testConfig: Boolean): Seq[Setting[_]] = Seq(
+    scalacOptions += s"-P:scalanative:positionRelativizationPaths:${sourceDirectories.value
+        .map(_.absString())
+        .mkString(";")}",
     nativeLinkReleaseFull := Def
       .task {
         val sbtLogger = streams.value.log

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -188,9 +188,8 @@ object ScalaNativePluginInternal {
    *  times per project.
    */
   def scalaNativeConfigSettings(testConfig: Boolean): Seq[Setting[_]] = Seq(
-    scalacOptions += s"-P:scalanative:positionRelativizationPaths:${sourceDirectories.value
-        .map(_.absString())
-        .mkString(";")}",
+    scalacOptions +=
+      s"-P:scalanative:positionRelativizationPaths:${sourceDirectories.value.map(_.getAbsolutePath()).mkString(";")}",
     nativeLinkReleaseFull := Def
       .task {
         val sbtLogger = streams.value.log

--- a/tools/src/main/scala/scala/scalanative/codegen/SourceCodeCache.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/SourceCodeCache.scala
@@ -43,7 +43,7 @@ class SourceCodeCache(config: build.Config) {
   private val cwd = Paths.get(".").toRealPath()
 
   def findSources(
-      source: nir.SourceFile.SourceRootRelative,
+      source: nir.SourceFile.Relative,
       pos: nir.Position
   ): Option[Path] = {
     assert(

--- a/tools/src/main/scala/scala/scalanative/codegen/SourceCodeCache.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/SourceCodeCache.scala
@@ -2,9 +2,8 @@ package scala.scalanative
 package codegen
 
 import scala.scalanative.io.VirtualDirectory
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.nio.file.Files
+import java.nio.file._
+import java.nio.file.attribute.BasicFileAttributes
 import scala.collection.mutable
 import scala.collection.concurrent.TrieMap
 import scala.annotation.nowarn
@@ -41,6 +40,33 @@ class SourceCodeCache(config: build.Config) {
   private val loggedMissingSourcesForCp = mutable.Set.empty[Path]
 
   private val cwd = Paths.get(".").toRealPath()
+  private lazy val localSourceDirs = {
+    val directories = IndexedSeq.newBuilder[Path]
+    Files.walkFileTree(
+      cwd,
+      java.util.EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+      Integer.MAX_VALUE,
+      new SimpleFileVisitor[Path] {
+        override def visitFile(
+            file: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult = FileVisitResult.CONTINUE
+
+        override def preVisitDirectory(
+            dir: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult = {
+          val sourcesStream = Files.newDirectoryStream(dir, "*.scala")
+          val hasScalaSources =
+            try sourcesStream.iterator().hasNext()
+            finally sourcesStream.close()
+          if (hasScalaSources) directories += dir
+          FileVisitResult.CONTINUE
+        }
+      }
+    )
+    directories.result()
+  }
 
   def findSources(
       source: nir.SourceFile.Relative,
@@ -67,14 +93,6 @@ class SourceCodeCache(config: build.Config) {
           ).map(_.resolve(filename))
             .getOrElse(filename)
         }
-        @nowarn
-        def isLocalProject = {
-          import scala.collection.JavaConverters._
-          pos.nirSource.directory
-            .iterator()
-            .asScala
-            .exists(_.toString() == "target")
-        }
 
         // most-likely for external dependency
         def fromCorrespondingSourcesJar = classpathJarsSources
@@ -89,13 +107,16 @@ class SourceCodeCache(config: build.Config) {
             .find(Files.exists(_))
 
         // likekly for local sub-projects
-        def fromRelativePath =
-          if (!isLocalProject) None
-          else {
-            val projectSource = cwd.resolve(source.path)
-            if (Files.exists(projectSource)) Some(projectSource)
-            else None
-          }
+        def fromRelativePath = {
+          val filename = source.path.getFileName()
+          source.directory
+            .foldLeft(localSourceDirs.iterator) {
+              case (it, sourceRelativeDir) =>
+                it.filter(_.endsWith(sourceRelativeDir))
+            }
+            .map(_.resolve(filename))
+            .find(Files.exists(_))
+        }
 
         def fromCustomSourceRoots = {
           def asJar = customSourceRootJars.iterator
@@ -117,8 +138,8 @@ class SourceCodeCache(config: build.Config) {
         }
 
         fromCorrespondingSourcesJar
-          .orElse(fromRelativePath)
           .orElse(fromCustomSourceRoots)
+          .orElse(fromRelativePath)
           .orElse(fromAnySourcesJar)
           .orElse {
             if (loggedMissingSourcesForCp.add(pos.nirSource.directory))
@@ -189,12 +210,12 @@ class SourceCodeCache(config: build.Config) {
 
   private def sourcesJarToJar(sourcesJar: Path): Path = {
     sourcesJar.resolveSibling(
-      sourcesJar.getFileName().toString().stripPrefix("-sources.jar") + "jar"
+      sourcesJar.getFileName().toString().stripSuffix("-sources.jar") + "jar"
     )
   }
   private def jarToSourcesJar(sourcesJar: Path): Path = {
     sourcesJar.resolveSibling(
-      sourcesJar.getFileName().toString().stripPrefix(".jar") + "-sources.jar"
+      sourcesJar.getFileName().toString().stripSuffix(".jar") + "-sources.jar"
     )
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -73,13 +73,9 @@ object CodeGen {
       val outputDir = VirtualDirectory.real(outputDirPath)
       val sourceCodeCache = new SourceCodeCache(config)
 
-      def outputFileId(defn: nir.Defn): String = {
-        val nirSource = defn.pos.nirSource
-        if (nirSource.exists)
-          s"${nirSource.path.getParent()}"
-        else
-          EmptyPath
-      }
+      def outputFileId(defn: nir.Defn): String =
+        defn.pos.source.directory
+          .getOrElse(EmptyPath)
 
       // Partition into multiple LLVM IR files proportional to number
       // of available processesors. This prevents LLVM from optimizing

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -73,10 +73,10 @@ object CodeGen {
       val outputDir = VirtualDirectory.real(outputDirPath)
       val sourceCodeCache = new SourceCodeCache(config)
 
-      def sourceDirOf(defn: nir.Defn): String = {
+      def outputFileId(defn: nir.Defn): String = {
         val nirSource = defn.pos.nirSource
         if (nirSource.exists)
-          s"${nirSource.directory}:${nirSource.path.getParent()}"
+          s"${nirSource.path.getParent()}"
         else
           EmptyPath
       }
@@ -86,11 +86,11 @@ object CodeGen {
       // across IR module boundary unless LTO is turned on.
       def separate(): Future[Seq[Path]] =
         Future
-          .traverse(partitionBy(assembly, procs)(sourceDirOf).toSeq) {
+          .traverse(partitionBy(assembly, procs)(outputFileId).toSeq) {
             case (id, defns) =>
               Future {
                 val sorted = defns.sortBy(_.name)
-                Impl(env, sorted, sourceCodeCache).gen(id.toString, outputDir)
+                Impl(env, sorted, sourceCodeCache).gen(id.toString(), outputDir)
               }
           }
 
@@ -116,10 +116,10 @@ object CodeGen {
         // This will ensure that each LLVM IR file only references a single Scala source file,
         // which will prevent the Darwin linker failing to generate N_OSO symbols.
         Future
-          .traverse(assembly.groupBy(sourceDirOf).toSeq) {
-            case (dir, defns) =>
+          .traverse(assembly.groupBy(outputFileId).toSeq) {
+            case (id, defns) =>
               Future {
-                val hash = dir.hashCode().toHexString
+                val hash = id.hashCode().toHexString
                 val outFile = outputDirPath.resolve(s"$hash.ll")
                 val ownerDirectory = outFile.getParent()
 
@@ -132,7 +132,7 @@ object CodeGen {
                 } else {
                   assert(ownerDirectory.toFile.exists())
                   config.logger.debug(
-                    s"Content of directory in $dir has not changed, skiping generation of $hash.ll"
+                    s"Content of definitions in chunk '$id' has not changed, skipping generation of $hash.ll"
                   )
                   outFile
                 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -21,7 +21,7 @@ import scala.scalanative.linker.{
 import scala.scalanative.linker.ReachabilityAnalysis
 import scala.scalanative.util.ScopedVar
 import scala.scalanative.codegen.llvm.Metadata.conversions.optionWrapper
-import scala.scalanative.nir.SourceFile.SourceRootRelative
+import scala.scalanative.nir.SourceFile.Relative
 
 // scalafmt: { maxColumn = 100}
 trait MetadataCodeGen { self: AbstractCodeGen =>
@@ -210,8 +210,8 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
   def toDIFile(pos: nir.Position): DIFile = {
     pos.source
       .flatMap {
-        case source: SourceRootRelative => sourceCodeCache.findSources(source, pos)
-        case _                          => None
+        case source: Relative => sourceCodeCache.findSources(source, pos)
+        case _                => None
       }
       .map { sourcePath =>
         DIFile(


### PR DESCRIPTION
* Allows to define custom relativization paths - previous solution based on -sourcepath,-sourceroot could have impacted compilations (like it did in scalalib for Scala 2) and was not handling custom paths well (see scalalib and it's fetched/patched sources) 
* In codegen split files by directory and not be package - fixes again issue with reporting missing symbols on x86_64 macos when multiple packages were defined in the same file. 
* Rename `nir.SourceFile.SourceRootRelative` to `nir.SourceFile.Relative`
* In sbt prepopulate custom relativization paths by default using configured source directories.
* Fix generation of illegal names for reflective instantiation constructors - use index instead of mangled constructor signature.