### PR TITLE
Fix #3787, #936: javalib ZipEntry now gets & sets MS-DOS  times correctly

### DIFF
--- a/javalib/src/main/scala/java/util/zip/ZipEntry.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipEntry.scala
@@ -89,6 +89,8 @@ class ZipEntry private (
       tm.tm_min = (time >> 5) & 0x3f
       tm.tm_sec = (time & 0x1f) << 1
 
+      tm.tm_isdst = -1
+
       val unixEpochSeconds = mktime(tm)
 
       if (unixEpochSeconds < 0) -1L // Per JVM doc, -1 means "Unspecified"

--- a/javalib/src/main/scala/java/util/zip/ZipEntry.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipEntry.scala
@@ -30,7 +30,7 @@ class ZipEntry private (
     with Cloneable {
 
   def this(name: String) =
-    this(name, null, -1, -1, -1, -1, -1, -1, null, -1, -1)
+    this(name, null, -1L, -1L, -1L, -1, -1, -1, null, -1, -1L)
 
   def this(e: ZipEntry) =
     this(
@@ -50,6 +50,7 @@ class ZipEntry private (
   if (name == null) {
     throw new NullPointerException()
   }
+
   if (name.length() > 0xffff) {
     throw new IllegalArgumentException()
   }
@@ -76,7 +77,7 @@ class ZipEntry private (
     size
 
   def getTime(): Long = {
-    if (time == -1) -1L
+    if ((time == -1) || (modDate == -1)) -1L
     else {
       val tm = stackalloc[tm]()
 

--- a/javalib/src/main/scala/java/util/zip/ZipEntry.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipEntry.scala
@@ -78,24 +78,25 @@ class ZipEntry private (
 
   def getTime(): Long = {
     if ((time == -1) || (modDate == -1)) -1L
-    else {
-      val tm = stackalloc[tm]()
+    else
+      synchronized {
+        val tm = stackalloc[tm]()
 
-      tm.tm_year = ((modDate >> 9) & 0x7f) + 80
-      tm.tm_mon = ((modDate >> 5) & 0xf) - 1
-      tm.tm_mday = modDate & 0x1f
+        tm.tm_year = ((modDate >> 9) & 0x7f) + 80
+        tm.tm_mon = ((modDate >> 5) & 0xf) - 1
+        tm.tm_mday = modDate & 0x1f
 
-      tm.tm_hour = (time >> 11) & 0x1f
-      tm.tm_min = (time >> 5) & 0x3f
-      tm.tm_sec = (time & 0x1f) << 1
+        tm.tm_hour = (time >> 11) & 0x1f
+        tm.tm_min = (time >> 5) & 0x3f
+        tm.tm_sec = (time & 0x1f) << 1
 
-      tm.tm_isdst = -1
+        tm.tm_isdst = -1
 
-      val unixEpochSeconds = mktime(tm)
+        val unixEpochSeconds = mktime(tm)
 
-      if (unixEpochSeconds < 0) -1L // Per JVM doc, -1 means "Unspecified"
-      else unixEpochSeconds * 1000L
-    }
+        if (unixEpochSeconds < 0) -1L // Per JVM doc, -1 means "Unspecified"
+        else unixEpochSeconds * 1000L
+      }
   }
 
   def isDirectory(): Boolean =

--- a/javalib/src/main/scala/java/util/zip/ZipEntry.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipEntry.scala
@@ -1,6 +1,6 @@
 package java.util.zip
 
-// Ported from Apache Harmony
+// Ported from Apache Harmony. Extensive changes for Scala Native.
 
 import java.io.{
   EOFException,
@@ -8,6 +8,12 @@ import java.io.{
   RandomAccessFile,
   UnsupportedEncodingException
 }
+
+import scala.scalanative.posix.time._
+import scala.scalanative.posix.timeOps.tmOps
+
+import scala.scalanative.unsafe._
+
 class ZipEntry private (
     private[zip] var name: String,
     private[zip] var comment: String,
@@ -69,22 +75,25 @@ class ZipEntry private (
   def getSize(): Long =
     size
 
-  def getTime(): Long =
-    -1
-  // TODO: Uncomment once we have Calendar
-  // if (time != -1) {
-  //   val cal = new GregorianCalendar()
-  //   cal.set(Calendar.MILLISECOND, 0)
-  //   cal.set(1980 + ((modDate >> 9) & 0x7f),
-  //           ((modDate >> 5) & 0xf) - 1,
-  //           modDate & 0x1f,
-  //           (time >> 11) & 0x1f,
-  //           (time >> 5) & 0x3f,
-  //           (time & 0x1f) << 1)
-  //   cal.getTime().getTime()
-  // } else {
-  //   -1
-  // }
+  def getTime(): Long = {
+    if (time == -1) -1L
+    else {
+      val tm = stackalloc[tm]()
+
+      tm.tm_year = ((modDate >> 9) & 0x7f) + 80
+      tm.tm_mon = ((modDate >> 5) & 0xf) - 1
+      tm.tm_mday = modDate & 0x1f
+
+      tm.tm_hour = (time >> 11) & 0x1f
+      tm.tm_min = (time >> 5) & 0x3f
+      tm.tm_sec = (time & 0x1f) << 1
+
+      val unixEpochSeconds = mktime(tm)
+
+      if (unixEpochSeconds < 0) -1L // Per JVM doc, -1 means "Unspecified"
+      else unixEpochSeconds * 1000L
+    }
+  }
 
   def isDirectory(): Boolean =
     name.charAt(name.length - 1) == '/'
@@ -130,21 +139,50 @@ class ZipEntry private (
     }
 
   def setTime(value: Long): Unit = {
-    // TODO: Uncomment once we have Date
-    // val cal = new GregorianCalendar()
-    // cal.setTime(new Date(value))
-    // val year = cal.get(Calendar.YEAR)
-    // if (year < 1980) {
-    //   modDate = 0x21
-    //   time = 0
-    // } else {
-    //   modDate = cal.get(Calendar.DATE)
-    //   modDate = (cal.get(Calendar.MONTH) + 1 << 5) | modDate
-    //   modDate = ((cal.get(Calendar.YEAR) - 1980) << 9) | modDate
-    //   time = cal.get(Calendar.SECOND) >> 1
-    //   time = (cal.get(Calendar.MINUTE) << 5) | time
-    //   time = (cal.get(Calendar.HOUR_OF_DAY) << 11) | time
-    // }
+    /* Convert Java time in milliseconds since the Unix epoch to
+     * MS-DOS standard time.
+     *
+     * This URL gives a good description of standard MS-DOS time & the
+     * required bit manipulations:
+     *     https://learn.microsoft.com/en-us/windows/win32/api/oleauto/
+     *         nf-oleauto-dosdatetimetovarianttime
+     *
+     * Someone familiar with Windows could probably provide an operating
+     * system specific version of this method.
+     */
+
+    /* Concurrency issue:
+     *   localtime() is not required to be thread-safe, but is likely to exist
+     *   on Windows. Change to known thread-safe localtime_r() when this
+     *   section is unix-only.
+     */
+
+    val timer = stackalloc[time_t]()
+
+    // truncation OK, MS-DOS uses 2 second intervals, no rounding.
+    !timer = (value / 1000L).toSize
+
+    val tm = localtime(timer) // Not necessarily thread safe.
+
+    if (tm == null) {
+      modDate = 0x21
+      time = 0
+    } else {
+      val msDosYears = tm.tm_year - 80
+
+      if (msDosYears <= 0) {
+        modDate = 0x21 // 01-01-1980 00:00 MS-DOS epoch
+        time = 0
+      } else {
+        modDate = tm.tm_mday
+        modDate = ((tm.tm_mon + 1) << 5) | modDate
+        modDate = (msDosYears << 9) | modDate
+
+        time = tm.tm_sec >> 1
+        time = (tm.tm_min << 5) | time
+        time = (tm.tm_hour << 11) | time
+      }
+    }
   }
 
   override def toString(): String =

--- a/javalib/src/main/scala/java/util/zip/ZipFile.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipFile.scala
@@ -121,10 +121,13 @@ class ZipFile(file: File, mode: Int, charset: Charset) extends Closeable {
     if (entryName == null)
       throw new NullPointerException()
 
-    mEntries.getOrDefault(
-      entryName,
-      mEntries.getOrDefault(entryName + "/", null)
-    )
+    mEntries
+      .getOrDefault(
+        entryName,
+        mEntries.getOrDefault(entryName + "/", null)
+      )
+      .clone()
+      .asInstanceOf[ZipEntry]
   }
 
   def getInputStream(_entry: ZipEntry): InputStream = {

--- a/javalib/src/main/scala/java/util/zip/ZipFile.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipFile.scala
@@ -121,13 +121,14 @@ class ZipFile(file: File, mode: Int, charset: Charset) extends Closeable {
     if (entryName == null)
       throw new NullPointerException()
 
-    mEntries
+    val me = mEntries
       .getOrDefault(
         entryName,
         mEntries.getOrDefault(entryName + "/", null)
       )
-      .clone()
-      .asInstanceOf[ZipEntry]
+
+    if (me == null) null
+    else me.clone().asInstanceOf[ZipEntry] // keep original entry immutable
   }
 
   def getInputStream(_entry: ZipEntry): InputStream = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipBytes.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipBytes.scala
@@ -9,7 +9,8 @@ import java.nio.file.Files
 object ZipBytes {
 
   def getFile(bs: Array[Byte]): File = {
-    val path = Files.createTempFile("zipFile", ".zip")
+    val path =
+      Files.createTempFile("scala-native-testsuite_javalib_zipFile", ".zip")
     Files.write(path, bs)
     path.toFile
   }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryIssuesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryIssuesTest.scala
@@ -3,7 +3,6 @@ package org.scalanative.testsuite.javalib.util.zip
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.BeforeClass
-import org.junit.Ignore // FIXME
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
@@ -61,6 +61,11 @@ class ZipEntryTest {
     assertEquals("getComment", "Testing", zentry2.getComment())
     assertEquals("getCompressedSize", 4L, zentry2.getCompressedSize())
     assertEquals("getCrc", orgCrc, zentry2.getCrc())
+
+    /* First test against known JVM value. This checks that
+     * Daylight Saving Time offset is handled.
+     */
+    assertEquals("orgTime", 927667206000L, orgTime)
     assertEquals("getTime", orgTime, zentry2.getTime())
   }
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
@@ -22,6 +22,17 @@ class ZipEntryTest {
   var orgTime: Long = 0L
   var orgComment: String = null
 
+  @Before
+  def setUp(): Unit = {
+    zfile = getZipFile(zipFile)
+    zentry = zfile.getEntry("File1.txt")
+    orgSize = zentry.getSize()
+    orgCompressedSize = zentry.getCompressedSize()
+    orgCrc = zentry.getCrc()
+    orgTime = zentry.getTime()
+    orgComment = zentry.getComment()
+  }
+
   @Test def constructorString(): Unit = {
     zentry = zfile.getEntry("File3.txt")
     assertTrue(zentry != null)
@@ -41,16 +52,16 @@ class ZipEntryTest {
   }
 
   @Test def constructorZipEntry(): Unit = {
-    zentry.setSize(2)
-    zentry.setCompressedSize(4)
+    zentry.setSize(2L)
+    zentry.setCompressedSize(4L)
     zentry.setComment("Testing")
 
     val zentry2 = new ZipEntry(zentry)
-    assertTrue(zentry2.getSize() == 2)
-    assertTrue(zentry2.getComment() == "Testing")
-    assertTrue(zentry2.getCompressedSize() == 4)
-    assertTrue(zentry2.getCrc() == orgCrc)
-    assertTrue(zentry2.getTime() == orgTime)
+    assertEquals("getSize", 2L, zentry2.getSize())
+    assertEquals("getComment", "Testing", zentry2.getComment())
+    assertEquals("getCompressedSize", 4L, zentry2.getCompressedSize())
+    assertEquals("getCrc", orgCrc, zentry2.getCrc())
+    assertEquals("getTime", orgTime, zentry2.getTime())
   }
 
   @Test def getComment(): Unit = {
@@ -96,7 +107,7 @@ class ZipEntryTest {
   }
 
   @Test def getTime(): Unit = {
-    assertTrue(zentry.getTime() == orgTime)
+    assertEquals("getTime", orgTime, zentry.getTime())
   }
 
   @Test def isDirectory(): Unit = {
@@ -234,16 +245,4 @@ class ZipEntryTest {
       )
     }
   }
-
-  @Before
-  def setUp(): Unit = {
-    zfile = getZipFile(zipFile)
-    zentry = zfile.getEntry("File1.txt")
-    orgSize = zentry.getSize()
-    orgCompressedSize = zentry.getCompressedSize()
-    orgCrc = zentry.getCrc()
-    orgTime = zentry.getTime()
-    orgComment = zentry.getComment()
-  }
-
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
@@ -19,12 +19,11 @@ object ZipEntryTest {
   val zfile: ZipFile = getZipFile(zipFile)
   val zentry = zfile.getEntry("File1.txt")
 
-  var orgSize = zentry.getSize()
-  var orgCompressedSize = zentry.getCompressedSize()
-  var orgCrc = zentry.getCrc()
-  var orgTime = zentry.getTime()
-  var orgComment = zentry.getComment()
-
+  val orgSize = zentry.getSize()
+  val orgCompressedSize = zentry.getCompressedSize()
+  val orgCrc = zentry.getCrc()
+  lazy val orgTime = zentry.getTime()
+  val orgComment = zentry.getComment()
 }
 
 class ZipEntryTest {
@@ -88,7 +87,7 @@ class ZipEntryTest {
     assertEquals("getComment", "Testing", ze2.getComment())
     assertEquals("getCompressedSize", 4L, ze2.getCompressedSize())
     assertEquals("getCrc", orgCrc, ze2.getCrc())
-    assertEquals("getTime", orgTime, ze2.getTime())
+    assertEquals("getTime", ze.getTime(), ze2.getTime())
   }
 
   @Test def getComment(): Unit = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
@@ -4,6 +4,7 @@ package org.scalanative.testsuite.javalib.util.zip
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.AfterClass
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform.executingInJVM
@@ -16,7 +17,7 @@ import java.util.zip._
 object ZipEntryTest {
   import ZipBytes.{getZipFile, zipFile}
 
-  val zfile: ZipFile = getZipFile(zipFile)
+  val zfile = getZipFile(zipFile)
   val zentry = zfile.getEntry("File1.txt")
 
   val orgSize = zentry.getSize()
@@ -24,6 +25,11 @@ object ZipEntryTest {
   val orgCrc = zentry.getCrc()
   lazy val orgTime = zentry.getTime()
   val orgComment = zentry.getComment()
+
+  @AfterClass
+  def cleanup(): Unit =
+    zfile.close()
+
 }
 
 class ZipEntryTest {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
@@ -61,11 +61,6 @@ class ZipEntryTest {
     assertEquals("getComment", "Testing", zentry2.getComment())
     assertEquals("getCompressedSize", 4L, zentry2.getCompressedSize())
     assertEquals("getCrc", orgCrc, zentry2.getCrc())
-
-    /* First test against known JVM value. This checks that
-     * Daylight Saving Time offset is handled.
-     */
-    assertEquals("orgTime", 927667206000L, orgTime)
     assertEquals("getTime", orgTime, zentry2.getTime())
   }
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/ZipEntryTest.scala
@@ -1,192 +1,233 @@
 package org.scalanative.testsuite.javalib.util.zip
 
-// Ported from Apache Harmony
+// Ported from Apache Harmony. Contains extensive changes for Scala Native.
 
-import java.util.zip._
-
-import org.junit.Before
 import org.junit.Test
 import org.junit.Assert._
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform.executingInJVM
-import ZipBytes._
+
+import java.{lang => jl}
+
+import java.util.Arrays
+import java.util.zip._
+
+object ZipEntryTest {
+  import ZipBytes.{getZipFile, zipFile}
+
+  val zfile: ZipFile = getZipFile(zipFile)
+  val zentry = zfile.getEntry("File1.txt")
+
+  var orgSize = zentry.getSize()
+  var orgCompressedSize = zentry.getCompressedSize()
+  var orgCrc = zentry.getCrc()
+  var orgTime = zentry.getTime()
+  var orgComment = zentry.getComment()
+
+}
 
 class ZipEntryTest {
+  import ZipEntryTest._
 
-  var zfile: ZipFile = null
-  var zentry: ZipEntry = null
-  var orgSize: Long = 0L
-  var orgCompressedSize: Long = 0L
-  var orgCrc: Long = 0L
-  var orgTime: Long = 0L
-  var orgComment: String = null
+  /* Use a 'def' rather than a 'val' because two tests each append a char
+   * to the StringBuilder returned.
+   *
+   * It is unclear if these tests are ever run in parallel.  If they were
+   * un-synchronized access to a 'val' might show intermittent errors.
+   * A person with some time could probably develop a synchronized 'val'
+   * and save some allocation and setting of memory.  An optimization for
+   * a future devo. java.util.zip has bigger problems today.
+   */
+  private def jumboZipNameSB(): jl.StringBuilder = {
+    //  Also the maximum comment length.
+    val maxZipNameLen = 0xffff // decimal 65535.
 
-  @Before
-  def setUp(): Unit = {
-    zfile = getZipFile(zipFile)
-    zentry = zfile.getEntry("File1.txt")
-    orgSize = zentry.getSize()
-    orgCompressedSize = zentry.getCompressedSize()
-    orgCrc = zentry.getCrc()
-    orgTime = zentry.getTime()
-    orgComment = zentry.getComment()
+    // 0xFFFF has 4 prime factors, decimal 3, 5, 17, 257
+    val maxChunk = 3 * 5 * 257 // 3855, approx 4K, yielding 17 loops iterations
+    val chunk = new Array[Char](maxChunk)
+    Arrays.fill(chunk, 'a')
+
+    // Allocate +1 to allow testing going over the max, without reallocation.
+    val s = new jl.StringBuilder(maxZipNameLen + 1)
+
+    for (j <- 1 to maxZipNameLen / maxChunk)
+      s.append(chunk)
+
+    assertEquals("jumboZipName length", maxZipNameLen, s.length())
+
+    s
   }
 
   @Test def constructorString(): Unit = {
-    zentry = zfile.getEntry("File3.txt")
-    assertTrue(zentry != null)
-
     assertThrows(classOf[NullPointerException], zfile.getEntry(null))
-    val s = new StringBuffer()
-    var i = 0
-    while (i < 65535) {
-      s.append('a')
-      i += 1
-    }
 
-    new ZipEntry(s.toString)
+    val atMax = jumboZipNameSB()
 
-    s.append('a')
-    assertThrows(classOf[IllegalArgumentException], new ZipEntry(s.toString()))
+    val ze = new ZipEntry(atMax.toString())
+    assertNotNull("string == 0xFFFF", ze)
+
+    val overMax = atMax.append('a')
+    assertThrows(
+      classOf[IllegalArgumentException],
+      new ZipEntry(overMax.toString())
+    )
   }
 
   @Test def constructorZipEntry(): Unit = {
-    zentry.setSize(2L)
-    zentry.setCompressedSize(4L)
-    zentry.setComment("Testing")
+    val ze = zfile.getEntry("File1.txt")
+    ze.setSize(2L)
+    ze.setCompressedSize(4L)
+    ze.setComment("Testing")
 
-    val zentry2 = new ZipEntry(zentry)
-    assertEquals("getSize", 2L, zentry2.getSize())
-    assertEquals("getComment", "Testing", zentry2.getComment())
-    assertEquals("getCompressedSize", 4L, zentry2.getCompressedSize())
-    assertEquals("getCrc", orgCrc, zentry2.getCrc())
-    assertEquals("getTime", orgTime, zentry2.getTime())
+    val ze2 = new ZipEntry(ze)
+
+    assertNotEquals("Need clone, not identity", ze, ze2)
+
+    assertEquals("getSize", 2L, ze2.getSize())
+    assertEquals("getComment", "Testing", ze2.getComment())
+    assertEquals("getCompressedSize", 4L, ze2.getCompressedSize())
+    assertEquals("getCrc", orgCrc, ze2.getCrc())
+    assertEquals("getTime", orgTime, ze2.getTime())
   }
 
   @Test def getComment(): Unit = {
-    val zipEntry = new ZipEntry("zippy.zip")
-    assertTrue(zipEntry.getComment() == null)
-    zipEntry.setComment("This Is A Comment")
-    assertTrue(zipEntry.getComment() == "This Is A Comment")
+    val ze = new ZipEntry("zippy.zip")
+    assertNull("null comment", ze.getComment())
+
+    val expected = "This Is A Comment"
+    ze.setComment(expected)
+    assertEquals("comment", expected, ze.getComment())
   }
 
   @Test def getCompressedSize(): Unit = {
-    assertTrue(zentry.getCompressedSize() == orgCompressedSize)
+    val ze = zfile.getEntry("File1.txt")
+    assertEquals("compressed size", orgCompressedSize, ze.getCompressedSize())
   }
 
   @Test def getCrc(): Unit = {
-    assertTrue(zentry.getCrc() == orgCrc)
+    val ze = zfile.getEntry("File1.txt")
+    assertTrue(ze.getCrc() == orgCrc)
   }
 
   @Test def getExtra(): Unit = {
-    assertTrue(zentry.getExtra() == null)
+    val ze = zfile.getEntry("File1.txt")
+    assertTrue(ze.getExtra() == null)
     val ba = Array[Byte]('T', 'E', 'S', 'T')
-    zentry = new ZipEntry("test.tst")
-    zentry.setExtra(ba)
-    assertTrue(zentry.getExtra() == ba)
+    val ze2 = new ZipEntry("test.tst")
+    ze2.setExtra(ba)
+    assertTrue(ze2.getExtra() == ba)
   }
 
   @Test def getMethod(): Unit = {
-    zentry = zfile.getEntry("File1.txt")
-    assertTrue(zentry.getMethod() == ZipEntry.STORED)
+    val ze = zfile.getEntry("File1.txt")
+    assertTrue(ze.getMethod() == ZipEntry.STORED)
+    assertEquals("File1.txt", ZipEntry.STORED, ze.getMethod())
 
-    zentry = zfile.getEntry("File3.txt")
-    assertTrue(zentry.getMethod() == ZipEntry.DEFLATED)
+    val ze2 = zfile.getEntry("File3.txt")
+    assertEquals("File2.txt", ZipEntry.DEFLATED, ze2.getMethod())
 
-    zentry = new ZipEntry("test.tst")
-    assertTrue(zentry.getMethod() == -1)
+    val ze3 = new ZipEntry("test.tst")
+    assertTrue(ze3.getMethod() == -1)
+    assertEquals("test.tst", -1, ze3.getMethod())
   }
 
   @Test def getName(): Unit = {
-    assertTrue(zentry.getName() == "File1.txt")
+    val expected = "File1.txt"
+    val ze = zfile.getEntry(expected)
+    assertEquals(expected, ze.getName())
   }
 
   @Test def getSize(): Unit = {
-    assertTrue(zentry.getSize() == orgSize)
+    val ze = zfile.getEntry("File1.txt")
+    assertTrue(ze.getSize() == orgSize)
   }
 
   @Test def getTime(): Unit = {
-    assertEquals("getTime", orgTime, zentry.getTime())
+    val ze = zfile.getEntry("File1.txt")
+    assertEquals("getTime", orgTime, ze.getTime())
   }
 
   @Test def isDirectory(): Unit = {
-    assertTrue(!zentry.isDirectory())
-    zentry = new ZipEntry("Directory/")
-    assertTrue(zentry.isDirectory())
+    val ze = zfile.getEntry("File1.txt")
+    assertTrue("Expected non-directory", !ze.isDirectory())
+
+    val ze2 = new ZipEntry("Directory/")
+    assertTrue("Expected non-directory", ze2.isDirectory())
   }
 
   @Test def setCommentString(): Unit = {
-    zentry = zfile.getEntry("File1.txt")
-    zentry.setComment("Set comment using api")
-    assertTrue(zentry.getComment() == "Set comment using api")
-    zentry.setComment(null)
-    assertTrue(zentry.getComment() == null)
-    val s = new StringBuffer()
-    var i = 0
-    while (i < 0xffff) {
-      s.append('a')
-      i += 1
-    }
-    zentry.setComment(s.toString)
+    val ze = zfile.getEntry("File1.txt")
+    ze.setComment("Set comment using api")
+    assertTrue(ze.getComment() == "Set comment using api")
+    assertEquals("getComment", "Set comment using api", ze.getComment())
+
+    ze.setComment(null)
+    assertNull("setComment(null)", ze.getComment())
+
+    val atMax = jumboZipNameSB()
+    ze.setComment(atMax.toString())
 
     // From Java API docs:
     // ZIP entry comments have maximum length of 0xffff. If the length of the
     // specified comment string is greater than 0xFFFF bytes after encoding,
     // only the first 0xFFFF bytes are output to the ZIP file entry.
-    s.append('a')
-    zentry.setComment(s.toString)
+
+    val overMax = atMax.append('a')
+    ze.setComment(overMax.toString()) // Should silently truncate, not throw().
   }
 
   @Test def setCompressedSizeLong(): Unit = {
-    zentry.setCompressedSize(orgCompressedSize + 10)
-    assertTrue(zentry.getCompressedSize() == orgCompressedSize + 10)
+    val ze = zfile.getEntry("File1.txt")
+    ze.setCompressedSize(orgCompressedSize + 10)
+    assertTrue(ze.getCompressedSize() == orgCompressedSize + 10)
 
-    zentry.setCompressedSize(0)
-    assertTrue(zentry.getCompressedSize() == 0)
+    ze.setCompressedSize(0)
+    assertTrue(ze.getCompressedSize() == 0)
 
-    zentry.setCompressedSize(-25)
-    assertTrue(zentry.getCompressedSize() == -25)
+    ze.setCompressedSize(-25)
+    assertTrue(ze.getCompressedSize() == -25)
 
-    zentry.setCompressedSize(4294967296L)
-    assertTrue(zentry.getCompressedSize() == 4294967296L)
+    ze.setCompressedSize(4294967296L)
+    assertTrue(ze.getCompressedSize() == 4294967296L)
   }
 
   @Test def setCrcLong(): Unit = {
-    zentry.setCrc(orgCrc + 100)
-    assertTrue(zentry.getCrc == orgCrc + 100)
+    val ze = zfile.getEntry("File1.txt")
+    ze.setCrc(orgCrc + 100)
+    assertTrue(ze.getCrc == orgCrc + 100)
 
-    zentry.setCrc(0)
-    assertTrue(zentry.getCrc == 0)
+    ze.setCrc(0)
+    assertTrue(ze.getCrc == 0)
 
-    assertThrows(classOf[IllegalArgumentException], zentry.setCrc(-25))
+    assertThrows(classOf[IllegalArgumentException], ze.setCrc(-25))
 
-    zentry.setCrc(4294967295L)
-    assertTrue(zentry.getCrc == 4294967295L)
+    ze.setCrc(4294967295L)
+    assertTrue(ze.getCrc == 4294967295L)
 
-    assertThrows(classOf[IllegalArgumentException], zentry.setCrc(4294967296L))
+    assertThrows(classOf[IllegalArgumentException], ze.setCrc(4294967296L))
   }
 
   @Test def setExtraArrayByte(): Unit = {
-    zentry = zfile.getEntry("File1.txt")
-    zentry.setExtra("Test setting extra information".getBytes())
+    val ze = zfile.getEntry("File1.txt")
+    ze.setExtra("Test setting extra information".getBytes())
     assertTrue(
       new String(
-        zentry.getExtra(),
+        ze.getExtra(),
         0,
-        zentry.getExtra().length
+        ze.getExtra().length
       ) == "Test setting extra information"
     )
 
-    zentry = new ZipEntry("test.tst")
+    val ze2 = new ZipEntry("test.tst")
     var ba = new Array[Byte](0xffff)
-    zentry.setExtra(ba)
-    assertTrue(zentry.getExtra() == ba)
+    ze2.setExtra(ba)
+    assertTrue(ze2.getExtra() == ba)
 
     assertThrows(
       classOf[IllegalArgumentException], {
         ba = new Array[Byte](0xffff + 1)
-        zentry.setExtra(ba)
+        ze2.setExtra(ba)
       }
     )
 
@@ -205,43 +246,42 @@ class ZipEntryTest {
   }
 
   @Test def setMethodInt(): Unit = {
-    zentry = zfile.getEntry("File3.txt")
-    zentry.setMethod(ZipEntry.STORED)
-    assertTrue(zentry.getMethod() == ZipEntry.STORED)
+    val ze = zfile.getEntry("File3.txt")
+    ze.setMethod(ZipEntry.STORED)
+    assertTrue(ze.getMethod() == ZipEntry.STORED)
 
-    zentry.setMethod(ZipEntry.DEFLATED)
-    assertTrue(zentry.getMethod() == ZipEntry.DEFLATED)
+    ze.setMethod(ZipEntry.DEFLATED)
+    assertTrue(ze.getMethod() == ZipEntry.DEFLATED)
 
     val error = 1
     assertThrows(
-      classOf[IllegalArgumentException], {
-        zentry = new ZipEntry("test.tst")
-        zentry.setMethod(error)
-      }
+      classOf[IllegalArgumentException],
+      (new ZipEntry("test.tst")).setMethod(error)
     )
   }
 
   @Test def setSizeLong(): Unit = {
-    zentry.setSize(orgSize + 10)
-    assertTrue(zentry.getSize() == orgSize + 10)
+    val ze = zfile.getEntry("File1.txt")
+    ze.setSize(orgSize + 10)
+    assertTrue(ze.getSize() == orgSize + 10)
 
-    zentry.setSize(0)
-    assertTrue(zentry.getSize() == 0)
+    ze.setSize(0)
+    assertTrue(ze.getSize() == 0)
 
-    assertThrows(classOf[IllegalArgumentException], zentry.setSize(-25))
+    assertThrows(classOf[IllegalArgumentException], ze.setSize(-25))
 
     if (!executingInJVM) {
-      // Cannot determinate wheter ZIP64 support is uspported on Windows
+      // Cannot determine whether ZIP64 support is supported on Windows
       // From Java API: throws IllegalArgumentException if:
       // * the specified size is less than 0
       // * is greater than 0xFFFFFFFF when ZIP64 format is not supported
       // * or is less than 0 when ZIP64 is supported
       // ScalaNative supports ZIP64
-      zentry.setSize(4294967295L)
+      ze.setSize(4294967295L)
 
       assertThrows(
         classOf[IllegalArgumentException],
-        zentry.setSize(4294967296L)
+        ze.setSize(4294967296L)
       )
     }
   }


### PR DESCRIPTION
Fix #3787 Fix #936 August 15, 2017

javalib `java.util.zip.ZipEntry` now gets & sets MS-DOS times correctly.

Extended timestamps (i.e. unix times), introduced in Java 8, are the subject of another Issue
which describes them as not yet implemented.