### PR TITLE
Implement javalib ZipFile stream method

### DIFF
--- a/javalib/src/main/scala/java/util/zip/ZipFile.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipFile.scala
@@ -72,7 +72,7 @@ class ZipFile(file: File, mode: Int, charset: Charset) extends Closeable {
    * boot. The number could probably be more like 128 or so.
    */
 
-  private val mEntries = ju.LinkedHashMap[String, ZipEntry](64)
+  private val mEntries = new ju.LinkedHashMap[String, ZipEntry](64)
 
   readCentralDir()
 

--- a/javalib/src/main/scala/java/util/zip/ZipFile.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipFile.scala
@@ -121,7 +121,10 @@ class ZipFile(file: File, mode: Int, charset: Charset) extends Closeable {
     if (entryName == null)
       throw new NullPointerException()
 
-    mEntries.getOrDefault(entryName + "/", null)
+    mEntries.getOrDefault(
+      entryName,
+      mEntries.getOrDefault(entryName + "/", null)
+    )
   }
 
   def getInputStream(_entry: ZipEntry): InputStream = {
@@ -169,6 +172,7 @@ class ZipFile(file: File, mode: Int, charset: Charset) extends Closeable {
   }
 
   def stream(): jus.Stream[ZipEntry] = {
+    checkNotClosed()
     val spliter = mEntries.values().spliterator()
     jus.StreamSupport.stream(spliter, parallel = false)
   }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipFileStreamMethodTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipFileStreamMethodTest.scala
@@ -81,7 +81,7 @@ class ZipFileStreamMethodTest {
 
     var index = 0
 
-    val zf = ZipFile(zfileName)
+    val zf = new ZipFile(zfileName)
     try {
       zf.stream()
         .forEach(e => {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipFileStreamMethodTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipFileStreamMethodTest.scala
@@ -45,8 +45,6 @@ class ZipFileStreamMethodTest {
       location: String,
       entryNames: Array[String]
   ): Unit = {
-    val index = 0
-
     val zipOut = new ZipOutputStream(new FileOutputStream(location))
     try {
       zipOut.setComment("Some interesting moons of Saturn.")

--- a/unit-tests/shared/src/test/scala/scala/util/zip/ZipFileStreamMethodTest.scala
+++ b/unit-tests/shared/src/test/scala/scala/util/zip/ZipFileStreamMethodTest.scala
@@ -1,0 +1,102 @@
+package org.scalanative.testsuite.javalib.util.zip
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.BeforeClass
+
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.util.Arrays
+
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+
+object ZipFileStreamMethodTest {
+
+  private var workDirString: String = _
+
+  private val zipFileName = "ZipFileStreamMethodsTestData.zip"
+
+  private def makeTestDirs(): String = {
+    val orgDir = Files.createTempDirectory("scala-native-testsuite")
+    val javalibDir = orgDir.resolve("javalib")
+    val testDirRootPath = javalibDir
+      .resolve("java")
+      .resolve("util")
+      .resolve("zip")
+      .resolve("ZipFileStreamMethodTest")
+
+    val testDirDstPath = testDirRootPath.resolve("dst")
+    Files.createDirectories(testDirRootPath)
+    Files.createDirectory(testDirDstPath)
+
+    testDirRootPath.toString()
+  }
+
+  @BeforeClass
+  def beforeClass(): Unit = {
+    workDirString = makeTestDirs()
+  }
+}
+
+class ZipFileStreamMethodTest {
+  import ZipFileStreamMethodTest._
+
+  private def createZipFile(
+      location: String,
+      entryNames: Array[String]
+  ): Unit = {
+    val index = 0
+
+    val zipOut = new ZipOutputStream(new FileOutputStream(location))
+    try {
+      zipOut.setComment("Some interesting moons of Saturn.")
+
+      Arrays
+        .stream(entryNames)
+        .forEach(e => zipOut.putNextEntry(new ZipEntry(e)))
+
+    } finally {
+      zipOut.close()
+    }
+  }
+
+  @Test def streamMethod(): Unit = {
+    val zfileName =
+      s"${workDirString}/dst/${zipFileName}"
+
+    /* To help failure message give better clues,  names should _not_ be
+     * in alphabetical order. Suffix gives expected encounter order.
+     */
+    val entryNames = Array(
+      "Rhea_1",
+      "Prometheus_2",
+      "Phoebe_3",
+      "Tethys_4",
+      "Iapetus_5"
+    )
+
+    createZipFile(zfileName, entryNames)
+
+    // Now check that that the stream()'ed entries are in encounter order.
+
+    var index = 0
+
+    val zf = ZipFile(zfileName)
+    try {
+      zf.stream()
+        .forEach(e => {
+          assertEquals(
+            "unexpected stream order",
+            entryNames(index),
+            e.getName()
+          )
+          index += 1
+        })
+
+      assertEquals("unexpected stream size", entryNames.length, index)
+
+    } finally {
+      zf.close()
+    }
+  }
+}


### PR DESCRIPTION
This is a partial fix for Issue #3748, which should remain open.

Implement the  `stream() method of javalib `java.util.zip.ZipFile` and a corresponding
unit-test.

<hr \hr>

  * I am reasonably confident in these changes but would like to see them  get reviewed and exercised 
    in preliminary `jdk.zipfs` work before rolling them, _mutatis mutandis_,  into `JarFile`.

  * For the same reason, I think it wise to hold off porting these changes to the SN 4.n
branch for a few weeks.
