### PR TITLE
improvement: Eliminate empty positions in generated NIR

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -20,17 +20,13 @@ import scala.scalanative.nir.Defn.Define
  *  their semantics (e.g., whether a method may be inlined). Attributes are also
  *  used to mark special-purpose definitions, such as stubs, proxies and FFIs.
  */
-sealed abstract class Defn {
+sealed abstract class Defn extends Positioned {
 
   /** Returns the name of the definition. */
   def name: Global
 
   /** Returns the attributes of the definition. */
   def attrs: Attrs
-
-  /** Returns the site in the program sources corresponding to the definition.
-   */
-  def pos: SourcePosition
 
   /** Returns a textual representation of `this`. */
   final def show: String =

--- a/nir/src/main/scala/scala/scalanative/nir/Insts.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Insts.scala
@@ -1,9 +1,8 @@
 package scala.scalanative
 package nir
 
-sealed abstract class Inst {
+sealed abstract class Inst extends Positioned {
   final def show: String = nir.Show(this)
-  def pos: SourcePosition
 }
 
 object Inst {

--- a/nir/src/main/scala/scala/scalanative/nir/Positioned.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Positioned.scala
@@ -1,0 +1,21 @@
+package scala.scalanative.nir
+
+trait Positioned {
+
+  /** Returns the site in the program sources corresponding to the definition.
+   */
+  def pos: SourcePosition
+
+  if (Positioned.debugEmptyPositions && pos.isEmpty) {
+    System.err.println(s"\nFound empty position in $this, backtrace:")
+    new RuntimeException()
+      .getStackTrace()
+      .take(10)
+      .foreach(println)
+  }
+}
+
+object Positioned {
+  private final val debugEmptyPositions =
+    sys.props.contains("scalanative.debug.nir.positions")
+}

--- a/nir/src/main/scala/scala/scalanative/nir/SourcePosition.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/SourcePosition.scala
@@ -11,6 +11,7 @@ sealed case class NIRSource(directory: Path, path: Path) {
 object NIRSource {
   object None extends NIRSource(null, null) {
     override def debugName: String = "<no-source>"
+    override def toString(): String = s"NIRSource($debugName)"
   }
 }
 
@@ -36,6 +37,9 @@ final case class SourcePosition(
 
   def isEmpty: Boolean = this eq SourcePosition.NoPosition
   def isDefined: Boolean = !isEmpty
+  def orElse(other: => SourcePosition): SourcePosition =
+    if (isEmpty) other
+    else this
 }
 
 object SourcePosition {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExports.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExports.scala
@@ -168,7 +168,7 @@ trait NirGenExports[G <: nsc.Global with Singleton] {
           val boxedParams = paramTypes
             .zip(entryParams)
             .map((buf.fromExtern _).tupled(_))
-          val argsp = boxedParams.map(ValTree(_))
+          val argsp = boxedParams.map(ValTree(_)(member.pos))
           val res = buf.genApplyModuleMethod(owner, member, argsp)
           val unboxedRes = buf.toExtern(externRetType, res)
           buf.ret(unboxedRes)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -178,6 +178,8 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
     }
   }
 
+  def fallbackSourcePosition: nir.SourcePosition = curMethodSym.get.pos
+
   protected implicit def toNirPosition(
       pos: global.Position
   ): nir.SourcePosition = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNativeExports.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNativeExports.scala
@@ -173,7 +173,7 @@ trait GenNativeExports(using Context):
           val boxedParams = paramTypes
             .zip(entryParams)
             .map(buf.fromExtern(_, _))
-          val argsp = boxedParams.map(ValTree(_))
+          val argsp = boxedParams.map(ValTree(_)(member.span))
           val res = buf.genApplyModuleMethod(owner, member, argsp)
           val unboxedRes = buf.toExtern(externRetType, res)
           buf.ret(unboxedRes)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -110,7 +110,7 @@ trait GenReflectiveInstantisation(using Context) {
       buf.genApplyModuleMethod(
         defnNir.ReflectModule,
         defnNir.Reflect_registerLoadableModuleClass,
-        Seq(fqcnArg, runtimeClassArg, loadModuleFunArg).map(ValTree(_))
+        Seq(fqcnArg, runtimeClassArg, loadModuleFunArg).map(ValTree(_)(td.span))
       )
       buf.ret(nir.Val.Unit)
       buf.toSeq
@@ -148,7 +148,7 @@ trait GenReflectiveInstantisation(using Context) {
           defnNir.ReflectModule,
           defnNir.Reflect_registerInstantiatableClass,
           Seq(fqcnArg, runtimeClassArg, instantiateClassFunArg)
-            .map(ValTree(_))
+            .map(ValTree(_)(td.span))
         )
         buf.ret(nir.Val.Unit)
         buf.toSeq

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPositions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPositions.scala
@@ -28,7 +28,6 @@ class NirPositions(positionRelativizationPaths: Seq[Path])(using Context) {
       val line = source.offsetToLine(point)
       val column = source.column(point)
       nir.SourcePosition(nirSource, line, column)
-    else if (source.exists) nir.SourcePosition(nirSource, 0, 0)
     else nir.SourcePosition.NoPosition
   }
 


### PR DESCRIPTION
Use positions of enclosing tree or current method symbols. Created dedicated trait for positioned NIR types (Insts,Defns) with a configurable detection of empty positions