### PR TITLE
Fix #3540: FreeBSD test-all now runs to successful completion

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -107,11 +107,6 @@ installation of FreeBSD.
 *Note 3:* Using the boehm GC with multi-threaded binaries doesn't work
 out-of-the-box yet.
 
-*Note 4:* A number of tests, primarily unit-tests, are known to fail
-or not terminate on FreeBSD. It is believed that the code-under-test
-is correct and that the defect is in the test itself.
-Work is underway to fix these tests.
-
 **Nix/NixOS**
 
 .. code-block:: shell

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -31,8 +31,9 @@ final class Inet6Address private (
    */
 
   override def equals(that: Any): Boolean = that match {
-    case that: Inet6Address => this.hashCode() == that.hashCode()
-    case _                  => false
+    case that: Inet6Address =>
+      (that != null) && (this.hashCode() == that.hashCode())
+    case _ => false
   }
 
   def getScopedInterface(): NetworkInterface = nif
@@ -58,13 +59,21 @@ final class Inet6Address private (
   override def isLinkLocalAddress(): Boolean =
     (ipAddress(0) == -2) && ((ipAddress(1) & 255) >>> 6) == 2
 
-  override def isAnyLocalAddress(): Boolean = ipAddress.forall(_ == 0)
+  // avoid cost of functional style forall().
+  private def sumByteRange(bytes: Array[Byte], start: Int, end: Int): Int = {
+    // "end" is Java style exclusive, i.e. one past active range.
+    var count = 0
+    for (j <- start until end)
+      count += bytes(j)
+    count
+  }
+
+  override def isAnyLocalAddress(): Boolean =
+    sumByteRange(ipAddress, 0, 16) == 0
 
   override def isLoopbackAddress(): Boolean = {
-    if (ipAddress(15) != 1)
-      return false
-
-    ipAddress.dropRight(1).forall(_ == 0)
+    if ((ipAddress(0) != 0) || (ipAddress(15) != 1)) false
+    else sumByteRange(ipAddress, 2, 15) == 0
   }
 
   override def isMCGlobal(): Boolean =
@@ -87,16 +96,18 @@ final class Inet6Address private (
   override def isSiteLocalAddress(): Boolean =
     (ipAddress(0) == -2) && ((ipAddress(1) & 255) >>> 6) == 3
 
-  def isIPv4CompatibleAddress(): Boolean = ipAddress.take(12).forall(_ == 0)
+  def isIPv4CompatibleAddress(): Boolean =
+    sumByteRange(ipAddress, 0, 12) == 0
 
   private def formatScopeId(): String = {
     if (nif != null)
       nif.getDisplayName()
-    else if (useScopeId) {
+    else if (!useScopeId) ""
+    else {
       val netIf = NetworkInterface.getByIndex(scopeId)
       if (netIf == null) String.valueOf(scopeId)
       else netIf.getDisplayName()
-    } else ""
+    }
   }
 
 }

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -743,7 +743,7 @@ object InetAddress {
          *   to creating an InetAddress using the hostname and the IPv4
          *   loopback address 127.0.0.1.  Be robust and do the same here.
          */
-        case e: UnknownHostException => SocketHelpers.loopbackIPv4()
+        case e: UnknownHostException => SocketHelpers.loopbackIPv4
       }
     }
   }

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -323,20 +323,22 @@ object SocketHelpers {
     new InetSocketAddress(addr, port)
   }
 
-  // Create copies of loopback & wildcard, so that originals never get changed
+  /* InetAddress() & Inet6Address() make defensive copies of the Array[Byte].
+   * As a result, these originals can never get changed.
+   */
 
   // ScalaJVM shows loopbacks with null host, wildcards with numeric host.
-  private[net] def loopbackIPv4(): InetAddress =
+  private[net] lazy val loopbackIPv4: InetAddress =
     InetAddress.getByAddress(Array[Byte](127, 0, 0, 1))
 
-  private[net] def loopbackIPv6(): InetAddress = InetAddress.getByAddress(
+  private[net] lazy val loopbackIPv6: InetAddress = InetAddress.getByAddress(
     Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
   )
 
-  private def wildcardIPv4(): InetAddress =
+  private lazy val wildcardIPv4: InetAddress =
     InetAddress.getByAddress("0.0.0.0", Array[Byte](0, 0, 0, 0))
 
-  private def wildcardIPv6(): InetAddress = InetAddress.getByAddress(
+  private lazy val wildcardIPv6: InetAddress = InetAddress.getByAddress(
     "0:0:0:0:0:0:0:0",
     Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
   )
@@ -360,8 +362,8 @@ object SocketHelpers {
   }
 
   private[net] def getLoopbackAddress(): InetAddress = {
-    if (useLoopbackIPv6) loopbackIPv6()
-    else loopbackIPv4()
+    if (useLoopbackIPv6) loopbackIPv6
+    else loopbackIPv4
   }
 
   private lazy val useWildcardIPv6: Boolean = {
@@ -373,8 +375,8 @@ object SocketHelpers {
   }
 
   private[net] def getWildcardAddress(): InetAddress = {
-    if (useWildcardIPv6) wildcardIPv6()
-    else wildcardIPv4()
+    if (useWildcardIPv6) wildcardIPv6
+    else wildcardIPv4
   }
 
   /* Return the wildcard address corresponding directly to the IP stack in use.
@@ -387,9 +389,9 @@ object SocketHelpers {
    */
 
   private[net] def getWildcardAddressForBind(): InetAddress = {
-    if (LinktimeInfo.isFreeBSD) wildcardIPv4()
-    else if (useIPv4Stack) wildcardIPv4()
-    else wildcardIPv6()
+    if (LinktimeInfo.isFreeBSD) wildcardIPv4
+    else if (useIPv4Stack) wildcardIPv4
+    else wildcardIPv6
   }
 
   private[net] def fetchFdLocalAddress(osFd: Int): InetAddress = {

--- a/scripted-tests/run/build-library-dynamic/src/main/c/testlib.cpp
+++ b/scripted-tests/run/build-library-dynamic/src/main/c/testlib.cpp
@@ -42,17 +42,18 @@ int main() {
     }
     assert(exceptionCaught);
 
-#ifndef __APPLE__
-    // For some unknown reason on macOS our exception wrapper is not being
-    // caught. It works fine on Linux and Windows however.
-    // It's still possible to catch std::exception though
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+    // For some unknown reason on macOS or FreeBSD our exception wrapper is
+    // not being caught. It works fine on Linux and Windows however.
+    // It's still possible to catch std::exception though.
+
     exceptionCaught = false;
     try {
         fail();
     } catch (const scalanative::ExceptionWrapper &e) {
         exceptionCaught = true;
     }
-    assert(exceptionCaught);
+    assert(("exceptionCaught", exceptionCaught));
 #endif
 
     return 0;

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/MonetaryTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/MonetaryTest.scala
@@ -77,6 +77,8 @@ class MonetaryTest {
 
         val expected = if (Platform.isLinux()) {
           "[ $**1234.57] [ USD **1,234.57]"
+        } else if (Platform.isFreeBSD()) {
+          "[ **1234.57 ] [ **1234.57 ]"
         } else {
           "[ $**1234.57] [ USD**1,234.57]"
         }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/ResourceTest.scala
@@ -51,9 +51,9 @@ class ResourceTest {
 
     // Most operating systems will return EINVAL. Handle corner cases here.
     if (errno != EINVAL) {
-      if (!Platform.isLinux()) {
+      if (!(Platform.isLinux() || Platform.isFreeBSD())) {
         assertEquals("unexpected errno", EINVAL, errno)
-      } else if (errno != 0) { // Linux
+      } else if (errno != 0) { // Linux, FreeBSD
         // A pid of UInt.MaxValue is highly unlikely but, by one reading,
         // possible. If it exists and is found, it should not cause this test
         // to fail, just to be specious (have false look of genuineness).

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/NetworkInterfaceTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/NetworkInterfaceTest.scala
@@ -5,6 +5,7 @@ import java.net._
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
+import org.junit.BeforeClass
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform
@@ -20,23 +21,36 @@ import org.scalanative.testsuite.utils.Platform
  *       editing to reflect that local configuration.
  */
 
+object NetworkInterfaceTest {
+  @BeforeClass
+  def beforeClass(): Unit = {
+
+    assumeFalse("Not implemented in Windows", Platform.isWindows)
+  }
+}
+
 class NetworkInterfaceTest {
 
-  val localhostIf =
+  val loopbackIfName =
     if (Platform.isLinux) "lo"
     else "lo0"
 
+  val loopbackIfIndex =
+    if (Platform.isFreeBSD) 2
+    else 1
+
   val osIPv6LoopbackSuffix =
-    s":0:0:0:0:0:0:1%${localhostIf}"
+    s":0:0:0:0:0:0:1%${loopbackIfName}"
 
   val osIPv6LoopbackAddress =
-    if (Platform.isMacOs) s"fe80${osIPv6LoopbackSuffix}"
-    else s"0${osIPv6LoopbackSuffix}"
+    if ((Platform.isMacOs) || (Platform.isFreeBSD))
+      s"fe80${osIPv6LoopbackSuffix}"
+    else
+      s"0${osIPv6LoopbackSuffix}"
 
 // Test static (object) methods
 
   @Test def getByIndexMinusTwo(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
     assertThrows(
       "getByIndex(-2)",
       classOf[IllegalArgumentException],
@@ -45,29 +59,27 @@ class NetworkInterfaceTest {
   }
 
   @Test def getByIndexZero(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
     assertNull(NetworkInterface.getByIndex(0))
   }
 
   @Test def getByIndexOne(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-    val netIf = NetworkInterface.getByIndex(1) // loopback
+    val netIf = NetworkInterface.getByIndex(1)
 
     assertNotNull("a1", netIf)
 
-    val sought = localhostIf
+    val sought =
+      if (Platform.isFreeBSD) "em0"
+      else loopbackIfName
     val ifName = netIf.getName()
     assertEquals("a2", sought, ifName)
   }
 
   @Test def getByIndexMaxValue(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
     val netIf = NetworkInterface.getByIndex(Integer.MAX_VALUE)
     assertNull("Unlikely interface found for MAX_VALUE index", netIf)
   }
 
   @Test def getByInetAddressNull(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
     assertThrows(
       "getByInetAddress(null)",
       classOf[NullPointerException],
@@ -76,34 +88,31 @@ class NetworkInterfaceTest {
   }
 
   @Test def getByInetAddressLoopbackIPv4(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
     val lba4 = InetAddress.getByName("127.0.0.1")
 
     val netIf = NetworkInterface.getByInetAddress(lba4)
 
     assertNotNull("a1", netIf)
 
-    val sought = localhostIf
+    val sought = loopbackIfName
     val ifName = netIf.getName()
     assertEquals("a1", sought, ifName)
   }
 
   @Test def getByInetAddressLoopbackIPv6(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
     val lba6 = InetAddress.getByName("::1")
 
     val netIf = NetworkInterface.getByInetAddress(lba6)
 
     // Do not fail on null. IPv6 might not be enabled on the system.
     if (netIf != null) {
-      val sought = localhostIf
+      val sought = loopbackIfName
       val ifName = netIf.getName()
       assertEquals("a1", sought, ifName)
     }
   }
 
   @Test def getByNameNull(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
     assertThrows(
       "getByName(null)",
       classOf[NullPointerException],
@@ -112,9 +121,7 @@ class NetworkInterfaceTest {
   }
 
   @Test def getByName(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val sought = localhostIf
+    val sought = loopbackIfName
     val netIf = NetworkInterface.getByName(sought)
     assertNotNull(netIf)
 
@@ -124,9 +131,7 @@ class NetworkInterfaceTest {
   }
 
   @Test def testToString(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val netIf = NetworkInterface.getByIndex(1) // loopback
+    val netIf = NetworkInterface.getByIndex(loopbackIfIndex)
     assertNotNull(netIf)
 
     val ifName = netIf.getName()
@@ -138,8 +143,6 @@ class NetworkInterfaceTest {
   }
 
   @Test def getNetworkInterfaces(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
     val netIfs = NetworkInterface.getNetworkInterfaces()
     assertNotNull(netIfs)
 
@@ -157,11 +160,9 @@ class NetworkInterfaceTest {
 // Test instance methods
 
   @Test def instanceGetIndex(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val lbIf1 = NetworkInterface.getByName(localhostIf)
+    val lbIf1 = NetworkInterface.getByName(loopbackIfName)
     assertNotNull(lbIf1)
-    assertEquals(1, lbIf1.getIndex())
+    assertEquals(loopbackIfIndex, lbIf1.getIndex())
   }
 
   /*  @Test def instanceGetHardwareAddress(): Unit = {
@@ -171,9 +172,7 @@ class NetworkInterfaceTest {
    */
 
   @Test def instanceGetMTU(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val lbIf = NetworkInterface.getByName(localhostIf)
+    val lbIf = NetworkInterface.getByName(loopbackIfName)
     assertNotNull(lbIf)
 
     val mtu = lbIf.getMTU()
@@ -184,47 +183,36 @@ class NetworkInterfaceTest {
   }
 
   @Test def instanceIsLoopback(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val lbIf = NetworkInterface.getByName(localhostIf)
+    val lbIf = NetworkInterface.getByName(loopbackIfName)
     assertNotNull(lbIf)
     assertEquals("a1", true, lbIf.isLoopback())
   }
 
   @Test def instanceIsPoinToPoint(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val lbIf = NetworkInterface.getByName(localhostIf)
+    val lbIf = NetworkInterface.getByName(loopbackIfName)
     assertNotNull(lbIf)
     assertEquals("a1", false, lbIf.isPointToPoint())
   }
 
   @Test def instanceIsUp(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val lbIf = NetworkInterface.getByName(localhostIf)
+    val lbIf = NetworkInterface.getByName(loopbackIfName)
     assertNotNull(lbIf)
     assertEquals("a1", true, lbIf.isUp())
   }
 
   @Test def instanceSupportsMulticast(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val lbIf = NetworkInterface.getByName(localhostIf)
+    val lbIf = NetworkInterface.getByName(loopbackIfName)
     assertNotNull(lbIf)
 
     val expected =
-      if (Platform.isMacOs) true
+      if ((Platform.isMacOs) || (Platform.isFreeBSD)) true
       else false // Linux
-    // else (FreeBSD?)
 
     assertEquals("a1", expected, lbIf.supportsMulticast())
   }
 
   @Test def instanceGetInetAddresses(): Unit = {
-    assumeFalse("Not implemented in Windows", Platform.isWindows)
-
-    val lbIf = NetworkInterface.getByName(localhostIf)
+    val lbIf = NetworkInterface.getByName(loopbackIfName)
     assertNotNull(lbIf)
 
     val iaEnumeration = lbIf.getInetAddresses()
@@ -239,7 +227,9 @@ class NetworkInterfaceTest {
         if (!hostAddr.contains(":")) {
           "127.0.0.1"
         } else if (hostAddr.startsWith("0")) {
-          s"0:0:0:0:0:0:0:1%${localhostIf}"
+          val stem = "0:0:0:0:0:0:0:1"
+          if (Platform.isFreeBSD) stem
+          else s"${stem}%${loopbackIfName}"
         } else if (hostAddr.startsWith("f")) {
           s"${osIPv6LoopbackAddress}"
         } else "" // fail in a way that will print out ifAddrString


### PR DESCRIPTION
Fix #3540

`test-all` and it components `test-tools`, `test-runtime`, and `test-scripted` now run to a successful completion.

The entire run took about 32 minutes on a slow FreeBSD 14 system. As on macOS & Linux, there are several
long (many second) pauses in `test-tools`, so one must be patient. Some things can not be rushed.

Most of the changes were to change Tests so that they followed FreeBSD configuration (e.g. 
network device names & order). The underlying code was performing correctly.

javalib `InterfaceAddress` and `NetworkInterface` were edited to follow FreeBSD practice of
not displaying NetworkInterface indices on IPv6 Global or "special" (loopback, etc). addresses.