### PR TITLE
Fix #3697: posixlib unit-tests now use JUnit BeforeClass more consistently

### DIFF
--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LocaleTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LocaleTest.scala
@@ -3,7 +3,7 @@ package org.scalanative.testsuite.posixlib
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.junit.{Before, After}
+import org.junit.{BeforeClass, AfterClass}
 
 import scala.scalanative.meta.LinktimeInfo.{isLinux, isWindows}
 
@@ -16,14 +16,16 @@ import scala.scalanative.posix.localeOps._
 import scala.scalanative.posix.stdlib
 import scala.scalanative.posix.string
 
-class LocaleTest {
-
-  // See also MonetaryTest.scala where number of locale methods are exercised.
-
+object LocaleTest {
   var savedLocale: Option[CString] = None
 
-  @Before
-  def before(): Unit = {
+  @BeforeClass
+  def beforeClass(): Unit = {
+    assumeTrue(
+      "locale.scala is not implemented on Windows",
+      !isWindows
+    )
+
     if (!isWindows) {
       val entryLocale = setlocale(LC_ALL, null)
       assertNotNull(
@@ -49,8 +51,8 @@ class LocaleTest {
     }
   }
 
-  @After
-  def after(): Unit = {
+  @AfterClass
+  def afterClass(): Unit = {
     if (!isWindows) {
       savedLocale.map { sl =>
         errno = 0
@@ -64,12 +66,15 @@ class LocaleTest {
       }
     }
   }
+}
+
+// See also MonetaryTest.scala where number of locale methods are exercised.
+
+class LocaleTest {
+
+  import LocaleTest.savedLocale
 
   @Test def localeconv_Using_en_US(): Unit = {
-    assumeTrue(
-      "locale.scala is not implemented on Windows",
-      !isWindows
-    )
 
     // Multi-arch CI tests do not have an en_US locale; warn not fail
     assumeTrue(

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/MonetaryTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/MonetaryTest.scala
@@ -3,7 +3,7 @@ package org.scalanative.testsuite.posixlib
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.junit.Before
+import org.junit.BeforeClass
 
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
@@ -20,15 +20,18 @@ import scala.scalanative.posix.errno.errno
 import scala.scalanative.posix.locale._
 import scala.scalanative.posix.monetary._
 
-class MonetaryTest {
+object MonetaryTest {
 
-  @Before
-  def before(): Unit = {
+  @BeforeClass
+  def beforeClass(): Unit = {
     assumeTrue(
       "monetary.scala is not implemented on Windows",
       !isWindows
     )
   }
+}
+
+class MonetaryTest {
 
   @Test def strfmon_l_Using_en_US(): Unit =
     if (!isWindows) {

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
@@ -3,7 +3,7 @@ package org.scalanative.testsuite.posixlib
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.junit.Before
+import org.junit.BeforeClass
 
 import java.io.IOException
 
@@ -26,23 +26,27 @@ import scala.scalanative.unsigned._
 import scala.scalanative.posix.time._
 import scala.scalanative.posix.timeOps.{timespecOps, tmOps}
 
-class TimeTest {
-  @Before
-  def before(): Unit = {
-    tzset()
+object TimeTest {
 
-    /* Many tests below use the "if (!isWindows)" idiom rather than one
-     * obvious and simpler, but wrong, assumption here:
-     *     assumeFalse("POSIX tests are not run on Windows", isWindows)
-     *
-     * The reason is that "isWindows" is a link time option which avoids
-     * linking "!isWindows" code. "assumeFalse()" is executed at runtime,
-     * after the link on Windows fails from missing symbols.
-     *
-     * A motivated developer could arrange for POSIX tests never to be
-     * compiled at all on Windows. A bigger task than today allows.
-     */
+  @BeforeClass
+  def beforeClass(): Unit = {
+    tzset()
   }
+}
+
+class TimeTest {
+
+  /* Many tests below use the "if (!isWindows)" idiom rather than one
+   * obvious and simpler, but wrong, assumption here:
+   *     assumeFalse("POSIX tests are not run on Windows", isWindows)
+   *
+   * The reason is that "isWindows" is a link time option which avoids
+   * linking "!isWindows" code. "assumeFalse()" is executed at runtime,
+   * after the link on Windows fails from missing symbols.
+   *
+   * A motivated developer could arrange for POSIX tests never to be
+   * compiled at all on Windows. A bigger task than today allows.
+   */
 
   // Note: both alloc & stackalloc clears allocated memory.
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/MsgIoSocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/MsgIoSocketTest.scala
@@ -26,15 +26,16 @@ import org.scalanative.testsuite.utils.Platform
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.junit.Before
+import org.junit.BeforeClass
 
 /** Exercise the POSIX socket.h sendmsg and recvmg routines.
  *
  *  Those functions do not exist on Windows.
  */
-class MsgIoSocketTest {
 
-  @Before
+object MsgIoSocketTest {
+
+  @BeforeClass
   def before(): Unit = {
     val isIPv4Available = hasLoopbackAddress(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
     assumeTrue("IPv4 UDP loopback is not available", isIPv4Available)
@@ -44,7 +45,9 @@ class MsgIoSocketTest {
       !isWindows
     )
   }
+}
 
+class MsgIoSocketTest {
   /* Percy Bysshe Shelly - Ozymandias - 1818
    * This poem is in the public domain.
    *

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/Udp6SocketTest.scala
@@ -27,11 +27,12 @@ import org.scalanative.testsuite.utils.Platform
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.junit.Before
+import org.junit.BeforeClass
 
-class Udp6SocketTest {
-  @Before
-  def before(): Unit = {
+object Udp6SocketTest {
+
+  @BeforeClass
+  def beforeClass(): Unit = {
     assumeTrue(
       "IPv6 UDP loopback is not available",
       hasLoopbackAddress(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
@@ -63,6 +64,9 @@ class Udp6SocketTest {
       )
     }
   }
+}
+
+class Udp6SocketTest {
 
   private def formatIn6addr(addr: in6_addr): String = Zone { implicit z =>
     val dstSize = INET6_ADDRSTRLEN + 1

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UdpSocketTest.scala
@@ -22,14 +22,17 @@ import scala.scalanative.windows.ErrorHandlingApi._
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.junit.Before
+import org.junit.BeforeClass
 
-class UdpSocketTest {
-  @Before
-  def before(): Unit = {
+object UdpSocketTest {
+  @BeforeClass
+  def beforeClass(): Unit = {
     val isIPv4Available = hasLoopbackAddress(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
     assumeTrue("IPv4 UDP loopback is not available", isIPv4Available)
   }
+}
+
+class UdpSocketTest {
 
   @Test def sendtoRecvfrom(): Unit = Zone { implicit z =>
     if (isWindows) {

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UioTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UioTest.scala
@@ -21,16 +21,12 @@ import scalanative.meta.LinktimeInfo.isWindows
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.junit.Before
+import org.junit.BeforeClass
 
-class UioTest {
-  /* writev() & readv() also work with files. Using sockets here makes
-   * it easier to eventually create a unit-test for socket-only methods
-   * sendmsg() & recvmsg() and to highlight the parallels.
-   */
+object UioTest {
 
-  @Before
-  def before(): Unit = {
+  @BeforeClass
+  def beforeClass(): Unit = {
     assumeTrue(
       "POSIX uio writev() & readv() are not available on Windows",
       !isWindows
@@ -39,6 +35,13 @@ class UioTest {
     val isIPv4Available = hasLoopbackAddress(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
     assumeTrue("IPv4 UDP loopback is not available", isIPv4Available)
   }
+}
+
+class UioTest {
+  /* writev() & readv() also work with files. Using sockets here makes
+   * it easier to eventually create a unit-test for socket-only methods
+   * sendmsg() & recvmsg() and to highlight the parallels.
+   */
 
   private def getConnectedUdp4LoopbackSockets()(implicit
       z: Zone


### PR DESCRIPTION
Fix #3697

Seven posixlib unit-tests now use JUnit BeforeClass so that setup is done once per class, not once
per Test. This consistency adds marginal runtime performance in the case were a class contains
more than one Test. The change is primarily done to aid future maintenance and to provide
a more consistent model for future Tests.