### PR TITLE
fix[gc]: Make sure conservative marking of ranges uses alligned pointers

### DIFF
--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -191,6 +191,7 @@ void scalanative_continuation_init(void *(*alloc_f)(unsigned long, void *)) {
     atomic_init(&label_count, 0);
 }
 
+NO_SANITIZE
 __returnstwice void *
 __continuation_boundary_impl(void **btm, ContinuationBody *body, void *arg) {
     // debug_printf("Boundary btm is %p\n", btm);
@@ -243,6 +244,7 @@ static void *continuation_alloc_by_malloc(unsigned long size, void *arg) {
 }
 
 // suspend[T, R] : BoundaryLabel[T] -> T -> R
+NO_SANITIZE
 void *scalanative_continuation_suspend(ContinuationBoundaryLabel b,
                                        SuspendFn *f, void *arg, void *alloc_arg)
     __attribute__((disable_tail_calls)) {
@@ -292,6 +294,7 @@ static Handlers *handler_clone_fix(Handlers *other, ptrdiff_t diff) {
 }
 
 // Resumes the continuation to [tail - size, tail).
+NO_SANITIZE
 void __continuation_resume_impl(void *tail, Continuation *continuation,
                                 void *out, void *ret_addr) {
     // Allocate all values up front so we know how many to deal with.

--- a/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
@@ -189,12 +189,11 @@ NO_SANITIZE int Marker_markRange(Heap *heap, Stats *stats,
                                  GreyPacket **outWeakRefHolder, word_t **from,
                                  size_t length) {
     int objectsTraced = 0;
-    word_t **limit = from + length;
-    for (word_t **current = from; current <= limit; current++) {
+    const intptr_t alignmentMask = ~(sizeof(word_t) - 1);
+    word_t **alignedFrom = (word_t **)((intptr_t)from & alignmentMask);
+    word_t **limit = alignedFrom + length;
+    for (word_t **current = alignedFrom; current <= limit; current++) {
         word_t *field = *current;
-        // Memory allocated by GC is alligned, ignore unaligned pointers e.g.
-        // interim pointers, otherwise we risk undefined behaviour when assuming
-        // memory layout of underlying object.
         if (Heap_IsWordInHeap(heap, field)) {
             Marker_markConservative(heap, stats, outHolder, outWeakRefHolder,
                                     field);

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -131,7 +131,7 @@ NO_SANITIZE static void Marker_markRange(Heap *heap, Stack *stack,
     // Align start address
     const intptr_t alignmentMask = ~(sizeof(word_t) - 1);
     word_t **alignedFrom = (word_t **)((intptr_t)from & alignmentMask);
-    // Align end address to be optionally 1 higher when unalligned
+    // Align end address to be optionally 1 higher when unaligned
     word_t **alignedTo = (word_t **)((intptr_t)(to + 1) & alignmentMask);
     for (word_t **current = alignedFrom; current <= alignedTo; current += 1) {
         word_t *addr = *current;

--- a/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Marker.c
@@ -128,7 +128,12 @@ NO_SANITIZE static void Marker_markRange(Heap *heap, Stack *stack,
                                          word_t **from, word_t **to) {
     assert(from != NULL);
     assert(to != NULL);
-    for (word_t **current = from; current <= to; current += 1) {
+    // Align start address
+    const intptr_t alignmentMask = ~(sizeof(word_t) - 1);
+    word_t **alignedFrom = (word_t **)((intptr_t)from & alignmentMask);
+    // Align end address to be optionally 1 higher when unalligned
+    word_t **alignedTo = (word_t **)((intptr_t)(to + 1) & alignmentMask);
+    for (word_t **current = alignedFrom; current <= alignedTo; current += 1) {
         word_t *addr = *current;
         if (Heap_IsWordInHeap(heap, addr)) {
             Marker_markConservative(heap, stack, addr);


### PR DESCRIPTION
Unaligned pointer reads might lead to undefined behaviour, ensure to align them. 
Also disable sanitization of delimited continuations functions