### PR TITLE
fix 0.4.x: Allow extraction of CFuncPtr info based on materialization context

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -119,6 +119,9 @@ trait NirDefinitions {
     lazy val CStructTagMethod = (0 to 22).map { n =>
       getDecl(TagModule, TermName("materializeCStruct" + n + "Tag"))
     }
+    lazy val CFuncPtrNTagMethod = (0 to 22).map { n =>
+      getDecl(TagModule, TermName("materializeCFuncPtr" + n))
+    }
 
     // scala names
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -83,6 +83,8 @@ trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
             just(NatBaseClass(NatBaseTagMethod.indexOf(sym)))
           case sym if NatDigitTagMethod.contains(sym) =>
             wrap(NatDigitClass(NatDigitTagMethod.indexOf(sym)))
+          case sym if CFuncPtrNTagMethod.contains(sym) =>
+            wrap(CFuncPtrNClass(CFuncPtrNTagMethod.indexOf(sym)))
           case _ =>
             None
         }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -119,6 +119,8 @@ final class NirDefinitions()(using ctx: Context) {
     (2 to 9).map(n => TagModule.requiredMethodRef(s"materializeNatDigit${n}Tag"))
   @tu lazy val UnsafeTag_materializeCStructTagsR =
     (0 to 22).map(n => TagModule.requiredMethodRef(s"materializeCStruct${n}Tag"))
+  @tu lazy val UnsafeTag_materializeCFuncPtrTagsR =
+    (0 to 22).map(n => TagModule.requiredMethodRef(s"materializeCFuncPtr${n}"))
   def UnsafeTag_materializeUnitTag(using Context) = UnsafeTag_materializeUnitTagR.symbol
   def UnsafeTag_materializeBooleanTag(using Context) = UnsafeTag_materializeBooleanTagR.symbol
   def UnsafeTag_materializeCharTag(using Context) = UnsafeTag_materializeCharTagR.symbol
@@ -138,6 +140,7 @@ final class NirDefinitions()(using ctx: Context) {
   def UnsafeTag_materializeNatBaseTags(using Context) = UnsafeTag_materializeNatBaseTagsR.map(_.symbol)
   def UnsafeTag_materializeNatDigitTags(using Context) = UnsafeTag_materializeNatDigitTagsR.map(_.symbol)
   def UnsafeTag_materializeCStructTags(using Context) = UnsafeTag_materializeCStructTagsR.map(_.symbol)
+  def UnsafeTag_materializeCFuncPtrTags(using Context) = UnsafeTag_materializeCFuncPtrTagsR.map(_.symbol)
   @tu lazy val UnsafeTag_materializePtrWildcardTag = TagModule.requiredMethod("materializePtrWildcard")
   @tu lazy val UnsafeTag_materializePtrClassNotGivenClassTag =
     TagModule.requiredMethod("materializePtrClassNotGivenClassTag")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -124,7 +124,12 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
               defnNir.NatDigitClasses
             ).flatMap(wrap)
 
-            asCStruct.orElse(asNatBase).orElse(asNatDigit)
+            def asCFuncPtr = optIndexOf(
+              defnNir.UnsafeTag_materializeCFuncPtrTags,
+              defnNir.CFuncPtrNClass
+            ).flatMap(wrap)
+
+            asCStruct.orElse(asNatBase).orElse(asNatDigit).orElse(asCFuncPtr)
           }
         }
 


### PR DESCRIPTION
Fixes #3740 in 0.4.x branch. 0.5.x branch is already supporting callbacks with CFuncPtr.