### PR TITLE
Provide some missing method declarations for posixlib stdlib.scala

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
@@ -75,10 +75,6 @@ import scalanative.unsafe._
       comparator: CFuncPtr2[Ptr[Byte], Ptr[Byte], CInt]
   ): Unit = extern
 
-  // File management
-
-  def realpath(file_name: CString, resolved_name: CString): CString = extern
-
   // Macros
 
   @name("scalanative_exit_success")

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -13,6 +13,7 @@ import scala.scalanative.libc.stdio._
 import scala.scalanative.libc.stdlib._
 import scala.scalanative.libc.string._
 import scala.scalanative.nio.fs.FileHelpers
+import scala.scalanative.posix
 import scala.scalanative.posix.sys.stat
 import scala.scalanative.posix.unistd._
 import scala.scalanative.posix.{limits, unistd, utime}
@@ -299,7 +300,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
       fromCWideString(resolvedName, StandardCharsets.UTF_16LE)
     } else {
       val resolvedName: Ptr[Byte] = alloc[Byte](limits.PATH_MAX)
-      if (realpath(toCString(path), resolvedName) == null) {
+      if (posix.stdlib.realpath(toCString(path), resolvedName) == null) {
         throw new IOException(
           s"realpath can't resolve: ${fromCString(resolvedName)}"
         )

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -10,10 +10,9 @@ import scala.annotation.tailrec
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.libc._
 import scala.scalanative.libc.stdio._
-import scala.scalanative.libc.stdlib._
 import scala.scalanative.libc.string._
 import scala.scalanative.nio.fs.FileHelpers
-import scala.scalanative.posix
+import scala.scalanative.posix.stdlib._
 import scala.scalanative.posix.sys.stat
 import scala.scalanative.posix.unistd._
 import scala.scalanative.posix.{limits, unistd, utime}
@@ -300,7 +299,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
       fromCWideString(resolvedName, StandardCharsets.UTF_16LE)
     } else {
       val resolvedName: Ptr[Byte] = alloc[Byte](limits.PATH_MAX)
-      if (posix.stdlib.realpath(toCString(path), resolvedName) == null) {
+      if (realpath(toCString(path), resolvedName) == null) {
         throw new IOException(
           s"realpath can't resolve: ${fromCString(resolvedName)}"
         )

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
@@ -1,7 +1,9 @@
 package scala.scalanative
 package posix
 
-import scala.scalanative.unsafe.{CInt, CString, extern}
+import scala.scalanative.unsafe._
+
+import scalanative.posix.sys.types.size_t
 
 /** POSIX stdlib.h for Scala
  *
@@ -13,10 +15,119 @@ import scala.scalanative.unsafe.{CInt, CString, extern}
  *  Extension to the ISO C standard: The functionality described is an extension
  *  to the ISO C standard. Application developers may make use of an extension
  *  as it is supported on all POSIX.1-2017-conforming systems.
+ *
+ *  All the methods declared in this file and not libc.stdlib are Open Group
+ *  extensions to the ISO/IEC C standard.
+ *
+ *  A method with an XSI comment indicates it is defined in extended POSIX
+ *  X/Open System Interfaces, not base POSIX.
+ *
+ *  A method with an ADV comment indicates it Open Group 2018 "Advisory
+ *  Information" meaning, from the specification: "The functionality described
+ *  is optional. The functionality described is also an extension to the ISO C
+ *  standard."
  */
 @extern object stdlib extends stdlib
 
+/** posixlib stdlib is known to be incomplete. It contains the methods from the
+ *  Open Group 2028 specification but, not yet, all of the declarations. For an
+ *  incomplete example, he data types div_t, ldiv_t, lldiv_t returned by div() &
+ *  ldiv and the constants described in sys/wait.h are not defined.
+ */
 @extern trait stdlib extends libc.stdlib {
+
+  /** XSI */
+  def a64l(str64: CString): CLong = extern
+
+  /** XSI */
+  def drand48(): Double = extern
+
+  /** XSI */
+  def erand48(xsubi: Ptr[CUnsignedShort]): Double = extern
+
+  def getsubopt(
+      optionp: Ptr[CString],
+      tokens: Ptr[CString],
+      valuep: Ptr[CString]
+  ): CInt = extern
+
+  /** XSI */
+  def grantpt(fd: CInt): CInt = extern
+
+  /** XSI */
+  def initstate(
+      seed: CUnsignedInt,
+      state: Ptr[CChar],
+      size: size_t
+  ): Ptr[CChar] =
+    extern
+
+  /** XSI */
+  def jrand48(xsubi: Ptr[CUnsignedShort]): CLong = extern
+
+  /** XSI */
+  def l64a(value: CLong): CString = extern
+
+  /** XSI */
+  def lcong48(param: Ptr[CUnsignedShort]): Unit = extern
+
+  /** XSI */
+  def lrand48(): CLong = extern
+
+  def mkdtemp(template: CString): CString = extern
+
+  def mkstemp(template: CString): CInt = extern
+
+  /** XSI */
+  def mrand48(): CLong = extern
+
+  /** XSI */
+  def nrand48(xsubi: Ptr[CUnsignedShort]): CLong = extern
+
+  /** ADV */
+  def posix_memalign(
+      memptr: Ptr[Ptr[Byte]],
+      alignment: size_t,
+      size: size_t
+  ): CInt = extern
+
+  /** XSI */
+  def posix_openpt(flags: CInt): CInt = extern
+
+  /** XSI */
+  def ptsname(fd: CInt): CString = extern
+
+  /** XSI */
+  def putenv(string: CString): CInt = extern
+
+  // OB CX - not implemented
+  // int rand_r(unsigned *);
+
+  /** XSI */
+  def random(): CLong = extern
+
+  /** XSI */
+  def realpath(path: CString, resolved_path: CString): CString = extern
+
+  /** XSI */
+  def seed48(seed16v: Ptr[CUnsignedShort]): Ptr[CUnsignedShort] = extern
+
   def setenv(name: CString, value: CString, overwrite: CInt): CInt = extern
+
+  /** XSI */
+  def setkey(key: CString): Unit = extern
+
+  /** XSI */
+  def setstate(state: Ptr[CChar]): Ptr[CChar] = extern
+
+  /** XSI */
+  def srand48(seedval: CLong): Unit = extern
+
+  /** XSI */
+  def srandom(seed: CUnsignedInt): Unit = extern
+
+  /** XSI */
+  def unlockpt(fd: CInt): CInt = extern
+
   def unsetenv(name: CString): CInt = extern
 }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
@@ -1,0 +1,82 @@
+package org.scalanative.testsuite.posixlib
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.BeforeClass
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+import scala.scalanative.posix.stdlib
+
+import org.scalanative.testsuite.utils.Platform
+
+object StdlibTest {
+
+  @BeforeClass
+  def beforeClass(): Unit = {
+    assumeTrue(
+      "posixlib stdlib.scala is not implemented on Windows",
+      !Platform.isWindows
+    )
+  }
+}
+
+class StdlibTest {
+  /* Test some Open Group 2018 methods which have complicated argument
+   * declarations. That is, the ones which keep me awake at night, wondering
+   * if they will blow up on the first person who goes to use them.
+   *
+   * Also gives end users a working example of how to setup and use these
+   * methods.
+   */
+
+  @Test def testGetsubopt(): Unit = Zone { implicit z =>
+    val expectedNameValue = "SvantePääbo"
+    val expectedAccessValue = "ro"
+
+    val optionp = stackalloc[CString](2)
+
+    // optionp string must be mutable.
+    optionp(0) = toCString(
+      s"doNotFind,name=${expectedNameValue},access=${expectedAccessValue}"
+    )
+    // Last option, optionp(1) is already null, keep it that way.
+
+    val tokens = stackalloc[CString](4)
+
+    // Specification describes these as 'const'
+    tokens(0) = c"skip"
+    tokens(1) = c"access"
+    tokens(2) = c"name"
+    // Last token, tokens(3) is already null, keep it that way.
+
+    val valuep = stackalloc[CString]()
+
+    // Options not in tokens are not found, even at index 0.
+    val status_1 = stdlib.getsubopt(optionp, tokens, valuep)
+    assertEquals("Should not have found first option", -1, status_1)
+
+    // Options with tokens are found, even at an index offset > 0.
+    val status_name = stdlib.getsubopt(optionp, tokens, valuep)
+    assertEquals("failed to get 'name' option", 2, status_name)
+    assertNotNull("'name' value is NULL", valuep)
+    assertEquals(
+      "Unexpected 'name' value",
+      expectedNameValue,
+      fromCString(valuep(0))
+    )
+
+    // Do it again, to make sure pointer offsets are working properly.
+    val status_access = stdlib.getsubopt(optionp, tokens, valuep)
+    assertEquals("failed to get 'access' option", 1, status_access)
+    assertNotNull("'access' value is NULL", valuep)
+    assertEquals(
+      "Unexpected 'access' value",
+      expectedAccessValue,
+      fromCString(valuep(0))
+    )
+  }
+
+}

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
@@ -10,15 +10,16 @@ import scala.scalanative.unsigned._
 
 import scala.scalanative.posix.stdlib
 
+import scala.scalanative.meta.LinktimeInfo
 import org.scalanative.testsuite.utils.Platform
 
 object StdlibTest {
 
   @BeforeClass
   def beforeClass(): Unit = {
-    assumeTrue(
+    assumeFalse(
       "posixlib stdlib.scala is not implemented on Windows",
-      !Platform.isWindows
+      Platform.isWindows
     )
   }
 }
@@ -34,7 +35,7 @@ class StdlibTest {
 
   @Test def testGetsubopt(): Unit = {
 
-    if (!Platform.isWindows) Zone { implicit z =>
+    if (!LinktimeInfo.isWindows) Zone { implicit z =>
       val expectedNameValue = "SvantePääbo"
       val expectedAccessValue = "ro"
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
@@ -32,51 +32,54 @@ class StdlibTest {
    * methods.
    */
 
-  @Test def testGetsubopt(): Unit = Zone { implicit z =>
-    val expectedNameValue = "SvantePääbo"
-    val expectedAccessValue = "ro"
+  @Test def testGetsubopt(): Unit = {
 
-    val optionp = stackalloc[CString](2)
+    if (!Platform.isWindows) Zone { implicit z =>
+      val expectedNameValue = "SvantePääbo"
+      val expectedAccessValue = "ro"
 
-    // optionp string must be mutable.
-    optionp(0) = toCString(
-      s"doNotFind,name=${expectedNameValue},access=${expectedAccessValue}"
-    )
-    // Last option, optionp(1) is already null, keep it that way.
+      val optionp = stackalloc[CString](2)
 
-    val tokens = stackalloc[CString](4)
+      // optionp string must be mutable.
+      optionp(0) = toCString(
+        s"doNotFind,name=${expectedNameValue},access=${expectedAccessValue}"
+      )
+      // Last option, optionp(1) is already null, keep it that way.
 
-    // Specification describes these as 'const'
-    tokens(0) = c"skip"
-    tokens(1) = c"access"
-    tokens(2) = c"name"
-    // Last token, tokens(3) is already null, keep it that way.
+      val tokens = stackalloc[CString](4)
 
-    val valuep = stackalloc[CString]()
+      // Specification describes these as 'const'
+      tokens(0) = c"skip"
+      tokens(1) = c"access"
+      tokens(2) = c"name"
+      // Last token, tokens(3) is already null, keep it that way.
 
-    // Options not in tokens are not found, even at index 0.
-    val status_1 = stdlib.getsubopt(optionp, tokens, valuep)
-    assertEquals("Should not have found first option", -1, status_1)
+      val valuep = stackalloc[CString]()
 
-    // Options with tokens are found, even at an index offset > 0.
-    val status_name = stdlib.getsubopt(optionp, tokens, valuep)
-    assertEquals("failed to get 'name' option", 2, status_name)
-    assertNotNull("'name' value is NULL", valuep)
-    assertEquals(
-      "Unexpected 'name' value",
-      expectedNameValue,
-      fromCString(valuep(0))
-    )
+      // Options not in tokens are not found, even at index 0.
+      val status_1 = stdlib.getsubopt(optionp, tokens, valuep)
+      assertEquals("Should not have found first option", -1, status_1)
 
-    // Do it again, to make sure pointer offsets are working properly.
-    val status_access = stdlib.getsubopt(optionp, tokens, valuep)
-    assertEquals("failed to get 'access' option", 1, status_access)
-    assertNotNull("'access' value is NULL", valuep)
-    assertEquals(
-      "Unexpected 'access' value",
-      expectedAccessValue,
-      fromCString(valuep(0))
-    )
+      // Options with tokens are found, even at an index offset > 0.
+      val status_name = stdlib.getsubopt(optionp, tokens, valuep)
+      assertEquals("failed to get 'name' option", 2, status_name)
+      assertNotNull("'name' value is NULL", valuep)
+      assertEquals(
+        "Unexpected 'name' value",
+        expectedNameValue,
+        fromCString(valuep(0))
+      )
+
+      // Do it again, to make sure pointer offsets are working properly.
+      val status_access = stdlib.getsubopt(optionp, tokens, valuep)
+      assertEquals("failed to get 'access' option", 1, status_access)
+      assertNotNull("'access' value is NULL", valuep)
+      assertEquals(
+        "Unexpected 'access' value",
+        expectedAccessValue,
+        fromCString(valuep(0))
+      )
+    }
   }
 
 }


### PR DESCRIPTION
This PR provides some methods previously missing in posixlib stdlib.scala.

It is a reduction-in-strength partial fix to Issue #3650.  That Issue should remain open so that type declarations
missing from this PR eventually get added.

This PR removes impediments to fixing Issues #3690 and, eventually,  #3651.

###### Backporting: 
Because this PR moves/corrects the `realpath()` location from clib to posixlib, it is probably not an economic candidate
for backporting.
