### PR TITLE
Fix #3778: show ReadTheDocs document build date

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,8 @@ language = 'en'
 #
 # today_fmt = '%B %d, %Y'
 
+today_fmt = '%Y-%m-%d %H:%M:%S' # Scala Native change. Use ISO format.
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,8 @@
 Scala Native
 ============
 
+Document built at : |today|
+
 Version: |release|
 
 Scala Native is an optimizing ahead-of-time compiler and lightweight managed

--- a/docs/sn_alabaster/layout.html
+++ b/docs/sn_alabaster/layout.html
@@ -18,7 +18,7 @@ https://www.sphinx-doc.org/en/master/development/templating.html#working-with-th
                 meta.getAttribute("content") !== ""
             ) {
                 const el = document.createElement("p");
-                el.textContent = "Last updated: " + meta.getAttribute("content") + ".";
+                el.textContent = "Entry last updated: " + meta.getAttribute("content");
                 h1s[0].insertAdjacentElement("afterend", el);
             }
         });


### PR DESCRIPTION
Fix #3778

Show the document build date on the ReadTheDocs landing (index.html) page in addition to the
date the git file changed.  Doing so shows Scala Native in a better and more encouraging light. 
The document might be published nightly or weekly but the index.html might not have changed
in git for 6 months.

1. I changed the "Last updated:" text to "Entry last updated:" to better distinguish the date of
    the document and that of the entry.  One could advocate for "Page last updated:" or other
    text. My concern is with the concept, not the exact wording.

2. I removed the terminal period/full_stop from the former "Last updated:" line.  That line is not
    a full sentence.  I forget what my high school grammar teacher wanted us to call it. Guess
    that is why I became an engineer rather than a writer.

3. I changed the format of the "|today|" substitution from the former "Feb 17, 2024" format to
    the current "2024-02-16 20:44:07" format. This means that the "Entry last updated" both
    use the more international friendly ISO format. That and a little hackery in the file allow
    the two dates to align.

    It also means that the `Quick Start` section of the `Contributor's Guide` will now show the ISO format.

4. I would have liked to get the sequence of information to be:

    ```
    Scala Native version 
    Document build date 
    Entry date.
    ```
    I could not achieve that with economic effort. The entry date is generated and inserted at the top
    of the file.  The SN version is at the bottom in this PR to allow the two timestamp to be together.
    The reader need not switch concepts from timestamp to version and back to timestamp.

5. I would also like to have the two timestamps on immediately adjacent lines, with no intervening
    blank line. I could not figure how to insert a line break. Sphinx wanted put them both on the 
    same line and that looked _ugly_.

The Art of the Possible.
