### PR TITLE
fix: Generate bridges for inherited trait methods with narrowed types

### DIFF
--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -648,7 +648,7 @@ class IssuesTest {
     }
 
     object Names {
-      def single[T <: Named](t: T): Names = Names(List(t))
+      def single[T <: Named](t: T): Names = new Names(List(t))
     }
 
     // Test

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -632,6 +632,29 @@ class IssuesTest {
     assertNotNull(xs.sortBy(i => -i))
   }
 
+  @Test def dottyIssue15402(): Unit = {
+    trait Named {
+      def name: String
+      def me: Named
+    }
+    trait Foo extends Named {
+      def name = "foo"
+      def me: Foo = this
+      def foo(x: String): String
+    }
+
+    class Names(xs: List[Named]) {
+      def mkString = xs.iterator.map(_.me.name).mkString(",")
+    }
+
+    object Names {
+      def single[T <: Named](t: T): Names = Names(List(t))
+    }
+
+    // Test
+    val names = Names.single[Foo](x => x)
+    assertEquals("foo", names.mkString)
+  }
 }
 
 package issue1090 {


### PR DESCRIPTION
This PR is temporal fix for Scala 3 until https://github.com/lampepfl/dotty/issues/15402 is resolved