### PR TITLE
Improvement: Improve ByteBuffers performance

### DIFF
--- a/javalib/src/main/scala/java/nio/Buffer.scala
+++ b/javalib/src/main/scala/java/nio/Buffer.scala
@@ -14,9 +14,9 @@ abstract class Buffer private[nio] (
     type ElementType = Buffer.this.ElementType
   }
 
-  // TODO: Teach optimizer to conver Ptr[A].asInstanceOf[Ptr[B]] as identitye2
+  // TODO: Teach optimizer to convert Ptr[A].asInstanceOf[Ptr[B]] as identity
   // Keep only RawPtr as field, this way optimizer would erase boxed variant
-  private val _rawAddress = toRawPtr(_address)
+  protected val _rawAddress = toRawPtr(_address)
   private[nio] def address: unsafe.Ptr[Byte] = fromRawPtr(_rawAddress)
   private[nio] def data: unsafe.Ptr[ElementType] = fromRawPtr(_rawAddress)
 

--- a/javalib/src/main/scala/java/nio/Buffer.scala
+++ b/javalib/src/main/scala/java/nio/Buffer.scala
@@ -2,13 +2,23 @@ package java.nio
 
 // Ported from Scala.js
 import scala.scalanative.unsafe
+import scala.scalanative.runtime.{toRawPtr, fromRawPtr}
 
-abstract class Buffer private[nio] (val _capacity: Int) {
+abstract class Buffer private[nio] (
+    val _capacity: Int,
+    _address: unsafe.Ptr[_]
+) {
   private[nio] type ElementType
 
   private[nio] type BufferType >: this.type <: Buffer {
     type ElementType = Buffer.this.ElementType
   }
+
+  // TODO: Teach optimizer to conver Ptr[A].asInstanceOf[Ptr[B]] as identitye2
+  // Keep only RawPtr as field, this way optimizer would erase boxed variant
+  private val _rawAddress = toRawPtr(_address)
+  private[nio] def address: unsafe.Ptr[Byte] = fromRawPtr(_rawAddress)
+  private[nio] def data: unsafe.Ptr[ElementType] = fromRawPtr(_rawAddress)
 
   // Normal implementation of Buffer
 
@@ -127,15 +137,6 @@ abstract class Buffer private[nio] (val _capacity: Int) {
 
   // PointerByteBuffer specific
   private[nio] def _rawDataPointer: unsafe.Ptr[Byte] = null
-
-  private[nio] def address: unsafe.Ptr[Byte] =
-    if (_rawDataPointer != null) _rawDataPointer + _offset
-    else if (_mappedData != null) _mappedData.data + _offset
-    else
-      _array
-        .asInstanceOf[scalanative.runtime.Array[_]]
-        .atUnsafe(_offset)
-        .asInstanceOf[unsafe.Ptr[Byte]]
 
   // HeapByteBuffer specific
   private[nio] def _byteArray: Array[Byte] =

--- a/javalib/src/main/scala/java/nio/Buffers.scala
+++ b/javalib/src/main/scala/java/nio/Buffers.scala
@@ -52,9 +52,13 @@ abstract class ByteBuffer private[nio] (
 
   def asReadOnlyBuffer(): ByteBuffer
 
-  def get(): Byte
+  def get(): Byte = load(getPosAndAdvanceRead())
 
-  def put(b: Byte): ByteBuffer
+  def put(elem: Byte): ByteBuffer ={
+    ensureNotReadOnly()
+    store(getPosAndAdvanceWrite(), elem)
+    this
+  }
 
   def get(index: Int): Byte = load(validateIndex(index))
 
@@ -234,10 +238,10 @@ abstract class ByteBuffer private[nio] (
   // Internal API
   override private[nio] def isBigEndian: Boolean = _isBigEndian
 
-  // @inline
+  @inline
   private[nio] def load(index: Int): Byte = this.data(index)
 
-  // @inline
+  @inline
   private[nio] def store(index: Int, elem: Byte): Unit = this.data(index) = elem
 
   @inline
@@ -309,9 +313,13 @@ abstract class CharBuffer private[nio] (
 
   def asReadOnlyBuffer(): CharBuffer
 
-  def get(): Char
+  def get(): Char = load(getPosAndAdvanceRead())
 
-  def put(b: Char): CharBuffer
+  def put(elem: Char): CharBuffer ={
+    ensureNotReadOnly()
+    store(getPosAndAdvanceWrite(), elem)
+    this
+  }
 
   def get(index: Int): Char = load(validateIndex(index))
 
@@ -469,10 +477,10 @@ abstract class CharBuffer private[nio] (
 
   // Internal API
 
-  // @inline
+  @inline
   private[nio] def load(index: Int): Char = this.data(index)
 
-  // @inline
+  @inline
   private[nio] def store(index: Int, elem: Char): Unit = this.data(index) = elem
 
   @inline
@@ -537,9 +545,13 @@ abstract class ShortBuffer private[nio] (
 
   def asReadOnlyBuffer(): ShortBuffer
 
-  def get(): Short
+  def get(): Short = load(getPosAndAdvanceRead())
 
-  def put(b: Short): ShortBuffer
+  def put(elem: Short): ShortBuffer ={
+    ensureNotReadOnly()
+    store(getPosAndAdvanceWrite(), elem)
+    this
+  }
 
   def get(index: Int): Short = load(validateIndex(index))
 
@@ -649,10 +661,10 @@ abstract class ShortBuffer private[nio] (
 
   // Internal API
 
-  // @inline
+  @inline
   private[nio] def load(index: Int): Short = this.data(index)
 
-  // @inline
+  @inline
   private[nio] def store(index: Int, elem: Short): Unit = this.data(index) = elem
 
   @inline
@@ -717,9 +729,13 @@ abstract class IntBuffer private[nio] (
 
   def asReadOnlyBuffer(): IntBuffer
 
-  def get(): Int
+  def get(): Int = load(getPosAndAdvanceRead())
 
-  def put(b: Int): IntBuffer
+  def put(elem: Int): IntBuffer ={
+    ensureNotReadOnly()
+    store(getPosAndAdvanceWrite(), elem)
+    this
+  }
 
   def get(index: Int): Int = load(validateIndex(index))
 
@@ -829,10 +845,10 @@ abstract class IntBuffer private[nio] (
 
   // Internal API
 
-  // @inline
+  @inline
   private[nio] def load(index: Int): Int = this.data(index)
 
-  // @inline
+  @inline
   private[nio] def store(index: Int, elem: Int): Unit = this.data(index) = elem
 
   @inline
@@ -897,9 +913,13 @@ abstract class LongBuffer private[nio] (
 
   def asReadOnlyBuffer(): LongBuffer
 
-  def get(): Long
+  def get(): Long = load(getPosAndAdvanceRead())
 
-  def put(b: Long): LongBuffer
+  def put(elem: Long): LongBuffer ={
+    ensureNotReadOnly()
+    store(getPosAndAdvanceWrite(), elem)
+    this
+  }
 
   def get(index: Int): Long = load(validateIndex(index))
 
@@ -1009,10 +1029,10 @@ abstract class LongBuffer private[nio] (
 
   // Internal API
 
-  // @inline
+  @inline
   private[nio] def load(index: Int): Long = this.data(index)
 
-  // @inline
+  @inline
   private[nio] def store(index: Int, elem: Long): Unit = this.data(index) = elem
 
   @inline
@@ -1077,9 +1097,13 @@ abstract class FloatBuffer private[nio] (
 
   def asReadOnlyBuffer(): FloatBuffer
 
-  def get(): Float
+  def get(): Float = load(getPosAndAdvanceRead())
 
-  def put(b: Float): FloatBuffer
+  def put(elem: Float): FloatBuffer ={
+    ensureNotReadOnly()
+    store(getPosAndAdvanceWrite(), elem)
+    this
+  }
 
   def get(index: Int): Float = load(validateIndex(index))
 
@@ -1189,10 +1213,10 @@ abstract class FloatBuffer private[nio] (
 
   // Internal API
 
-  // @inline
+  @inline
   private[nio] def load(index: Int): Float = this.data(index)
 
-  // @inline
+  @inline
   private[nio] def store(index: Int, elem: Float): Unit = this.data(index) = elem
 
   @inline
@@ -1257,9 +1281,13 @@ abstract class DoubleBuffer private[nio] (
 
   def asReadOnlyBuffer(): DoubleBuffer
 
-  def get(): Double
+  def get(): Double = load(getPosAndAdvanceRead())
 
-  def put(b: Double): DoubleBuffer
+  def put(elem: Double): DoubleBuffer ={
+    ensureNotReadOnly()
+    store(getPosAndAdvanceWrite(), elem)
+    this
+  }
 
   def get(index: Int): Double = load(validateIndex(index))
 
@@ -1369,10 +1397,10 @@ abstract class DoubleBuffer private[nio] (
 
   // Internal API
 
-  // @inline
+  @inline
   private[nio] def load(index: Int): Double = this.data(index)
 
-  // @inline
+  @inline
   private[nio] def store(index: Int, elem: Double): Unit = this.data(index) = elem
 
   @inline

--- a/javalib/src/main/scala/java/nio/Buffers.scala
+++ b/javalib/src/main/scala/java/nio/Buffers.scala
@@ -4,6 +4,9 @@ package java.nio
 // Ported from Scala.js
 import scala.scalanative.unsafe
 import scala.scalanative.unsafe.UnsafeRichArray
+import scala.scalanative.runtime.{fromRawPtr, toRawPtr}
+import scala.scalanative.runtime.Intrinsics
+import scala.scalanative.annotation.alwaysinline
 
 object ByteBuffer {
   private final val HashSeed = -547316498 // "java.nio.ByteBuffer".##
@@ -192,47 +195,134 @@ abstract class ByteBuffer private[nio] (
     ((this.address.toLong + index) & (unitSize -1)).toInt
   }
 
-  def getChar(): Char
-  def putChar(value: Char): ByteBuffer
-  def getChar(index: Int): Char
-  def putChar(index: Int, value: Char): ByteBuffer
-
   def asCharBuffer(): CharBuffer
-
-  def getShort(): Short
-  def putShort(value: Short): ByteBuffer
-  def getShort(index: Int): Short
-  def putShort(index: Int, value: Short): ByteBuffer
-
+  def getChar(): Char = loadChar(getPosAndAdvanceRead(2))
+  def putChar(value: Char): ByteBuffer = {
+    ensureNotReadOnly()
+    storeChar(getPosAndAdvanceWrite(2), value)
+  }
+  def getChar(index: Int): Char = loadChar(validateIndex(index, 2))
+  def putChar(index: Int, value: Char): ByteBuffer = {
+    ensureNotReadOnly()
+    storeChar(validateIndex(index, 2), value)
+  }  
+  @alwaysinline private def loadChar(index: Int): Char = {
+    val value = Intrinsics.loadChar(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.Character.reverseBytes(value) else value
+    maybeReversed
+  }
+  @alwaysinline private def storeChar(index: Int, value: Char): ByteBuffer = {
+    val maybeReversed = if (isBigEndian) java.lang.Character.reverseBytes(value) else value
+    Intrinsics.storeChar(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+    this
+  }
   def asShortBuffer(): ShortBuffer
-
-  def getInt(): Int
-  def putInt(value: Int): ByteBuffer
-  def getInt(index: Int): Int
-  def putInt(index: Int, value: Int): ByteBuffer
-
+  def getShort(): Short = loadShort(getPosAndAdvanceRead(2))
+  def putShort(value: Short): ByteBuffer = {
+    ensureNotReadOnly()
+    storeShort(getPosAndAdvanceWrite(2), value)
+  }
+  def getShort(index: Int): Short = loadShort(validateIndex(index, 2))
+  def putShort(index: Int, value: Short): ByteBuffer = {
+    ensureNotReadOnly()
+    storeShort(validateIndex(index, 2), value)
+  }  
+  @alwaysinline private def loadShort(index: Int): Short = {
+    val value = Intrinsics.loadShort(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.Short.reverseBytes(value) else value
+    maybeReversed
+  }
+  @alwaysinline private def storeShort(index: Int, value: Short): ByteBuffer = {
+    val maybeReversed = if (isBigEndian) java.lang.Short.reverseBytes(value) else value
+    Intrinsics.storeShort(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+    this
+  }
   def asIntBuffer(): IntBuffer
-
-  def getLong(): Long
-  def putLong(value: Long): ByteBuffer
-  def getLong(index: Int): Long
-  def putLong(index: Int, value: Long): ByteBuffer
-
+  def getInt(): Int = loadInt(getPosAndAdvanceRead(4))
+  def putInt(value: Int): ByteBuffer = {
+    ensureNotReadOnly()
+    storeInt(getPosAndAdvanceWrite(4), value)
+  }
+  def getInt(index: Int): Int = loadInt(validateIndex(index, 4))
+  def putInt(index: Int, value: Int): ByteBuffer = {
+    ensureNotReadOnly()
+    storeInt(validateIndex(index, 4), value)
+  }  
+  @alwaysinline private def loadInt(index: Int): Int = {
+    val value = Intrinsics.loadInt(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.Integer.reverseBytes(value) else value
+    maybeReversed
+  }
+  @alwaysinline private def storeInt(index: Int, value: Int): ByteBuffer = {
+    val maybeReversed = if (isBigEndian) java.lang.Integer.reverseBytes(value) else value
+    Intrinsics.storeInt(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+    this
+  }
   def asLongBuffer(): LongBuffer
-
-  def getFloat(): Float
-  def putFloat(value: Float): ByteBuffer
-  def getFloat(index: Int): Float
-  def putFloat(index: Int, value: Float): ByteBuffer
-
+  def getLong(): Long = loadLong(getPosAndAdvanceRead(8))
+  def putLong(value: Long): ByteBuffer = {
+    ensureNotReadOnly()
+    storeLong(getPosAndAdvanceWrite(8), value)
+  }
+  def getLong(index: Int): Long = loadLong(validateIndex(index, 8))
+  def putLong(index: Int, value: Long): ByteBuffer = {
+    ensureNotReadOnly()
+    storeLong(validateIndex(index, 8), value)
+  }  
+  @alwaysinline private def loadLong(index: Int): Long = {
+    val value = Intrinsics.loadLong(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.Long.reverseBytes(value) else value
+    maybeReversed
+  }
+  @alwaysinline private def storeLong(index: Int, value: Long): ByteBuffer = {
+    val maybeReversed = if (isBigEndian) java.lang.Long.reverseBytes(value) else value
+    Intrinsics.storeLong(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+    this
+  }
   def asFloatBuffer(): FloatBuffer
-
-  def getDouble(): Double
-  def putDouble(value: Double): ByteBuffer
-  def getDouble(index: Int): Double
-  def putDouble(index: Int, value: Double): ByteBuffer
-
+  def getFloat(): Float = loadFloat(getPosAndAdvanceRead(4))
+  def putFloat(value: Float): ByteBuffer = {
+    ensureNotReadOnly()
+    storeFloat(getPosAndAdvanceWrite(4), value)
+  }
+  def getFloat(index: Int): Float = loadFloat(validateIndex(index, 4))
+  def putFloat(index: Int, value: Float): ByteBuffer = {
+    ensureNotReadOnly()
+    storeFloat(validateIndex(index, 4), value)
+  }  
+  @alwaysinline private def loadFloat(index: Int): Float = {
+    val value = Intrinsics.loadInt(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.Integer.reverseBytes(value) else value
+    java.lang.Float.intBitsToFloat(maybeReversed)
+  }
+  @alwaysinline private def storeFloat(index: Int, value: Float): ByteBuffer = {
+    val integerValue = java.lang.Float.floatToIntBits(value)
+    val maybeReversed = if (isBigEndian) java.lang.Integer.reverseBytes(integerValue) else integerValue
+    Intrinsics.storeInt(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+    this
+  }
   def asDoubleBuffer(): DoubleBuffer
+  def getDouble(): Double = loadDouble(getPosAndAdvanceRead(8))
+  def putDouble(value: Double): ByteBuffer = {
+    ensureNotReadOnly()
+    storeDouble(getPosAndAdvanceWrite(8), value)
+  }
+  def getDouble(index: Int): Double = loadDouble(validateIndex(index, 8))
+  def putDouble(index: Int, value: Double): ByteBuffer = {
+    ensureNotReadOnly()
+    storeDouble(validateIndex(index, 8), value)
+  }  
+  @alwaysinline private def loadDouble(index: Int): Double = {
+    val value = Intrinsics.loadLong(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.Long.reverseBytes(value) else value
+    java.lang.Double.longBitsToDouble(maybeReversed)
+  }
+  @alwaysinline private def storeDouble(index: Int, value: Double): ByteBuffer = {
+    val integerValue = java.lang.Double.doubleToLongBits(value)
+    val maybeReversed = if (isBigEndian) java.lang.Long.reverseBytes(integerValue) else integerValue
+    Intrinsics.storeLong(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+    this
+  }
 
 
   // Internal API

--- a/javalib/src/main/scala/java/nio/Buffers.scala.gyb
+++ b/javalib/src/main/scala/java/nio/Buffers.scala.gyb
@@ -3,6 +3,8 @@ package java.nio
 
 // Ported from Scala.js
 import scala.scalanative.unsafe
+import scala.scalanative.unsafe.UnsafeRichArray
+
 %{
    variants = [
     ('Byte',   '-547316498' ),
@@ -46,8 +48,9 @@ object ${T}Buffer {
 abstract class ${T}Buffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[${T}],
-    private[nio] val _offset: Int
-) extends Buffer(_capacity)
+    private[nio] val _offset: Int,
+    _address: unsafe.Ptr[_],
+) extends Buffer(_capacity, _address)
     with Comparable[${T}Buffer] 
 % if T == 'Char':
     with CharSequence
@@ -67,7 +70,8 @@ abstract class ${T}Buffer private[nio] (
 
   private def genBuffer = GenBuffer[${T}Buffer](this)
 
-  def this(_capacity: Int) = this(_capacity, null: Array[${T}], -1)
+  private[nio] def this(_capacity: Int, _array: Array[${T}], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
+  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[${T}], -1, address)
 
   def slice(): ${T}Buffer
   // Since JDK 13
@@ -81,9 +85,13 @@ abstract class ${T}Buffer private[nio] (
 
   def put(b: ${T}): ${T}Buffer
 
-  def get(index: Int): ${T}
+  def get(index: Int): ${T} = load(validateIndex(index))
 
-  def put(index: Int, b: ${T}): ${T}Buffer
+  def put(index: Int, elem: ${T}): ${T}Buffer = {
+    ensureNotReadOnly()
+    store(validateIndex(index), elem)
+    this
+  }
   
   // Since: JDK 13
   def get(index: Int, dst: Array[${T}], offset: Int, length: Int): ${T}Buffer = GenBuffer[${T}Buffer](this).generic_get(index, dst, offset, length)
@@ -314,9 +322,11 @@ abstract class ${T}Buffer private[nio] (
   override private[nio] def isBigEndian: Boolean = _isBigEndian
 % end
 
-  private[nio] def load(index: Int): ${T}
+  // @inline
+  private[nio] def load(index: Int): ${T} = this.data(index)
 
-  private[nio] def store(index: Int, elem: ${T}): Unit
+  // @inline
+  private[nio] def store(index: Int, elem: ${T}): Unit = this.data(index) = elem
 
   @inline
   private[nio] def load(

--- a/javalib/src/main/scala/java/nio/Buffers.scala.gyb
+++ b/javalib/src/main/scala/java/nio/Buffers.scala.gyb
@@ -81,9 +81,13 @@ abstract class ${T}Buffer private[nio] (
 
   def asReadOnlyBuffer(): ${T}Buffer
 
-  def get(): ${T}
+  def get(): ${T} = load(getPosAndAdvanceRead())
 
-  def put(b: ${T}): ${T}Buffer
+  def put(elem: ${T}): ${T}Buffer ={
+    ensureNotReadOnly()
+    store(getPosAndAdvanceWrite(), elem)
+    this
+  }
 
   def get(index: Int): ${T} = load(validateIndex(index))
 
@@ -322,10 +326,10 @@ abstract class ${T}Buffer private[nio] (
   override private[nio] def isBigEndian: Boolean = _isBigEndian
 % end
 
-  // @inline
+  @inline
   private[nio] def load(index: Int): ${T} = this.data(index)
 
-  // @inline
+  @inline
   private[nio] def store(index: Int, elem: ${T}): Unit = this.data(index) = elem
 
   @inline

--- a/javalib/src/main/scala/java/nio/Buffers.scala.gyb
+++ b/javalib/src/main/scala/java/nio/Buffers.scala.gyb
@@ -4,19 +4,22 @@ package java.nio
 // Ported from Scala.js
 import scala.scalanative.unsafe
 import scala.scalanative.unsafe.UnsafeRichArray
+import scala.scalanative.runtime.{fromRawPtr, toRawPtr}
+import scala.scalanative.runtime.Intrinsics
+import scala.scalanative.annotation.alwaysinline
 
 %{
    variants = [
-    ('Byte',   '-547316498' ),
-    ('Char',   '-182887236' ),
-    ('Short',  '383731478'  ),
-    ('Int',    '39599817'   ),
-    ('Long',   '-1709696158'),
-    ('Float',  '1920204022' ),
-    ('Double', '2140173175' )
+    ('Byte',   '-547316498' , 1, 'Byte'),
+    ('Char',   '-182887236' , 2, 'Character'),
+    ('Short',  '383731478'  , 2, 'Short'),
+    ('Int',    '39599817'   , 4, 'Integer'),
+    ('Long',   '-1709696158', 8, 'Long'),
+    ('Float',  '1920204022' , 4, 'Float'),
+    ('Double', '2140173175' , 8, 'Double')
    ]
 }%
-% for (T, Seed) in variants:
+% for (T, Seed, unusedSize, unusedJavaType) in variants:
 object ${T}Buffer {
   private final val HashSeed = ${Seed} // "java.nio.${T}Buffer".##
 
@@ -233,47 +236,51 @@ abstract class ${T}Buffer private[nio] (
 %end 
 
 %if T == 'Byte':
-  def getChar(): Char
-  def putChar(value: Char): ByteBuffer
-  def getChar(index: Int): Char
-  def putChar(index: Int, value: Char): ByteBuffer
-
-  def asCharBuffer(): CharBuffer
-
-  def getShort(): Short
-  def putShort(value: Short): ByteBuffer
-  def getShort(index: Int): Short
-  def putShort(index: Int, value: Short): ByteBuffer
-
-  def asShortBuffer(): ShortBuffer
-
-  def getInt(): Int
-  def putInt(value: Int): ByteBuffer
-  def getInt(index: Int): Int
-  def putInt(index: Int, value: Int): ByteBuffer
-
-  def asIntBuffer(): IntBuffer
-
-  def getLong(): Long
-  def putLong(value: Long): ByteBuffer
-  def getLong(index: Int): Long
-  def putLong(index: Int, value: Long): ByteBuffer
-
-  def asLongBuffer(): LongBuffer
-
-  def getFloat(): Float
-  def putFloat(value: Float): ByteBuffer
-  def getFloat(index: Int): Float
-  def putFloat(index: Int, value: Float): ByteBuffer
-
-  def asFloatBuffer(): FloatBuffer
-
-  def getDouble(): Double
-  def putDouble(value: Double): ByteBuffer
-  def getDouble(index: Int): Double
-  def putDouble(index: Int, value: Double): ByteBuffer
-
-  def asDoubleBuffer(): DoubleBuffer
+%for (E, unused, Size, JavaType) in variants:
+%if E != 'Byte':
+  def as${E}Buffer(): ${E}Buffer
+  def get${E}(): ${E} = load${E}(getPosAndAdvanceRead(${Size}))
+  def put${E}(value: ${E}): ByteBuffer = {
+    ensureNotReadOnly()
+    store${E}(getPosAndAdvanceWrite(${Size}), value)
+  }
+  def get${E}(index: Int): ${E} = load${E}(validateIndex(index, ${Size}))
+  def put${E}(index: Int, value: ${E}): ByteBuffer = {
+    ensureNotReadOnly()
+    store${E}(validateIndex(index, ${Size}), value)
+  }  
+  @alwaysinline private def load${E}(index: Int): ${E} = {
+%if E == 'Float':
+    val value = Intrinsics.loadInt(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.Integer.reverseBytes(value) else value
+    java.lang.Float.intBitsToFloat(maybeReversed)
+%elif E == 'Double':
+    val value = Intrinsics.loadLong(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.Long.reverseBytes(value) else value
+    java.lang.Double.longBitsToDouble(maybeReversed)
+%else:
+    val value = Intrinsics.load${E}(Intrinsics.elemRawPtr(_rawAddress, index))
+    val maybeReversed = if (isBigEndian) java.lang.${JavaType}.reverseBytes(value) else value
+    maybeReversed
+%end
+  }
+  @alwaysinline private def store${E}(index: Int, value: ${E}): ByteBuffer = {
+%if E == 'Float':
+    val integerValue = java.lang.Float.floatToIntBits(value)
+    val maybeReversed = if (isBigEndian) java.lang.Integer.reverseBytes(integerValue) else integerValue
+    Intrinsics.storeInt(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+%elif E == 'Double':
+    val integerValue = java.lang.Double.doubleToLongBits(value)
+    val maybeReversed = if (isBigEndian) java.lang.Long.reverseBytes(integerValue) else integerValue
+    Intrinsics.storeLong(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+%else:
+    val maybeReversed = if (isBigEndian) java.lang.${JavaType}.reverseBytes(value) else value
+    Intrinsics.store${E}(Intrinsics.elemRawPtr(_rawAddress, index), maybeReversed)
+%end
+    this
+  }
+%end
+%end
 
 % elif T == 'Char':
   override def toString(): String = {

--- a/javalib/src/main/scala/java/nio/HeapBuffers.scala
+++ b/javalib/src/main/scala/java/nio/HeapBuffers.scala
@@ -52,14 +52,6 @@ private[nio] final class HeapCharBuffer private (
   }
 
   @noinline
-  def get(): Char =
-    GenBuffer[CharBuffer](this).generic_get()
-
-  @noinline
-  def put(v: Char): CharBuffer =
-    GenBuffer[CharBuffer](this).generic_put(v)
-
-  @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
     GenBuffer[CharBuffer](this).generic_get(dst, offset, length)
 
@@ -172,14 +164,6 @@ private[nio] final class HeapShortBuffer private (
   def asReadOnlyBuffer(): ShortBuffer =
     GenHeapBuffer[ShortBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Short =
-    GenBuffer[ShortBuffer](this).generic_get()
-
-  @noinline
-  def put(v: Short): ShortBuffer =
-    GenBuffer[ShortBuffer](this).generic_put(v)
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
@@ -296,14 +280,6 @@ private[nio] final class HeapIntBuffer private (
 
 
   @noinline
-  def get(): Int =
-    GenBuffer[IntBuffer](this).generic_get()
-
-  @noinline
-  def put(v: Int): IntBuffer =
-    GenBuffer[IntBuffer](this).generic_put(v)
-
-  @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
     GenBuffer[IntBuffer](this).generic_get(dst, offset, length)
 
@@ -416,14 +392,6 @@ private[nio] final class HeapLongBuffer private (
   def asReadOnlyBuffer(): LongBuffer =
     GenHeapBuffer[LongBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Long =
-    GenBuffer[LongBuffer](this).generic_get()
-
-  @noinline
-  def put(v: Long): LongBuffer =
-    GenBuffer[LongBuffer](this).generic_put(v)
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
@@ -540,14 +508,6 @@ private[nio] final class HeapFloatBuffer private (
 
 
   @noinline
-  def get(): Float =
-    GenBuffer[FloatBuffer](this).generic_get()
-
-  @noinline
-  def put(v: Float): FloatBuffer =
-    GenBuffer[FloatBuffer](this).generic_put(v)
-
-  @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
     GenBuffer[FloatBuffer](this).generic_get(dst, offset, length)
 
@@ -660,14 +620,6 @@ private[nio] final class HeapDoubleBuffer private (
   def asReadOnlyBuffer(): DoubleBuffer =
     GenHeapBuffer[DoubleBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Double =
-    GenBuffer[DoubleBuffer](this).generic_get()
-
-  @noinline
-  def put(v: Double): DoubleBuffer =
-    GenBuffer[DoubleBuffer](this).generic_put(v)
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =

--- a/javalib/src/main/scala/java/nio/HeapBuffers.scala
+++ b/javalib/src/main/scala/java/nio/HeapBuffers.scala
@@ -60,14 +60,6 @@ private[nio] final class HeapCharBuffer private (
     GenBuffer[CharBuffer](this).generic_put(v)
 
   @noinline
-  def get(index: Int): Char =
-    GenBuffer[CharBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, v: Char): CharBuffer =
-    GenBuffer[CharBuffer](this).generic_put(index, v)
-
-  @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
     GenBuffer[CharBuffer](this).generic_get(dst, offset, length)
 
@@ -82,14 +74,6 @@ private[nio] final class HeapCharBuffer private (
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Char =
-    GenHeapBuffer[CharBuffer](this).generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Char): Unit =
-    GenHeapBuffer[CharBuffer](this).generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -198,14 +182,6 @@ private[nio] final class HeapShortBuffer private (
     GenBuffer[ShortBuffer](this).generic_put(v)
 
   @noinline
-  def get(index: Int): Short =
-    GenBuffer[ShortBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, v: Short): ShortBuffer =
-    GenBuffer[ShortBuffer](this).generic_put(index, v)
-
-  @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
     GenBuffer[ShortBuffer](this).generic_get(dst, offset, length)
 
@@ -220,14 +196,6 @@ private[nio] final class HeapShortBuffer private (
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Short =
-    GenHeapBuffer[ShortBuffer](this).generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Short): Unit =
-    GenHeapBuffer[ShortBuffer](this).generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -336,14 +304,6 @@ private[nio] final class HeapIntBuffer private (
     GenBuffer[IntBuffer](this).generic_put(v)
 
   @noinline
-  def get(index: Int): Int =
-    GenBuffer[IntBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, v: Int): IntBuffer =
-    GenBuffer[IntBuffer](this).generic_put(index, v)
-
-  @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
     GenBuffer[IntBuffer](this).generic_get(dst, offset, length)
 
@@ -358,14 +318,6 @@ private[nio] final class HeapIntBuffer private (
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Int =
-    GenHeapBuffer[IntBuffer](this).generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Int): Unit =
-    GenHeapBuffer[IntBuffer](this).generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -474,14 +426,6 @@ private[nio] final class HeapLongBuffer private (
     GenBuffer[LongBuffer](this).generic_put(v)
 
   @noinline
-  def get(index: Int): Long =
-    GenBuffer[LongBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, v: Long): LongBuffer =
-    GenBuffer[LongBuffer](this).generic_put(index, v)
-
-  @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
     GenBuffer[LongBuffer](this).generic_get(dst, offset, length)
 
@@ -496,14 +440,6 @@ private[nio] final class HeapLongBuffer private (
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Long =
-    GenHeapBuffer[LongBuffer](this).generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Long): Unit =
-    GenHeapBuffer[LongBuffer](this).generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -612,14 +548,6 @@ private[nio] final class HeapFloatBuffer private (
     GenBuffer[FloatBuffer](this).generic_put(v)
 
   @noinline
-  def get(index: Int): Float =
-    GenBuffer[FloatBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, v: Float): FloatBuffer =
-    GenBuffer[FloatBuffer](this).generic_put(index, v)
-
-  @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
     GenBuffer[FloatBuffer](this).generic_get(dst, offset, length)
 
@@ -634,14 +562,6 @@ private[nio] final class HeapFloatBuffer private (
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Float =
-    GenHeapBuffer[FloatBuffer](this).generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Float): Unit =
-    GenHeapBuffer[FloatBuffer](this).generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -750,14 +670,6 @@ private[nio] final class HeapDoubleBuffer private (
     GenBuffer[DoubleBuffer](this).generic_put(v)
 
   @noinline
-  def get(index: Int): Double =
-    GenBuffer[DoubleBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, v: Double): DoubleBuffer =
-    GenBuffer[DoubleBuffer](this).generic_put(index, v)
-
-  @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
     GenBuffer[DoubleBuffer](this).generic_get(dst, offset, length)
 
@@ -772,14 +684,6 @@ private[nio] final class HeapDoubleBuffer private (
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Double =
-    GenHeapBuffer[DoubleBuffer](this).generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Double): Unit =
-    GenHeapBuffer[DoubleBuffer](this).generic_store(index, elem)
 
   @inline
   override private[nio] def load(

--- a/javalib/src/main/scala/java/nio/HeapBuffers.scala.gyb
+++ b/javalib/src/main/scala/java/nio/HeapBuffers.scala.gyb
@@ -61,14 +61,6 @@ private[nio] final class Heap${T}Buffer private (
   % end
 
   @noinline
-  def get(): ${T} =
-    GenBuffer[${T}Buffer](this).generic_get()
-
-  @noinline
-  def put(v: ${T}): ${T}Buffer =
-    GenBuffer[${T}Buffer](this).generic_put(v)
-
-  @noinline
   override def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
     GenBuffer[${T}Buffer](this).generic_get(dst, offset, length)
 

--- a/javalib/src/main/scala/java/nio/HeapBuffers.scala.gyb
+++ b/javalib/src/main/scala/java/nio/HeapBuffers.scala.gyb
@@ -69,14 +69,6 @@ private[nio] final class Heap${T}Buffer private (
     GenBuffer[${T}Buffer](this).generic_put(v)
 
   @noinline
-  def get(index: Int): ${T} =
-    GenBuffer[${T}Buffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, v: ${T}): ${T}Buffer =
-    GenBuffer[${T}Buffer](this).generic_put(index, v)
-
-  @noinline
   override def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
     GenBuffer[${T}Buffer](this).generic_get(dst, offset, length)
 
@@ -91,14 +83,6 @@ private[nio] final class Heap${T}Buffer private (
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): ${T} =
-    GenHeapBuffer[${T}Buffer](this).generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: ${T}): Unit =
-    GenHeapBuffer[${T}Buffer](this).generic_store(index, elem)
 
   @inline
   override private[nio] def load(

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -43,14 +43,6 @@ private[nio] class HeapByteBuffer(
     genHeapBuffer.generic_asReadOnlyBuffer()
 
   @noinline
-  def get(): Byte =
-    genBuffer.generic_get()
-
-  @noinline
-  def put(b: Byte): ByteBuffer =
-    genBuffer.generic_put(b)
-
-  @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
     genBuffer.generic_get(dst, offset, length)
 

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -55,117 +55,20 @@ private[nio] class HeapByteBuffer(
     genHeapBuffer.generic_compact()
 
   // Here begins the stuff specific to ByteArrays
-
-  @inline private def byteArrayBits: ByteArrayBits =
-    ByteArrayBits(
-      _array.at(0),
-      _offset,
-      isBigEndian
-    )
-
-  @noinline def getChar(): Char =
-    byteArrayBits.loadChar(getPosAndAdvanceRead(2))
-  @noinline def putChar(value: Char): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeChar(getPosAndAdvanceWrite(2), value);
-    this
-  }
-  @noinline def getChar(index: Int): Char =
-    byteArrayBits.loadChar(validateIndex(index, 2))
-  @noinline def putChar(index: Int, value: Char): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeChar(validateIndex(index, 2), value);
-    this
-  }
-
   def asCharBuffer(): CharBuffer =
     HeapByteBufferCharView.fromHeapByteBuffer(this)
-
-  @noinline def getShort(): Short =
-    byteArrayBits.loadShort(getPosAndAdvanceRead(2))
-  @noinline def putShort(value: Short): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeShort(getPosAndAdvanceWrite(2), value);
-    this
-  }
-  @noinline def getShort(index: Int): Short =
-    byteArrayBits.loadShort(validateIndex(index, 2))
-  @noinline def putShort(index: Int, value: Short): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeShort(validateIndex(index, 2), value);
-    this
-  }
 
   def asShortBuffer(): ShortBuffer =
     HeapByteBufferShortView.fromHeapByteBuffer(this)
 
-  @noinline def getInt(): Int =
-    byteArrayBits.loadInt(getPosAndAdvanceRead(4))
-  @noinline def putInt(value: Int): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeInt(getPosAndAdvanceWrite(4), value);
-    this
-  }
-  @noinline def getInt(index: Int): Int =
-    byteArrayBits.loadInt(validateIndex(index, 4))
-  @noinline def putInt(index: Int, value: Int): ByteBuffer = {
-    ensureNotReadOnly(); byteArrayBits.storeInt(validateIndex(index, 4), value);
-    this
-  }
-
   def asIntBuffer(): IntBuffer =
     HeapByteBufferIntView.fromHeapByteBuffer(this)
-
-  @noinline def getLong(): Long =
-    byteArrayBits.loadLong(getPosAndAdvanceRead(8))
-  @noinline def putLong(value: Long): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeLong(getPosAndAdvanceWrite(8), value);
-    this
-  }
-  @noinline def getLong(index: Int): Long =
-    byteArrayBits.loadLong(validateIndex(index, 8))
-  @noinline def putLong(index: Int, value: Long): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeLong(validateIndex(index, 8), value);
-    this
-  }
 
   def asLongBuffer(): LongBuffer =
     HeapByteBufferLongView.fromHeapByteBuffer(this)
 
-  @noinline def getFloat(): Float =
-    byteArrayBits.loadFloat(getPosAndAdvanceRead(4))
-  @noinline def putFloat(value: Float): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeFloat(getPosAndAdvanceWrite(4), value);
-    this
-  }
-  @noinline def getFloat(index: Int): Float =
-    byteArrayBits.loadFloat(validateIndex(index, 4))
-  @noinline def putFloat(index: Int, value: Float): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeFloat(validateIndex(index, 4), value);
-    this
-  }
-
   def asFloatBuffer(): FloatBuffer =
     HeapByteBufferFloatView.fromHeapByteBuffer(this)
-
-  @noinline def getDouble(): Double =
-    byteArrayBits.loadDouble(getPosAndAdvanceRead(8))
-  @noinline def putDouble(value: Double): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeDouble(getPosAndAdvanceWrite(8), value);
-    this
-  }
-  @noinline def getDouble(index: Int): Double =
-    byteArrayBits.loadDouble(validateIndex(index, 8))
-  @noinline def putDouble(index: Int, value: Double): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeDouble(validateIndex(index, 8), value);
-    this
-  }
 
   def asDoubleBuffer(): DoubleBuffer =
     HeapByteBufferDoubleView.fromHeapByteBuffer(this)

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -51,14 +51,6 @@ private[nio] class HeapByteBuffer(
     genBuffer.generic_put(b)
 
   @noinline
-  def get(index: Int): Byte =
-    genBuffer.generic_get(index)
-
-  @noinline
-  def put(index: Int, b: Byte): ByteBuffer =
-    genBuffer.generic_put(index, b)
-
-  @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
     genBuffer.generic_get(dst, offset, length)
 
@@ -187,14 +179,6 @@ private[nio] class HeapByteBuffer(
     HeapByteBufferDoubleView.fromHeapByteBuffer(this)
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Byte =
-    genHeapBuffer.generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Byte): Unit =
-    genHeapBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(

--- a/javalib/src/main/scala/java/nio/HeapByteBufferViews.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferViews.scala
@@ -2,6 +2,8 @@
 
 package java.nio
 
+import scala.scalanative.unsafe._
+
 private[nio] final class HeapByteBufferCharView private (
     _capacity: Int,
     override private[nio] val _byteArray: Array[Byte],
@@ -10,7 +12,7 @@ private[nio] final class HeapByteBufferCharView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends CharBuffer(_capacity) {
+) extends CharBuffer(_capacity, _byteArray.atUnsafe(_offset)) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -62,14 +64,6 @@ private[nio] final class HeapByteBufferCharView private (
     GenBuffer[CharBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Char =
-    GenBuffer[CharBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Char): CharBuffer =
-    GenBuffer[CharBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
     GenBuffer[CharBuffer](this).generic_get(dst, offset, length)
 
@@ -88,11 +82,11 @@ private[nio] final class HeapByteBufferCharView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Char =
+  private[nio] override def load(index: Int): Char =
     GenHeapBufferView[CharBuffer](this).byteArrayBits.loadChar(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Char): Unit =
+  private[nio] override def store(index: Int, elem: Char): Unit =
     GenHeapBufferView[CharBuffer](this).byteArrayBits.storeChar(index, elem)
 }
 
@@ -134,7 +128,7 @@ private[nio] final class HeapByteBufferShortView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends ShortBuffer(_capacity) {
+) extends ShortBuffer(_capacity, _byteArray.atUnsafe(_offset)) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -173,14 +167,6 @@ private[nio] final class HeapByteBufferShortView private (
     GenBuffer[ShortBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Short =
-    GenBuffer[ShortBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Short): ShortBuffer =
-    GenBuffer[ShortBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
     GenBuffer[ShortBuffer](this).generic_get(dst, offset, length)
 
@@ -199,11 +185,11 @@ private[nio] final class HeapByteBufferShortView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Short =
+  private[nio] override def load(index: Int): Short =
     GenHeapBufferView[ShortBuffer](this).byteArrayBits.loadShort(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Short): Unit =
+  private[nio] override def store(index: Int, elem: Short): Unit =
     GenHeapBufferView[ShortBuffer](this).byteArrayBits.storeShort(index, elem)
 }
 
@@ -245,7 +231,7 @@ private[nio] final class HeapByteBufferIntView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends IntBuffer(_capacity) {
+) extends IntBuffer(_capacity, _byteArray.atUnsafe(_offset)) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -284,14 +270,6 @@ private[nio] final class HeapByteBufferIntView private (
     GenBuffer[IntBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Int =
-    GenBuffer[IntBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Int): IntBuffer =
-    GenBuffer[IntBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
     GenBuffer[IntBuffer](this).generic_get(dst, offset, length)
 
@@ -310,11 +288,11 @@ private[nio] final class HeapByteBufferIntView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Int =
+  private[nio] override def load(index: Int): Int =
     GenHeapBufferView[IntBuffer](this).byteArrayBits.loadInt(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Int): Unit =
+  private[nio] override def store(index: Int, elem: Int): Unit =
     GenHeapBufferView[IntBuffer](this).byteArrayBits.storeInt(index, elem)
 }
 
@@ -356,7 +334,7 @@ private[nio] final class HeapByteBufferLongView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends LongBuffer(_capacity) {
+) extends LongBuffer(_capacity, _byteArray.atUnsafe(_offset)) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -395,14 +373,6 @@ private[nio] final class HeapByteBufferLongView private (
     GenBuffer[LongBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Long =
-    GenBuffer[LongBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Long): LongBuffer =
-    GenBuffer[LongBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
     GenBuffer[LongBuffer](this).generic_get(dst, offset, length)
 
@@ -421,11 +391,11 @@ private[nio] final class HeapByteBufferLongView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Long =
+  private[nio] override def load(index: Int): Long =
     GenHeapBufferView[LongBuffer](this).byteArrayBits.loadLong(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Long): Unit =
+  private[nio] override def store(index: Int, elem: Long): Unit =
     GenHeapBufferView[LongBuffer](this).byteArrayBits.storeLong(index, elem)
 }
 
@@ -467,7 +437,7 @@ private[nio] final class HeapByteBufferFloatView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends FloatBuffer(_capacity) {
+) extends FloatBuffer(_capacity, _byteArray.atUnsafe(_offset)) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -506,14 +476,6 @@ private[nio] final class HeapByteBufferFloatView private (
     GenBuffer[FloatBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Float =
-    GenBuffer[FloatBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Float): FloatBuffer =
-    GenBuffer[FloatBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
     GenBuffer[FloatBuffer](this).generic_get(dst, offset, length)
 
@@ -532,11 +494,11 @@ private[nio] final class HeapByteBufferFloatView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Float =
+  private[nio] override def load(index: Int): Float =
     GenHeapBufferView[FloatBuffer](this).byteArrayBits.loadFloat(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Float): Unit =
+  private[nio] override def store(index: Int, elem: Float): Unit =
     GenHeapBufferView[FloatBuffer](this).byteArrayBits.storeFloat(index, elem)
 }
 
@@ -578,7 +540,7 @@ private[nio] final class HeapByteBufferDoubleView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends DoubleBuffer(_capacity) {
+) extends DoubleBuffer(_capacity, _byteArray.atUnsafe(_offset)) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -617,14 +579,6 @@ private[nio] final class HeapByteBufferDoubleView private (
     GenBuffer[DoubleBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Double =
-    GenBuffer[DoubleBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Double): DoubleBuffer =
-    GenBuffer[DoubleBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
     GenBuffer[DoubleBuffer](this).generic_get(dst, offset, length)
 
@@ -643,11 +597,11 @@ private[nio] final class HeapByteBufferDoubleView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Double =
+  private[nio] override def load(index: Int): Double =
     GenHeapBufferView[DoubleBuffer](this).byteArrayBits.loadDouble(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Double): Unit =
+  private[nio] override def store(index: Int, elem: Double): Unit =
     GenHeapBufferView[DoubleBuffer](this).byteArrayBits.storeDouble(index, elem)
 }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferViews.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferViews.scala
@@ -56,14 +56,6 @@ private[nio] final class HeapByteBufferCharView private (
   }
 
   @noinline
-  def get(): Char =
-    GenBuffer[CharBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Char): CharBuffer =
-    GenBuffer[CharBuffer](this).generic_put(c)
-
-  @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
     GenBuffer[CharBuffer](this).generic_get(dst, offset, length)
 
@@ -157,14 +149,6 @@ private[nio] final class HeapByteBufferShortView private (
   def asReadOnlyBuffer(): ShortBuffer =
     GenHeapBufferView[ShortBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Short =
-    GenBuffer[ShortBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Short): ShortBuffer =
-    GenBuffer[ShortBuffer](this).generic_put(c)
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
@@ -262,14 +246,6 @@ private[nio] final class HeapByteBufferIntView private (
 
 
   @noinline
-  def get(): Int =
-    GenBuffer[IntBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Int): IntBuffer =
-    GenBuffer[IntBuffer](this).generic_put(c)
-
-  @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
     GenBuffer[IntBuffer](this).generic_get(dst, offset, length)
 
@@ -363,14 +339,6 @@ private[nio] final class HeapByteBufferLongView private (
   def asReadOnlyBuffer(): LongBuffer =
     GenHeapBufferView[LongBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Long =
-    GenBuffer[LongBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Long): LongBuffer =
-    GenBuffer[LongBuffer](this).generic_put(c)
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
@@ -468,14 +436,6 @@ private[nio] final class HeapByteBufferFloatView private (
 
 
   @noinline
-  def get(): Float =
-    GenBuffer[FloatBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Float): FloatBuffer =
-    GenBuffer[FloatBuffer](this).generic_put(c)
-
-  @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
     GenBuffer[FloatBuffer](this).generic_get(dst, offset, length)
 
@@ -569,14 +529,6 @@ private[nio] final class HeapByteBufferDoubleView private (
   def asReadOnlyBuffer(): DoubleBuffer =
     GenHeapBufferView[DoubleBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Double =
-    GenBuffer[DoubleBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Double): DoubleBuffer =
-    GenBuffer[DoubleBuffer](this).generic_put(c)
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =

--- a/javalib/src/main/scala/java/nio/HeapByteBufferViews.scala.gyb
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferViews.scala.gyb
@@ -65,14 +65,6 @@ private[nio] final class HeapByteBuffer${T}View private (
   % end
 
   @noinline
-  def get(): ${T} =
-    GenBuffer[${T}Buffer](this).generic_get()
-
-  @noinline
-  def put(c: ${T}): ${T}Buffer =
-    GenBuffer[${T}Buffer](this).generic_put(c)
-
-  @noinline
   override def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
     GenBuffer[${T}Buffer](this).generic_get(dst, offset, length)
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferViews.scala.gyb
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferViews.scala.gyb
@@ -2,6 +2,8 @@
 
 package java.nio
 
+import scala.scalanative.unsafe._
+
 % types = [('Char', '2'),
 %          ('Short', '2'),
 %          ('Int', '4'),
@@ -17,7 +19,7 @@ private[nio] final class HeapByteBuffer${T}View private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends ${T}Buffer(_capacity) {
+) extends ${T}Buffer(_capacity, _byteArray.atUnsafe(_offset)) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -71,14 +73,6 @@ private[nio] final class HeapByteBuffer${T}View private (
     GenBuffer[${T}Buffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): ${T} =
-    GenBuffer[${T}Buffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: ${T}): ${T}Buffer =
-    GenBuffer[${T}Buffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
     GenBuffer[${T}Buffer](this).generic_get(dst, offset, length)
 
@@ -97,11 +91,11 @@ private[nio] final class HeapByteBuffer${T}View private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): ${T} =
+  private[nio] override def load(index: Int): ${T} =
     GenHeapBufferView[${T}Buffer](this).byteArrayBits.load${T}(index)
 
   @inline
-  private[nio] def store(index: Int, elem: ${T}): Unit =
+  private[nio] override def store(index: Int, elem: ${T}): Unit =
     GenHeapBufferView[${T}Buffer](this).byteArrayBits.store${T}(index, elem)
 }
 

--- a/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
@@ -7,7 +7,13 @@ abstract class MappedByteBuffer private[nio] (
     initialPosition: Int,
     initialLimit: Int,
     isReadOnly: Boolean
-) extends ByteBuffer(_capacity, null, _offset) {
+) extends ByteBuffer(
+      _capacity,
+      null,
+      _offset,
+      if (_mappedData.data != null) _mappedData.data + _offset
+      else _mappedData.data
+    ) {
 
   def force(): MappedByteBuffer
 

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -82,14 +82,6 @@ private class MappedByteBufferImpl(
     genMappedBuffer.generic_asReadOnlyBuffer()
 
   @noinline
-  def get(): Byte =
-    genBuffer.generic_get()
-
-  @noinline
-  def put(b: Byte): ByteBuffer =
-    genBuffer.generic_put(b)
-
-  @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
     genBuffer.generic_get(dst, offset, length)
 

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -90,14 +90,6 @@ private class MappedByteBufferImpl(
     genBuffer.generic_put(b)
 
   @noinline
-  def get(index: Int): Byte =
-    genBuffer.generic_get(index)
-
-  @noinline
-  def put(index: Int, b: Byte): ByteBuffer =
-    genBuffer.generic_put(index, b)
-
-  @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
     genBuffer.generic_get(dst, offset, length)
 
@@ -222,14 +214,6 @@ private class MappedByteBufferImpl(
     MappedByteBufferDoubleView.fromMappedByteBuffer(this)
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Byte =
-    genMappedBuffer.generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Byte): Unit =
-    genMappedBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -95,112 +95,20 @@ private class MappedByteBufferImpl(
 
   // Here begins the stuff specific to ByteArrays
 
-  @inline @inline private def byteArrayBits: ByteArrayBits =
-    ByteArrayBits(_mappedData.data, _offset, isBigEndian)
-
-  @noinline def getChar(): Char =
-    byteArrayBits.loadChar(getPosAndAdvanceRead(2))
-  @noinline def putChar(value: Char): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeChar(getPosAndAdvanceWrite(2), value);
-    this
-  }
-  @noinline def getChar(index: Int): Char =
-    byteArrayBits.loadChar(validateIndex(index, 2))
-  @noinline def putChar(index: Int, value: Char): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeChar(validateIndex(index, 2), value);
-    this
-  }
-
   def asCharBuffer(): CharBuffer =
     MappedByteBufferCharView.fromMappedByteBuffer(this)
-
-  @noinline def getShort(): Short =
-    byteArrayBits.loadShort(getPosAndAdvanceRead(2))
-  @noinline def putShort(value: Short): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeShort(getPosAndAdvanceWrite(2), value);
-    this
-  }
-  @noinline def getShort(index: Int): Short =
-    byteArrayBits.loadShort(validateIndex(index, 2))
-  @noinline def putShort(index: Int, value: Short): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeShort(validateIndex(index, 2), value);
-    this
-  }
 
   def asShortBuffer(): ShortBuffer =
     MappedByteBufferShortView.fromMappedByteBuffer(this)
 
-  @noinline def getInt(): Int =
-    byteArrayBits.loadInt(getPosAndAdvanceRead(4))
-  @noinline def putInt(value: Int): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeInt(getPosAndAdvanceWrite(4), value);
-    this
-  }
-  @noinline def getInt(index: Int): Int =
-    byteArrayBits.loadInt(validateIndex(index, 4))
-  @noinline def putInt(index: Int, value: Int): ByteBuffer = {
-    ensureNotReadOnly(); byteArrayBits.storeInt(validateIndex(index, 4), value);
-    this
-  }
-
   def asIntBuffer(): IntBuffer =
     MappedByteBufferIntView.fromMappedByteBuffer(this)
-
-  @noinline def getLong(): Long =
-    byteArrayBits.loadLong(getPosAndAdvanceRead(8))
-  @noinline def putLong(value: Long): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeLong(getPosAndAdvanceWrite(8), value);
-    this
-  }
-  @noinline def getLong(index: Int): Long =
-    byteArrayBits.loadLong(validateIndex(index, 8))
-  @noinline def putLong(index: Int, value: Long): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeLong(validateIndex(index, 8), value);
-    this
-  }
 
   def asLongBuffer(): LongBuffer =
     MappedByteBufferLongView.fromMappedByteBuffer(this)
 
-  @noinline def getFloat(): Float =
-    byteArrayBits.loadFloat(getPosAndAdvanceRead(4))
-  @noinline def putFloat(value: Float): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeFloat(getPosAndAdvanceWrite(4), value);
-    this
-  }
-  @noinline def getFloat(index: Int): Float =
-    byteArrayBits.loadFloat(validateIndex(index, 4))
-  @noinline def putFloat(index: Int, value: Float): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeFloat(validateIndex(index, 4), value);
-    this
-  }
-
   def asFloatBuffer(): FloatBuffer =
     MappedByteBufferFloatView.fromMappedByteBuffer(this)
-
-  @noinline def getDouble(): Double =
-    byteArrayBits.loadDouble(getPosAndAdvanceRead(8))
-  @noinline def putDouble(value: Double): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeDouble(getPosAndAdvanceWrite(8), value);
-    this
-  }
-  @noinline def getDouble(index: Int): Double =
-    byteArrayBits.loadDouble(validateIndex(index, 8))
-  @noinline def putDouble(index: Int, value: Double): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeDouble(validateIndex(index, 8), value);
-    this
-  }
 
   def asDoubleBuffer(): DoubleBuffer =
     MappedByteBufferDoubleView.fromMappedByteBuffer(this)

--- a/javalib/src/main/scala/java/nio/MappedByteBufferViews.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferViews.scala
@@ -10,7 +10,7 @@ private[nio] final class MappedByteBufferCharView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends CharBuffer(_capacity) {
+) extends CharBuffer(_capacity, if(_mappedData.data != null) _mappedData.data + _offset else _mappedData.data) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -61,13 +61,6 @@ private[nio] final class MappedByteBufferCharView private (
   def put(c: Char): CharBuffer =
     GenBuffer[CharBuffer](this).generic_put(c)
 
-  @noinline
-  def get(index: Int): Char =
-    GenBuffer[CharBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Char): CharBuffer =
-    GenBuffer[CharBuffer](this).generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
@@ -88,11 +81,11 @@ private[nio] final class MappedByteBufferCharView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Char =
+  private[nio] override def load(index: Int): Char =
     GenMappedBufferView[CharBuffer](this).byteArrayBits.loadChar(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Char): Unit =
+  private[nio] override def store(index: Int, elem: Char): Unit =
     GenMappedBufferView[CharBuffer](this).byteArrayBits.storeChar(index, elem)
 }
 
@@ -136,7 +129,7 @@ private[nio] final class MappedByteBufferShortView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends ShortBuffer(_capacity) {
+) extends ShortBuffer(_capacity, if(_mappedData.data != null) _mappedData.data + _offset else _mappedData.data) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -174,13 +167,6 @@ private[nio] final class MappedByteBufferShortView private (
   def put(c: Short): ShortBuffer =
     GenBuffer[ShortBuffer](this).generic_put(c)
 
-  @noinline
-  def get(index: Int): Short =
-    GenBuffer[ShortBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Short): ShortBuffer =
-    GenBuffer[ShortBuffer](this).generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
@@ -201,11 +187,11 @@ private[nio] final class MappedByteBufferShortView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Short =
+  private[nio] override def load(index: Int): Short =
     GenMappedBufferView[ShortBuffer](this).byteArrayBits.loadShort(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Short): Unit =
+  private[nio] override def store(index: Int, elem: Short): Unit =
     GenMappedBufferView[ShortBuffer](this).byteArrayBits.storeShort(index, elem)
 }
 
@@ -249,7 +235,7 @@ private[nio] final class MappedByteBufferIntView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends IntBuffer(_capacity) {
+) extends IntBuffer(_capacity, if(_mappedData.data != null) _mappedData.data + _offset else _mappedData.data) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -287,13 +273,6 @@ private[nio] final class MappedByteBufferIntView private (
   def put(c: Int): IntBuffer =
     GenBuffer[IntBuffer](this).generic_put(c)
 
-  @noinline
-  def get(index: Int): Int =
-    GenBuffer[IntBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Int): IntBuffer =
-    GenBuffer[IntBuffer](this).generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
@@ -314,11 +293,11 @@ private[nio] final class MappedByteBufferIntView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Int =
+  private[nio] override def load(index: Int): Int =
     GenMappedBufferView[IntBuffer](this).byteArrayBits.loadInt(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Int): Unit =
+  private[nio] override def store(index: Int, elem: Int): Unit =
     GenMappedBufferView[IntBuffer](this).byteArrayBits.storeInt(index, elem)
 }
 
@@ -362,7 +341,7 @@ private[nio] final class MappedByteBufferLongView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends LongBuffer(_capacity) {
+) extends LongBuffer(_capacity, if(_mappedData.data != null) _mappedData.data + _offset else _mappedData.data) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -400,13 +379,6 @@ private[nio] final class MappedByteBufferLongView private (
   def put(c: Long): LongBuffer =
     GenBuffer[LongBuffer](this).generic_put(c)
 
-  @noinline
-  def get(index: Int): Long =
-    GenBuffer[LongBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Long): LongBuffer =
-    GenBuffer[LongBuffer](this).generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
@@ -427,11 +399,11 @@ private[nio] final class MappedByteBufferLongView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Long =
+  private[nio] override def load(index: Int): Long =
     GenMappedBufferView[LongBuffer](this).byteArrayBits.loadLong(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Long): Unit =
+  private[nio] override def store(index: Int, elem: Long): Unit =
     GenMappedBufferView[LongBuffer](this).byteArrayBits.storeLong(index, elem)
 }
 
@@ -475,7 +447,7 @@ private[nio] final class MappedByteBufferFloatView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends FloatBuffer(_capacity) {
+) extends FloatBuffer(_capacity, if(_mappedData.data != null) _mappedData.data + _offset else _mappedData.data) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -513,13 +485,6 @@ private[nio] final class MappedByteBufferFloatView private (
   def put(c: Float): FloatBuffer =
     GenBuffer[FloatBuffer](this).generic_put(c)
 
-  @noinline
-  def get(index: Int): Float =
-    GenBuffer[FloatBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Float): FloatBuffer =
-    GenBuffer[FloatBuffer](this).generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
@@ -540,11 +505,11 @@ private[nio] final class MappedByteBufferFloatView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Float =
+  private[nio] override def load(index: Int): Float =
     GenMappedBufferView[FloatBuffer](this).byteArrayBits.loadFloat(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Float): Unit =
+  private[nio] override def store(index: Int, elem: Float): Unit =
     GenMappedBufferView[FloatBuffer](this).byteArrayBits.storeFloat(index, elem)
 }
 
@@ -588,7 +553,7 @@ private[nio] final class MappedByteBufferDoubleView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends DoubleBuffer(_capacity) {
+) extends DoubleBuffer(_capacity, if(_mappedData.data != null) _mappedData.data + _offset else _mappedData.data) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -626,13 +591,6 @@ private[nio] final class MappedByteBufferDoubleView private (
   def put(c: Double): DoubleBuffer =
     GenBuffer[DoubleBuffer](this).generic_put(c)
 
-  @noinline
-  def get(index: Int): Double =
-    GenBuffer[DoubleBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Double): DoubleBuffer =
-    GenBuffer[DoubleBuffer](this).generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
@@ -653,11 +611,11 @@ private[nio] final class MappedByteBufferDoubleView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Double =
+  private[nio] override def load(index: Int): Double =
     GenMappedBufferView[DoubleBuffer](this).byteArrayBits.loadDouble(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Double): Unit =
+  private[nio] override def store(index: Int, elem: Double): Unit =
     GenMappedBufferView[DoubleBuffer](this).byteArrayBits.storeDouble(index, elem)
 }
 

--- a/javalib/src/main/scala/java/nio/MappedByteBufferViews.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferViews.scala
@@ -54,15 +54,6 @@ private[nio] final class MappedByteBufferCharView private (
   }
 
   @noinline
-  def get(): Char =
-    GenBuffer[CharBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Char): CharBuffer =
-    GenBuffer[CharBuffer](this).generic_put(c)
-
-
-  @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
     GenBuffer[CharBuffer](this).generic_get(dst, offset, length)
 
@@ -157,15 +148,6 @@ private[nio] final class MappedByteBufferShortView private (
   @noinline
   def asReadOnlyBuffer(): ShortBuffer =
     GenMappedBufferView[ShortBuffer](this).generic_asReadOnlyBuffer()
-
-
-  @noinline
-  def get(): Short =
-    GenBuffer[ShortBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Short): ShortBuffer =
-    GenBuffer[ShortBuffer](this).generic_put(c)
 
 
   @noinline
@@ -266,15 +248,6 @@ private[nio] final class MappedByteBufferIntView private (
 
 
   @noinline
-  def get(): Int =
-    GenBuffer[IntBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Int): IntBuffer =
-    GenBuffer[IntBuffer](this).generic_put(c)
-
-
-  @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
     GenBuffer[IntBuffer](this).generic_get(dst, offset, length)
 
@@ -369,15 +342,6 @@ private[nio] final class MappedByteBufferLongView private (
   @noinline
   def asReadOnlyBuffer(): LongBuffer =
     GenMappedBufferView[LongBuffer](this).generic_asReadOnlyBuffer()
-
-
-  @noinline
-  def get(): Long =
-    GenBuffer[LongBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Long): LongBuffer =
-    GenBuffer[LongBuffer](this).generic_put(c)
 
 
   @noinline
@@ -478,15 +442,6 @@ private[nio] final class MappedByteBufferFloatView private (
 
 
   @noinline
-  def get(): Float =
-    GenBuffer[FloatBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Float): FloatBuffer =
-    GenBuffer[FloatBuffer](this).generic_put(c)
-
-
-  @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
     GenBuffer[FloatBuffer](this).generic_get(dst, offset, length)
 
@@ -581,15 +536,6 @@ private[nio] final class MappedByteBufferDoubleView private (
   @noinline
   def asReadOnlyBuffer(): DoubleBuffer =
     GenMappedBufferView[DoubleBuffer](this).generic_asReadOnlyBuffer()
-
-
-  @noinline
-  def get(): Double =
-    GenBuffer[DoubleBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Double): DoubleBuffer =
-    GenBuffer[DoubleBuffer](this).generic_put(c)
 
 
   @noinline

--- a/javalib/src/main/scala/java/nio/MappedByteBufferViews.scala.gyb
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferViews.scala.gyb
@@ -63,15 +63,6 @@ private[nio] final class MappedByteBuffer${T}View private (
   % end
 
   @noinline
-  def get(): ${T} =
-    GenBuffer[${T}Buffer](this).generic_get()
-
-  @noinline
-  def put(c: ${T}): ${T}Buffer =
-    GenBuffer[${T}Buffer](this).generic_put(c)
-
-
-  @noinline
   override def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
     GenBuffer[${T}Buffer](this).generic_get(dst, offset, length)
 

--- a/javalib/src/main/scala/java/nio/MappedByteBufferViews.scala.gyb
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferViews.scala.gyb
@@ -17,7 +17,7 @@ private[nio] final class MappedByteBuffer${T}View private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends ${T}Buffer(_capacity) {
+) extends ${T}Buffer(_capacity, if(_mappedData.data != null) _mappedData.data + _offset else _mappedData.data) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -70,13 +70,6 @@ private[nio] final class MappedByteBuffer${T}View private (
   def put(c: ${T}): ${T}Buffer =
     GenBuffer[${T}Buffer](this).generic_put(c)
 
-  @noinline
-  def get(index: Int): ${T} =
-    GenBuffer[${T}Buffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: ${T}): ${T}Buffer =
-    GenBuffer[${T}Buffer](this).generic_put(index, c)
 
   @noinline
   override def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
@@ -97,11 +90,11 @@ private[nio] final class MappedByteBuffer${T}View private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): ${T} =
+  private[nio] override def load(index: Int): ${T} =
     GenMappedBufferView[${T}Buffer](this).byteArrayBits.load${T}(index)
 
   @inline
-  private[nio] def store(index: Int, elem: ${T}): Unit =
+  private[nio] override def store(index: Int, elem: ${T}): Unit =
     GenMappedBufferView[${T}Buffer](this).byteArrayBits.store${T}(index, elem)
 }
 

--- a/javalib/src/main/scala/java/nio/PointerByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/PointerByteBuffer.scala
@@ -9,7 +9,7 @@ private[nio] final class PointerByteBuffer private (
     _initialPosition: Int,
     _initialLimit: Int,
     _readOnly: Boolean
-) extends ByteBuffer(_capacity) {
+) extends ByteBuffer(_capacity, _rawDataPointer + _offset) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -44,14 +44,6 @@ private[nio] final class PointerByteBuffer private (
   @noinline
   def put(b: Byte): ByteBuffer =
     GenBuffer[ByteBuffer](this).generic_put(b)
-
-  @noinline
-  def get(index: Int): Byte =
-    GenBuffer[ByteBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, b: Byte): ByteBuffer =
-    GenBuffer[ByteBuffer](this).generic_put(index, b)
 
   @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
@@ -177,15 +169,6 @@ private[nio] final class PointerByteBuffer private (
     PointerByteBufferDoubleView.fromPointerByteBuffer(this)
 
   // Internal API
-
-  @inline
-  private[nio] def load(index: Int): Byte =
-    GenPointerBuffer[ByteBuffer](this).generic_load(index)
-
-  @inline
-  private[nio] def store(index: Int, elem: Byte): Unit =
-    GenPointerBuffer[ByteBuffer](this).generic_store(index, elem)
-
   @inline
   override private[nio] def load(
       startIndex: Int,

--- a/javalib/src/main/scala/java/nio/PointerByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/PointerByteBuffer.scala
@@ -50,112 +50,20 @@ private[nio] final class PointerByteBuffer private (
     GenPointerBuffer[ByteBuffer](this).generic_compact()
 
   // Here begins the stuff specific to ByteArrays
-  @inline private def byteArrayBits: ByteArrayBits =
-    ByteArrayBits(_rawDataPointer, _offset, isBigEndian)
-
-  @noinline def getChar(): Char =
-    byteArrayBits.loadChar(getPosAndAdvanceRead(2))
-  @noinline def putChar(value: Char): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeChar(getPosAndAdvanceWrite(2), value);
-    this
-  }
-  @noinline def getChar(index: Int): Char =
-    byteArrayBits.loadChar(validateIndex(index, 2))
-  @noinline def putChar(index: Int, value: Char): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeChar(validateIndex(index, 2), value);
-    this
-  }
-
   def asCharBuffer(): CharBuffer =
     PointerByteBufferCharView.fromPointerByteBuffer(this)
-
-  @noinline def getShort(): Short =
-    byteArrayBits.loadShort(getPosAndAdvanceRead(2))
-  @noinline def putShort(value: Short): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeShort(getPosAndAdvanceWrite(2), value);
-    this
-  }
-  @noinline def getShort(index: Int): Short =
-    byteArrayBits.loadShort(validateIndex(index, 2))
-  @noinline def putShort(index: Int, value: Short): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeShort(validateIndex(index, 2), value);
-    this
-  }
 
   def asShortBuffer(): ShortBuffer =
     PointerByteBufferShortView.fromPointerByteBuffer(this)
 
-  @noinline def getInt(): Int =
-    byteArrayBits.loadInt(getPosAndAdvanceRead(4))
-  @noinline def putInt(value: Int): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeInt(getPosAndAdvanceWrite(4), value);
-    this
-  }
-  @noinline def getInt(index: Int): Int =
-    byteArrayBits.loadInt(validateIndex(index, 4))
-  @noinline def putInt(index: Int, value: Int): ByteBuffer = {
-    ensureNotReadOnly(); byteArrayBits.storeInt(validateIndex(index, 4), value);
-    this
-  }
-
   def asIntBuffer(): IntBuffer =
     PointerByteBufferIntView.fromPointerByteBuffer(this)
-
-  @noinline def getLong(): Long =
-    byteArrayBits.loadLong(getPosAndAdvanceRead(8))
-  @noinline def putLong(value: Long): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeLong(getPosAndAdvanceWrite(8), value);
-    this
-  }
-  @noinline def getLong(index: Int): Long =
-    byteArrayBits.loadLong(validateIndex(index, 8))
-  @noinline def putLong(index: Int, value: Long): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeLong(validateIndex(index, 8), value);
-    this
-  }
 
   def asLongBuffer(): LongBuffer =
     PointerByteBufferLongView.fromPointerByteBuffer(this)
 
-  @noinline def getFloat(): Float =
-    byteArrayBits.loadFloat(getPosAndAdvanceRead(4))
-  @noinline def putFloat(value: Float): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeFloat(getPosAndAdvanceWrite(4), value);
-    this
-  }
-  @noinline def getFloat(index: Int): Float =
-    byteArrayBits.loadFloat(validateIndex(index, 4))
-  @noinline def putFloat(index: Int, value: Float): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeFloat(validateIndex(index, 4), value);
-    this
-  }
-
   def asFloatBuffer(): FloatBuffer =
     PointerByteBufferFloatView.fromPointerByteBuffer(this)
-
-  @noinline def getDouble(): Double =
-    byteArrayBits.loadDouble(getPosAndAdvanceRead(8))
-  @noinline def putDouble(value: Double): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeDouble(getPosAndAdvanceWrite(8), value);
-    this
-  }
-  @noinline def getDouble(index: Int): Double =
-    byteArrayBits.loadDouble(validateIndex(index, 8))
-  @noinline def putDouble(index: Int, value: Double): ByteBuffer = {
-    ensureNotReadOnly();
-    byteArrayBits.storeDouble(validateIndex(index, 8), value);
-    this
-  }
 
   def asDoubleBuffer(): DoubleBuffer =
     PointerByteBufferDoubleView.fromPointerByteBuffer(this)

--- a/javalib/src/main/scala/java/nio/PointerByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/PointerByteBuffer.scala
@@ -38,14 +38,6 @@ private[nio] final class PointerByteBuffer private (
     GenPointerBuffer[ByteBuffer](this).generic_asReadOnlyBuffer()
 
   @noinline
-  def get(): Byte =
-    GenBuffer[ByteBuffer](this).generic_get()
-
-  @noinline
-  def put(b: Byte): ByteBuffer =
-    GenBuffer[ByteBuffer](this).generic_put(b)
-
-  @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
     GenBuffer[ByteBuffer](this).generic_get(dst, offset, length)
 

--- a/javalib/src/main/scala/java/nio/PointerByteBufferViews.scala
+++ b/javalib/src/main/scala/java/nio/PointerByteBufferViews.scala
@@ -56,14 +56,6 @@ private[nio] final class PointerByteBufferCharView private (
   }
 
   @noinline
-  def get(): Char =
-    GenBuffer[CharBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Char): CharBuffer =
-    GenBuffer[CharBuffer](this).generic_put(c)
-
-  @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
     GenBuffer[CharBuffer](this).generic_get(dst, offset, length)
 
@@ -159,14 +151,6 @@ private[nio] final class PointerByteBufferShortView private (
   def asReadOnlyBuffer(): ShortBuffer =
     GenPointerBufferView[ShortBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Short =
-    GenBuffer[ShortBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Short): ShortBuffer =
-    GenBuffer[ShortBuffer](this).generic_put(c)
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
@@ -266,14 +250,6 @@ private[nio] final class PointerByteBufferIntView private (
 
 
   @noinline
-  def get(): Int =
-    GenBuffer[IntBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Int): IntBuffer =
-    GenBuffer[IntBuffer](this).generic_put(c)
-
-  @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
     GenBuffer[IntBuffer](this).generic_get(dst, offset, length)
 
@@ -369,14 +345,6 @@ private[nio] final class PointerByteBufferLongView private (
   def asReadOnlyBuffer(): LongBuffer =
     GenPointerBufferView[LongBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Long =
-    GenBuffer[LongBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Long): LongBuffer =
-    GenBuffer[LongBuffer](this).generic_put(c)
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
@@ -476,14 +444,6 @@ private[nio] final class PointerByteBufferFloatView private (
 
 
   @noinline
-  def get(): Float =
-    GenBuffer[FloatBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Float): FloatBuffer =
-    GenBuffer[FloatBuffer](this).generic_put(c)
-
-  @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
     GenBuffer[FloatBuffer](this).generic_get(dst, offset, length)
 
@@ -579,14 +539,6 @@ private[nio] final class PointerByteBufferDoubleView private (
   def asReadOnlyBuffer(): DoubleBuffer =
     GenPointerBufferView[DoubleBuffer](this).generic_asReadOnlyBuffer()
 
-
-  @noinline
-  def get(): Double =
-    GenBuffer[DoubleBuffer](this).generic_get()
-
-  @noinline
-  def put(c: Double): DoubleBuffer =
-    GenBuffer[DoubleBuffer](this).generic_put(c)
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =

--- a/javalib/src/main/scala/java/nio/PointerByteBufferViews.scala
+++ b/javalib/src/main/scala/java/nio/PointerByteBufferViews.scala
@@ -12,7 +12,7 @@ private[nio] final class PointerByteBufferCharView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends CharBuffer(_capacity) {
+) extends CharBuffer(_capacity, _rawDataPointer + _offset) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -64,14 +64,6 @@ private[nio] final class PointerByteBufferCharView private (
     GenBuffer[CharBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Char =
-    GenBuffer[CharBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Char): CharBuffer =
-    GenBuffer[CharBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
     GenBuffer[CharBuffer](this).generic_get(dst, offset, length)
 
@@ -90,11 +82,11 @@ private[nio] final class PointerByteBufferCharView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Char =
+  private[nio] override def load(index: Int): Char =
     GenPointerBufferView[CharBuffer](this).byteArrayBits.loadChar(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Char): Unit =
+  private[nio] override def store(index: Int, elem: Char): Unit =
     GenPointerBufferView[CharBuffer](this).byteArrayBits.storeChar(index, elem)
 }
 
@@ -138,7 +130,7 @@ private[nio] final class PointerByteBufferShortView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends ShortBuffer(_capacity) {
+) extends ShortBuffer(_capacity, _rawDataPointer + _offset) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -177,14 +169,6 @@ private[nio] final class PointerByteBufferShortView private (
     GenBuffer[ShortBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Short =
-    GenBuffer[ShortBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Short): ShortBuffer =
-    GenBuffer[ShortBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
     GenBuffer[ShortBuffer](this).generic_get(dst, offset, length)
 
@@ -203,11 +187,11 @@ private[nio] final class PointerByteBufferShortView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Short =
+  private[nio] override def load(index: Int): Short =
     GenPointerBufferView[ShortBuffer](this).byteArrayBits.loadShort(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Short): Unit =
+  private[nio] override def store(index: Int, elem: Short): Unit =
     GenPointerBufferView[ShortBuffer](this).byteArrayBits.storeShort(index, elem)
 }
 
@@ -251,7 +235,7 @@ private[nio] final class PointerByteBufferIntView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends IntBuffer(_capacity) {
+) extends IntBuffer(_capacity, _rawDataPointer + _offset) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -290,14 +274,6 @@ private[nio] final class PointerByteBufferIntView private (
     GenBuffer[IntBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Int =
-    GenBuffer[IntBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Int): IntBuffer =
-    GenBuffer[IntBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
     GenBuffer[IntBuffer](this).generic_get(dst, offset, length)
 
@@ -316,11 +292,11 @@ private[nio] final class PointerByteBufferIntView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Int =
+  private[nio] override def load(index: Int): Int =
     GenPointerBufferView[IntBuffer](this).byteArrayBits.loadInt(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Int): Unit =
+  private[nio] override def store(index: Int, elem: Int): Unit =
     GenPointerBufferView[IntBuffer](this).byteArrayBits.storeInt(index, elem)
 }
 
@@ -364,7 +340,7 @@ private[nio] final class PointerByteBufferLongView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends LongBuffer(_capacity) {
+) extends LongBuffer(_capacity, _rawDataPointer + _offset) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -403,14 +379,6 @@ private[nio] final class PointerByteBufferLongView private (
     GenBuffer[LongBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Long =
-    GenBuffer[LongBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Long): LongBuffer =
-    GenBuffer[LongBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
     GenBuffer[LongBuffer](this).generic_get(dst, offset, length)
 
@@ -429,11 +397,11 @@ private[nio] final class PointerByteBufferLongView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Long =
+  private[nio] override def load(index: Int): Long =
     GenPointerBufferView[LongBuffer](this).byteArrayBits.loadLong(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Long): Unit =
+  private[nio] override def store(index: Int, elem: Long): Unit =
     GenPointerBufferView[LongBuffer](this).byteArrayBits.storeLong(index, elem)
 }
 
@@ -477,7 +445,7 @@ private[nio] final class PointerByteBufferFloatView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends FloatBuffer(_capacity) {
+) extends FloatBuffer(_capacity, _rawDataPointer + _offset) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -516,14 +484,6 @@ private[nio] final class PointerByteBufferFloatView private (
     GenBuffer[FloatBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Float =
-    GenBuffer[FloatBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Float): FloatBuffer =
-    GenBuffer[FloatBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
     GenBuffer[FloatBuffer](this).generic_get(dst, offset, length)
 
@@ -542,11 +502,11 @@ private[nio] final class PointerByteBufferFloatView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Float =
+  private[nio] override def load(index: Int): Float =
     GenPointerBufferView[FloatBuffer](this).byteArrayBits.loadFloat(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Float): Unit =
+  private[nio] override def store(index: Int, elem: Float): Unit =
     GenPointerBufferView[FloatBuffer](this).byteArrayBits.storeFloat(index, elem)
 }
 
@@ -590,7 +550,7 @@ private[nio] final class PointerByteBufferDoubleView private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends DoubleBuffer(_capacity) {
+) extends DoubleBuffer(_capacity, _rawDataPointer + _offset) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -629,14 +589,6 @@ private[nio] final class PointerByteBufferDoubleView private (
     GenBuffer[DoubleBuffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): Double =
-    GenBuffer[DoubleBuffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: Double): DoubleBuffer =
-    GenBuffer[DoubleBuffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
     GenBuffer[DoubleBuffer](this).generic_get(dst, offset, length)
 
@@ -655,11 +607,11 @@ private[nio] final class PointerByteBufferDoubleView private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): Double =
+  private[nio] override def load(index: Int): Double =
     GenPointerBufferView[DoubleBuffer](this).byteArrayBits.loadDouble(index)
 
   @inline
-  private[nio] def store(index: Int, elem: Double): Unit =
+  private[nio] override def store(index: Int, elem: Double): Unit =
     GenPointerBufferView[DoubleBuffer](this).byteArrayBits.storeDouble(index, elem)
 }
 

--- a/javalib/src/main/scala/java/nio/PointerByteBufferViews.scala.gyb
+++ b/javalib/src/main/scala/java/nio/PointerByteBufferViews.scala.gyb
@@ -19,7 +19,7 @@ private[nio] final class PointerByteBuffer${T}View private (
     _initialLimit: Int,
     _readOnly: Boolean,
     override private[nio] val isBigEndian: Boolean
-) extends ${T}Buffer(_capacity) {
+) extends ${T}Buffer(_capacity, _rawDataPointer + _offset) {
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -73,14 +73,6 @@ private[nio] final class PointerByteBuffer${T}View private (
     GenBuffer[${T}Buffer](this).generic_put(c)
 
   @noinline
-  def get(index: Int): ${T} =
-    GenBuffer[${T}Buffer](this).generic_get(index)
-
-  @noinline
-  def put(index: Int, c: ${T}): ${T}Buffer =
-    GenBuffer[${T}Buffer](this).generic_put(index, c)
-
-  @noinline
   override def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
     GenBuffer[${T}Buffer](this).generic_get(dst, offset, length)
 
@@ -99,11 +91,11 @@ private[nio] final class PointerByteBuffer${T}View private (
   // Private API
 
   @inline
-  private[nio] def load(index: Int): ${T} =
+  private[nio] override def load(index: Int): ${T} =
     GenPointerBufferView[${T}Buffer](this).byteArrayBits.load${T}(index)
 
   @inline
-  private[nio] def store(index: Int, elem: ${T}): Unit =
+  private[nio] override def store(index: Int, elem: ${T}): Unit =
     GenPointerBufferView[${T}Buffer](this).byteArrayBits.store${T}(index, elem)
 }
 

--- a/javalib/src/main/scala/java/nio/PointerByteBufferViews.scala.gyb
+++ b/javalib/src/main/scala/java/nio/PointerByteBufferViews.scala.gyb
@@ -65,14 +65,6 @@ private[nio] final class PointerByteBuffer${T}View private (
   % end
 
   @noinline
-  def get(): ${T} =
-    GenBuffer[${T}Buffer](this).generic_get()
-
-  @noinline
-  def put(c: ${T}): ${T}Buffer =
-    GenBuffer[${T}Buffer](this).generic_put(c)
-
-  @noinline
   override def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
     GenBuffer[${T}Buffer](this).generic_get(dst, offset, length)
 

--- a/javalib/src/main/scala/java/nio/StringCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/StringCharBuffer.scala
@@ -55,10 +55,10 @@ private[nio] final class StringCharBuffer private (
   }
 
   @noinline
-  def get(): Char =
+  override def get(): Char =
     genBuffer.generic_get()
 
-  def put(c: Char): CharBuffer =
+  override def put(c: Char): CharBuffer =
     throw new ReadOnlyBufferException
 
   @noinline

--- a/javalib/src/main/scala/java/nio/StringCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/StringCharBuffer.scala
@@ -10,7 +10,7 @@ private[nio] final class StringCharBuffer private (
     _csqOffset: Int,
     _initialPosition: Int,
     _initialLimit: Int
-) extends CharBuffer(_capacity) {
+) extends CharBuffer(_capacity, null) { // TODO: eliminate nulls
 
   position(_initialPosition)
   limit(_initialLimit)
@@ -62,10 +62,10 @@ private[nio] final class StringCharBuffer private (
     throw new ReadOnlyBufferException
 
   @noinline
-  def get(index: Int): Char =
+  override def get(index: Int): Char =
     genBuffer.generic_get(index)
 
-  def put(index: Int, c: Char): CharBuffer =
+  override def put(index: Int, c: Char): CharBuffer =
     throw new ReadOnlyBufferException
 
   @noinline
@@ -88,11 +88,11 @@ private[nio] final class StringCharBuffer private (
   // Internal API
 
   @inline
-  private[nio] def load(index: Int): Char =
+  private[nio] override def load(index: Int): Char =
     _csq.charAt(_csqOffset + index)
 
   @inline
-  private[nio] def store(index: Int, elem: Char): Unit =
+  private[nio] override def store(index: Int, elem: Char): Unit =
     throw new ReadOnlyBufferException
 
   @inline


### PR DESCRIPTION
This PR continues onging effort on improving nio Buffers performance. Should allow for up to 50% faster execution (no exact benchmark data from before changes), based on debugging of 1 Billions Rows Challange in Scala Native 

* All Buffers define  `rawAddress` which is equal to address calculated from `array.at(arrayOffset)` / `mappedData.data + offset`.  The only exception is `StringCharBuffer` which does not expose pointer to underlying arrays. It's methods are overriden.
* Use a common implemention of relativate and absolute `get`/`put` methods in `TBuffer` instead of using `GenBuffers`. 
* Don't use `ByteArrayBits` to implement `getX`/`putX` operations on ByteBuffers. Use pointer directly. Each usage of ByteArrayBits coused creation of new instance of this class. ByteArraBits are still used in BufferViews