### PR TITLE
refactor/fix: Use object offsets instead of field indexes for precise object scanning

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -105,11 +105,13 @@ void Marker_Mark(Heap *heap, Stack *stack) {
             }
             // non-object arrays do not contain pointers
         } else {
-            int64_t *ptr_map = object->rtti->refMapStruct;
-            for (int i = 0; ptr_map[i] != LAST_FIELD_OFFSET; i++) {
-                if (Object_IsReferantOfWeakReference(object, ptr_map[i]))
+            int32_t *refFieldOffsets = object->rtti->refFieldOffsets;
+            for (int i = 0; refFieldOffsets[i] != LAST_FIELD_OFFSET; i++) {
+                size_t fieldOffset = (size_t)refFieldOffsets[i];
+                Field_t *fieldRef = (Field_t *)((int8_t *)object + fieldOffset);
+                if (Object_IsReferantOfWeakReference(object, fieldOffset))
                     continue;
-                Marker_markField(heap, stack, object->fields[ptr_map[i]]);
+                Marker_markField(heap, stack, *fieldRef);
             }
             if (objectId == __boxed_ptr_id) {
                 // Boxed ptr always has a single field

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/headers/ObjectHeader.h
@@ -41,7 +41,8 @@ typedef struct {
     } rt;
     int32_t size;
     int32_t idRangeUntil;
-    int64_t *refMapStruct;
+    int32_t *refFieldOffsets; // Array of field offsets (in bytes) from object
+                              // start, terminated with -1
 } Rtti;
 
 typedef word_t *Field_t;

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -44,7 +44,7 @@ class CommonMemoryLayouts(implicit meta: Metadata) {
       Rtti.layout ::
         nir.Type.Int :: // class size
         nir.Type.Int :: // id range
-        FieldLayout.referenceOffsetsTy :: // reference offsets
+        nir.Type.Ptr :: // reference offsets
         dynMapType.toList
 
     override val layout =

--- a/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
@@ -3,12 +3,6 @@ package codegen
 
 import scalanative.linker.{Class, Field}
 
-object FieldLayout {
-
-  val referenceOffsetsTy = nir.Type.StructValue(Seq(nir.Type.Ptr))
-
-}
-
 class FieldLayout(cls: Class)(implicit meta: Metadata) {
 
   import meta.layouts.{Object, ObjectHeader}
@@ -39,12 +33,8 @@ class FieldLayout(cls: Class)(implicit meta: Metadata) {
 
   val struct = nir.Type.StructValue(layout.tys.map(_.ty))
   val size = layout.size
-  val referenceOffsetsValue = nir.Val.StructValue(
-    Seq(
-      nir.Val.Const(
-        nir.Val.ArrayValue(nir.Type.Long, layout.referenceFieldsOffsets)
-      )
-    )
+  val referenceOffsetsValue = nir.Val.Const(
+    nir.Val.ArrayValue(nir.Type.Int, layout.referenceFieldsOffsets)
   )
 
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -548,7 +548,7 @@ object Generate {
                 .index(weakRefReferantField)
                 .ensuring(
                   _ > 0,
-                  "Runtime implementaiton error, no \"_gc_modified_referent\" field in java.lang.ref.WeakReference"
+                  "Runtime implementation error, no \"_gc_modified_referent\" field in java.lang.ref.WeakReference"
                 )
               val gcModifiedFieldReferentOffset = layout.layout
                 .tys(gcModifiedFieldReferentIdx)

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -4,6 +4,7 @@ package codegen
 import scala.collection.mutable
 import scala.scalanative.linker.{
   Class,
+  Field,
   ScopeInfo,
   Unavailable,
   ReachabilityAnalysis
@@ -523,28 +524,42 @@ object Generate {
             nir.Val.Int(value)
           )
 
-      val (weakRefIdsMin, weakRefIdsMax, modifiedFieldOffset) = reachabilityAnalysis.infos
-        .get(nir.Global.Top("java.lang.ref.WeakReference"))
+      val WeakReferenceClass = nir.Global.Top("java.lang.ref.WeakReference")
+      val WeakReferenceGCReferent = WeakReferenceClass.member(
+        nir.Sig.Field("_gc_modified_referent")
+      )
+      def weakRefClsInfo = reachabilityAnalysis.infos
+        .get(WeakReferenceClass)
         .collect { case cls: Class if cls.allocated => cls }
-        .fold((-1, -1, -1)) { weakRef =>
-          // if WeakReferences are being compiled and therefore supported
-          val gcModifiedFieldIndexes: Seq[Int] =
-            meta.layout(weakRef).entries.zipWithIndex.collect {
-              case (field, index) if field.name.mangle.contains("_gc_modified_") =>
-                index
-            }
+      def weakRefReferentField =
+        reachabilityAnalysis.infos
+          .get(WeakReferenceGCReferent)
+          .collect { case field: Field => field }
 
-          if (gcModifiedFieldIndexes.size != 1)
-            throw new Exception(
-              "Exactly one field should have the \"_gc_modified_\" modifier in java.lang.ref.WeakReference"
-            )
+      val (weakRefIdsMin, weakRefIdsMax, modifiedFieldOffset) =
+        weakRefClsInfo
+          .zip(weakRefReferentField)
+          .headOption
+          .fold((-1, -1, -1)) {
+            case (weakRef, weakRefReferantField) =>
+              // if WeakReferences are being compiled and therefore supported
+              val layout = meta.layout(weakRef)
+              val gcModifiedFieldReferentIdx = layout
+                .index(weakRefReferantField)
+                .ensuring(
+                  _ > 0,
+                  "Runtime implementaiton error, no \"_gc_modified_referent\" field in java.lang.ref.WeakReference"
+                )
+              val gcModifiedFieldReferentOffset = layout.layout
+                .tys(gcModifiedFieldReferentIdx)
+                .offset
 
-          (
-            meta.ranges(weakRef).start,
-            meta.ranges(weakRef).end,
-            gcModifiedFieldIndexes.head
-          )
-        }
+              (
+                meta.ranges(weakRef).start,
+                meta.ranges(weakRef).end,
+                gcModifiedFieldReferentOffset.toInt
+              )
+          }
       addToBuf(weakRefIdsMaxName, weakRefIdsMax)
       addToBuf(weakRefIdsMinName, weakRefIdsMin)
       addToBuf(weakRefFieldOffsetName, modifiedFieldOffset)

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -21,10 +21,11 @@ final case class MemoryLayout(
    *  end expresed as number of words. Used by the GC for scanning objects.
    *  Terminated with offset=-1
    */
-  def referenceFieldsOffsets(implicit meta: Metadata): Seq[nir.Val.Long] = {
-    val sizeOfHeader = meta.layouts.ObjectHeader.size
+  private[codegen] def referenceFieldsOffsets(implicit
+      meta: Metadata
+  ): Seq[nir.Val.Int] = {
     import nir.Type._
-    val ptrOffsets =
+    val offsets =
       tys.collect {
         // offset in words without object header
         case MemoryLayout.PositionedType(
@@ -32,12 +33,10 @@ final case class MemoryLayout(
               StructValue((_: RefKind) :: ArrayValue(nir.Type.Byte, _) :: Nil),
               offset
             ) =>
-          nir.Val.Long(
-            (offset - sizeOfHeader) / MemoryLayout.BYTES_IN_LONG
-          )
+          offset.toInt
       }
 
-    ptrOffsets :+ nir.Val.Long(-1)
+    (offsets :+ -1).map(nir.Val.Int(_))
   }
 
   /** A list of offsets pointing to all inner reference types excluding object


### PR DESCRIPTION
Immix and Commix scan objects precisely based on array of indexes containing possible references. Previously this list was populate by indexes of fields, now it's a list of offsets starting from object address (also known as start of object header) to make the code more readable. 

It also can possibly some issues on 32-bit CPU architectures, see code comment below. 
As an additional improvement used when debugging we're adding an utility to extract Class name as wide-string allowing to show it in debug information from the GC (best effort, no guarantess about String object layout)