### PR TITLE
refactor: More explicit `NativeConfig.multithreading` setting

### DIFF
--- a/.github/workflows/run-tests-linux-multiarch.yml
+++ b/.github/workflows/run-tests-linux-multiarch.yml
@@ -166,7 +166,7 @@ jobs:
                 .withCheck(true)
                 .withCheckFatalWarnings(true)
                 .withTargetTriple(sys.env.get("CROSS_TRIPLE"))
-                .withMultithreadingSupport(${{ matrix.gc != 'commix' }})
+                .withMultithreading(${{ matrix.gc != 'commix' }})
                 .withCompileOptions(_ ++ sysRoot ++ List("-fuse-ld=lld"))
                 .withLinkingOptions(_ ++ sysRoot ++ List("-fuse-ld=lld", "-latomic"))
             }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -868,9 +868,6 @@ object Build {
         noIDEExportSettings,
         Test / fork := true,
         Test / javaOptions += "-Xmx1G",
-        Test / envVars ++= Map(
-          "SCALANATIVE_DISABLE_UNUSED_MULTITHREADING" -> "0"
-        ),
         // Override the dependency of partest - see Scala.js issue #1889
         dependencyOverrides += Deps.ScalaLibrary(scalaVersion.value) % "test",
         testFrameworks ++= {
@@ -1006,7 +1003,7 @@ object Build {
               val base =
                 denylistedFromFile(versionTestsDir / "DenylistedTests.txt")
               val requiringMultithreading =
-                if (nativeConfig.value.multithreadingSupport) Set.empty[String]
+                if (nativeConfig.value.multithreading.contains(true)) Set.empty[String]
                 else
                   denylistedFromFile(
                     versionTestsDir / "DenylistedTests-require-threads.txt",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1003,7 +1003,8 @@ object Build {
               val base =
                 denylistedFromFile(versionTestsDir / "DenylistedTests.txt")
               val requiringMultithreading =
-                if (nativeConfig.value.multithreading.contains(true)) Set.empty[String]
+                if (nativeConfig.value.multithreading.getOrElse(true))
+                  Set.empty[String]
                 else
                   denylistedFromFile(
                     versionTestsDir / "DenylistedTests-require-threads.txt",

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -150,9 +150,10 @@ object MyScalaNativePlugin extends AutoPlugin {
         .withCheckFatalWarnings(true)
         .withDump(true)
         .withSourceLevelDebuggingConfig(_.enableAll)
-        .withMultithreadingSupport(
+        .withGC(scala.scalanative.build.GC.commix)
+        .withMultithreading(
           multithreadingEnabledBySbtSysProps()
-            .getOrElse(nc.multithreadingSupport)
+            .orElse(nc.multithreading)
         )
     },
     inConfig(Compile) {

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -150,7 +150,6 @@ object MyScalaNativePlugin extends AutoPlugin {
         .withCheckFatalWarnings(true)
         .withDump(true)
         .withSourceLevelDebuggingConfig(_.enableAll)
-        .withGC(scala.scalanative.build.GC.commix)
         .withMultithreading(
           multithreadingEnabledBySbtSysProps()
             .orElse(nc.multithreading)

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/Defaults.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/Defaults.scala
@@ -43,5 +43,6 @@ object Defaults {
           .withLTO(Discover.LTO())
           .withLinkingOptions(Discover.linkingOptions())
           .withCompileOptions(Discover.compileOptions())
+          .withMultithreading(true)
       )
 }

--- a/scripted-tests/run/execution-context/build.sbt
+++ b/scripted-tests/run/execution-context/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := {
   else scalaVersion
 }
 
-nativeConfig ~= { _.withMultithreadingSupport(false) }
+nativeConfig ~= { _.withMultithreading(false) }
 
 lazy val runAndCheck = taskKey[Unit]("...")
 

--- a/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/testinterface/CodeGenBench.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/testinterface/CodeGenBench.scala
@@ -64,12 +64,12 @@ abstract class CodeGenBench(nativeConfig: NativeConfig => NativeConfig) {
 
 class CodeGen
     extends CodeGenBench(
-      nativeConfig = _.withMultithreadingSupport(false)
+      nativeConfig = _.withMultithreading(false)
         .withIncrementalCompilation(false)
     )
 class CodeGenWithMultithreading
     extends CodeGenBench(
-      nativeConfig = _.withMultithreadingSupport(true)
+      nativeConfig = _.withMultithreading(true)
         .withGC(GC.Immix) // to ensure generation of GC yieldpoints
         .withIncrementalCompilation(false)
     )

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -38,8 +38,8 @@ private[scalanative] object ScalaNative {
     dumpFile = "linked",
     forceQuickCheck = true
   )(Future {
-    val mtSupport = config.compilerConfig.multithreadingSupport.toString()
-    val linkingMsg = s"Linking (multithreading ${mtSupport})"
+    val mtSupport = config.compilerConfig.multithreading.getOrElse("true, disable if not used")
+    val linkingMsg = s"Linking (multithreadingEnabled=${mtSupport})"
     config.logger.time(linkingMsg) {
       Link(config, entries)
     }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -38,7 +38,8 @@ private[scalanative] object ScalaNative {
     dumpFile = "linked",
     forceQuickCheck = true
   )(Future {
-    val mtSupport = config.compilerConfig.multithreading.getOrElse("true, disable if not used")
+    val mtSupport = config.compilerConfig.multithreading
+      .getOrElse("true, disable if not used")
     val linkingMsg = s"Linking (multithreadingEnabled=${mtSupport})"
     config.logger.time(linkingMsg) {
       Link(config, entries)

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -332,7 +332,7 @@ object Generate {
         LoadModuleSig
       )
       val LoadModule = nir.Val.Global(LoadModuleDecl.name, nir.Type.Ptr)
-      val useSynchronizedAccessors = meta.config.multithreadingSupport
+      val useSynchronizedAccessors = meta.platform.isMultithreadingEnabled
       if (useSynchronizedAccessors) {
         buf += LoadModuleDecl
       }

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -70,7 +70,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
     assertEquals(
       "multithreading",
       withMultithreading,
-      config.compilerConfig.multithreading
+      config.compilerConfig.multithreadingSupport
     )
     assertEquals(
       "targetTriple",

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -59,7 +59,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
     _.withSourceLevelDebuggingConfig(conf =>
       if (withDebugMetadata) conf.enableAll else conf.disableAll
     )
-      .withMultithreadingSupport(withMultithreading)
+      .withMultithreading(withMultithreading)
       .withTargetTriple(withTargetTriple)
   ) { (config: Config, result: ReachabilityAnalysis.Result) =>
     assertEquals(
@@ -70,7 +70,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
     assertEquals(
       "multithreading",
       withMultithreading,
-      config.compilerConfig.multithreadingSupport
+      config.compilerConfig.multithreading
     )
     assertEquals(
       "targetTriple",


### PR DESCRIPTION
* Rename `multithreadingSupport` to `multithreading` 
* Make `NativeThread.multithreading` `Option[Boolean]`, defaulting to `None`. When not defined assume multithreading is enabled, but detect if threads are used. If not, relink with disabled multithreading to improve performance.
* Remove control env variable `SCALANATIVE_DISABLE_UNUSED_MULTITHREADING` 