### PR TITLE
feature: Implement experimental javalib IntStream & LongStream classes

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -580,6 +580,12 @@ java.util.stream
 * ``DoubleStream``
 * ``DoubleStream.Builder``
 * ``DoubleStream.DoubleMapMultiConsumer``
+* ``IntStream``
+* ``IntStream.Builder``
+* ``IntStream.IntMapMultiConsumer``
+* ``LongStream``
+* ``LongStream.Builder``
+* ``LongStream.LongMapMultiConsumer``
 * ``Stream``
 * ``Stream.Builder``
 * ``StreamSupport``

--- a/javalib/src/main/scala/java/lang/CharSequence.scala
+++ b/javalib/src/main/scala/java/lang/CharSequence.scala
@@ -1,6 +1,121 @@
 package java.lang
 
+import java.util.{Spliterator, Spliterators}
+import java.util.stream.{IntStream, StreamSupport}
+import java.util.function.IntConsumer
+
 trait CharSequence {
+
+  /* sub classes, particularly those with fast access to an internal array,
+   * should override the default implementations of chars() and
+   * codePoints() to avoid the cost of the frequent charAt(index) calls
+   * below.
+   */
+
+  def chars(): IntStream = {
+
+    val characteristics =
+      (Spliterator.ORDERED | Spliterator.SIZED | Spliterator.SUBSIZED)
+
+    val src = this
+    val len = this.length()
+    val spl = new Spliterators.AbstractIntSpliterator(
+      len,
+      characteristics
+    ) {
+      var index = 0
+
+      /* Qualify the return type so that signatures match.
+       * Otherwise, java.lang.Boolean is found because this file is
+       * in the java.lang package.  Such knowledge was won by a few
+       * wasted hours of debugging.
+       */
+
+      def tryAdvance(action: IntConsumer): scala.Boolean = {
+        val remaining = len - index
+        if (remaining <= 0) false
+        else {
+          action.accept(src.charAt(index).toInt)
+          index += 1
+          true
+        }
+      }
+    }
+
+    StreamSupport.intStream(spl, parallel = false)
+  }
+
+  def codePoints(): IntStream = {
+
+    /* These characteristics may be incomplete.
+     *
+     * What _is_ certain is that they should not contain either SIZED or
+     * SUBSIZED.
+     *
+     * this.length() gives a good upper bound estimate of the size, so
+     * one would think that the spliterator should be SIZED. This
+     * spliterators reason for existence is to combine surrogate pairs,
+     * when found, into one code point. This means that the real size
+     * is not known. It may be less than the estimate.
+     *
+     * Marking the spliterator as SIZED causes toArray() methods on
+     * the resultant stream to have more slots than stream elements
+     * when surrogate pairs are combined. This causes tests which
+     * check that the array size and number of elements match to fail
+     * and other woes. Just don't do it, Nancy.
+     */
+
+    val characteristics = Spliterator.ORDERED // No SIZED or SUBSIZED allowed
+
+    val src = this
+    val len = this.length()
+    val spl = new Spliterators.AbstractIntSpliterator(
+      len,
+      characteristics
+    ) {
+      var index = 0
+
+      var haveHighSurrogate = false
+      var highSurrogate: Char = _
+
+      /* qualify the return type so that signatures match.
+       * See rationale in method chars() above.
+       */
+
+      def tryAdvance(action: IntConsumer): scala.Boolean = {
+        val remaining = len - index
+        if (remaining <= 0) false
+        else {
+          val ch = src.charAt(index)
+
+          if (Character.isHighSurrogate(ch)) {
+            if (!haveHighSurrogate && (remaining > 0)) {
+              highSurrogate = ch
+              haveHighSurrogate = true
+            } else {
+              haveHighSurrogate = false
+              action.accept(highSurrogate.toInt)
+            }
+          } else if (Character.isLowSurrogate(ch)) {
+            if (!haveHighSurrogate) {
+              action.accept(ch.toInt)
+            } else {
+              haveHighSurrogate = false
+              action.accept(Character.toCodePoint(highSurrogate, ch))
+            }
+          } else {
+            action.accept(ch.toInt)
+          }
+
+          index += 1
+          true
+        }
+      }
+    }
+
+    StreamSupport.intStream(spl, parallel = false)
+  }
+
   def length(): scala.Int
   def charAt(index: scala.Int): scala.Char
   def subSequence(start: scala.Int, end: scala.Int): CharSequence

--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -80,7 +80,7 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
    *   algorithms. Yes, including the JSR-166 code. Such unbounded
    *   loops can easily become what appear to be time consuming if not
    *   infinite loops.
-   * 
+   *
    *   TL; DR
    *      Each of the loops will terminate but have a worst case which can
    *      take substantial time.
@@ -127,20 +127,19 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
    *  With a range where "bound - origin" is 1 and that value is exactly one of
    *  the values which nextLong() could not return, the loop would not
    *  terminate.
-   * 
+   *
    *  However, the while() loop is called only when the range
    *  is larger than Long.MAX_VALUE. The probability of nextLong() not being
-   *  able to return _any_ of those values is vanishing low. 
+   *  able to return _any_ of those values is vanishing low.
    *  From there, the reasoning is similar to the ints case, but with
    *  larger values.
    *  In particular, the denominator for probSuccess is much larger, making
    *  the probability of success on any given draw smaller. That, in turn,
    *  requires a larger number of draws for a given overall probability of
    *  success.
-   * 
+   *
    *  The worst case could look like a "busy wait" non-terminating loop.
    */
-
 
   // By convention, caller has checked that origin < bound
 

--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -1,8 +1,9 @@
 package java.util
 
 import java.{lang => jl}
-import java.util.function.DoubleConsumer
-import java.util.stream.{StreamSupport, DoubleStream}
+import java.util.function.{DoubleConsumer, IntConsumer, LongConsumer}
+import java.util.stream.StreamSupport
+import java.util.stream.{DoubleStream, IntStream, LongStream}
 
 import scala.annotation.tailrec
 
@@ -59,6 +60,68 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
 
       loop()
     }
+  }
+
+  /* Implementation Note:
+   *   The two private methods nextInt(origin, bound) and
+   *   nextLong(origin, bound) use the algorithms documented by
+   *   JDK 8.
+   *
+   *   The same basic algorithms are implemented in the JSR-166 code
+   *   in the Scala Native code for java.util.concurrent.
+   *
+   *   This class is documented as requiring the capability of setting
+   *   a "seed" value for the random number generator.  The JSR-166
+   *   code does not allow that.  So these two methods can not delegate
+   *   to the corresponding JSR-166 methods.  That would be too easy, by far.
+   *
+   *   Anyone interested in robust code will note that these methods
+   *   use unbounded "while" loops. Those loops are in the original
+   *   algorithms. Yes, including the JSR-166 code. Such unbounded
+   *   loops can easily become what appear to be time consuming if not
+   *   infinite loops. Consider the case where the origin and bound are close
+   *   together, say 0 and 2. There are way more Ints or Longs that are
+   *   not in the range than that are. You do the math.
+   */
+
+  private def nextInt(origin: Int, bound: Int): Int = {
+    val n = bound - origin;
+    if (n > 0) {
+      nextInt(n) + origin
+    } else { // range not representable as int
+      var r: Integer = 0
+      while ({ r = nextInt(); (r < origin || r >= bound); }) ()
+      r
+    }
+  }
+
+  /* See the comments above nextInt(origin, bound) above.
+   * Also read the  "def internalNextLong(origin: Long, bound: Long)"
+   * code in Scala Native java.util.concurrent.ThreadLocalRandom.scala
+   * The loop code in the "reject over-represented" clause is adapted
+   * from there. Same algorithm as Java code but already in Scala.
+   */
+
+  private def nextLong(origin: Long, bound: Long): Long = {
+    var r = nextLong()
+    val n = bound - origin
+    val m = n - 1
+
+    if ((n & m) == 0L) // power of two
+      r = (r & m) + origin
+    else if (n > 0L) { // reject over-represented candidates
+      var u: Long = r >>> 1 // ensure nonnegative
+      r = u % n
+      while ((u + m - r) < 0L) // rejection check
+        u = nextLong() >>> 1 // retry
+
+      r += origin;
+    } else { // range not representable as long
+      while (r < origin || r >= bound)
+        r = nextLong()
+    }
+
+    r
   }
 
   def nextLong(): Long = (next(32).toLong << 32) + next(32)
@@ -185,12 +248,8 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
     }
   }
 
-  def doubles(): DoubleStream = {
-    val spliter =
-      new RandomDoublesSpliterator(0L, jl.Long.MAX_VALUE, 0.0, 1.0)
-
-    StreamSupport.doubleStream(spliter, parallel = false)
-  }
+  def doubles(): DoubleStream =
+    doubles(jl.Long.MAX_VALUE)
 
   def doubles(
       randomNumberOrigin: Double,
@@ -229,6 +288,196 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
       )
 
     StreamSupport.doubleStream(spliter, parallel = false)
+  }
+
+  final private class RandomIntsSpliterator(
+      var index: Long,
+      fence: Long,
+      origin: Int,
+      bound: Int
+  ) extends Spliterator.OfInt {
+
+    override def trySplit(): RandomIntsSpliterator = {
+      val m = (index + fence) >>> 1
+      if (m <= index) null
+      else {
+        val i = index
+        index = m
+        new RandomIntsSpliterator(i, m, origin, bound)
+      }
+    }
+
+    override def estimateSize(): Long = fence - index
+    override def characteristics(): Int = randomStreamCharacteristics
+
+    override def tryAdvance(consumer: IntConsumer): Boolean = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      if (index >= fence) false
+      else {
+        consumer.accept(nextInt(origin, bound))
+        index += 1
+        true
+      }
+    }
+
+    override def forEachRemaining(consumer: IntConsumer): Unit = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      if (index < fence) {
+        var i = index
+        index = fence
+        while ({
+          consumer.accept(nextInt(origin, bound))
+          i += 1
+          i < fence
+        }) ()
+      }
+    }
+  }
+
+  def ints(): IntStream =
+    ints(jl.Long.MAX_VALUE)
+
+  def ints(
+      randomNumberOrigin: Int,
+      randomNumberBound: Int
+  ): IntStream = {
+    ints(jl.Long.MAX_VALUE, randomNumberOrigin, randomNumberBound)
+  }
+
+  def ints(streamSize: Long): IntStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(invalidStreamSizeMsg)
+
+    val spliter =
+      new RandomIntsSpliterator(
+        0L,
+        streamSize,
+        jl.Integer.MIN_VALUE,
+        jl.Integer.MAX_VALUE
+      )
+
+    StreamSupport.intStream(spliter, parallel = false)
+  }
+
+  def ints(
+      streamSize: Long,
+      randomNumberOrigin: Int,
+      randomNumberBound: Int
+  ): IntStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(invalidStreamSizeMsg)
+
+    if (!(randomNumberOrigin < randomNumberBound))
+      throw new IllegalArgumentException("bound must be greater than origin")
+
+    val spliter =
+      new RandomIntsSpliterator(
+        0L,
+        streamSize,
+        randomNumberOrigin,
+        randomNumberBound
+      )
+
+    StreamSupport.intStream(spliter, parallel = false)
+  }
+
+  final private class RandomLongsSpliterator(
+      var index: Long,
+      fence: Long,
+      origin: Long,
+      bound: Long
+  ) extends Spliterator.OfLong {
+
+    override def trySplit(): RandomLongsSpliterator = {
+      val m = (index + fence) >>> 1
+      if (m <= index) null
+      else {
+        val i = index
+        index = m
+        new RandomLongsSpliterator(i, m, origin, bound)
+      }
+    }
+
+    override def estimateSize(): Long = fence - index
+    override def characteristics(): Int = randomStreamCharacteristics
+
+    override def tryAdvance(consumer: LongConsumer): Boolean = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      if (index >= fence) false
+      else {
+        consumer.accept(nextLong(origin, bound))
+        index += 1
+        true
+      }
+    }
+
+    override def forEachRemaining(consumer: LongConsumer): Unit = {
+      if (consumer == null)
+        throw new NullPointerException
+
+      if (index < fence) {
+        var i = index
+        index = fence
+        while ({
+          consumer.accept(nextLong(origin, bound))
+          i += 1
+          i < fence
+        }) ()
+      }
+    }
+  }
+
+  def longs(): LongStream =
+    longs(jl.Long.MAX_VALUE)
+
+  def longs(
+      randomNumberOrigin: Long,
+      randomNumberBound: Long
+  ): LongStream = {
+    longs(jl.Long.MAX_VALUE, randomNumberOrigin, randomNumberBound)
+  }
+
+  def longs(streamSize: Long): LongStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(invalidStreamSizeMsg)
+
+    val spliter =
+      new RandomLongsSpliterator(
+        0L,
+        streamSize,
+        jl.Long.MIN_VALUE,
+        jl.Long.MAX_VALUE
+      )
+
+    StreamSupport.longStream(spliter, parallel = false)
+  }
+
+  def longs(
+      streamSize: Long,
+      randomNumberOrigin: Long,
+      randomNumberBound: Long
+  ): LongStream = {
+    if (streamSize < 0L)
+      throw new IllegalArgumentException(invalidStreamSizeMsg)
+
+    if (!(randomNumberOrigin < randomNumberBound))
+      throw new IllegalArgumentException("bound must be greater than origin")
+
+    val spliter =
+      new RandomLongsSpliterator(
+        0L,
+        streamSize,
+        randomNumberOrigin,
+        randomNumberBound
+      )
+
+    StreamSupport.longStream(spliter, parallel = false)
   }
 
 }

--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -460,7 +460,7 @@ class ThreadLocalRandom private () extends Random {
     v1 * multiplier
   }
 
-  def ints(streamSize: Long): IntStream = {
+  override def ints(streamSize: Long): IntStream = {
     if (streamSize < 0L)
       throw new IllegalArgumentException(ThreadLocalRandom.BAD_SIZE)
     StreamSupport.intStream(
@@ -474,7 +474,7 @@ class ThreadLocalRandom private () extends Random {
     )
   }
 
-  def ints(): IntStream =
+  override def ints(): IntStream =
     StreamSupport.intStream(
       new ThreadLocalRandom.RandomIntsSpliterator(
         0L,
@@ -485,7 +485,7 @@ class ThreadLocalRandom private () extends Random {
       false
     )
 
-  def ints(
+  override def ints(
       streamSize: Long,
       randomNumberOrigin: Int,
       randomNumberBound: Int
@@ -505,7 +505,10 @@ class ThreadLocalRandom private () extends Random {
     )
   }
 
-  def ints(randomNumberOrigin: Int, randomNumberBound: Int): IntStream = {
+  override def ints(
+      randomNumberOrigin: Int,
+      randomNumberBound: Int
+  ): IntStream = {
     if (randomNumberOrigin >= randomNumberBound)
       throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
     StreamSupport.intStream(
@@ -519,7 +522,7 @@ class ThreadLocalRandom private () extends Random {
     )
   }
 
-  def longs(streamSize: Long): LongStream = {
+  override def longs(streamSize: Long): LongStream = {
     if (streamSize < 0L)
       throw new IllegalArgumentException(ThreadLocalRandom.BAD_SIZE)
     StreamSupport.longStream(
@@ -533,7 +536,7 @@ class ThreadLocalRandom private () extends Random {
     )
   }
 
-  def longs(): LongStream =
+  override def longs(): LongStream =
     StreamSupport.longStream(
       new ThreadLocalRandom.RandomLongsSpliterator(
         0L,
@@ -544,7 +547,7 @@ class ThreadLocalRandom private () extends Random {
       false
     )
 
-  def longs(
+  override def longs(
       streamSize: Long,
       randomNumberOrigin: Long,
       randomNumberBound: Long
@@ -564,7 +567,10 @@ class ThreadLocalRandom private () extends Random {
     )
   }
 
-  def longs(randomNumberOrigin: Long, randomNumberBound: Long): LongStream = {
+  override def longs(
+      randomNumberOrigin: Long,
+      randomNumberBound: Long
+  ): LongStream = {
     if (randomNumberOrigin >= randomNumberBound)
       throw new IllegalArgumentException(ThreadLocalRandom.BAD_RANGE)
     StreamSupport.longStream(

--- a/javalib/src/main/scala/java/util/stream/IntStream.scala
+++ b/javalib/src/main/scala/java/util/stream/IntStream.scala
@@ -1,0 +1,381 @@
+package java.util.stream
+
+import java.{lang => jl}
+
+import java.util._
+import java.util.function._
+
+/* Design Note:
+ *
+ * IntStream extends BaseStream[jl.Int, IntStream]
+ * in correspondence to the documentation & usage of Spliterator.Of*
+ * and PrimitiveIterator.Of*. That is, the first type is a Java container.
+ */
+
+trait IntStream extends BaseStream[jl.Integer, IntStream] {
+
+  def allMatch(pred: IntPredicate): Boolean
+
+  def anyMatch(pred: IntPredicate): Boolean
+
+  def asDoubleStream(): DoubleStream
+
+  def asLongStream(): LongStream
+
+  def average(): OptionalDouble
+
+  def boxed(): Stream[jl.Integer]
+
+  def collect[R](
+      supplier: Supplier[R],
+      accumulator: ObjIntConsumer[R],
+      combiner: BiConsumer[R, R]
+  ): R
+
+  def count(): scala.Long
+
+  def distinct(): IntStream
+
+  // Since: Java 9
+  def dropWhile(pred: IntPredicate): IntStream = {
+    Objects.requireNonNull(pred)
+
+    val spliter = this.spliterator() //  also marks this stream "operated upon"
+
+    // JVM appears to use an unsized iterator for dropWhile()
+    // May need to adjust other characteristics.
+    val unSized = spliter.characteristics() &
+      ~(Spliterator.SIZED | Spliterator.SUBSIZED)
+
+    val spl = new Spliterators.AbstractIntSpliterator(
+      Long.MaxValue,
+      unSized
+    ) {
+
+      override def trySplit(): Spliterator.OfInt =
+        null.asInstanceOf[Spliterator.OfInt]
+
+      var doneDropping = false
+
+      def tryAdvance(action: IntConsumer): Boolean = {
+        if (doneDropping) {
+          spliter.tryAdvance(e => action.accept(e))
+        } else {
+          var doneLooping = false
+          while (!doneLooping) {
+            val advanced =
+              spliter.tryAdvance(e => {
+                if (!pred.test(e)) {
+                  action.accept(e)
+                  doneDropping = true
+                  doneLooping = true
+                }
+
+              })
+            if (!advanced)
+              doneLooping = true
+          }
+          doneDropping // true iff some element was accepted
+        }
+      }
+    }
+
+    new IntStreamImpl(spl, parallel = false, parent = this)
+  }
+
+  def filter(pred: IntPredicate): IntStream
+
+  def findAny(): OptionalInt
+
+  def findFirst(): OptionalInt
+
+  def flatMap(mapper: IntFunction[_ <: IntStream]): IntStream
+
+  def forEach(action: IntConsumer): Unit
+
+  def forEachOrdered(action: IntConsumer): Unit
+
+  def limit(maxSize: scala.Long): IntStream
+
+  def map(mapper: IntUnaryOperator): IntStream
+
+  // Since: Java 16
+  def mapMulti(mapper: IntStream.IntMapMultiConsumer): IntStream = {
+
+    /* Design Note:
+     *    This implementation differs from the reference default implementation
+     *   described in the Java Stream#mapMulti documentation.
+     *
+     * That implementation is basically:
+     *    this.flatMap(e => {
+     *      val buffer = new ArrayList[R]()
+     *      mapper.accept(e, r => buffer.add(r))
+     *      buffer.stream()
+     *    })
+     *
+     * It offers few of the benefits described for the multiMap method:
+     * reduced number of streams created, runtime efficiency, etc.
+     *
+     * This implementation should actually provide the benefits of mapMulti().
+     */
+
+    val spliter = this.spliterator() //  also marks this stream "operated upon"
+
+    val buffer = new ArrayDeque[Int]()
+
+    // Can not predict replacements, so Spliterator can not be SIZED.
+    // May need to adjust other characteristics.
+    val unSized = spliter.characteristics() &
+      ~(Spliterator.SIZED | Spliterator.SUBSIZED)
+
+    val spl =
+      new Spliterators.AbstractIntSpliterator(Long.MaxValue, unSized) {
+
+        def tryAdvance(action: IntConsumer): Boolean = {
+          var advanced = false
+
+          var done = false
+          while (!done) {
+            if (buffer.size() == 0) {
+              val stepped =
+                spliter.tryAdvance(e => mapper.accept(e, r => buffer.add(r)))
+              done = !stepped
+            } else {
+              action.accept(buffer.removeFirst())
+              advanced = true
+              done = true
+            }
+          }
+
+          advanced
+        }
+      }
+
+    new IntStreamImpl(
+      spl,
+      parallel = false,
+      parent = this.asInstanceOf[IntStream]
+    )
+  }
+
+  def mapToDouble(mapper: IntToDoubleFunction): DoubleStream
+
+  def mapToLong(mapper: IntToLongFunction): LongStream
+
+  def mapToObj[U](mapper: IntFunction[_ <: U]): Stream[U]
+
+  def max(): OptionalInt
+
+  def min(): OptionalInt
+
+  def noneMatch(pred: IntPredicate): Boolean
+
+  def peek(action: IntConsumer): IntStream
+
+  def reduce(identity: scala.Int, op: IntBinaryOperator): scala.Int
+
+  def reduce(op: IntBinaryOperator): OptionalInt
+
+  def skip(n: scala.Long): IntStream
+
+  def sorted(): IntStream
+
+  def sum(): scala.Int
+
+  def summaryStatistics(): IntSummaryStatistics
+
+  // Since: Java 9
+  def takeWhile(pred: IntPredicate): IntStream = {
+    Objects.requireNonNull(pred)
+
+    val spliter = this.spliterator() //  also marks this stream "operated upon"
+
+    // JVM appears to use an unsized iterator for takeWhile()
+    // May need to adjust other characteristics.
+    val unSized = spliter.characteristics() &
+      ~(Spliterator.SIZED | Spliterator.SUBSIZED)
+
+    val spl = new Spliterators.AbstractIntSpliterator(
+      Long.MaxValue,
+      unSized
+    ) {
+      var done = false // short-circuit
+
+      override def trySplit(): Spliterator.OfInt =
+        null.asInstanceOf[Spliterator.OfInt]
+
+      def tryAdvance(action: IntConsumer): Boolean = {
+        if (done) false
+        else
+          spliter.tryAdvance(e =>
+            if (!pred.test(e)) done = true
+            else action.accept(e)
+          )
+      }
+    }
+
+    new IntStreamImpl(spl, parallel = false, parent = this)
+  }
+
+  def toArray(): Array[scala.Int]
+
+}
+
+object IntStream {
+
+  trait Builder extends IntConsumer {
+    def accept(t: scala.Int): Unit
+    def add(t: scala.Int): IntStream.Builder = {
+      accept(t)
+      this
+    }
+    def build(): IntStream
+  }
+
+  @FunctionalInterface
+  trait IntMapMultiConsumer {
+    def accept(value: scala.Int, dc: IntConsumer): Unit
+  }
+
+  def builder(): IntStream.Builder =
+    new IntStreamImpl.Builder
+
+  def concat(a: IntStream, b: IntStream): IntStream =
+    IntStreamImpl.concat(a, b)
+
+  def empty(): IntStream =
+    new IntStreamImpl(
+      Spliterators.emptyIntSpliterator(),
+      parallel = false
+    )
+
+  def generate(s: IntSupplier): IntStream = {
+    val spliter =
+      new Spliterators.AbstractIntSpliterator(Long.MaxValue, 0) {
+        def tryAdvance(action: IntConsumer): Boolean = {
+          action.accept(s.getAsInt())
+          true
+        }
+      }
+
+    new IntStreamImpl(spliter, parallel = false)
+  }
+
+  // Since: Java 9
+  def iterate(
+      seed: scala.Int,
+      hasNext: IntPredicate,
+      next: IntUnaryOperator
+  ): IntStream = {
+    // "seed" on RHS here is to keep compiler happy with local var initialize.
+    var previous = seed
+    var seedUsed = false
+
+    val spliter =
+      new Spliterators.AbstractIntSpliterator(
+        Long.MaxValue,
+        Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.NONNULL
+      ) {
+        def tryAdvance(action: IntConsumer): Boolean = {
+          val current =
+            if (seedUsed) next.applyAsInt(previous)
+            else {
+              seedUsed = true
+              seed
+            }
+
+          val advanceOK = hasNext.test(current)
+          if (advanceOK) {
+            action.accept(current)
+            previous = current
+          }
+          advanceOK
+        }
+      }
+
+    new IntStreamImpl(spliter, parallel = false)
+  }
+
+  def iterate(
+      seed: scala.Int,
+      f: IntUnaryOperator
+  ): IntStream = {
+    // "seed" on RHS here is to keep compiler happy with local var initialize.
+    var previous = seed
+    var seedUsed = false
+
+    val spliter =
+      new Spliterators.AbstractIntSpliterator(
+        Long.MaxValue,
+        Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.NONNULL
+      ) {
+        def tryAdvance(action: IntConsumer): Boolean = {
+          val current =
+            if (seedUsed) f.applyAsInt(previous)
+            else {
+              seedUsed = true
+              seed
+            }
+
+          action.accept(current)
+          previous = current
+          true
+        }
+      }
+
+    new IntStreamImpl(spliter, parallel = false)
+  }
+
+  def of(values: Array[Int]): IntStream = {
+    /* One would expect variables arguments to be declared as
+     * "values: Objects*" here.
+     * However, that causes "symbol not found" errors at OS link time.
+     * An implicit conversion must be missing in the javalib environment.
+     */
+
+    Arrays.stream(values)
+  }
+
+  def of(t: Int): IntStream = {
+    val values = new Array[Int](1)
+    values(0) = t
+    IntStream.of(values)
+  }
+
+  private def rangeImpl(start: Int, end: Int, inclusive: Boolean): IntStream = {
+
+    val exclusiveSpan = end - start
+    val size =
+      if (inclusive) exclusiveSpan + 1
+      else exclusiveSpan
+
+    val spl = new Spliterators.AbstractIntSpliterator(
+      size,
+      Spliterator.SIZED | Spliterator.SUBSIZED
+    ) {
+
+      override def trySplit(): Spliterator.OfInt =
+        null.asInstanceOf[Spliterator.OfInt]
+
+      var cursor = start
+
+      def tryAdvance(action: IntConsumer): Boolean = {
+        val advance = (cursor < end) || ((cursor == end) && inclusive)
+        if (advance) {
+          action.accept(cursor)
+          cursor += 1
+        }
+        advance
+      }
+    }
+
+    new IntStreamImpl(spl, parallel = false)
+  }
+
+  def range(startInclusive: Int, endExclusive: Int): IntStream =
+    IntStream.rangeImpl(startInclusive, endExclusive, inclusive = false)
+
+  def rangeClosed(startInclusive: Int, endInclusive: Int): IntStream =
+    IntStream.rangeImpl(startInclusive, endInclusive, inclusive = true)
+
+}

--- a/javalib/src/main/scala/java/util/stream/LongStream.scala
+++ b/javalib/src/main/scala/java/util/stream/LongStream.scala
@@ -1,0 +1,383 @@
+package java.util.stream
+
+import java.{lang => jl}
+
+import java.util._
+import java.util.function._
+
+/* Design Note:
+ *
+ * LongStream extends BaseStream[jl.Long, LongStream]
+ * in correspondence to the documentation & usage of Spliterator.Of*
+ * and PrimitiveIterator.Of*. That is, the first type is a Java container.
+ */
+
+trait LongStream extends BaseStream[jl.Long, LongStream] {
+
+  def allMatch(pred: LongPredicate): Boolean
+
+  def anyMatch(pred: LongPredicate): Boolean
+
+  def asDoubleStream(): DoubleStream
+
+  def average(): OptionalDouble
+
+  def boxed(): Stream[jl.Long]
+
+  def collect[R](
+      supplier: Supplier[R],
+      accumulator: ObjLongConsumer[R],
+      combiner: BiConsumer[R, R]
+  ): R
+
+  def count(): scala.Long
+
+  def distinct(): LongStream
+
+  // Since: Java 9
+  def dropWhile(pred: LongPredicate): LongStream = {
+    Objects.requireNonNull(pred)
+
+    val spliter = this.spliterator() //  also marks this stream "operated upon"
+
+    // JVM appears to use an unsized iterator for dropWhile()
+    // May need to adjust other characteristics.
+    val unSized = spliter.characteristics() &
+      ~(Spliterator.SIZED | Spliterator.SUBSIZED)
+
+    val spl = new Spliterators.AbstractLongSpliterator(
+      Long.MaxValue,
+      unSized
+    ) {
+
+      override def trySplit(): Spliterator.OfLong =
+        null.asInstanceOf[Spliterator.OfLong]
+
+      var doneDropping = false
+
+      def tryAdvance(action: LongConsumer): Boolean = {
+        if (doneDropping) {
+          spliter.tryAdvance(e => action.accept(e))
+        } else {
+          var doneLooping = false
+          while (!doneLooping) {
+            val advanced =
+              spliter.tryAdvance(e => {
+                if (!pred.test(e)) {
+                  action.accept(e)
+                  doneDropping = true
+                  doneLooping = true
+                }
+
+              })
+            if (!advanced)
+              doneLooping = true
+          }
+          doneDropping // true iff some element was accepted
+        }
+      }
+    }
+
+    new LongStreamImpl(spl, parallel = false, parent = this)
+  }
+
+  def filter(pred: LongPredicate): LongStream
+
+  def findAny(): OptionalLong
+
+  def findFirst(): OptionalLong
+
+  def flatMap(mapper: LongFunction[_ <: LongStream]): LongStream
+
+  def forEach(action: LongConsumer): Unit
+
+  def forEachOrdered(action: LongConsumer): Unit
+
+  def limit(maxSize: scala.Long): LongStream
+
+  def map(mapper: LongUnaryOperator): LongStream
+
+  // Since: Java 16
+  def mapMulti(mapper: LongStream.LongMapMultiConsumer): LongStream = {
+
+    /* Design Note:
+     *    This implementation differs from the reference default implementation
+     *   described in the Java Stream#mapMulti documentation.
+     *
+     * That implementation is basically:
+     *    this.flatMap(e => {
+     *      val buffer = new ArrayList[R]()
+     *      mapper.accept(e, r => buffer.add(r))
+     *      buffer.stream()
+     *    })
+     *
+     * It offers few of the benefits described for the multiMap method:
+     * reduced number of streams created, runtime efficiency, etc.
+     *
+     * This implementation should actually provide the benefits of mapMulti().
+     */
+
+    val spliter = this.spliterator() //  also marks this stream "operated upon"
+
+    val buffer = new ArrayDeque[Long]()
+
+    // Can not predict replacements, so Spliterator can not be SIZED.
+    // May need to adjust other characteristics.
+    val unSized = spliter.characteristics() &
+      ~(Spliterator.SIZED | Spliterator.SUBSIZED)
+
+    val spl =
+      new Spliterators.AbstractLongSpliterator(Long.MaxValue, unSized) {
+
+        def tryAdvance(action: LongConsumer): Boolean = {
+          var advanced = false
+
+          var done = false
+          while (!done) {
+            if (buffer.size() == 0) {
+              val stepped =
+                spliter.tryAdvance(e => mapper.accept(e, r => buffer.add(r)))
+              done = !stepped
+            } else {
+              action.accept(buffer.removeFirst())
+              advanced = true
+              done = true
+            }
+          }
+
+          advanced
+        }
+      }
+
+    new LongStreamImpl(
+      spl,
+      parallel = false,
+      parent = this.asInstanceOf[LongStream]
+    )
+  }
+
+  def mapToDouble(mapper: LongToDoubleFunction): DoubleStream
+
+  def mapToInt(mapper: LongToIntFunction): IntStream
+
+  def mapToObj[U](mapper: LongFunction[_ <: U]): Stream[U]
+
+  def max(): OptionalLong
+
+  def min(): OptionalLong
+
+  def noneMatch(pred: LongPredicate): Boolean
+
+  def peek(action: LongConsumer): LongStream
+
+  def reduce(identity: scala.Long, op: LongBinaryOperator): scala.Long
+
+  def reduce(op: LongBinaryOperator): OptionalLong
+
+  def skip(n: scala.Long): LongStream
+
+  def sorted(): LongStream
+
+  def sum(): scala.Long
+
+  def summaryStatistics(): LongSummaryStatistics
+
+  // Since: Java 9
+  def takeWhile(pred: LongPredicate): LongStream = {
+    Objects.requireNonNull(pred)
+
+    val spliter = this.spliterator() //  also marks this stream "operated upon"
+
+    // JVM appears to use an unsized iterator for takeWhile()
+    // May need to adjust other characteristics.
+    val unSized = spliter.characteristics() &
+      ~(Spliterator.SIZED | Spliterator.SUBSIZED)
+
+    val spl = new Spliterators.AbstractLongSpliterator(
+      Long.MaxValue,
+      unSized
+    ) {
+      var done = false // short-circuit
+
+      override def trySplit(): Spliterator.OfLong =
+        null.asInstanceOf[Spliterator.OfLong]
+
+      def tryAdvance(action: LongConsumer): Boolean = {
+        if (done) false
+        else
+          spliter.tryAdvance(e =>
+            if (!pred.test(e)) done = true
+            else action.accept(e)
+          )
+      }
+    }
+
+    new LongStreamImpl(spl, parallel = false, parent = this)
+  }
+
+  def toArray(): Array[scala.Long]
+
+}
+
+object LongStream {
+
+  trait Builder extends LongConsumer {
+    def accept(t: scala.Long): Unit
+    def add(t: scala.Long): LongStream.Builder = {
+      accept(t)
+      this
+    }
+    def build(): LongStream
+  }
+
+  @FunctionalInterface
+  trait LongMapMultiConsumer {
+    def accept(value: scala.Long, dc: LongConsumer): Unit
+  }
+
+  def builder(): LongStream.Builder =
+    new LongStreamImpl.Builder
+
+  def concat(a: LongStream, b: LongStream): LongStream =
+    LongStreamImpl.concat(a, b)
+
+  def empty(): LongStream =
+    new LongStreamImpl(
+      Spliterators.emptyLongSpliterator(),
+      parallel = false
+    )
+
+  def generate(s: LongSupplier): LongStream = {
+    val spliter =
+      new Spliterators.AbstractLongSpliterator(Long.MaxValue, 0) {
+        def tryAdvance(action: LongConsumer): Boolean = {
+          action.accept(s.getAsLong())
+          true
+        }
+      }
+
+    new LongStreamImpl(spliter, parallel = false)
+  }
+
+  // Since: Java 9
+  def iterate(
+      seed: scala.Long,
+      hasNext: LongPredicate,
+      next: LongUnaryOperator
+  ): LongStream = {
+    // "seed" on RHS here is to keep compiler happy with local var initialize.
+    var previous = seed
+    var seedUsed = false
+
+    val spliter =
+      new Spliterators.AbstractLongSpliterator(
+        Long.MaxValue,
+        Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.NONNULL
+      ) {
+        def tryAdvance(action: LongConsumer): Boolean = {
+          val current =
+            if (seedUsed) next.applyAsLong(previous)
+            else {
+              seedUsed = true
+              seed
+            }
+
+          val advanceOK = hasNext.test(current)
+          if (advanceOK) {
+            action.accept(current)
+            previous = current
+          }
+          advanceOK
+        }
+      }
+
+    new LongStreamImpl(spliter, parallel = false)
+  }
+
+  def iterate(
+      seed: scala.Long,
+      f: LongUnaryOperator
+  ): LongStream = {
+    // "seed" on RHS here is to keep compiler happy with local var initialize.
+    var previous = seed
+    var seedUsed = false
+
+    val spliter =
+      new Spliterators.AbstractLongSpliterator(
+        Long.MaxValue,
+        Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.NONNULL
+      ) {
+        def tryAdvance(action: LongConsumer): Boolean = {
+          val current =
+            if (seedUsed) f.applyAsLong(previous)
+            else {
+              seedUsed = true
+              seed
+            }
+
+          action.accept(current)
+          previous = current
+          true
+        }
+      }
+
+    new LongStreamImpl(spliter, parallel = false)
+  }
+
+  def of(values: Array[Long]): LongStream = {
+    /* One would expect variables arguments to be declared as
+     * "values: Objects*" here.
+     * However, that causes "symbol not found" errors at OS link time.
+     * An implicit conversion must be missing in the javalib environment.
+     */
+
+    Arrays.stream(values)
+  }
+
+  def of(t: Long): LongStream = {
+    val values = new Array[Long](1)
+    values(0) = t
+    LongStream.of(values)
+  }
+
+  private def rangeImpl(
+      start: Long,
+      end: Long,
+      inclusive: Boolean
+  ): LongStream = {
+
+    val exclusiveSpan = end - start
+    val size =
+      if (inclusive) exclusiveSpan + 1L
+      else exclusiveSpan
+
+    val spl = new Spliterators.AbstractLongSpliterator(
+      size,
+      Spliterator.SIZED | Spliterator.SUBSIZED
+    ) {
+
+      override def trySplit(): Spliterator.OfLong =
+        null.asInstanceOf[Spliterator.OfLong]
+
+      var cursor = start
+
+      def tryAdvance(action: LongConsumer): Boolean = {
+        val advance = (cursor < end) || ((cursor == end) && inclusive)
+        if (advance) {
+          action.accept(cursor)
+          cursor += 1
+        }
+        advance
+      }
+    }
+
+    new LongStreamImpl(spl, parallel = false)
+  }
+
+  def range(startInclusive: Long, endExclusive: Long): LongStream =
+    LongStream.rangeImpl(startInclusive, endExclusive, inclusive = false)
+
+  def rangeClosed(startInclusive: Long, endInclusive: Long): LongStream =
+    LongStream.rangeImpl(startInclusive, endInclusive, inclusive = true)
+
+}

--- a/javalib/src/main/scala/java/util/stream/Stream.scala
+++ b/javalib/src/main/scala/java/util/stream/Stream.scala
@@ -151,7 +151,6 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
       parallel = false,
       parent = this.asInstanceOf[Stream[R]]
     ))
-      .asInstanceOf[Stream[R]]
   }
 
   // Since: Java 16
@@ -202,7 +201,6 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
       parallel = false,
       coercedPriorStages
     ))
-      .asInstanceOf[DoubleStream]
   }
 
   // Since: Java 16
@@ -253,7 +251,6 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
       parallel = false,
       coercedPriorStages
     ))
-      .asInstanceOf[IntStream]
   }
 
   // Since: Java 16
@@ -304,7 +301,6 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
       parallel = false,
       coercedPriorStages
     ))
-      .asInstanceOf[LongStream]
   }
 
   def mapToDouble(mapper: ToDoubleFunction[_ >: T]): DoubleStream

--- a/javalib/src/main/scala/java/util/stream/StreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamImpl.scala
@@ -515,7 +515,6 @@ private[stream] class StreamImpl[T](
       _parallel,
       coercedPriorStages
     )
-      .asInstanceOf[DoubleStream]
   }
 
   def mapToInt(mapper: ToIntFunction[_ >: T]): IntStream = {
@@ -537,7 +536,6 @@ private[stream] class StreamImpl[T](
       _parallel,
       coercedPriorStages
     )
-      .asInstanceOf[IntStream]
   }
 
   def mapToLong(mapper: ToLongFunction[_ >: T]): LongStream = {
@@ -559,7 +557,6 @@ private[stream] class StreamImpl[T](
       _parallel,
       coercedPriorStages
     )
-      .asInstanceOf[LongStream]
   }
 
   def max(comparator: Comparator[_ >: T]): Optional[T] = {

--- a/javalib/src/main/scala/java/util/stream/StreamSupport.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamSupport.scala
@@ -5,13 +5,6 @@ import java.util.Spliterator
 
 object StreamSupport {
 
-  /* Design Note:
-   *   stream() and doubleStream() are implemented. intStream() and
-   *   longStream() are not.  The first two need to mature before
-   *   doubleStream() gets propagated into the latter two. No sense
-   *   multiplying bugs beyond necessity, said William.
-   */
-
   def doubleStream(
       spliterator: Spliterator.OfDouble,
       parallel: Boolean
@@ -31,7 +24,7 @@ object StreamSupport {
       spliterator: Spliterator.OfInt,
       parallel: Boolean
   ): IntStream = {
-    throw new UnsupportedOperationException("Not Yet Implemented")
+    new IntStreamImpl(spliterator, parallel)
   }
 
   def intStream(
@@ -39,14 +32,14 @@ object StreamSupport {
       characteristics: Int,
       parallel: Boolean
   ): IntStream = {
-    throw new UnsupportedOperationException("Not Yet Implemented")
+    new IntStreamImpl(supplier, characteristics, parallel)
   }
 
   def longStream(
       spliterator: Spliterator.OfLong,
       parallel: Boolean
   ): LongStream = {
-    throw new UnsupportedOperationException("Not Yet Implemented")
+    new LongStreamImpl(spliterator, parallel)
   }
 
   def longStream(
@@ -54,7 +47,7 @@ object StreamSupport {
       characteristics: Int,
       parallel: Boolean
   ): LongStream = {
-    throw new UnsupportedOperationException("Not Yet Implemented")
+    new LongStreamImpl(supplier, characteristics, parallel)
   }
 
   def stream[T](
@@ -71,4 +64,5 @@ object StreamSupport {
   ): Stream[T] = {
     new StreamImpl[T](supplier, characteristics, parallel)
   }
+
 }

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/IntStreamTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/IntStreamTestOnJDK16.scala
@@ -1,0 +1,74 @@
+package org.scalanative.testsuite.javalib.util.stream
+
+import java.{lang => jl}
+import java.util.Arrays
+import java.util.stream._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class IntStreamTestOnJDK16 {
+
+  // Since: Java 16
+  @Test def intStreamMapMulti_Eliding(): Unit = {
+    val initialCount = 6
+    val expectedCount = 4
+
+    val data = new Array[Int](initialCount)
+    data(0) = 55
+    data(1) = 44
+    data(2) = -11
+    data(3) = 0
+    data(4) = -22
+    data(5) = 33
+
+    val s = Arrays.stream(data)
+
+    // By design, the mapper will return empty results for two items.
+    val mappedMulti = s.mapMulti((element, consumer) =>
+      if ((element != 0) && (element != 44)) {
+        consumer.accept(element)
+      }
+    )
+
+    var count = mappedMulti.count()
+
+    assertTrue("unexpected empty stream", count > 0)
+    assertEquals("unexpected number of elements", expectedCount, count)
+  }
+
+  // Since: Java 16
+  @Test def intStreamMapMulti_Expanding(): Unit = {
+
+    val initialCount = 6
+    val expectedCount = 7
+
+    val data = new Array[Int](initialCount)
+    data(0) = 55
+    data(1) = 44
+    data(2) = -11
+    data(3) = 0
+    data(4) = -22
+    data(5) = 33
+
+    val s = Arrays.stream(data)
+
+    // Expand one item with multiple replacements. Otherwise 1 to 1.
+    val mappedMulti = s.mapMulti((element, consumer) =>
+      if (element != 0) {
+        consumer.accept(element)
+      } else {
+        consumer.accept(jl.Integer.MIN_VALUE)
+        consumer.accept(jl.Integer.MIN_VALUE)
+      }
+    )
+
+    var count = mappedMulti.count()
+
+    assertTrue("unexpected empty stream", count > 0)
+    assertEquals("unexpected number of elements", expectedCount, count)
+  }
+
+}

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/LongStreamTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/LongStreamTestOnJDK16.scala
@@ -1,0 +1,74 @@
+package org.scalanative.testsuite.javalib.util.stream
+
+import java.{lang => jl}
+import java.util.Arrays
+import java.util.stream._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class LongStreamTestOnJDK16 {
+
+  // Since: Java 16
+  @Test def longStreamMapMulti_Eliding(): Unit = {
+    val initialCount = 6
+    val expectedCount = 4
+
+    val data = new Array[Long](initialCount)
+    data(0) = 55
+    data(1) = 44
+    data(2) = -11
+    data(3) = 0
+    data(4) = -22
+    data(5) = 33L
+
+    val s = Arrays.stream(data)
+
+    // By design, the mapper will return empty results for two items.
+    val mappedMulti = s.mapMulti((element, consumer) =>
+      if ((element != 0) && (element != 44)) {
+        consumer.accept(element)
+      }
+    )
+
+    var count = mappedMulti.count()
+
+    assertTrue("unexpected empty stream", count > 0)
+    assertEquals("unexpected number of elements", expectedCount, count)
+  }
+
+  // Since: Java 16
+  @Test def longStreamMapMulti_Expanding(): Unit = {
+
+    val initialCount = 6
+    val expectedCount = 7
+
+    val data = new Array[Long](initialCount)
+    data(0) = 55
+    data(1) = 44
+    data(2) = -11
+    data(3) = 0
+    data(4) = -22
+    data(5) = 33L
+
+    val s = Arrays.stream(data)
+
+    // Expand one item with multiple replacements. Otherwise 1 to 1.
+    val mappedMulti = s.mapMulti((element, consumer) =>
+      if (element != 0) {
+        consumer.accept(element)
+      } else {
+        consumer.accept(jl.Long.MIN_VALUE)
+        consumer.accept(jl.Long.MIN_VALUE)
+      }
+    )
+
+    var count = mappedMulti.count()
+
+    assertTrue("unexpected empty stream", count > 0)
+    assertEquals("unexpected number of elements", expectedCount, count)
+  }
+
+}

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/StreamTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/StreamTestOnJDK16.scala
@@ -1,5 +1,7 @@
 package org.scalanative.testsuite.javalib.util.stream
 
+import java.{lang => jl}
+
 import java.util.Arrays
 import java.util.function.Consumer
 import java.util.stream._
@@ -112,6 +114,68 @@ class StreamTestOnJDK16 {
     var sum = mappedMultiToDouble.sum()
 
     assertEquals("unexpected sum", expectedSum, sum, epsilon)
+  }
+
+  // Since: Java 16
+  @Test def streamMapMultiToInt(): Unit = {
+    case class Item(name: String, upc: Double)
+
+    val initialCount = 6
+
+    val data = new Array[Item](initialCount)
+    data(0) = Item("Hydrogen", 1.1)
+    data(1) = Item("Helium", 2.2)
+    data(2) = Item("", 3.3)
+    data(3) = Item("Rabbit", 4.4)
+    data(4) = Item("Beryllium", 5.5)
+    data(5) = Item("Boron", 6.6)
+
+    val expectedSum = (4 + 8) + (5 + 10) + (6 + 12) + (7 + 14)
+
+    val s = Arrays.stream(data)
+
+    // By design & intent, the element and result types differ.
+    val mappedMultiToInt = s.mapMultiToInt((element, intConsumer) =>
+      if (element.upc >= 3.0)
+        for (j <- 1 to 2) // One way to increase your silver.
+          intConsumer.accept(j * element.upc.ceil.toInt)
+    )
+
+    var sum = mappedMultiToInt.sum()
+
+    assertEquals("unexpected sum", expectedSum, sum)
+  }
+
+  // Since: Java 16
+  @Test def streamMapMultiToLong(): Unit = {
+    case class Item(name: String, upc: Double)
+
+    val initialCount = 6
+    val willConvertToLong = (jl.Integer.MAX_VALUE + 1L).toDouble
+
+    val data = new Array[Item](initialCount)
+    data(0) = Item("Hydrogen", 1.1)
+    data(1) = Item("Helium", 2.2)
+    data(2) = Item("", 3.3)
+    data(3) = Item("Rabbit", 4.4)
+    data(4) = Item("Beryllium", 5.5)
+    data(5) = Item("Boron", willConvertToLong)
+
+    val expectedSum = (4 + 8) + (5 + 10) + (6 + 12) +
+      ((3 * willConvertToLong.ceil).toLong)
+
+    val s = Arrays.stream(data)
+
+    // By design & intent, the element and result types differ.
+    val mappedMultiToLong = s.mapMultiToLong((element, longConsumer) =>
+      if (element.upc >= 3.0)
+        for (j <- 1 to 2) // One way to increase your bronze.
+          longConsumer.accept(j * element.upc.ceil.toLong)
+    )
+
+    var sum = mappedMultiToLong.sum()
+
+    assertEquals("unexpected sum", expectedSum, sum)
   }
 
   // Since: Java 16

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/stream/IntStreamTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/stream/IntStreamTestOnJDK9.scala
@@ -1,0 +1,140 @@
+package org.scalanative.testsuite.javalib.util.stream
+
+import java.util.stream._
+import java.util.Spliterator
+
+import org.junit.Test
+import org.junit.Assert._
+
+class IntStreamTestOnJDK9 {
+
+  final val epsilon = 0.00001 // tolerance for Floating point comparisons.
+
+  @Test def intStreamDropWhile_Empty(): Unit = {
+    val s = IntStream.empty()
+
+    val remaining = s.dropWhile(_ < 0)
+
+    assertFalse("stream should be empty", remaining.findFirst().isPresent)
+  }
+
+  @Test def intStreamDropWhile_NoMatch(): Unit = {
+    val expectedRemainingCount = 6
+
+    val s = IntStream.of(11, 22, 44, 1, -1, 2)
+
+    val remaining = s.dropWhile(_ > 100)
+
+    assertEquals(
+      "unexpected remaining count",
+      expectedRemainingCount,
+      remaining.count()
+    )
+  }
+
+  @Test def intStreamDropWhile_SomeMatch(): Unit = {
+    val expectedRemainingCount = 4
+
+    val s = IntStream.of(11, 22, 44, 1, -1, 2)
+
+    val remaining = s.dropWhile(_ < 30)
+
+    assertEquals(
+      "unexpected remaining count",
+      expectedRemainingCount,
+      remaining.count()
+    )
+  }
+
+  @Test def intStreamIterate_BoundedByPredicate(): Unit = {
+    var count = -1
+    val limit = 5
+
+    val expectedSeed = 271828
+
+    val s = IntStream.iterate(
+      expectedSeed,
+      e => count < limit,
+      e => {
+        count += 1
+        e + 1
+      }
+    )
+
+    val it = s.iterator()
+
+    assertTrue("stream should not be empty", it.hasNext())
+
+    assertEquals(s"seed", expectedSeed, it.nextInt())
+
+    for (j <- 1 to limit) {
+      assertEquals(s"element: ${j}", expectedSeed + j, it.nextInt())
+    }
+
+    assertFalse("stream should be empty", it.hasNext())
+  }
+
+  @Test def intStreamIterate_BoundedByPredicate_Characteristics(): Unit = {
+    var count = -1
+    val limit = 5
+
+    val expectedSeed = 271828
+
+    val s = IntStream.iterate(
+      expectedSeed,
+      e => count < limit,
+      e => {
+        count += 1
+        e + 1
+      }
+    )
+    val spliter = s.spliterator()
+
+    // spliterator should have required characteristics and no others.
+    // Note: IntStream requires NONNULL, whereas Stream[T] does not.
+    val requiredPresent =
+      Seq(Spliterator.ORDERED, Spliterator.IMMUTABLE, Spliterator.NONNULL)
+
+    val requiredAbsent = Seq(
+      Spliterator.SORTED,
+      Spliterator.SIZED,
+      Spliterator.SUBSIZED
+    )
+
+    StreamTestHelpers.verifyCharacteristics(
+      spliter,
+      requiredPresent,
+      requiredAbsent
+    )
+
+    // If SIZED is really missing, these conditions should hold.
+    assertEquals(s"getExactSizeIfKnown", -1L, spliter.getExactSizeIfKnown())
+    assertEquals(s"estimateSize", Long.MaxValue, spliter.estimateSize())
+  }
+
+  @Test def intStreamTakeWhile_Empty(): Unit = {
+    val s = IntStream.empty()
+
+    val taken = s.takeWhile(_ < 523)
+
+    assertFalse("stream should be empty", taken.findFirst().isPresent)
+  }
+
+  @Test def intStreamTakeWhile_NoMatch(): Unit = {
+    val s = IntStream.of(11, 22, 44, 1, -1, 2)
+
+    val taken = s.takeWhile(_ > 101)
+    assertFalse("stream should be empty", taken.findFirst().isPresent)
+  }
+
+  @Test def intStreamTakeWhile_SomeMatch(): Unit = {
+    val expectedTakenCount = 3
+
+    val s = IntStream.of(11, 22, 44, 1, -1, 2)
+
+    val taken = s.takeWhile(_ > 5)
+
+    assertEquals("unexpected taken count", expectedTakenCount, taken.count())
+  }
+
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/stream/LongStreamTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/stream/LongStreamTestOnJDK9.scala
@@ -1,0 +1,140 @@
+package org.scalanative.testsuite.javalib.util.stream
+
+import java.util.stream._
+import java.util.Spliterator
+
+import org.junit.Test
+import org.junit.Assert._
+
+class LongStreamTestOnJDK9 {
+
+  final val epsilon = 0.00001 // tolerance for Floating point comparisons.
+
+  @Test def longStreamDropWhile_Empty(): Unit = {
+    val s = LongStream.empty()
+
+    val remaining = s.dropWhile(_ < 0L)
+
+    assertFalse("stream should be empty", remaining.findFirst().isPresent)
+  }
+
+  @Test def longStreamDropWhile_NoMatch(): Unit = {
+    val expectedRemainingCount = 6
+
+    val s = LongStream.of(11, 22, 44, 1, -1, 2L)
+
+    val remaining = s.dropWhile(_ > 100L)
+
+    assertEquals(
+      "unexpected remaining count",
+      expectedRemainingCount,
+      remaining.count()
+    )
+  }
+
+  @Test def longStreamDropWhile_SomeMatch(): Unit = {
+    val expectedRemainingCount = 4
+
+    val s = LongStream.of(11, 22, 44, 1, -1, 2L)
+
+    val remaining = s.dropWhile(_ < 30L)
+
+    assertEquals(
+      "unexpected remaining count",
+      expectedRemainingCount,
+      remaining.count()
+    )
+  }
+
+  @Test def longStreamIterate_BoundedByPredicate(): Unit = {
+    var count = -1
+    val limit = 5
+
+    val expectedSeed = 271828L
+
+    val s = LongStream.iterate(
+      expectedSeed,
+      e => count < limit,
+      e => {
+        count += 1
+        e + 1
+      }
+    )
+
+    val it = s.iterator()
+
+    assertTrue("stream should not be empty", it.hasNext())
+
+    assertEquals(s"seed", expectedSeed, it.nextLong())
+
+    for (j <- 1 to limit) {
+      assertEquals(s"element: ${j}", expectedSeed + j, it.nextLong())
+    }
+
+    assertFalse("stream should be empty", it.hasNext())
+  }
+
+  @Test def longStreamIterate_BoundedByPredicate_Characteristics(): Unit = {
+    var count = -1
+    val limit = 5
+
+    val expectedSeed = 271828L
+
+    val s = LongStream.iterate(
+      expectedSeed,
+      e => count < limit,
+      e => {
+        count += 1
+        e + 1
+      }
+    )
+    val spliter = s.spliterator()
+
+    // spliterator should have required characteristics and no others.
+    // Note: LongStream requires NONNULL, whereas Stream[T] does not.
+    val requiredPresent =
+      Seq(Spliterator.ORDERED, Spliterator.IMMUTABLE, Spliterator.NONNULL)
+
+    val requiredAbsent = Seq(
+      Spliterator.SORTED,
+      Spliterator.SIZED,
+      Spliterator.SUBSIZED
+    )
+
+    StreamTestHelpers.verifyCharacteristics(
+      spliter,
+      requiredPresent,
+      requiredAbsent
+    )
+
+    // If SIZED is really missing, these conditions should hold.
+    assertEquals(s"getExactSizeIfKnown", -1L, spliter.getExactSizeIfKnown())
+    assertEquals(s"estimateSize", Long.MaxValue, spliter.estimateSize())
+  }
+
+  @Test def longStreamTakeWhile_Empty(): Unit = {
+    val s = LongStream.empty()
+
+    val taken = s.takeWhile(_ < 523L)
+
+    assertFalse("stream should be empty", taken.findFirst().isPresent)
+  }
+
+  @Test def longStreamTakeWhile_NoMatch(): Unit = {
+    val s = LongStream.of(11, 22, 44, 1, -1, 2L)
+
+    val taken = s.takeWhile(_ > 101L)
+    assertFalse("stream should be empty", taken.findFirst().isPresent)
+  }
+
+  @Test def intStreamTakeWhile_SomeMatch(): Unit = {
+    val expectedTakenCount = 3
+
+    val s = LongStream.of(11, 22, 44, 1, -1, 2L)
+
+    val taken = s.takeWhile(_ > 5L)
+
+    assertEquals("unexpected taken count", expectedTakenCount, taken.count())
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/CharSequenceTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/CharSequenceTest.scala
@@ -1,0 +1,115 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.{lang => jl}
+
+import java.util.Arrays
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+/* Test only the Java 8 default methods of java.lang.CharSequence.
+ * Abstract methods may get tested in the Tests of classes which
+ * implement the CharSequence interface.
+ */
+
+class CharSequenceTest {
+
+  @Test def charseqChars(): Unit = {
+    val src = "secure the Blessings of Liberty to ourselves and our Posterity"
+
+    val charSeq = new String(src)
+    val srcChars = charSeq.toCharArray()
+    val srcCharLen = srcChars.length
+
+    assertEquals("srcCharLen", src.length, srcCharLen)
+
+    val csInts = charSeq.chars().toArray
+
+    val csIntsLen = csInts.length
+    assertEquals("chars().toArray length", srcChars.length, csIntsLen)
+
+    assertEquals("first character", 's'.toInt, csInts(0))
+    assertEquals("last character", 'y'.toInt, csInts(csIntsLen - 1))
+
+    for (j <- 1 until srcCharLen - 1)
+      assertEquals("character at index: ${j}", srcChars(j).toInt, csInts(j))
+  }
+
+  @Test def charseqCharsPassesSurogatesUnchanged(): Unit = {
+    val highSurrogateByte = '\uD8FF'
+    val lowSurrogateByte = '\uDCFF'
+    val src = s"a${highSurrogateByte}${lowSurrogateByte}z"
+
+    val charSeq = new String(src)
+    val srcChars = charSeq.toCharArray()
+    val srcCharLen = srcChars.length
+
+    assertEquals("srcCharLen", src.length, srcCharLen)
+
+    val csInts = charSeq.chars().toArray
+
+    val csIntsLen = csInts.length
+    assertEquals("chars().toArray length", srcChars.length, csIntsLen)
+
+    assertEquals("first character", 'a'.toInt, csInts(0))
+
+    assertEquals("second character", highSurrogateByte.toInt, csInts(1))
+    assertEquals("third character", lowSurrogateByte.toInt, csInts(2))
+
+    assertEquals("last character", 'z'.toInt, csInts(3))
+  }
+
+  @Test def charseqCodePoints(): Unit = {
+    val src = "secure the Blessings of Liberty to ourselves and our Posterity"
+
+    val charSeq = new String(src)
+    val srcChars = charSeq.toCharArray()
+    val srcCharLen = srcChars.length
+
+    assertEquals("srcCharLen", src.length, srcCharLen)
+
+    val csCodePoints = charSeq.codePoints().toArray
+
+    val csCodePointsLen = csCodePoints.length
+    assertEquals("chars.toArray() length", srcChars.length, csCodePointsLen)
+
+    assertEquals("first character", 's'.toInt, csCodePoints(0))
+    assertEquals("last character", 'y'.toInt, csCodePoints(csCodePointsLen - 1))
+
+    for (j <- 1 until srcCharLen - 1)
+      assertEquals(
+        "character at index: ${j}",
+        srcChars(j).toInt,
+        csCodePoints(j)
+      )
+  }
+
+  @Test def charseqCodePointsCombinesSurogatePairs(): Unit = {
+    val highSurrogateByte = '\uD8FF'
+    val lowSurrogateByte = '\uDCFF'
+    val src = s"a${highSurrogateByte}${lowSurrogateByte}z"
+
+    val charSeq = new String(src)
+    val srcChars = charSeq.toCharArray()
+    val srcCharLen = srcChars.length
+
+    assertEquals("srcCharLen", src.length, srcCharLen)
+
+    val csCodePoints = charSeq.codePoints().toArray
+
+    val csCodePointsLen = csCodePoints.length
+
+    // csCodePointsLen will differ by one if surrogate pair was combined.
+    assertEquals("chars().toArray length", srcChars.length - 1, csCodePointsLen)
+
+    assertEquals("first character", 'a'.toInt, csCodePoints(0))
+
+    val combinedCodePoint = charSeq.codePointAt(1)
+    assertEquals("combined codePoint", combinedCodePoint, csCodePoints(1))
+
+    assertEquals("last character", 'z'.toInt, csCodePoints(2))
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/RandomTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/RandomTest.scala
@@ -3,13 +3,22 @@ package org.scalanative.testsuite.javalib.util
 import java.{lang => jl}
 
 import java.util._
-import java.util.function.DoubleConsumer
+import java.util.function.{DoubleConsumer, IntConsumer, LongConsumer}
 
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
 import scala.scalanative.junit.utils.AssumesHelper._
+
+/* Design note:
+ *   The content, characteristics, and when appropriate the size of
+ *   the Streams returned by the various doubles(), ints(), and longs()
+ *   methods are checked. None of them are checked to have a uniform
+ *   distribution of values. If the one checked content item is correct
+ *   it is assumed/hoped/reasoned that the distribution of the rest of
+ *   the stream is correct, in order to get to that point.
+ */
 
 class RandomTest {
 
@@ -461,6 +470,430 @@ class RandomTest {
     }
 
     ds3.forEach(doubleConsumer)
+  }
+
+  @Test def intsZeroArg(): Unit = {
+    // ints()
+
+    val seed = 0xa5a5a5a5a5a5a5a5L
+
+    val rng1 = new Random(seed)
+    val ds1 = rng1.ints()
+
+    val ds1Spliter = ds1.spliterator()
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      ds1Spliter.characteristics()
+    )
+
+    assertEquals("estimated size", jl.Long.MAX_VALUE, ds1Spliter.estimateSize())
+
+    assertEquals(
+      s"getExactSizeIfKnown",
+      jl.Long.MAX_VALUE,
+      ds1Spliter.getExactSizeIfKnown()
+    )
+
+    assertFalse(
+      "Expected sequential stream",
+      ds1.isParallel()
+    )
+
+    val rng2 = new Random(seed)
+    val ds2 = rng2.ints()
+
+    val expectedContent = -1324917134 // JVM value
+
+    // for the skipTo element to be right, everything before it should be OK.
+    val actualContent = ds2
+      .skip(10)
+      .findFirst()
+      .orElse(0)
+
+    assertEquals("content", expectedContent, actualContent)
+  }
+
+  @Test def intsOneArg(): Unit = {
+    // ints(long streamSize)
+    val seed = 0xa5a5a5a5a5a5a5a5L
+    val streamSize = 7
+
+    val rng1 = new Random(seed)
+    val ds1 = rng1.ints(streamSize)
+
+    val ds1Spliter = ds1.spliterator()
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      ds1Spliter.characteristics()
+    )
+
+    assertEquals("estimated size", streamSize, ds1Spliter.estimateSize())
+
+    assertEquals(
+      s"getExactSizeIfKnown",
+      streamSize,
+      ds1Spliter.getExactSizeIfKnown()
+    )
+
+    assertFalse(
+      "Expected sequential stream",
+      ds1.isParallel()
+    )
+
+    val rng2 = new Random(seed)
+    val ds2 = rng2.ints(streamSize)
+
+    assertEquals("count", streamSize, ds2.count())
+
+    val rng3 = new Random(seed)
+    val ds3 = rng3.ints(streamSize)
+
+    val expectedContent = -1689095446 // JVM value
+
+    // for the skipTo element to be right, everything before it should be OK.
+    val actualContent = ds3
+      .skip(5)
+      .findFirst()
+      .orElse(0)
+
+    assertEquals("content", expectedContent, actualContent)
+  }
+
+  @Test def intsTwoArg(): Unit = {
+    // ints(int randomNumberOrigin, int randomNumberBound)
+
+    // This test is not guaranteed. It samples to build correctness confidence.
+
+    val seed = 0xa5a5a5a5a5a5a5a5L
+    val streamSize = 100
+
+    val rnOrigin = 2
+    val rnBound = 80
+
+    val rng1 = new Random(seed)
+    val ds1 = rng1.ints(rnOrigin, rnBound)
+
+    val ds1Spliter = ds1.spliterator()
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      ds1Spliter.characteristics()
+    )
+
+    assertEquals("estimated size", jl.Long.MAX_VALUE, ds1Spliter.estimateSize())
+
+    assertEquals(
+      s"getExactSizeIfKnown",
+      jl.Long.MAX_VALUE,
+      ds1Spliter.getExactSizeIfKnown()
+    )
+
+    assertFalse(
+      "Expected sequential stream",
+      ds1.isParallel()
+    )
+
+    val rng2 = new Random(seed)
+    val ds2 = rng2
+      .ints(rnOrigin, rnBound)
+      .limit(streamSize)
+
+    // Keep Scala 2 happy. Can use lambda when only Scala > 2 is supported.
+    val intConsumer = new IntConsumer {
+      def accept(d: Int): Unit = {
+        assertTrue(
+          s"Found value ${d} < low bound ${rnOrigin}",
+          d >= rnOrigin
+        )
+
+        assertTrue(
+          s"Found value ${d} >= high bound ${rnBound}",
+          d < rnBound
+        )
+      }
+    }
+
+    ds2.forEach(intConsumer)
+  }
+
+  @Test def intsThreeArg(): Unit = {
+    // ints(long streamSize, int randomNumberOrigin,
+    //         int randomNumberBound)
+
+    // This test is not guaranteed. It samples to build correctness confidence.
+
+    val seed = 0xa5a5a5a5a5a5a5a5L
+    val streamSize = 100
+
+    val rnOrigin = 1
+    val rnBound = 90
+
+    val rng1 = new Random(seed)
+    val ds1 = rng1.ints(streamSize, rnOrigin, rnBound)
+
+    val ds1Spliter = ds1.spliterator()
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      ds1Spliter.characteristics()
+    )
+
+    assertEquals("estimated size", streamSize, ds1Spliter.estimateSize())
+
+    assertEquals(
+      s"getExactSizeIfKnown",
+      streamSize,
+      ds1Spliter.getExactSizeIfKnown()
+    )
+
+    assertFalse(
+      "Expected sequential stream",
+      ds1.isParallel()
+    )
+
+    val rng2 = new Random(seed)
+    val ds2 = rng2.ints(streamSize, rnOrigin, rnBound)
+
+    assertEquals("count", streamSize, ds2.count())
+
+    val rng3 = new Random(seed)
+    val ds3 = rng3.ints(streamSize, rnOrigin, rnBound)
+
+    // Keep Scala 2 happy. Can use lambda when only Scala > 2 is supported.
+    val intConsumer = new IntConsumer {
+      def accept(d: Int): Unit = {
+        assertTrue(
+          s"Found value ${d} < low bound ${rnOrigin}",
+          d >= rnOrigin
+        )
+
+        assertTrue(
+          s"Found value ${d} >= high bound ${rnBound}",
+          d < rnBound
+        )
+      }
+    }
+
+    ds3.forEach(intConsumer)
+  }
+
+  @Test def longsZeroArg(): Unit = {
+    // longs()
+
+    val seed = 0xa5a5a5a5a5a5a5a5L
+
+    val rng1 = new Random(seed)
+    val ds1 = rng1.longs()
+
+    val ds1Spliter = ds1.spliterator()
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      ds1Spliter.characteristics()
+    )
+
+    assertEquals("estimated size", jl.Long.MAX_VALUE, ds1Spliter.estimateSize())
+
+    assertEquals(
+      s"getExactSizeIfKnown",
+      jl.Long.MAX_VALUE,
+      ds1Spliter.getExactSizeIfKnown()
+    )
+
+    assertFalse(
+      "Expected sequential stream",
+      ds1.isParallel()
+    )
+
+    val rng2 = new Random(seed)
+    val ds2 = rng2.longs()
+
+    val expectedContent = 1924946078025745628L // JVM value
+
+    // for the skipTo element to be right, everything before it should be OK.
+    val actualContent = ds2
+      .skip(10)
+      .findFirst()
+      .orElse(0)
+
+    assertEquals("content", expectedContent, actualContent)
+  }
+
+  @Test def longsOneArg(): Unit = {
+    // longs(long streamSize)
+    val seed = 0xa5a5a5a5a5a5a5a5L
+    val streamSize = 7
+
+    val rng1 = new Random(seed)
+    val ds1 = rng1.longs(streamSize)
+
+    val ds1Spliter = ds1.spliterator()
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      ds1Spliter.characteristics()
+    )
+
+    assertEquals("estimated size", streamSize, ds1Spliter.estimateSize())
+
+    assertEquals(
+      s"getExactSizeIfKnown",
+      streamSize,
+      ds1Spliter.getExactSizeIfKnown()
+    )
+
+    assertFalse(
+      "Expected sequential stream",
+      ds1.isParallel()
+    )
+
+    val rng2 = new Random(seed)
+    val ds2 = rng2.longs(streamSize)
+
+    assertEquals("count", streamSize, ds2.count())
+
+    val rng3 = new Random(seed)
+    val ds3 = rng3.longs(streamSize)
+
+    val expectedContent = -5690475761489855045L // JVM value
+
+    // for the skipTo element to be right, everything before it should be OK.
+    val actualContent = ds3
+      .skip(5)
+      .findFirst()
+      .orElse(0L)
+
+    assertEquals("content", expectedContent, actualContent)
+  }
+
+  @Test def longsTwoArg(): Unit = {
+    // longs(long randomNumberOrigin, long randomNumberBound)
+
+    // This test is not guaranteed. It samples to build correctness confidence.
+
+    val seed = 0xa5a5a5a5a5a5a5a5L
+    val streamSize = 100
+
+    val longBase = jl.Integer.MAX_VALUE.toLong
+    val rnOrigin = -longBase - 202L // Try to trip it up, use a negative origin
+    val rnBound = 80L + longBase
+
+    val rng1 = new Random(seed)
+    val ds1 = rng1.longs(rnOrigin, rnBound)
+
+    val ds1Spliter = ds1.spliterator()
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      ds1Spliter.characteristics()
+    )
+
+    assertEquals("estimated size", jl.Long.MAX_VALUE, ds1Spliter.estimateSize())
+
+    assertEquals(
+      s"getExactSizeIfKnown",
+      jl.Long.MAX_VALUE,
+      ds1Spliter.getExactSizeIfKnown()
+    )
+
+    assertFalse(
+      "Expected sequential stream",
+      ds1.isParallel()
+    )
+
+    val rng2 = new Random(seed)
+    val ds2 = rng2
+      .longs(rnOrigin, rnBound)
+      .limit(streamSize)
+
+    // Keep Scala 2 happy. Can use lambda when only Scala > 2 is supported.
+    val longConsumer = new LongConsumer {
+      def accept(d: Long): Unit = {
+        assertTrue(
+          s"Found value ${d} < low bound ${rnOrigin}",
+          d >= rnOrigin
+        )
+
+        assertTrue(
+          s"Found value ${d} >= high bound ${rnBound}",
+          d < rnBound
+        )
+      }
+    }
+
+    ds2.forEach(longConsumer)
+  }
+
+  @Test def longsThreeArg(): Unit = {
+    // longs(long streamSize, long randomNumberOrigin,
+    //         long randomNumberBound)
+
+    // This test is not guaranteed. It samples to build correctness confidence.
+
+    val seed = 0xa5a5a5a5a5a5a5a5L
+    val streamSize = 100
+
+    val longBase = jl.Integer.MAX_VALUE.toLong
+    val rnOrigin = 1L + longBase
+    val rnBound = 90L + longBase
+
+    val rng1 = new Random(seed)
+    val ds1 = rng1.longs(streamSize, rnOrigin, rnBound)
+
+    val ds1Spliter = ds1.spliterator()
+
+    assertEquals(
+      "characteristics",
+      expectedCharacteristics,
+      ds1Spliter.characteristics()
+    )
+
+    assertEquals("estimated size", streamSize, ds1Spliter.estimateSize())
+
+    assertEquals(
+      s"getExactSizeIfKnown",
+      streamSize,
+      ds1Spliter.getExactSizeIfKnown()
+    )
+
+    assertFalse(
+      "Expected sequential stream",
+      ds1.isParallel()
+    )
+
+    val rng2 = new Random(seed)
+    val ds2 = rng2.longs(streamSize, rnOrigin, rnBound)
+
+    assertEquals("count", streamSize, ds2.count())
+
+    val rng3 = new Random(seed)
+    val ds3 = rng3.longs(streamSize, rnOrigin, rnBound)
+
+    // Keep Scala 2 happy. Can use lambda when only Scala > 2 is supported.
+    val longConsumer = new LongConsumer {
+      def accept(d: Long): Unit = {
+        assertTrue(
+          s"Found value ${d} < low bound ${rnOrigin}",
+          d >= rnOrigin
+        )
+
+        assertTrue(
+          s"Found value ${d} >= high bound ${rnBound}",
+          d < rnBound
+        )
+      }
+    }
+
+    ds3.forEach(longConsumer)
   }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/IntStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/IntStreamTest.scala
@@ -2,7 +2,7 @@ package org.scalanative.testsuite.javalib.util.stream
 
 /* It is hard to assure oneself that the desired primitive DoubleStream,
  * LongStream, & IntStream are being used instead of a/an (object) Stream.
- * Create DoubleStream & kin using the methods in Arrays.
+ * Create IntStream & kin using the methods in Arrays.
  *
  * Do not import ArrayList here, to guard against a Test populating
  * an ArrayList and then inadvertently creating an (object) Stream with it.
@@ -12,39 +12,38 @@ package org.scalanative.testsuite.javalib.util.stream
 import java.{lang => jl}
 
 import java.{util => ju}
-import java.util.{Arrays, ArrayList}
-import java.util.{OptionalDouble, DoubleSummaryStatistics}
-import java.util.Spliterator
-import java.util.Spliterators
+import java.util.Arrays
+import java.util.IntSummaryStatistics
+import java.util.OptionalInt
+import java.util.{Spliterator, Spliterators}
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.CountDownLatch._
 
-import java.util.function.{DoubleConsumer, DoubleFunction, DoubleSupplier}
+import java.util.function.{IntConsumer, IntFunction, IntSupplier}
 import java.util.function.Supplier
 
 import java.util.stream._
 
 import org.junit.Test
 import org.junit.Assert._
-import org.junit.BeforeClass
 import org.junit.Ignore
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 
-class DoubleStreamTest {
+class IntStreamTest {
 
   final val epsilon = 0.00001 // tolerance for Floating point comparisons.
 
 // Methods specified in interface BaseStream ----------------------------
 
   @Test def streamUnorderedOnUnorderedStream(): Unit = {
-    val dataSet = new ju.HashSet[Double]()
-    dataSet.add(0.1)
-    dataSet.add(1.1)
-    dataSet.add(-1.1)
-    dataSet.add(2.2)
-    dataSet.add(-2.2)
+    val dataSet = new ju.HashSet[Int]()
+    dataSet.add(1)
+    dataSet.add(11)
+    dataSet.add(-11)
+    dataSet.add(22)
+    dataSet.add(-22)
 
     val s0 = dataSet.stream()
     val s0Spliter = s0.spliterator()
@@ -63,7 +62,7 @@ class DoubleStreamTest {
   }
 
   @Test def streamUnorderedOnOrderedStream(): Unit = {
-    val s = DoubleStream.of(0.1, 1.1, -1.1, 2.2, -2.2)
+    val s = IntStream.of(1, 11, -11, 22, -22)
     val sSpliter = s.spliterator()
 
     assertTrue(
@@ -72,7 +71,7 @@ class DoubleStreamTest {
     )
 
     // s was ordered, 'so' should be same same. Avoid "already used" exception
-    val so = DoubleStream.of(0.1, 1.1, -1.1, 2.2, -2.2)
+    val so = IntStream.of(1, 11, -11, 22, -22)
     val su = so.unordered()
     val suSpliter = su.spliterator()
 
@@ -85,15 +84,15 @@ class DoubleStreamTest {
   @Test def streamParallel(): Unit = {
     val nElements = 5
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 132.45
-    wild(1) = 4.21
-    wild(2) = 2.11
-    wild(3) = 55.31
-    wild(4) = 16.68
+    val wild = new Array[Int](nElements) // holds arbitrarily jumbled data
+    wild(0) = 13245
+    wild(1) = 421
+    wild(2) = 211
+    wild(3) = 5531
+    wild(4) = 1668
 
     val sPar0 =
-      StreamSupport.doubleStream(Spliterators.spliterator(wild, 0), true)
+      StreamSupport.intStream(Spliterators.spliterator(wild, 0), true)
 
     assertTrue(
       "Expected parallel stream",
@@ -111,7 +110,7 @@ class DoubleStreamTest {
     )
 
     val sPar =
-      StreamSupport.doubleStream(Spliterators.spliterator(wild, 0), true)
+      StreamSupport.intStream(Spliterators.spliterator(wild, 0), true)
 
     val sSeq = sPar.sequential()
     assertFalse(
@@ -135,12 +134,11 @@ class DoubleStreamTest {
 
     // sequential stream has expected contents
     var count = 0
-    sSeqSpliterator.forEachRemaining((e: Double) => {
+    sSeqSpliterator.forEachRemaining((e: Int) => {
       assertEquals(
         s"sequential stream contents(${count})",
         wild(count),
-        e,
-        epsilon
+        e
       )
       count += 1
     })
@@ -149,15 +147,15 @@ class DoubleStreamTest {
   @Test def streamSequential(): Unit = {
     val nElements = 5
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 132.45
-    wild(1) = 4.21
-    wild(2) = 2.11
-    wild(3) = 55.31
-    wild(4) = 16.68
+    val wild = new Array[Int](nElements) // holds arbitrarily jumbled data
+    wild(0) = 13245
+    wild(1) = 421
+    wild(2) = 211
+    wild(3) = 5531
+    wild(4) = 1668
 
     val sSeq0 =
-      StreamSupport.doubleStream(Spliterators.spliterator(wild, 0), false)
+      StreamSupport.intStream(Spliterators.spliterator(wild, 0), false)
 
     assertFalse(
       "Expected sequential stream",
@@ -175,7 +173,7 @@ class DoubleStreamTest {
     )
 
     val sSeq =
-      StreamSupport.doubleStream(Spliterators.spliterator(wild, 0), false)
+      StreamSupport.intStream(Spliterators.spliterator(wild, 0), false)
 
     val sPar = sSeq.parallel()
     assertTrue(
@@ -199,31 +197,30 @@ class DoubleStreamTest {
 
     // parallel stream has expected contents
     var count = 0
-    sParSpliterator.forEachRemaining((e: Double) => {
+    sParSpliterator.forEachRemaining((e: Int) => {
       assertEquals(
         s"parallel stream contents(${count})",
         wild(count),
-        e,
-        epsilon
+        e
       )
       count += 1
     })
   }
 
-// Methods specified in interface Double Stream -------------------------
+// Methods specified in interface Int Stream -------------------------
 
-  @Test def doubleStreamBuilderCanBuildAnEmptyStream(): Unit = {
-    val s = DoubleStream.builder().build()
+  @Test def intStreamBuilderCanBuildAnEmptyStream(): Unit = {
+    val s = IntStream.builder().build()
     val it = s.iterator()
     assertFalse(it.hasNext())
   }
 
-  @Test def doubleStreamBuilderCharacteristics(): Unit = {
-    val bldr = Stream.builder[Double]()
+  @Test def intStreamBuilderCharacteristics(): Unit = {
+    val bldr = Stream.builder[Int]()
     bldr
-      .add(1.1)
-      .add(-1.1)
-      .add(9.9)
+      .add(11)
+      .add(-11)
+      .add(99)
 
     val s = bldr.build()
     val spliter = s.spliterator()
@@ -238,25 +235,25 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamEmptyIsEmpty(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamEmptyIsEmpty(): Unit = {
+    val s = IntStream.empty()
     val it = s.iterator()
     assertFalse(it.hasNext())
   }
 
-  @Test def doubleStreamOf_SingleElement(): Unit = {
-    val expected = 7.7
-    val s = DoubleStream.of(expected)
+  @Test def intStreamOf_SingleElement(): Unit = {
+    val expected = 77
+    val s = IntStream.of(expected)
     val it = s.iterator()
-    assertTrue("DoubleStream should not be empty", it.hasNext())
-    assertEquals("unexpected element", it.nextDouble(), expected, epsilon)
-    assertFalse("DoubleStream should be empty and is not.", it.hasNext())
+    assertTrue("IntStream should not be empty", it.hasNext())
+    assertEquals("unexpected element", it.nextInt(), expected)
+    assertFalse("IntStream should be empty and is not.", it.hasNext())
   }
 
   @Test def streamOf_SingleElementCharacteristics(): Unit = {
-    val expected = 7.7
+    val expected = 77
 
-    val s = DoubleStream.of(expected)
+    val s = IntStream.of(expected)
     val spliter = s.spliterator()
 
     val expectedCharacteristics =
@@ -270,17 +267,17 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamOf_MultipleElements(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def intStreamOf_MultipleElements(): Unit = {
+    val s = IntStream.of(11, 22, 33)
     val it = s.iterator()
-    assertEquals("element_1", 1.1, it.nextDouble(), epsilon)
-    assertEquals("element_2", 2.2, it.nextDouble(), epsilon)
-    assertEquals("element_3", 3.3, it.nextDouble(), epsilon)
+    assertEquals("element_1", 11, it.nextInt())
+    assertEquals("element_2", 22, it.nextInt())
+    assertEquals("element_3", 33, it.nextInt())
     assertFalse(it.hasNext())
   }
 
   @Test def streamOf_MultipleElementsCharacteristics(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+    val s = IntStream.of(11, 22, 33)
     val spliter = s.spliterator()
 
     val expectedCharacteristics =
@@ -294,53 +291,53 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamFlatMapWorks(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def intStreamFlatMapWorks(): Unit = {
+    val s = IntStream.of(11, 22, 33)
 
-    val mapper = new DoubleFunction[DoubleStream] {
-      override def apply(v: Double): DoubleStream =
-        DoubleStream.of(v, v)
+    val mapper = new IntFunction[IntStream] {
+      override def apply(v: Int): IntStream =
+        IntStream.of(v, v)
     }
 
     val s2 = s.flatMap(mapper)
 
     val it = s2.iterator()
 
-    assertEquals(1.1, it.nextDouble(), epsilon)
-    assertEquals(1.1, it.nextDouble(), epsilon)
+    assertEquals(11, it.nextInt())
+    assertEquals(11, it.nextInt())
 
-    assertEquals(2.2, it.nextDouble(), epsilon)
-    assertEquals(2.2, it.nextDouble(), epsilon)
+    assertEquals(22, it.nextInt())
+    assertEquals(22, it.nextInt())
 
-    assertEquals(3.3, it.nextDouble(), epsilon)
-    assertEquals(3.3, it.nextDouble(), epsilon)
+    assertEquals(33, it.nextInt())
+    assertEquals(33, it.nextInt())
 
     assertFalse(it.hasNext())
   }
 
-  @Test def doubleStreamForEachWorks(): Unit = {
-    val s = DoubleStream.of(-1.1, -2.2, -3.3, 0.0)
+  @Test def intStreamForEachWorks(): Unit = {
+    val s = IntStream.of(-11, -22, -33, 0)
 
-    var sum = 0.0
-    val doubleConsumer = new DoubleConsumer {
-      def accept(d: Double): Unit = sum += d
+    var sum = 0
+    val intConsumer = new IntConsumer {
+      def accept(i: Int): Unit = sum += i
     }
 
-    s.forEach(doubleConsumer)
-    assertEquals(-6.6, sum, epsilon)
+    s.forEach(intConsumer)
+    assertEquals(-66, sum)
   }
 
-  @Test def doubleStreamFlatMapWorksTwice(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def intStreamFlatMapWorksTwice(): Unit = {
+    val s = IntStream.of(11, 22, 33)
 
-    val mapper1 = new DoubleFunction[DoubleStream] {
-      override def apply(v: Double): DoubleStream =
-        DoubleStream.of(v, v)
+    val mapper1 = new IntFunction[IntStream] {
+      override def apply(v: Int): IntStream =
+        IntStream.of(v, v)
     }
 
-    val mapper2 = new DoubleFunction[DoubleStream] {
-      override def apply(v: Double): DoubleStream =
-        DoubleStream.of(-v, -v, -v)
+    val mapper2 = new IntFunction[IntStream] {
+      override def apply(v: Int): IntStream =
+        IntStream.of(-v, -v, -v)
     }
 
     val s2 = s
@@ -350,30 +347,30 @@ class DoubleStreamTest {
 // format: off
     val expected =
       Seq(
-        -1.1, -1.1, -1.1, -1.1, -1.1, -1.1,
-        -2.2, -2.2, -2.2, -2.2, -2.2, -2.2,
-        -3.3, -3.3, -3.3, -3.3, -3.3, -3.3
+        -11, -11, -11, -11, -11, -11,
+        -22, -22, -22, -22, -22, -22,
+        -33, -33, -33, -33, -33, -33
       )
 // format: on
 
-    val result = scala.collection.mutable.ArrayBuffer.empty[Double]
+    val result = scala.collection.mutable.ArrayBuffer.empty[Int]
     val it = s2.iterator()
 
     while (it.hasNext()) {
-      result += it.nextDouble()
+      result += it.nextInt()
     }
 
     assertTrue(result == expected)
   }
 
-  @Test def doubleStreamOnCloseWorks(): Unit = {
+  @Test def intStreamOnCloseWorks(): Unit = {
     var latch = new CountDownLatch(1)
 
     class Closer(cdLatch: CountDownLatch) extends Runnable {
       override def run(): Unit = cdLatch.countDown()
     }
 
-    val s = DoubleStream.empty().onClose(new Closer(latch))
+    val s = IntStream.empty().onClose(new Closer(latch))
     s.close()
 
     val timeout = 30L
@@ -385,88 +382,88 @@ class DoubleStreamTest {
 
 // Static methods -------------------------------------------------------
 
-  @Test def doubleStreamConcat(): Unit = {
-    val a = DoubleStream.of(9.9, 8.8, 6.6, 7.7, 5.5)
-    val b = DoubleStream.of(0.0, 3.3, 2.2)
+  @Test def intStreamConcat(): Unit = {
+    val a = IntStream.of(99, 88, 66, 77, 55)
+    val b = IntStream.of(0, 33, 22)
 
-    val s = DoubleStream.concat(a, b)
+    val s = IntStream.concat(a, b)
 
     val it = s.iterator()
     assertNotNull("s.iterator() should not be NULL", it)
     assertTrue("stream should not be empty", it.hasNext())
 
-    assertEquals(s"element", 9.9, it.nextDouble(), epsilon)
-    assertEquals(s"element", 8.8, it.nextDouble(), epsilon)
-    assertEquals(s"element", 6.6, it.nextDouble(), epsilon)
-    assertEquals(s"element", 7.7, it.nextDouble(), epsilon)
-    assertEquals(s"element", 5.5, it.nextDouble(), epsilon)
+    assertEquals(s"element", 99, it.nextInt())
+    assertEquals(s"element", 88, it.nextInt())
+    assertEquals(s"element", 66, it.nextInt())
+    assertEquals(s"element", 77, it.nextInt())
+    assertEquals(s"element", 55, it.nextInt())
 
-    assertEquals(s"element", 0.0, it.nextDouble(), epsilon)
-    assertEquals(s"element", 3.3, it.nextDouble(), epsilon)
-    assertEquals(s"element", 2.2, it.nextDouble(), epsilon)
+    assertEquals(s"element", 0, it.nextInt())
+    assertEquals(s"element", 33, it.nextInt())
+    assertEquals(s"element", 22, it.nextInt())
 
     assertFalse("stream should be empty", it.hasNext())
   }
 
   @Test def doubleStreamGenerate(): Unit = {
     val nElements = 5
-    val data = new Array[Double](nElements)
-    data(0) = 0.0
-    data(1) = 1.1
-    data(2) = 2.2
-    data(3) = 3.3
-    data(4) = 4.4
+    val data = new Array[Int](nElements)
+    data(0) = 0
+    data(1) = 11
+    data(2) = 22
+    data(3) = 33
+    data(4) = 44
 
-    val src = new DoubleSupplier() {
+    val src = new IntSupplier() {
       var count = -1
 
-      def getAsDouble(): Double = {
+      def getAsInt(): Int = {
         count += 1
         data(count % nElements)
       }
     }
 
-    val s = DoubleStream.generate(src)
+    val s = IntStream.generate(src)
 
     val it = s.iterator()
 
-    assertTrue("DoubleStream should not be empty", it.hasNext())
+    assertTrue("IntStream should not be empty", it.hasNext())
 
     for (j <- 0 until nElements)
-      assertEquals(s"data(${j})", it.nextDouble(), data(j), epsilon)
+      assertEquals(s"data(${j})", it.nextInt(), data(j))
 
-    assertTrue("DoubleStream should not be empty", it.hasNext())
+    assertTrue("IntStream should not be empty", it.hasNext())
   }
 
-  @Test def doubleStreamIterate_Unbounded(): Unit = {
+  @Test def intStreamIterate_Unbounded(): Unit = {
     val nElements = 4
     var count = -1.0
 
-    val expectedSeed = 3.14
+    val expectedSeed = 1775
 
-    val expected = Seq(expectedSeed, 4.24, 5.34, 6.44)
+    val expected = Seq(expectedSeed, 1786, 1797, 1808)
 
-    val s = DoubleStream.iterate(
+    val s = IntStream.iterate(
       expectedSeed,
-      e => e + 1.1
+      e => e + 11
     )
 
     val it = s.iterator()
 
-    assertTrue("DoubleStream should not be empty", it.hasNext())
+    assertTrue("IntStream should not be empty", it.hasNext())
 
     for (j <- 0 until nElements)
-      assertEquals(s"element: ${j})", expected(j), it.nextDouble(), epsilon)
+      assertEquals(s"element: ${j})", expected(j), it.nextInt())
 
-    assertTrue("DoubleStream should not be empty", it.hasNext())
+    assertTrue("IntStream should not be empty", it.hasNext())
   }
 
-  @Test def doubleStreamIterate_Unbounded_Characteristics(): Unit = {
-    val s = DoubleStream.iterate(0.0, n => n + 1.1)
+  @Test def intStreamIterate_Unbounded_Characteristics(): Unit = {
+    val s = IntStream.iterate(0, n => n + 11)
     val spliter = s.spliterator()
 
     // spliterator should have required characteristics and no others.
-    // Note: DoubleStream requires NONNULL, whereas Stream[T] does not.
+    // Note: IntStream requires NONNULL, whereas Stream[T] does not.
     val requiredPresent =
       Seq(Spliterator.ORDERED, Spliterator.IMMUTABLE, Spliterator.NONNULL)
 
@@ -487,108 +484,214 @@ class DoubleStreamTest {
     assertEquals(s"estimateSize", Long.MaxValue, spliter.estimateSize())
   }
 
-  @Test def doubleStreamOf_NoItems(): Unit = {
-    val s = DoubleStream.of()
+  @Test def intStreamOf_NoItems(): Unit = {
+    val s = IntStream.of()
 
     val it = s.iterator()
-    assertFalse("DoubleStream should be empty", it.hasNext())
+    assertFalse("IntStream should be empty", it.hasNext())
   }
 
-  @Test def doubleStreamOf_OneItem(): Unit = {
-    val expected = 6.67
-    val s = DoubleStream.of(expected)
+  @Test def intStreamOf_OneItem(): Unit = {
+    val expected = 667
+    val s = IntStream.of(expected)
 
     val it = s.iterator()
     assertTrue("stream should not be empty", it.hasNext())
-    assertEquals(s"element", expected, it.nextDouble(), epsilon)
+    assertEquals(s"element", expected, it.nextInt())
 
-    assertFalse("DoubleStream should be empty", it.hasNext())
+    assertFalse("IntStream should be empty", it.hasNext())
   }
 
-  // DoubleStream.of() with more than two arguments is exercised in many other
+  // IntStream.of() with more than two arguments is exercised in many other
   // places in this file, so no Test for that case here.
+
+  @Test def intStreamRange(): Unit = {
+    val startInclusive = 5
+    val endExclusive = 15
+    val expectedCount = endExclusive - startInclusive
+
+    val s = IntStream.range(startInclusive, endExclusive)
+
+    var count = 0
+
+    s.spliterator()
+      .forEachRemaining((e: Int) => {
+        assertEquals(
+          s"range contents",
+          count + startInclusive,
+          e
+        )
+        count += 1
+      })
+
+    assertEquals(s"unexpected range count", expectedCount, count)
+  }
+
+  @Test def intStreamRangeClosed(): Unit = {
+
+    val startInclusive = 5
+    val endInclusive = 15
+    val expectedCount = endInclusive - startInclusive + 1
+
+    val s = IntStream.rangeClosed(startInclusive, endInclusive)
+
+    var count = 0
+
+    s.spliterator()
+      .forEachRemaining((e: Int) => {
+        assertEquals(
+          s"rangeClosed contents",
+          count + startInclusive,
+          e
+        )
+        count += 1
+      })
+
+    assertEquals(s"unexpected rangeClosed count", expectedCount, count)
+  }
 
 // Instance methods -----------------------------------------------------
 
-  @Test def doubleStreamAllMatch_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamAllMatch_EmptyStream(): Unit = {
+    val s = IntStream.empty()
     var predEvaluated = false
 
-    val matched = s.allMatch((e) => { predEvaluated = true; true })
+    val matched = s.allMatch(e => { predEvaluated = true; true })
     assertTrue("unexpected match failure", matched)
     assertFalse("predicate should not have been evaluated", predEvaluated)
   }
 
-  @Test def doubleStreamAllMatch_True(): Unit = {
+  @Test def intStreamAllMatch_True(): Unit = {
 
-    /* DoubleStream.allMatch() will return "true" on an empty stream.
-     *  Try to distinguish that "true" from an actual all-elements-match "true"
-     *  Since streams can not be re-used, count s0. If it is non-empty, assume
+    /* IntStream.allMatch() will return "true" on an empty stream.
+     * Try to distinguish that "true" from an actual all-elements-match "true"
+     * Since streams can not be re-used, count s0. If it is non-empty, assume
      * its sibling s is also non-empty, distingishing the two "true"s.
      */
-    val s0 = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+    val s0 = IntStream.of(0, 11, 22, 33)
     assertTrue("unexpected empty stream", s0.count > 0)
 
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+    val s = IntStream.of(0, 11, 22, 33)
 
-    val matched = s.allMatch((e) => { (e >= 0.0) && (e < 10.0) })
+    val matched = s.allMatch(e => { (e >= 0) && (e < 90) })
     assertTrue("unexpected match failure", matched)
   }
 
-  @Test def doubleStreamAllMatch_False(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def intStreamAllMatch_False(): Unit = {
+    val s = IntStream.of(0, 11, 22, 33)
 
-    val matched = s.allMatch((e) => e > 2.2)
+    val matched = s.allMatch(e => e > 22)
     assertFalse("unexpected match", matched)
   }
 
-  @Test def doubleStreamAnyMatch_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamAnyMatch_EmptyStream(): Unit = {
+    val s = IntStream.empty()
     var predEvaluated = false
 
-    val matched = s.anyMatch((e) => { predEvaluated = true; true })
+    val matched = s.anyMatch(e => { predEvaluated = true; true })
     assertFalse("unexpected match", matched)
     assertFalse("predicate should not have been evaluated", predEvaluated)
   }
 
-  @Test def doubleStreamAnyMatch_True(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def intStreamAnyMatch_True(): Unit = {
+    val s = IntStream.of(0, 11, 22, 33)
 
-    val matched = s.anyMatch((e) => (e > 1.0) && (e < 2.0))
+    val matched = s.anyMatch(e => (e > 10) && (e < 20))
     assertTrue("unexpected predicate failure", matched)
   }
 
-  @Test def doubleStreamAnyMatch_False(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def intStreamAnyMatch_False(): Unit = {
+    val s = IntStream.of(0, 11, 22, 33)
 
-    val matched = s.anyMatch((e) => e > 10.0)
+    val matched = s.anyMatch((e) => e > 90)
     assertFalse("unexpected predicate failure", matched)
   }
 
-  @Test def doubleStreamAverage_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamAsDoubleStream(): Unit = {
+    val nElements = 4
+    var count = 0
+
+    val s0 = IntStream.of(11, 22, 33, 44)
+
+    val s1 = s0.asDoubleStream()
+
+    // Right resultant types
+    s1.forEach(e => {
+      count += 1
+      assertEquals(s"unexpected type", classOf[Double], e.getClass())
+    })
+
+    // Right count
+    assertEquals("unexpected count", nElements, count)
+
+    // Right content
+    val s2 = IntStream.of(11, 22, 33, 44)
+
+    val s3 = s2.asDoubleStream()
+
+    val it = s3.iterator()
+
+    for (j <- 1 to nElements)
+      assertEquals(
+        "unexpected element",
+        (j * 11).toDouble,
+        it.nextDouble(),
+        epsilon
+      )
+  }
+
+  @Test def intStreamAsLongStream(): Unit = {
+    val nElements = 4
+    var count = 0
+
+    val s0 = IntStream.of(11, 22, 33, 44)
+
+    val s1 = s0.asLongStream()
+
+    // Right resultant types
+    s1.forEach(e => {
+      count += 1
+      assertEquals(s"unexpected type", classOf[Long], e.getClass())
+    })
+
+    // Right count
+    assertEquals("unexpected count", nElements, count)
+
+    // Right content
+    val s2 = IntStream.of(11, 22, 33, 44)
+
+    val s3 = s2.asLongStream()
+
+    val it = s3.iterator()
+
+    for (j <- 1 to nElements)
+      assertEquals("unexpected element", (j * 11).toLong, it.nextLong())
+  }
+
+  @Test def intStreamAverage_EmptyStream(): Unit = {
+    val s = IntStream.empty()
 
     val optional = s.average()
 
     assertFalse(s"expected empty optional, got value", optional.isPresent())
   }
 
-  @Test def doubleStreamAverage(): Unit = {
+  @Test def intStreamAverage(): Unit = {
     val nElements = 8
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 132.45
-    wild(1) = 4.21
-    wild(2) = 2.11
-    wild(3) = 55.31
-    wild(4) = 16.68
-    wild(5) = 77.3
-    wild(6) = 44.61
-    wild(7) = 60.9
+    val wild = new Array[Int](nElements) // holds arbitrarily jumbled data
+    wild(0) = 13245
+    wild(1) = 421
+    wild(2) = 211
+    wild(3) = 5531
+    wild(4) = 1668
+    wild(5) = 773
+    wild(6) = 4461
+    wild(7) = 609
 
-    val expectedAverage = 49.19625
+    val expectedAverage = 3364.875 // test against known value, not calculated.
 
-    val s = DoubleStream.of(wild: _*)
+    val s = IntStream.of(wild: _*)
 
     val optional = s.average()
 
@@ -602,39 +705,39 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamBoxed(): Unit = {
+  @Test def intStreamBoxed(): Unit = {
     val nElements = 5
-    val data = new Array[Double](nElements)
-    data(0) = 0.0
-    data(1) = 1.1
-    data(2) = 2.2
-    data(3) = 3.3
-    data(4) = 4.4
+    val data = new Array[Int](nElements)
+    data(0) = 0
+    data(1) = 11
+    data(2) = 22
+    data(3) = 33
+    data(4) = 44
 
     val sd = Arrays.stream(data)
 
     assertTrue(
-      "stream should be a DoubleStream",
-      sd.isInstanceOf[DoubleStream]
+      "stream should be a IntStream",
+      sd.isInstanceOf[IntStream]
     )
 
     val sBoxed = sd.boxed()
 
     assertTrue(
-      "resultant stream should be boxed Stream[Double]",
+      "resultant stream should be boxed Stream[Int]",
       sBoxed.isInstanceOf[Stream[_]]
     )
 
     assertFalse(
-      "resultant stream should not be a DoubleStream",
-      sBoxed.isInstanceOf[DoubleStream]
+      "resultant stream should not be a IntStream",
+      sBoxed.isInstanceOf[IntStream]
     )
   }
 
-  @Test def doubleStreamCollect_EmptyStreamUsingSupplier(): Unit = {
-    type U = ju.ArrayList[Double]
+  @Test def intStreamCollect_EmptyStreamUsingSupplier(): Unit = {
+    type U = ju.ArrayList[Int]
 
-    val s = DoubleStream.empty()
+    val s = IntStream.empty()
 
     val supplier = new Supplier[U]() {
       def get(): U = new U
@@ -642,7 +745,7 @@ class DoubleStreamTest {
 
     val collected = s.collect(
       supplier,
-      (list: U, e: Double) => list.add(e),
+      (list: U, e: Int) => list.add(e),
       (list1: U, list2: U) => list1.addAll(list2)
     )
 
@@ -650,16 +753,16 @@ class DoubleStreamTest {
     assertEquals("list size", 0, collected.size())
   }
 
-  @Test def doubleStreamCollect_UsingSupplier(): Unit = {
-    type U = ju.ArrayList[Double]
+  @Test def intStreamCollect_UsingSupplier(): Unit = {
+    type U = ju.ArrayList[Int]
 
     val nElements = 5
-    val data = new Array[Double](nElements)
-    data(0) = 0.0
-    data(1) = 1.1
-    data(2) = 2.2
-    data(3) = 3.3
-    data(4) = 4.4
+    val data = new Array[Int](nElements)
+    data(0) = 0
+    data(1) = 11
+    data(2) = 22
+    data(3) = 33
+    data(4) = 44
 
     val s = Arrays.stream(data)
 
@@ -669,7 +772,7 @@ class DoubleStreamTest {
 
     val collected = s.collect(
       supplier,
-      (list: U, e: Double) => list.add(e),
+      (list: U, e: Int) => list.add(e),
       (list1: U, list2: U) => list1.addAll(list2)
     )
 
@@ -678,59 +781,59 @@ class DoubleStreamTest {
 
     // Proper elements, in encounter order
     for (j <- 0 until nElements)
-      assertEquals("list element", data(j), collected.get(j), epsilon)
+      assertEquals("list element", data(j), collected.get(j))
   }
 
-  @Test def doubleStreamCollect_UsingSummaryStatistics(): Unit = {
+  @Test def intStreamCollect_UsingSummaryStatistics(): Unit = {
     /* This is the example given at the top of the JVM
-     *  DoubleSummaryStatistics description, translate to Scala.
+     *  DoubleSummaryStatistics description, translate to Scala & Int.
      *
-     *  It tests DoubleStream.collect() using user-designated arguments.
+     *  It tests IntStream.collect() using user-designated arguments.
      *
      *  Along the way, it shows a succinct way of using collect() in Scala.
      */
 
-    type U = DoubleSummaryStatistics
+    type U = IntSummaryStatistics
 
     val nElements = 6
-    val expectedSum = 16.5
-    val expectedMin = 0.0
-    val expectedAverage = expectedSum / nElements
-    val expectedMax = 5.5
+    val expectedSum = 165
+    val expectedMin = 0
+    val expectedAverage = expectedSum.toDouble / nElements
+    val expectedMax = 55
 
-    val data = new Array[Double](nElements)
-    data(0) = 1.1
-    data(1) = 2.2
+    val data = new Array[Int](nElements)
+    data(0) = 11
+    data(1) = 22
     data(2) = expectedMin
-    data(3) = 3.3
+    data(3) = 33
     data(4) = expectedMax
-    data(5) = 4.4
+    data(5) = 44
 
     val s = Arrays.stream(data)
 
     val collected = s.collect(
       () => new U,
-      (summary: U, e: Double) => summary.accept(e),
+      (summary: U, e: Int) => summary.accept(e),
       (summary1: U, summary2: U) => summary1.combine(summary2)
     )
 
     // Proper stats
     assertEquals("count", nElements, collected.getCount())
-    assertEquals("sum", expectedSum, collected.getSum(), epsilon)
-    assertEquals("min", expectedMin, collected.getMin(), epsilon)
+    assertEquals("sum", expectedSum, collected.getSum())
+    assertEquals("min", expectedMin, collected.getMin())
     assertEquals("average", expectedAverage, collected.getAverage(), epsilon)
-    assertEquals("max", expectedMax, collected.getMax(), epsilon)
+    assertEquals("max", expectedMax, collected.getMax())
   }
 
-  @Test def doubleStreamCount(): Unit = {
+  @Test def intStreamCount(): Unit = {
     val expectedCount = 5
 
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3, 4.4)
+    val s = IntStream.of(0, 11, 22, 33, 44)
 
     assertEquals(s"unexpected element count", expectedCount, s.count())
   }
 
-  @Test def doubleStreamDistinct(): Unit = {
+  @Test def intStreamDistinct(): Unit = {
 
     // There must be a harder way of doing this setup.
     // Using " scala.jdk.CollectionConverters._" and futzing with it
@@ -740,17 +843,17 @@ class DoubleStreamTest {
     val expectedCount = 5
     val range = 0 until expectedCount
 
-    val expectedElements = new Array[Double](expectedCount)
+    val expectedElements = new Array[Int](expectedCount)
     for (j <- range)
-      expectedElements(j) = j * 2.0
+      expectedElements(j) = j * 2
 
-    val expectedSet = new ju.HashSet[Double]()
+    val expectedSet = new ju.HashSet[Int]()
     for (j <- range)
       expectedSet.add(expectedElements(j))
 
-    val s = DoubleStream
+    val s = IntStream
       .of(expectedElements: _*)
-      .flatMap((e) => DoubleStream.of(e, e, e))
+      .flatMap((e) => IntStream.of(e, e, e))
       .distinct()
 
     assertEquals(s"unexpected count", expectedCount, s.count())
@@ -759,9 +862,9 @@ class DoubleStreamTest {
 
     // count() exhausted s1, so create second stream, s2
 
-    val s2 = DoubleStream
+    val s2 = IntStream
       .of(expectedElements: _*)
-      .flatMap((e) => DoubleStream.of(e, e, e))
+      .flatMap((e) => IntStream.of(e, e, e))
       .distinct()
 
     s2.forEach((e) => {
@@ -775,40 +878,40 @@ class DoubleStreamTest {
     assertTrue("expectedSet has remaining elements", expectedSet.isEmpty())
   }
 
-  @Test def doubleStreamFindAny_Null(): Unit = {
-    val s = DoubleStream.of(null.asInstanceOf[Double])
-    // Double nulls get seen as 0.0
+  @Test def intStreamFindAny_Null(): Unit = {
+    val s = IntStream.of(null.asInstanceOf[Int])
+    // Int nulls get seen as 0
     val optional = s.findAny()
     assertTrue("unexpected failure to findAny", optional.isPresent())
-    assertEquals("unexpected element", 0.0, optional.getAsDouble(), epsilon)
+    assertEquals("unexpected element", 0, optional.getAsInt())
   }
 
-  @Test def doubleStreamFindAny_True(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
-    val acceptableValues = List(0.0, 1.1, 2.2, 3.3)
+  @Test def intStreamFindAny_True(): Unit = {
+    val s = IntStream.of(0, 11, 22, 33)
+    val acceptableValues = List(0, 11, 22, 33)
 
     val optional = s.findAny()
 
     assertTrue("unexpected empty optional", optional.isPresent())
 
-    val found = optional.getAsDouble()
+    val found = optional.getAsInt()
     assertTrue(
       s"unexpected value: '${found}'",
       acceptableValues.contains(found)
     )
   }
 
-  @Test def doubleStreamFindAny_False(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamFindAny_False(): Unit = {
+    val s = IntStream.empty()
 
     val optional = s.findAny()
 
     assertFalse("unexpected failure", optional.isPresent())
   }
 
-  @Test def doubleStreamFindFirst_True(): Unit = {
-    val expectedFirst = 0.0
-    val s = DoubleStream.of(expectedFirst, 1.1, 2.2, 3.3)
+  @Test def intStreamFindFirst_True(): Unit = {
+    val expectedFirst = 0
+    val s = IntStream.of(expectedFirst, 11, 22, 33)
 
     val optional = s.findFirst()
 
@@ -816,53 +919,52 @@ class DoubleStreamTest {
     assertEquals(
       "unexpected mismatch",
       expectedFirst,
-      optional.getAsDouble(),
-      epsilon
+      optional.getAsInt()
     )
   }
 
-  @Test def doubleStreamFindFirst_False(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamFindFirst_False(): Unit = {
+    val s = IntStream.empty()
 
     val optional = s.findFirst()
 
     assertFalse("unexpected failure", optional.isPresent())
   }
 
-  @Test def doubleStreamFilter(): Unit = {
+  @Test def intStreamFilter(): Unit = {
     val expectedCount = 4
 
-    val s0 = DoubleStream.of(
-      101.1, 1.1, 102.2, 2.2, 103.2, 3.3, 4.4
+    val s0 = IntStream.of(
+      1011, 11, 1022, 22, 1032, 33, 44
     )
 
-    val s1 = s0.filter(e => e < 100.0)
+    val s1 = s0.filter(e => e < 1000)
     assertEquals(s"unexpected element count", expectedCount, s1.count())
   }
 
-  @Test def doubleStreamForeachOrdered(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def intStreamForeachOrdered(): Unit = {
+    val s = IntStream.of(11, 22, 33)
 
-    var sum = 0.0
-    val consumer = new DoubleConsumer {
-      def accept(i: Double): Unit = { sum = sum + i }
+    var sum = 0
+    val consumer = new IntConsumer {
+      def accept(i: Int): Unit = { sum = sum + i }
     }
     s.forEachOrdered(consumer)
-    assertEquals("unexpected sum", 6.6, sum, epsilon)
+    assertEquals("unexpected sum", 66, sum)
   }
 
-  @Test def doubleStreamLimit_NegativeArg(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def intStreamLimit_NegativeArg(): Unit = {
+    val s = IntStream.of(11, 22, 33)
     assertThrows(classOf[IllegalArgumentException], s.limit(-1))
   }
 
-  @Test def doubleStreamLimit(): Unit = {
+  @Test def intStreamLimit(): Unit = {
     val expectedCount = 10
     var data = -1
 
-    val s0 = DoubleStream.iterate(
-      1.61803,
-      e => e + 1.0
+    val s0 = IntStream.iterate(
+      161803,
+      e => e + 10
     )
 
     val s1 = s0.limit(expectedCount)
@@ -875,13 +977,13 @@ class DoubleStreamTest {
    */
 
   // Issue #3309 - 1 of 5
-  @Test def doubleSstreamLimit_Size(): Unit = {
+  @Test def intStreamLimit_Size(): Unit = {
     StreamTestHelpers.requireJDK8CompatibleCharacteristics()
 
     val srcSize = 10
 
-    val spliter = DoubleStream
-      .iterate(2.71828, e => e + 1.0)
+    val spliter = IntStream
+      .iterate(271828, e => e + 10)
       .limit(srcSize)
       .spliterator()
 
@@ -901,15 +1003,15 @@ class DoubleStreamTest {
   }
 
   // Issue #3309 - 2 of 5
-  @Test def doubleStreamLimit_Characteristics(): Unit = {
+  @Test def intStreamLimit_Characteristics(): Unit = {
     StreamTestHelpers.requireJDK8CompatibleCharacteristics()
 
     val zeroCharacteristicsSpliter =
-      new Spliterators.AbstractDoubleSpliterator(Long.MaxValue, 0x0) {
-        def tryAdvance(action: DoubleConsumer): Boolean = true
+      new Spliterators.AbstractIntSpliterator(Long.MaxValue, 0x0) {
+        def tryAdvance(action: IntConsumer): Boolean = true
       }
 
-    val sZero = StreamSupport.doubleStream(zeroCharacteristicsSpliter, false)
+    val sZero = StreamSupport.intStream(zeroCharacteristicsSpliter, false)
     val sZeroLimited = sZero.limit(9)
 
     val sZeroLimitedSpliter = sZeroLimited.spliterator()
@@ -930,11 +1032,11 @@ class DoubleStreamTest {
      * streamLimit_SortedCharacteristics() handle SORTED.
      */
     val allCharacteristicsSpliter =
-      new Spliterators.AbstractDoubleSpliterator(Long.MaxValue, 0x5551) {
-        def tryAdvance(action: DoubleConsumer): Boolean = true
+      new Spliterators.AbstractIntSpliterator(Long.MaxValue, 0x5551) {
+        def tryAdvance(action: IntConsumer): Boolean = true
       }
 
-    val sAll = StreamSupport.doubleStream(allCharacteristicsSpliter, false)
+    val sAll = StreamSupport.intStream(allCharacteristicsSpliter, false)
 
     val sAllLimited = sAll.limit(9)
     val sAllLimitedSpliter = sAllLimited.spliterator()
@@ -953,18 +1055,18 @@ class DoubleStreamTest {
   }
 
   // Issue #3309 - 3 of 5
-  @Test def streamLimit_SortedCharacteristics(): Unit = {
+  @Test def intStreamLimit_SortedCharacteristics(): Unit = {
     StreamTestHelpers.requireJDK8CompatibleCharacteristics()
 
     /* Address issues with SORTED described in Test
      * streamLimit_sequentialAlwaysCharacteristics
      */
     val allCharacteristicsSpliter =
-      new Spliterators.AbstractDoubleSpliterator(0, 0x5551) {
-        def tryAdvance(action: DoubleConsumer): Boolean = false
+      new Spliterators.AbstractIntSpliterator(0, 0x5551) {
+        def tryAdvance(action: IntConsumer): Boolean = false
       }
 
-    val sAll = StreamSupport.doubleStream(allCharacteristicsSpliter, false)
+    val sAll = StreamSupport.intStream(allCharacteristicsSpliter, false)
 
     val sAllLimited = sAll.sorted().limit(9)
     val sAllLimitedSpliter = sAllLimited.spliterator()
@@ -986,8 +1088,8 @@ class DoubleStreamTest {
 
     val srcSize = 20
 
-    val unsizedSpliter = DoubleStream
-      .iterate(1.2, n => n + 1.1)
+    val unsizedSpliter = IntStream
+      .iterate(12, n => n + 11)
       .limit(srcSize)
       .spliterator()
 
@@ -1004,7 +1106,7 @@ class DoubleStreamTest {
   @Test def streamLimit_SizedCharacteristics(): Unit = {
     StreamTestHelpers.requireJDK8CompatibleCharacteristics()
 
-    val proofSpliter = DoubleStream.of(1.12, 2.23, 3.34, -1.12).spliterator()
+    val proofSpliter = IntStream.of(112, 223, 334, -112).spliterator()
 
     val expectedProofCharacteristics =
       Spliterator.SIZED | Spliterator.SUBSIZED |
@@ -1016,8 +1118,8 @@ class DoubleStreamTest {
       proofSpliter.characteristics()
     )
 
-    val sizedSpliter = DoubleStream
-      .of(1.12, 2.23, 3.34, -1.12)
+    val sizedSpliter = IntStream
+      .of(112, 223, 334, -112)
       .limit(3)
       .spliterator()
 
@@ -1031,12 +1133,12 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamMap(): Unit = {
+  @Test def intStreamMap(): Unit = {
     val nElements = 4
     val prefix = "mapped_"
     var count = 0
 
-    val s0 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s0 = IntStream.of(11, 22, 33, 44)
 
     val s1 = s0.map((e) => {
       count += 1
@@ -1053,45 +1155,50 @@ class DoubleStreamTest {
     s1.forEach((e) =>
       assertTrue(
         s"unexpected map element: ${e}",
-        (e > 10.0) && (e < 45.0)
+        (e > 100) && (e < 450)
       )
     )
     assertEquals("unexpected count", nElements, count)
   }
 
-  @Test def doubleStreamMapToInt(): Unit = {
+  @Test def intStreamMapToDouble(): Unit = {
     val nElements = 4
     var count = 0
 
-    val s0 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s0 = IntStream.of(11, 22, 33, 44)
 
-    val s1 = s0.mapToInt((e) => e.toInt)
+    val s1 = s0.mapToDouble((e) => e.toDouble)
 
     // Right resultant types
     s1.forEach(e => {
       count += 1
-      assertEquals(s"unexpected type", classOf[Int], e.getClass())
+      assertEquals(s"unexpected type", classOf[Double], e.getClass())
     })
 
     // Right count
     assertEquals("unexpected count", nElements, count)
 
     // Right content
-    val s2 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s2 = IntStream.of(11, 22, 33, 44)
 
-    val s3 = s2.mapToInt((e) => e.toInt)
+    val s3 = s2.mapToDouble((e) => e.toDouble)
 
     val it = s3.iterator()
 
     for (j <- 1 to nElements)
-      assertEquals("unexpected element", j, it.nextInt())
+      assertEquals(
+        "unexpected element",
+        (j * 11).toDouble,
+        it.nextDouble(),
+        epsilon
+      )
   }
 
-  @Test def doubleStreamMapToLong: Unit = {
+  @Test def intStreamMapToLong: Unit = {
     val nElements = 4
     var count = 0
 
-    val s0 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s0 = IntStream.of(11, 22, 33, 44)
 
     val s1 = s0.mapToLong((e) => e.toLong)
 
@@ -1105,22 +1212,22 @@ class DoubleStreamTest {
     assertEquals("unexpected count", nElements, count)
 
     // Right content
-    val s2 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s2 = IntStream.of(11, 22, 33, 44)
 
     val s3 = s2.mapToLong((e) => e.toLong)
 
     val it = s3.iterator()
 
     for (j <- 1 to nElements)
-      assertEquals("unexpected element", j.toLong, it.nextLong())
+      assertEquals("unexpected element", (j * 11).toLong, it.nextLong())
   }
 
-  @Test def doubleStreamMapToObj(): Unit = {
+  @Test def intStreamMapToObj(): Unit = {
     val nElements = 4
     val prefix = "mapped_"
     var count = 0
 
-    val s0 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s0 = IntStream.of(11, 22, 33, 44)
 
     val s1 = s0.mapToObj[String]((e) => {
       count += 1
@@ -1150,8 +1257,8 @@ class DoubleStreamTest {
     assertEquals("unexpected count", nElements, count)
   }
 
-  @Test def doubleStreamNoneMatch_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamNoneMatch_EmptyStream(): Unit = {
+    val s = IntStream.empty()
     var predEvaluated = false
 
     val noneMatched = s.noneMatch((e) => { predEvaluated = true; true })
@@ -1159,30 +1266,30 @@ class DoubleStreamTest {
     assertFalse("predicate should not have been evaluated", predEvaluated)
   }
 
-  @Test def doubleStreamNoneMatch_True(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def intStreamNoneMatch_True(): Unit = {
+    val s = IntStream.of(0, 11, 22, 33)
 
-    val matched = s.noneMatch((e) => e < 0.0)
+    val matched = s.noneMatch((e) => e < 0)
     assertTrue("unexpected predicate failure", matched)
   }
 
-  @Test def doubleStreamNone_MatchFalse(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def intStreamNone_MatchFalse(): Unit = {
+    val s = IntStream.of(0, 11, 22, 33)
 
-    val matched = s.noneMatch((e) => e > 2.2)
+    val matched = s.noneMatch((e) => e > 22)
     assertFalse("unexpected predicate failure", matched)
   }
 
-  @Test def doubleStreamMax_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamMax_EmptyStream(): Unit = {
+    val s = IntStream.empty()
 
     val max = s.max()
 
     assertFalse("max optional should be empty", max.isPresent)
   }
 
-  @Test def doubleStreamMax(): Unit = {
-    val stream = DoubleStream.of(85.85, 4.4, 87.87, 25.25, 7.7)
+  @Test def intStreamMax(): Unit = {
+    val stream = IntStream.of(8585, 44, 8787, 2525, 77)
 
     val maxOpt = stream.max()
 
@@ -1190,55 +1297,35 @@ class DoubleStreamTest {
 
     assertEquals(
       "wrong max item found",
-      87.87,
-      maxOpt.getAsDouble(),
-      epsilon
+      8787,
+      maxOpt.getAsInt()
     )
   }
 
-  @Test def doubleStreamMax_NaN(): Unit = {
-    val stream = DoubleStream.of(85.85, Double.NaN, 87.87, 25.25, 7.7)
+  @Test def intStreamMax_NegativeZero(): Unit = {
+    val stream = IntStream.of(-8585, -0, -8787, -2525, -77)
 
     val maxOpt = stream.max()
 
     assertTrue("max not found", maxOpt.isPresent())
 
     assertEquals(
-      "wrong max item found",
-      Double.NaN,
-      maxOpt.getAsDouble(),
-      epsilon
-    )
-  }
-
-  @Test def doubleStreamMax_NegativeZero(): Unit = {
-    val stream = DoubleStream.of(-85.85, -0.0, -87.87, -25.25, -7.7)
-
-    val maxOpt = stream.max()
-
-    assertTrue("max not found", maxOpt.isPresent())
-
-    /* This Test expects a -0.0, exactly, not a -0.0 squashed to 0.0.
-     * ==, <, and > will conflate -0.0 and 0.0: i.e. -0.0 == 0.0.
-     * Double.compare will distinguish them: i.e. -0.0 != 0.0.
-     */
-    assertEquals(
-      s"wrong max item found: '${maxOpt.getAsDouble()}'",
+      s"wrong max item found: '${maxOpt.getAsInt()}'",
       0,
-      jl.Double.compare(-0.0, maxOpt.getAsDouble()) // distinguish -0.0
+      maxOpt.getAsInt()
     )
   }
 
-  @Test def doubleStreamMin_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamMin_EmptyStream(): Unit = {
+    val s = IntStream.empty()
 
     val minOpt = s.min()
 
     assertFalse("min optional should be empty", minOpt.isPresent)
   }
 
-  @Test def doubleStreamMin(): Unit = {
-    val stream = DoubleStream.of(85.85, 4.4, 87.87, 25.25, 7.7)
+  @Test def intStreamMin(): Unit = {
+    val stream = IntStream.of(8585, 44, 8787, 2525, 77)
 
     val minOpt = stream.min()
 
@@ -1246,42 +1333,22 @@ class DoubleStreamTest {
 
     assertEquals(
       "wrong min item found",
-      4.4,
-      minOpt.getAsDouble(),
-      epsilon
+      44,
+      minOpt.getAsInt()
     )
   }
 
-  @Test def doubleStreamMin_NaN(): Unit = {
-    val stream = DoubleStream.of(85.85, Double.NaN, 87.87, 25.25, 7.7)
+  @Test def intStreamMin_NegativeZero(): Unit = {
+    val stream = IntStream.of(8585, -0, 8787, 0, 2525, 77)
 
     val minOpt = stream.min()
 
     assertTrue("min not found", minOpt.isPresent())
 
     assertEquals(
-      "wrong min item found",
-      Double.NaN,
-      minOpt.getAsDouble(),
-      epsilon
-    )
-  }
-
-  @Test def doubleStreamMin_NegativeZero(): Unit = {
-    val stream = DoubleStream.of(85.85, -0.0, 87.87, 0.0, 25.25, 7.7)
-
-    val minOpt = stream.min()
-
-    assertTrue("min not found", minOpt.isPresent())
-
-    /* This Test expects a -0.0, exactly, not a -0.0 squashed to 0.0.
-     * ==, <, and > will conflate -0.0 and 0.0: i.e. -0.0 == 0.0.
-     * Double.compare will distinguish them: i.e. -0.0 != 0.0.
-     */
-    assertEquals(
-      s"wrong min item found: '${minOpt.getAsDouble()}'",
+      s"wrong min item found: '${minOpt.getAsInt()}'",
       0,
-      jl.Double.compare(-0.0, minOpt.getAsDouble()) // distinguish -0.0
+      minOpt.getAsInt()
     )
   }
 
@@ -1290,115 +1357,118 @@ class DoubleStreamTest {
    * JVM documentations suggests that "peek()" be mainly used for debugging.
    */
   @Ignore
-  @Test def doubleStreamPeek(): Unit = {
+  @Test def intStreamPeek(): Unit = {
     val expectedCount = 3
 
-    val s = DoubleStream.of(7.7, 5.5, 3.3)
+    val s = IntStream.of(7, 5, 3)
 
     // The ".count()" is a terminal operation to force the pipeline to
     // evalute. The real interest is if the peek() side-effect happened
     // correctly.  Currently that can only be evaluated manually/visually.
-    val n = s.peek((e: Double) => printf(s"peek: |${e}|\n")).count()
+
+    val n = s.peek((e: Int) => printf(s"peek: |${e}|\n")).count()
 
     assertEquals(s"unexpected count", expectedCount, n)
   }
 
   @Ignore // see @Ignore comment above "streamShouldPeek()" above.
-  @Test def doubleStreamPeek_CompositeStream(): Unit = {
+  @Test def intStreamPeek_CompositeStream(): Unit = {
     // Test that peek() works with all substreams of a composite stream.
-    val expectedCount = 8
+    val expectedCount = 10
 
     // See ".count()" comment in streamShouldPeek above.
 
     // One should see the original data before and then after transformation
     // done by flatmap to each original element. Something like:
-    //   before: <1.1>
-    //     after: <1.1>
-    //     after: <1.1>
-    //   before: <2.2>
-    //     after: <2.2>
-    //     after: <2.2>
-    //   before: <3.3>
-    //     after: <3.3>
-    //     after: <3.3>
-    //   before: <4.4>
-    //     after: <4.4>
-    //     after: <4.4>
+    //   before: <1>
+    //     after: <1>
+    //   before: <2>
+    //     after: <1>
+    //     after: <2>
+    //   before: <3>
+    //     after: <1>
+    //     after: <2>
+    //     after: <3>
+    //   before: <4>
+    //     after: <1>
+    //     after: <2>
+    //     after: <3>
+    //     after: <4>
 
-    val n = DoubleStream
-      .of(1.1, 2.2, 3.3, 4.4)
-      .peek((e: Double) =>
+    val n = IntStream
+      .of(1, 2, 3, 4)
+      .peek((e: Int) =>
         printf(s"composite peek - before: <${e}>|\n")
       ) // simple str
-      .flatMap((e: Double) => DoubleStream.of(e, e))
-      .peek((e) => printf(s"composite peek - after: <${e}>|\n")) // composite
+      .flatMap((e: Int) => IntStream.of((1 to e): _*))
+      .peek((e: Int) =>
+        printf(s"composite peek - after: <${e}>|\n")
+      ) // composite
       .count()
 
     assertEquals(s"unexpected count", expectedCount, n)
   }
 
-  @Test def doubleStreamReduce_OneArgEmpty(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamReduce_OneArgEmpty(): Unit = {
+    val s = IntStream.empty()
 
-    val optional: OptionalDouble = s.reduce((r, e) => r + e)
+    val optional: OptionalInt = s.reduce((r, e) => r + e)
 
     assertFalse("unexpected non-empty optional", optional.isPresent())
   }
 
-  @Test def doubleStreamReduce_OneArg(): Unit = {
-    val s = DoubleStream.of(3.3, 5.5, 7.7, 11.11)
-    val expectedSum = 27.61
+  @Test def intStreamReduce_OneArg(): Unit = {
+    val s = IntStream.of(33, 55, 77, 1111)
+    val expectedSum = 1276
 
-    val optional: OptionalDouble = s.reduce((r, e) => r + e)
+    val optional: OptionalInt = s.reduce((r, e) => r + e)
 
     assertTrue("unexpected empty optional", optional.isPresent())
     assertEquals(
       "unexpected reduction result",
       expectedSum,
-      optional.getAsDouble(),
-      epsilon
+      optional.getAsInt()
     )
   }
 
-  @Test def doubleStreamReduce_TwoArgEmpty(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamReduce_TwoArgEmpty(): Unit = {
+    val s = IntStream.empty()
 
-    val firstArg = 1.1
+    val firstArg = 11
 
-    val product: Double = s.reduce(firstArg, (r, e) => r * e)
+    val product: Int = s.reduce(firstArg, (r, e) => r * e)
 
-    assertEquals("unexpected reduction result", firstArg, product, epsilon)
+    assertEquals("unexpected reduction result", firstArg, product)
   }
 
-  @Test def doubleStreamReduce_TwoArg(): Unit = {
-    val s = DoubleStream.of(3.3, 5.5, 7.7, 11.11)
-    val expectedProduct = 1552.67805
+  @Test def intStreamReduce_TwoArg(): Unit = {
+    val s = IntStream.of(33, 55, 77, 1111)
+    val expectedProduct = 155267805
 
-    val product: Double = s.reduce(1, (r, e) => r * e)
+    val product: Int = s.reduce(1, (r, e) => r * e)
 
     assertEquals(
       "unexpected reduction result",
       expectedProduct,
-      product,
-      epsilon
+      product
     )
   }
 
-  @Test def doubleStreamSkip_NegativeArg(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def intStreamSkip_NegativeArg(): Unit = {
+    val s = IntStream.of(11, 22, 33)
     assertThrows(classOf[IllegalArgumentException], s.skip(-1))
   }
 
-  @Test def doubleStreamSkip_TooMany(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def intStreamSkip_TooMany(): Unit = {
+    val s = IntStream.of(11, 22, 33)
 
     val isEmptyStream = !s.skip(10).iterator.hasNext()
     assertTrue("expected empty stream", isEmptyStream)
   }
 
-  @Test def doubleStreamSkip(): Unit = {
-    val expectedValue = 99.99
-    val s = DoubleStream.of(1.1, 2.2, 3.3, 4.4, expectedValue, 6.6, 7.7)
+  @Test def intStreamSkip(): Unit = {
+    val expectedValue = 9999
+    val s = IntStream.of(11, 22, 33, 44, expectedValue, 66, 77)
 
     val iter = s.skip(4).iterator()
 
@@ -1406,43 +1476,42 @@ class DoubleStreamTest {
     assertEquals(
       "unexpected first value: ",
       expectedValue,
-      iter.nextDouble(),
-      epsilon
+      iter.nextInt()
     )
   }
 
-  @Test def doubleStreamSorted(): Unit = {
+  @Test def intStreamSorted(): Unit = {
     val nElements = 8
-    val wild = new Array[Double](nElements)
+    val wild = new Array[Int](nElements)
 
     // Ensure that the Elements are not inserted in sorted or reverse order.
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val ordered = new Array[Double](nElements)
-    ordered(0) = 3.77
-    ordered(1) = 9.60
-    ordered(2) = 11.2
-    ordered(3) = 21.4
-    ordered(4) = 31.5
-    ordered(5) = 45.32
-    ordered(6) = 61.44
-    ordered(7) = 68.16
+    val ordered = new Array[Int](nElements)
+    ordered(0) = 112
+    ordered(1) = 214
+    ordered(2) = 315
+    ordered(3) = 377
+    ordered(4) = 960
+    ordered(5) = 4532
+    ordered(6) = 6144
+    ordered(7) = 6816
 
-    val s = DoubleStream.of(wild: _*)
+    val s = IntStream.of(wild: _*)
 
     val sorted = s.sorted()
 
     var count = 0
 
     sorted.forEachOrdered((e) => {
-      assertEquals("mismatched elements", ordered(count), e, epsilon)
+      assertEquals("mismatched elements", ordered(count), e)
       count += 1
     })
 
@@ -1453,26 +1522,26 @@ class DoubleStreamTest {
     assertEquals(msg, nElements, count)
   }
 
-  @Test def doubleStreamSorted_Characteristics(): Unit = {
+  @Test def intStreamSorted_Characteristics(): Unit = {
     // See comments in StreamTest#streamSorted_Characteristics
 
     val nElements = 8
-    val wild = new Array[Double](nElements)
+    val wild = new Array[Int](nElements)
 
     // Ensure that the Elements are not inserted in sorted or reverse order.
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val seqDoubleStream = DoubleStream.of(wild: _*)
+    val seqIntStream = IntStream.of(wild: _*)
     assertFalse(
       "Expected sequential stream",
-      seqDoubleStream.isParallel()
+      seqIntStream.isParallel()
     )
 
     // same expected values for SN sequential, SN parallel, & JVM streams
@@ -1492,26 +1561,25 @@ class DoubleStreamTest {
       (expectedPreCharacteristics & ~Spliterator.IMMUTABLE) +
         Spliterator.SORTED
 
-    val seqDoubleSpliter = seqDoubleStream.spliterator()
+    val seqIntSpliter = seqIntStream.spliterator()
 
     assertEquals(
       "sequential characteristics",
       expectedPreCharacteristics,
-      seqDoubleSpliter.characteristics()
+      seqIntSpliter.characteristics()
     )
 
-    val sortedSeqDoubleStream = DoubleStream.of(wild: _*).sorted()
-    val sortedSeqSpliter = sortedSeqDoubleStream.spliterator()
+    val sortedSeqIntStream = IntStream.of(wild: _*).sorted()
+    val sortedSeqSpliter = sortedSeqIntStream.spliterator()
 
     assertEquals(
       "sorted sequential characteristics",
       expectedPostCharacteristics,
       sortedSeqSpliter.characteristics()
     )
-
   }
 
-  @Test def doubleStreamSortedUnknownSizeButSmall(): Unit = {
+  @Test def intStreamSortedUnknownSizeButSmall(): Unit = {
 
     /* To fit array, nElements should be <= Integer.MAX_VALUE.
      * Machine must have sufficient memory to support chosen number of
@@ -1523,7 +1591,7 @@ class DoubleStreamTest {
     val rng = new ju.Random(567890123)
 
     val wild = rng
-      .doubles(nElements, 0.0, jl.Double.MAX_VALUE)
+      .ints(nElements, 0, jl.Integer.MAX_VALUE)
       .toArray()
 
     val ordered = wild.clone()
@@ -1533,7 +1601,7 @@ class DoubleStreamTest {
     val iter0 = Spliterators.iterator(Spliterators.spliterator(wild, 0))
     val spliter0 = Spliterators.spliteratorUnknownSize(iter0, 0)
 
-    val s0 = StreamSupport.doubleStream(spliter0, false)
+    val s0 = StreamSupport.intStream(spliter0, false)
 
     val s0Spliter = s0.spliterator()
     assertFalse(
@@ -1545,14 +1613,14 @@ class DoubleStreamTest {
     val iter1 = Spliterators.iterator(Spliterators.spliterator(wild, 0))
     val spliter1 = Spliterators.spliteratorUnknownSize(iter1, 0)
 
-    val s = StreamSupport.doubleStream(spliter1, false)
+    val s = StreamSupport.intStream(spliter1, false)
 
     val ascending = s.sorted()
 
     var count = 0
 
     ascending.forEachOrdered((e) => {
-      assertEquals("mismatched elements", ordered(count), e, epsilon)
+      assertEquals("mismatched elements", ordered(count), e)
       count += 1
     })
 
@@ -1565,7 +1633,7 @@ class DoubleStreamTest {
   }
 
   @Ignore
-  @Test def doubleStreamSortedUnknownSizeButHuge(): Unit = {
+  @Test def intStreamSortedUnknownSizeButHuge(): Unit = {
     /* This test is for development and Issue verification.
      * It is Ignored in normal Continuous Integration because it takes
      * a long time.
@@ -1579,11 +1647,11 @@ class DoubleStreamTest {
 
     // Are the characteristics correct?
     val rs0 = rng
-      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+      .ints(0, jl.Integer.MAX_VALUE) // "Infinite" stream
 
     val iter0 = rs0.iterator()
     val spliter0 = Spliterators.spliteratorUnknownSize(iter0, 0)
-    val s0 = StreamSupport.doubleStream(spliter0, false)
+    val s0 = StreamSupport.intStream(spliter0, false)
 
     val s0Spliter = s0.spliterator()
     assertFalse(
@@ -1593,10 +1661,10 @@ class DoubleStreamTest {
 
     // Validating un-SIZED terminated s0, so need fresh similar stream.
     val rs1 = rng
-      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+      .ints(0, jl.Integer.MAX_VALUE) // "Infinite" stream
 
     val spliter1 = Spliterators.spliteratorUnknownSize(iter0, 0)
-    val s = StreamSupport.doubleStream(spliter1, false)
+    val s = StreamSupport.intStream(spliter1, false)
 
     val uut = s.sorted() // unit-under-test
 
@@ -1604,13 +1672,13 @@ class DoubleStreamTest {
     assertThrows(classOf[OutOfMemoryError], uut.findFirst())
   }
 
-  @Test def doubleStreamSortedZeroSize(): Unit = {
+  @Test def intStreamSortedZeroSize(): Unit = {
     val nElements = 0
 
     val rng = new ju.Random(567890123)
 
     val wild = rng
-      .doubles(nElements, 0.0, jl.Double.MAX_VALUE)
+      .ints(nElements, 0, jl.Integer.MAX_VALUE)
       .toArray()
 
     val ordered = wild.clone()
@@ -1618,7 +1686,7 @@ class DoubleStreamTest {
 
     val spliter = Spliterators.spliterator(wild, 0)
 
-    val s = StreamSupport.doubleStream(spliter, false)
+    val s = StreamSupport.intStream(spliter, false)
 
     val sorted = s.sorted()
     val count = sorted.count()
@@ -1627,7 +1695,7 @@ class DoubleStreamTest {
   }
 
   // Issue 3378
-  @Test def doubleStreamSortedLongSize(): Unit = {
+  @Test def intStreamSortedLongSize(): Unit = {
     /* This tests streams with the SIZED characteristics and a
      *  know length is larger than the largest possible Java array:
      *  approximately Integer.MAX_VALUE.
@@ -1635,7 +1703,7 @@ class DoubleStreamTest {
     val rng = new ju.Random(1234567890)
 
     val s = rng
-      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+      .ints(0, jl.Integer.MAX_VALUE) // "Infinite" stream
 
     /* The sorted() implementation should be a late binding, intermediate
      * operation. Expect no "max array size" error here, but later.
@@ -1652,48 +1720,48 @@ class DoubleStreamTest {
     assertThrows(classOf[IllegalArgumentException], uut.findFirst())
   }
 
-  @Test def doubleStreamSum(): Unit = {
+  @Test def intStreamSum(): Unit = {
     val nElements = 9
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    val wild = new Array[Int](nElements) // holds arbitrarily jumbled data
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val expectedSum = 252.39
+    val expectedSum = 19470
 
-    val s = DoubleStream.of(wild: _*)
+    val s = IntStream.of(wild: _*)
 
     val sum = s.sum()
 
-    assertEquals("unexpected sum", expectedSum, sum, epsilon)
+    assertEquals("unexpected sum", expectedSum, sum)
   }
 
-  @Test def doubleStreamSummaryStatistics(): Unit = {
+  @Test def intStreamSummaryStatistics(): Unit = {
     val nElements = 8
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    val wild = new Array[Int](nElements) // holds arbitrarily jumbled data
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val expectedAverage = 31.54875
     val expectedCount = nElements
-    val expectedMax = 68.16
-    val expectedMin = 3.77
-    val expectedSum = 252.39
+    val expectedMax = 6816
+    val expectedMin = 112
+    val expectedSum = 19470
+    val expectedAverage = expectedSum.toDouble / nElements
 
-    val s = DoubleStream.of(wild: _*)
+    val s = IntStream.of(wild: _*)
 
     val stats = s.summaryStatistics()
 
@@ -1706,27 +1774,27 @@ class DoubleStreamTest {
 
     assertEquals("unexpected count", expectedCount, stats.getCount())
 
-    assertEquals("unexpected max", expectedMax, stats.getMax(), epsilon)
+    assertEquals("unexpected max", expectedMax, stats.getMax())
 
-    assertEquals("unexpected min", expectedMin, stats.getMin(), epsilon)
+    assertEquals("unexpected min", expectedMin, stats.getMin())
 
-    assertEquals("unexpected sum", expectedSum, stats.getSum(), epsilon)
+    assertEquals("unexpected sum", expectedSum, stats.getSum())
   }
 
-  @Test def doubleStreamToArray(): Unit = {
+  @Test def intStreamToArray(): Unit = {
     val nElements = 9
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    val wild = new Array[Int](nElements) // holds arbitrarily jumbled data
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val s = DoubleStream.of(wild: _*)
+    val s = IntStream.of(wild: _*)
 
     val resultantArray = s.toArray()
 
@@ -1735,7 +1803,7 @@ class DoubleStreamTest {
 
     // Proper elements, in encounter order
     for (j <- 0 until nElements)
-      assertEquals("elements do not match", wild(j), resultantArray(j), epsilon)
+      assertEquals("elements do not match", wild(j), resultantArray(j))
   }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/LongStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/LongStreamTest.scala
@@ -2,7 +2,7 @@ package org.scalanative.testsuite.javalib.util.stream
 
 /* It is hard to assure oneself that the desired primitive DoubleStream,
  * LongStream, & IntStream are being used instead of a/an (object) Stream.
- * Create DoubleStream & kin using the methods in Arrays.
+ * Create IntStream & kin using the methods in Arrays.
  *
  * Do not import ArrayList here, to guard against a Test populating
  * an ArrayList and then inadvertently creating an (object) Stream with it.
@@ -12,39 +12,38 @@ package org.scalanative.testsuite.javalib.util.stream
 import java.{lang => jl}
 
 import java.{util => ju}
-import java.util.{Arrays, ArrayList}
-import java.util.{OptionalDouble, DoubleSummaryStatistics}
-import java.util.Spliterator
-import java.util.Spliterators
+import java.util.Arrays
+import java.util.LongSummaryStatistics
+import java.util.OptionalLong
+import java.util.{Spliterator, Spliterators}
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.CountDownLatch._
 
-import java.util.function.{DoubleConsumer, DoubleFunction, DoubleSupplier}
+import java.util.function.{LongConsumer, LongFunction, LongSupplier}
 import java.util.function.Supplier
 
 import java.util.stream._
 
 import org.junit.Test
 import org.junit.Assert._
-import org.junit.BeforeClass
 import org.junit.Ignore
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 
-class DoubleStreamTest {
+class LongStreamTest {
 
   final val epsilon = 0.00001 // tolerance for Floating point comparisons.
 
 // Methods specified in interface BaseStream ----------------------------
 
   @Test def streamUnorderedOnUnorderedStream(): Unit = {
-    val dataSet = new ju.HashSet[Double]()
-    dataSet.add(0.1)
-    dataSet.add(1.1)
-    dataSet.add(-1.1)
-    dataSet.add(2.2)
-    dataSet.add(-2.2)
+    val dataSet = new ju.HashSet[Long]()
+    dataSet.add(1L)
+    dataSet.add(11)
+    dataSet.add(-11)
+    dataSet.add(22)
+    dataSet.add(-22)
 
     val s0 = dataSet.stream()
     val s0Spliter = s0.spliterator()
@@ -63,7 +62,7 @@ class DoubleStreamTest {
   }
 
   @Test def streamUnorderedOnOrderedStream(): Unit = {
-    val s = DoubleStream.of(0.1, 1.1, -1.1, 2.2, -2.2)
+    val s = LongStream.of(1L, 11, -11, 22, -22)
     val sSpliter = s.spliterator()
 
     assertTrue(
@@ -72,7 +71,7 @@ class DoubleStreamTest {
     )
 
     // s was ordered, 'so' should be same same. Avoid "already used" exception
-    val so = DoubleStream.of(0.1, 1.1, -1.1, 2.2, -2.2)
+    val so = LongStream.of(1L, 11, -11, 22, -22)
     val su = so.unordered()
     val suSpliter = su.spliterator()
 
@@ -85,15 +84,15 @@ class DoubleStreamTest {
   @Test def streamParallel(): Unit = {
     val nElements = 5
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 132.45
-    wild(1) = 4.21
-    wild(2) = 2.11
-    wild(3) = 55.31
-    wild(4) = 16.68
+    val wild = new Array[Long](nElements) // holds arbitrarily jumbled data
+    wild(0) = 13245L
+    wild(1) = 421
+    wild(2) = 211
+    wild(3) = 5531
+    wild(4) = 1668
 
     val sPar0 =
-      StreamSupport.doubleStream(Spliterators.spliterator(wild, 0), true)
+      StreamSupport.longStream(Spliterators.spliterator(wild, 0), true)
 
     assertTrue(
       "Expected parallel stream",
@@ -111,7 +110,7 @@ class DoubleStreamTest {
     )
 
     val sPar =
-      StreamSupport.doubleStream(Spliterators.spliterator(wild, 0), true)
+      StreamSupport.longStream(Spliterators.spliterator(wild, 0), true)
 
     val sSeq = sPar.sequential()
     assertFalse(
@@ -135,12 +134,11 @@ class DoubleStreamTest {
 
     // sequential stream has expected contents
     var count = 0
-    sSeqSpliterator.forEachRemaining((e: Double) => {
+    sSeqSpliterator.forEachRemaining((e: Long) => {
       assertEquals(
         s"sequential stream contents(${count})",
         wild(count),
-        e,
-        epsilon
+        e
       )
       count += 1
     })
@@ -149,15 +147,15 @@ class DoubleStreamTest {
   @Test def streamSequential(): Unit = {
     val nElements = 5
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 132.45
-    wild(1) = 4.21
-    wild(2) = 2.11
-    wild(3) = 55.31
-    wild(4) = 16.68
+    val wild = new Array[Long](nElements) // holds arbitrarily jumbled data
+    wild(0) = 13245
+    wild(1) = 421
+    wild(2) = 211
+    wild(3) = 5531
+    wild(4) = 1668
 
     val sSeq0 =
-      StreamSupport.doubleStream(Spliterators.spliterator(wild, 0), false)
+      StreamSupport.longStream(Spliterators.spliterator(wild, 0), false)
 
     assertFalse(
       "Expected sequential stream",
@@ -175,7 +173,7 @@ class DoubleStreamTest {
     )
 
     val sSeq =
-      StreamSupport.doubleStream(Spliterators.spliterator(wild, 0), false)
+      StreamSupport.longStream(Spliterators.spliterator(wild, 0), false)
 
     val sPar = sSeq.parallel()
     assertTrue(
@@ -199,31 +197,30 @@ class DoubleStreamTest {
 
     // parallel stream has expected contents
     var count = 0
-    sParSpliterator.forEachRemaining((e: Double) => {
+    sParSpliterator.forEachRemaining((e: Long) => {
       assertEquals(
         s"parallel stream contents(${count})",
         wild(count),
-        e,
-        epsilon
+        e
       )
       count += 1
     })
   }
 
-// Methods specified in interface Double Stream -------------------------
+// Methods specified in interface Int Stream -------------------------
 
-  @Test def doubleStreamBuilderCanBuildAnEmptyStream(): Unit = {
-    val s = DoubleStream.builder().build()
+  @Test def longStreamBuilderCanBuildAnEmptyStream(): Unit = {
+    val s = LongStream.builder().build()
     val it = s.iterator()
     assertFalse(it.hasNext())
   }
 
-  @Test def doubleStreamBuilderCharacteristics(): Unit = {
-    val bldr = Stream.builder[Double]()
+  @Test def longStreamBuilderCharacteristics(): Unit = {
+    val bldr = Stream.builder[Long]()
     bldr
-      .add(1.1)
-      .add(-1.1)
-      .add(9.9)
+      .add(11)
+      .add(-11)
+      .add(99L)
 
     val s = bldr.build()
     val spliter = s.spliterator()
@@ -238,25 +235,25 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamEmptyIsEmpty(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamEmptyIsEmpty(): Unit = {
+    val s = LongStream.empty()
     val it = s.iterator()
     assertFalse(it.hasNext())
   }
 
-  @Test def doubleStreamOf_SingleElement(): Unit = {
-    val expected = 7.7
-    val s = DoubleStream.of(expected)
+  @Test def longStreamOf_SingleElement(): Unit = {
+    val expected = 77
+    val s = LongStream.of(expected)
     val it = s.iterator()
-    assertTrue("DoubleStream should not be empty", it.hasNext())
-    assertEquals("unexpected element", it.nextDouble(), expected, epsilon)
-    assertFalse("DoubleStream should be empty and is not.", it.hasNext())
+    assertTrue("LongStream should not be empty", it.hasNext())
+    assertEquals("unexpected element", it.nextLong(), expected)
+    assertFalse("LongStream should be empty and is not.", it.hasNext())
   }
 
   @Test def streamOf_SingleElementCharacteristics(): Unit = {
-    val expected = 7.7
+    val expected = 77
 
-    val s = DoubleStream.of(expected)
+    val s = LongStream.of(expected)
     val spliter = s.spliterator()
 
     val expectedCharacteristics =
@@ -270,17 +267,17 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamOf_MultipleElements(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def longStreamOf_MultipleElements(): Unit = {
+    val s = LongStream.of(11, 22, 33)
     val it = s.iterator()
-    assertEquals("element_1", 1.1, it.nextDouble(), epsilon)
-    assertEquals("element_2", 2.2, it.nextDouble(), epsilon)
-    assertEquals("element_3", 3.3, it.nextDouble(), epsilon)
+    assertEquals("element_1", 11, it.nextLong())
+    assertEquals("element_2", 22, it.nextLong())
+    assertEquals("element_3", 33, it.nextLong())
     assertFalse(it.hasNext())
   }
 
   @Test def streamOf_MultipleElementsCharacteristics(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+    val s = LongStream.of(11, 22, 33)
     val spliter = s.spliterator()
 
     val expectedCharacteristics =
@@ -294,53 +291,53 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamFlatMapWorks(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def longStreamFlatMapWorks(): Unit = {
+    val s = LongStream.of(11, 22, 33)
 
-    val mapper = new DoubleFunction[DoubleStream] {
-      override def apply(v: Double): DoubleStream =
-        DoubleStream.of(v, v)
+    val mapper = new LongFunction[LongStream] {
+      override def apply(v: Long): LongStream =
+        LongStream.of(v, v)
     }
 
     val s2 = s.flatMap(mapper)
 
     val it = s2.iterator()
 
-    assertEquals(1.1, it.nextDouble(), epsilon)
-    assertEquals(1.1, it.nextDouble(), epsilon)
+    assertEquals(11, it.nextLong())
+    assertEquals(11, it.nextLong())
 
-    assertEquals(2.2, it.nextDouble(), epsilon)
-    assertEquals(2.2, it.nextDouble(), epsilon)
+    assertEquals(22, it.nextLong())
+    assertEquals(22, it.nextLong())
 
-    assertEquals(3.3, it.nextDouble(), epsilon)
-    assertEquals(3.3, it.nextDouble(), epsilon)
+    assertEquals(33, it.nextLong())
+    assertEquals(33, it.nextLong())
 
     assertFalse(it.hasNext())
   }
 
-  @Test def doubleStreamForEachWorks(): Unit = {
-    val s = DoubleStream.of(-1.1, -2.2, -3.3, 0.0)
+  @Test def longStreamForEachWorks(): Unit = {
+    val s = LongStream.of(-11, -22, -33, 0)
 
-    var sum = 0.0
-    val doubleConsumer = new DoubleConsumer {
-      def accept(d: Double): Unit = sum += d
+    var sum = 0L
+    val longConsumer = new LongConsumer {
+      def accept(i: Long): Unit = sum += i
     }
 
-    s.forEach(doubleConsumer)
-    assertEquals(-6.6, sum, epsilon)
+    s.forEach(longConsumer)
+    assertEquals(-66, sum)
   }
 
-  @Test def doubleStreamFlatMapWorksTwice(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def longStreamFlatMapWorksTwice(): Unit = {
+    val s = LongStream.of(11, 22, 33)
 
-    val mapper1 = new DoubleFunction[DoubleStream] {
-      override def apply(v: Double): DoubleStream =
-        DoubleStream.of(v, v)
+    val mapper1 = new LongFunction[LongStream] {
+      override def apply(v: Long): LongStream =
+        LongStream.of(v, v)
     }
 
-    val mapper2 = new DoubleFunction[DoubleStream] {
-      override def apply(v: Double): DoubleStream =
-        DoubleStream.of(-v, -v, -v)
+    val mapper2 = new LongFunction[LongStream] {
+      override def apply(v: Long): LongStream =
+        LongStream.of(-v, -v, -v)
     }
 
     val s2 = s
@@ -350,30 +347,30 @@ class DoubleStreamTest {
 // format: off
     val expected =
       Seq(
-        -1.1, -1.1, -1.1, -1.1, -1.1, -1.1,
-        -2.2, -2.2, -2.2, -2.2, -2.2, -2.2,
-        -3.3, -3.3, -3.3, -3.3, -3.3, -3.3
+        -11, -11, -11, -11, -11, -11,
+        -22, -22, -22, -22, -22, -22,
+        -33, -33, -33, -33, -33, -33
       )
 // format: on
 
-    val result = scala.collection.mutable.ArrayBuffer.empty[Double]
+    val result = scala.collection.mutable.ArrayBuffer.empty[Long]
     val it = s2.iterator()
 
     while (it.hasNext()) {
-      result += it.nextDouble()
+      result += it.nextLong()
     }
 
     assertTrue(result == expected)
   }
 
-  @Test def doubleStreamOnCloseWorks(): Unit = {
+  @Test def longStreamOnCloseWorks(): Unit = {
     var latch = new CountDownLatch(1)
 
     class Closer(cdLatch: CountDownLatch) extends Runnable {
       override def run(): Unit = cdLatch.countDown()
     }
 
-    val s = DoubleStream.empty().onClose(new Closer(latch))
+    val s = LongStream.empty().onClose(new Closer(latch))
     s.close()
 
     val timeout = 30L
@@ -385,88 +382,88 @@ class DoubleStreamTest {
 
 // Static methods -------------------------------------------------------
 
-  @Test def doubleStreamConcat(): Unit = {
-    val a = DoubleStream.of(9.9, 8.8, 6.6, 7.7, 5.5)
-    val b = DoubleStream.of(0.0, 3.3, 2.2)
+  @Test def longStreamConcat(): Unit = {
+    val a = LongStream.of(99, 88, 66, 77, 55)
+    val b = LongStream.of(0, 33, 22)
 
-    val s = DoubleStream.concat(a, b)
+    val s = LongStream.concat(a, b)
 
     val it = s.iterator()
     assertNotNull("s.iterator() should not be NULL", it)
     assertTrue("stream should not be empty", it.hasNext())
 
-    assertEquals(s"element", 9.9, it.nextDouble(), epsilon)
-    assertEquals(s"element", 8.8, it.nextDouble(), epsilon)
-    assertEquals(s"element", 6.6, it.nextDouble(), epsilon)
-    assertEquals(s"element", 7.7, it.nextDouble(), epsilon)
-    assertEquals(s"element", 5.5, it.nextDouble(), epsilon)
+    assertEquals(s"element", 99, it.nextLong())
+    assertEquals(s"element", 88, it.nextLong())
+    assertEquals(s"element", 66, it.nextLong())
+    assertEquals(s"element", 77, it.nextLong())
+    assertEquals(s"element", 55, it.nextLong())
 
-    assertEquals(s"element", 0.0, it.nextDouble(), epsilon)
-    assertEquals(s"element", 3.3, it.nextDouble(), epsilon)
-    assertEquals(s"element", 2.2, it.nextDouble(), epsilon)
+    assertEquals(s"element", 0, it.nextLong())
+    assertEquals(s"element", 33, it.nextLong())
+    assertEquals(s"element", 22, it.nextLong())
 
     assertFalse("stream should be empty", it.hasNext())
   }
 
   @Test def doubleStreamGenerate(): Unit = {
     val nElements = 5
-    val data = new Array[Double](nElements)
-    data(0) = 0.0
-    data(1) = 1.1
-    data(2) = 2.2
-    data(3) = 3.3
-    data(4) = 4.4
+    val data = new Array[Long](nElements)
+    data(0) = 0
+    data(1) = 11
+    data(2) = 22
+    data(3) = 33
+    data(4) = 44
 
-    val src = new DoubleSupplier() {
+    val src = new LongSupplier() {
       var count = -1
 
-      def getAsDouble(): Double = {
+      def getAsLong(): Long = {
         count += 1
         data(count % nElements)
       }
     }
 
-    val s = DoubleStream.generate(src)
+    val s = LongStream.generate(src)
 
     val it = s.iterator()
 
-    assertTrue("DoubleStream should not be empty", it.hasNext())
+    assertTrue("LongStream should not be empty", it.hasNext())
 
     for (j <- 0 until nElements)
-      assertEquals(s"data(${j})", it.nextDouble(), data(j), epsilon)
+      assertEquals(s"data(${j})", it.nextLong(), data(j))
 
-    assertTrue("DoubleStream should not be empty", it.hasNext())
+    assertTrue("LongStream should not be empty", it.hasNext())
   }
 
-  @Test def doubleStreamIterate_Unbounded(): Unit = {
+  @Test def longStreamIterate_Unbounded(): Unit = {
     val nElements = 4
     var count = -1.0
 
-    val expectedSeed = 3.14
+    val expectedSeed = 1775
 
-    val expected = Seq(expectedSeed, 4.24, 5.34, 6.44)
+    val expected = Seq(expectedSeed, 1786, 1797, 1808)
 
-    val s = DoubleStream.iterate(
+    val s = LongStream.iterate(
       expectedSeed,
-      e => e + 1.1
+      e => e + 11
     )
 
     val it = s.iterator()
 
-    assertTrue("DoubleStream should not be empty", it.hasNext())
+    assertTrue("LongStream should not be empty", it.hasNext())
 
     for (j <- 0 until nElements)
-      assertEquals(s"element: ${j})", expected(j), it.nextDouble(), epsilon)
+      assertEquals(s"element: ${j})", expected(j), it.nextLong())
 
-    assertTrue("DoubleStream should not be empty", it.hasNext())
+    assertTrue("LongStream should not be empty", it.hasNext())
   }
 
-  @Test def doubleStreamIterate_Unbounded_Characteristics(): Unit = {
-    val s = DoubleStream.iterate(0.0, n => n + 1.1)
+  @Test def longStreamIterate_Unbounded_Characteristics(): Unit = {
+    val s = LongStream.iterate(0, n => n + 11)
     val spliter = s.spliterator()
 
     // spliterator should have required characteristics and no others.
-    // Note: DoubleStream requires NONNULL, whereas Stream[T] does not.
+    // Note: LongStream requires NONNULL, whereas Stream[T] does not.
     val requiredPresent =
       Seq(Spliterator.ORDERED, Spliterator.IMMUTABLE, Spliterator.NONNULL)
 
@@ -487,31 +484,76 @@ class DoubleStreamTest {
     assertEquals(s"estimateSize", Long.MaxValue, spliter.estimateSize())
   }
 
-  @Test def doubleStreamOf_NoItems(): Unit = {
-    val s = DoubleStream.of()
+  @Test def longStreamOf_NoItems(): Unit = {
+    val s = LongStream.of()
 
     val it = s.iterator()
-    assertFalse("DoubleStream should be empty", it.hasNext())
+    assertFalse("LongStream should be empty", it.hasNext())
   }
 
-  @Test def doubleStreamOf_OneItem(): Unit = {
-    val expected = 6.67
-    val s = DoubleStream.of(expected)
+  @Test def longStreamOf_OneItem(): Unit = {
+    val expected = 667
+    val s = LongStream.of(expected)
 
     val it = s.iterator()
     assertTrue("stream should not be empty", it.hasNext())
-    assertEquals(s"element", expected, it.nextDouble(), epsilon)
+    assertEquals(s"element", expected, it.nextLong())
 
-    assertFalse("DoubleStream should be empty", it.hasNext())
+    assertFalse("LongStream should be empty", it.hasNext())
   }
 
-  // DoubleStream.of() with more than two arguments is exercised in many other
+  // LongStream.of() with more than two arguments is exercised in many other
   // places in this file, so no Test for that case here.
+
+  @Test def longStreamRange(): Unit = {
+    val startInclusive = 5
+    val endExclusive = 15
+    val expectedCount = endExclusive - startInclusive
+
+    val s = LongStream.range(startInclusive, endExclusive)
+
+    var count = 0
+
+    s.spliterator()
+      .forEachRemaining((e: Long) => {
+        assertEquals(
+          s"range contents",
+          count + startInclusive,
+          e
+        )
+        count += 1
+      })
+
+    assertEquals(s"unexpected range count", expectedCount, count)
+  }
+
+  @Test def intStreamRangeClosed(): Unit = {
+
+    val startInclusive = 5
+    val endInclusive = 15
+    val expectedCount = endInclusive - startInclusive + 1
+
+    val s = LongStream.rangeClosed(startInclusive, endInclusive)
+
+    var count = 0
+
+    s.spliterator()
+      .forEachRemaining((e: Long) => {
+        assertEquals(
+          s"rangeClosed contents",
+          count + startInclusive,
+          e
+        )
+        count += 1
+      })
+
+    assertEquals(s"unexpected rangeClosed count", expectedCount, count)
+  }
 
 // Instance methods -----------------------------------------------------
 
-  @Test def doubleStreamAllMatch_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamAllMatch_EmptyStream(): Unit = {
+    val s = LongStream.empty()
     var predEvaluated = false
 
     val matched = s.allMatch((e) => { predEvaluated = true; true })
@@ -519,31 +561,31 @@ class DoubleStreamTest {
     assertFalse("predicate should not have been evaluated", predEvaluated)
   }
 
-  @Test def doubleStreamAllMatch_True(): Unit = {
+  @Test def longStreamAllMatch_True(): Unit = {
 
-    /* DoubleStream.allMatch() will return "true" on an empty stream.
-     *  Try to distinguish that "true" from an actual all-elements-match "true"
-     *  Since streams can not be re-used, count s0. If it is non-empty, assume
+    /* LongStream.allMatch() will return "true" on an empty stream.
+     * Try to distinguish that "true" from an actual all-elements-match "true"
+     * Since streams can not be re-used, count s0. If it is non-empty, assume
      * its sibling s is also non-empty, distingishing the two "true"s.
      */
-    val s0 = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+    val s0 = LongStream.of(0, 11, 22, 33)
     assertTrue("unexpected empty stream", s0.count > 0)
 
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+    val s = LongStream.of(0, 11, 22, 33)
 
-    val matched = s.allMatch((e) => { (e >= 0.0) && (e < 10.0) })
+    val matched = s.allMatch((e) => { (e >= 0) && (e < 90) })
     assertTrue("unexpected match failure", matched)
   }
 
-  @Test def doubleStreamAllMatch_False(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def longStreamAllMatch_False(): Unit = {
+    val s = LongStream.of(0, 11, 22, 33)
 
-    val matched = s.allMatch((e) => e > 2.2)
+    val matched = s.allMatch((e) => e > 22)
     assertFalse("unexpected match", matched)
   }
 
-  @Test def doubleStreamAnyMatch_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamAnyMatch_EmptyStream(): Unit = {
+    val s = LongStream.empty()
     var predEvaluated = false
 
     val matched = s.anyMatch((e) => { predEvaluated = true; true })
@@ -551,44 +593,77 @@ class DoubleStreamTest {
     assertFalse("predicate should not have been evaluated", predEvaluated)
   }
 
-  @Test def doubleStreamAnyMatch_True(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def longStreamAnyMatch_True(): Unit = {
+    val s = LongStream.of(0, 11, 22, 33)
 
-    val matched = s.anyMatch((e) => (e > 1.0) && (e < 2.0))
+    val matched = s.anyMatch((e) => (e > 10) && (e < 20))
     assertTrue("unexpected predicate failure", matched)
   }
 
-  @Test def doubleStreamAnyMatch_False(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def longStreamAnyMatch_False(): Unit = {
+    val s = LongStream.of(0, 11, 22, 33)
 
-    val matched = s.anyMatch((e) => e > 10.0)
+    val matched = s.anyMatch((e) => e > 90)
     assertFalse("unexpected predicate failure", matched)
   }
 
-  @Test def doubleStreamAverage_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def intStreamAsDoubleStream(): Unit = {
+    val nElements = 4
+    var count = 0
+
+    val s0 = LongStream.of(11, 22, 33, 44L)
+
+    val s1 = s0.asDoubleStream()
+
+    // Right resultant types
+    s1.forEach(e => {
+      count += 1
+      assertEquals(s"unexpected type", classOf[Double], e.getClass())
+    })
+
+    // Right count
+    assertEquals("unexpected count", nElements, count)
+
+    // Right content
+    val s2 = LongStream.of(11, 22, 33, 44L)
+
+    val s3 = s2.asDoubleStream()
+
+    val it = s3.iterator()
+
+    for (j <- 1 to nElements)
+      assertEquals(
+        "unexpected element",
+        (j * 11).toDouble,
+        it.nextDouble(),
+        epsilon
+      )
+  }
+
+  @Test def longStreamAverage_EmptyStream(): Unit = {
+    val s = LongStream.empty()
 
     val optional = s.average()
 
     assertFalse(s"expected empty optional, got value", optional.isPresent())
   }
 
-  @Test def doubleStreamAverage(): Unit = {
+  @Test def longStreamAverage(): Unit = {
     val nElements = 8
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 132.45
-    wild(1) = 4.21
-    wild(2) = 2.11
-    wild(3) = 55.31
-    wild(4) = 16.68
-    wild(5) = 77.3
-    wild(6) = 44.61
-    wild(7) = 60.9
+    val wild = new Array[Long](nElements) // holds arbitrarily jumbled data
+    wild(0) = 13245
+    wild(1) = 421
+    wild(2) = 211
+    wild(3) = 5531
+    wild(4) = 1668
+    wild(5) = 773
+    wild(6) = 4461
+    wild(7) = 609
 
-    val expectedAverage = 49.19625
+    val expectedAverage = 3364.875 // test against known value, not calculated.
 
-    val s = DoubleStream.of(wild: _*)
+    val s = LongStream.of(wild: _*)
 
     val optional = s.average()
 
@@ -602,39 +677,39 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamBoxed(): Unit = {
+  @Test def longStreamBoxed(): Unit = {
     val nElements = 5
-    val data = new Array[Double](nElements)
-    data(0) = 0.0
-    data(1) = 1.1
-    data(2) = 2.2
-    data(3) = 3.3
-    data(4) = 4.4
+    val data = new Array[Long](nElements)
+    data(0) = 0
+    data(1) = 11
+    data(2) = 22
+    data(3) = 33
+    data(4) = 44
 
     val sd = Arrays.stream(data)
 
     assertTrue(
-      "stream should be a DoubleStream",
-      sd.isInstanceOf[DoubleStream]
+      "stream should be a LongStream",
+      sd.isInstanceOf[LongStream]
     )
 
     val sBoxed = sd.boxed()
 
     assertTrue(
-      "resultant stream should be boxed Stream[Double]",
+      "resultant stream should be boxed Stream[Long]",
       sBoxed.isInstanceOf[Stream[_]]
     )
 
     assertFalse(
-      "resultant stream should not be a DoubleStream",
-      sBoxed.isInstanceOf[DoubleStream]
+      "resultant stream should not be a LongStream",
+      sBoxed.isInstanceOf[LongStream]
     )
   }
 
-  @Test def doubleStreamCollect_EmptyStreamUsingSupplier(): Unit = {
-    type U = ju.ArrayList[Double]
+  @Test def longStreamCollect_EmptyStreamUsingSupplier(): Unit = {
+    type U = ju.ArrayList[Long]
 
-    val s = DoubleStream.empty()
+    val s = LongStream.empty()
 
     val supplier = new Supplier[U]() {
       def get(): U = new U
@@ -642,7 +717,7 @@ class DoubleStreamTest {
 
     val collected = s.collect(
       supplier,
-      (list: U, e: Double) => list.add(e),
+      (list: U, e: Long) => list.add(e),
       (list1: U, list2: U) => list1.addAll(list2)
     )
 
@@ -650,16 +725,16 @@ class DoubleStreamTest {
     assertEquals("list size", 0, collected.size())
   }
 
-  @Test def doubleStreamCollect_UsingSupplier(): Unit = {
-    type U = ju.ArrayList[Double]
+  @Test def longStreamCollect_UsingSupplier(): Unit = {
+    type U = ju.ArrayList[Long]
 
     val nElements = 5
-    val data = new Array[Double](nElements)
-    data(0) = 0.0
-    data(1) = 1.1
-    data(2) = 2.2
-    data(3) = 3.3
-    data(4) = 4.4
+    val data = new Array[Long](nElements)
+    data(0) = 0
+    data(1) = 11
+    data(2) = 22
+    data(3) = 33
+    data(4) = 44
 
     val s = Arrays.stream(data)
 
@@ -669,7 +744,7 @@ class DoubleStreamTest {
 
     val collected = s.collect(
       supplier,
-      (list: U, e: Double) => list.add(e),
+      (list: U, e: Long) => list.add(e),
       (list1: U, list2: U) => list1.addAll(list2)
     )
 
@@ -678,59 +753,59 @@ class DoubleStreamTest {
 
     // Proper elements, in encounter order
     for (j <- 0 until nElements)
-      assertEquals("list element", data(j), collected.get(j), epsilon)
+      assertEquals("list element", data(j), collected.get(j))
   }
 
-  @Test def doubleStreamCollect_UsingSummaryStatistics(): Unit = {
+  @Test def longStreamCollect_UsingSummaryStatistics(): Unit = {
     /* This is the example given at the top of the JVM
-     *  DoubleSummaryStatistics description, translate to Scala.
+     *  DoubleSummaryStatistics description, translate to Scala & Int.
      *
-     *  It tests DoubleStream.collect() using user-designated arguments.
+     *  It tests LongStream.collect() using user-designated arguments.
      *
      *  Along the way, it shows a succinct way of using collect() in Scala.
      */
 
-    type U = DoubleSummaryStatistics
+    type U = LongSummaryStatistics
 
     val nElements = 6
-    val expectedSum = 16.5
-    val expectedMin = 0.0
-    val expectedAverage = expectedSum / nElements
-    val expectedMax = 5.5
+    val expectedSum = 165L
+    val expectedMin = 0L
+    val expectedAverage = expectedSum.toDouble / nElements
+    val expectedMax = 55L
 
-    val data = new Array[Double](nElements)
-    data(0) = 1.1
-    data(1) = 2.2
+    val data = new Array[Long](nElements)
+    data(0) = 11
+    data(1) = 22
     data(2) = expectedMin
-    data(3) = 3.3
+    data(3) = 33
     data(4) = expectedMax
-    data(5) = 4.4
+    data(5) = 44
 
     val s = Arrays.stream(data)
 
     val collected = s.collect(
       () => new U,
-      (summary: U, e: Double) => summary.accept(e),
+      (summary: U, e: Long) => summary.accept(e),
       (summary1: U, summary2: U) => summary1.combine(summary2)
     )
 
     // Proper stats
     assertEquals("count", nElements, collected.getCount())
-    assertEquals("sum", expectedSum, collected.getSum(), epsilon)
-    assertEquals("min", expectedMin, collected.getMin(), epsilon)
+    assertEquals("sum", expectedSum, collected.getSum())
+    assertEquals("min", expectedMin, collected.getMin())
     assertEquals("average", expectedAverage, collected.getAverage(), epsilon)
-    assertEquals("max", expectedMax, collected.getMax(), epsilon)
+    assertEquals("max", expectedMax, collected.getMax())
   }
 
-  @Test def doubleStreamCount(): Unit = {
+  @Test def longStreamCount(): Unit = {
     val expectedCount = 5
 
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3, 4.4)
+    val s = LongStream.of(0, 11, 22, 33, 44)
 
     assertEquals(s"unexpected element count", expectedCount, s.count())
   }
 
-  @Test def doubleStreamDistinct(): Unit = {
+  @Test def longStreamDistinct(): Unit = {
 
     // There must be a harder way of doing this setup.
     // Using " scala.jdk.CollectionConverters._" and futzing with it
@@ -740,17 +815,17 @@ class DoubleStreamTest {
     val expectedCount = 5
     val range = 0 until expectedCount
 
-    val expectedElements = new Array[Double](expectedCount)
+    val expectedElements = new Array[Long](expectedCount)
     for (j <- range)
-      expectedElements(j) = j * 2.0
+      expectedElements(j) = j * 2
 
-    val expectedSet = new ju.HashSet[Double]()
+    val expectedSet = new ju.HashSet[Long]()
     for (j <- range)
       expectedSet.add(expectedElements(j))
 
-    val s = DoubleStream
+    val s = LongStream
       .of(expectedElements: _*)
-      .flatMap((e) => DoubleStream.of(e, e, e))
+      .flatMap((e) => LongStream.of(e, e, e))
       .distinct()
 
     assertEquals(s"unexpected count", expectedCount, s.count())
@@ -759,9 +834,9 @@ class DoubleStreamTest {
 
     // count() exhausted s1, so create second stream, s2
 
-    val s2 = DoubleStream
+    val s2 = LongStream
       .of(expectedElements: _*)
-      .flatMap((e) => DoubleStream.of(e, e, e))
+      .flatMap((e) => LongStream.of(e, e, e))
       .distinct()
 
     s2.forEach((e) => {
@@ -775,40 +850,40 @@ class DoubleStreamTest {
     assertTrue("expectedSet has remaining elements", expectedSet.isEmpty())
   }
 
-  @Test def doubleStreamFindAny_Null(): Unit = {
-    val s = DoubleStream.of(null.asInstanceOf[Double])
-    // Double nulls get seen as 0.0
+  @Test def longStreamFindAny_Null(): Unit = {
+    val s = LongStream.of(null.asInstanceOf[Long])
+    // Long nulls get seen as 0
     val optional = s.findAny()
     assertTrue("unexpected failure to findAny", optional.isPresent())
-    assertEquals("unexpected element", 0.0, optional.getAsDouble(), epsilon)
+    assertEquals("unexpected element", 0, optional.getAsLong())
   }
 
-  @Test def doubleStreamFindAny_True(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
-    val acceptableValues = List(0.0, 1.1, 2.2, 3.3)
+  @Test def longStreamFindAny_True(): Unit = {
+    val s = LongStream.of(0, 11, 22, 33)
+    val acceptableValues = List(0, 11, 22, 33)
 
     val optional = s.findAny()
 
     assertTrue("unexpected empty optional", optional.isPresent())
 
-    val found = optional.getAsDouble()
+    val found = optional.getAsLong()
     assertTrue(
       s"unexpected value: '${found}'",
       acceptableValues.contains(found)
     )
   }
 
-  @Test def doubleStreamFindAny_False(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamFindAny_False(): Unit = {
+    val s = LongStream.empty()
 
     val optional = s.findAny()
 
     assertFalse("unexpected failure", optional.isPresent())
   }
 
-  @Test def doubleStreamFindFirst_True(): Unit = {
-    val expectedFirst = 0.0
-    val s = DoubleStream.of(expectedFirst, 1.1, 2.2, 3.3)
+  @Test def longStreamFindFirst_True(): Unit = {
+    val expectedFirst = 0
+    val s = LongStream.of(expectedFirst, 11, 22, 33)
 
     val optional = s.findFirst()
 
@@ -816,53 +891,52 @@ class DoubleStreamTest {
     assertEquals(
       "unexpected mismatch",
       expectedFirst,
-      optional.getAsDouble(),
-      epsilon
+      optional.getAsLong()
     )
   }
 
-  @Test def doubleStreamFindFirst_False(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamFindFirst_False(): Unit = {
+    val s = LongStream.empty()
 
     val optional = s.findFirst()
 
     assertFalse("unexpected failure", optional.isPresent())
   }
 
-  @Test def doubleStreamFilter(): Unit = {
+  @Test def longStreamFilter(): Unit = {
     val expectedCount = 4
 
-    val s0 = DoubleStream.of(
-      101.1, 1.1, 102.2, 2.2, 103.2, 3.3, 4.4
+    val s0 = LongStream.of(
+      1011, 11, 1022, 22, 1032, 33, 44
     )
 
-    val s1 = s0.filter(e => e < 100.0)
+    val s1 = s0.filter(e => e < 1000)
     assertEquals(s"unexpected element count", expectedCount, s1.count())
   }
 
-  @Test def doubleStreamForeachOrdered(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def longStreamForeachOrdered(): Unit = {
+    val s = LongStream.of(11, 22, 33)
 
-    var sum = 0.0
-    val consumer = new DoubleConsumer {
-      def accept(i: Double): Unit = { sum = sum + i }
+    var sum = 0L
+    val consumer = new LongConsumer {
+      def accept(i: Long): Unit = { sum = sum + i }
     }
     s.forEachOrdered(consumer)
-    assertEquals("unexpected sum", 6.6, sum, epsilon)
+    assertEquals("unexpected sum", 66, sum)
   }
 
-  @Test def doubleStreamLimit_NegativeArg(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def longStreamLimit_NegativeArg(): Unit = {
+    val s = LongStream.of(11, 22, 33)
     assertThrows(classOf[IllegalArgumentException], s.limit(-1))
   }
 
-  @Test def doubleStreamLimit(): Unit = {
+  @Test def longStreamLimit(): Unit = {
     val expectedCount = 10
     var data = -1
 
-    val s0 = DoubleStream.iterate(
-      1.61803,
-      e => e + 1.0
+    val s0 = LongStream.iterate(
+      161803,
+      e => e + 10
     )
 
     val s1 = s0.limit(expectedCount)
@@ -875,13 +949,13 @@ class DoubleStreamTest {
    */
 
   // Issue #3309 - 1 of 5
-  @Test def doubleSstreamLimit_Size(): Unit = {
+  @Test def longStreamLimit_Size(): Unit = {
     StreamTestHelpers.requireJDK8CompatibleCharacteristics()
 
     val srcSize = 10
 
-    val spliter = DoubleStream
-      .iterate(2.71828, e => e + 1.0)
+    val spliter = LongStream
+      .iterate(271828, e => e + 10)
       .limit(srcSize)
       .spliterator()
 
@@ -901,15 +975,15 @@ class DoubleStreamTest {
   }
 
   // Issue #3309 - 2 of 5
-  @Test def doubleStreamLimit_Characteristics(): Unit = {
+  @Test def longStreamLimit_Characteristics(): Unit = {
     StreamTestHelpers.requireJDK8CompatibleCharacteristics()
 
     val zeroCharacteristicsSpliter =
-      new Spliterators.AbstractDoubleSpliterator(Long.MaxValue, 0x0) {
-        def tryAdvance(action: DoubleConsumer): Boolean = true
+      new Spliterators.AbstractLongSpliterator(Long.MaxValue, 0x0) {
+        def tryAdvance(action: LongConsumer): Boolean = true
       }
 
-    val sZero = StreamSupport.doubleStream(zeroCharacteristicsSpliter, false)
+    val sZero = StreamSupport.longStream(zeroCharacteristicsSpliter, false)
     val sZeroLimited = sZero.limit(9)
 
     val sZeroLimitedSpliter = sZeroLimited.spliterator()
@@ -930,11 +1004,11 @@ class DoubleStreamTest {
      * streamLimit_SortedCharacteristics() handle SORTED.
      */
     val allCharacteristicsSpliter =
-      new Spliterators.AbstractDoubleSpliterator(Long.MaxValue, 0x5551) {
-        def tryAdvance(action: DoubleConsumer): Boolean = true
+      new Spliterators.AbstractLongSpliterator(Long.MaxValue, 0x5551) {
+        def tryAdvance(action: LongConsumer): Boolean = true
       }
 
-    val sAll = StreamSupport.doubleStream(allCharacteristicsSpliter, false)
+    val sAll = StreamSupport.longStream(allCharacteristicsSpliter, false)
 
     val sAllLimited = sAll.limit(9)
     val sAllLimitedSpliter = sAllLimited.spliterator()
@@ -953,18 +1027,18 @@ class DoubleStreamTest {
   }
 
   // Issue #3309 - 3 of 5
-  @Test def streamLimit_SortedCharacteristics(): Unit = {
+  @Test def longStreamLimit_SortedCharacteristics(): Unit = {
     StreamTestHelpers.requireJDK8CompatibleCharacteristics()
 
     /* Address issues with SORTED described in Test
      * streamLimit_sequentialAlwaysCharacteristics
      */
     val allCharacteristicsSpliter =
-      new Spliterators.AbstractDoubleSpliterator(0, 0x5551) {
-        def tryAdvance(action: DoubleConsumer): Boolean = false
+      new Spliterators.AbstractLongSpliterator(0, 0x5551) {
+        def tryAdvance(action: LongConsumer): Boolean = false
       }
 
-    val sAll = StreamSupport.doubleStream(allCharacteristicsSpliter, false)
+    val sAll = StreamSupport.longStream(allCharacteristicsSpliter, false)
 
     val sAllLimited = sAll.sorted().limit(9)
     val sAllLimitedSpliter = sAllLimited.spliterator()
@@ -986,8 +1060,8 @@ class DoubleStreamTest {
 
     val srcSize = 20
 
-    val unsizedSpliter = DoubleStream
-      .iterate(1.2, n => n + 1.1)
+    val unsizedSpliter = LongStream
+      .iterate(12, n => n + 11)
       .limit(srcSize)
       .spliterator()
 
@@ -1004,7 +1078,7 @@ class DoubleStreamTest {
   @Test def streamLimit_SizedCharacteristics(): Unit = {
     StreamTestHelpers.requireJDK8CompatibleCharacteristics()
 
-    val proofSpliter = DoubleStream.of(1.12, 2.23, 3.34, -1.12).spliterator()
+    val proofSpliter = LongStream.of(112, 223, 334, -112).spliterator()
 
     val expectedProofCharacteristics =
       Spliterator.SIZED | Spliterator.SUBSIZED |
@@ -1016,8 +1090,8 @@ class DoubleStreamTest {
       proofSpliter.characteristics()
     )
 
-    val sizedSpliter = DoubleStream
-      .of(1.12, 2.23, 3.34, -1.12)
+    val sizedSpliter = LongStream
+      .of(112, 223, 334, -112)
       .limit(3)
       .spliterator()
 
@@ -1031,12 +1105,12 @@ class DoubleStreamTest {
     )
   }
 
-  @Test def doubleStreamMap(): Unit = {
+  @Test def longStreamMap(): Unit = {
     val nElements = 4
     val prefix = "mapped_"
     var count = 0
 
-    val s0 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s0 = LongStream.of(11, 22, 33, 44)
 
     val s1 = s0.map((e) => {
       count += 1
@@ -1053,19 +1127,52 @@ class DoubleStreamTest {
     s1.forEach((e) =>
       assertTrue(
         s"unexpected map element: ${e}",
-        (e > 10.0) && (e < 45.0)
+        (e > 100) && (e < 450)
       )
     )
     assertEquals("unexpected count", nElements, count)
   }
 
-  @Test def doubleStreamMapToInt(): Unit = {
+  @Test def longStreamMapToDouble(): Unit = {
     val nElements = 4
     var count = 0
 
-    val s0 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s0 = LongStream.of(11, 22, 33, 44L)
 
-    val s1 = s0.mapToInt((e) => e.toInt)
+    val s1 = s0.mapToDouble((e) => e.toDouble)
+
+    // Right resultant types
+    s1.forEach(e => {
+      count += 1
+      assertEquals(s"unexpected type", classOf[Double], e.getClass())
+    })
+
+    // Right count
+    assertEquals("unexpected count", nElements, count)
+
+    // Right content
+    val s2 = LongStream.of(11, 22, 33, 44)
+
+    val s3 = s2.mapToDouble((e) => e.toDouble)
+
+    val it = s3.iterator()
+
+    for (j <- 1 to nElements)
+      assertEquals(
+        "unexpected element",
+        (j * 11).toDouble,
+        it.nextDouble(),
+        epsilon
+      )
+  }
+
+  @Test def longStreamMapToInt: Unit = {
+    val nElements = 4
+    var count = 0
+
+    val s0 = LongStream.of(11, 22, 33, 44L)
+
+    val s1 = s0.mapToInt((e: Long) => e.toInt)
 
     // Right resultant types
     s1.forEach(e => {
@@ -1077,50 +1184,22 @@ class DoubleStreamTest {
     assertEquals("unexpected count", nElements, count)
 
     // Right content
-    val s2 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s2 = LongStream.of(11, 22, 33, 44L)
 
-    val s3 = s2.mapToInt((e) => e.toInt)
-
-    val it = s3.iterator()
-
-    for (j <- 1 to nElements)
-      assertEquals("unexpected element", j, it.nextInt())
-  }
-
-  @Test def doubleStreamMapToLong: Unit = {
-    val nElements = 4
-    var count = 0
-
-    val s0 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
-
-    val s1 = s0.mapToLong((e) => e.toLong)
-
-    // Right resultant types
-    s1.forEach(e => {
-      count += 1
-      assertEquals(s"unexpected type", classOf[Long], e.getClass())
-    })
-
-    // Right count
-    assertEquals("unexpected count", nElements, count)
-
-    // Right content
-    val s2 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
-
-    val s3 = s2.mapToLong((e) => e.toLong)
+    val s3 = s2.mapToInt((e: Long) => e.toInt)
 
     val it = s3.iterator()
 
     for (j <- 1 to nElements)
-      assertEquals("unexpected element", j.toLong, it.nextLong())
+      assertEquals("unexpected element", (j * 11), it.nextInt())
   }
 
-  @Test def doubleStreamMapToObj(): Unit = {
+  @Test def longStreamMapToObj(): Unit = {
     val nElements = 4
     val prefix = "mapped_"
     var count = 0
 
-    val s0 = DoubleStream.of(1.1, 2.2, 3.3, 4.4)
+    val s0 = LongStream.of(11, 22, 33, 44)
 
     val s1 = s0.mapToObj[String]((e) => {
       count += 1
@@ -1150,8 +1229,8 @@ class DoubleStreamTest {
     assertEquals("unexpected count", nElements, count)
   }
 
-  @Test def doubleStreamNoneMatch_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamNoneMatch_EmptyStream(): Unit = {
+    val s = LongStream.empty()
     var predEvaluated = false
 
     val noneMatched = s.noneMatch((e) => { predEvaluated = true; true })
@@ -1159,30 +1238,30 @@ class DoubleStreamTest {
     assertFalse("predicate should not have been evaluated", predEvaluated)
   }
 
-  @Test def doubleStreamNoneMatch_True(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def longStreamNoneMatch_True(): Unit = {
+    val s = LongStream.of(0, 11, 22, 33)
 
-    val matched = s.noneMatch((e) => e < 0.0)
+    val matched = s.noneMatch((e) => e < 0)
     assertTrue("unexpected predicate failure", matched)
   }
 
-  @Test def doubleStreamNone_MatchFalse(): Unit = {
-    val s = DoubleStream.of(0.0, 1.1, 2.2, 3.3)
+  @Test def longStreamNone_MatchFalse(): Unit = {
+    val s = LongStream.of(0, 11, 22, 33)
 
-    val matched = s.noneMatch((e) => e > 2.2)
+    val matched = s.noneMatch((e) => e > 22)
     assertFalse("unexpected predicate failure", matched)
   }
 
-  @Test def doubleStreamMax_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamMax_EmptyStream(): Unit = {
+    val s = LongStream.empty()
 
     val max = s.max()
 
     assertFalse("max optional should be empty", max.isPresent)
   }
 
-  @Test def doubleStreamMax(): Unit = {
-    val stream = DoubleStream.of(85.85, 4.4, 87.87, 25.25, 7.7)
+  @Test def longStreamMax(): Unit = {
+    val stream = LongStream.of(8585, 44, 8787, 2525, 77)
 
     val maxOpt = stream.max()
 
@@ -1190,55 +1269,35 @@ class DoubleStreamTest {
 
     assertEquals(
       "wrong max item found",
-      87.87,
-      maxOpt.getAsDouble(),
-      epsilon
+      8787,
+      maxOpt.getAsLong()
     )
   }
 
-  @Test def doubleStreamMax_NaN(): Unit = {
-    val stream = DoubleStream.of(85.85, Double.NaN, 87.87, 25.25, 7.7)
+  @Test def longStreamMax_NegativeZero(): Unit = {
+    val stream = LongStream.of(-8585, -0, -8787, -2525, -77)
 
     val maxOpt = stream.max()
 
     assertTrue("max not found", maxOpt.isPresent())
 
     assertEquals(
-      "wrong max item found",
-      Double.NaN,
-      maxOpt.getAsDouble(),
-      epsilon
-    )
-  }
-
-  @Test def doubleStreamMax_NegativeZero(): Unit = {
-    val stream = DoubleStream.of(-85.85, -0.0, -87.87, -25.25, -7.7)
-
-    val maxOpt = stream.max()
-
-    assertTrue("max not found", maxOpt.isPresent())
-
-    /* This Test expects a -0.0, exactly, not a -0.0 squashed to 0.0.
-     * ==, <, and > will conflate -0.0 and 0.0: i.e. -0.0 == 0.0.
-     * Double.compare will distinguish them: i.e. -0.0 != 0.0.
-     */
-    assertEquals(
-      s"wrong max item found: '${maxOpt.getAsDouble()}'",
+      s"wrong max item found: '${maxOpt.getAsLong()}'",
       0,
-      jl.Double.compare(-0.0, maxOpt.getAsDouble()) // distinguish -0.0
+      maxOpt.getAsLong()
     )
   }
 
-  @Test def doubleStreamMin_EmptyStream(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamMin_EmptyStream(): Unit = {
+    val s = LongStream.empty()
 
     val minOpt = s.min()
 
     assertFalse("min optional should be empty", minOpt.isPresent)
   }
 
-  @Test def doubleStreamMin(): Unit = {
-    val stream = DoubleStream.of(85.85, 4.4, 87.87, 25.25, 7.7)
+  @Test def longStreamMin(): Unit = {
+    val stream = LongStream.of(8585, 44, 8787, 2525, 77)
 
     val minOpt = stream.min()
 
@@ -1246,42 +1305,22 @@ class DoubleStreamTest {
 
     assertEquals(
       "wrong min item found",
-      4.4,
-      minOpt.getAsDouble(),
-      epsilon
+      44,
+      minOpt.getAsLong()
     )
   }
 
-  @Test def doubleStreamMin_NaN(): Unit = {
-    val stream = DoubleStream.of(85.85, Double.NaN, 87.87, 25.25, 7.7)
+  @Test def longStreamMin_NegativeZero(): Unit = {
+    val stream = LongStream.of(8585, -0, 8787, 0, 2525, 77)
 
     val minOpt = stream.min()
 
     assertTrue("min not found", minOpt.isPresent())
 
     assertEquals(
-      "wrong min item found",
-      Double.NaN,
-      minOpt.getAsDouble(),
-      epsilon
-    )
-  }
-
-  @Test def doubleStreamMin_NegativeZero(): Unit = {
-    val stream = DoubleStream.of(85.85, -0.0, 87.87, 0.0, 25.25, 7.7)
-
-    val minOpt = stream.min()
-
-    assertTrue("min not found", minOpt.isPresent())
-
-    /* This Test expects a -0.0, exactly, not a -0.0 squashed to 0.0.
-     * ==, <, and > will conflate -0.0 and 0.0: i.e. -0.0 == 0.0.
-     * Double.compare will distinguish them: i.e. -0.0 != 0.0.
-     */
-    assertEquals(
-      s"wrong min item found: '${minOpt.getAsDouble()}'",
+      s"wrong min item found: '${minOpt.getAsLong()}'",
       0,
-      jl.Double.compare(-0.0, minOpt.getAsDouble()) // distinguish -0.0
+      minOpt.getAsLong()
     )
   }
 
@@ -1290,115 +1329,117 @@ class DoubleStreamTest {
    * JVM documentations suggests that "peek()" be mainly used for debugging.
    */
   @Ignore
-  @Test def doubleStreamPeek(): Unit = {
+  @Test def longStreamPeek(): Unit = {
     val expectedCount = 3
 
-    val s = DoubleStream.of(7.7, 5.5, 3.3)
+    val s = LongStream.of(13L, 17L, 19L)
 
     // The ".count()" is a terminal operation to force the pipeline to
     // evalute. The real interest is if the peek() side-effect happened
     // correctly.  Currently that can only be evaluated manually/visually.
-    val n = s.peek((e: Double) => printf(s"peek: |${e}|\n")).count()
+    val n = s.peek((e: Long) => printf(s"peek: |${e}|\n")).count()
 
     assertEquals(s"unexpected count", expectedCount, n)
   }
 
   @Ignore // see @Ignore comment above "streamShouldPeek()" above.
-  @Test def doubleStreamPeek_CompositeStream(): Unit = {
+  @Test def longStreamPeek_CompositeStream(): Unit = {
     // Test that peek() works with all substreams of a composite stream.
-    val expectedCount = 8
+    val expectedCount = 10
 
     // See ".count()" comment in streamShouldPeek above.
 
     // One should see the original data before and then after transformation
     // done by flatmap to each original element. Something like:
-    //   before: <1.1>
-    //     after: <1.1>
-    //     after: <1.1>
-    //   before: <2.2>
-    //     after: <2.2>
-    //     after: <2.2>
-    //   before: <3.3>
-    //     after: <3.3>
-    //     after: <3.3>
-    //   before: <4.4>
-    //     after: <4.4>
-    //     after: <4.4>
+    //   before: <1>
+    //     after: <1>
+    //   before: <2>
+    //     after: <1>
+    //     after: <2>
+    //   before: <3>
+    //     after: <1>
+    //     after: <2>
+    //     after: <3>
+    //   before: <4>
+    //     after: <1>
+    //     after: <2>
+    //     after: <3>
+    //     after: <4>
 
-    val n = DoubleStream
-      .of(1.1, 2.2, 3.3, 4.4)
-      .peek((e: Double) =>
+    val n = LongStream
+      .of(1, 2, 3, 4L)
+      .peek((e: Long) =>
         printf(s"composite peek - before: <${e}>|\n")
       ) // simple str
-      .flatMap((e: Double) => DoubleStream.of(e, e))
-      .peek((e) => printf(s"composite peek - after: <${e}>|\n")) // composite
+      .flatMap((e: Long) => LongStream.of((1L to e): _*))
+      .peek((e: Long) =>
+        printf(s"composite peek - after: <${e}>|\n")
+      ) // composite
       .count()
 
     assertEquals(s"unexpected count", expectedCount, n)
   }
 
-  @Test def doubleStreamReduce_OneArgEmpty(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamReduce_OneArgEmpty(): Unit = {
+    val s = LongStream.empty()
 
-    val optional: OptionalDouble = s.reduce((r, e) => r + e)
+    val optional: OptionalLong = s.reduce((r, e) => r + e)
 
     assertFalse("unexpected non-empty optional", optional.isPresent())
   }
 
-  @Test def doubleStreamReduce_OneArg(): Unit = {
-    val s = DoubleStream.of(3.3, 5.5, 7.7, 11.11)
-    val expectedSum = 27.61
+  @Test def longStreamReduce_OneArg(): Unit = {
+    val s = LongStream.of(33, 55, 77, 1111)
+    val expectedSum = 1276
 
-    val optional: OptionalDouble = s.reduce((r, e) => r + e)
+    val optional: OptionalLong = s.reduce((r, e) => r + e)
 
     assertTrue("unexpected empty optional", optional.isPresent())
     assertEquals(
       "unexpected reduction result",
       expectedSum,
-      optional.getAsDouble(),
-      epsilon
+      optional.getAsLong()
     )
   }
 
-  @Test def doubleStreamReduce_TwoArgEmpty(): Unit = {
-    val s = DoubleStream.empty()
+  @Test def longStreamReduce_TwoArgEmpty(): Unit = {
+    val s = LongStream.empty()
 
-    val firstArg = 1.1
+    val firstArg = 11L
 
-    val product: Double = s.reduce(firstArg, (r, e) => r * e)
+    val product: Long = s.reduce(firstArg, (r, e) => r * e)
 
-    assertEquals("unexpected reduction result", firstArg, product, epsilon)
+    assertEquals("unexpected reduction result", firstArg, product)
   }
 
-  @Test def doubleStreamReduce_TwoArg(): Unit = {
-    val s = DoubleStream.of(3.3, 5.5, 7.7, 11.11)
-    val expectedProduct = 1552.67805
+  @Test def longStreamReduce_TwoArg(): Unit = {
+    val s = LongStream.of(33, 55, 77, 1111L)
+    val expectedProduct = 155267805L
 
-    val product: Double = s.reduce(1, (r, e) => r * e)
+    val product: Long = s.reduce(1L, (r, e) => r * e)
 
     assertEquals(
       "unexpected reduction result",
       expectedProduct,
-      product,
-      epsilon
+      product
     )
   }
 
-  @Test def doubleStreamSkip_NegativeArg(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def longStreamSkip_NegativeArg(): Unit = {
+    val s = LongStream.of(11, 22, 33)
     assertThrows(classOf[IllegalArgumentException], s.skip(-1))
   }
 
-  @Test def doubleStreamSkip_TooMany(): Unit = {
-    val s = DoubleStream.of(1.1, 2.2, 3.3)
+  @Test def longStreamSkip_TooMany(): Unit = {
+    val s = LongStream.of(11, 22, 33)
 
     val isEmptyStream = !s.skip(10).iterator.hasNext()
     assertTrue("expected empty stream", isEmptyStream)
   }
 
-  @Test def doubleStreamSkip(): Unit = {
-    val expectedValue = 99.99
-    val s = DoubleStream.of(1.1, 2.2, 3.3, 4.4, expectedValue, 6.6, 7.7)
+  @Test def longStreamSkip(): Unit = {
+    val expectedValue = 9999
+    val s = LongStream.of(11, 22, 33, 44, expectedValue, 66, 77)
 
     val iter = s.skip(4).iterator()
 
@@ -1406,43 +1447,42 @@ class DoubleStreamTest {
     assertEquals(
       "unexpected first value: ",
       expectedValue,
-      iter.nextDouble(),
-      epsilon
+      iter.nextLong()
     )
   }
 
-  @Test def doubleStreamSorted(): Unit = {
+  @Test def longStreamSorted(): Unit = {
     val nElements = 8
-    val wild = new Array[Double](nElements)
+    val wild = new Array[Long](nElements)
 
     // Ensure that the Elements are not inserted in sorted or reverse order.
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960L
 
-    val ordered = new Array[Double](nElements)
-    ordered(0) = 3.77
-    ordered(1) = 9.60
-    ordered(2) = 11.2
-    ordered(3) = 21.4
-    ordered(4) = 31.5
-    ordered(5) = 45.32
-    ordered(6) = 61.44
-    ordered(7) = 68.16
+    val ordered = new Array[Long](nElements)
+    ordered(0) = 112
+    ordered(1) = 214
+    ordered(2) = 315
+    ordered(3) = 377
+    ordered(4) = 960
+    ordered(5) = 4532
+    ordered(6) = 6144
+    ordered(7) = 6816L
 
-    val s = DoubleStream.of(wild: _*)
+    val s = LongStream.of(wild: _*)
 
     val sorted = s.sorted()
 
     var count = 0
 
     sorted.forEachOrdered((e) => {
-      assertEquals("mismatched elements", ordered(count), e, epsilon)
+      assertEquals("mismatched elements", ordered(count), e)
       count += 1
     })
 
@@ -1453,26 +1493,26 @@ class DoubleStreamTest {
     assertEquals(msg, nElements, count)
   }
 
-  @Test def doubleStreamSorted_Characteristics(): Unit = {
+  @Test def longStreamSorted_Characteristics(): Unit = {
     // See comments in StreamTest#streamSorted_Characteristics
 
     val nElements = 8
-    val wild = new Array[Double](nElements)
+    val wild = new Array[Long](nElements)
 
     // Ensure that the Elements are not inserted in sorted or reverse order.
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val seqDoubleStream = DoubleStream.of(wild: _*)
+    val seqLongStream = LongStream.of(wild: _*)
     assertFalse(
       "Expected sequential stream",
-      seqDoubleStream.isParallel()
+      seqLongStream.isParallel()
     )
 
     // same expected values for SN sequential, SN parallel, & JVM streams
@@ -1492,26 +1532,25 @@ class DoubleStreamTest {
       (expectedPreCharacteristics & ~Spliterator.IMMUTABLE) +
         Spliterator.SORTED
 
-    val seqDoubleSpliter = seqDoubleStream.spliterator()
+    val seqIntSpliter = seqLongStream.spliterator()
 
     assertEquals(
       "sequential characteristics",
       expectedPreCharacteristics,
-      seqDoubleSpliter.characteristics()
+      seqIntSpliter.characteristics()
     )
 
-    val sortedSeqDoubleStream = DoubleStream.of(wild: _*).sorted()
-    val sortedSeqSpliter = sortedSeqDoubleStream.spliterator()
+    val sortedSeqLongStream = LongStream.of(wild: _*).sorted()
+    val sortedSeqSpliter = sortedSeqLongStream.spliterator()
 
     assertEquals(
       "sorted sequential characteristics",
       expectedPostCharacteristics,
       sortedSeqSpliter.characteristics()
     )
-
   }
 
-  @Test def doubleStreamSortedUnknownSizeButSmall(): Unit = {
+  @Test def longStreamSortedUnknownSizeButSmall(): Unit = {
 
     /* To fit array, nElements should be <= Integer.MAX_VALUE.
      * Machine must have sufficient memory to support chosen number of
@@ -1523,7 +1562,7 @@ class DoubleStreamTest {
     val rng = new ju.Random(567890123)
 
     val wild = rng
-      .doubles(nElements, 0.0, jl.Double.MAX_VALUE)
+      .longs(nElements, 0L, jl.Long.MAX_VALUE)
       .toArray()
 
     val ordered = wild.clone()
@@ -1533,7 +1572,7 @@ class DoubleStreamTest {
     val iter0 = Spliterators.iterator(Spliterators.spliterator(wild, 0))
     val spliter0 = Spliterators.spliteratorUnknownSize(iter0, 0)
 
-    val s0 = StreamSupport.doubleStream(spliter0, false)
+    val s0 = StreamSupport.longStream(spliter0, false)
 
     val s0Spliter = s0.spliterator()
     assertFalse(
@@ -1545,14 +1584,14 @@ class DoubleStreamTest {
     val iter1 = Spliterators.iterator(Spliterators.spliterator(wild, 0))
     val spliter1 = Spliterators.spliteratorUnknownSize(iter1, 0)
 
-    val s = StreamSupport.doubleStream(spliter1, false)
+    val s = StreamSupport.longStream(spliter1, false)
 
     val ascending = s.sorted()
 
     var count = 0
 
     ascending.forEachOrdered((e) => {
-      assertEquals("mismatched elements", ordered(count), e, epsilon)
+      assertEquals("mismatched elements", ordered(count), e)
       count += 1
     })
 
@@ -1565,13 +1604,13 @@ class DoubleStreamTest {
   }
 
   @Ignore
-  @Test def doubleStreamSortedUnknownSizeButHuge(): Unit = {
+  @Test def longStreamSortedUnknownSizeButHuge(): Unit = {
     /* This test is for development and Issue verification.
      * It is Ignored in normal Continuous Integration because it takes
      * a long time.
      *
      * See note for similar Test in StreamTest.scala for details.
-     * No sense copying same text to DoubleStreamTest, IntStreamTest,
+     * No sense copying same text to DoubleStreamTest, LongStreamTest,
      * & LongStreamTest.
      */
 
@@ -1579,11 +1618,11 @@ class DoubleStreamTest {
 
     // Are the characteristics correct?
     val rs0 = rng
-      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+      .longs(0L, jl.Long.MAX_VALUE) // "Infinite" stream
 
     val iter0 = rs0.iterator()
     val spliter0 = Spliterators.spliteratorUnknownSize(iter0, 0)
-    val s0 = StreamSupport.doubleStream(spliter0, false)
+    val s0 = StreamSupport.longStream(spliter0, false)
 
     val s0Spliter = s0.spliterator()
     assertFalse(
@@ -1593,10 +1632,10 @@ class DoubleStreamTest {
 
     // Validating un-SIZED terminated s0, so need fresh similar stream.
     val rs1 = rng
-      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+      .longs(0L, jl.Long.MAX_VALUE) // "Infinite" stream
 
     val spliter1 = Spliterators.spliteratorUnknownSize(iter0, 0)
-    val s = StreamSupport.doubleStream(spliter1, false)
+    val s = StreamSupport.longStream(spliter1, false)
 
     val uut = s.sorted() // unit-under-test
 
@@ -1604,13 +1643,13 @@ class DoubleStreamTest {
     assertThrows(classOf[OutOfMemoryError], uut.findFirst())
   }
 
-  @Test def doubleStreamSortedZeroSize(): Unit = {
+  @Test def longStreamSortedZeroSize(): Unit = {
     val nElements = 0
 
     val rng = new ju.Random(567890123)
 
     val wild = rng
-      .doubles(nElements, 0.0, jl.Double.MAX_VALUE)
+      .longs(nElements, 0L, jl.Long.MAX_VALUE)
       .toArray()
 
     val ordered = wild.clone()
@@ -1618,7 +1657,7 @@ class DoubleStreamTest {
 
     val spliter = Spliterators.spliterator(wild, 0)
 
-    val s = StreamSupport.doubleStream(spliter, false)
+    val s = StreamSupport.longStream(spliter, false)
 
     val sorted = s.sorted()
     val count = sorted.count()
@@ -1627,7 +1666,7 @@ class DoubleStreamTest {
   }
 
   // Issue 3378
-  @Test def doubleStreamSortedLongSize(): Unit = {
+  @Test def longStreamSortedLongSize(): Unit = {
     /* This tests streams with the SIZED characteristics and a
      *  know length is larger than the largest possible Java array:
      *  approximately Integer.MAX_VALUE.
@@ -1635,7 +1674,7 @@ class DoubleStreamTest {
     val rng = new ju.Random(1234567890)
 
     val s = rng
-      .doubles(0.0, jl.Double.MAX_VALUE) // "Infinite" stream
+      .longs(0, jl.Long.MAX_VALUE) // "Infinite" stream
 
     /* The sorted() implementation should be a late binding, intermediate
      * operation. Expect no "max array size" error here, but later.
@@ -1652,48 +1691,48 @@ class DoubleStreamTest {
     assertThrows(classOf[IllegalArgumentException], uut.findFirst())
   }
 
-  @Test def doubleStreamSum(): Unit = {
+  @Test def longStreamSum(): Unit = {
     val nElements = 9
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    val wild = new Array[Long](nElements) // holds arbitrarily jumbled data
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val expectedSum = 252.39
+    val expectedSum = 19470
 
-    val s = DoubleStream.of(wild: _*)
+    val s = LongStream.of(wild: _*)
 
     val sum = s.sum()
 
-    assertEquals("unexpected sum", expectedSum, sum, epsilon)
+    assertEquals("unexpected sum", expectedSum, sum)
   }
 
-  @Test def doubleStreamSummaryStatistics(): Unit = {
+  @Test def longStreamSummaryStatistics(): Unit = {
     val nElements = 8
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    val wild = new Array[Long](nElements) // holds arbitrarily jumbled data
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val expectedAverage = 31.54875
     val expectedCount = nElements
-    val expectedMax = 68.16
-    val expectedMin = 3.77
-    val expectedSum = 252.39
+    val expectedMax = 6816
+    val expectedMin = 112
+    val expectedSum = 19470
+    val expectedAverage = expectedSum.toDouble / nElements
 
-    val s = DoubleStream.of(wild: _*)
+    val s = LongStream.of(wild: _*)
 
     val stats = s.summaryStatistics()
 
@@ -1706,27 +1745,27 @@ class DoubleStreamTest {
 
     assertEquals("unexpected count", expectedCount, stats.getCount())
 
-    assertEquals("unexpected max", expectedMax, stats.getMax(), epsilon)
+    assertEquals("unexpected max", expectedMax, stats.getMax())
 
-    assertEquals("unexpected min", expectedMin, stats.getMin(), epsilon)
+    assertEquals("unexpected min", expectedMin, stats.getMin())
 
-    assertEquals("unexpected sum", expectedSum, stats.getSum(), epsilon)
+    assertEquals("unexpected sum", expectedSum, stats.getSum())
   }
 
-  @Test def doubleStreamToArray(): Unit = {
+  @Test def longStreamToArray(): Unit = {
     val nElements = 9
 
-    val wild = new Array[Double](nElements) // holds arbitrarily jumbled data
-    wild(0) = 45.32
-    wild(1) = 21.4
-    wild(2) = 11.2
-    wild(3) = 31.5
-    wild(4) = 68.16
-    wild(5) = 3.77
-    wild(6) = 61.44
-    wild(7) = 9.60
+    val wild = new Array[Long](nElements) // holds arbitrarily jumbled data
+    wild(0) = 4532
+    wild(1) = 214
+    wild(2) = 112
+    wild(3) = 315
+    wild(4) = 6816
+    wild(5) = 377
+    wild(6) = 6144
+    wild(7) = 960
 
-    val s = DoubleStream.of(wild: _*)
+    val s = LongStream.of(wild: _*)
 
     val resultantArray = s.toArray()
 
@@ -1735,7 +1774,7 @@ class DoubleStreamTest {
 
     // Proper elements, in encounter order
     for (j <- 0 until nElements)
-      assertEquals("elements do not match", wild(j), resultantArray(j), epsilon)
+      assertEquals("elements do not match", wild(j), resultantArray(j))
   }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -709,7 +709,7 @@ class StreamTest {
     s2.forEach((e) => {
       val inSet = expectedSet.remove(e)
       // Detect both unknown elements and
-      // occurances of unwanted, non-distinct elements
+      // occurrences of unwanted, non-distinct elements
       assertTrue(s"element ${e} not in expectedSet", inSet)
     })
 
@@ -795,11 +795,25 @@ class StreamTest {
   }
 
   @Test def streamFlatMapToInt(): Unit = {
-    // Stream#flatMapToInt is Not Yet Implemented
+    val expectedSum = 9
+
+    val s = jus.Stream.of[String]("AA", "B", "CC", "D", "EE", "F")
+
+    val sum = s.flatMapToInt(e => IntStream.of(e.length())).sum()
+
+    assertEquals(s"unexpected sum", expectedSum, sum)
   }
 
   @Test def streamFlatMapToLong(): Unit = {
-    // Stream#flatMapToLong is Not Yet Implemented
+    val offset = jl.Integer.MAX_VALUE.toLong
+    val expectedSum = 9 + (6 * offset)
+
+    val s = jus.Stream.of[String]("AA", "B", "CC", "D", "EE", "F")
+
+    val sum =
+      s.flatMapToLong(e => LongStream.of(e.length().toLong + offset)).sum()
+
+    assertEquals(s"unexpected sum", expectedSum, sum)
   }
 
   @Test def streamForeachOrdered(): Unit = {
@@ -1064,6 +1078,34 @@ class StreamTest {
     val sum = s.mapToDouble(e => 3.14 * e.length()).sum()
 
     assertEquals(s"unexpected sum", expectedSum, sum, 0.00001)
+  }
+
+  @Test def streamMapToInt(): Unit = {
+    val expectedSum = 9
+
+    val s = jus.Stream.of[String]("AA", "B", "CC", "D", "EE", "F")
+
+    /* Chose the items in S and the mapper function to yield an obviously
+     * floating point sum, not something that could be an Int implicitly
+     * converted to Double.
+     * Let the compiler distinguish Double as Object and Double
+     * as primitive. Only DoubleStream will have the sum method.
+     */
+
+    val sum = s.mapToInt(e => e.length()).sum()
+
+    assertEquals(s"unexpected sum", expectedSum, sum)
+  }
+
+  @Test def streamMapToLong(): Unit = {
+    val offset = jl.Integer.MAX_VALUE.toLong
+    val expectedSum = 9 + (6 * offset)
+
+    val s = jus.Stream.of[String]("AA", "B", "CC", "D", "EE", "F")
+
+    val sum = s.mapToLong(e => e.length().toLong + offset).sum()
+
+    assertEquals(s"unexpected sum", expectedSum, sum)
   }
 
   @Test def streamNoneMatch_EmptyStream(): Unit = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTestHelpers.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTestHelpers.scala
@@ -67,7 +67,7 @@ object StreamTestHelpers {
       System.getProperty("java.version", s"${defaultVersion}")
 
     /* This parse is lazy in the sense of developer lazy & easier to get right.
-     * It is reasonably robust but not fool-proof. Feel free to to better.
+     * It is reasonably robust but not fool-proof. Feel free to do better.
      */
 
     val parseFailMsg = s"Could not parse java.version: ${jvmVersionString}"


### PR DESCRIPTION
The javalib `IntStream` and `LongStream` classes now have an experimental implementation.

A number of classes, noticibly the `Random` and `CharSequence` classes, were modified
to provide previously missing methods which  `IntStream` and `LongStream`.

unit-tests are provided for the change of this PR.

Individual morsels of this PR might be backported to SN 4.n, but the overall PR is
probably not a good candidate: too many interconnected pieces.