### PR TITLE
feautre: Relaxed memory model for final fields, strict semantics with `@safePublish` annotation

### DIFF
--- a/docs/user/lang.rst
+++ b/docs/user/lang.rst
@@ -23,7 +23,9 @@ allowing to get rid of redundant synchronization, as the state is never shared b
 Scala Native tries to follow the Java Memory Model, but by default uses more relaxed semantics in some areas. 
 Due to the majority of immutable shared states in most Scala programs, Scala Native does not follow Java final fields semantics. 
 Safe publication of final fields (`val`s in Scala) can be enabled by annotating fields or the whole class with `@scala.scalanative.annotation.safePublish`, 
-this behaviour can be also enabled on whole project scope by providing a Scala compiler plugin options `-Pscalanative:forceStrictFinalFields`
+this behaviour can be also enabled on whole project scope by providing a Scala compiler plugin options `-Pscalanative:forceStrictFinalFields`.
+Semantics of final fields can be also overriden at linktime using `NativeConfig.semanticsConfig` - 
+it can be configured to override default relaxed memory model, allowing to replace it with strict JMM semantics or disable synchronization entierely.
 
 Scala Native ensures that all class field operations would be executed atomically, but does not impose any synchronization or happens-before guarantee. 
 

--- a/docs/user/lang.rst
+++ b/docs/user/lang.rst
@@ -16,11 +16,16 @@ those in :ref:`interop` section.
 Multithreading
 --------------
 
-Scala Native doesn't yet provide libraries for parallel multi-threaded
-programming and assumes single-threaded execution by default.
+Scala Native supports parallel multi-threaded programming and assumes multi-threaded execution by default.
+Upon the absence of system threads in the linked program, Scala Native can automatically switch to single-threaded mode, 
+allowing to get rid of redundant synchronization, as the state is never shared between threads.
 
-It's possible to use C libraries to get access to multi-threading and
-synchronization primitives but this is not officially supported at the moment.
+Scala Native tries to follow the Java Memory Model, but by default uses more relaxed semantics in some areas. 
+Due to the majority of immutable shared states in most Scala programs, Scala Native does not follow Java final fields semantics. 
+Safe publication of final fields (`val`s in Scala) can be enabled by annotating fields or the whole class with `@scala.scalanative.annotation.safePublish`.
+
+Scala Native ensures that all class field operations would be executed atomically, but does not impose any synchronization or happens-before guarantee. 
+
 
 Finalization
 ------------

--- a/docs/user/lang.rst
+++ b/docs/user/lang.rst
@@ -22,7 +22,8 @@ allowing to get rid of redundant synchronization, as the state is never shared b
 
 Scala Native tries to follow the Java Memory Model, but by default uses more relaxed semantics in some areas. 
 Due to the majority of immutable shared states in most Scala programs, Scala Native does not follow Java final fields semantics. 
-Safe publication of final fields (`val`s in Scala) can be enabled by annotating fields or the whole class with `@scala.scalanative.annotation.safePublish`.
+Safe publication of final fields (`val`s in Scala) can be enabled by annotating fields or the whole class with `@scala.scalanative.annotation.safePublish`, 
+this behaviour can be also enabled on whole project scope by providing a Scala compiler plugin options `-Pscalanative:forceStrictFinalFields`
 
 Scala Native ensures that all class field operations would be executed atomically, but does not impose any synchronization or happens-before guarantee. 
 

--- a/javalib/src/main/scala/java/util/concurrent/ArrayBlockingQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ArrayBlockingQueue.scala
@@ -11,6 +11,7 @@ import java.util._
 import java.util.concurrent.locks._
 import java.util.function._
 import scala.annotation.tailrec
+import scala.scalanative.annotation.safePublish
 
 @SerialVersionUID(-817911632652898426L)
 object ArrayBlockingQueue {
@@ -62,6 +63,7 @@ class ArrayBlockingQueue[E <: AnyRef](val capacity: Int, val fair: Boolean)
 
   if (capacity <= 0) throw new IllegalArgumentException
 
+  @safePublish
   private[concurrent] final val items = new Array[AnyRef](capacity)
 
   private[concurrent] var takeIndex = 0
@@ -72,6 +74,7 @@ class ArrayBlockingQueue[E <: AnyRef](val capacity: Int, val fair: Boolean)
 
   private[concurrent] var itrs: Itrs = _
 
+  @safePublish
   final private[concurrent] val lock: ReentrantLock = new ReentrantLock(fair)
 
   final private val notEmpty: Condition = lock.newCondition()

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -19,7 +19,7 @@ import java.util.function._
 import java.util.stream.Stream
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
-import scala.scalanative.annotation.{align => Contended}
+import scala.scalanative.annotation.{align => Contended, safePublish}
 import scala.scalanative.unsafe._
 import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
 import scala.scalanative.runtime.fromRawPtr
@@ -295,8 +295,8 @@ object ConcurrentHashMap {
 
   /* ---------------- Nodes -------------- */
   private[concurrent] class Node[K <: AnyRef, V <: AnyRef] private[concurrent] (
-      private[concurrent] val hash: Int,
-      private[concurrent] val key: K,
+      @safePublish private[concurrent] val hash: Int,
+      @safePublish private[concurrent] val key: K,
       @volatile private[concurrent] var `val`: V
   ) extends util.Map.Entry[K, V] {
     @volatile private[concurrent] var next: Node[K, V] = _

--- a/javalib/src/main/scala/java/util/concurrent/CountDownLatch.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CountDownLatch.scala
@@ -7,6 +7,7 @@ package java.util.concurrent
 
 import java.util.concurrent.locks.AbstractQueuedSynchronizer
 import scala.annotation.tailrec
+import scala.scalanative.annotation.safePublish
 
 object CountDownLatch {
 
@@ -39,7 +40,7 @@ object CountDownLatch {
   }
 }
 
-class CountDownLatch private (sync: CountDownLatch.Sync) {
+class CountDownLatch private (@safePublish sync: CountDownLatch.Sync) {
   def this(count: Int) = {
     this(sync = {
       if (count < 0) throw new IllegalArgumentException("count < 0")

--- a/javalib/src/main/scala/java/util/concurrent/CountedCompleter.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CountedCompleter.scala
@@ -9,14 +9,15 @@ package java.util.concurrent
 import scala.scalanative.runtime.{Intrinsics, fromRawPtr}
 import scala.scalanative.libc.stdatomic.AtomicInt
 import scala.annotation.tailrec
+import scala.scalanative.annotation.safePublish
 
 abstract class CountedCompleter[T] protected (
-    final private[concurrent] val completer: CountedCompleter[_],
+    @safePublish final private[concurrent] val completer: CountedCompleter[_],
     initialPendingCount: Int
 ) extends ForkJoinTask[T] {
 
   @volatile private var pending = initialPendingCount
-  private val atomicPending = new AtomicInt(
+  private def atomicPending = new AtomicInt(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "pending"))
   )
 

--- a/javalib/src/main/scala/java/util/concurrent/CyclicBarrier.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CyclicBarrier.scala
@@ -7,6 +7,7 @@
 package java.util.concurrent
 
 import java.util.concurrent.locks.ReentrantLock
+import scala.scalanative.annotation.safePublish
 
 object CyclicBarrier {
   private[concurrent] class Generation() {
@@ -15,9 +16,9 @@ object CyclicBarrier {
 }
 class CyclicBarrier(
     /* The number of parties */
-    val parties: Int,
+    @safePublish val parties: Int,
     /* The command to run when tripped */
-    val barrierCommand: Runnable
+    @safePublish val barrierCommand: Runnable
 ) {
 
   def this(parties: Int) = this(parties, null)

--- a/javalib/src/main/scala/java/util/concurrent/ExecutorCompletionService.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ExecutorCompletionService.scala
@@ -5,10 +5,11 @@
  */
 
 package java.util.concurrent
+import scala.scalanative.annotation.safePublish
 
 class ExecutorCompletionService[V <: AnyRef](
-    val executor: Executor,
-    val completionQueue: BlockingQueue[Future[V]]
+    @safePublish val executor: Executor,
+    @safePublish val completionQueue: BlockingQueue[Future[V]]
 ) extends CompletionService[V] {
   import ExecutorCompletionService._
 
@@ -59,8 +60,8 @@ class ExecutorCompletionService[V <: AnyRef](
 
 object ExecutorCompletionService {
   private class QueueingFuture[V <: AnyRef](
-      task: RunnableFuture[V],
-      completionQueue: BlockingQueue[Future[V]]
+      @safePublish task: RunnableFuture[V],
+      @safePublish completionQueue: BlockingQueue[Future[V]]
   ) extends FutureTask(task, null.asInstanceOf[V]) {
     override protected def done(): Unit = completionQueue.add(task)
   }

--- a/javalib/src/main/scala/java/util/concurrent/Executors.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Executors.scala
@@ -8,7 +8,7 @@ package java.util.concurrent
 import java.util.Collection
 import java.util.List
 import java.util.concurrent.atomic.AtomicInteger
-import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.annotation.{alwaysinline, safePublish}
 import java.security.{PrivilegedAction, PrivilegedExceptionAction}
 
 object Executors {
@@ -164,8 +164,8 @@ object Executors {
   }
 
   final private class RunnableAdapter[T](
-      val task: Runnable,
-      val result: T
+      @safePublish val task: Runnable,
+      @safePublish val result: T
   ) extends Callable[T] {
     override def call(): T = {
       task.run()
@@ -177,7 +177,7 @@ object Executors {
   }
 
   final private class PrivilegedCallable[T](
-      val task: Callable[T]
+      @safePublish val task: Callable[T]
   ) extends Callable[T] {
     @throws[Exception]
     override def call(): T = task.call()
@@ -188,7 +188,7 @@ object Executors {
   }
 
   final private class PrivilegedCallableUsingCurrentClassLoader[T](
-      val task: Callable[T]
+      @safePublish val task: Callable[T]
   ) extends Callable[T] {
 
     @throws[Exception]
@@ -231,7 +231,7 @@ object Executors {
   }
 
   private class DelegatedExecutorService(
-      val executor: ExecutorService
+      @safePublish val executor: ExecutorService
   ) extends ExecutorService {
 
     // Stub used in place of JVM intrinsic

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -44,7 +44,7 @@ class ForkJoinPool private (
   // target number of workers
   @Contended("fjpctl") final var parallelism: Int = _
 
-  final val registrationLock = new ReentrantLock()
+  @safePublish final val registrationLock = new ReentrantLock()
 
   private[concurrent] var queues: Array[WorkQueue] = _ // main registry
   private[concurrent] var termination: Condition = _
@@ -1949,7 +1949,6 @@ object ForkJoinPool {
     final def setClearThreadLocals(): Unit = config |= CLEAR_TLS
   }
 
-  // TODO should be final, but it leads to problems with static forwarders
   final val defaultForkJoinWorkerThreadFactory: ForkJoinWorkerThreadFactory =
     new DefaultForkJoinWorkerThreadFactory()
 

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinWorkerThread.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinWorkerThread.scala
@@ -5,10 +5,11 @@
  */
 
 package java.util.concurrent;
+import scala.scalanative.annotation.safePublish
 
 class ForkJoinWorkerThread private[concurrent] (
     group: ThreadGroup,
-    private[concurrent] val pool: ForkJoinPool,
+    @safePublish private[concurrent] val pool: ForkJoinPool,
     useSystemClassLoader: Boolean, // unused
     clearThreadLocals: Boolean
 ) extends Thread(
@@ -18,6 +19,7 @@ class ForkJoinWorkerThread private[concurrent] (
       stackSize = 0L,
       inheritThreadLocals = !clearThreadLocals
     ) {
+  @safePublish
   private[concurrent] val workQueue =
     new ForkJoinPool.WorkQueue(this, 0)
 

--- a/javalib/src/main/scala/java/util/concurrent/LinkedBlockingQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/LinkedBlockingQueue.scala
@@ -11,6 +11,7 @@ import java.util._
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks._
 import java.util.function._
+import scala.scalanative.annotation.safePublish
 
 @SerialVersionUID(-6903933977591709194L)
 object LinkedBlockingQueue {
@@ -34,14 +35,19 @@ class LinkedBlockingQueue[E <: AnyRef](
 
   private var last = head
 
+  @safePublish
   final private val count = new AtomicInteger()
 
+  @safePublish
   final private val takeLock = new ReentrantLock()
 
+  @safePublish
   final private val notEmpty: Condition = takeLock.newCondition()
 
+  @safePublish
   final private val putLock = new ReentrantLock()
 
+  @safePublish
   final private val notFull = putLock.newCondition()
 
   private def signalNotEmpty(): Unit = {

--- a/javalib/src/main/scala/java/util/concurrent/PriorityBlockingQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/PriorityBlockingQueue.scala
@@ -12,6 +12,7 @@ import java.util.function._
 import scala.annotation.tailrec
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
 import scala.scalanative.libc.stdatomic.AtomicInt
+import scala.scalanative.annotation.safePublish
 
 @SerialVersionUID(5595510919245408276L)
 object PriorityBlockingQueue {
@@ -156,13 +157,15 @@ class PriorityBlockingQueue[E <: AnyRef] private (
 
   private var curSize = 0
 
+  @safePublish
   final private val lock = new ReentrantLock
 
+  @safePublish
   final private val notEmpty: Condition = lock.newCondition()
 
   @volatile private var allocationSpinLock = 0
 
-  private val atomicAllocationSpinLock = new AtomicInt(
+  private def atomicAllocationSpinLock = new AtomicInt(
     fromRawPtr(Intrinsics.classFieldRawPtr(this, "allocationSpinLock"))
   )
 

--- a/javalib/src/main/scala/java/util/concurrent/ScheduledThreadPoolExecutor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ScheduledThreadPoolExecutor.scala
@@ -12,9 +12,11 @@ import java.util._
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks._
 import scala.annotation.tailrec
+import scala.scalanative.annotation.safePublish
 
 object ScheduledThreadPoolExecutor {
 
+  @safePublish
   private val sequencer = new AtomicLong
 
   private val DEFAULT_KEEPALIVE_MILLIS = 10L

--- a/javalib/src/main/scala/java/util/concurrent/Semaphore.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Semaphore.scala
@@ -8,6 +8,7 @@ package java.util.concurrent
 import java.util.Collection
 import java.util.concurrent.locks.AbstractQueuedSynchronizer
 import scala.annotation.tailrec
+import scala.scalanative.annotation.safePublish
 
 object Semaphore {
 
@@ -89,7 +90,8 @@ object Semaphore {
 }
 
 @SerialVersionUID(-3222578661600680210L)
-class Semaphore private (sync: Semaphore.Sync) extends Serializable {
+class Semaphore private (@safePublish sync: Semaphore.Sync)
+    extends Serializable {
 
   def this(permits: Int) = {
     this(sync = new Semaphore.NonfairSync(permits))

--- a/javalib/src/main/scala/java/util/concurrent/SynchronousQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/SynchronousQueue.scala
@@ -12,6 +12,7 @@ import java.util.concurrent.locks._
 import scala.scalanative.libc.stdatomic.AtomicRef
 import scala.scalanative.libc.stdatomic.memory_order._
 import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
+import scala.scalanative.annotation.safePublish
 
 /** A {@linkplain BlockingQueue blocking queue} in which each insert operation
  *  must wait for a corresponding remove operation by another thread, and vice
@@ -563,12 +564,12 @@ object SynchronousQueue {
   private[concurrent] class FifoWaitQueue extends SynchronousQueue.WaitQueue {}
 }
 
-class SynchronousQueue[E <: AnyRef](val fair: Boolean)
+class SynchronousQueue[E <: AnyRef](@safePublish val fair: Boolean)
     extends util.AbstractQueue[E]
     with BlockingQueue[E]
     with Serializable {
   import SynchronousQueue._
-  @volatile private var transferer =
+  @safePublish private val transferer =
     if (fair) new SynchronousQueue.TransferQueue[E]
     else new SynchronousQueue.TransferStack[E]
 

--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -10,6 +10,7 @@ import java.util._
 import java.util.function._
 import java.util.stream._
 import java.util.concurrent.atomic._
+import scala.scalanative.annotation.safePublish
 
 @SerialVersionUID(-5851777807851030925L)
 object ThreadLocalRandom {
@@ -265,8 +266,10 @@ object ThreadLocalRandom {
 
   private val nextLocalGaussian = new ThreadLocal[java.lang.Double]
 
+  @safePublish
   private val probeGenerator = new AtomicInteger
 
+  @safePublish
   private[concurrent] val instance = new ThreadLocalRandom
 
   private val seeder = new AtomicLong(

--- a/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
@@ -10,6 +10,7 @@ import java.util.ConcurrentModificationException
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks._
 import scala.annotation.tailrec
+import scala.scalanative.annotation.safePublish
 
 object ThreadPoolExecutor {
   private val COUNT_BITS: Int = Integer.SIZE - 3
@@ -77,7 +78,7 @@ class ThreadPoolExecutor(
     @volatile private var maximumPoolSize: Int,
     @volatile private var keepAliveTime: Long,
     unit: TimeUnit,
-    workQueue: BlockingQueue[Runnable],
+    @safePublish workQueue: BlockingQueue[Runnable],
     @volatile private var threadFactory: ThreadFactory,
     @volatile private var handler: RejectedExecutionHandler
 ) extends AbstractExecutorService {
@@ -144,10 +145,13 @@ class ThreadPoolExecutor(
 
   private def decrementWorkerCount(): Unit = ctl.addAndGet(-(1))
 
+  @safePublish
   final private val mainLock: ReentrantLock = new ReentrantLock
 
+  @safePublish
   final private val workers: util.HashSet[Worker] = new util.HashSet[Worker]
 
+  @safePublish
   final private val termination: Condition = mainLock.newCondition()
 
   private var largestPoolSize: Int = 0
@@ -164,7 +168,8 @@ class ThreadPoolExecutor(
       with Runnable {
     setState(-1) // inhibit interrupts until runWorker
 
-    final private[concurrent] var thread: Thread =
+    @safePublish
+    final private[concurrent] val thread: Thread =
       getThreadFactory().newThread(this)
 
     @volatile private[concurrent] var completedTasks: Long = 0L

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
@@ -29,13 +29,13 @@ object AbstractQueuedLongSynchronizer { // Node status bits, also used as argume
     @volatile var next: Node = _ // visibly nonnull when signallable
     @volatile var status: Int = 0 // written by owner, atomic bit ops by others
 
-    private val prevAtomic = new AtomicRef[Node](
+    private def prevAtomic = new AtomicRef[Node](
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "prev"))
     )
-    private val nextAtomic = new AtomicRef[Node](
+    private def nextAtomic = new AtomicRef[Node](
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "next"))
     )
-    private val statusAtomic = new AtomicInt(
+    private def statusAtomic = new AtomicInt(
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "status"))
     )
 

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
@@ -29,13 +29,13 @@ object AbstractQueuedSynchronizer { // Node status bits, also used as argument a
     @volatile var next: Node = _ // visibly nonnull when signallable
     @volatile var status: Int = 0 // written by owner, atomic bit ops by others
 
-    private val prevAtomic = new AtomicRef[Node](
+    private def prevAtomic = new AtomicRef[Node](
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "prev"))
     )
-    private val nextAtomic = new AtomicRef[Node](
+    private def nextAtomic = new AtomicRef[Node](
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "next"))
     )
-    private val statusAtomic = new AtomicInt(
+    private def statusAtomic = new AtomicInt(
       fromRawPtr(Intrinsics.classFieldRawPtr(this, "status"))
     )
 

--- a/javalib/src/main/scala/java/util/concurrent/locks/ReentrantLock.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/ReentrantLock.scala
@@ -8,6 +8,7 @@ package java.util
 package concurrent.locks
 
 import java.util.concurrent.TimeUnit
+import scala.scalanative.annotation.safePublish
 
 @SerialVersionUID(7373984872572414699L)
 object ReentrantLock {
@@ -144,7 +145,7 @@ object ReentrantLock {
 }
 
 @SerialVersionUID(7373984872572414699L)
-class ReentrantLock private (sync: ReentrantLock.Sync)
+class ReentrantLock private (@safePublish sync: ReentrantLock.Sync)
     extends Lock
     with Serializable {
 

--- a/javalib/src/main/scala/java/util/concurrent/locks/ReentrantReadWriteLock.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/ReentrantReadWriteLock.scala
@@ -8,6 +8,7 @@ package java.util.concurrent.locks
 
 import java.util
 import java.util.concurrent.TimeUnit
+import scala.scalanative.annotation.safePublish
 
 object ReentrantReadWriteLock {
 
@@ -341,8 +342,9 @@ object ReentrantReadWriteLock {
     override final def readerShouldBlock: Boolean = hasQueuedPredecessors()
   }
 
-  class ReadLock private (final private val sync: ReentrantReadWriteLock.Sync)
-      extends Lock
+  class ReadLock private (
+      @safePublish final private val sync: ReentrantReadWriteLock.Sync
+  ) extends Lock
       with Serializable {
     protected[ReentrantReadWriteLock] def this(lock: ReentrantReadWriteLock) =
       this(lock.sync)
@@ -413,8 +415,10 @@ class ReentrantReadWriteLock(val fair: Boolean)
     if (fair) new ReentrantReadWriteLock.FairSync
     else new ReentrantReadWriteLock.NonfairSync
 
+  @safePublish
   final private val readerLock = new ReentrantReadWriteLock.ReadLock(this)
 
+  @safePublish
   final private val writerLock = new ReentrantReadWriteLock.WriteLock(this)
 
   override def writeLock(): ReentrantReadWriteLock.WriteLock = this.writerLock

--- a/nativelib/src/main/scala/scala/scalanative/annotation/memoryModel.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/memoryModel.scala
@@ -1,0 +1,17 @@
+package scala.scalanative
+package annotation
+
+import scala.annotation.meta.field
+
+/** Follow the Java Memory Model and its final fields semantics when
+ *  initializing and reading final fields.
+ *
+ *  The compiler would ensure that final field would be reachable in fully
+ *  innitialized state by other reads, by introducing synchronization primitives
+ *  on each it's access. Applies only to type immutable field mebers (`val`s)
+ *
+ *  Can be used either on single field or whole type if all of it's fields
+ *  should be safetly published.
+ */
+@field
+final class safePublish extends scala.annotation.StaticAnnotation

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -32,6 +32,7 @@ object Attr {
   case object Abstract extends Attr
   case object Volatile extends Attr
   case object Final extends Attr
+  case object SafePublish extends Attr
   case object LinktimeResolved extends Attr
   case object UsesIntrinsic extends Attr
   case class Alignment(size: Int, group: Option[String]) extends Attr
@@ -53,11 +54,13 @@ final case class Attrs(
     isAbstract: Boolean = false,
     isVolatile: Boolean = false,
     isFinal: Boolean = false,
+    isSafePublish: Boolean = false,
     isLinktimeResolved: Boolean = false,
     isUsingIntrinsics: Boolean = false,
     links: Seq[Attr.Link] = Seq.empty,
     preprocessorDefinitions: Seq[Attr.Define] = Seq.empty
 ) {
+  def finalWithSafePublish: Boolean = isFinal && isSafePublish
   def toSeq: Seq[Attr] = {
     val out = Seq.newBuilder[Attr]
 
@@ -71,6 +74,7 @@ final case class Attrs(
     if (isAbstract) out += Abstract
     if (isVolatile) out += Volatile
     if (isFinal) out += Final
+    if (isSafePublish) out += SafePublish
     if (isLinktimeResolved) out += LinktimeResolved
     if (isUsingIntrinsics) out += UsesIntrinsic
     out ++= links
@@ -94,6 +98,7 @@ object Attrs {
     var isBlocking = false
     var isVolatile = false
     var isFinal = false
+    var isSafePublish = false
     var isLinktimeResolved = false
     var isUsingIntrinsics = false
     val links = Seq.newBuilder[Attr.Link]
@@ -115,6 +120,7 @@ object Attrs {
       case Abstract            => isAbstract = true
       case Volatile            => isVolatile = true
       case Final               => isFinal = true
+      case SafePublish         => isSafePublish = true
 
       case LinktimeResolved => isLinktimeResolved = true
       case UsesIntrinsic    => isUsingIntrinsics = true
@@ -132,6 +138,7 @@ object Attrs {
       isAbstract = isAbstract,
       isVolatile = isVolatile,
       isFinal = isFinal,
+      isSafePublish = isSafePublish,
       isLinktimeResolved = isLinktimeResolved,
       isUsingIntrinsics = isUsingIntrinsics,
       links = links.result(),

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -114,6 +114,7 @@ object Show {
         str("volatile")
       case Attr.Final =>
         str("final")
+      case Attr.SafePublish => str("safe-publish")
       case Attr.LinktimeResolved =>
         str("linktime")
       case Attr.Alignment(size, group) =>

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -195,14 +195,15 @@ final class BinaryDeserializer(buffer: ByteBuffer, nirSource: NIRSource) {
     case T.DidOptAttr  => Attr.DidOpt
     case T.BailOptAttr => Attr.BailOpt(getString())
 
-    case T.DynAttr      => Attr.Dyn
-    case T.StubAttr     => Attr.Stub
-    case T.ExternAttr   => Attr.Extern(getBool())
-    case T.LinkAttr     => Attr.Link(getString())
-    case T.DefineAttr   => Attr.Define(getString())
-    case T.AbstractAttr => Attr.Abstract
-    case T.VolatileAttr => Attr.Volatile
-    case T.FinalAttr    => Attr.Final
+    case T.DynAttr         => Attr.Dyn
+    case T.StubAttr        => Attr.Stub
+    case T.ExternAttr      => Attr.Extern(getBool())
+    case T.LinkAttr        => Attr.Link(getString())
+    case T.DefineAttr      => Attr.Define(getString())
+    case T.AbstractAttr    => Attr.Abstract
+    case T.VolatileAttr    => Attr.Volatile
+    case T.FinalAttr       => Attr.Final
+    case T.SafePublishAttr => Attr.SafePublish
 
     case T.LinktimeResolvedAttr => Attr.LinktimeResolved
     case T.UsesIntrinsicAttr    => Attr.UsesIntrinsic

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -199,6 +199,7 @@ final class BinarySerializer(channel: WritableByteChannel) {
       case Attr.Abstract           => putTag(T.AbstractAttr)
       case Attr.Volatile           => putTag(T.VolatileAttr)
       case Attr.Final              => putTag(T.FinalAttr)
+      case Attr.SafePublish        => putTag(T.SafePublishAttr)
 
       case Attr.LinktimeResolved => putTag(T.LinktimeResolvedAttr)
       case Attr.UsesIntrinsic    => putTag(T.UsesIntrinsicAttr)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -26,7 +26,8 @@ object Tags {
   final val AbstractAttr = 1 + StubAttr
   final val VolatileAttr = 1 + AbstractAttr
   final val FinalAttr = 1 + VolatileAttr
-  final val LinktimeResolvedAttr = 1 + FinalAttr
+  final val SafePublishAttr = 1 + FinalAttr
+  final val LinktimeResolvedAttr = 1 + SafePublishAttr
   final val UsesIntrinsicAttr = 1 + LinktimeResolvedAttr
   final val AlignAttr = 1 + UsesIntrinsicAttr
   final val DefineAttr = 1 + AlignAttr

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -68,6 +68,9 @@ trait NirDefinitions {
       "scala.scalanative.annotation.nospecialize"
     )
     lazy val AlignClass = getRequiredClass("scala.scalanative.annotation.align")
+    lazy val SafePublishClass = getRequiredClass(
+      "scala.scalanative.annotation.safePublish"
+    )
 
     lazy val NativeModule = getRequiredModule(
       "scala.scalanative.unsafe.package"

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -254,6 +254,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           isVolatile = f.isVolatile,
           isFinal = isFinal,
           isSafePublish = isFinal && {
+            scalaNativeOpts.forceStrictFinalFields ||
             f.hasAnnotation(SafePublishClass) ||
             f.owner.hasAnnotation(SafePublishClass)
           },

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -249,9 +249,14 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val pos: nir.Position = f.pos
         // Thats what JVM backend does
         // https://github.com/scala/scala/blob/fe724bcbbfdc4846e5520b9708628d994ae76798/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala#L760-L764
+        val isFinal = !f.isMutable
         val fieldAttrs = attrs.copy(
           isVolatile = f.isVolatile,
-          isFinal = !f.isMutable,
+          isFinal = isFinal,
+          isSafePublish = isFinal && {
+            f.hasAnnotation(SafePublishClass) ||
+            f.owner.hasAnnotation(SafePublishClass)
+          },
           align = getAlignmentAttr(f).orElse(classAlign)
         )
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativeOptions.scala
@@ -19,4 +19,7 @@ trait ScalaNativeOptions {
 
   /** List of paths usd for relativization of source file positions */
   def positionRelativizationPaths: Seq[Path]
+
+  /** Treat all final fields like if they would be marked with safePublish */
+  def forceStrictFinalFields: Boolean
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -24,7 +24,7 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
 
   object scalaNativeOpts extends ScalaNativeOptions {
     var genStaticForwardersForNonTopLevelObjects: Boolean = false
-
+    var forceStrictFinalFields: Boolean = false
     var positionRelativizationPaths: Seq[Path] = Nil
   }
 
@@ -49,6 +49,8 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
     options.foreach {
       case "genStaticForwardersForNonTopLevelObjects" =>
         genStaticForwardersForNonTopLevelObjects = true
+      case "forceStrictFinalFields" =>
+        forceStrictFinalFields = true
 
       case opt if opt.startsWith("positionRelativizationPaths:") =>
         positionRelativizationPaths = {
@@ -64,6 +66,7 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
           global.NoPosition,
           "'mapSourceURI' is deprecated, it is ignored"
         )
+
       case option =>
         error("Option not understood: " + option)
     }
@@ -76,6 +79,10 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
       |     Generate static forwarders for non-top-level objects.
       |     This option should be used by codebases that implement JDK classes.
       |     When used together with -Xno-forwarders, this option has no effect.
+      |  -P:$name:forceStrictFinalFields
+      |     Treat all final fields as if they we're marked with @safePublish.
+      |     This option should be used by codebased that rely heavily on Java Final Fields semantics
+      |     It should not be required by most of normal Scala code.
       |  -P:$name:positionRelativizationPaths
       |     Change the source file positions in generated outputs based on list of provided paths.
       |     It would strip the prefix of the source file if it matches given path.

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
@@ -31,6 +31,10 @@ object GenNIR {
        */
       genStaticForwardersForNonTopLevelObjects: Boolean = false,
 
+      /** Treat all final fields like if they would be marked with safePublish
+       */
+      forceStrictFinalFields: Boolean = false,
+
       /** List of paths usd for relativization of source file positions
        */
       positionRelativizationPaths: Seq[Path] = Nil

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -27,6 +27,7 @@ final class NirDefinitions()(using ctx: Context) {
 
   @tu lazy val StubClass = requiredClass("scala.scalanative.annotation.stub")
   @tu lazy val AlignClass = requiredClass("scala.scalanative.annotation.align")
+  @tu lazy val SafePublishClass = requiredClass("scala.scalanative.annotation.safePublish")
   @tu lazy val NameClass = requiredClass("scala.scalanative.unsafe.name")
   @tu lazy val LinkClass = requiredClass("scala.scalanative.unsafe.link")
   @tu lazy val DefineClass = requiredClass("scala.scalanative.unsafe.define")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -190,10 +190,15 @@ trait NirGenStat(using Context) {
       }
       // That what JVM backend does
       // https://github.com/lampepfl/dotty/blob/786ad3ff248cca39e2da80c3a15b27b38eec2ff6/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala#L340-L347
+      val isFinal = !f.is(Mutable)
       val attrs = nir.Attrs(
         isExtern = isExtern,
         isVolatile = f.isVolatile,
-        isFinal = !f.is(Mutable),
+        isFinal = isFinal,
+        isSafePublish = isFinal && {
+          f.hasAnnotation(defnNir.SafePublishClass) ||
+          f.owner.hasAnnotation(defnNir.SafePublishClass)
+        },
         align = getAlignmentAttr(f).orElse(classAlignment)
       )
       val ty = genType(f.info.resultType)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -196,6 +196,7 @@ trait NirGenStat(using Context) {
         isVolatile = f.isVolatile,
         isFinal = isFinal,
         isSafePublish = isFinal && {
+          settings.forceStrictFinalFields ||
           f.hasAnnotation(defnNir.SafePublishClass) ||
           f.owner.hasAnnotation(defnNir.SafePublishClass)
         },

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -18,6 +18,10 @@ class ScalaNativePlugin extends StandardPlugin:
       |     Generate static forwarders for non-top-level objects.
       |     This option should be used by codebases that implement JDK classes.
       |     When used together with -Xno-forwarders, this option has no effect.
+      |  -P:$name:forceStrictFinalFields
+      |     Treat all final fields as if they we're marked with @safePublish.
+      |     This option should be used by codebased that rely heavily on Java Final Fields semantics
+      |     It should not be required by most of normal Scala code.
       |  -P:$name:positionRelativizationPaths
       |     Change the source file positions in generated outputs based on list of provided paths.
       |     It would strip the prefix of the source file if it matches given path.
@@ -31,6 +35,8 @@ class ScalaNativePlugin extends StandardPlugin:
       .foldLeft(GenNIR.Settings()) {
         case (config, "genStaticForwardersForNonTopLevelObjects") =>
           config.copy(genStaticForwardersForNonTopLevelObjects = true)
+        case (config, "forceStrictFinalFields") =>
+          config.copy(forceStrictFinalFields = true)
         case (config, s"positionRelativizationPaths:${paths}") =>
           config.copy(positionRelativizationPaths =
             (config.positionRelativizationPaths ++ paths

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -88,6 +88,9 @@ sealed trait NativeConfig {
   /** Configuration when doing optimization */
   def optimizerConfig: OptimizerConfig
 
+  /** Configuration for semantics of generated program */
+  def semanticsConfig: SemanticsConfig
+
   /** Configuration for LLVM metadata generation controlling source level
    *  debugging support
    */
@@ -241,6 +244,13 @@ sealed trait NativeConfig {
 
   /** Modify a optimization configuration */
   def withOptimizerConfig(update: Mapping[OptimizerConfig]): NativeConfig
+
+  /** Create a semantics configuration */
+  final def withSemanticsConfig(value: SemanticsConfig): NativeConfig =
+    withSemanticsConfig(_ => value)
+
+  /** Modify a semantics configuration */
+  def withSemanticsConfig(update: Mapping[SemanticsConfig]): NativeConfig
 }
 
 object NativeConfig {
@@ -277,7 +287,8 @@ object NativeConfig {
       serviceProviders = Map.empty,
       baseName = "",
       optimizerConfig = OptimizerConfig.empty,
-      sourceLevelDebuggingConfig = SourceLevelDebuggingConfig.disabled
+      sourceLevelDebuggingConfig = SourceLevelDebuggingConfig.disabled,
+      semanticsConfig = SemanticsConfig.default
     )
 
   private final case class Impl(
@@ -306,7 +317,8 @@ object NativeConfig {
       serviceProviders: Map[ServiceName, Iterable[ServiceProviderName]],
       baseName: String,
       optimizerConfig: OptimizerConfig,
-      sourceLevelDebuggingConfig: SourceLevelDebuggingConfig
+      sourceLevelDebuggingConfig: SourceLevelDebuggingConfig,
+      semanticsConfig: SemanticsConfig
   ) extends NativeConfig {
 
     def withClang(value: Path): NativeConfig =
@@ -414,6 +426,10 @@ object NativeConfig {
     ): NativeConfig =
       copy(sourceLevelDebuggingConfig = update(sourceLevelDebuggingConfig))
 
+    override def withSemanticsConfig(
+        update: Mapping[SemanticsConfig]
+    ): NativeConfig = copy(semanticsConfig = update(semanticsConfig))
+
     override def toString: String = {
       def showSeq(it: Iterable[Any]) = it.mkString("[", ", ", "]")
       def showMap(map: Map[String, Any], indent: Int = 4): String =
@@ -461,6 +477,7 @@ object NativeConfig {
         | - resourceExcludePatterns: ${showSeq(resourceExcludePatterns)}
         | - serviceProviders:        ${showMap(serviceProviders)}
         | - optimizerConfig:         ${optimizerConfig.show(" " * 4)}
+        | - semanticsConfig:         ${semanticsConfig.show(" " * 4)}
         | - sourceLevelDebuggingConfig: ${sourceLevelDebuggingConfig.show(
           " " * 4
         )}

--- a/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
@@ -1,0 +1,56 @@
+package scala.scalanative.build
+
+/** An object describing configuration of the Scala Native semantics. */
+sealed trait SemanticsConfig {
+//format: off
+  /** Describes Behaviour of final fields and their complaince with the Java Memory Model. 
+   *  The outputs of the program would depend of compliance level:
+   *  - [[JVMMemoryModelCompliance.Strict]] all final fields are synchronized - ensures safe publication,but it might lead to runtime performance overhead.
+   *  - [[JVMMemoryModelCompliance.None]] final fields are never synchronized - no runtime overhead when accessing final fields, but it might lead to unexpected state in highly concurrent programs.
+   *  - [[JVMMemoryModelCompliance.Relaxed]] (default) only fields marked with scala.scalanative.annotation.safePublish are synchronized.
+   */
+  def finalFields: JVMMemoryModelCompliance
+// format: on
+  def withFinalFields(value: JVMMemoryModelCompliance): SemanticsConfig
+
+  private[scalanative] def show(indent: String): String
+}
+
+object SemanticsConfig {
+  val default: SemanticsConfig =
+    Impl(finalFields = JVMMemoryModelCompliance.Relaxed)
+
+  private[build] case class Impl(finalFields: JVMMemoryModelCompliance)
+      extends SemanticsConfig {
+    override def withFinalFields(
+        value: JVMMemoryModelCompliance
+    ): SemanticsConfig = copy(finalFields = value)
+
+    override def toString: String = show(indent = " ")
+    override private[scalanative] def show(indent: String): String = {
+      s"""SemanticsConfig(
+          |$indent- finalFields: ${finalFields}
+          |$indent)""".stripMargin
+    }
+  }
+}
+
+sealed abstract class JVMMemoryModelCompliance {
+  final def isStrict = this == JVMMemoryModelCompliance.Strict
+  final def isRelaxed = this == JVMMemoryModelCompliance.Relaxed
+  final def isNone = this == JVMMemoryModelCompliance.None
+}
+object JVMMemoryModelCompliance {
+
+  /** Guide toolchain to ignore JVM memory model specification */
+  case object None extends JVMMemoryModelCompliance
+
+  /** Guide toolchain to use a relaxed JVM memory model specification, typically
+   *  guided with source code annotations
+   */
+  case object Relaxed extends JVMMemoryModelCompliance
+
+  /** Guide toolchain to strictly follow JVM memory model */
+  case object Strict extends JVMMemoryModelCompliance
+
+}

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -197,13 +197,17 @@ object Lower {
 
         case inst @ nir.Inst.Ret(v) =>
           implicit val pos: nir.Position = inst.pos
-          currentDefn.get.name match {
-            case nir.Global.Member(ClassRef(cls), sig)
-                if sig.isCtor && cls.hasFinalSafePublishFields =>
-              // Release memory fence after initialization of constructor with final fields
-              buf.fence(nir.MemoryOrder.Release)
-            case _ => ()
-          }
+          if (config.semanticsConfig.finalFields.isNone) () // no-op
+          else
+            currentDefn.get.name match {
+              case nir.Global.Member(ClassRef(cls), sig) if sig.isCtor && {
+                    (config.semanticsConfig.finalFields.isStrict && cls.hasFinalFields) ||
+                    (config.semanticsConfig.finalFields.isRelaxed && cls.hasFinalSafePublishFields)
+                  } =>
+                // Release memory fence after initialization of constructor with final fields
+                buf.fence(nir.MemoryOrder.Release)
+              case _ => () // no-op
+            }
           genGCYieldpoint(buf)
           val retVal =
             if (v.ty == nir.Type.Unit) optionallyBoxedUnit(v)
@@ -601,8 +605,10 @@ object Lower {
         else nir.MemoryOrder.Unordered
 
       // Acquire memory fence before loading a final field
-      if (field.attrs.finalWithSafePublish)
-        buf.fence(nir.MemoryOrder.Acquire)
+      if (field.attrs.isFinal && {
+            config.semanticsConfig.finalFields.isStrict ||
+            (field.attrs.isSafePublish && config.semanticsConfig.finalFields.isRelaxed)
+          }) buf.fence(nir.MemoryOrder.Acquire)
 
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
       genLoadOp(buf, n, nir.Op.Load(ty, elem, Some(memoryOrder)))

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -126,6 +126,7 @@ final class Class(
     out.toSeq
   }
 
+  lazy val hasFinalFields: Boolean = fields.exists(_.attrs.isFinal)
   lazy val hasFinalSafePublishFields: Boolean =
     fields.exists(_.attrs.finalWithSafePublish)
 

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -126,7 +126,8 @@ final class Class(
     out.toSeq
   }
 
-  lazy val hasFinalFields: Boolean = fields.exists(_.attrs.isFinal)
+  lazy val hasFinalSafePublishFields: Boolean =
+    fields.exists(_.attrs.finalWithSafePublish)
 
   def isConstantModule(implicit
       analysis: ReachabilityAnalysis.Result


### PR DESCRIPTION
resolves #3673  
Final fields are now by default unsynchronized. We introduce a `@safePublish` annotation to restore Java final fields semantics

TODO: 
* [x] - Introduce a compile time config (not linking time) that library authors can use to automatically apply the "@safePublish" annotation to all vals within an entire compilation unit. This would essentially be an escape hatch.
* [x] - Introduce a linking time config that applications can use to restore final Field Semantics for all vals, in their own code and library NIR. Another escape hatch.