### PR TITLE
Fix misleading Heap_Grow logs

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
@@ -328,7 +328,7 @@ void Heap_Grow(Heap *heap, uint32_t incrementInBlocks) {
     size_t incrementInBytes = incrementInBlocks * SPACE_USED_PER_BLOCK;
 
 #ifdef DEBUG_PRINT
-    printf("Growing small heap by %zu bytes, to %zu bytes\n", incrementInBytes,
+    printf("Growing heap by %zu bytes, to %zu bytes\n", incrementInBytes,
            heap->heapSize + incrementInBytes);
     fflush(stdout);
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
@@ -313,7 +313,7 @@ void Heap_Grow(Heap *heap, uint32_t incrementInBlocks) {
     size_t incrementInBytes = incrementInBlocks * SPACE_USED_PER_BLOCK;
 
 #ifdef DEBUG_PRINT
-    printf("Growing small heap by %zu bytes, to %zu bytes\n", incrementInBytes,
+    printf("Growing heap by %zu bytes, to %zu bytes\n", incrementInBytes,
            heap->heapSize + incrementInBytes);
     fflush(stdout);
 #endif


### PR DESCRIPTION
I believe the log message here is misleading, as `Heap_Grow` is also called by the large allocator: https://github.com/scala-native/scala-native/blob/main/nativelib/src/main/resources/scala-native/gc/immix/LargeAllocator.c#L231

(I might have misunderstood the concept of small heap, though)