### PR TITLE
Api change: Replace `Ptr[Byte]` with Ptr[_] where applicable. 

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stddef.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stddef.scala
@@ -12,9 +12,9 @@ import scala.scalanative.unsafe._
 
   // Macros
 
-  // Ptr[Byte] is Scala Native convention for C (void *).
+  // Ptr[_] is Scala Native convention for C (void *).
   @name("scalanative_clib_null")
-  def NULL: Ptr[Byte] = extern
+  def NULL: Ptr[_] = extern
 
   // offsetof() is not implemented in Scala Native.
 }

--- a/clib/src/main/scala/scala/scalanative/libc/stddef.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stddef.scala
@@ -12,9 +12,8 @@ import scala.scalanative.unsafe._
 
   // Macros
 
-  // Ptr[_] is Scala Native convention for C (void *).
   @name("scalanative_clib_null")
-  def NULL: Ptr[_] = extern
+  def NULL: CVoidPtr = extern
 
   // offsetof() is not implemented in Scala Native.
 }

--- a/clib/src/main/scala/scala/scalanative/libc/stdio.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdio.scala
@@ -153,7 +153,7 @@ import stddef.size_t
    *    [[https://en.cppreference.com/w/c/io/fread]]
    */
   @blocking def fread(
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       size: CSize,
       count: CSize,
       stream: Ptr[FILE]
@@ -190,7 +190,7 @@ import stddef.size_t
    */
 
   @blocking def fwrite(
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       size: CSize,
       count: CSize,
       stream: Ptr[FILE]

--- a/clib/src/main/scala/scala/scalanative/libc/stdio.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdio.scala
@@ -153,7 +153,7 @@ import stddef.size_t
    *    [[https://en.cppreference.com/w/c/io/fread]]
    */
   @blocking def fread(
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       size: CSize,
       count: CSize,
       stream: Ptr[FILE]
@@ -190,7 +190,7 @@ import stddef.size_t
    */
 
   @blocking def fwrite(
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       size: CSize,
       count: CSize,
       stream: Ptr[FILE]

--- a/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
@@ -12,7 +12,7 @@ import scalanative.unsafe._
   def malloc(size: CSize): Ptr[Byte] = extern
   def calloc(num: CSize, size: CSize): Ptr[Byte] = extern
   def realloc[T](ptr: Ptr[T], newSize: CSize): Ptr[T] = extern
-  def free(ptr: Ptr[_]): Unit = extern
+  def free(ptr: CVoidPtr): Unit = extern
   def aligned_alloc(alignment: CSize, size: CSize): Unit = extern
 
   // Program utilities
@@ -61,18 +61,18 @@ import scalanative.unsafe._
   // Searching and sorting
 
   def bsearch(
-      key: Ptr[_],
-      data: Ptr[_],
+      key: CVoidPtr,
+      data: CVoidPtr,
       num: CSize,
       size: CSize,
-      comparator: CFuncPtr2[Ptr[_], Ptr[_], CInt]
+      comparator: CFuncPtr2[CVoidPtr, CVoidPtr, CInt]
   ): Unit = extern
 
   def qsort[T](
       data: Ptr[T],
       num: CSize,
       size: CSize,
-      comparator: CFuncPtr2[Ptr[_], Ptr[_], CInt]
+      comparator: CFuncPtr2[CVoidPtr, CVoidPtr, CInt]
   ): Unit = extern
 
   // Macros

--- a/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
@@ -11,7 +11,7 @@ import scalanative.unsafe._
 
   def malloc(size: CSize): Ptr[Byte] = extern
   def calloc(num: CSize, size: CSize): Ptr[Byte] = extern
-  def realloc(ptr: Ptr[Byte], newSize: CSize): Ptr[Byte] = extern
+  def realloc[T](ptr: Ptr[T], newSize: CSize): Ptr[T] = extern
   def free(ptr: Ptr[_]): Unit = extern
   def aligned_alloc(alignment: CSize, size: CSize): Unit = extern
 
@@ -61,18 +61,18 @@ import scalanative.unsafe._
   // Searching and sorting
 
   def bsearch(
-      key: Ptr[Byte],
-      data: Ptr[Byte],
+      key: Ptr[_],
+      data: Ptr[_],
       num: CSize,
       size: CSize,
-      comparator: CFuncPtr2[Ptr[Byte], Ptr[Byte], CInt]
+      comparator: CFuncPtr2[Ptr[_], Ptr[_], CInt]
   ): Unit = extern
 
-  def qsort(
-      data: Ptr[Byte],
+  def qsort[T](
+      data: Ptr[T],
       num: CSize,
       size: CSize,
-      comparator: CFuncPtr2[Ptr[Byte], Ptr[Byte], CInt]
+      comparator: CFuncPtr2[Ptr[_], Ptr[_], CInt]
   ): Unit = extern
 
   // Macros

--- a/clib/src/main/scala/scala/scalanative/libc/string.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/string.scala
@@ -22,11 +22,11 @@ import scalanative.unsafe._
   def strpbrk(dest: CString, breakset: CString): CString = extern
   def strstr(str: CString, substr: CString): CString = extern
   def strtok(str: CString, delim: CString): CString = extern
-  def memchr(ptr: Ptr[Byte], ch: CInt, count: CSize): Ptr[Byte] = extern
-  def memcmp(lhs: Ptr[Byte], rhs: Ptr[Byte], count: CSize): CInt = extern
-  def memset(dest: Ptr[Byte], ch: CInt, count: CSize): Ptr[Byte] = extern
-  def memcpy(dest: Ptr[Byte], src: Ptr[Byte], count: CSize): Ptr[Byte] = extern
-  def memmove(dest: Ptr[Byte], src: Ptr[Byte], count: CSize): Ptr[Byte] =
+  def memchr(ptr: Ptr[_], ch: CInt, count: CSize): Ptr[Byte] = extern
+  def memcmp(lhs: Ptr[_], rhs: Ptr[_], count: CSize): CInt = extern
+  def memset[T](dest: Ptr[T], ch: CInt, count: CSize): Ptr[T] = extern
+  def memcpy[T](dest: Ptr[T], src: Ptr[_], count: CSize): Ptr[T] = extern
+  def memmove[T](dest: Ptr[T], src: Ptr[_], count: CSize): Ptr[T] =
     extern
   def strerror(errnum: CInt): CString = extern
 }

--- a/clib/src/main/scala/scala/scalanative/libc/string.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/string.scala
@@ -22,11 +22,11 @@ import scalanative.unsafe._
   def strpbrk(dest: CString, breakset: CString): CString = extern
   def strstr(str: CString, substr: CString): CString = extern
   def strtok(str: CString, delim: CString): CString = extern
-  def memchr(ptr: Ptr[_], ch: CInt, count: CSize): Ptr[Byte] = extern
-  def memcmp(lhs: Ptr[_], rhs: Ptr[_], count: CSize): CInt = extern
+  def memchr(ptr: CVoidPtr, ch: CInt, count: CSize): Ptr[Byte] = extern
+  def memcmp(lhs: CVoidPtr, rhs: CVoidPtr, count: CSize): CInt = extern
   def memset[T](dest: Ptr[T], ch: CInt, count: CSize): Ptr[T] = extern
-  def memcpy[T](dest: Ptr[T], src: Ptr[_], count: CSize): Ptr[T] = extern
-  def memmove[T](dest: Ptr[T], src: Ptr[_], count: CSize): Ptr[T] =
+  def memcpy[T](dest: Ptr[T], src: CVoidPtr, count: CSize): Ptr[T] = extern
+  def memmove[T](dest: Ptr[T], src: CVoidPtr, count: CSize): Ptr[T] =
     extern
   def strerror(errnum: CInt): CString = extern
 }

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -67,7 +67,7 @@ C Type                    Scala Type
 ``char32_t``              ``unsafe.CChar32``
 ``float``                 ``unsafe.CFloat``
 ``double``                ``unsafe.CDouble``
-``void*``                 ``unsafe.Ptr[Byte]`` [2]_
+``void*``                 ``unsafe.Ptr[_]`` [2]_
 ``int*``                  ``unsafe.Ptr[unsafe.CInt]`` [2]_
 ``char*``                 ``unsafe.CString`` [2]_ [3]_
 ``int (*)(int)``          ``unsafe.CFuncPtr1[unsafe.CInt, unsafe.CInt]`` [2]_ [4]_
@@ -263,7 +263,7 @@ and unboxing result. You can create them from C pointer using `CFuncPtr` helper 
 
     def fnDef(str: CString): CInt = ???
 
-    val anyPtr: Ptr[Byte] = CFuncPtr.toPtr {
+    val anyPtr: Ptr[_] = CFuncPtr.toPtr {
       CFuncPtr1.fromScalaFunction(fnDef)
     }
 

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -67,7 +67,7 @@ C Type                    Scala Type
 ``char32_t``              ``unsafe.CChar32``
 ``float``                 ``unsafe.CFloat``
 ``double``                ``unsafe.CDouble``
-``void*``                 ``unsafe.Ptr[_]`` [2]_
+``void*``                 ``unsafe.CVoidPtr`` [2]_
 ``int*``                  ``unsafe.Ptr[unsafe.CInt]`` [2]_
 ``char*``                 ``unsafe.CString`` [2]_ [3]_
 ``int (*)(int)``          ``unsafe.CFuncPtr1[unsafe.CInt, unsafe.CInt]`` [2]_ [4]_
@@ -263,7 +263,7 @@ and unboxing result. You can create them from C pointer using `CFuncPtr` helper 
 
     def fnDef(str: CString): CInt = ???
 
-    val anyPtr: Ptr[_] = CFuncPtr.toPtr {
+    val anyPtr: CVoidPtr = CFuncPtr.toPtr {
       CFuncPtr1.fromScalaFunction(fnDef)
     }
 

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -18,7 +18,7 @@ private[lang] object StackTrace {
       ip: CUnsignedLong
   ): StackTraceElement = {
     val nameMax = 1024
-    val name = calloc(nameMax.toUSize, sizeof[CChar])
+    val name = calloc(nameMax.toUSize, sizeof[CChar]).asInstanceOf[Ptr[CChar]]
     val offset = stackalloc[scala.Long]()
 
     unwind.get_proc_name(cursor, name, nameMax.toUSize, offset)

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -1,5 +1,8 @@
 package java.lang.process
 
+// Required only for cross-compilation with Scala 2
+import scala.language.existentials
+
 import java.io.{FileDescriptor, InputStream, OutputStream}
 import java.lang.ProcessBuilder._
 

--- a/javalib/src/main/scala/java/nio/Buffer.scala
+++ b/javalib/src/main/scala/java/nio/Buffer.scala
@@ -6,7 +6,7 @@ import scala.scalanative.runtime.{toRawPtr, fromRawPtr}
 
 abstract class Buffer private[nio] (
     val _capacity: Int,
-    _address: unsafe.Ptr[_]
+    _address: unsafe.CVoidPtr
 ) {
   private[nio] type ElementType
 

--- a/javalib/src/main/scala/java/nio/Buffers.scala
+++ b/javalib/src/main/scala/java/nio/Buffers.scala
@@ -30,7 +30,7 @@ abstract class ByteBuffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[Byte],
     private[nio] val _offset: Int,
-    _address: unsafe.Ptr[_],
+    _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
     with Comparable[ByteBuffer] 
   {
@@ -45,7 +45,7 @@ abstract class ByteBuffer private[nio] (
   private def genBuffer = GenBuffer[ByteBuffer](this)
 
   private[nio] def this(_capacity: Int, _array: Array[Byte], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
-  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[Byte], -1, address)
+  private[nio] def this(_capacity: Int, address: unsafe.CVoidPtr) = this(_capacity, null: Array[Byte], -1, address)
 
   def slice(): ByteBuffer
   // Since JDK 13
@@ -376,7 +376,7 @@ abstract class CharBuffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[Char],
     private[nio] val _offset: Int,
-    _address: unsafe.Ptr[_],
+    _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
     with Comparable[CharBuffer] 
     with CharSequence
@@ -393,7 +393,7 @@ abstract class CharBuffer private[nio] (
   private def genBuffer = GenBuffer[CharBuffer](this)
 
   private[nio] def this(_capacity: Int, _array: Array[Char], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
-  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[Char], -1, address)
+  private[nio] def this(_capacity: Int, address: unsafe.CVoidPtr) = this(_capacity, null: Array[Char], -1, address)
 
   def slice(): CharBuffer
   // Since JDK 13
@@ -611,7 +611,7 @@ abstract class ShortBuffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[Short],
     private[nio] val _offset: Int,
-    _address: unsafe.Ptr[_],
+    _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
     with Comparable[ShortBuffer] 
   {
@@ -625,7 +625,7 @@ abstract class ShortBuffer private[nio] (
   private def genBuffer = GenBuffer[ShortBuffer](this)
 
   private[nio] def this(_capacity: Int, _array: Array[Short], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
-  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[Short], -1, address)
+  private[nio] def this(_capacity: Int, address: unsafe.CVoidPtr) = this(_capacity, null: Array[Short], -1, address)
 
   def slice(): ShortBuffer
   // Since JDK 13
@@ -795,7 +795,7 @@ abstract class IntBuffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[Int],
     private[nio] val _offset: Int,
-    _address: unsafe.Ptr[_],
+    _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
     with Comparable[IntBuffer] 
   {
@@ -809,7 +809,7 @@ abstract class IntBuffer private[nio] (
   private def genBuffer = GenBuffer[IntBuffer](this)
 
   private[nio] def this(_capacity: Int, _array: Array[Int], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
-  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[Int], -1, address)
+  private[nio] def this(_capacity: Int, address: unsafe.CVoidPtr) = this(_capacity, null: Array[Int], -1, address)
 
   def slice(): IntBuffer
   // Since JDK 13
@@ -979,7 +979,7 @@ abstract class LongBuffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[Long],
     private[nio] val _offset: Int,
-    _address: unsafe.Ptr[_],
+    _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
     with Comparable[LongBuffer] 
   {
@@ -993,7 +993,7 @@ abstract class LongBuffer private[nio] (
   private def genBuffer = GenBuffer[LongBuffer](this)
 
   private[nio] def this(_capacity: Int, _array: Array[Long], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
-  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[Long], -1, address)
+  private[nio] def this(_capacity: Int, address: unsafe.CVoidPtr) = this(_capacity, null: Array[Long], -1, address)
 
   def slice(): LongBuffer
   // Since JDK 13
@@ -1163,7 +1163,7 @@ abstract class FloatBuffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[Float],
     private[nio] val _offset: Int,
-    _address: unsafe.Ptr[_],
+    _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
     with Comparable[FloatBuffer] 
   {
@@ -1177,7 +1177,7 @@ abstract class FloatBuffer private[nio] (
   private def genBuffer = GenBuffer[FloatBuffer](this)
 
   private[nio] def this(_capacity: Int, _array: Array[Float], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
-  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[Float], -1, address)
+  private[nio] def this(_capacity: Int, address: unsafe.CVoidPtr) = this(_capacity, null: Array[Float], -1, address)
 
   def slice(): FloatBuffer
   // Since JDK 13
@@ -1347,7 +1347,7 @@ abstract class DoubleBuffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[Double],
     private[nio] val _offset: Int,
-    _address: unsafe.Ptr[_],
+    _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
     with Comparable[DoubleBuffer] 
   {
@@ -1361,7 +1361,7 @@ abstract class DoubleBuffer private[nio] (
   private def genBuffer = GenBuffer[DoubleBuffer](this)
 
   private[nio] def this(_capacity: Int, _array: Array[Double], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
-  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[Double], -1, address)
+  private[nio] def this(_capacity: Int, address: unsafe.CVoidPtr) = this(_capacity, null: Array[Double], -1, address)
 
   def slice(): DoubleBuffer
   // Since JDK 13

--- a/javalib/src/main/scala/java/nio/Buffers.scala.gyb
+++ b/javalib/src/main/scala/java/nio/Buffers.scala.gyb
@@ -52,7 +52,7 @@ abstract class ${T}Buffer private[nio] (
     _capacity: Int,
     override private[nio] val _array: Array[${T}],
     private[nio] val _offset: Int,
-    _address: unsafe.Ptr[_],
+    _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
     with Comparable[${T}Buffer] 
 % if T == 'Char':
@@ -74,7 +74,7 @@ abstract class ${T}Buffer private[nio] (
   private def genBuffer = GenBuffer[${T}Buffer](this)
 
   private[nio] def this(_capacity: Int, _array: Array[${T}], _offset: Int) = this(_capacity, _array, _offset, _array.atUnsafe(_offset))
-  private[nio] def this(_capacity: Int, address: unsafe.Ptr[_]) = this(_capacity, null: Array[${T}], -1, address)
+  private[nio] def this(_capacity: Int, address: unsafe.CVoidPtr) = this(_capacity, null: Array[${T}], -1, address)
 
   def slice(): ${T}Buffer
   // Since JDK 13

--- a/javalib/src/main/scala/scala/scalanative/ffi/zlib.scala
+++ b/javalib/src/main/scala/scala/scalanative/ffi/zlib.scala
@@ -22,9 +22,9 @@ private[ffi] object zlibPlatformCompat {
 @extern
 trait zlib {
   import zlibOps.{z_stream, gz_header}
-  type voidpf = Ptr[Byte]
-  type voidp = Ptr[Byte]
-  type voidpc = Ptr[Byte]
+  type voidpf = CVoidPtr
+  type voidp = CVoidPtr
+  type voidpc = CVoidPtr
   type uInt = CUnsignedInt
   type uLong = CUnsignedLong
   type uLongf = CUnsignedLong
@@ -38,7 +38,7 @@ trait zlib {
     CFuncPtr2[Ptr[Byte], Ptr[Ptr[CUnsignedChar]], CUnsignedInt]
   type out_func =
     CFuncPtr3[Ptr[Byte], Ptr[CUnsignedChar], CUnsignedInt, CInt]
-  type gzFile = Ptr[Byte]
+  type gzFile = CVoidPtr
   type z_streamp = Ptr[z_stream[AnyVal, AnyVal]]
   type gz_headerp = Ptr[gz_header[AnyVal, AnyVal]]
 

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
@@ -98,7 +98,7 @@ object Continuations:
     def apply(x: R): T =
       resume(inner, x).get
 
-    private[Continuations] def alloc(size: CUnsignedLong): Ptr[Byte] =
+    private[Continuations] def alloc(size: CUnsignedLong): Ptr[_] =
       val obj = BlobArray.alloc(size.toInt) // round up the blob size
       allocas += obj
       obj.atUnsafe(0)
@@ -109,10 +109,10 @@ object Continuations:
   /** Transformed version of the suspend lambda, to be passed to cont_suspend.
    *  Takes:
    *    - `continuation`: the reified continuation
-   *    - `onSuspend`: The suspend lambda as Continuation => Ptr[Byte] (the
+   *    - `onSuspend`: The suspend lambda as Continuation => Ptr[_] (the
    *      returned object, cast to a pointer)
    *
-   *  Returns Ptr[Byte] / void*.
+   *  Returns Ptr[_] / void*.
    */
   inline def suspendFn[R, T] = suspendFnAny.asInstanceOf[SuspendFnPtr[R, T]]
   private val suspendFnAny: SuspendFnPtr[Any, Any] =
@@ -123,10 +123,10 @@ object Continuations:
   /** Transformed version of the boundary body, to be passed to cont_boundary.
    *  Takes:
    *    - `label`: the boundary label
-   *    - `arg`: The boundary body as BoundaryLabel ?=> Ptr[Byte] (the returned
+   *    - `arg`: The boundary body as BoundaryLabel ?=> Ptr[_] (the returned
    *      object, cast to a pointer)
    *
-   *  Returns Ptr[Byte] / void*.
+   *  Returns Ptr[_] / void*.
    */
   inline def boundaryBodyFn[T] =
     boundaryBodyFnAny.asInstanceOf[ContinuationBodyPtr[T]]
@@ -139,14 +139,14 @@ object Continuations:
   private def allocateBlob(
       size: CUnsignedLong,
       continuation: Continuation[Any, Any]
-  ): Ptr[Byte] = continuation.alloc(size)
+  ): Ptr[_] = continuation.alloc(size)
 
   /** Continuations implementation imported from C (see `delimcc.h`) */
   @extern private object Impl:
     private type ContinuationLabel = CUnsignedLong
     type BoundaryLabel = ContinuationLabel
 
-    type Continuation = Ptr[Byte]
+    type Continuation = Ptr[_]
 
     // We narrow the arguments of `boundary` to functions returning Try[T]
     type ContinuationBody[T] = BoundaryLabel => Try[T]
@@ -180,7 +180,7 @@ object Continuations:
         continuation_alloc_fn: CFuncPtr2[
           CUnsignedLong,
           Continuations.Continuation[Any, Any],
-          Ptr[Byte]
+          Ptr[_]
         ]
     ): Unit =
       extern

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
@@ -98,7 +98,7 @@ object Continuations:
     def apply(x: R): T =
       resume(inner, x).get
 
-    private[Continuations] def alloc(size: CUnsignedLong): Ptr[_] =
+    private[Continuations] def alloc(size: CUnsignedLong): Ptr[?] =
       val obj = BlobArray.alloc(size.toInt) // round up the blob size
       allocas += obj
       obj.atUnsafe(0)
@@ -109,10 +109,10 @@ object Continuations:
   /** Transformed version of the suspend lambda, to be passed to cont_suspend.
    *  Takes:
    *    - `continuation`: the reified continuation
-   *    - `onSuspend`: The suspend lambda as Continuation => Ptr[_] (the
+   *    - `onSuspend`: The suspend lambda as Continuation => Ptr[?] (the
    *      returned object, cast to a pointer)
    *
-   *  Returns Ptr[_] / void*.
+   *  Returns Ptr[?] / void*.
    */
   inline def suspendFn[R, T] = suspendFnAny.asInstanceOf[SuspendFnPtr[R, T]]
   private val suspendFnAny: SuspendFnPtr[Any, Any] =
@@ -123,10 +123,10 @@ object Continuations:
   /** Transformed version of the boundary body, to be passed to cont_boundary.
    *  Takes:
    *    - `label`: the boundary label
-   *    - `arg`: The boundary body as BoundaryLabel ?=> Ptr[_] (the returned
+   *    - `arg`: The boundary body as BoundaryLabel ?=> Ptr[?] (the returned
    *      object, cast to a pointer)
    *
-   *  Returns Ptr[_] / void*.
+   *  Returns Ptr[?] / void*.
    */
   inline def boundaryBodyFn[T] =
     boundaryBodyFnAny.asInstanceOf[ContinuationBodyPtr[T]]
@@ -139,14 +139,14 @@ object Continuations:
   private def allocateBlob(
       size: CUnsignedLong,
       continuation: Continuation[Any, Any]
-  ): Ptr[_] = continuation.alloc(size)
+  ): Ptr[?] = continuation.alloc(size)
 
   /** Continuations implementation imported from C (see `delimcc.h`) */
   @extern private object Impl:
     private type ContinuationLabel = CUnsignedLong
     type BoundaryLabel = ContinuationLabel
 
-    type Continuation = Ptr[_]
+    type Continuation = Ptr[?]
 
     // We narrow the arguments of `boundary` to functions returning Try[T]
     type ContinuationBody[T] = BoundaryLabel => Try[T]
@@ -180,7 +180,7 @@ object Continuations:
         continuation_alloc_fn: CFuncPtr2[
           CUnsignedLong,
           Continuations.Continuation[Any, Any],
-          Ptr[_]
+          Ptr[?]
         ]
     ): Unit =
       extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -39,10 +39,10 @@ object GC {
    */
   private type pthread_t = CUnsignedLongInt
   private type pthread_attr_t = CUnsignedLongLong
-  private type Handle = Ptr[Byte]
+  private type Handle = Ptr[_]
   private type DWord = CUnsignedInt
-  private type SecurityAttributes = CStruct3[DWord, Ptr[Byte], Boolean]
-  private type PtrAny = Ptr[Byte]
+  private type SecurityAttributes = CStruct3[DWord, Ptr[_], Boolean]
+  private type PtrAny = Ptr[_]
   type ThreadRoutineArg = PtrAny
   type ThreadStartRoutine = CFuncPtr1[ThreadRoutineArg, PtrAny]
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -39,10 +39,10 @@ object GC {
    */
   private type pthread_t = CUnsignedLongInt
   private type pthread_attr_t = CUnsignedLongLong
-  private type Handle = Ptr[_]
+  private type Handle = CVoidPtr
   private type DWord = CUnsignedInt
-  private type SecurityAttributes = CStruct3[DWord, Ptr[_], Boolean]
-  private type PtrAny = Ptr[_]
+  private type SecurityAttributes = CStruct3[DWord, CVoidPtr, Boolean]
+  private type PtrAny = CVoidPtr
   type ThreadRoutineArg = PtrAny
   type ThreadStartRoutine = CFuncPtr1[ThreadRoutineArg, PtrAny]
 
@@ -123,7 +123,7 @@ object GC {
    *    marking
    */
   @name("scalanative_GC_add_roots")
-  def addRoots(addressLow: Ptr[_], addressHigh: Ptr[_]): Unit = extern
+  def addRoots(addressLow: CVoidPtr, addressHigh: CVoidPtr): Unit = extern
 
   /** Notify the Garbage Collector about the range of memory which should no
    *  longer should be scanned when marking the objects. Every previously
@@ -140,5 +140,5 @@ object GC {
    *    marking
    */
   @name("scalanative_GC_remove_roots")
-  def removeRoots(addressLow: Ptr[_], addressHigh: Ptr[_]): Unit = extern
+  def removeRoots(addressLow: CVoidPtr, addressHigh: CVoidPtr): Unit = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/MemoryPool.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/MemoryPool.scala
@@ -93,7 +93,7 @@ object MemoryPool {
 final class MemoryPoolZone(private val pool: MemoryPool) extends Zone {
   private var tailPage = pool.claim()
   private var headPage = tailPage
-  private var largeAllocations: scala.Array[Ptr[_]] = null
+  private var largeAllocations: scala.Array[CVoidPtr] = null
   private var largeOffset = 0
 
   private def checkOpen(): Unit =
@@ -173,11 +173,11 @@ final class MemoryPoolZone(private val pool: MemoryPool) extends Zone {
 
   private def allocLarge(size: CSize): Ptr[Byte] = {
     if (largeAllocations == null) {
-      largeAllocations = new scala.Array[Ptr[_]](16)
+      largeAllocations = new scala.Array[CVoidPtr](16)
     }
     if (largeOffset == largeAllocations.length) {
       val newLargeAllocations =
-        new scala.Array[Ptr[_]](largeAllocations.length * 2)
+        new scala.Array[CVoidPtr](largeAllocations.length * 2)
       Array.copy(
         largeAllocations,
         0,

--- a/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
@@ -12,7 +12,7 @@ object libc {
   def malloc(size: RawSize): RawPtr = extern
   def realloc(ptr: RawPtr, size: RawSize): RawPtr = extern
   def free(ptr: RawPtr): Unit = extern
-  def free(ptr: Ptr[_]): Unit = extern
+  def free(ptr: CVoidPtr): Unit = extern
   def strlen(str: CString): CSize = extern
   def strchr(str: CString, ch: CInt): CString = extern
   def strrchr(str: CString, ch: CInt): CString = extern
@@ -20,11 +20,11 @@ object libc {
   def strncpy(dest: CString, src: CString, count: RawSize): CString = extern
   def strcpy(dest: CString, src: CString): CString = extern
   def strcat(dest: CString, src: CString): CString = extern
-  def memcpy(dst: Ptr[_], src: Ptr[_], count: CSize): RawPtr = extern
+  def memcpy(dst: CVoidPtr, src: CVoidPtr, count: CSize): RawPtr = extern
   def memcpy(dst: RawPtr, src: RawPtr, count: RawSize): RawPtr = extern
   def memcmp(lhs: RawPtr, rhs: RawPtr, count: RawSize): CInt = extern
   def memset(dest: RawPtr, ch: CInt, count: RawSize): RawPtr = extern
-  def memset(dest: Ptr[_], ch: CInt, count: CSize): RawPtr = extern
+  def memset(dest: CVoidPtr, ch: CInt, count: CSize): RawPtr = extern
   def memmove(dest: RawPtr, src: RawPtr, count: RawSize): RawPtr = extern
   def remove(fname: CString): CInt = extern
   def atexit(func: CFuncPtr0[Unit]): CInt = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
@@ -325,7 +325,7 @@ private[monitor] class ObjectMonitor() {
       expected: Thread,
       value: Thread
   ): Boolean = {
-    val expectedPtr = stackalloc[Ptr[_]]()
+    val expectedPtr = stackalloc[CVoidPtr]()
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(
       ownerThreadPtr,
@@ -338,7 +338,7 @@ private[monitor] class ObjectMonitor() {
       expected: Thread,
       value: Thread
   ): Boolean = {
-    val expectedPtr = stackalloc[Ptr[_]]()
+    val expectedPtr = stackalloc[CVoidPtr]()
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(
       activeWaiterThreadPtr,
@@ -352,7 +352,7 @@ private[monitor] class ObjectMonitor() {
       expected: WaiterNode,
       value: WaiterNode
   ): Boolean = {
-    val expectedPtr = stackalloc[Ptr[_]]()
+    val expectedPtr = stackalloc[CVoidPtr]()
     storeObject(expectedPtr, expected)
     atomic_compare_exchange_intptr(ref, expectedPtr, castObjectToRawPtr(value))
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -6,21 +6,21 @@ import scalanative.unsafe._
 @extern
 object unwind {
   @name("scalanative_unwind_get_context")
-  def get_context(context: Ptr[_]): CInt = extern
+  def get_context(context: CVoidPtr): CInt = extern
   @name("scalanative_unwind_init_local")
-  def init_local(cursor: Ptr[_], context: Ptr[_]): CInt = extern
+  def init_local(cursor: CVoidPtr, context: CVoidPtr): CInt = extern
   @name("scalanative_unwind_step")
-  def step(cursor: Ptr[_]): CInt = extern
+  def step(cursor: CVoidPtr): CInt = extern
   @name("scalanative_unwind_get_proc_name")
   def get_proc_name(
-      cursor: Ptr[_],
+      cursor: CVoidPtr,
       buffer: CString,
       length: CSize,
       offset: Ptr[Long]
   ): CInt = extern
   @name("scalanative_unwind_get_reg")
   def get_reg(
-      cursor: Ptr[_],
+      cursor: CVoidPtr,
       reg: CInt,
       valp: Ptr[CSize]
   ): CInt = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -6,21 +6,21 @@ import scalanative.unsafe._
 @extern
 object unwind {
   @name("scalanative_unwind_get_context")
-  def get_context(context: Ptr[Byte]): CInt = extern
+  def get_context(context: Ptr[_]): CInt = extern
   @name("scalanative_unwind_init_local")
-  def init_local(cursor: Ptr[Byte], context: Ptr[Byte]): CInt = extern
+  def init_local(cursor: Ptr[_], context: Ptr[_]): CInt = extern
   @name("scalanative_unwind_step")
-  def step(cursor: Ptr[Byte]): CInt = extern
+  def step(cursor: Ptr[_]): CInt = extern
   @name("scalanative_unwind_get_proc_name")
   def get_proc_name(
-      cursor: Ptr[Byte],
+      cursor: Ptr[_],
       buffer: CString,
       length: CSize,
       offset: Ptr[Long]
   ): CInt = extern
   @name("scalanative_unwind_get_reg")
   def get_reg(
-      cursor: Ptr[Byte],
+      cursor: Ptr[_],
       reg: CInt,
       valp: Ptr[CSize]
   ): CInt = extern

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala
@@ -19,11 +19,11 @@ import scala.scalanative.runtime.{RawPtr, intrinsic}
 sealed abstract class CFuncPtr private[unsafe] (private[scalanative] val rawptr: RawPtr)
 
 object CFuncPtr {
-  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[Byte])(implicit tag: Tag.CFuncPtrTag[F]): F =
+  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[_])(implicit tag: Tag.CFuncPtrTag[F]): F =
     tag.fromRawPtr(ptr.rawptr)
 
-  @alwaysinline def toPtr(ptr: CFuncPtr): Ptr[Byte] = {
-    boxToPtr[Byte](ptr.rawptr)
+  @alwaysinline def toPtr(ptr: CFuncPtr): Ptr[_] = {
+    boxToPtr(ptr.rawptr)
   }
 }
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala
@@ -19,10 +19,10 @@ import scala.scalanative.runtime.{RawPtr, intrinsic}
 sealed abstract class CFuncPtr private[unsafe] (private[scalanative] val rawptr: RawPtr)
 
 object CFuncPtr {
-  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[_])(implicit tag: Tag.CFuncPtrTag[F]): F =
+  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: CVoidPtr)(implicit tag: Tag.CFuncPtrTag[F]): F =
     tag.fromRawPtr(ptr.rawptr)
 
-  @alwaysinline def toPtr(ptr: CFuncPtr): Ptr[_] = {
+  @alwaysinline def toPtr(ptr: CFuncPtr): CVoidPtr = {
     boxToPtr(ptr.rawptr)
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb
@@ -19,11 +19,11 @@ import scala.scalanative.runtime.{RawPtr, intrinsic}
 sealed abstract class CFuncPtr private[unsafe] (private[scalanative] val rawptr: RawPtr)
 
 object CFuncPtr {
-  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[Byte])(implicit tag: Tag.CFuncPtrTag[F]): F =
+  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[_])(implicit tag: Tag.CFuncPtrTag[F]): F =
     tag.fromRawPtr(ptr.rawptr)
 
-  @alwaysinline def toPtr(ptr: CFuncPtr): Ptr[Byte] = {
-    boxToPtr[Byte](ptr.rawptr)
+  @alwaysinline def toPtr(ptr: CFuncPtr): Ptr[_] = {
+    boxToPtr(ptr.rawptr)
   }
 }
 % for N in range(0, 23):

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb
@@ -19,10 +19,10 @@ import scala.scalanative.runtime.{RawPtr, intrinsic}
 sealed abstract class CFuncPtr private[unsafe] (private[scalanative] val rawptr: RawPtr)
 
 object CFuncPtr {
-  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[_])(implicit tag: Tag.CFuncPtrTag[F]): F =
+  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: CVoidPtr)(implicit tag: Tag.CFuncPtrTag[F]): F =
     tag.fromRawPtr(ptr.rawptr)
 
-  @alwaysinline def toPtr(ptr: CFuncPtr): Ptr[_] = {
+  @alwaysinline def toPtr(ptr: CFuncPtr): CVoidPtr = {
     boxToPtr(ptr.rawptr)
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -83,10 +83,13 @@ package object unsafe extends unsafe.UnsafePackageCompat {
   /** The C/C++ 'ptrdiff_t' type. */
   type CPtrDiff = Size
 
+  /** The C/C++ 'void *' type; by convention, not declaration. */
+  type CVoidPtr = Ptr[_]
+
   /** C-style string with trailing 0. */
   type CString = Ptr[CChar]
 
-  /* C-style wide string with trail 0. */
+  /** C-style wide string with trail 0. */
   type CWideString = Ptr[CWideChar]
 
   /** Materialize tag for given type. */

--- a/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
@@ -41,12 +41,12 @@ object inet {
 
   def inet_ntop(
       af: CInt,
-      src: Ptr[_],
+      src: CVoidPtr,
       dst: CString,
       size: socklen_t
   ): CString = extern
 
-  def inet_pton(af: CInt, src: CString, dst: Ptr[_]): CInt = extern
+  def inet_pton(af: CInt, src: CString, dst: CVoidPtr): CInt = extern
 
   def inet_addr(in: CString): in_addr_t = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
@@ -41,12 +41,12 @@ object inet {
 
   def inet_ntop(
       af: CInt,
-      src: Ptr[Byte],
+      src: Ptr[_],
       dst: CString,
       size: socklen_t
   ): CString = extern
 
-  def inet_pton(af: CInt, src: CString, dst: Ptr[Byte]): CInt = extern
+  def inet_pton(af: CInt, src: CString, dst: Ptr[_]): CInt = extern
 
   def inet_addr(in: CString): in_addr_t = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
@@ -28,13 +28,13 @@ import scala.scalanative.unsafe._
 
 // Methods
 
-  // Convention: A C "void *" is represented in Scala Native as a "Ptr[Byte]".
+  // Convention: A C "void *" is represented in Scala Native as a "Ptr[_]".
 
-  def dlclose(handle: Ptr[Byte]): Int = extern
+  def dlclose(handle: Ptr[_]): Int = extern
 
   def dlerror(): CString = extern
 
-  def dlopen(filename: CString, flags: Int): Ptr[Byte] = extern
+  def dlopen(filename: CString, flags: Int): Ptr[_] = extern
 
-  def dlsym(handle: Ptr[Byte], symbol: CString): Ptr[Byte] = extern
+  def dlsym(handle: Ptr[_], symbol: CString): Ptr[_] = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
@@ -28,13 +28,13 @@ import scala.scalanative.unsafe._
 
 // Methods
 
-  // Convention: A C "void *" is represented in Scala Native as a "Ptr[_]".
+  // Convention: A C "void *" is represented in Scala Native as a "CVoidPtr".
 
-  def dlclose(handle: Ptr[_]): Int = extern
+  def dlclose(handle: CVoidPtr): Int = extern
 
   def dlerror(): CString = extern
 
-  def dlopen(filename: CString, flags: Int): Ptr[_] = extern
+  def dlopen(filename: CString, flags: Int): CVoidPtr = extern
 
-  def dlsym(handle: Ptr[_], symbol: CString): Ptr[_] = extern
+  def dlsym(handle: CVoidPtr, symbol: CString): CVoidPtr = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
@@ -14,7 +14,7 @@ import scala.scalanative.unsafe._
 
 @extern object locale extends libc.locale {
 
-  type locale_t = Ptr[Byte] // CX, so can get no simpler.
+  type locale_t = Ptr[_] // CX, so can get no simpler.
 
 // Symbolic constants
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
@@ -14,7 +14,7 @@ import scala.scalanative.unsafe._
 
 @extern object locale extends libc.locale {
 
-  type locale_t = Ptr[_] // CX, so can get no simpler.
+  type locale_t = CVoidPtr // CX, so can get no simpler.
 
 // Symbolic constants
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -36,7 +36,7 @@ object netdb {
     socket.socklen_t, // ai_addrlen
     Ptr[socket.sockaddr], // ai_addr
     Ptr[CChar], // ai_canonname
-    Ptr[Byte] // ai_next
+    Ptr[_] // ai_next
   ]
 
   def freeaddrinfo(addr: Ptr[addrinfo]): Unit = extern
@@ -168,7 +168,7 @@ object netdbOps {
       if (!useBsdAddrinfo) ptr._7
       else ptr._6.asInstanceOf[Ptr[CChar]]
 
-    def ai_next: Ptr[Byte] = ptr._8
+    def ai_next: Ptr[addrinfo] = ptr._8.asInstanceOf[Ptr[addrinfo]]
 
     def ai_flags_=(v: CInt): Unit = ptr._1 = v
     def ai_family_=(v: CInt): Unit = ptr._2 = v
@@ -184,6 +184,6 @@ object netdbOps {
       if (!useBsdAddrinfo) ptr._7 = v
       else ptr._6 = v.asInstanceOf[Ptr[socket.sockaddr]]
 
-    def ai_next_=(v: Ptr[Byte]): Unit = ptr._8 = v
+    def ai_next_=(v: Ptr[addrinfo]): Unit = ptr._8 = v
   }
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -36,7 +36,7 @@ object netdb {
     socket.socklen_t, // ai_addrlen
     Ptr[socket.sockaddr], // ai_addr
     Ptr[CChar], // ai_canonname
-    Ptr[_] // ai_next
+    CVoidPtr // ai_next
   ]
 
   def freeaddrinfo(addr: Ptr[addrinfo]): Unit = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
@@ -11,7 +11,7 @@ import scala.scalanative.unsafe._
 
 @extern object nl_types {
 
-  type nl_catd = Ptr[Byte] // Scala Native idiom for void *.
+  type nl_catd = Ptr[_] // Scala Native idiom for void *.
 
   type nl_item = CInt
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
@@ -11,7 +11,7 @@ import scala.scalanative.unsafe._
 
 @extern object nl_types {
 
-  type nl_catd = Ptr[_] // Scala Native idiom for void *.
+  type nl_catd = CVoidPtr // Scala Native idiom for void *.
 
   type nl_item = CInt
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -88,7 +88,7 @@ object pthread {
 
   def pthread_attr_setstackaddr(
       attr: Ptr[pthread_attr_t],
-      stackaddr: Ptr[_]
+      stackaddr: CVoidPtr
   ): CInt = extern
 
   def pthread_attr_setstacksize(
@@ -150,15 +150,15 @@ object pthread {
   def pthread_create(
       thread: Ptr[pthread_t],
       attr: Ptr[pthread_attr_t],
-      startroutine: CFuncPtr1[Ptr[_], Ptr[_]],
-      args: Ptr[_]
+      startroutine: CFuncPtr1[CVoidPtr, CVoidPtr],
+      args: CVoidPtr
   ): CInt = extern
 
   def pthread_detach(thread: pthread_t): CInt = extern
 
   def pthread_equal(thread1: pthread_t, thread2: pthread_t): CInt = extern
 
-  def pthread_exit(retval: Ptr[_]): Unit = extern
+  def pthread_exit(retval: CVoidPtr): Unit = extern
 
   def pthread_getconcurrency(): CInt = extern
 
@@ -168,14 +168,14 @@ object pthread {
       param: Ptr[sched_param]
   ): CInt = extern
 
-  def pthread_getspecific(key: pthread_key_t): Ptr[_] = extern
+  def pthread_getspecific(key: pthread_key_t): CVoidPtr = extern
 
   @blocking
-  def pthread_join(thread: pthread_t, value_ptr: Ptr[Ptr[_]]): CInt = extern
+  def pthread_join(thread: pthread_t, value_ptr: Ptr[CVoidPtr]): CInt = extern
 
   def pthread_key_create(
       key: Ptr[pthread_key_t],
-      destructor: CFuncPtr1[Ptr[_], Unit]
+      destructor: CFuncPtr1[CVoidPtr, Unit]
   ): CInt = extern
 
   def pthread_key_delete(key: pthread_key_t): CInt = extern
@@ -303,7 +303,7 @@ object pthread {
       param: Ptr[sched_param]
   ): CInt = extern
 
-  def pthread_setspecific(key: pthread_key_t, value: Ptr[_]): CInt = extern
+  def pthread_setspecific(key: pthread_key_t, value: CVoidPtr): CInt = extern
 
   def pthread_testcancel(): Unit = extern
 
@@ -322,7 +322,7 @@ object pthread {
   def PTHREAD_CANCEL_DISABLE: CInt = extern
 
   @name("scalanative_pthread_canceled")
-  def PTHREAD_CANCELED: Ptr[_] = extern
+  def PTHREAD_CANCELED: CVoidPtr = extern
 
   @name("scalanative_pthread_create_detached")
   def PTHREAD_CREATE_DETACHED: CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -88,7 +88,7 @@ object pthread {
 
   def pthread_attr_setstackaddr(
       attr: Ptr[pthread_attr_t],
-      stackaddr: Ptr[Byte]
+      stackaddr: Ptr[_]
   ): CInt = extern
 
   def pthread_attr_setstacksize(
@@ -150,15 +150,15 @@ object pthread {
   def pthread_create(
       thread: Ptr[pthread_t],
       attr: Ptr[pthread_attr_t],
-      startroutine: CFuncPtr1[Ptr[Byte], Ptr[Byte]],
-      args: Ptr[Byte]
+      startroutine: CFuncPtr1[Ptr[_], Ptr[_]],
+      args: Ptr[_]
   ): CInt = extern
 
   def pthread_detach(thread: pthread_t): CInt = extern
 
   def pthread_equal(thread1: pthread_t, thread2: pthread_t): CInt = extern
 
-  def pthread_exit(retval: Ptr[Byte]): Unit = extern
+  def pthread_exit(retval: Ptr[_]): Unit = extern
 
   def pthread_getconcurrency(): CInt = extern
 
@@ -168,14 +168,14 @@ object pthread {
       param: Ptr[sched_param]
   ): CInt = extern
 
-  def pthread_getspecific(key: pthread_key_t): Ptr[Byte] = extern
+  def pthread_getspecific(key: pthread_key_t): Ptr[_] = extern
 
   @blocking
-  def pthread_join(thread: pthread_t, value_ptr: Ptr[Ptr[Byte]]): CInt = extern
+  def pthread_join(thread: pthread_t, value_ptr: Ptr[Ptr[_]]): CInt = extern
 
   def pthread_key_create(
       key: Ptr[pthread_key_t],
-      destructor: CFuncPtr1[Ptr[Byte], Unit]
+      destructor: CFuncPtr1[Ptr[_], Unit]
   ): CInt = extern
 
   def pthread_key_delete(key: pthread_key_t): CInt = extern
@@ -303,7 +303,7 @@ object pthread {
       param: Ptr[sched_param]
   ): CInt = extern
 
-  def pthread_setspecific(key: pthread_key_t, value: Ptr[Byte]): CInt = extern
+  def pthread_setspecific(key: pthread_key_t, value: Ptr[_]): CInt = extern
 
   def pthread_testcancel(): Unit = extern
 
@@ -322,7 +322,7 @@ object pthread {
   def PTHREAD_CANCEL_DISABLE: CInt = extern
 
   @name("scalanative_pthread_canceled")
-  def PTHREAD_CANCELED: Ptr[Byte] = extern
+  def PTHREAD_CANCELED: Ptr[_] = extern
 
   @name("scalanative_pthread_create_detached")
   def PTHREAD_CREATE_DETACHED: CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
@@ -47,7 +47,7 @@ import scala.scalanative.unsafe._
   // Integer or structure type of an object used to represent sets of signals
   // macOS CUnsignedInt
   // Linux CStruct1[CArray[CUnsignedLong, Nat.Digit[Nat._1, Nat._6]]]
-  type sigset_t = Ptr[_]
+  type sigset_t = CVoidPtr
 
   type pid_t = types.pid_t
   type pthread_attr_t = types.pthread_attr_t
@@ -164,7 +164,7 @@ import scala.scalanative.unsafe._
                            // of the signal handling func
     CInt,                  // sa_flags Special flags
                            // sa_sigaction Pointer to a signal-catching function
-    CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[_], Unit]
+    CFuncPtr3[CInt, Ptr[siginfo_t], CVoidPtr, Unit]
   ]
 
 // format: on
@@ -217,17 +217,17 @@ import scala.scalanative.unsafe._
   // A machine-specific representation of the saved context
   // mac OS type mcontext_t = Ptr[__darwin_mcontext64]
   // __darwin_mcontext64 -> _STRUCT_MCONTEXT64 -> typedef _STRUCT_MCONTEXT64	*mcontext_t;
-  type mcontext_t = Ptr[_]
+  type mcontext_t = CVoidPtr
 
   type ucontext_t = CStruct4[
-    Ptr[_], // ucontext_t *uc_link Ptr to the resumed context when context returns (Ptr[_] instead)
+    CVoidPtr, // ucontext_t *uc_link Ptr to the resumed context when context returns (CVoidPtr instead)
     sigset_t, // c_sigmask The set of signals that are blocked when this context is active
     Ptr[stack_t], // uc_stack The stack context (Ptr instead of value)
     mcontext_t // uc_mcontext A machine-specific representation of the saved context
   ]
 
   type stack_t = CStruct3[
-    Ptr[_], // void *ss_sp Stack base or pointer
+    CVoidPtr, // void *ss_sp Stack base or pointer
     size_t, // ss_size Stack size
     CInt // ss_flags Flags
   ]
@@ -238,7 +238,7 @@ import scala.scalanative.unsafe._
     CInt, // si_errno If non-zero, an errno value associated with this signal, as described in <errno.h>
     pid_t, // si_pid Sending process ID
     uid_t, // si_uid Real user ID of sending process
-    Ptr[_], // void *si_addr Address of faulting instruction
+    CVoidPtr, // void *si_addr Address of faulting instruction
     CInt, // si_status Exit value or signal
     CLong, // si_band Band event for SIGPOLL
     Ptr[sigval] // si_value Signal value (Ptr instead of value)
@@ -401,9 +401,9 @@ object signalOps {
   implicit class sigval_ops(val p: Ptr[sigval]) extends AnyVal {
     def sival_int: Ptr[CInt] = p.asInstanceOf[Ptr[CInt]]
     def sival_int_=(value: CInt): Unit = !p.asInstanceOf[Ptr[CInt]] = value
-    def sival_ptr: Ptr[Ptr[_]] = p.asInstanceOf[Ptr[Ptr[_]]]
-    def sival_ptr_=(value: Ptr[_]): Unit =
-      !p.asInstanceOf[Ptr[Ptr[_]]] = value
+    def sival_ptr: Ptr[CVoidPtr] = p.asInstanceOf[Ptr[CVoidPtr]]
+    def sival_ptr_=(value: CVoidPtr): Unit =
+      !p.asInstanceOf[Ptr[CVoidPtr]] = value
   }
 
   def union_sigval()(implicit z: Zone): Ptr[sigval] = alloc[sigval]()
@@ -415,9 +415,9 @@ object signalOps {
     def sa_mask_=(value: sigset_t): Unit = p._2 = value
     def sa_flags: CInt = p._3
     def sa_flags_=(value: CInt): Unit = p._3 = value
-    def sa_sigaction: CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[_], Unit] = p._4
+    def sa_sigaction: CFuncPtr3[CInt, Ptr[siginfo_t], CVoidPtr, Unit] = p._4
     def sa_sigaction_=(
-        value: CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[_], Unit]
+        value: CFuncPtr3[CInt, Ptr[siginfo_t], CVoidPtr, Unit]
     ): Unit =
       p._4 = value
   }
@@ -427,8 +427,8 @@ object signalOps {
   // mcontext_t - platform specific
 
   implicit class ucontext_t_ops(val p: Ptr[ucontext_t]) extends AnyVal {
-    def uc_link: Ptr[_] = p._1
-    def uc_link_=(value: Ptr[_]): Unit = p._1 = value
+    def uc_link: CVoidPtr = p._1
+    def uc_link_=(value: CVoidPtr): Unit = p._1 = value
     def c_sigmask: sigset_t = p._2
     def c_sigmask_=(value: sigset_t): Unit = p._2 = value
     def uc_stack: Ptr[stack_t] = p._3
@@ -441,8 +441,8 @@ object signalOps {
     alloc[ucontext_t]()
 
   implicit class stack_t_ops(val p: Ptr[stack_t]) extends AnyVal {
-    def ss_sp: Ptr[_] = p._1
-    def ss_sp_=(value: Ptr[_]): Unit = p._1 = value
+    def ss_sp: CVoidPtr = p._1
+    def ss_sp_=(value: CVoidPtr): Unit = p._1 = value
     def ss_size: size_t = p._2
     def ss_size_=(value: size_t): Unit = p._2 = value
     def ss_flags: CInt = p._3
@@ -462,8 +462,8 @@ object signalOps {
     def si_pid_=(value: pid_t): Unit = p._4 = value
     def si_uid: uid_t = p._5
     def si_uid_=(value: uid_t): Unit = p._5 = value
-    def si_addr: Ptr[_] = p._6
-    def si_addr_=(value: Ptr[_]): Unit = p._6 = value
+    def si_addr: CVoidPtr = p._6
+    def si_addr_=(value: CVoidPtr): Unit = p._6 = value
     def si_status: CInt = p._7
     def si_status_=(value: CInt): Unit = p._7 = value
     def si_band: CLong = p._8

--- a/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
@@ -47,7 +47,7 @@ import scala.scalanative.unsafe._
   // Integer or structure type of an object used to represent sets of signals
   // macOS CUnsignedInt
   // Linux CStruct1[CArray[CUnsignedLong, Nat.Digit[Nat._1, Nat._6]]]
-  type sigset_t = Ptr[Byte]
+  type sigset_t = Ptr[_]
 
   type pid_t = types.pid_t
   type pthread_attr_t = types.pthread_attr_t
@@ -164,7 +164,7 @@ import scala.scalanative.unsafe._
                            // of the signal handling func
     CInt,                  // sa_flags Special flags
                            // sa_sigaction Pointer to a signal-catching function
-    CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[Byte], Unit]
+    CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[_], Unit]
   ]
 
 // format: on
@@ -217,17 +217,17 @@ import scala.scalanative.unsafe._
   // A machine-specific representation of the saved context
   // mac OS type mcontext_t = Ptr[__darwin_mcontext64]
   // __darwin_mcontext64 -> _STRUCT_MCONTEXT64 -> typedef _STRUCT_MCONTEXT64	*mcontext_t;
-  type mcontext_t = Ptr[Byte]
+  type mcontext_t = Ptr[_]
 
   type ucontext_t = CStruct4[
-    Ptr[Byte], // ucontext_t *uc_link Ptr to the resumed context when context returns (Ptr[Byte] instead)
+    Ptr[_], // ucontext_t *uc_link Ptr to the resumed context when context returns (Ptr[_] instead)
     sigset_t, // c_sigmask The set of signals that are blocked when this context is active
     Ptr[stack_t], // uc_stack The stack context (Ptr instead of value)
     mcontext_t // uc_mcontext A machine-specific representation of the saved context
   ]
 
   type stack_t = CStruct3[
-    Ptr[Byte], // void *ss_sp Stack base or pointer
+    Ptr[_], // void *ss_sp Stack base or pointer
     size_t, // ss_size Stack size
     CInt // ss_flags Flags
   ]
@@ -238,7 +238,7 @@ import scala.scalanative.unsafe._
     CInt, // si_errno If non-zero, an errno value associated with this signal, as described in <errno.h>
     pid_t, // si_pid Sending process ID
     uid_t, // si_uid Real user ID of sending process
-    Ptr[Byte], // void *si_addr Address of faulting instruction
+    Ptr[_], // void *si_addr Address of faulting instruction
     CInt, // si_status Exit value or signal
     CLong, // si_band Band event for SIGPOLL
     Ptr[sigval] // si_value Signal value (Ptr instead of value)
@@ -401,9 +401,9 @@ object signalOps {
   implicit class sigval_ops(val p: Ptr[sigval]) extends AnyVal {
     def sival_int: Ptr[CInt] = p.asInstanceOf[Ptr[CInt]]
     def sival_int_=(value: CInt): Unit = !p.asInstanceOf[Ptr[CInt]] = value
-    def sival_ptr: Ptr[Ptr[Byte]] = p.asInstanceOf[Ptr[Ptr[Byte]]]
-    def sival_ptr_=(value: Ptr[Byte]): Unit =
-      !p.asInstanceOf[Ptr[Ptr[Byte]]] = value
+    def sival_ptr: Ptr[Ptr[_]] = p.asInstanceOf[Ptr[Ptr[_]]]
+    def sival_ptr_=(value: Ptr[_]): Unit =
+      !p.asInstanceOf[Ptr[Ptr[_]]] = value
   }
 
   def union_sigval()(implicit z: Zone): Ptr[sigval] = alloc[sigval]()
@@ -415,9 +415,9 @@ object signalOps {
     def sa_mask_=(value: sigset_t): Unit = p._2 = value
     def sa_flags: CInt = p._3
     def sa_flags_=(value: CInt): Unit = p._3 = value
-    def sa_sigaction: CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[Byte], Unit] = p._4
+    def sa_sigaction: CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[_], Unit] = p._4
     def sa_sigaction_=(
-        value: CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[Byte], Unit]
+        value: CFuncPtr3[CInt, Ptr[siginfo_t], Ptr[_], Unit]
     ): Unit =
       p._4 = value
   }
@@ -427,22 +427,22 @@ object signalOps {
   // mcontext_t - platform specific
 
   implicit class ucontext_t_ops(val p: Ptr[ucontext_t]) extends AnyVal {
-    def uc_link: Ptr[Byte] = p._1
-    def uc_link_=(value: Ptr[Byte]): Unit = !p._1
+    def uc_link: Ptr[_] = p._1
+    def uc_link_=(value: Ptr[_]): Unit = p._1 = value
     def c_sigmask: sigset_t = p._2
-    def c_sigmask_=(value: sigset_t): Unit = !p._2
+    def c_sigmask_=(value: sigset_t): Unit = p._2 = value
     def uc_stack: Ptr[stack_t] = p._3
-    def uc_stack_=(value: Ptr[stack_t]): Unit = !p._3
+    def uc_stack_=(value: Ptr[stack_t]): Unit = p._3 = value
     def uc_mcontext: mcontext_t = p._4
-    def uc_mcontext_=(value: mcontext_t): Unit = !p._4
+    def uc_mcontext_=(value: mcontext_t): Unit = p._4 = value
   }
 
   def struct_ucontext_t()(implicit z: Zone): Ptr[ucontext_t] =
     alloc[ucontext_t]()
 
   implicit class stack_t_ops(val p: Ptr[stack_t]) extends AnyVal {
-    def ss_sp: Ptr[Byte] = p._1
-    def ss_sp_=(value: Ptr[Byte]): Unit = p._1 = value
+    def ss_sp: Ptr[_] = p._1
+    def ss_sp_=(value: Ptr[_]): Unit = p._1 = value
     def ss_size: size_t = p._2
     def ss_size_=(value: size_t): Unit = p._2 = value
     def ss_flags: CInt = p._3
@@ -462,8 +462,8 @@ object signalOps {
     def si_pid_=(value: pid_t): Unit = p._4 = value
     def si_uid: uid_t = p._5
     def si_uid_=(value: uid_t): Unit = p._5 = value
-    def si_addr: Ptr[Byte] = p._6
-    def si_addr_=(value: Ptr[Byte]): Unit = p._6 = value
+    def si_addr: Ptr[_] = p._6
+    def si_addr_=(value: Ptr[_]): Unit = p._6 = value
     def si_status: CInt = p._7
     def si_status_=(value: CInt): Unit = p._7 = value
     def si_band: CLong = p._8

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
@@ -41,7 +41,7 @@ import scalanative.posix.sys.types, types.{off_t, size_t}
   @blocking def flockfile(filehandle: Ptr[FILE]): Unit = extern
 
   @blocking def fmemopen(
-      buf: Ptr[_],
+      buf: CVoidPtr,
       size: size_t,
       mode: CString
   ): Ptr[FILE] = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
@@ -41,7 +41,7 @@ import scalanative.posix.sys.types, types.{off_t, size_t}
   @blocking def flockfile(filehandle: Ptr[FILE]): Unit = extern
 
   @blocking def fmemopen(
-      buf: Ptr[Byte],
+      buf: Ptr[_],
       size: size_t,
       mode: CString
   ): Ptr[FILE] = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
@@ -86,7 +86,7 @@ import scalanative.posix.sys.types.size_t
 
   /** ADV */
   def posix_memalign(
-      memptr: Ptr[Ptr[_]],
+      memptr: Ptr[CVoidPtr],
       alignment: size_t,
       size: size_t
   ): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
@@ -86,7 +86,7 @@ import scalanative.posix.sys.types.size_t
 
   /** ADV */
   def posix_memalign(
-      memptr: Ptr[Ptr[Byte]],
+      memptr: Ptr[Ptr[_]],
       alignment: size_t,
       size: size_t
   ): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/string.scala
@@ -28,14 +28,14 @@ import scala.scalanative.posix.sys.types
   type locale_t = locale.locale_t
 
   /** XSI */
-  def memccpy(dest: Ptr[_], src: Ptr[_], c: CInt, n: size_t): Ptr[_] =
+  def memccpy(dest: CVoidPtr, src: CVoidPtr, c: CInt, n: size_t): CVoidPtr =
     extern
 
   /** CX */
-  def stpcpy(dest: CString, src: CString): Ptr[_] = extern
+  def stpcpy(dest: CString, src: CString): CVoidPtr = extern
 
   /** CX */
-  def stpncpy(dest: CString, src: CString, n: size_t): Ptr[_] = extern
+  def stpncpy(dest: CString, src: CString, n: size_t): CVoidPtr = extern
 
   def stroll(s1: CString, s2: CString): CInt = extern
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/string.scala
@@ -28,14 +28,14 @@ import scala.scalanative.posix.sys.types
   type locale_t = locale.locale_t
 
   /** XSI */
-  def memccpy(dest: Ptr[Byte], src: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] =
+  def memccpy(dest: Ptr[_], src: Ptr[_], c: CInt, n: size_t): Ptr[_] =
     extern
 
   /** CX */
-  def stpcpy(dest: Ptr[Byte], src: String): Ptr[Byte] = extern
+  def stpcpy(dest: CString, src: CString): Ptr[_] = extern
 
   /** CX */
-  def stpncpy(dest: Ptr[Byte], src: String, n: size_t): Ptr[Byte] = extern
+  def stpncpy(dest: CString, src: CString, n: size_t): Ptr[_] = extern
 
   def stroll(s1: CString, s2: CString): CInt = extern
 
@@ -63,13 +63,13 @@ import scala.scalanative.posix.sys.types
   def strsignal(signum: CInt): CString = extern
 
   /** CX */
-  def strtok_r(str: CString, delim: CString, saveptr: Ptr[Ptr[Byte]]): CString =
+  def strtok_r(str: CString, delim: CString, saveptr: Ptr[CString]): CString =
     extern
 
   /** CX */
   def strxfrm_l(
-      dest: Ptr[Byte],
-      src: Ptr[Byte],
+      dest: CString,
+      src: CString,
       n: size_t,
       locale: locale_t
   ): size_t = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
@@ -9,7 +9,7 @@ import scala.scalanative.posix.sys.types._
 @extern
 object mman {
   def mmap(
-      addr: Ptr[_],
+      addr: CVoidPtr,
       length: size_t,
       prot: CInt,
       flags: CInt,
@@ -17,10 +17,10 @@ object mman {
       offset: off_t
   ): Ptr[Byte] = extern
 
-  def munmap(addr: Ptr[_], length: size_t): CInt = extern
+  def munmap(addr: CVoidPtr, length: size_t): CInt = extern
 
   @blocking
-  def msync(addr: Ptr[_], length: size_t, flags: CInt): CInt = extern
+  def msync(addr: CVoidPtr, length: size_t, flags: CInt): CInt = extern
 
   @name("scalanative_prot_exec")
   def PROT_EXEC: CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -307,7 +307,7 @@ object socket {
       socket: CInt,
       level: CInt,
       option_name: CInt,
-      options_value: Ptr[Byte],
+      options_value: Ptr[_],
       option_len: Ptr[socklen_t]
   ): CInt = extern
 
@@ -316,7 +316,7 @@ object socket {
   @blocking
   def recv(
       socket: CInt,
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       length: CSize,
       flags: CInt
   ): CSSize = extern
@@ -324,7 +324,7 @@ object socket {
   @blocking
   def recvfrom(
       socket: CInt,
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       length: CSize,
       flags: CInt,
       dest_addr: Ptr[sockaddr],
@@ -343,7 +343,7 @@ object socket {
   @blocking
   def send(
       socket: CInt,
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       length: CSize,
       flags: CInt
   ): CSSize = extern
@@ -360,7 +360,7 @@ object socket {
   @blocking
   def sendto(
       socket: CInt,
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       length: CSize,
       flags: CInt,
       dest_addr: Ptr[sockaddr],
@@ -371,7 +371,7 @@ object socket {
       socket: CInt,
       level: CInt,
       option_name: CInt,
-      options_value: Ptr[Byte],
+      options_value: Ptr[_],
       option_len: socklen_t
   ): CInt = extern
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -307,7 +307,7 @@ object socket {
       socket: CInt,
       level: CInt,
       option_name: CInt,
-      options_value: Ptr[_],
+      options_value: CVoidPtr,
       option_len: Ptr[socklen_t]
   ): CInt = extern
 
@@ -316,7 +316,7 @@ object socket {
   @blocking
   def recv(
       socket: CInt,
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       length: CSize,
       flags: CInt
   ): CSSize = extern
@@ -324,7 +324,7 @@ object socket {
   @blocking
   def recvfrom(
       socket: CInt,
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       length: CSize,
       flags: CInt,
       dest_addr: Ptr[sockaddr],
@@ -343,7 +343,7 @@ object socket {
   @blocking
   def send(
       socket: CInt,
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       length: CSize,
       flags: CInt
   ): CSSize = extern
@@ -360,7 +360,7 @@ object socket {
   @blocking
   def sendto(
       socket: CInt,
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       length: CSize,
       flags: CInt,
       dest_addr: Ptr[sockaddr],
@@ -371,7 +371,7 @@ object socket {
       socket: CInt,
       level: CInt,
       option_name: CInt,
-      options_value: Ptr[_],
+      options_value: CVoidPtr,
       option_len: socklen_t
   ): CInt = extern
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -141,14 +141,14 @@ object unistd {
   def pause(): CInt = extern
   def pipe(fildes: Ptr[CInt]): CInt = extern
   @blocking
-  def pread(fd: CInt, buf: Ptr[_], count: size_t, offset: off_t): ssize_t =
+  def pread(fd: CInt, buf: CVoidPtr, count: size_t, offset: off_t): ssize_t =
     extern
   @blocking
-  def pwrite(fd: CInt, buf: Ptr[_], count: size_t, offset: off_t): ssize_t =
+  def pwrite(fd: CInt, buf: CVoidPtr, count: size_t, offset: off_t): ssize_t =
     extern
 
   @blocking
-  def read(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
+  def read(fildes: CInt, buf: CVoidPtr, nbyte: CSize): CInt = extern
   def readlink(path: CString, buf: CString, bufsize: CSize): CInt = extern
   def readlinkat(
       dirfd: CInt,
@@ -175,7 +175,7 @@ object unistd {
   def sleep(seconds: CUnsignedInt): CUnsignedInt = extern
 
 // XSI
-  def swab(from: Ptr[_], to: Ptr[_], n: ssize_t): Unit = extern
+  def swab(from: CVoidPtr, to: CVoidPtr, n: ssize_t): Unit = extern
 
   def symlink(path1: CString, path2: CString): CInt = extern
   def symlinkat(path1: CString, fd: CInt, path2: CString): CInt = extern
@@ -214,7 +214,7 @@ object unistd {
   )
   def vfork(): CInt = extern
 
-  @blocking def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
+  @blocking def write(fildes: CInt, buf: CVoidPtr, nbyte: CSize): CInt = extern
 
 // Symbolic constants
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -141,10 +141,10 @@ object unistd {
   def pause(): CInt = extern
   def pipe(fildes: Ptr[CInt]): CInt = extern
   @blocking
-  def pread(fd: CInt, buf: Ptr[Byte], count: size_t, offset: off_t): ssize_t =
+  def pread(fd: CInt, buf: Ptr[_], count: size_t, offset: off_t): ssize_t =
     extern
   @blocking
-  def pwrite(fd: CInt, buf: Ptr[Byte], count: size_t, offset: off_t): ssize_t =
+  def pwrite(fd: CInt, buf: Ptr[_], count: size_t, offset: off_t): ssize_t =
     extern
 
   @blocking
@@ -175,7 +175,7 @@ object unistd {
   def sleep(seconds: CUnsignedInt): CUnsignedInt = extern
 
 // XSI
-  def swab(from: Ptr[Byte], to: Ptr[Byte], n: ssize_t): Unit = extern
+  def swab(from: Ptr[_], to: Ptr[_], n: ssize_t): Unit = extern
 
   def symlink(path1: CString, path2: CString): CInt = extern
   def symlinkat(path1: CString, fd: CInt, path2: CString): CInt = extern

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -22,7 +22,7 @@ object ScalaVersions {
   val crossScala213 = (8 to 12).map(v => s"2.13.$v")
   val crossScala3 = List(
     // Bug in compiler leads to errors in tests, don't use it as default until RC2
-    Seq("3.4.0-RC1"),
+    Seq("3.4.0-RC2"),
     // windowslib fails to compile with 3.1.{0-1}
     (2 to 3).map(v => s"3.1.$v"),
     (0 to 2).map(v => s"3.2.$v"),

--- a/tools/src/test/scala/scala/scalanative/optimizer/StackallocStateRestoreTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/StackallocStateRestoreTest.scala
@@ -299,7 +299,7 @@ class StackallocStateRestoreTest extends OptimizerSpec {
           |}
           |
           |object CList {
-          |  type Node = CStruct2[Int, Ptr[_]]
+          |  type Node = CStruct2[Int, CVoidPtr]
           |
           |  implicit class NodeOps(val self: Ptr[Node]) extends AnyVal {
           |    def init(value: Int, next: Ptr[Node]) = {
@@ -357,7 +357,7 @@ class StackallocStateRestoreTest extends OptimizerSpec {
           |}
           |
           |object CList {
-          |  type Node = CStruct2[Int, Ptr[_]]
+          |  type Node = CStruct2[Int, CVoidPtr]
           |
           |  implicit class NodeOps(val self: Ptr[Node]) extends AnyVal {
           |    def init(value: Int, next: Ptr[Node]) = {
@@ -420,7 +420,7 @@ class StackallocStateRestoreTest extends OptimizerSpec {
           |}
           |
           |object CList {
-          |  type Node = CStruct2[Int, Ptr[_]]
+          |  type Node = CStruct2[Int, CVoidPtr]
           |
           |  implicit class NodeOps(val self: Ptr[Node]) extends AnyVal {
           |    def init(value: Int, next: Ptr[Node]) = {

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrOpsTest.scala
@@ -35,7 +35,7 @@ class PtrOpsTest {
   val fn0: CFuncPtr0[CInt] = () => 1
 
   @Test def castsPtrByteToCFuncPtr(): Unit = {
-    val fnPtr: Ptr[Byte] = CFuncPtr.toPtr(fn0)
+    val fnPtr: Ptr[_] = CFuncPtr.toPtr(fn0)
     val fnFromPtr = CFuncPtr.fromPtr[CFuncPtr0[CInt]](fnPtr)
     val expectedResult = 1
 
@@ -47,7 +47,7 @@ class PtrOpsTest {
 
   @Test def castedCFuncPtrHandlesArguments(): Unit = {
     type Add1Fn = CFuncPtr1[Int, Int]
-    val ptr: Ptr[Byte] = CFuncPtr.toPtr(fn1)
+    val ptr: Ptr[_] = CFuncPtr.toPtr(fn1)
     val fnFromPtr = CFuncPtr.fromPtr[CFuncPtr1[Int, Int]](ptr)
     val aliasedFn = CFuncPtr.fromPtr[Add1Fn](ptr)
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
@@ -161,10 +161,10 @@ object FileApi {
   @blocking
   def ReadFile(
       fileHandle: Handle,
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       bytesToRead: DWord,
       bytesReadPtr: Ptr[DWord],
-      overlapped: Ptr[_]
+      overlapped: CVoidPtr
   ): Boolean = extern
 
   def RemoveDirectoryW(filename: CWString): Boolean = extern
@@ -189,10 +189,10 @@ object FileApi {
 
   @blocking def WriteFile(
       fileHandle: Handle,
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       bytesToRead: DWord,
       bytesWritten: Ptr[DWord],
-      overlapped: Ptr[_]
+      overlapped: CVoidPtr
   ): Boolean = extern
 
   def LockFile(

--- a/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
@@ -161,10 +161,10 @@ object FileApi {
   @blocking
   def ReadFile(
       fileHandle: Handle,
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       bytesToRead: DWord,
       bytesReadPtr: Ptr[DWord],
-      overlapped: Ptr[Byte]
+      overlapped: Ptr[_]
   ): Boolean = extern
 
   def RemoveDirectoryW(filename: CWString): Boolean = extern
@@ -189,10 +189,10 @@ object FileApi {
 
   @blocking def WriteFile(
       fileHandle: Handle,
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       bytesToRead: DWord,
       bytesWritten: Ptr[DWord],
-      overlapped: Ptr[Byte]
+      overlapped: Ptr[_]
   ): Boolean = extern
 
   def LockFile(

--- a/windowslib/src/main/scala/scala/scalanative/windows/HandleApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/HandleApi.scala
@@ -8,7 +8,7 @@ import scala.scalanative.windows.HandleApi.Handle
 
 @extern
 object HandleApi {
-  type Handle = Ptr[Byte]
+  type Handle = Ptr[_]
 
   @blocking
   def CloseHandle(handle: Handle): Boolean = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/HandleApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/HandleApi.scala
@@ -8,7 +8,7 @@ import scala.scalanative.windows.HandleApi.Handle
 
 @extern
 object HandleApi {
-  type Handle = Ptr[_]
+  type Handle = CVoidPtr
 
   @blocking
   def CloseHandle(handle: Handle): Boolean = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
@@ -14,11 +14,11 @@ object MemoryApi {
       dwNumberOfBytesToMap: CSize
   ): Ptr[Byte] = extern
 
-  def UnmapViewOfFile(lpBaseAddress: Ptr[_]): Boolean = extern
+  def UnmapViewOfFile(lpBaseAddress: CVoidPtr): Boolean = extern
 
   @blocking
   def FlushViewOfFile(
-      lpBaseAddress: Ptr[_],
+      lpBaseAddress: CVoidPtr,
       dwNumberOfBytesToFlush: DWord
   ): Boolean = extern
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
@@ -14,11 +14,11 @@ object MemoryApi {
       dwNumberOfBytesToMap: CSize
   ): Ptr[Byte] = extern
 
-  def UnmapViewOfFile(lpBaseAddress: Ptr[Byte]): Boolean = extern
+  def UnmapViewOfFile(lpBaseAddress: Ptr[_]): Boolean = extern
 
   @blocking
   def FlushViewOfFile(
-      lpBaseAddress: Ptr[Byte],
+      lpBaseAddress: Ptr[_],
       dwNumberOfBytesToFlush: DWord
   ): Boolean = extern
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/NamedPipeApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/NamedPipeApi.scala
@@ -15,7 +15,7 @@ object NamedPipeApi {
 
   def PeekNamedPipe(
       pipe: Handle,
-      buffer: Ptr[_],
+      buffer: CVoidPtr,
       bufferSize: DWord,
       bytesRead: Ptr[DWord],
       totalBytesAvailable: Ptr[DWord],

--- a/windowslib/src/main/scala/scala/scalanative/windows/NamedPipeApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/NamedPipeApi.scala
@@ -15,7 +15,7 @@ object NamedPipeApi {
 
   def PeekNamedPipe(
       pipe: Handle,
-      buffer: Ptr[Byte],
+      buffer: Ptr[_],
       bufferSize: DWord,
       bytesRead: Ptr[DWord],
       totalBytesAvailable: Ptr[DWord],

--- a/windowslib/src/main/scala/scala/scalanative/windows/ProcessThreadsApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ProcessThreadsApi.scala
@@ -24,7 +24,7 @@ object ProcessThreadsApi {
     DWord,
     Word,
     Word,
-    Ptr[Byte],
+    Ptr[_],
     Handle,
     Handle,
     Handle
@@ -38,7 +38,7 @@ object ProcessThreadsApi {
       threadAttributes: Ptr[SecurityAttributes],
       inheritHandle: Boolean,
       creationFlags: DWord,
-      environment: Ptr[Byte],
+      environment: Ptr[_],
       currentDirectory: CWString,
       startupInfo: Ptr[StartupInfoW],
       processInformation: Ptr[ProcessInformation]
@@ -156,7 +156,7 @@ object ProcessThreadsApiOps {
     def flags: DWord = ref._12
     def showWindow: Word = ref._13
     def cbReserved2: Word = ref._14
-    def lpReserved2: Ptr[Byte] = ref._15
+    def lpReserved2: Ptr[_] = ref._15
     def stdInput: Handle = ref._16
     def stdOutput: Handle = ref._17
     def stdError: Handle = ref._18
@@ -175,7 +175,7 @@ object ProcessThreadsApiOps {
     def flags_=(v: DWord): Unit = ref._12 = v
     def showWindow_=(v: Word): Unit = ref._13 = v
     def cbReserved2_=(v: Word): Unit = ref._14 = v
-    def lpReserved2_=(v: Ptr[Byte]): Unit = ref._15 = v
+    def lpReserved2_=(v: Ptr[_]): Unit = ref._15 = v
     def stdInput_=(v: Handle): Unit = ref._16 = v
     def stdOutput_=(v: Handle): Unit = ref._17 = v
     def stdError_=(v: Handle): Unit = ref._18 = v

--- a/windowslib/src/main/scala/scala/scalanative/windows/ProcessThreadsApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ProcessThreadsApi.scala
@@ -24,7 +24,7 @@ object ProcessThreadsApi {
     DWord,
     Word,
     Word,
-    Ptr[_],
+    CVoidPtr,
     Handle,
     Handle,
     Handle
@@ -38,7 +38,7 @@ object ProcessThreadsApi {
       threadAttributes: Ptr[SecurityAttributes],
       inheritHandle: Boolean,
       creationFlags: DWord,
-      environment: Ptr[_],
+      environment: CVoidPtr,
       currentDirectory: CWString,
       startupInfo: Ptr[StartupInfoW],
       processInformation: Ptr[ProcessInformation]
@@ -156,7 +156,7 @@ object ProcessThreadsApiOps {
     def flags: DWord = ref._12
     def showWindow: Word = ref._13
     def cbReserved2: Word = ref._14
-    def lpReserved2: Ptr[_] = ref._15
+    def lpReserved2: CVoidPtr = ref._15
     def stdInput: Handle = ref._16
     def stdOutput: Handle = ref._17
     def stdError: Handle = ref._18
@@ -175,7 +175,7 @@ object ProcessThreadsApiOps {
     def flags_=(v: DWord): Unit = ref._12 = v
     def showWindow_=(v: Word): Unit = ref._13 = v
     def cbReserved2_=(v: Word): Unit = ref._14 = v
-    def lpReserved2_=(v: Ptr[_]): Unit = ref._15 = v
+    def lpReserved2_=(v: CVoidPtr): Unit = ref._15 = v
     def stdInput_=(v: Handle): Unit = ref._16 = v
     def stdOutput_=(v: Handle): Unit = ref._17 = v
     def stdError_=(v: Handle): Unit = ref._18 = v

--- a/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
@@ -24,9 +24,9 @@ object SecurityBaseApi {
   type GenericMapping = CStruct4[AccessMask, AccessMask, AccessMask, AccessMask]
 
   // Internal Windows structures, might have variable size and should not be modifed by the user
-  type SIDPtr = Ptr[Byte]
-  type ACLPtr = Ptr[Byte]
-  type PrivilegeSetPtr = Ptr[Byte]
+  type SIDPtr = Ptr[_]
+  type ACLPtr = Ptr[_]
+  type PrivilegeSetPtr = Ptr[_]
 
   def AccessCheck(
       securityDescriptor: Ptr[SecurityDescriptor],
@@ -46,11 +46,11 @@ object SecurityBaseApi {
       duplicateTokenHandle: Ptr[Handle]
   ): Boolean = extern
 
-  def FreeSid(sid: SIDPtr): Ptr[Byte] = extern
+  def FreeSid(sid: SIDPtr): Ptr[_] = extern
   def GetTokenInformation(
       handle: Handle,
       informationClass: TokenInformationClass,
-      information: Ptr[Byte],
+      information: Ptr[_],
       informationLength: DWord,
       returnLength: Ptr[DWord]
   ): Boolean = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
@@ -24,9 +24,9 @@ object SecurityBaseApi {
   type GenericMapping = CStruct4[AccessMask, AccessMask, AccessMask, AccessMask]
 
   // Internal Windows structures, might have variable size and should not be modifed by the user
-  type SIDPtr = Ptr[_]
-  type ACLPtr = Ptr[_]
-  type PrivilegeSetPtr = Ptr[_]
+  type SIDPtr = CVoidPtr
+  type ACLPtr = CVoidPtr
+  type PrivilegeSetPtr = CVoidPtr
 
   def AccessCheck(
       securityDescriptor: Ptr[SecurityDescriptor],
@@ -46,11 +46,11 @@ object SecurityBaseApi {
       duplicateTokenHandle: Ptr[Handle]
   ): Boolean = extern
 
-  def FreeSid(sid: SIDPtr): Ptr[_] = extern
+  def FreeSid(sid: SIDPtr): CVoidPtr = extern
   def GetTokenInformation(
       handle: Handle,
       informationClass: TokenInformationClass,
-      information: Ptr[_],
+      information: CVoidPtr,
       informationLength: DWord,
       returnLength: Ptr[DWord]
   ): Boolean = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/SynchApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SynchApi.scala
@@ -7,8 +7,8 @@ import HandleApi.Handle
 
 @extern
 object SynchApi {
-  type CriticalSection = Ptr[_]
-  type ConditionVariable = Ptr[_]
+  type CriticalSection = CVoidPtr
+  type ConditionVariable = CVoidPtr
 
   @name("scalanative_sizeof_CriticalSection")
   def SizeOfCriticalSection: CSize = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/SynchApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SynchApi.scala
@@ -7,8 +7,8 @@ import HandleApi.Handle
 
 @extern
 object SynchApi {
-  type CriticalSection = Ptr[Byte]
-  type ConditionVariable = Ptr[Byte]
+  type CriticalSection = Ptr[_]
+  type ConditionVariable = Ptr[_]
 
   @name("scalanative_sizeof_CriticalSection")
   def SizeOfCriticalSection: CSize = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/SysInfoApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SysInfoApi.scala
@@ -9,8 +9,8 @@ object SysInfoApi {
   type SystemInfo = CStruct10[
     DWord, // oemId
     DWord, // pagesSize
-    Ptr[_], // minimum application address
-    Ptr[_], // max application address
+    CVoidPtr, // minimum application address
+    CVoidPtr, // max application address
     Ptr[DWord], // active processors mask
     DWord, // number of processors
     DWord, // processor type
@@ -33,8 +33,8 @@ object SysInfoApiOps {
   implicit class SystemInfoOps(val ref: Ptr[SystemInfo]) extends AnyVal {
     def oemId: DWord = ref._1
     def pagesSize: DWord = ref._2
-    def minimumApplicationAddress: Ptr[_] = ref._3
-    def maximalApplicationAddress: Ptr[_] = ref._4
+    def minimumApplicationAddress: CVoidPtr = ref._3
+    def maximalApplicationAddress: CVoidPtr = ref._4
     def activeProcessorsMask: Ptr[DWord] = ref._5
     def numberOfProcessors: DWord = ref._6
     def processorType: DWord = ref._7

--- a/windowslib/src/main/scala/scala/scalanative/windows/SysInfoApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SysInfoApi.scala
@@ -9,8 +9,8 @@ object SysInfoApi {
   type SystemInfo = CStruct10[
     DWord, // oemId
     DWord, // pagesSize
-    Ptr[Byte], // minimum application address
-    Ptr[Byte], // max application address
+    Ptr[_], // minimum application address
+    Ptr[_], // max application address
     Ptr[DWord], // active processors mask
     DWord, // number of processors
     DWord, // processor type
@@ -33,8 +33,8 @@ object SysInfoApiOps {
   implicit class SystemInfoOps(val ref: Ptr[SystemInfo]) extends AnyVal {
     def oemId: DWord = ref._1
     def pagesSize: DWord = ref._2
-    def minimumApplicationAddress: Ptr[Byte] = ref._3
-    def maximalApplicationAddress: Ptr[Byte] = ref._4
+    def minimumApplicationAddress: Ptr[_] = ref._3
+    def maximalApplicationAddress: Ptr[_] = ref._4
     def activeProcessorsMask: Ptr[DWord] = ref._5
     def numberOfProcessors: DWord = ref._6
     def processorType: DWord = ref._7

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -11,10 +11,10 @@ object WinBaseApi {
   import SecurityBaseApi._
 
   type SecurityInformation = DWord
-  type SecurityAttributes = CStruct3[DWord, Ptr[_], Boolean]
-  type CallbackContext = Ptr[_]
+  type SecurityAttributes = CStruct3[DWord, CVoidPtr, Boolean]
+  type CallbackContext = CVoidPtr
   type WaitOrTimerCallback = CFuncPtr2[CallbackContext, Boolean, Unit]
-  type LocalHandle = Ptr[_]
+  type LocalHandle = CVoidPtr
 
   def CreateHardLinkW(
       linkFileName: CWString,
@@ -29,7 +29,7 @@ object WinBaseApi {
   ): Boolean = extern
   def FormatMessageA(
       flags: DWord,
-      source: Ptr[_],
+      source: CVoidPtr,
       messageId: DWord,
       languageId: DWord,
       buffer: Ptr[CWString],
@@ -39,7 +39,7 @@ object WinBaseApi {
 
   def FormatMessageW(
       flags: DWord,
-      source: Ptr[_],
+      source: CVoidPtr,
       messageId: DWord,
       languageId: DWord,
       buffer: Ptr[CWString],
@@ -111,7 +111,7 @@ object WinBaseApi {
       retHandle: Ptr[Handle],
       ref: Handle,
       callbackFn: WaitOrTimerCallback,
-      context: Ptr[_],
+      context: CVoidPtr,
       miliseconds: DWord,
       flags: DWord
   ): Boolean = extern
@@ -195,11 +195,11 @@ object WinBaseApiOps {
   implicit class SecurityAttributesOps(val ref: Ptr[SecurityAttributes])
       extends AnyVal {
     def length: DWord = ref._1
-    def securityDescriptor: Ptr[_] = ref._2
+    def securityDescriptor: CVoidPtr = ref._2
     def inheritHandle: Boolean = ref._3
 
     def length_=(v: DWord): Unit = ref._1 = v
-    def securityDescriptor_=(v: Ptr[_]): Unit = ref._2 = v
+    def securityDescriptor_=(v: CVoidPtr): Unit = ref._2 = v
     def inheritHandle_=(v: Boolean): Unit = ref._3 = v
   }
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -11,8 +11,8 @@ object WinBaseApi {
   import SecurityBaseApi._
 
   type SecurityInformation = DWord
-  type SecurityAttributes = CStruct3[DWord, Ptr[Byte], Boolean]
-  type CallbackContext = Ptr[Byte]
+  type SecurityAttributes = CStruct3[DWord, Ptr[_], Boolean]
+  type CallbackContext = Ptr[_]
   type WaitOrTimerCallback = CFuncPtr2[CallbackContext, Boolean, Unit]
   type LocalHandle = Ptr[_]
 
@@ -29,7 +29,7 @@ object WinBaseApi {
   ): Boolean = extern
   def FormatMessageA(
       flags: DWord,
-      source: Ptr[Byte],
+      source: Ptr[_],
       messageId: DWord,
       languageId: DWord,
       buffer: Ptr[CWString],
@@ -39,7 +39,7 @@ object WinBaseApi {
 
   def FormatMessageW(
       flags: DWord,
-      source: Ptr[Byte],
+      source: Ptr[_],
       messageId: DWord,
       languageId: DWord,
       buffer: Ptr[CWString],
@@ -111,7 +111,7 @@ object WinBaseApi {
       retHandle: Ptr[Handle],
       ref: Handle,
       callbackFn: WaitOrTimerCallback,
-      context: Ptr[Byte],
+      context: Ptr[_],
       miliseconds: DWord,
       flags: DWord
   ): Boolean = extern
@@ -195,11 +195,11 @@ object WinBaseApiOps {
   implicit class SecurityAttributesOps(val ref: Ptr[SecurityAttributes])
       extends AnyVal {
     def length: DWord = ref._1
-    def securityDescriptor: Ptr[Byte] = ref._2
+    def securityDescriptor: Ptr[_] = ref._2
     def inheritHandle: Boolean = ref._3
 
     def length_=(v: DWord): Unit = ref._1 = v
-    def securityDescriptor_=(v: Ptr[Byte]): Unit = ref._2 = v
+    def securityDescriptor_=(v: Ptr[_]): Unit = ref._2 = v
     def inheritHandle_=(v: Boolean): Unit = ref._3 = v
   }
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
@@ -8,9 +8,9 @@ import scalanative.windows.{Word => WinWord}
 @extern
 object WinSocketApi {
 
-  type Socket = Ptr[_]
+  type Socket = CVoidPtr
   type Group = DWord
-  type WSAProtocolInfoW = Ptr[_]
+  type WSAProtocolInfoW = CVoidPtr
   type WSAPollFd = CStruct3[Socket, CShort, CShort]
   // This structures contains additional 5 fields with different order in Win_64 and others
   // Should only be treated as read-only and never allocated in ScalaNative.

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
@@ -8,9 +8,9 @@ import scalanative.windows.{Word => WinWord}
 @extern
 object WinSocketApi {
 
-  type Socket = Ptr[Byte]
+  type Socket = Ptr[_]
   type Group = DWord
-  type WSAProtocolInfoW = Ptr[Byte]
+  type WSAProtocolInfoW = Ptr[_]
   type WSAPollFd = CStruct3[Socket, CShort, CShort]
   // This structures contains additional 5 fields with different order in Win_64 and others
   // Should only be treated as read-only and never allocated in ScalaNative.

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/ops.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/ops.scala
@@ -34,20 +34,20 @@ object ops {
       ref._5.asInstanceOf[Ptr[ObjectsAndNameW]]
 
     def multipleTrustee_=(v: Ptr[TrusteeW]): Unit = {
-      ref._1 = v.asInstanceOf[Ptr[Byte]]
+      ref._1 = v.asInstanceOf[Ptr[_]]
     }
     def multipleTrusteeOperation_=(v: MultipleTruteeOperation): Unit = {
       ref._2 = v
     }
     def trusteeForm_=(v: TrusteeForm): Unit = { ref._3 = v }
     def trusteeType_=(v: TrusteeType): Unit = { ref._4 = v }
-    def strName_=(v: CWString): Unit = { ref._5 = v.asInstanceOf[Ptr[Byte]] }
-    def sid_=(v: SIDPtr): Unit = { ref._5 = v.asInstanceOf[Ptr[Byte]] }
+    def strName_=(v: CWString): Unit = { ref._5 = v.asInstanceOf[Ptr[_]] }
+    def sid_=(v: SIDPtr): Unit = { ref._5 = v.asInstanceOf[Ptr[_]] }
     def objectsAndSid_=(v: Ptr[ObjectsAndSid]): Unit = {
-      ref._5 = v.asInstanceOf[Ptr[Byte]]
+      ref._5 = v.asInstanceOf[Ptr[_]]
     }
     def objectsAndName_=(v: Ptr[ObjectsAndNameW]): Unit = {
-      ref._5 = v.asInstanceOf[Ptr[Byte]]
+      ref._5 = v.asInstanceOf[Ptr[_]]
     }
   }
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/ops.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/ops.scala
@@ -34,20 +34,20 @@ object ops {
       ref._5.asInstanceOf[Ptr[ObjectsAndNameW]]
 
     def multipleTrustee_=(v: Ptr[TrusteeW]): Unit = {
-      ref._1 = v.asInstanceOf[Ptr[_]]
+      ref._1 = v.asInstanceOf[CVoidPtr]
     }
     def multipleTrusteeOperation_=(v: MultipleTruteeOperation): Unit = {
       ref._2 = v
     }
     def trusteeForm_=(v: TrusteeForm): Unit = { ref._3 = v }
     def trusteeType_=(v: TrusteeType): Unit = { ref._4 = v }
-    def strName_=(v: CWString): Unit = { ref._5 = v.asInstanceOf[Ptr[_]] }
-    def sid_=(v: SIDPtr): Unit = { ref._5 = v.asInstanceOf[Ptr[_]] }
+    def strName_=(v: CWString): Unit = { ref._5 = v.asInstanceOf[CVoidPtr] }
+    def sid_=(v: SIDPtr): Unit = { ref._5 = v.asInstanceOf[CVoidPtr] }
     def objectsAndSid_=(v: Ptr[ObjectsAndSid]): Unit = {
-      ref._5 = v.asInstanceOf[Ptr[_]]
+      ref._5 = v.asInstanceOf[CVoidPtr]
     }
     def objectsAndName_=(v: Ptr[ObjectsAndNameW]): Unit = {
-      ref._5 = v.asInstanceOf[Ptr[_]]
+      ref._5 = v.asInstanceOf[CVoidPtr]
     }
   }
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/package.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/package.scala
@@ -15,11 +15,11 @@ package object accctrl {
   type ObjectsPresent = DWord
   type ExplicitAccessW = CStruct4[DWord, AccessMode, DWord, TrusteeW]
   type TrusteeW = CStruct6[
-    Ptr[Byte],
+    Ptr[_],
     MultipleTruteeOperation,
     TrusteeForm,
     TrusteeType,
-    Ptr[Byte],
+    Ptr[_],
     CWString
   ]
   type GUID = CStruct4[UInt, UShort, UShort, CArray[UByte, Nat._8]]

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/package.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/package.scala
@@ -15,11 +15,11 @@ package object accctrl {
   type ObjectsPresent = DWord
   type ExplicitAccessW = CStruct4[DWord, AccessMode, DWord, TrusteeW]
   type TrusteeW = CStruct6[
-    Ptr[_],
+    CVoidPtr,
     MultipleTruteeOperation,
     TrusteeForm,
     TrusteeType,
-    Ptr[_],
+    CVoidPtr,
     CWString
   ]
   type GUID = CStruct4[UInt, UShort, UShort, CArray[UByte, Nat._8]]


### PR DESCRIPTION
Typically consumers of opaque inputs (void* in C) are good candidates for using Ptr[_]. This allows for better DX allowing to skip redundant .asInstanceOf[Ptr[Byte]] conversion. 
Allocators `malloc`, `calloc` are still returniong `Ptr[Byte]` becouse it's literally what they do - these function return pointer to first byte of allocated area.