### PR TITLE
improvement: Detect user config change and prune generated/native sources on change

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -306,17 +306,19 @@ object Build {
 
   private[scalanative] def userConfigHasChanged(config: Config): Boolean = {
     val hashFile = config.workDir.resolve(userConfigHashFile)
-    !Files.exists(hashFile) || Files
-      .readString(hashFile)
-      .trim() != config.compilerConfig.##.toString()
+    !Files.exists(hashFile) || {
+      val source = scala.io.Source.fromFile(hashFile.toFile())
+      try source.mkString.trim() != config.compilerConfig.##.toString()
+      finally source.close()
+    }
   }
 
   private[scalanative] def dumpUserConfigHash(config: Config): Unit = {
     val hashFile = config.workDir.resolve(userConfigHashFile)
     Files.createDirectories(hashFile.getParent())
-    Files.writeString(
+    Files.write(
       hashFile,
-      config.compilerConfig.##.toString(),
+      config.compilerConfig.##.toString().getBytes(),
       StandardOpenOption.CREATE,
       StandardOpenOption.WRITE
     )

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -6,6 +6,7 @@ import scala.scalanative.util.Scope
 import scala.scalanative.linker.ReachabilityAnalysis
 import scala.util.Try
 import java.nio.file.FileVisitOption
+import java.nio.file.StandardOpenOption
 import java.util.Optional
 import java.nio.file.attribute.FileTime
 import scala.concurrent._
@@ -123,6 +124,7 @@ object Build {
             .map(objects => link(config, linkerResult, objects))
             .map(artifact => postProcess(config, artifact))
         )
+        .andThen { case Success(_) => dumpUserConfigHash(config) }
     }
   }
 
@@ -299,5 +301,25 @@ object Build {
         .map[FileTime](getLastModified(_))
         .max(_.compareTo(_))
     else Optional.empty()
+
+  private[scalanative] final val userConfigHashFile = "userConfigHash"
+
+  private[scalanative] def userConfigHasChanged(config: Config): Boolean = {
+    val hashFile = config.workDir.resolve(userConfigHashFile)
+    !Files.exists(hashFile) || Files
+      .readString(hashFile)
+      .trim() != config.compilerConfig.##.toString()
+  }
+
+  private[scalanative] def dumpUserConfigHash(config: Config): Unit = {
+    val hashFile = config.workDir.resolve(userConfigHashFile)
+    Files.createDirectories(hashFile.getParent())
+    Files.writeString(
+      hashFile,
+      config.compilerConfig.##.toString(),
+      StandardOpenOption.CREATE,
+      StandardOpenOption.WRITE
+    )
+  }
 
 }

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -189,6 +189,8 @@ private[scalanative] object NativeLib {
     val workDir = config.workDir
     val classpath = config.classPath
     val nativeCodeDir = workDir.resolve("dependencies")
+    if (Build.userConfigHasChanged(config))
+      IO.deleteRecursive(nativeCodeDir)
 
     val nativeLibPaths = classpath.flatMap { path =>
       if (isJar(path)) readJar(path)

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -7,13 +7,14 @@ import java.nio.file.{Path, Paths, Files}
 import scala.collection.mutable
 import scala.scalanative.build.Config
 import scala.scalanative.build.ScalaNative.{dumpDefns, encodedMainClass}
+import scala.scalanative.build.Build
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.build
+import scala.scalanative.build.IO
 import scala.scalanative.linker.ReachabilityAnalysis
 import scala.scalanative.util.{Scope, partitionBy, procs}
 import java.nio.file.StandardCopyOption
 
-import scala.scalanative.build.ScalaNative
 import scala.scalanative.codegen.{Metadata => CodeGenMetadata}
 import scala.concurrent._
 import scala.util.Success
@@ -69,6 +70,8 @@ object CodeGen {
     Scope { implicit in =>
       val env = assembly.map(defn => defn.name -> defn).toMap
       val outputDirPath = config.workDir.resolve("generated")
+      if (Build.userConfigHasChanged(config))
+        IO.deleteRecursive(outputDirPath)
       Files.createDirectories(outputDirPath)
       val outputDir = VirtualDirectory.real(outputDirPath)
       val sourceCodeCache = new SourceCodeCache(config)


### PR DESCRIPTION
It should allow to get rid of problems when switching multithreaded <-> singlethread setups, especially in context of automatic multithreading detection. 