### PR TITLE
Fix #3733: javalib FileChannel transfer* methods now honor Long counts

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/channels/FileChannelTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/channels/FileChannelTest.scala
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.BeforeClass
+import org.junit.Ignore
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform
@@ -965,6 +966,18 @@ class FileChannelTest {
     assertTrue("file contents are not equal", filesHaveSameContents(src, dst))
   }
 
+  /* Make this test available to be run manually. Do not run it in CI
+   * because some of the Linux systems there are like macOS and always
+   * return 0 bytes read on /dev/zero.
+   *
+   * The "Platform.isLinux" test is not sufficiently determinative.
+   *
+   * See what your system of interest does when you run it manually.
+   * If you get a zero read count from /dev/zero, then, if you have enough
+   * disk space, you can create file > 2 GB and specify it as the 'src'.
+   */
+
+  @Ignore
   @Test def canTransferToGivenLongCount(): Unit = {
     assumeTrue("Test is Linux specific", Platform.isLinux)
 


### PR DESCRIPTION
Fix #3733

Two javalib `java.nio.channels.FileChannel` methods, `transferFrom` and `transferTo` now more closely
follow the JVM specification by honoring counts which exceed Integer.MAX_VALUE. 

They also more closely follow the specification in a number of ways, argument checking, zero transfers, etc.
Internally, the methods now buffer if the transfer count is greater than an internal limit.
That limit is currently 8192 or 8KB and is subject to change without notice or deprecation.

Two Linux only unit-test cases are provided which transfer more than Integer.MAX_VALUE bytes. These
cases are surprisingly fast and are enabled for CI.  If CI execution time or cost becomes a
concern, they can be `@Ignore`d and run manually.  

A surprising macOS feature/quirk with reading more than a zero byte count from "/dev/zero' keeps these tests
from running  there.