### PR TITLE
feature: Allow to create overload of extern method 

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
@@ -1,7 +1,8 @@
 package scala.scalanative
 package libc
 
-import scalanative.unsafe._
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
 
 @extern object stdlib extends stdlib
 
@@ -14,6 +15,20 @@ import scalanative.unsafe._
   def realloc[T](ptr: Ptr[T], newSize: CSize): Ptr[T] = extern
   def free(ptr: CVoidPtr): Unit = extern
   def aligned_alloc(alignment: CSize, size: CSize): Unit = extern
+
+  def malloc(size: Int): Ptr[Byte] = malloc(size.toCSize)
+  def malloc(size: Long): Ptr[Byte] = malloc(size.toCSize)
+  def calloc(num: Int, size: Int): Ptr[Byte] = calloc(num.toCSize, size.toCSize)
+  def calloc(num: Long, size: Long): Ptr[Byte] =
+    calloc(num.toCSize, size.toCSize)
+  def realloc[T](ptr: Ptr[T], newSize: Int): Ptr[T] =
+    realloc(ptr, newSize.toCSize)
+  def realloc[T](ptr: Ptr[T], newSize: Long): Ptr[T] =
+    realloc(ptr, newSize.toCSize)
+  def aligned_alloc(alignment: Int, size: Int): Unit =
+    aligned_alloc(alignment.toCSize, size.toCSize)
+  def aligned_alloc(alignment: Long, size: Long): Unit =
+    aligned_alloc(alignment.toCSize, size.toCSize)
 
   // Program utilities
 
@@ -33,6 +48,7 @@ import scalanative.unsafe._
 
   def rand(): CInt = extern
   def srand(seed: CUnsignedInt): Unit = extern
+  def srand(seed: Int): Unit = srand(seed.toUInt)
 
   // Conversions to numeric formats
 
@@ -68,12 +84,27 @@ import scalanative.unsafe._
       comparator: CFuncPtr2[CVoidPtr, CVoidPtr, CInt]
   ): Unit = extern
 
+  def bsearch(
+      key: CVoidPtr,
+      data: CVoidPtr,
+      num: Int,
+      size: Int,
+      comparator: CFuncPtr2[CVoidPtr, CVoidPtr, CInt]
+  ): Unit = bsearch(key, data, num.toCSize, size.toCSize, comparator)
+
   def qsort[T](
       data: Ptr[T],
       num: CSize,
       size: CSize,
       comparator: CFuncPtr2[CVoidPtr, CVoidPtr, CInt]
   ): Unit = extern
+
+  def qsort[T](
+      data: Ptr[T],
+      num: Int,
+      size: Int,
+      comparator: CFuncPtr2[CVoidPtr, CVoidPtr, CInt]
+  ): Unit = qsort(data, num.toCSize, size.toCSize, comparator)
 
   // Macros
 

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -222,7 +222,7 @@ object Type {
       unreachable
   }.toSeq
 
-  private def isBoxOf(primitiveType: Type)(boxType: Type) =
+  private[scalanative] def isBoxOf(primitiveType: Type)(boxType: Type) =
     unbox
       .get(normalize(boxType))
       .contains(primitiveType)

--- a/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -140,6 +140,20 @@ class NIRCompilerTest {
     )
   }
 
+  @Test def externMemberOverload(): Unit = {
+    val code =
+      """import scala.scalanative.unsafe.extern
+          |
+          |@extern object Dummy {
+          |  def foo(v: Long): Int = extern
+          |  def foo(v: Int): Int = foo(v.toLong)
+          |}
+          |
+          |""".stripMargin
+
+    NIRCompiler(_.compile(code))
+  }
+
   @Test def externExternTrait(): Unit = {
     val code =
       """import scala.scalanative.unsafe.extern

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
@@ -15,8 +15,8 @@ class PtrBoxingTest {
   var any: Any = null
 
   @noinline lazy val nullPtr: Ptr[Byte] = null
-  @noinline lazy val ptr: Ptr[Byte] = malloc(64.toUSize)
-  @noinline lazy val ptr2: Ptr[Byte] = malloc(64.toUSize)
+  @noinline lazy val ptr: Ptr[Byte] = malloc(64)
+  @noinline lazy val ptr2: Ptr[Byte] = malloc(64L)
 
   @noinline def f[T](x: T): T = x
   @noinline def cond(): Boolean = true


### PR DESCRIPTION
Allow to create overload of extern method using a method that is only calling the method with the same name, but with different set of arguments. This allows for very convenient utility of defining overrides taking eg. `Int`/`Long` and using them to call extern using `Size`