### PR TITLE
Fix #3672: Improve javalib java.net handling of NetworkInterface indices

### DIFF
--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -93,53 +93,6 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     portOpt.map(inet.ntohs(_).toInt)
   }
 
-  /* Fill in the given sockaddr_in6 with the given InetAddress, either
-   * Inet4Address or Inet6Address, and the given port.
-   * Set the af_family for IPv6.  On return, the sockaddr_in6 should
-   * be ready to use in bind() or connect().
-   *
-   * By contract, all the bytes in sa6 are zero coming in.
-   */
-  private def prepareSockaddrIn6(
-      inetAddress: InetAddress,
-      port: Int,
-      sa6: Ptr[in.sockaddr_in6]
-  ): Unit = {
-
-    /* BEWARE: This is Unix-only code.
-     *   Currently (2022-08-27) execution on Windows never get here. IPv4Only
-     *   is forced on.  If that ever changes, this method may need
-     *   Windows code.
-     *
-     *   Having the complexity in one place, it should make adding
-     *   Windows support easier.
-     */
-
-    sa6.sin6_family = socket.AF_INET6.toUShort
-    sa6.sin6_port = inet.htons(port.toUShort)
-
-    val src = inetAddress.getAddress()
-
-    if (inetAddress.isInstanceOf[Inet6Address]) {
-      val from = src.asInstanceOf[scala.scalanative.runtime.Array[Byte]].at(0)
-      val dst = sa6.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
-      memcpy(dst, from, 16.toUInt)
-    } else { // Use IPv4mappedIPv6 address
-      val dst = sa6.sin6_addr.toPtr.s6_addr
-
-      // By contract, the leading bytes are already zero already.
-      val FF = 255.toUByte
-      dst(10) = FF // set the IPv4mappedIPv6 indicator bytes
-      dst(11) = FF
-
-      // add the IPv4 trailing bytes, unrolling small loop
-      dst(12) = src(0).toUByte
-      dst(13) = src(1).toUByte
-      dst(14) = src(2).toUByte
-      dst(15) = src(3).toUByte
-    }
-  }
-
   private def bind4(addr: InetAddress, port: Int): Unit = {
     val hints = stackalloc[addrinfo]()
     val ret = stackalloc[Ptr[addrinfo]]()
@@ -174,7 +127,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     val sa6 = stackalloc[in.sockaddr_in6]()
 
     // By contract, all the bytes in sa6 are zero going in.
-    prepareSockaddrIn6(addr, port, sa6)
+    SocketHelpers.prepareSockaddrIn6(addr, port, sa6)
 
     val bindRes = socket.bind(
       fd.fd,
@@ -305,7 +258,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     val sa6 = stackalloc[in.sockaddr_in6]()
 
     // By contract, all the bytes in sa6 are zero going in.
-    prepareSockaddrIn6(insAddr.getAddress, insAddr.getPort, sa6)
+    SocketHelpers.prepareSockaddrIn6(insAddr.getAddress, insAddr.getPort, sa6)
 
     if (timeout != 0)
       setSocketFdBlocking(fd, blocking = false)


### PR DESCRIPTION
Fix #3672 

Most end users of java.net use IPv6 global addresses. This PR is for the few who use link-local addresses.

javalib java.net methods should now handle  IPv6 sin6_scope_ids, known to Java as `NetworkInterface` indices
so that a connection using an IPv6 link-local (FE80::) address should be accepted on by a server yielding 
an IPv6Address which can be used to connect back over the local link. That is, a round trip using
 link-local addresses should work.
