### PR TITLE
Fix #3707: javalib Inet6Address#hashCode is now more robust to null hostnames

### DIFF
--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -45,7 +45,8 @@ final class Inet6Address private (
   override def hashCode(): Int = {
     var res = 1
     res = 31 * res + ju.Arrays.hashCode(ipAddress)
-    res = 31 * res + host.hashCode()
+    if (host != null)
+      res = 31 * res + host.hashCode()
     res = 31 * res + useScopeId.hashCode()
     res = 31 * res + scopeId.hashCode()
     if (nif != null)

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -44,6 +44,7 @@ final class Inet6Address private (
 
   override def hashCode(): Int = {
     var res = 1
+    // Arrays.hashCode() returns 0 if ipAddress is null.
     res = 31 * res + ju.Arrays.hashCode(ipAddress)
     if (host != null)
       res = 31 * res + host.hashCode()


### PR DESCRIPTION
Fix #3707: 

javalib `Inet6Address#hashCode` is now more robust to null hostnames.