### PR TITLE
Fix #3705: java.net ServerSockets can now listen on both IPv6 & IPv4

### DIFF
--- a/javalib/src/main/scala/java/net/DatagramSocket.scala
+++ b/javalib/src/main/scala/java/net/DatagramSocket.scala
@@ -98,7 +98,7 @@ class DatagramSocket protected (
     val inetAddr =
       if (addr == null ||
           addr.asInstanceOf[InetSocketAddress].getAddress == null)
-        new InetSocketAddress(InetAddress.getLoopbackAddress(), 0)
+        new InetSocketAddress(SocketHelpers.getWildcardAddressForBind(), 0)
       else {
         addr.asInstanceOf[InetSocketAddress]
       }

--- a/javalib/src/main/scala/java/net/Socket.scala
+++ b/javalib/src/main/scala/java/net/Socket.scala
@@ -137,7 +137,7 @@ class Socket protected (
     val addr =
       if (bindpoint == null ||
           bindpoint.asInstanceOf[InetSocketAddress].getAddress == null)
-        new InetSocketAddress(InetAddress.getLoopbackAddress(), 0)
+        new InetSocketAddress(SocketHelpers.getWildcardAddressForBind(), 0)
       else {
         bindpoint.asInstanceOf[InetSocketAddress]
       }

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -12,6 +12,7 @@ import scala.scalanative.posix.sys.socket._
 import scala.scalanative.posix.sys.socketOps._
 import scala.scalanative.posix.string.memcpy
 
+import scala.scalanative.meta.LinktimeInfo
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
 import scala.scalanative.windows.WinSocketApiOps
@@ -372,6 +373,21 @@ object SocketHelpers {
   private[net] def getWildcardAddress(): InetAddress = {
     if (useWildcardIPv6) wildcardIPv6()
     else wildcardIPv4()
+  }
+
+  /* Return the wildcard address corresponding directly to the IP stack in use.
+   * This address has not been selected by getPreferIPv6Addresses().
+   *
+   * This section will need to be revisited as more robust FreeBSD support
+   * is added.  The assumption here is that FreeBSD always returns the
+   * IPv4 wildcard. That assumption/guess needs to be verified.
+   * FreeBSD & NetBSD are reported to separate IPv4 & IPv6 stacks.
+   */
+
+  private[net] def getWildcardAddressForBind(): InetAddress = {
+    if (LinktimeInfo.isFreeBSD) wildcardIPv4()
+    else if (useIPv4Stack) wildcardIPv4()
+    else wildcardIPv6()
   }
 
 }


### PR DESCRIPTION
Fix #3705

When the configuration allows  `java.net ServerSockets` on Linux & maxOS can now listen on both IPv6 & IPv4
when a null address is given, implicitly or explicitly.

On FreeBSD, the "pick one" implied by the null address always listens on the IPv4 wildcard address.

Behavior on Windows needs to be determined. It follows the JDK specification of "pick one" but the
address chosen by Scala Native may not be the same as the one chosen by Scala JVM.


The short answer is if you want the results you expect, always choose a constructor which
allows you to specify the address and eschew nulls, implicit or explicit.