### PR TITLE
nativelib: Make `Zone.apply` context-function based, add `Zone.acquire` for Scala2 compat

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/package.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/package.scala
@@ -4,31 +4,39 @@ import scalanative.unsafe._
 package object libc {
   implicit class StdioHelpers(val _stdio: libc.stdio.type) extends AnyVal {
     def printf(format: CString, args: CVarArg*): CInt =
-      Zone { implicit z => stdio.vprintf(format, toCVarArgList(args.toSeq)) }
+      Zone.acquire { implicit z =>
+        stdio.vprintf(format, toCVarArgList(args.toSeq))
+      }
 
     def sprintf(s: CString, format: CString, args: CVarArg*): CInt =
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         stdio.vsprintf(s, format, toCVarArgList(args.toSeq))
       }
 
     def snprintf(s: CString, n: CSize, format: CString, args: CVarArg*): CInt =
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         stdio.vsnprintf(s, n.toInt, format, toCVarArgList(args.toSeq))
       }
 
     def fprintf(f: Ptr[stdio.FILE], format: CString, args: CVarArg*): CInt =
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         stdio.vfprintf(f, format, toCVarArgList(args.toSeq))
       }
 
     def scanf(format: CString, args: CVarArg*): CInt =
-      Zone { implicit z => stdio.vscanf(format, toCVarArgList(args.toSeq)) }
+      Zone.acquire { implicit z =>
+        stdio.vscanf(format, toCVarArgList(args.toSeq))
+      }
 
     def sscanf(s: CString, format: CString, args: CVarArg*): CInt =
-      Zone { implicit z => stdio.vsscanf(s, format, toCVarArgList(args.toSeq)) }
+      Zone.acquire { implicit z =>
+        stdio.vsscanf(s, format, toCVarArgList(args.toSeq))
+      }
 
     def fscanf(f: Ptr[stdio.FILE], format: CString, args: CVarArg*): CInt =
-      Zone { implicit z => stdio.vfscanf(f, format, toCVarArgList(args.toSeq)) }
+      Zone.acquire { implicit z =>
+        stdio.vfscanf(f, format, toCVarArgList(args.toSeq))
+      }
 
   }
 }

--- a/docs/changelog/0.5.0.draft.md
+++ b/docs/changelog/0.5.0.draft.md
@@ -14,6 +14,7 @@ Check out the documentation at
 * Removed `java.net.URL` related stubs we don't plan to implement.
 
 ## Breaking changes
+* `scala.scalanative.unsafe.Zone.apply` by default uses a context function argument. For Scala 2 cross-compilation use `Zone.acquire` instead. 
 * There is a breaking change in the `utsnameOps` of the posixlib. Prior to version 0.4.x, this Ops provided an API
 that returned system properties as `String` for `Ptr[utsname.utsname]`. However, like other posixlib Ops,
 it has been changed to return a `CArray` instead of a `String`.
@@ -147,7 +148,7 @@ import scala.scalanative.posix.sys.stat
 import scala.scalanative.posix.timeOps._
 import scala.scalanative.posix.sys.statOps.statOps
 
-Zone { implicit z =>
+Zone {
   val filepath = c"/path/to/file"
   val stat = alloc[stat.stat]()
   stat.stat(filepath, stat)

--- a/docs/changelog/0.5.0.draft.md
+++ b/docs/changelog/0.5.0.draft.md
@@ -14,7 +14,7 @@ Check out the documentation at
 * Removed `java.net.URL` related stubs we don't plan to implement.
 
 ## Breaking changes
-* `scala.scalanative.unsafe.Zone.apply` by default uses a context function argument. For Scala 2 cross-compilation use `Zone.acquire` instead. 
+* `scala.scalanative.unsafe.Zone.apply` by default uses a context function argument. For Scala 2 cross-compilation see [Memory managment section](../user/interop.rst#Memory-management)
 * There is a breaking change in the `utsnameOps` of the posixlib. Prior to version 0.4.x, this Ops provided an API
 that returned system properties as `String` for `Ptr[utsname.utsname]`. However, like other posixlib Ops,
 it has been changed to return a `CArray` instead of a `String`.
@@ -148,7 +148,7 @@ import scala.scalanative.posix.sys.stat
 import scala.scalanative.posix.timeOps._
 import scala.scalanative.posix.sys.statOps.statOps
 
-Zone {
+Zone { implicit z =>
   val filepath = c"/path/to/file"
   val stat = alloc[stat.stat]()
   stat.stat(filepath, stat)

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -126,8 +126,14 @@ Variadic functions
 ``````````````````
 
 Scala Native supports native interoperability with C's variadic argument
-list type (i.e. ``va_list``), but not ``...`` varargs. For example ``vprintf``
-can be declared as:
+list type (i.e. ``va_list``), and partially for ``...`` varargs. For example ``vprintf`` and ``printf``
+defined in C as:
+
+.. code-block:: C
+  int vprintf(const char * format, va_list arg);
+  int printf(const char * format, ... );  
+
+can be declared in Scala as:
 
 .. code-block:: scala
 
@@ -136,9 +142,14 @@ can be declared as:
    @extern
    object mystdio {
      def vprintf(format: CString, args: CVarArgList): CInt = extern
+     def printf(format: CString, args: Any*): CInt = extern
    }
 
-One can wrap a function in a nicer API like:
+The limitation of `...` interop requires that it's arguments needs to passed directly to variadic arguments function or arguments need to be inlined.
+This is required to obtain enough information on how arguments show be passed in regards to C ABI.
+Passing a sequence to extern method variadic arguments is not allowed and would result in compilation failure. 
+
+For ``va_list`` interop, one can wrap a function in a nicer API like:
 
 .. code-block:: scala
 
@@ -149,11 +160,13 @@ One can wrap a function in a nicer API like:
        mystdio.vprintf(format, toCVarArgList(args.toSeq))
      }
 
+See `Memory management`_ for a guide of using ``unsafe.Zone``
 And then call it just like a regular Scala function:
 
 .. code-block:: scala
 
    myprintf(c"2 + 3 = %d, 4 + 5 = %d", 2 + 3, 4 + 5)
+   printf(c"2 + 3 = %d, 4 + 5 = %d", 2 + 3, 4 + 5)
 
 Exported methods
 ----------------
@@ -312,7 +325,7 @@ runtime system, one has to be extra careful when working with unmanaged memory.
       Zone {
         val buffer = alloc[Byte](n)
       }
-      // For Scala 2.13
+      // For Scala 2, works, but is not idiomatic on Scala 3
       Zone.acquire { implicit z =>
         val buffer = alloc[Byte](n)
       }

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -145,7 +145,7 @@ One can wrap a function in a nicer API like:
    import scala.scalanative.unsafe._
 
    def myprintf(format: CString, args: CVarArg*): CInt =
-     Zone { implicit z =>
+     Zone { 
        mystdio.vprintf(format, toCVarArgList(args.toSeq))
      }
 
@@ -308,7 +308,12 @@ runtime system, one has to be extra careful when working with unmanaged memory.
 
       import scala.scalanative.unsafe._
 
-      Zone { implicit z =>
+      // For Scala 3
+      Zone {
+        val buffer = alloc[Byte](n)
+      }
+      // For Scala 2.13
+      Zone.acquire { implicit z =>
         val buffer = alloc[Byte](n)
       }
 

--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -116,7 +116,7 @@ object FileDescriptor {
   }
 
   private[io] def openReadOnly(file: File): FileDescriptor =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       def fail() =
         throw new FileNotFoundException("No such file " + file.getPath())
 

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -53,7 +53,7 @@ class FileOutputStream(fd: FileDescriptor, file: Option[File])
 
 object FileOutputStream {
   private def fileDescriptor(file: File, append: Boolean) =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       if (isWindows) {
         val handle = CreateFileW(
           toCWideStringUTF16LE(file.getPath()),

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -246,7 +246,7 @@ private object RandomAccessFile {
         s"""Illegal mode "${_flags}" must be one of "r", "rw", "rws" or "rwd""""
       )
 
-    def unixFileDescriptor() = Zone { implicit z =>
+    def unixFileDescriptor() = Zone.acquire { implicit z =>
       import fcntl._
       import stat._
 
@@ -265,7 +265,7 @@ private object RandomAccessFile {
       new FileDescriptor(FileDescriptor.FileHandle(fd), readOnly = false)
     }
 
-    def windowsFileDescriptor() = Zone { implicit z =>
+    def windowsFileDescriptor() = Zone.acquire { implicit z =>
       import windows.winnt.AccessRights._
       val (access, dispostion) = _flags match {
         case "r" => FILE_GENERIC_READ -> OPEN_EXISTING

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -150,7 +150,7 @@ object UnixProcessGen1 {
   private def waitForPid(pid: Int, ts: Ptr[timespec], res: Ptr[CInt]): CInt =
     ProcessMonitor.waitForPid(pid, ts, res)
 
-  def apply(builder: ProcessBuilder): Process = Zone { implicit z =>
+  def apply(builder: ProcessBuilder): Process = Zone.acquire { implicit z =>
     val infds: Ptr[CInt] = stackalloc[CInt](2)
     val outfds: Ptr[CInt] = stackalloc[CInt](2)
     val errfds =
@@ -306,7 +306,7 @@ object UnixProcessGen1 {
     }
   }
 
-  @inline def open(f: File, flags: CInt) = Zone { implicit z =>
+  @inline def open(f: File, flags: CInt) = Zone.acquire { implicit z =>
     fcntl.open(toCString(f.getAbsolutePath()), flags, 0.toUInt) match {
       case -1 => throw new IOException(s"Unable to open file $f ($errno)")
       case fd => fd

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -352,7 +352,7 @@ private[lang] class UnixProcessGen2 private (
 
 object UnixProcessGen2 {
 
-  def apply(builder: ProcessBuilder): Process = Zone { implicit z =>
+  def apply(builder: ProcessBuilder): Process = Zone.acquire { implicit z =>
     /* If builder.directory is not null, it specifies a new working
      * directory for the process (chdir()).
      *
@@ -762,7 +762,7 @@ object UnixProcessGen2 {
     }
   }
 
-  def open(f: File, flags: CInt) = Zone { implicit z =>
+  def open(f: File, flags: CInt) = Zone.acquire { implicit z =>
     fcntl.open(toCString(f.getAbsolutePath()), flags, 0.toUInt) match {
       case -1 => throw new IOException(s"Unable to open file $f ($errno)")
       case fd => fd

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -125,7 +125,7 @@ object WindowsProcess {
   private final val readEnd = 0
   private final val writeEnd = 1
 
-  def apply(builder: ProcessBuilder): Process = Zone { implicit z =>
+  def apply(builder: ProcessBuilder): Process = Zone.acquire { implicit z =>
     val (inRead, inWrite) =
       createPipeOrThrow(
         builder.redirectInput(),
@@ -253,7 +253,7 @@ object WindowsProcess {
         disposition: DWord,
         flagsAndAttributes: DWord = FILE_ATTRIBUTE_NORMAL,
         sharing: DWord = FILE_SHARE_ALL
-    ) = Zone { implicit z =>
+    ) = Zone.acquire { implicit z =>
       val handle = FileApi.CreateFileW(
         filename = toCWideStringUTF16LE(redirect.file().getAbsolutePath()),
         desiredAccess = access,

--- a/javalib/src/main/scala/java/net/AbstractPlainDatagramSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainDatagramSocketImpl.scala
@@ -109,7 +109,7 @@ private[net] abstract class AbstractPlainDatagramSocketImpl
     hints.ai_flags = AI_NUMERICHOST
     hints.ai_socktype = posix.sys.socket.SOCK_DGRAM
 
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val cIP = toCString(inetAddress.getHostAddress())
       if (getaddrinfo(cIP, toCString(port.toString), hints, ret) != 0) {
         throw new BindException(

--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -100,7 +100,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     hints.ai_flags = AI_NUMERICHOST
     hints.ai_socktype = socket.SOCK_STREAM
 
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val cIP = toCString(addr.getHostAddress())
       if (getaddrinfo(cIP, toCString(port.toString), hints, ret) != 0) {
         throw new BindException(
@@ -201,7 +201,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     hints.ai_socktype = socket.SOCK_STREAM
     val remoteAddress = inetAddr.getAddress.getHostAddress()
 
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val cIP = toCString(remoteAddress)
       val cPort = toCString(inetAddr.getPort.toString)
 

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -246,8 +246,8 @@ object InetAddress {
     fromCString(dst)
   }
 
-  private def getByNumericName(host: String): Option[InetAddress] = Zone {
-    implicit z =>
+  private def getByNumericName(host: String): Option[InetAddress] =
+    Zone.acquire { implicit z =>
       val hints = stackalloc[addrinfo]() // stackalloc clears its memory
       val addrinfo = stackalloc[Ptr[addrinfo]]()
 
@@ -303,7 +303,7 @@ object InetAddress {
         } finally {
           freeaddrinfo(!addrinfo)
         }
-  }
+    }
 
   private def vetScopeText(host: String): Unit = { // callers have handled null
     // Fail on either numeric %-2 and non-numeric (text) %-abc
@@ -314,7 +314,7 @@ object InetAddress {
     }
   }
 
-  private def getByNonNumericName(host: String): InetAddress = Zone {
+  private def getByNonNumericName(host: String): InetAddress = Zone.acquire {
     implicit z =>
       /* Design Note:
        *   Host-to-ip-address translation is known to be fraught with
@@ -469,7 +469,7 @@ object InetAddress {
     }
 
     def ipToHost(ipBA: Array[Byte]): Option[String] =
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         // Reserve extra space for NUL terminator.
         val hostSize = MAXDNAME + 1.toUInt
         val host: Ptr[CChar] = alloc[CChar](hostSize)
@@ -498,7 +498,7 @@ object InetAddress {
   }
 
   private def hostToInetAddressArray(host: String): Array[InetAddress] =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       /* The JVM implementations in both the manual testing &
        * Continuous Integration environments have the "feature" of
        * not filling in the host field of an InetAddress if the name

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -358,7 +358,7 @@ private[java] final class FileChannelImpl(
       if (GetFileSizeEx(fd.handle, size)) (!size).toLong
       else 0L
     } else
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         /* statbuf is too large to be thread stack friendly.
          * Even a Zone and an alloc() per size() call should be cheaper than
          * the required three (yes 3 to get it right and not move current

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -28,7 +28,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       lastModifiedTime: FileTime,
       lastAccessTime: FileTime,
       createTime: FileTime
-  ): Unit = Zone { implicit z =>
+  ): Unit = Zone.acquire { implicit z =>
     import scala.scalanative.posix.sys.statOps.statOps
     val sb = getStat()
 
@@ -45,7 +45,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
   }
 
   override def setOwner(owner: UserPrincipal): Unit =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val uid = owner match {
         case u: PosixUserPrincipal => u.uid
 
@@ -58,7 +58,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
     }
 
   override def setPermissions(perms: Set[PosixFilePermission]): Unit =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       var mask = 0.toUInt
       PosixFileAttributeViewImpl.permMap.foreach {
         case (flag, value) => if (perms.contains(value)) mask = mask | flag
@@ -71,7 +71,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
   override def getOwner(): UserPrincipal = attributes.owner()
 
   override def setGroup(group: GroupPrincipal): Unit =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val gid = group match {
         case g: PosixGroupPrincipal => g.gid
 
@@ -96,7 +96,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       private var st_mtime: time.time_t = _
       private var st_mode: stat.mode_t = _
 
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         val buf = getStat()
         import scala.scalanative.posix.sys.statOps.statOps
 

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -59,7 +59,7 @@ object Date {
   else tzset()
 
   private def secondsToString(seconds: Long, default: => String): String =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val ttPtr = alloc[time_t]()
       !ttPtr = seconds.toSize
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
@@ -67,7 +67,7 @@ class UnixFileSystem(
   override def isOpen(): Boolean =
     closed == false
 
-  override def isReadOnly(): Boolean = Zone { implicit z =>
+  override def isReadOnly(): Boolean = Zone.acquire { implicit z =>
     val stat = alloc[statvfs.statvfs]()
     val err = statvfs.statvfs(toCString(root), stat)
     if (err != 0) {

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsAclFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsAclFileAttributeView.scala
@@ -19,7 +19,7 @@ class WindowsAclFileAttributeView(path: Path, options: Array[LinkOption])
   def name(): String = "acl"
 
   def getOwner(): UserPrincipal =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val filename = toCWideStringUTF16LE(path.toString)
       val ownerSid = stackalloc[SIDPtr]()
 
@@ -38,7 +38,7 @@ class WindowsAclFileAttributeView(path: Path, options: Array[LinkOption])
       WindowsUserPrincipal(!ownerSid)
     }
 
-  def setOwner(owner: UserPrincipal): Unit = Zone { implicit z =>
+  def setOwner(owner: UserPrincipal): Unit = Zone.acquire { implicit z =>
     val filename = toCWideStringUTF16LE(path.toString)
 
     val sidCString = owner match {

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
@@ -31,8 +31,8 @@ object WindowsUserPrincipalLookupService extends UserPrincipalLookupService {
     }
   }
 
-  private def lookupByName(name: String): Try[WindowsUserPrincipal] = Zone {
-    implicit z =>
+  private def lookupByName(name: String): Try[WindowsUserPrincipal] =
+    Zone.acquire { implicit z =>
       val cbSid, domainSize = stackalloc[DWord]()
       !cbSid = 0.toUInt
       !domainSize = 0.toUInt
@@ -69,5 +69,5 @@ object WindowsUserPrincipalLookupService extends UserPrincipalLookupService {
           Failure(WindowsException("Failed to lookup sid for account name"))
         } else Try(WindowsUserPrincipal(sidRef))
       }
-  }
+    }
 }

--- a/javalib/src/main/scala/scala/scalanative/runtime/DeleteOnExit.scala
+++ b/javalib/src/main/scala/scala/scalanative/runtime/DeleteOnExit.scala
@@ -8,7 +8,9 @@ object DeleteOnExit {
   private val toDelete: mutable.ArrayBuffer[String] =
     mutable.ArrayBuffer.empty
   Shutdown.addHook(() =>
-    toDelete.foreach { f => Zone { implicit z => libc.remove(toCString(f)) } }
+    toDelete.foreach { f =>
+      Zone.acquire { implicit z => libc.remove(toCString(f)) }
+    }
   )
   def addFile(name: String) = toDelete.synchronized {
     if (toDeleteSet.add(name)) toDelete += name

--- a/nativelib/src/main/scala-2/scala/scalanative/unsafe/ZoneScalaVersionSpecific.scala
+++ b/nativelib/src/main/scala-2/scala/scalanative/unsafe/ZoneScalaVersionSpecific.scala
@@ -1,0 +1,6 @@
+package scala.scalanative.unsafe
+
+trait ZoneCompanionScalaVersionSpecific { self: Zone.type =>
+  /** Run given function with a fresh zone and destroy it afterwards. */
+  def apply[T](f: Zone => T): T = acquire(f)
+}

--- a/nativelib/src/main/scala-2/scala/scalanative/unsafe/ZoneScalaVersionSpecific.scala
+++ b/nativelib/src/main/scala-2/scala/scalanative/unsafe/ZoneScalaVersionSpecific.scala
@@ -1,6 +1,7 @@
 package scala.scalanative.unsafe
 
 trait ZoneCompanionScalaVersionSpecific { self: Zone.type =>
+
   /** Run given function with a fresh zone and destroy it afterwards. */
   def apply[T](f: Zone => T): T = acquire(f)
 }

--- a/nativelib/src/main/scala-3/scala/scalanative/unsafe/ZoneScalaVersionSpecific.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/unsafe/ZoneScalaVersionSpecific.scala
@@ -1,0 +1,13 @@
+package scala.scalanative.unsafe
+
+import scala.annotation.targetName
+
+trait ZoneCompanionScalaVersionSpecific { self: Zone.type =>
+
+  /** Run given function with a fresh zone and destroy it afterwards. */
+  inline def apply[T](inline f: Zone ?=> T): T = {
+    val zone = open()
+    try f(using zone)
+    finally zone.close()
+  }
+}

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
@@ -39,10 +39,10 @@ trait Zone {
 
 }
 
-object Zone {
+object Zone extends ZoneCompanionScalaVersionSpecific {
 
   /** Run given function with a fresh zone and destroy it afterwards. */
-  final def apply[T](f: Zone => T): T = {
+  final def acquire[T](f: Zone => T): T = {
     val zone = open()
     try f(zone)
     finally zone.close()

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -78,7 +78,7 @@ object stat {
    *    {{{
    *    import scala.scalanative.unsafe._
    *    import scala.scalanative.posix.sys.stat
-   *    Zone { implicit z =>
+   *    Zone.acquire { implicit z =>
    *      val s = alloc[stat.stat]()
    *      val code = stat.stat(filename,s)
    *      if (code == 0) {

--- a/scripted-tests/run/errors-reported/src/main/scala/Hello.scala
+++ b/scripted-tests/run/errors-reported/src/main/scala/Hello.scala
@@ -3,6 +3,8 @@ import scala.scalanative.libc.stdio._
 
 object Hello {
   def main(args: Array[String]): Unit = {
-    Zone { implicit z => vfprintf(stderr, c"Hello, world!", toCVarArgList()) }
+    Zone.acquire { implicit z =>
+      vfprintf(stderr, c"Hello, world!", toCVarArgList())
+    }
   }
 }

--- a/scripted-tests/run/hello-world/src/main/scala/Hello.scala
+++ b/scripted-tests/run/hello-world/src/main/scala/Hello.scala
@@ -3,6 +3,8 @@ import scala.scalanative.libc.stdio._
 
 object Hello {
   def main(args: Array[String]): Unit = {
-    Zone { implicit z => vfprintf(stderr, c"Hello, world!", toCVarArgList()) }
+    Zone.acquire { implicit z =>
+      vfprintf(stderr, c"Hello, world!", toCVarArgList())
+    }
   }
 }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessInheritTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessInheritTest.scala
@@ -22,7 +22,7 @@ class ProcessInheritTest {
       val f = Files.createTempFile("/tmp", "out")
       val savedFD = unistd.dup(unistd.STDOUT_FILENO)
       val flags = fcntl.O_RDWR | fcntl.O_TRUNC | fcntl.O_CREAT
-      val fd = Zone { implicit z =>
+      val fd = Zone.acquire { implicit z =>
         fcntl.open(toCString(f.toAbsolutePath.toString), flags, 0.toUInt)
       }
 
@@ -62,7 +62,7 @@ class ProcessInheritTest {
         )
       )
 
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         val handle = CreateFileW(
           toCWideStringUTF16LE(f.toAbsolutePath.toString),
           desiredAccess = FILE_GENERIC_WRITE | FILE_GENERIC_READ,

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/DlfcnTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/DlfcnTest.scala
@@ -22,7 +22,7 @@ class DlfcnTest {
    */
 
   @Test def dlfcnOpensAndObtainsSymbolAddressLinux(): Unit = {
-    if (isLinux) Zone { implicit z =>
+    if (isLinux) Zone.acquire { implicit z =>
       val soFilePrefix =
         if (is32BitPlatform)
           "/lib/i386-linux-gnu/"
@@ -81,7 +81,7 @@ class DlfcnTest {
   }
 
   @Test def dlfcnOpensAndObtainsSymbolAddressMacOs(): Unit = {
-    if (isMac) Zone { implicit z =>
+    if (isMac) Zone.acquire { implicit z =>
       val soFile = "/usr/lib/libSystem.dylib"
 
       val handle = dlopen(toCString(soFile), RTLD_LAZY | RTLD_LOCAL)

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/GlobTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/GlobTest.scala
@@ -74,7 +74,7 @@ class GlobTest {
       !isWindows
     )
 
-    if (!isWindows) Zone { implicit z =>
+    if (!isWindows) Zone.acquire { implicit z =>
       val globP = stackalloc[glob_t]()
 
       val wdAbsP = workDir.toAbsolutePath()
@@ -101,7 +101,7 @@ class GlobTest {
       !isWindows
     )
 
-    if (!isWindows) Zone { implicit z =>
+    if (!isWindows) Zone.acquire { implicit z =>
       val globP = stackalloc[glob_t]()
 
       val wdAbsP = workDir.toAbsolutePath()

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/NetdbTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/NetdbTest.scala
@@ -103,45 +103,46 @@ class NetdbTest {
     !resultPtr
   }
 
-  @Test def gai_strerrorMustTranslateErrorCodes(): Unit = Zone { implicit z =>
-    if (!isWindows) {
-      val resultPtr = stackalloc[Ptr[addrinfo]]()
+  @Test def gai_strerrorMustTranslateErrorCodes(): Unit = Zone.acquire {
+    implicit z =>
+      if (!isWindows) {
+        val resultPtr = stackalloc[Ptr[addrinfo]]()
 
-      // Workaround Issue #2314 - getaddrinfo fails with null hints.
-      val hints = stackalloc[addrinfo]()
-      hints.ai_family = AF_INET
-      hints.ai_socktype = SOCK_DGRAM
+        // Workaround Issue #2314 - getaddrinfo fails with null hints.
+        val hints = stackalloc[addrinfo]()
+        hints.ai_family = AF_INET
+        hints.ai_socktype = SOCK_DGRAM
 
-      // Calling with no host & no service should cause gai error EAI_NONAME.
-      val status = getaddrinfo(null, null, hints, resultPtr);
+        // Calling with no host & no service should cause gai error EAI_NONAME.
+        val status = getaddrinfo(null, null, hints, resultPtr);
 
-      assertNotEquals(s"Expected getaddrinfo call to fail,", 0, status)
+        assertNotEquals(s"Expected getaddrinfo call to fail,", 0, status)
 
-      assertEquals(s"Unexpected getaddrinfo failure,", EAI_NONAME, status)
+        assertEquals(s"Unexpected getaddrinfo failure,", EAI_NONAME, status)
 
-      val gaiFailureMsg = gai_strerror(status)
+        val gaiFailureMsg = gai_strerror(status)
 
-      assertNotNull(s"gai_strerror returned NULL/null,", status)
+        assertNotNull(s"gai_strerror returned NULL/null,", status)
 
-      /* Check that translated text exists but not for the exact text.
-       * The text may vary by operating system and C locale.
-       * Such translations from integers to varying text is gai_strerror()'s
-       * very reason for being.
-       *
-       * One common linux translation of EAI_NONAME is:
-       * "Name or service not known".
-       */
+        /* Check that translated text exists but not for the exact text.
+         * The text may vary by operating system and C locale.
+         * Such translations from integers to varying text is gai_strerror()'s
+         * very reason for being.
+         *
+         * One common linux translation of EAI_NONAME is:
+         * "Name or service not known".
+         */
 
-      assertNotEquals(
-        s"gai_strerror returned zero length string,",
-        0,
-        strlen(gaiFailureMsg)
-      )
-    }
+        assertNotEquals(
+          s"gai_strerror returned zero length string,",
+          0,
+          strlen(gaiFailureMsg)
+        )
+      }
   }
 
-  @Test def getaddrinfoWithNullHintsShouldFollowPosixSpec(): Unit = Zone {
-    implicit z =>
+  @Test def getaddrinfoWithNullHintsShouldFollowPosixSpec(): Unit =
+    Zone.acquire { implicit z =>
       if (!isWindows) {
 
         val host = c"127.0.0.1"
@@ -183,6 +184,6 @@ class NetdbTest {
           freeaddrinfo(nullHintsAiPtr)
         }
       }
-  }
+    }
 
 }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
@@ -35,7 +35,7 @@ class StdlibTest {
 
   @Test def testGetsubopt(): Unit = {
 
-    if (!LinktimeInfo.isWindows) Zone { implicit z =>
+    if (!LinktimeInfo.isWindows) Zone.acquire { implicit z =>
       val expectedNameValue = "SvantePääbo"
       val expectedAccessValue = "ro"
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StringTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StringTest.scala
@@ -45,7 +45,7 @@ class StringTest {
     }
 
   @Test def strtok_rShouldFindTokens(): Unit =
-    if (!isWindows) Zone { implicit z =>
+    if (!isWindows) Zone.acquire { implicit z =>
       /* On this happy path, strtok_r() will attempt to write NULs into
        * the string, so DO NOT USE c"" interpolator.
        * "Segmentation fault caught" will remind you

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
@@ -114,7 +114,7 @@ class TimeTest {
 
   @Test def localtime_rShouldHandleEpochPlusTimezone(): Unit =
     if (!isWindows) {
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         assumeFalse(
           "Skipping localtime_r test since FreeBSD hasn't the 'timezone' variable",
           Platform.isFreeBSD
@@ -145,7 +145,7 @@ class TimeTest {
 
   @Test def strftimeDoesNotReadMemoryOutsideStructTm(): Unit =
     if (!isWindows) {
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         // The purpose of this test is to check two closely related conditions.
         // These conditions not a concern when the size of the C structure
         // is the same as the Scala Native structure and the order of the
@@ -225,7 +225,7 @@ class TimeTest {
     }
 
   @Test def strftimeForJanOne1900ZeroZulu(): Unit = if (!isWindows) {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val isoDatePtr: Ptr[CChar] = alloc[CChar](70)
       val timePtr = alloc[tm]()
 
@@ -240,7 +240,7 @@ class TimeTest {
   }
 
   @Test def strftimeForMondayJanOne1990ZeroTime(): Unit = if (!isWindows) {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val timePtr = alloc[tm]()
       val datePtr: Ptr[CChar] = alloc[CChar](70)
 
@@ -293,7 +293,7 @@ class TimeTest {
 
   @Test def strptimeDoesNotWriteMemoryOutsideStructTm(): Unit =
     if (!isWindows) {
-      Zone { implicit z =>
+      Zone.acquire { implicit z =>
         // The purpose of this test is to check that time.scala method
         // declaration had an "@name" annotation, so that structure
         // copy-in/copy-out happened? Failure case is if 36 byte

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/WordexpTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/WordexpTest.scala
@@ -35,7 +35,7 @@ class WordexpTest {
       "wordexp.scala is not implemented on Windows",
       !isWindows
     )
-    if (!isWindows) Zone { implicit z =>
+    if (!isWindows) Zone.acquire { implicit z =>
       val wrdeP = stackalloc[wordexp_t]()
 
       /* wordexp is defined as using the sh shell. That shell does not
@@ -59,7 +59,7 @@ class WordexpTest {
       !isWindows
     )
 
-    if (!isWindows) Zone { implicit z =>
+    if (!isWindows) Zone.acquire { implicit z =>
       val wrdeP = stackalloc[wordexp_t]()
 
       val pattern = "~"
@@ -102,7 +102,7 @@ class WordexpTest {
       hasHomeEnvvar != null
     )
 
-    if (!isWindows) Zone { implicit z =>
+    if (!isWindows) Zone.acquire { implicit z =>
       val wrdeP = stackalloc[wordexp_t]()
 
       val pattern = "Phil $HOME Ochs"

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/netinet/In6Test.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/netinet/In6Test.scala
@@ -16,7 +16,7 @@ import org.junit.Assert._
 
 class In6Test {
 
-  @Test def testSetSin6Family(): Unit = Zone { implicit z =>
+  @Test def testSetSin6Family(): Unit = Zone.acquire { implicit z =>
     /* Setting the sin6_family field should work and should not clobber the
      * sin6_len field, if such exists on executing OS.
      */
@@ -40,7 +40,7 @@ class In6Test {
     )
   }
 
-  @Test def testSetSin6Len(): Unit = Zone { implicit z =>
+  @Test def testSetSin6Len(): Unit = Zone.acquire { implicit z =>
     /* Setting the sin6_len field should work and should not clobber the
      * sin6_family field.
      */

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/netinet/InTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/netinet/InTest.scala
@@ -16,7 +16,7 @@ import org.junit.Assert._
 
 class InTest {
 
-  @Test def testSetSinFamily(): Unit = Zone { implicit z =>
+  @Test def testSetSinFamily(): Unit = Zone.acquire { implicit z =>
     /* Setting the sin_family field should work and should not clobber the
      * sin_len field, if such exists on executing OS.
      */
@@ -40,7 +40,7 @@ class InTest {
     )
   }
 
-  @Test def testSetSinLen(): Unit = Zone { implicit z =>
+  @Test def testSetSinLen(): Unit = Zone.acquire { implicit z =>
     /* Setting the sin_len field should work and should not clobber the
      * sin_family field.
      */

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/ResourceTest.scala
@@ -86,7 +86,7 @@ class ResourceTest {
   }
 
   @Test def getrlimitInvalidArgResource() = if (!isWindows) {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       errno = 0
       val rlimPtr = alloc[rlimit]()
 
@@ -97,7 +97,7 @@ class ResourceTest {
   }
 
   @Test def testGetrlimit() = if (!isWindows) {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val cases = Array(
         TestInfo("RLIMIT_AS", RLIMIT_AS),
         TestInfo("RLIMIT_CORE", RLIMIT_CORE),
@@ -140,7 +140,7 @@ class ResourceTest {
   }
 
   @Test def getrusageInvalidArgWho() = if (!isWindows) {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       errno = 0
       val rusagePtr = alloc[rusage]()
 
@@ -151,7 +151,7 @@ class ResourceTest {
   }
 
   @Test def getrusageSelf() = if (!isWindows) {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       errno = 0
       val rusagePtr = alloc[rusage]()
 
@@ -183,7 +183,7 @@ class ResourceTest {
   }
 
   @Test def getrusageChildren() = if (!isWindows) {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       errno = 0
       val rusagePtr = alloc[rusage]()
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/StatTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/StatTest.scala
@@ -43,7 +43,7 @@ class StatTest {
   import StatTest.workDirString
 
   @Test def fileStatTest(): Unit = if (!LinktimeInfo.isWindows) {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       import scala.scalanative.posix.sys.statOps.statOps
 
       // Note: tmpname template gets modified by a successful mkstemp().

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/Udp6SocketTest.scala
@@ -68,23 +68,24 @@ object Udp6SocketTest {
 
 class Udp6SocketTest {
 
-  private def formatIn6addr(addr: in6_addr): String = Zone { implicit z =>
-    val dstSize = INET6_ADDRSTRLEN + 1
-    val dst = alloc[Byte](dstSize)
+  private def formatIn6addr(addr: in6_addr): String = Zone.acquire {
+    implicit z =>
+      val dstSize = INET6_ADDRSTRLEN + 1
+      val dst = alloc[Byte](dstSize)
 
-    val result = inet_ntop(
-      AF_INET6,
-      addr.at1.at(0).asInstanceOf[Ptr[Byte]],
-      dst,
-      dstSize.toUInt
-    )
+      val result = inet_ntop(
+        AF_INET6,
+        addr.at1.at(0).asInstanceOf[Ptr[Byte]],
+        dst,
+        dstSize.toUInt
+      )
 
-    assertNotEquals(s"inet_ntop failed errno: ${errno}", result, null)
+      assertNotEquals(s"inet_ntop failed errno: ${errno}", result, null)
 
-    fromCString(dst)
+      fromCString(dst)
   }
 
-  @Test def sendtoRecvfrom(): Unit = Zone { implicit z =>
+  @Test def sendtoRecvfrom(): Unit = Zone.acquire { implicit z =>
     if (isWindows) {
       WinSocketApiOps.init()
     }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UdpSocketTest.scala
@@ -34,7 +34,7 @@ object UdpSocketTest {
 
 class UdpSocketTest {
 
-  @Test def sendtoRecvfrom(): Unit = Zone { implicit z =>
+  @Test def sendtoRecvfrom(): Unit = Zone.acquire { implicit z =>
     if (isWindows) {
       WinSocketApiOps.init()
     }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UioTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/UioTest.scala
@@ -124,7 +124,7 @@ class UioTest {
           |
           |""".stripMargin
 
-  @Test def writevReadvShouldPlayNicely(): Unit = Zone { implicit z =>
+  @Test def writevReadvShouldPlayNicely(): Unit = Zone.acquire { implicit z =>
     // writev() should gather, readv() should scatter, the 2 should pass data.
     if (!isWindows) {
       val (inSocket, outSocket) = getConnectedUdp4LoopbackSockets()

--- a/unit-tests/native/src/test/scala/scala/scalanative/libc/CComplexTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/libc/CComplexTest.scala
@@ -66,7 +66,7 @@ class CComplexTest {
     alloc[CFloatComplex]().init(real.toFloat, imag.toFloat)
 
   @Test def testCacosf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         cacosf(tf, buff),
         res(toFloat(0x3f67910a), toFloat(0xbf87d7dc))
@@ -75,7 +75,7 @@ class CComplexTest {
   }
 
   @Test def testCasinf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         casinf(tf, buff),
         res(toFloat(0x3f2a8eab), toFloat(0x3f87d7dc))
@@ -84,7 +84,7 @@ class CComplexTest {
   }
 
   @Test def testCatanf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         catanf(tf, buff),
         res(toFloat(0x3f823454), toFloat(0x3ece0210))
@@ -93,7 +93,7 @@ class CComplexTest {
   }
 
   @Test def testCcosf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         ccosf(tf, buff),
         res(toFloat(0x3f556f55), toFloat(0xbf7d2866))
@@ -102,7 +102,7 @@ class CComplexTest {
   }
 
   @Test def testCsinf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         csinf(tf, buff),
         res(toFloat(0x3fa633dc), toFloat(0x3f228cff))
@@ -111,7 +111,7 @@ class CComplexTest {
   }
 
   @Test def testCtanf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         ctanf(tf, buff),
         res(toFloat(0x3e8b2327), toFloat(0x3f8abe00))
@@ -121,7 +121,7 @@ class CComplexTest {
   }
 
   @Test def testCacoshf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         cacoshf(tf, buff),
         res(toFloat(0x3f87d7dc), toFloat(0x3f67910a))
@@ -130,7 +130,7 @@ class CComplexTest {
   }
 
   @Test def testCasinhf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         casinhf(tf, buff),
         res(toFloat(0x3f87d7dc), toFloat(0x3f2a8eab))
@@ -139,7 +139,7 @@ class CComplexTest {
   }
 
   @Test def testCatanhf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         catanhf(tf, buff),
         res(toFloat(0x3ece0210), toFloat(0x3f823454))
@@ -148,7 +148,7 @@ class CComplexTest {
   }
 
   @Test def testCcoshf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         ccoshf(tf, buff),
         res(toFloat(0x3f556f55), toFloat(0x3f7d2866))
@@ -157,7 +157,7 @@ class CComplexTest {
   }
 
   @Test def testCsinhf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         csinhf(tf, buff),
         res(toFloat(0x3f228cff), toFloat(0x3fa633dc))
@@ -166,7 +166,7 @@ class CComplexTest {
   }
 
   @Test def testCtanhf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         ctanhf(tf, buff),
         res(toFloat(0x3f8abe00), toFloat(0x3e8b2327))
@@ -175,7 +175,7 @@ class CComplexTest {
   }
 
   @Test def testCexpf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         cexpf(tf, buff),
         res(toFloat(0x3fbbfe2a), toFloat(0x40126407))
@@ -184,7 +184,7 @@ class CComplexTest {
   }
 
   @Test def testClogf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         clogf(tf, buff),
         res(toFloat(0x3eb17218), toFloat(0x3f490fdb))
@@ -193,11 +193,11 @@ class CComplexTest {
   }
 
   @Test def testCabsf(): Unit = {
-    Zone { implicit z => assertEquals(cabsf(tf), sqrt2.toFloat, 0.0f) }
+    Zone.acquire { implicit z => assertEquals(cabsf(tf), sqrt2.toFloat, 0.0f) }
   }
 
   @Test def testCpowf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       // macOS values:   0x3e8c441e, 0x3f156d6a
       // FreeBSD values: 0x3e8c4421, 0x3f156d69
       assertEqualsComplexF(
@@ -208,7 +208,7 @@ class CComplexTest {
   }
 
   @Test def testCsqrtf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(
         csqrtf(tf, buff),
         res(toFloat(0x3f8ca1af), toFloat(0x3ee90189))
@@ -217,25 +217,25 @@ class CComplexTest {
   }
 
   @Test def testCargf(): Unit = {
-    Zone { implicit z => assertEquals(cargf(tf), qtrPI.toFloat, 0.0f) }
+    Zone.acquire { implicit z => assertEquals(cargf(tf), qtrPI.toFloat, 0.0f) }
   }
 
   @Test def testCimagf(): Unit = {
-    Zone { implicit z => assertEquals(cimagf(tf), imag, 0.0f) }
+    Zone.acquire { implicit z => assertEquals(cimagf(tf), imag, 0.0f) }
   }
 
   @Test def testConjf(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexF(conjf(tf, buff), res(real.toFloat, -imag.toFloat))
     }
   }
 
   @Test def testCprojf(): Unit = {
-    Zone { implicit z => assertEqualsComplexF(cprojf(tf, buff), tf) }
+    Zone.acquire { implicit z => assertEqualsComplexF(cprojf(tf, buff), tf) }
   }
 
   @Test def testCrealf(): Unit = {
-    Zone { implicit z => assertEquals(crealf(tf), real, 0.0f) }
+    Zone.acquire { implicit z => assertEquals(crealf(tf), real, 0.0f) }
   }
 
   // double complex helper fcns
@@ -273,7 +273,7 @@ class CComplexTest {
     alloc[CDoubleComplex]().init(real, imag)
 
   @Test def testCacos(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         cacos(td, buf),
         res(toDouble("3fecf2214ccccd44"), toDouble("bff0fafb8f2f147f"))
@@ -282,7 +282,7 @@ class CComplexTest {
   }
 
   @Test def testCasin(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         casin(td, buf),
         res(toDouble("3fe551d55bbb8ced"), toDouble("3ff0fafb8f2f147f"))
@@ -291,7 +291,7 @@ class CComplexTest {
   }
 
   @Test def testCcos(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         ccos(td, buf),
         res(toDouble("3feaadea96f4359b"), toDouble("bfefa50ccd2ae8f3"))
@@ -300,7 +300,7 @@ class CComplexTest {
   }
 
   @Test def testCsin(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         csin(td, buf),
         res(toDouble("3ff4c67b74f6cc4f"), toDouble("3fe4519fd8047f92"))
@@ -309,7 +309,7 @@ class CComplexTest {
   }
 
   @Test def testCtan(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         ctan(td, buf),
         res(toDouble("3fd16464f4a33f88"), toDouble("3ff157bffca4a8bc"))
@@ -318,7 +318,7 @@ class CComplexTest {
   }
 
   @Test def testCacosh(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         cacosh(td, buf),
         res(toDouble("3ff0fafb8f2f147f"), toDouble("3fecf2214ccccd44"))
@@ -327,7 +327,7 @@ class CComplexTest {
   }
 
   @Test def testCasinh(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         casinh(td, buf),
         res(toDouble("3ff0fafb8f2f147f"), toDouble("3fe551d55bbb8ced"))
@@ -336,7 +336,7 @@ class CComplexTest {
   }
 
   @Test def testCatanh(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         catanh(td, buf),
         res(toDouble("3fd9c041f7ed8d33"), toDouble("3ff0468a8ace4df6"))
@@ -345,7 +345,7 @@ class CComplexTest {
   }
 
   @Test def testCcosh(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         ccosh(td, buf),
         res(toDouble("3feaadea96f4359b"), toDouble("3fefa50ccd2ae8f3"))
@@ -354,7 +354,7 @@ class CComplexTest {
   }
 
   @Test def testCsinh(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         csinh(td, buf),
         res(toDouble("3fe4519fd8047f92"), toDouble("3ff4c67b74f6cc4f"))
@@ -363,7 +363,7 @@ class CComplexTest {
   }
 
   @Test def testCtanh(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         ctanh(td, buf),
         res(toDouble("3ff157bffca4a8bc"), toDouble("3fd16464f4a33f88"))
@@ -372,7 +372,7 @@ class CComplexTest {
   }
 
   @Test def testCexp(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         cexp(td, buf),
         res(toDouble("3ff77fc5377c5a96"), toDouble("40024c80edc62064"))
@@ -381,7 +381,7 @@ class CComplexTest {
   }
 
   @Test def testClog(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         clog(td, buf),
         res(toDouble("3fd62e42fefa39ef"), toDouble("3fe921fb54442d18"))
@@ -390,11 +390,11 @@ class CComplexTest {
   }
 
   @Test def testCabs(): Unit = {
-    Zone { implicit z => assertEquals(cabs(td), sqrt2, 0.0) }
+    Zone.acquire { implicit z => assertEquals(cabs(td), sqrt2, 0.0) }
   }
 
   @Test def testCpow(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         cpow(td, td, buf),
         res(toDouble("3fd18884016cf327"), toDouble("3fe2adad36b098aa"))
@@ -403,7 +403,7 @@ class CComplexTest {
   }
 
   @Test def testCsqrt(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       assertEqualsComplexD(
         csqrt(td, buf),
         res(toDouble("3ff19435caffa9f9"), toDouble("3fdd203138f6c828"))
@@ -412,23 +412,25 @@ class CComplexTest {
   }
 
   @Test def testCarg(): Unit = {
-    Zone { implicit z => assertEquals(carg(td), qtrPI, 0.0) }
+    Zone.acquire { implicit z => assertEquals(carg(td), qtrPI, 0.0) }
   }
 
   @Test def testCimag(): Unit = {
-    Zone { implicit z => assertEquals(cimag(td), imag, 0.0) }
+    Zone.acquire { implicit z => assertEquals(cimag(td), imag, 0.0) }
   }
 
   @Test def testConj(): Unit = {
-    Zone { implicit z => assertEqualsComplexD(conj(td, buf), res(real, -imag)) }
+    Zone.acquire { implicit z =>
+      assertEqualsComplexD(conj(td, buf), res(real, -imag))
+    }
   }
 
   @Test def testCproj(): Unit = {
-    Zone { implicit z => assertEqualsComplexD(cproj(td, buf), td) }
+    Zone.acquire { implicit z => assertEqualsComplexD(cproj(td, buf), td) }
   }
 
   @Test def testCreal(): Unit = {
-    Zone { implicit z => assertEquals(creal(td), real, 0.0) }
+    Zone.acquire { implicit z => assertEquals(creal(td), real, 0.0) }
   }
 }
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/libc/IntTypesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/libc/IntTypesTest.scala
@@ -26,14 +26,14 @@ class IntTypesTest {
     assertEquals(3, res._2)
   }
   @Test def testStrtoimax(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val nptr = toCString("10345134932abc")
       val res = strtoimax(nptr, null, 10)
       assertEquals(res, 10345134932L)
     }
   }
   @Test def testStrtoumax(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val res = strtoimax(toCString("10345134932abc"), null, 10)
       assertEquals(res, 10345134932L)
     }

--- a/unit-tests/native/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationTest.scala
@@ -224,7 +224,7 @@ class ReflectiveInstantiationTest {
     val classData = optClassData.get
 
     // test with array of bytes
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val size = 64
       val buffer: Ptr[Byte] = alloc[Byte](size)
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
@@ -86,11 +86,11 @@ class CStringTest {
   }
 
   @Test def toCStringNullReturnsNullIssue1796(): Unit = {
-    Zone { implicit z => assertNull(toCString(null)) }
+    Zone.acquire { implicit z => assertNull(toCString(null)) }
   }
 
   @Test def testToCString(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val szFrom = "abcde"
       val cstrTo = toCString(szFrom)
       assertEquals(5.toUSize, strlen(cstrTo))
@@ -114,7 +114,7 @@ class CStringTest {
   }
 
   @Test def toFromCString(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       type _11 = Nat.Digit2[Nat._1, Nat._1]
       val arr = unsafe.stackalloc[CArray[Byte, _11]]()
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
@@ -15,7 +15,7 @@ import scala.scalanative.junit.utils.AssumesHelper._
 
 class CVarArgListTest {
   def vatest(cstr: CString, varargs: Seq[CVarArg], output: String): Unit =
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val buff: Ptr[CChar] = alloc[CChar](1024)
       stdio.vsprintf(buff, cstr, toCVarArgList(varargs))
       val got = fromCString(buff)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -35,7 +35,7 @@ object ExternTest {
   }
 
   // workaround for CI
-  def runTest(): Unit = Zone { implicit z: Zone =>
+  def runTest(): Unit = Zone.acquire { implicit z: Zone =>
     import scalanative.libc.string
     val bufsize = 10.toUInt
     val buf1: Ptr[Byte] = stackalloc[Byte](bufsize)
@@ -63,7 +63,7 @@ class ExternTest {
 
     val args = Seq("skipped", "skipped", "skipped", "-b", "-f", "farg")
 
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val argv: Ptr[CString] = stackalloc[CString](args.length)
 
       for ((arg, i) <- args.zipWithIndex) {

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
@@ -178,7 +178,7 @@ class PtrBoxingTest {
       v
     }
 
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val out = collection.mutable.ListBuffer.empty[Int]
       var head = cons(10, cons(20, cons(30, null)))
       while (head != null) {
@@ -190,7 +190,7 @@ class PtrBoxingTest {
   }
 
   @Test def loadAndStoreCFuncPtr(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val x: Ptr[Functions] = stackalloc[Functions]()
       x._1 = CFuncPtr0.fromScalaFunction(getInt _)
       x._2 = CFuncPtr1.fromScalaFunction(stringLength _)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrOpsTest.scala
@@ -13,7 +13,7 @@ import scalanative.unsafe.Ptr.ptrToCArray
 class PtrOpsTest {
 
   @Test def substraction(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val carr: Ptr[CChar] = toCString("abcdefg")
       val cptr: Ptr[CChar] = string.strchr(carr, 'd')
       assertTrue(cptr - carr == 3)
@@ -77,7 +77,7 @@ class PtrOpsTest {
     val fnFromPtr = CFuncPtr.fromPtr[CFuncPtr2[CString, StructA, StructA]](ptr)
     val aliasedFn = CFuncPtr.fromPtr[AssignCString](ptr)
 
-    def test(fn: CFuncPtr2[CString, StructA, StructA]): Unit = Zone {
+    def test(fn: CFuncPtr2[CString, StructA, StructA]): Unit = Zone.acquire {
       implicit z =>
         val str = alloc[StructA]()
         val charset = java.nio.charset.StandardCharsets.UTF_8
@@ -105,8 +105,8 @@ class PtrOpsTest {
       arr
     }
   @Test def castedCFuncPtrHandlesArrays(): Unit = {
-    def test(fn: CFuncPtr3[CInt, CUnsignedLongLong, LLArr, LLArr]) = Zone {
-      implicit z =>
+    def test(fn: CFuncPtr3[CInt, CUnsignedLongLong, LLArr, LLArr]) =
+      Zone.acquire { implicit z =>
         val arr = alloc[LLArr]()
 
         val value = ULong.MaxValue
@@ -116,7 +116,7 @@ class PtrOpsTest {
         val result = !resultArray.at(idx)
         // Some strange thing occurred here: assertEquals resulted in assertionFailed
         assert(result == value)
-    }
+      }
 
     type FnAlias = CFuncPtr3[CInt, CUnsignedLongLong, LLArr, LLArr]
     val fn = fn3

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
@@ -27,7 +27,7 @@ class ZoneTest {
   }
 
   @Test def zoneAllocatorAllocWithApply(): Unit = {
-    Zone { implicit z =>
+    Zone.acquire { implicit z =>
       val ptr = z.alloc(64.toUSize * sizeof[Int])
 
       assertAccessible(ptr, 64)


### PR DESCRIPTION
These are the last moments to modify the API of Scala Native 0.5.x and to introduce braking changes. Here's proposal for one of them.

This change changes `Zone.apply` to take a context-function as an argument allowing for clean DSL: 
```scala
Zone {
  val a = alloc[Int]()
  Zone:
    val b = alloc[Int]
    println(b - a)
}
```

instead of 
```scala
Zone{ implicit z =>
  val a = alloc[Int]()
  Zone { implicit z2 => 
     // actually it would not compile in Scala 2 becouse of ambigious Zone implicits
    val b = alloc[Int]
    println(b - a)
 }
 ```
 
We add `Zone.acquire` to allow for cross compilation with Scala 2 - it should allow for easy search-and-replace in the userbase. 