### PR TITLE
fix: Ensure to always call monitorEnter and monitorExit statically

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -90,7 +90,7 @@ object NativeThread {
   @alwaysinline def onSpinWait(): Unit = Platform.yieldProcessor()
 
   @inline def holdsLock(obj: Object): Boolean = if (isMultithreadingEnabled) {
-    getMonitor(obj).isLockedBy(currentThread)
+    getMonitor(obj.asInstanceOf[_Object]).isLockedBy(currentThread)
   } else false
 
   def threadRoutineArgs(thread: NativeThread): ThreadRoutineArg =

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -20,24 +20,25 @@ package object runtime {
   /** Used as a stub right hand of intrinsified methods. */
   private[scalanative] def intrinsic: Nothing = throwUndefined()
 
+  // Called statically by the compiler, do not modify!
   /** Enter monitor of given object. */
   @alwaysinline
-  def enterMonitor(obj: Object): Unit =
+  private[runtime] def enterMonitor(obj: _Object): Unit =
     if (isMultithreadingEnabled) {
       getMonitor(obj).enter(obj)
     }
 
+  // Called statically by the compiler, do not modify!
   /** Enter monitor of given object. */
-
   @alwaysinline
-  def exitMonitor(obj: Object): Unit =
+  private[runtime] def exitMonitor(obj: _Object): Unit =
     if (isMultithreadingEnabled) {
       getMonitor(obj).exit(obj)
     }
 
   /** Get monitor for given object. */
   @alwaysinline
-  def getMonitor(obj: Object) = {
+  def getMonitor(obj: _Object) = {
     if (isMultithreadingEnabled)
       new BasicMonitor(
         elemRawPtr(

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -1200,9 +1200,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         (o eq ObjectClass) || (o eq AnyRefClass) || (o eq AnyClass)
       }
 
-      m.isDeferred || m.isConstructor || m.hasAccessBoundary ||
-        m.isExtern ||
-        isOfJLObject
+      m.isDeferred || m.isConstructor || m.isExtern || isOfJLObject
     }
 
     val forwarders = for {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -208,15 +208,19 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     case _            => 'O'
   }
 
-  def genMethodSig(sym: Symbol): nir.Type.Function =
-    genMethodSigImpl(sym, isExtern = false)
+  def genMethodSig(
+      sym: Symbol,
+      statically: Boolean = false
+  ): nir.Type.Function =
+    genMethodSigImpl(sym, statically = statically, isExtern = false)
 
   def genExternMethodSig(sym: Symbol): nir.Type.Function =
-    genMethodSigImpl(sym, isExtern = true)
+    genMethodSigImpl(sym, isExtern = true, statically = true)
 
   private def genMethodSigImpl(
       sym: Symbol,
-      isExtern: Boolean
+      isExtern: Boolean,
+      statically: Boolean
   ): nir.Type.Function = {
     def resolve() = {
       require(sym.isMethod || sym.isStaticMember, "symbol is not a method")
@@ -225,7 +229,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
       val owner = sym.owner
       val paramtys = genMethodSigParamsImpl(sym, isExtern)
       val selfty =
-        if (isExtern || sym.isStaticInNIR) None
+        if (statically | isExtern || sym.isStaticInNIR) None
         else Some(genType(owner.tpe))
       val retty =
         if (sym.isClassConstructor) nir.Type.Unit

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -906,10 +906,6 @@ trait NirGenExpr(using Context) {
         finallyp: Tree,
         insts: Seq[nir.Inst]
     ): Seq[nir.Inst] = {
-      println()
-      // println(finallyp)
-      // insts.foreach(println)
-      // println("---")
       val labels =
         insts.collect {
           case nir.Inst.Label(n, _) => n

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -40,7 +40,7 @@ trait NirGenExpr(using Context) {
   import positionsConversions.fromSpan
 
   sealed case class ValTree(value: nir.Val) extends Tree
-  sealed case class ContTree(f: () => nir.Val) extends Tree
+  sealed case class ContTree(f: ExprBuffer => nir.Val) extends Tree
 
   class ExprBuffer(using fresh: nir.Fresh) extends FixupBuffer {
     buf =>
@@ -49,7 +49,7 @@ trait NirGenExpr(using Context) {
       tree match {
         case EmptyTree      => nir.Val.Unit
         case ValTree(value) => value
-        case ContTree(f)    => f()
+        case ContTree(f)    => f(this)
         case tree: Apply =>
           val updatedTree = lazyValsAdapter.transformApply(tree)
           genApply(updatedTree)
@@ -679,8 +679,8 @@ trait NirGenExpr(using Context) {
               buf.genIf(
                 retty = retty,
                 condp = ValTree(cond),
-                thenp = ContTree(() => genExpr(body)),
-                elsep = ContTree(() => loop(elsep))
+                thenp = ContTree(_.genExpr(body)),
+                elsep = ContTree(_ => loop(elsep))
               )
 
             case Nil => optDefaultLabel.getOrElse(genExpr(defaultp))
@@ -867,7 +867,7 @@ trait NirGenExpr(using Context) {
             case Bind(_, _) =>
               genType(pat.tpe) -> Some(pat.symbol)
           }
-          val f = { () =>
+          val f = ContTree { (buf: ExprBuffer) =>
             withFreshBlockScope(body.span) { _ =>
               symopt.foreach { sym =>
                 val cast = buf.as(excty, exc, unwind)(cd.span, getScopeId)
@@ -883,7 +883,7 @@ trait NirGenExpr(using Context) {
       }
 
       def wrap(
-          cases: Seq[(nir.Type, () => nir.Val, nir.SourcePosition)]
+          cases: Seq[(nir.Type, ContTree, nir.SourcePosition)]
       ): nir.Val =
         cases match {
           case Seq() =>
@@ -894,8 +894,8 @@ trait NirGenExpr(using Context) {
             genIf(
               retty,
               ValTree(cond),
-              ContTree(f),
-              ContTree(() => wrap(rest))
+              f,
+              ContTree(_ => wrap(rest))
             )(using pos)
         }
 
@@ -906,6 +906,10 @@ trait NirGenExpr(using Context) {
         finallyp: Tree,
         insts: Seq[nir.Inst]
     ): Seq[nir.Inst] = {
+      println()
+      // println(finallyp)
+      // insts.foreach(println)
+      // println("---")
       val labels =
         insts.collect {
           case nir.Inst.Label(n, _) => n
@@ -1296,7 +1300,7 @@ trait NirGenExpr(using Context) {
     )(using nir.SourcePosition): nir.Val = {
       require(!sym.isExtern, sym)
 
-      val sig = genMethodSig(sym)
+      val sig = genMethodSig(sym, statically = true)
       val args = genMethodArgs(sym, argsp)
       val methodName = genStaticMemberName(sym, receiver)
       val method = nir.Val.Global(methodName, nir.Type.Ptr)
@@ -1969,7 +1973,11 @@ trait NirGenExpr(using Context) {
       val mergen = fresh()
 
       // scalanative.runtime.`package`.enterMonitor(receiver)
-      genExpr(Apply(ref(defnNir.RuntimePackage_enterMonitor), List(receiverp)))
+      genApplyStaticMethod(
+        defnNir.RuntimePackage_enterMonitor,
+        defnNir.RuntimePackageClass,
+        List(receiverp)
+      )
 
       // synchronized block
       val retValue = scoped(curUnwindHandler := Some(handler)) {
@@ -1993,7 +2001,13 @@ trait NirGenExpr(using Context) {
       buf.jump(nir.Next(normaln))
       buf ++= genTryFinally(
         // scalanative.runtime.`package`.exitMonitor(receiver)
-        Apply(ref(defnNir.RuntimePackage_exitMonitor), List(receiverp)),
+        ContTree(
+          _.genApplyStaticMethod(
+            defnNir.RuntimePackage_exitMonitor,
+            defnNir.RuntimePackageClass,
+            List(receiverp)
+          )
+        ),
         nested.toSeq
       )
       buf.labelExcludeUnitValue(mergen, mergev)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -309,15 +309,19 @@ trait NirGenType(using Context) {
     defn.DoubleClass -> 'D'
   )
 
-  def genMethodSig(sym: Symbol): nir.Type.Function =
-    genMethodSigImpl(sym, isExtern = false)
+  def genMethodSig(
+      sym: Symbol,
+      statically: Boolean = false
+  ): nir.Type.Function =
+    genMethodSigImpl(sym, statically = statically, isExtern = false)
 
   def genExternMethodSig(sym: Symbol): nir.Type.Function =
-    genMethodSigImpl(sym, isExtern = true)
+    genMethodSigImpl(sym, isExtern = true, statically = true)
 
   private def genMethodSigImpl(
       sym: Symbol,
-      isExtern: Boolean
+      isExtern: Boolean,
+      statically: Boolean
   ): nir.Type.Function = {
     def resolve() = {
       require(
@@ -327,7 +331,7 @@ trait NirGenType(using Context) {
 
       val owner = sym.owner
       val paramtys = genMethodSigParamsImpl(sym, isExtern)
-      val selfty = Option.unless(isExtern || sym.isStaticInNIR) {
+      val selfty = Option.unless(statically | isExtern || sym.isStaticInNIR) {
         genType(owner)
       }
       val resultType = sym.info.resultType

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/MethodCallsTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/MethodCallsTest.scala
@@ -76,4 +76,77 @@ class MethodCallTest {
     }
   }
 
+  @Test def emitsStaticObjectMonitorCalls(): Unit = {
+    compileAndLoad(
+      "Test.scala" ->
+        """
+        |object Test{  
+        |  def main(): Unit = synchronized {
+        |   Test.synchronized{
+        |     println("")
+        |    }
+        |  }
+        |}""".stripMargin
+    ) { defns =>
+      val TestModule = Global.Top("Test$")
+      val MainMethod =
+        TestModule.member(Sig.Method("main", Seq(Type.Unit)))
+
+      val expected: Seq[Global] =
+        Seq(TestModule, MainMethod)
+      assertEquals(Set.empty, expected.diff(defns.map(_.name)).toSet)
+
+      defns
+        .collectFirst {
+          case defn: Defn.Define if defn.name == MainMethod => defn
+        }
+        .foreach { defn =>
+          // format: off
+          val RuntimePackageCls = Global.Top("scala.scalanative.runtime.package")
+          val RuntimePackage    = Global.Top("scala.scalanative.runtime.package$")
+          val EnterMonitorSig   = Sig.Method("enterMonitor", Seq(Rt.Object, Type.Unit)).mangled
+          val ExitMonitorSig    = Sig.Method("exitMonitor",  Seq(Rt.Object, Type.Unit)).mangled
+          val EnterMonitorStaticSig   = Sig.Method("enterMonitor", Seq(Rt.Object, Type.Unit), Sig.Scope.PublicStatic).mangled
+          val ExitMonitorStaticSig    = Sig.Method("exitMonitor",  Seq(Rt.Object, Type.Unit), Sig.Scope.PublicStatic).mangled
+          object MonitorEnter{
+            def unapply(v: Val): Option[Boolean] = v match {
+              case Val.Global(Global.Member(RuntimePackage, EnterMonitorSig), _) => Some(false)
+              case Val.Global(Global.Member(RuntimePackageCls, EnterMonitorStaticSig), _) => Some(true)
+              case _ => None
+            } 
+          }
+          object MonitorExit{
+            def unapply(v: Val): Option[Boolean] = v match {
+              case Val.Global(Global.Member(RuntimePackage, ExitMonitorSig), _) => Some(false)
+              case Val.Global(Global.Member(RuntimePackageCls, ExitMonitorStaticSig), _) => Some(true)
+              case _ => None
+            } 
+          }
+          // format: on
+          var monitorEnters, monitorExits = 0
+          defn.insts.foreach {
+            case inst @ Inst.Let(_, op, _) =>
+              op match {
+                case Op.Method(MonitorEnter(_) | MonitorExit(_), _) =>
+                  fail(s"Unexpected method dispatch: ${inst.show}")
+                case Op.Call(_, MonitorEnter(isStatic), args) =>
+                  assert(isStatic)
+                  monitorEnters += 1
+                case Op.Call(_, MonitorExit(isStatic), args) =>
+                  assert(isStatic)
+                  monitorExits += 1
+                case _ => ()
+              }
+            case _ => ()
+          }
+          // For each monitor enter there are 2 monitor exits:
+          // - first for successfull path before reutrning value
+          // - second for erronous path before throwing exception
+          // synchronised call is emitted as try-finally block
+          assertEquals(2, monitorEnters)
+          assertEquals(4, monitorExits)
+        }
+    }
+  }
+
 }


### PR DESCRIPTION
Ensure to always call monitorEnter and monitorExit statically. It would significantly simplify  their detection in optimiser, allowing to apply optimisation in the future, e.g. merging multiple synchronized blocks together. 