### PR TITLE
refactor: Make ZipConstants more useful for manually parsing .zip files

### DIFF
--- a/javalib/src/main/scala/java/util/zip/ZipConstants.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipConstants.scala
@@ -1,44 +1,63 @@
 package java.util.zip
 
+// FIXME :: describe use of hex to ease matching Linux/macOS "hexdump -C"
+// with documentation.
+/* Reference:
+ *   https://en.wikipedia.org/wiki/ZIP_(file_format) // or your local language
+ *
+ * Use hexadecimal for *SIG to ease manual parsing of Linux/macOS
+ * "hexdump -C foo.zip" output. May your Fate never bring you there.
+ *
+ * Other fields are decimal, ordered alphabetically, as they are in the
+ * JDK description of ZipFile and kin.
+ */
+
 private[util] trait ZipConstants {
-  final val LOCSIG = 67324752L
-  final val EXTSIG = 134695760L
-  final val CENSIG = 33639248L
-  final val ENDSIG = 101010256L
-  final val LOCHDR = 30
-  final val EXTHDR = 16
-  final val CENHDR = 46
-  final val ENDHDR = 22
-  final val LOCVER = 4
-  final val LOCFLG = 6
-  final val LOCHOW = 8
-  final val LOCTIM = 10
-  final val LOCCRC = 14
-  final val LOCSIZ = 18
-  final val LOCLEN = 22
-  final val LOCNAM = 26
-  final val LOCEXT = 28
-  final val EXTCRC = 4
-  final val EXTSIZ = 8
-  final val EXTLEN = 12
-  final val CENVEM = 4
-  final val CENVER = 6
-  final val CENFLG = 8
-  final val CENHOW = 10
-  final val CENTIM = 12
-  final val CENCRC = 16
-  final val CENSIZ = 20
-  final val CENLEN = 24
-  final val CENNAM = 28
-  final val CENEXT = 30
-  final val CENCOM = 32
-  final val CENDSK = 34
+  // Header signatures
+  final val CENSIG = 0x02014b50L // decimal: 33639248L  "PK\1\2"
+  final val ENDSIG = 0x06054b50L // decimal: 101010256L "PK\5\6"
+  final val EXTSIG = 0x08074b50L // decimal: 134695760L "PK\7\8"
+  final val LOCSIG = 0x04034b50L // decimal: 67324752L "PK\3\4"
+
+  // Offsets to fields in various headers
   final val CENATT = 36
   final val CENATX = 38
+  final val CENCOM = 32
+  final val CENCRC = 16
+  final val CENDSK = 34
+  final val CENEXT = 30
+  final val CENFLG = 8
+  final val CENHDR = 46
+  final val CENHOW = 10
+  final val CENLEN = 24
+  final val CENNAM = 28
   final val CENOFF = 42
+  // CENSIG is a header, so it is defined above.
+  final val CENSIZ = 20
+  final val CENTIM = 12
+  final val CENVEM = 4
+  final val CENVER = 6
+  final val ENDCOM = 20
+  final val ENDHDR = 22
+  final val ENDOFF = 16
+  // ENDSIG is a header, so it is defined above.
+  final val ENDSIZ = 12
   final val ENDSUB = 8
   final val ENDTOT = 10
-  final val ENDSIZ = 12
-  final val ENDOFF = 16
-  final val ENDCOM = 20
+  final val EXTCRC = 4
+  final val EXTHDR = 16
+  final val EXTLEN = 12
+  // EXTSIG is a header, so it is defined above.
+  final val EXTSIZ = 8
+  final val LOCCRC = 14
+  final val LOCEXT = 28
+  final val LOCFLG = 6
+  final val LOCHDR = 30
+  final val LOCHOW = 8
+  final val LOCLEN = 22
+  final val LOCNAM = 26
+  // LOCSIG is a header, so it is defined above.
+  final val LOCSIZ = 18
+  final val LOCTIM = 10
+  final val LOCVER = 4
 }


### PR DESCRIPTION
The zip file format uses certain binary byte patterns, called signatures, to identify the start of sections
of the file.  Refactor `ZipConstants` to make it easier to find signatures when manually/visually parsing
the output of Linux/macOS "hexdump -C".  This refactor also makes it easier to match up the constants
in `ZipConstants` with those specified by JDK for `ZipFile` and kin.

There should be no externally visible effect of this re-factor.