### PR TITLE
fix: Ensure to mark aligned fields by fixing `MemoryLayout.referenceFieldsOffsets` bug

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -23,10 +23,15 @@ final case class MemoryLayout(
    */
   def referenceFieldsOffsets(implicit meta: Metadata): Seq[nir.Val.Long] = {
     val sizeOfHeader = meta.layouts.ObjectHeader.size
+    import nir.Type._
     val ptrOffsets =
       tys.collect {
         // offset in words without object header
-        case MemoryLayout.PositionedType(_: nir.Type.RefKind, offset) =>
+        case MemoryLayout.PositionedType(
+              _: RefKind | // normal or alligned reference field
+              StructValue((_: RefKind) :: ArrayValue(nir.Type.Byte, _) :: Nil),
+              offset
+            ) =>
           nir.Val.Long(
             (offset - sizeOfHeader) / MemoryLayout.BYTES_IN_LONG
           )


### PR DESCRIPTION
This PR fixes bug introduced to `scalanative.annotation.align` annotation. Our mostly-precise Immix/Commix GC implementation is using list of offset to reference fields that shall be marked. `@align` has introduced additional padding of class fields by replacing `x: nir.Type` with `nir.Type.StructValue(x: nir.Type, ArrayValue(Byte, paddingSize))` This wrapped type was not checked in `MemoryLayout.referenceFieldsOffsets` - it lead to skipping fields marking in the GC. 

This issue lead to frequent GC issues, especially under releaseFull mode (and probably under LTO.thin)