### PR TITLE
fix: Fix emitting of stack-growth guards  and `Await.result`

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -316,7 +316,10 @@ class ForkJoinPool private (
   import scala.scalanative.unsafe._
   def debug(pivot: CVoidPtr) = {
     val alloca = stackalloc[Int]().asInstanceOf[CVoidPtr]
-    if((alloca.toLong - pivot.toLong).abs > 100) println(s"Stack leak in ${Thread.currentThread()}: pivot=$pivot, current=$alloca")
+    if ((alloca.toLong - pivot.toLong).abs > 100)
+      println(
+        s"Stack leak in ${Thread.currentThread()}: pivot=$pivot, current=$alloca"
+      )
   }
 
   final private[concurrent] def runWorker(w: WorkQueue): Unit = {

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -1510,16 +1510,16 @@ object ForkJoinPool {
 
   final val UNCOMPENSATE = 1 << 16 // tryCompensate return
   // Lower and upper word masks
-  private val SP_MASK: Long = 0xffffffffL
-  private val UC_MASK: Long = ~SP_MASK
+  private final val SP_MASK: Long = 0xffffffffL
+  private final val UC_MASK: Long = ~SP_MASK
   // Release counts
-  private val RC_SHIFT: Int = 48
-  private val RC_UNIT: Long = 0x0001L << RC_SHIFT
-  private val RC_MASK: Long = 0xffffL << RC_SHIFT
+  private final val RC_SHIFT: Int = 48
+  private final val RC_UNIT: Long = 0x0001L << RC_SHIFT
+  private final val RC_MASK: Long = 0xffffL << RC_SHIFT
   // Total counts
-  private val TC_SHIFT: Int = 32
-  private val TC_UNIT: Long = 0x0001L << TC_SHIFT
-  private val TC_MASK: Long = 0xffffL << TC_SHIFT
+  private final val TC_SHIFT: Int = 32
+  private final val TC_UNIT: Long = 0x0001L << TC_SHIFT
+  private final val TC_MASK: Long = 0xffffL << TC_SHIFT
   // sp bits
   private final val SS_SEQ = 1 << 16; // version count
   private final val INACTIVE = 1 << 31; // phase bit when idle

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -313,15 +313,6 @@ class ForkJoinPool private (
     false // unreachable
   }
 
-  import scala.scalanative.unsafe._
-  def debug(pivot: CVoidPtr) = {
-    val alloca = stackalloc[Int]().asInstanceOf[CVoidPtr]
-    if ((alloca.toLong - pivot.toLong).abs > 100)
-      println(
-        s"Stack leak in ${Thread.currentThread()}: pivot=$pivot, current=$alloca"
-      )
-  }
-
   final private[concurrent] def runWorker(w: WorkQueue): Unit = {
     if (w != null) { // skip on failed init
 
@@ -337,14 +328,13 @@ class ForkJoinPool private (
         src = awaitWork(w)
         src == 0
       }
-      val alloca = stackalloc[Int]()
 
       while ({
         r ^= r << 13
         r ^= r >>> 17
         r ^= r << 5 // xorshift
         tryScan() || tryAwaitWork()
-      }) debug(alloca)
+      }) ()
       w.access = STOP; // record normal termination
     }
   }

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQeueuedLongSynchronizer.scala
@@ -182,7 +182,8 @@ abstract class AbstractQueuedLongSynchronizer protected ()
     val current = Thread.currentThread()
 
     var node: Node = _node
-    var spins, postSpins = 0 // retries upon unpark of first thread
+    var spins: Byte = 0
+    var postSpins: Byte = 0 // retries upon unpark of first thread
     var interrupted, first = false
     var pred: Node = null // predecessor of node when enqueued
 
@@ -256,7 +257,7 @@ abstract class AbstractQueuedLongSynchronizer protected ()
           else if (!casTail(t, node)) node.setPrevRelaxed(null) // back out
           else t.next = node
         } else if (first && spins != 0) {
-          spins -= 1 // reduce unfairness on rewaits
+          spins = (spins - 1).toByte // reduce unfairness on rewaits
           Thread.onSpinWait()
         } else if (node.status == 0)
           node.status = WAITING // enable signal and recheck

--- a/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/AbstractQueuedSynchronizer.scala
@@ -180,7 +180,8 @@ abstract class AbstractQueuedSynchronizer protected ()
     val current = Thread.currentThread()
 
     var node: Node = _node
-    var spins, postSpins = 0 // retries upon unpark of first thread
+    var spins: Byte = 0
+    var postSpins: Byte = 0 // retries upon unpark of first thread
     var interrupted, first = false
     var pred: Node = null // predecessor of node when enqueued
 
@@ -254,7 +255,7 @@ abstract class AbstractQueuedSynchronizer protected ()
           else if (!casTail(t, node)) node.setPrevRelaxed(null) // back out
           else t.next = node
         } else if (first && spins != 0) {
-          spins -= 1 // reduce unfairness on rewaits
+          spins = (spins - 1).toByte // reduce unfairness on rewaits
           Thread.onSpinWait()
         } else if (node.status == 0)
           node.status = WAITING // enable signal and recheck

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -6,9 +6,9 @@ import scalanative.util.unreachable
 import scalanative.linker._
 import scalanative.codegen.Lower
 
-final class State(block: nir.Local)(preserveDebugInfo: Boolean) {
+final class State(val blockId: nir.Local)(preserveDebugInfo: Boolean) {
 
-  var fresh = nir.Fresh(block.id)
+  var fresh = nir.Fresh(blockId.id)
   /* Performance Note: nir.OpenHashMap/LongMap/AnyRefMap have a faster clone()
    * operation. This really makes a difference on fullClone() */
   var heap = mutable.LongMap.empty[Instance]

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -634,22 +634,22 @@ class IssuesTest {
     assertNotNull(xs.sortBy(i => -i))
   }
 
-  @Test def issue3799(): Unit = {
-    assumeTrue(isMultithreadingEnabled)
-    import scala.concurrent._
-    import scala.concurrent.duration._
-    implicit val ec: ExecutionContext = ExecutionContext.global
-    def loop(nextSchedule: Long): Future[Unit] = Future {
-      if (System.currentTimeMillis() > nextSchedule) {
-        System.currentTimeMillis() + 100
-      } else nextSchedule
-    }.flatMap { next => loop(next) }
+  // @Test def issue3799(): Unit = {
+  //   assumeTrue(isMultithreadingEnabled)
+  //   import scala.concurrent._
+  //   import scala.concurrent.duration._
+  //   implicit val ec: ExecutionContext = ExecutionContext.global
+  //   def loop(nextSchedule: Long): Future[Unit] = Future {
+  //     if (System.currentTimeMillis() > nextSchedule) {
+  //       System.currentTimeMillis() + 100
+  //     } else nextSchedule
+  //   }.flatMap { next => loop(next) }
 
-    assertThrows(
-      classOf[java.util.concurrent.TimeoutException],
-      Await.result(loop(0), 2.seconds)
-    )
-  }
+  //   assertThrows(
+  //     classOf[java.util.concurrent.TimeoutException],
+  //     Await.result(loop(0), 2.seconds)
+  //   )
+  // }
 
   @Test def dottyIssue15402(): Unit = {
     trait Named {

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -647,7 +647,7 @@ class IssuesTest {
 
     assertThrows(
       classOf[java.util.concurrent.TimeoutException],
-      Await.result(loop(0), 5.seconds)
+      Await.result(loop(0), 2.seconds)
     )
   }
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -669,7 +669,7 @@ class IssuesTest {
     finally {
       println("issue3799: done")
       executor.shutdown()
-      if(!executor.awaitTermination(5, TimeUnit.SECONDS)){
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
         executor.shutdownNow()
       }
     }

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -634,22 +634,24 @@ class IssuesTest {
     assertNotNull(xs.sortBy(i => -i))
   }
 
-  // @Test def issue3799(): Unit = {
-  //   assumeTrue(isMultithreadingEnabled)
-  //   import scala.concurrent._
-  //   import scala.concurrent.duration._
-  //   implicit val ec: ExecutionContext = ExecutionContext.global
-  //   def loop(nextSchedule: Long): Future[Unit] = Future {
-  //     if (System.currentTimeMillis() > nextSchedule) {
-  //       System.currentTimeMillis() + 100
-  //     } else nextSchedule
-  //   }.flatMap { next => loop(next) }
+  @Test def issue3799(): Unit = if (isMultithreadingEnabled) {
+    import scala.concurrent._
+    import scala.concurrent.duration._
+    implicit val ec: ExecutionContext = ExecutionContext.global
+    var i, cycles = 0
+    def loop(nextSchedule: Long): Future[Unit] = Future {
+      i += 1
+      if (System.currentTimeMillis() > nextSchedule) {
+        println(s"issue3799: cycles=$cycles, iteration=$i")
+        System.currentTimeMillis() + 100
+      } else nextSchedule
+    }.flatMap { next => loop(next) }
 
-  //   assertThrows(
-  //     classOf[java.util.concurrent.TimeoutException],
-  //     Await.result(loop(0), 2.seconds)
-  //   )
-  // }
+    assertThrows(
+      classOf[java.util.concurrent.TimeoutException],
+      Await.result(loop(0), 2.seconds)
+    )
+  }
 
   @Test def dottyIssue15402(): Unit = {
     trait Named {

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -647,7 +647,7 @@ class IssuesTest {
         Thread.currentThread().getThreadGroup(),
         _,
         "test-issue3799:",
-        32 * 1024L
+        128 * 1024L
       )
     )
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executor)

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -643,6 +643,7 @@ class IssuesTest {
       i += 1
       if (System.currentTimeMillis() > nextSchedule) {
         println(s"issue3799: cycles=$cycles, iteration=$i")
+        cycles += 1
         System.currentTimeMillis() + 100
       } else nextSchedule
     }.flatMap { next => loop(next) }
@@ -651,6 +652,7 @@ class IssuesTest {
       classOf[java.util.concurrent.TimeoutException],
       Await.result(loop(0), 2.seconds)
     )
+    println("issue3799: done")
   }
 
   @Test def dottyIssue15402(): Unit = {

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -651,12 +651,8 @@ class IssuesTest {
       )
     )
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executor)
-    var i, cycles = 0
     def loop(nextSchedule: Long): Future[Unit] = Future {
-      i += 1
       if (System.currentTimeMillis() > nextSchedule) {
-        println(s"issue3799: cycles=$cycles, iteration=$i")
-        cycles += 1
         System.currentTimeMillis() + 100
       } else nextSchedule
     }.flatMap { next => loop(next) }
@@ -667,7 +663,6 @@ class IssuesTest {
         Await.result(loop(0), 2.seconds)
       )
     finally {
-      println("issue3799: done")
       executor.shutdown()
       if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
         executor.shutdownNow()


### PR DESCRIPTION
Fixes #3799 containing 2 bugs: 
 - in release-full mode while loop with stack alllcation with multiple loop exits were not handling correctly the stack-reset (restoring the stack pointer to clean an dynamic stack allocations) in strongly inlined code
 - Invalid spin-wait  in `AbstractQueuedSynchronizer` iterating for Int.MaxValue iterations instead of Byte.MaxValue. It coused waiting for Awaitable stuck. 