### PR TITLE
feature: Define an extension method for conversion `.toCSize` as an alias to `.toUSize`

### DIFF
--- a/nativelib/src/main/scala-3/scala/scalanative/unsigned/extensions.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/unsigned/extensions.scala
@@ -1,6 +1,7 @@
 package scala.scalanative.unsigned
 
 import scala.scalanative.runtime.Intrinsics._
+import scala.scalanative.unsafe.CSize
 
 /** Scala Native unsigned extensions to the standard Byte. */
 extension (inline value: Byte) {
@@ -8,6 +9,10 @@ extension (inline value: Byte) {
   inline def toUShort: UShort = unsignedOf(value.toShort)
   inline def toUInt: UInt = unsignedOf(byteToUInt(value))
   inline def toULong: ULong = unsignedOf(byteToULong(value))
+  inline def toUSize: CSize = unsignedOf(
+    castIntToRawSizeUnsigned(byteToUInt(value))
+  )
+  inline def toCSize: CSize = toUSize
 }
 
 /** Scala Native unsigned extensions to the standard Short. */
@@ -16,6 +21,10 @@ extension (inline value: Short) {
   inline def toUShort: UShort = unsignedOf(value)
   inline def toUInt: UInt = unsignedOf(shortToUInt(value))
   inline def toULong: ULong = unsignedOf(shortToULong(value))
+  inline def toUSize: USize = unsignedOf(
+    castIntToRawSizeUnsigned(shortToUInt((value)))
+  )
+  inline def toCSize: CSize = toUSize
 }
 
 /** Scala Native unsigned extensions to the standard Int. */
@@ -25,6 +34,7 @@ extension (inline value: Int) {
   inline def toUInt: UInt = unsignedOf(value)
   inline def toULong: ULong = unsignedOf(intToULong(value))
   inline def toUSize: USize = unsignedOf(castIntToRawSizeUnsigned(value))
+  inline def toCSize: CSize = toUSize
 }
 
 /** Scala Native unsigned extensions to the standard Long. */
@@ -34,4 +44,5 @@ extension (inline value: Long) {
   inline def toUInt: UInt = unsignedOf(value.toInt)
   inline def toULong: ULong = unsignedOf(value)
   inline def toUSize: USize = unsignedOf(castLongToRawSize(value))
+  inline def toCSize: CSize = toUSize
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -112,7 +112,7 @@ object Array {
       val fromPtr = from.atRawUnsafe(fromPos)
       val toPtr   = to.atRawUnsafe(toPos)
       val size    = to.stride * len
-      libc.memmove(toPtr, fromPtr, castIntToRawSizeUnsigned(size))
+      ffi.memmove(toPtr, fromPtr, castIntToRawSizeUnsigned(size))
     }
   }
 
@@ -156,7 +156,7 @@ object Array {
     } else {
       val leftPtr  = left.atRaw(leftPos)
       val rightPtr = right.atRaw(rightPos)
-      libc.memcmp(leftPtr, rightPtr, castIntToRawSizeUnsigned(len * left.stride))
+      ffi.memcmp(leftPtr, rightPtr, castIntToRawSizeUnsigned(len * left.stride))
     }
   }
 }
@@ -229,7 +229,7 @@ final class ${T}Array private () extends Array[${Repr}] {
     val arrcls  = classOf[${T}Array]
     val arr     = GC.alloc_array(arrcls, length, ${sizeT})
     val src     = castObjectToRawPtr(this)
-    libc.memcpy(
+    ffi.memcpy(
       elemRawPtr(arr, MemoryLayout.Array.ValuesOffset),
       elemRawPtr(src, MemoryLayout.Array.ValuesOffset),
       castIntToRawSizeUnsigned(${sizeT} * length)
@@ -280,7 +280,7 @@ object ${T}Array {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(${sizeT} * length)
-      libc.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size)
     }
     arr
   }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala
@@ -33,6 +33,8 @@ final class Size(private[scalanative] val rawSize: RawSize)
   @inline def toUInt: UInt     = toUSize.toUInt
   @inline def toULong: ULong   = toUSize.toULong
   @inline def toUSize: USize   = USize.valueOf(rawSize)
+  @inline def toCSize: CSize = toUSize
+  @inline def toCSSize: CSSize = this
 
 
   @inline override def doubleValue(): Double = toLong.toDouble

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Size.scala.gyb
@@ -33,6 +33,8 @@ final class Size(private[scalanative] val rawSize: RawSize)
   @inline def toUInt: UInt     = toUSize.toUInt
   @inline def toULong: ULong   = toUSize.toULong
   @inline def toUSize: USize   = USize.valueOf(rawSize)
+  @inline def toCSize: CSize = toUSize
+  @inline def toCSSize: CSSize = this
 
 
   @inline override def doubleValue(): Double = toLong.toDouble

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
@@ -203,6 +203,8 @@ object Tag {
   private[scalanative] sealed trait NatTag {
     def toInt: Int
     def toUInt: UInt = toInt.toUInt
+    def toCSize: CSize = toInt.toCSize
+    def toCSSize: CSSize = toInt.toCSSize
   }
 
   object Nat0 extends Tag[unsafe.Nat._0] with NatTag {

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
@@ -112,6 +112,8 @@ object Tag {
   private[scalanative] sealed trait NatTag {
     def toInt: Int
     def toUInt: UInt = toInt.toUInt
+    def toCSize: CSize = toInt.toCSize
+    def toCSSize: CSSize = toInt.toCSSize
   }
 
   % for N in range(0, 10):
@@ -157,7 +159,7 @@ object Tag {
       val dst = rawptr
       if (value != null) {
         val src = value.rawptr
-        libc.memcpy(dst, src, castIntToRawSizeUnsigned(size))
+        ffi.memcpy(dst, src, castIntToRawSizeUnsigned(size))
       } else storeRawPtr(dst, null)
     }
   }
@@ -214,7 +216,7 @@ object Tag {
       val dst = rawptr
       if (value != null) {
         val src = value.rawptr
-        libc.memcpy(dst, src, castIntToRawSizeUnsigned(size))
+        ffi.memcpy(dst, src, castIntToRawSizeUnsigned(size))
       } else storeRawPtr(dst, null)
     }
   }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -120,23 +120,27 @@ package object unsafe extends unsafe.UnsafePackageCompat {
   /** Scala Native unsafe extensions to the standard Byte. */
   implicit class UnsafeRichByte(val value: Byte) extends AnyVal {
     @inline def toSize: Size = Size.valueOf(castIntToRawSize(value.toInt))
+    @inline def toCSSize: CSSize = toSize
   }
 
   /** Scala Native unsafe extensions to the standard Short. */
   implicit class UnsafeRichShort(val value: Short) extends AnyVal {
     @inline def toSize: Size = Size.valueOf(castIntToRawSize(value.toInt))
+    @inline def toCSSize: CSSize = toSize
   }
 
   /** Scala Native unsafe extensions to the standard Int. */
   implicit class UnsafeRichInt(val value: Int) extends AnyVal {
     @inline def toPtr[T]: Ptr[T] = fromRawPtr[T](castIntToRawPtr(value))
     @inline def toSize: Size = Size.valueOf(castIntToRawSize(value))
+    @inline def toCSSize: CSSize = toSize
   }
 
   /** Scala Native unsafe extensions to the standard Long. */
   implicit class UnsafeRichLong(val value: Long) extends AnyVal {
     @inline def toPtr[T]: Ptr[T] = fromRawPtr[T](castLongToRawPtr(value))
     @inline def toSize: Size = Size.valueOf(castLongToRawSize(value))
+    @inline def toCSSize: CSSize = toSize
   }
 
   /** Scala Native unsafe extensions to Arrays */

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala
@@ -28,10 +28,14 @@ final class USize(private[scalanative] val rawSize: RawSize) extends scala.math.
   @inline def toLong: Long        = castRawSizeToLongUnsigned(rawSize)
   @inline def toSize: unsafe.Size = new unsafe.Size(rawSize)
 
+  @inline def toCSize: unsafe.CSize = this
+  @inline def toCSSize: unsafe.CSSize = toSize
+
   @inline def toUByte: UByte   = toByte.toUByte
   @inline def toUShort: UShort = toShort.toUShort
   @inline def toUInt: UInt     = unsignedOf(castRawSizeToInt(rawSize))
   @inline def toULong: ULong   = unsignedOf(castRawSizeToLongUnsigned(rawSize))
+  @inline def toUSize: USize   = this
 
   @inline override def doubleValue(): Double = toLong.toDouble
   @inline override def floatValue(): Float = toInt.toFloat

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/USize.scala.gyb
@@ -28,10 +28,14 @@ final class USize(private[scalanative] val rawSize: RawSize) extends scala.math.
   @inline def toLong: Long        = castRawSizeToLongUnsigned(rawSize)
   @inline def toSize: unsafe.Size = new unsafe.Size(rawSize)
 
+  @inline def toCSize: unsafe.CSize = this
+  @inline def toCSSize: unsafe.CSSize = toSize
+
   @inline def toUByte: UByte   = toByte.toUByte
   @inline def toUShort: UShort = toShort.toUShort
   @inline def toUInt: UInt     = unsignedOf(castRawSizeToInt(rawSize))
   @inline def toULong: ULong   = unsignedOf(castRawSizeToLongUnsigned(rawSize))
+  @inline def toUSize: USize   = this
 
   @inline override def doubleValue(): Double = toLong.toDouble
   @inline override def floatValue(): Float = toInt.toFloat

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/package.scala
@@ -1,6 +1,7 @@
 package scala.scalanative
 
 import scala.scalanative.runtime.Intrinsics._
+import scala.scalanative.unsafe.CSize
 
 package object unsigned {
 
@@ -12,6 +13,9 @@ package object unsigned {
     @inline def toUShort: UShort = unsignedOf(value.toShort)
     @inline def toUInt: UInt = unsignedOf(byteToUInt(value))
     @inline def toULong: ULong = unsignedOf(byteToULong(value))
+    @inline def toCSize: CSize = unsignedOf(
+      castIntToRawSizeUnsigned(byteToUInt(value))
+    )
   }
 
   /** Scala Native unsigned extensions to the standard Short. */
@@ -20,6 +24,9 @@ package object unsigned {
     @inline def toUShort: UShort = unsignedOf(value)
     @inline def toUInt: UInt = unsignedOf(shortToUInt(value))
     @inline def toULong: ULong = unsignedOf(shortToULong(value))
+    @inline def toCSize: CSize = unsignedOf(
+      castIntToRawSizeUnsigned(shortToUInt(value))
+    )
   }
 
   /** Scala Native unsigned extensions to the standard Int. */
@@ -29,6 +36,7 @@ package object unsigned {
     @inline def toUInt: UInt = unsignedOf(value)
     @inline def toULong: ULong = unsignedOf(intToULong(value))
     @inline def toUSize: USize = unsignedOf(castIntToRawSizeUnsigned(value))
+    @inline def toCSize: CSize = toUSize
   }
 
   /** Scala Native unsigned extensions to the standard Long. */
@@ -38,5 +46,6 @@ package object unsigned {
     @inline def toUInt: UInt = unsignedOf(value.toInt)
     @inline def toULong: ULong = unsignedOf(value)
     @inline def toUSize: USize = unsignedOf(castLongToRawSize(value))
+    @inline def toCSize: CSize = toUSize
   }
 }


### PR DESCRIPTION
The `Size`, `USize` and their aliases `CSSize`, `CSize` might be confusing when migrating to 0.5.x. Let's define an `toCSize` conversion which is an alias to `toUSize` thus allowing to create more consistent code.