### PR TITLE
Rename 'nir.Buffer' to 'InstructionBuilder'

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -160,7 +160,7 @@ object ControlFlow {
 
   def removeDeadBlocks(insts: Seq[Inst]): Seq[Inst] = {
     val cfg = ControlFlow.Graph(insts)
-    val buf = new nir.Buffer()(Fresh(insts))
+    val buf = new nir.InstructionBuilder()(Fresh(insts))
 
     cfg.all.foreach { b =>
       buf += b.label

--- a/nir/src/main/scala/scala/scalanative/nir/InstructionBuilder.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/InstructionBuilder.scala
@@ -3,11 +3,13 @@ package nir
 
 import scala.collection.mutable
 
-class Buffer(implicit fresh: Fresh) {
+/** A class to build sequences of NIR instructions. */
+class InstructionBuilder(implicit fresh: Fresh) {
+
   private val buffer = mutable.UnrolledBuffer.empty[Inst]
   def +=(inst: Inst): Unit = buffer += inst
   def ++=(insts: Seq[Inst]): Unit = buffer ++= insts
-  def ++=(other: Buffer): Unit = buffer ++= other.buffer
+  def ++=(other: InstructionBuilder): Unit = buffer ++= other.buffer
 
   def toSeq: Seq[Inst] = buffer.toSeq
   def size: Int = buffer.size

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -19,7 +19,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
   sealed case class ValTree(value: nir.Val) extends Tree
   sealed case class ContTree(f: () => nir.Val) extends Tree
 
-  class FixupBuffer(implicit fresh: nir.Fresh) extends nir.Buffer {
+  class FixupBuffer(implicit fresh: nir.Fresh) extends nir.InstructionBuilder {
     private var labeled = false
 
     override def +=(inst: nir.Inst): Unit = {
@@ -49,7 +49,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     override def ++=(insts: Seq[nir.Inst]): Unit =
       insts.foreach { inst => this += inst }
 
-    override def ++=(other: nir.Buffer): Unit =
+    override def ++=(other: nir.InstructionBuilder): Unit =
       this ++= other.toSeq
   }
 
@@ -817,7 +817,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         nir.Type.Function(nir.Type.Ref(anonName) +: captureTypes, nir.Type.Unit)
       val ctorBody = scoped(curScopeId := nir.ScopeId.TopLevel) {
         val fresh = nir.Fresh()
-        val buf = new nir.Buffer()(fresh)
+        val buf = new nir.InstructionBuilder()(fresh)
         val self = nir.Val.Local(fresh(), nir.Type.Ref(anonName))
         val captureFormals = captureTypes.map { ty =>
           nir.Val.Local(fresh(), ty)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -293,7 +293,7 @@ trait NirGenExpr(using Context) {
             curScopeId := nir.ScopeId.TopLevel
           ) {
             val fresh = nir.Fresh()
-            val buf = new nir.Buffer()(fresh)
+            val buf = new nir.InstructionBuilder()(fresh)
 
             val superTy = nir.Type.Function(Seq(nir.Rt.Object), nir.Type.Unit)
             val superName = nir.Rt.Object.name.member(nir.Sig.Ctor(Seq.empty))
@@ -3100,7 +3100,8 @@ trait NirGenExpr(using Context) {
 
   }
 
-  sealed class FixupBuffer(using fresh: nir.Fresh) extends nir.Buffer {
+  sealed class FixupBuffer(using fresh: nir.Fresh)
+      extends nir.InstructionBuilder {
     private var labeled = false
 
     override def +=(inst: nir.Inst): Unit = {
@@ -3129,7 +3130,7 @@ trait NirGenExpr(using Context) {
     override def ++=(insts: Seq[nir.Inst]): Unit =
       insts.foreach { inst => this += inst }
 
-    override def ++=(other: nir.Buffer): Unit =
+    override def ++=(other: nir.InstructionBuilder): Unit =
       this ++= other.toSeq
   }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -184,7 +184,7 @@ trait Inline { self: Interflow =>
         parentScopeId = parentScopeId
       )
 
-      val emit = new nir.Buffer()(state.fresh)
+      val emit = new nir.InstructionBuilder()(state.fresh)
 
       def nothing = {
         emit.label(state.fresh(), Seq.empty)

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -25,7 +25,7 @@ final class MergeBlock(val label: nir.Inst.Label, val id: nir.Local) {
   def toInsts(): Seq[nir.Inst] = {
     import Interflow.LLVMIntrinsics._
     val block = this
-    val result = new nir.Buffer()(nir.Fresh(0))
+    val result = new nir.InstructionBuilder()(nir.Fresh(0))
 
     def mergeNext(next: nir.Next.Label): nir.Next.Label = {
       val nextBlock = outgoing(next.id)
@@ -98,7 +98,7 @@ final class MergeBlock(val label: nir.Inst.Label, val id: nir.Local) {
   private def emitIfMissing(
       id: => nir.Local,
       op: nir.Op.Call
-  )(result: nir.Buffer, block: MergeBlock): Boolean = {
+  )(result: nir.InstructionBuilder, block: MergeBlock): Boolean = {
     // Check if original defn already contains this op
     val alreadyEmmited = block.end.emit.exists {
       case nir.Inst.Let(_, `op`, _) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -255,7 +255,7 @@ final class MergeProcessor(
         // Wrap up anre rturn a new merge state
 
         val mergeState = new State(merge)(eval.preserveDebugInfo)
-        mergeState.emit = new nir.Buffer()(mergeFresh)
+        mergeState.emit = new nir.InstructionBuilder()(mergeFresh)
         mergeState.fresh = mergeFresh
         mergeState.locals = mergeLocals
         if (eval.preserveDebugInfo) {

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -15,7 +15,7 @@ final class State(block: nir.Local)(preserveDebugInfo: Boolean) {
   var locals = mutable.OpenHashMap.empty[nir.Local, nir.Val]
   var delayed = mutable.AnyRefMap.empty[nir.Op, nir.Val]
   var emitted = mutable.AnyRefMap.empty[nir.Op, nir.Val.Local]
-  var emit = new nir.Buffer()(fresh)
+  var emit = new nir.InstructionBuilder()(fresh)
   var inlineDepth = 0
 
   // Delayed init

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -152,7 +152,7 @@ object UseDef {
     val fresh = nir.Fresh(insts)
     val cfg = nir.ControlFlow.Graph(insts)
     val usedef = UseDef(cfg)
-    val buf = new nir.Buffer()(fresh)
+    val buf = new nir.InstructionBuilder()(fresh)
 
     cfg.all.foreach { block =>
       if (usedef(block.id).alive) {

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -59,7 +59,7 @@ trait LinktimeValueResolver { self: Reach =>
     def evaluated() = {
       implicit val fresh = nir.Fresh()
       lazy val buf = {
-        val buf = new nir.Buffer()
+        val buf = new nir.InstructionBuilder()
         buf += defn.insts.head
         buf
       }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -1079,7 +1079,7 @@ class Reach(
             ty = nir.Type.Function(Nil, nir.Type.Unit),
             insts = {
               implicit val fresh: nir.Fresh = nir.Fresh()
-              val buf = new nir.Buffer()
+              val buf = new nir.InstructionBuilder()
               buf.label(fresh(), Nil)
               buf.call(
                 throwUndefinedTy,


### PR DESCRIPTION
This PR renames `nir.Buffer` to `InstructionBuilder` to better reflect the role of the abstraction.