### PR TITLE
fix: Optimize inlining and set reasonable values to optimizer config 

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -93,7 +93,14 @@ object Defn {
       insts: Seq[Inst],
       debugInfo: Define.DebugInfo = Define.DebugInfo.empty
   )(implicit val pos: Position)
-      extends Defn
+      extends Defn {
+    private[scalanative] lazy val hasUnwind = insts.exists {
+      case nir.Inst.Let(_, _, unwind)   => unwind ne nir.Next.None
+      case nir.Inst.Throw(_, unwind)    => unwind ne nir.Next.None
+      case nir.Inst.Unreachable(unwind) => unwind ne nir.Next.None
+      case _                            => false
+    }
+  }
 
   object Define {
 

--- a/tools/src/main/scala/scala/scalanative/build/OptimizerConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/OptimizerConfig.scala
@@ -14,8 +14,8 @@ sealed trait OptimizerConfig {
   def maxCalleeSize: Int
 
   /** The maximum number of instructions defined in function classifing it as a
-   *  small function. Small functions are always inlined in relea value would be
-   *  used
+   *  small function. Small functions are always treated as inlining candidates
+   *  when release mode is being used.
    */
   def smallFunctionSize: Int
 
@@ -39,7 +39,7 @@ object OptimizerConfig {
   def empty: OptimizerConfig =
     Impl(
       maxInlineDepth = 32,
-      maxCallerSize = 1024,
+      maxCallerSize = 2048,
       maxCalleeSize = 256,
       smallFunctionSize = 12
     )

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -6,72 +6,41 @@ import scala.scalanative.linker._
 import scala.scalanative.util.unreachable
 
 trait Inline { self: Interflow =>
-
-  private val maxInlineSize =
-    config.compilerConfig.optimizerConfig.maxInlineSize
-      .getOrElse(8)
-  private val maxCallerSize =
-    config.compilerConfig.optimizerConfig.maxCallerSize
-      .getOrElse(8192)
-  private val maxInlineDepth =
-    config.compilerConfig.optimizerConfig.maxInlineDepth
+  val optimizerConfig = config.compilerConfig.optimizerConfig
+  import optimizerConfig.{
+    smallFunctionSize,
+    maxCallerSize,
+    maxCalleeSize,
+    maxInlineDepth
+  }
 
   def shallInline(name: nir.Global.Member, args: Seq[nir.Val])(implicit
       state: State,
       analysis: ReachabilityAnalysis.Result
   ): Boolean = {
     val maybeDefn = mode match {
-      case build.Mode.Debug =>
-        maybeOriginal(name)
-      case _: build.Mode.Release =>
-        maybeDone(name)
+      case build.Mode.Debug      => maybeOriginal(name)
+      case _: build.Mode.Release => maybeDone(name)
     }
 
     maybeDefn
       .fold[Boolean] {
         false
       } { defn =>
-        def isCtor = originalName(name) match {
-          case nir.Global.Member(_, sig) if sig.isCtor =>
-            true
-          case _ =>
-            false
-        }
-        def isSmall =
-          defn.insts.size <= maxInlineSize
-        val isExtern =
-          defn.attrs.isExtern
-        def hasVirtualArgs =
-          args.exists(_.isInstanceOf[nir.Val.Virtual])
-        val noOpt =
-          defn.attrs.opt == nir.Attr.NoOpt
-        val noInline =
-          defn.attrs.inlineHint == nir.Attr.NoInline
-        val alwaysInline =
-          defn.attrs.inlineHint == nir.Attr.AlwaysInline
-        val hintInline =
-          defn.attrs.inlineHint == nir.Attr.InlineHint
-        def isRecursive =
-          hasContext(s"inlining ${name.show}")
-        def isDenylisted =
-          this.isDenylisted(name)
-        def calleeTooBig =
-          defn.insts.size > maxCallerSize
-        def callerTooBig =
-          mergeProcessor.currentSize() > maxCallerSize
-        def inlineDepthLimitExceeded =
-          maxInlineDepth.exists(_ > state.inlineDepth)
-
-        def hasUnwind = defn.insts.exists {
-          case nir.Inst.Let(_, _, unwind) =>
-            unwind ne nir.Next.None
-          case nir.Inst.Throw(_, unwind) =>
-            unwind ne nir.Next.None
-          case nir.Inst.Unreachable(unwind) =>
-            unwind ne nir.Next.None
-          case _ =>
-            false
-        }
+        def isCtor = name.sig.isCtor
+        def isSmall = defn.insts.size <= smallFunctionSize
+        def isExtern = defn.attrs.isExtern
+        def hasVirtualArgs = args.exists(_.isInstanceOf[nir.Val.Virtual])
+        def noOpt = defn.attrs.opt == nir.Attr.NoOpt
+        def noInline = defn.attrs.inlineHint == nir.Attr.NoInline
+        def alwaysInline = defn.attrs.inlineHint == nir.Attr.AlwaysInline
+        def hintInline = defn.attrs.inlineHint == nir.Attr.InlineHint
+        def isRecursive = hasContext(s"inlining ${name.show}")
+        def isDenylisted = this.isDenylisted(name)
+        def calleeTooBig = defn.insts.size > maxCalleeSize
+        def callerTooBig = mergeProcessor.currentSize() > maxCallerSize
+        def inlineDepthLimitExceeded = state.inlineDepth > maxInlineDepth
+        def hasUnwind = defn.hasUnwind
 
         val shall = mode match {
           case build.Mode.Debug =>
@@ -89,21 +58,11 @@ trait Inline { self: Interflow =>
           if (shall) {
             if (shallNot) {
               logger(s"not inlining ${name.show}, because:")
-              if (noInline) {
-                logger("* has noinline attr")
-              }
-              if (isRecursive) {
-                logger("* is recursive")
-              }
-              if (isDenylisted) {
-                logger("* is denylisted")
-              }
-              if (callerTooBig) {
-                logger("* caller is too big")
-              }
-              if (calleeTooBig) {
-                logger("* callee is too big")
-              }
+              if (noInline) logger("* has noinline attr")
+              if (isRecursive) logger("* is recursive")
+              if (isDenylisted) logger("* is denylisted")
+              if (callerTooBig) logger("* caller is too big")
+              if (calleeTooBig) logger("* callee is too big")
               if (inlineDepthLimitExceeded)
                 logger("* inline depth limit exceeded")
             }

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -282,13 +282,6 @@ final class MergeProcessor(
         mergeState.heap = mergeHeap
         mergeState.delayed = mergeDelayed
         mergeState.emitted = mergeEmitted
-        mergeState.inlineDepth = incoming match {
-          case Seq(head @ (_, (_, state)), tail @ _*) => state.inlineDepth
-          case _ =>
-            throw new IllegalStateException(
-              "Merging empty list of incoming blocks"
-            )
-        }
         (mergePhis.toSeq, mergeState)
     }
   }
@@ -568,8 +561,6 @@ object MergeProcessor {
     val entryMergeBlock = builder.findMergeBlock(entryName)
     val entryState = new State(entryMergeBlock.id)(eval.preserveDebugInfo)
     entryState.inherit(state, args)
-    entryState.inlineDepth = state.inlineDepth
-    if (doInline) entryState.inlineDepth += 1
 
     entryMergeBlock.incoming(nir.Local(-1)) = (args, entryState)
     builder.todo += entryName

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -16,7 +16,6 @@ final class State(block: nir.Local)(preserveDebugInfo: Boolean) {
   var delayed = mutable.AnyRefMap.empty[nir.Op, nir.Val]
   var emitted = mutable.AnyRefMap.empty[nir.Op, nir.Val.Local]
   var emit = new nir.InstructionBuilder()(fresh)
-  var inlineDepth = 0
 
   // Delayed init
   var localNames: mutable.OpenHashMap[nir.Local, String] = _
@@ -284,7 +283,6 @@ final class State(block: nir.Local)(preserveDebugInfo: Boolean) {
     newstate.locals = locals.clone()
     newstate.delayed = delayed.clone()
     newstate.emitted = emitted.clone()
-    newstate.inlineDepth = inlineDepth
     if (preserveDebugInfo) {
       newstate.virtualNames = virtualNames.mapValuesNow(identity)
       newstate.localNames = localNames.clone()


### PR DESCRIPTION
This change does both shorten the build time in release-full mode AND increases peak performance. During 1BRC challange I've noticed that release-fast created a faster executable then release full while taking 7x longer to build.  With the new config the average run time of created binary dropper from 7.5s to 3.5s

* Cache Defn.hasUnwind and MergeProcessor.currentSize 
* Move default optimizer config values to OptimizerConfig. Set their values to be of  reasonable size
* Optimize tracking recursion and inlining depth 