### PR TITLE
Fix #3706: java.net.ServerSocket now reports local address of accepted socket correctly

### DIFF
--- a/javalib/src/main/scala/java/net/ServerSocket.scala
+++ b/javalib/src/main/scala/java/net/ServerSocket.scala
@@ -56,7 +56,7 @@ class ServerSocket(
     s.port = s.impl.port
     s.localPort = s.impl.localport
     s.addr = s.impl.address
-    s.localAddr = SocketHelpers.fetchFdLocalAddress(s.impl.fd)
+    s.localAddr = SocketHelpers.fetchFdLocalAddress(s.impl.fd.fd)
 
     s.created = true
     s.bound = true

--- a/javalib/src/main/scala/java/net/ServerSocket.scala
+++ b/javalib/src/main/scala/java/net/ServerSocket.scala
@@ -56,7 +56,7 @@ class ServerSocket(
     s.port = s.impl.port
     s.localPort = s.impl.localport
     s.addr = s.impl.address
-    s.localAddr = this.bindAddr
+    s.localAddr = SocketHelpers.fetchFdLocalAddress(s.impl.fd)
 
     s.created = true
     s.bound = true

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -392,15 +392,15 @@ object SocketHelpers {
     else wildcardIPv6()
   }
 
-  private[net] def fetchFdLocalAddress(fd: FileDescriptor): InetAddress = {
+  private[net] def fetchFdLocalAddress(osFd: Int): InetAddress = {
+    // allocate largest possible buffer, then pass generic overlay 'sin' to C.
     val storage = stackalloc[socket.sockaddr_storage]()
     val sin = storage.asInstanceOf[Ptr[socket.sockaddr]]
-    val address = storage.asInstanceOf[Ptr[socket.sockaddr]]
     val addressLen = stackalloc[socket.socklen_t]()
     !addressLen = sizeof[in.sockaddr_in6].toUInt
 
     if (socket.getsockname(
-          fd.fd,
+          osFd,
           sin,
           addressLen
         ) == -1) {


### PR DESCRIPTION
Fix #3706

`java.net.ServerSocket#accept` now correctly sets the local address of the Socket it returns.
This means that `Socket` now reports the correct/expected address.

 Previously it had been reporting the "any" or "wildcard" address `0.0.0.0` or its IPv6 equivalent.