### PR TITLE
Fix #3763: improved javalib AbstractStringBuilder indexOf and lastIndexOf methods

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringBuilderTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringBuilderTest.scala
@@ -312,4 +312,29 @@ class StringBuilderTest {
       'f' == s.charAt(0)
     )
   }
+
+  @Test def indexOfSubStringWithSurrogatePair(): Unit = {
+    // Outlined "hello" in surrogate pairs
+    val sb = new StringBuilder(
+      "\ud835\udd59\ud835\udd56\ud835\udd5d\ud835\udd5d\ud835\udd60"
+    )
+
+    val needle = "\ud835\udd5d\ud835\udd60" // outlined ell oh
+
+    val index = sb.indexOf(needle)
+    assertEquals("indexOf surrogate outlined ell oh", 6, index)
+  }
+
+  @Test def lastIndexOfSubStringWithSurrogatePair(): Unit = {
+    // Outlined "hello" in surrogate pairs
+    val sb = new StringBuilder(
+      "\ud835\udd59\ud835\udd56\ud835\udd5d\ud835\udd5d\ud835\udd60"
+    )
+
+    val needle = "\ud835\udd56\ud835\udd5d" // outlined e ell
+
+    val index = sb.lastIndexOf(needle)
+    assertEquals("lastIndexOf surrogate outlined ell", 2, index)
+  }
+
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
@@ -414,6 +414,16 @@ class StringTest {
     assertTrue("fubår".indexOf(97, 4) == -1)
   }
 
+  @Test def indexOfSubStringWithSurrogatePair(): Unit = {
+    val helloInSurrogatePairs =
+      "\ud835\udd59\ud835\udd56\ud835\udd5d\ud835\udd5d\ud835\udd60"
+
+    val needle = "\ud835\udd5d\ud835\udd60" // outlined ell oh
+
+    val index = helloInSurrogatePairs.indexOf(needle)
+    assertEquals("indexOf surrogate outlined ell oh", 6, index)
+  }
+
   @Test def lastIndexOf(): Unit = {
     assertTrue("afoobar".lastIndexOf("a") == 5)
     assertTrue("afoobar".lastIndexOf(97) == 5)
@@ -427,6 +437,16 @@ class StringTest {
     assertTrue("fubår".lastIndexOf(97) == -1)
     assertTrue("fubår".lastIndexOf("a", 4) == -1)
     assertTrue("fubår".lastIndexOf(97, 4) == -1)
+  }
+
+  @Test def lastIndexOfSubStringWithSurrogatePair(): Unit = {
+    val helloInSurrogatePairs =
+      "\ud835\udd59\ud835\udd56\ud835\udd5d\ud835\udd5d\ud835\udd60"
+
+    val needle = "\ud835\udd56\ud835\udd5d" // outlined e ell
+
+    val index = helloInSurrogatePairs.lastIndexOf(needle)
+    assertEquals("lastIndexOf surrorate outlined ell", 2, index)
   }
 
   @Test def toUpperCase(): Unit = {
@@ -646,7 +666,7 @@ class StringTest {
    */
 
 
-// format: off  
+// format: off
     val testByteArray = Array(
       'f'.toByte, 0.toByte,
       'o'.toByte, 0.toByte,


### PR DESCRIPTION
Fix #3763 Fix #2919 Fix #2918

javalib `AbstractStringBuilder` is a private implementation class used to provide common code between
`StringBuilder` and `StringBuffer`.  Previous to this PR, the `indexOf(substring)` and `lastIndexOf(substring)` 
used Scala `breakable` to exit loops. `breakable` throws Exceptions and has a code path length of probably
thousands of instructions, just to exit a loop.  It was also hard to trace to code to convince oneself that
Unicode surrogate pairs were being handled correctly.

This PR ports the well exercised `String` code for similar methods to `AbstractStringBuilder`. This should
increase performance and confidence in correct handling of Unicode surrogates.