### PR TITLE
Fix #3754: javalib ZipOutputStream#finish can now finish twice in a row

### DIFF
--- a/javalib/src/main/scala/java/util/zip/InflaterInputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/InflaterInputStream.scala
@@ -40,7 +40,7 @@ class InflaterInputStream private (
 
   override def read(buffer: Array[Byte], off: Int, nbytes: Int): Int = {
     if (closed) {
-      throw new IOException("Stream is closed")
+      throw new IOException("Stream closed")
     }
 
     if (null == buffer) {
@@ -102,7 +102,7 @@ class InflaterInputStream private (
 
   protected def fill(): Unit = {
     if (closed) {
-      throw new IOException("Stream is closed")
+      throw new IOException("Stream closed")
     } else if ({ len = in.read(buf); len > 0 }) {
       inf.setInput(buf, 0, len)
     }
@@ -136,7 +136,7 @@ class InflaterInputStream private (
 
   override def available(): Int = {
     if (closed) {
-      throw new IOException("Stream is closed")
+      throw new IOException("Stream closed")
     } else if (eof) {
       0
     } else {

--- a/javalib/src/main/scala/java/util/zip/ZipInputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipInputStream.scala
@@ -41,7 +41,7 @@ class ZipInputStream(_in: InputStream, charset: Charset)
 
   def closeEntry(): Unit = {
     if (closed) {
-      throw new IOException("Stream is closed")
+      throw new IOException("Stream closed")
     }
     if (currentEntry == null) {
       return
@@ -239,7 +239,7 @@ class ZipInputStream(_in: InputStream, charset: Charset)
 
   override def read(buffer: Array[Byte], start: Int, length: Int): Int = {
     if (closed) {
-      throw new IOException("Stream is closed")
+      throw new IOException("Stream closed")
     }
     if (inf.finished() || currentEntry == null) {
       return -1
@@ -317,7 +317,7 @@ class ZipInputStream(_in: InputStream, charset: Charset)
 
   override def available(): Int = {
     if (closed) {
-      throw new IOException("Stream is closed")
+      throw new IOException("Stream closed")
     } else if (currentEntry == null || inRead < currentEntry.size) {
       1
     } else {

--- a/javalib/src/main/scala/java/util/zip/ZipOutputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipOutputStream.scala
@@ -124,7 +124,7 @@ class ZipOutputStream(_out: OutputStream, charset: Charset)
 
   override def finish(): Unit = {
     if (out == null)
-      throw new IOException("Stream is closed")
+      throw new IOException("Stream closed")
 
     if (currentEntry != null)
       closeEntry()
@@ -172,7 +172,7 @@ class ZipOutputStream(_out: OutputStream, charset: Charset)
       }
     }
     if (cDir == null) {
-      throw new IOException("Stream is closed")
+      throw new IOException("Stream closed")
     }
     if (entries.contains(ze.name)) {
       /* [MSG "archive.29", "Entry already exists: {0}"] */

--- a/javalib/src/main/scala/java/util/zip/ZipOutputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipOutputStream.scala
@@ -123,35 +123,35 @@ class ZipOutputStream(_out: OutputStream, charset: Charset)
   }
 
   override def finish(): Unit = {
-    if (out == null) {
+    if (out == null)
       throw new IOException("Stream is closed")
-    } else if (cDir == null) {
-      ()
-    } else if (entries.size == 0) {
-      throw new ZipException("No entries")
-    } else if (currentEntry != null) {
+
+    if (currentEntry != null)
       closeEntry()
-    }
 
-    val cdirSize = cDir.size()
-    // Write Central Dir End
-    writeLong(cDir, ENDSIG)
-    writeShort(cDir, 0) // Disk Number
-    writeShort(cDir, 0) // Start Disk
-    writeShort(cDir, entries.size) // Number of entries
-    writeShort(cDir, entries.size) // Number of entries (yes, twice)
-    writeLong(cDir, cdirSize) // Size of central dir
-    writeLong(cDir, offset) // Offset of central dir
-    if (comment != null) {
-      writeShort(cDir, comment.length())
-      cDir.write(comment.getBytes())
-    } else {
-      writeShort(cDir, 0)
-    }
-    // Write the central dir
-    out.write(cDir.toByteArray())
-    cDir = null
+    if (entries.size == 0)
+      throw new ZipException("No entries")
 
+    if (cDir != null) {
+      val cdirSize = cDir.size()
+      // Write Central Dir End
+      writeLong(cDir, ENDSIG)
+      writeShort(cDir, 0) // Disk Number
+      writeShort(cDir, 0) // Start Disk
+      writeShort(cDir, entries.size) // Number of entries
+      writeShort(cDir, entries.size) // Number of entries (yes, twice)
+      writeLong(cDir, cdirSize) // Size of central dir
+      writeLong(cDir, offset) // Offset of central dir
+      if (comment != null) {
+        writeShort(cDir, comment.length())
+        cDir.write(comment.getBytes())
+      } else {
+        writeShort(cDir, 0)
+      }
+      // Write the central dir
+      out.write(cDir.toByteArray())
+      cDir = null
+    }
   }
 
   def putNextEntry(ze: ZipEntry): Unit = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipOutputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipOutputStreamTest.scala
@@ -1,0 +1,130 @@
+package org.scalanative.testsuite.javalib.util.zip
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.BeforeClass
+
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.util.Arrays
+
+import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
+
+object ZipOutputStreamTest {
+
+  private var workDirString: String = _
+
+  private val zipFileName = "ZipOutputStreamTestData.zip"
+
+  private def makeTestDirs(): String = {
+    val orgDir = Files.createTempDirectory("scala-native-testsuite")
+    val javalibDir = orgDir.resolve("javalib")
+    val testDirRootPath = javalibDir
+      .resolve("java")
+      .resolve("util")
+      .resolve("zip")
+      .resolve("ZipOutputStreamTest")
+
+    val testDirSrcPath = testDirRootPath.resolve("src")
+    val testDirDstPath = testDirRootPath.resolve("dst")
+    Files.createDirectories(testDirRootPath)
+    Files.createDirectory(testDirSrcPath)
+    Files.createDirectory(testDirDstPath)
+
+    testDirRootPath.toString()
+  }
+
+  @BeforeClass
+  def beforeClass(): Unit = {
+    workDirString = makeTestDirs()
+  }
+}
+
+class ZipOutputStreamTest {
+  import ZipOutputStreamTest._
+
+  private def createZipFile(
+      location: String,
+      entryNames: Array[String]
+  ): Unit = {
+    val zipOut = new ZipOutputStream(new FileOutputStream(location))
+    try {
+      zipOut.setComment("Some interesting moons of Saturn.")
+
+      Arrays
+        .stream(entryNames)
+        .forEach(e => zipOut.putNextEntry(new ZipEntry(e)))
+
+    } finally {
+      zipOut.close()
+    }
+  }
+
+  // Issue 3754
+  @Test def zipOutputStream(): Unit = {
+    val srcName =
+      s"${workDirString}/src/${zipFileName}"
+
+    val dstName =
+      s"${workDirString}/dst/copyOf_${zipFileName}"
+
+    val entryNames = Array(
+      "Rhea_1",
+      "Prometheus_2",
+      "Phoebe_3",
+      "Tethys_4",
+      "Iapetus_5"
+    )
+
+    createZipFile(srcName, entryNames)
+
+    val zf = new ZipFile(srcName)
+    try {
+      val zipOut = new ZipOutputStream(new FileOutputStream(dstName))
+      var outCount = 0
+
+      try {
+        zipOut.setComment(
+          "Archive written by Scala Native java.util.zip.ZipOutputStreamTest"
+        )
+
+        zf.stream()
+          .limit(99)
+          .forEach(e => {
+            outCount += 1
+            zipOut.putNextEntry(e)
+
+            if (!e.isDirectory()) {
+              val fis = zf.getInputStream(e)
+              val buf = new Array[Byte](2 * 1024)
+
+              try {
+                var nRead = 0
+                // Poor but useful idioms creep in: porting from Java style
+                while ({ nRead = fis.read(buf); nRead } > 0) {
+                  zipOut.write(buf, 0, nRead)
+                  assertEquals("fis nRead", e.getSize(), nRead)
+                }
+              } finally {
+                fis.close()
+              }
+            }
+            zipOut.closeEntry()
+          })
+
+        assertEquals("number of entries written", entryNames.size, outCount)
+      } finally {
+        /* Down to the point of this Test: verifying a robust
+         * "finish(); close()" sequence, without someone throwing an NPE.
+         */
+
+        zipOut.finish() // Throws no Null Pointer Exception
+        zipOut.finish() // and can be done more than once without error.
+
+        zipOut.close() // internally calls finish() again; for 3rd time series
+      }
+    } finally {
+      zf.close()
+    }
+  }
+}


### PR DESCRIPTION
Fix #3754

The javalib `java.util.zip.ZipOutputStream#finish` method now matches JVM behavior in
that it can be called more than once, say be a "finish(); close()" sequence, without throwing
a Null Pointer Exception (NPE).