### PR TITLE
refactor: Restrict access to tools and nir types

### DIFF
--- a/docs/user/sbt.md
+++ b/docs/user/sbt.md
@@ -120,15 +120,13 @@ nativeConfig ~= { c =>
 | 0.1    | `publish`               | `Unit`          | Similar to standard publish with addition of NIR (1)                          |
 | 0.1    | `nativeLink`            | `File`          | Link NIR and generate native binary                                           |
 | 0.4.0  | `nativeConfig`          | `NativeConfig`  | Configuration of the Scala Native plugin                                      |
-| 0.5.0  | `nativeLinkReleaseFast` | `File`          | Alias for `nativeLink` using fast release build mode                          |
-| 0.5.0  | `nativeLinkReleaseFull` | `File`          | Alias for `nativeLink` using full release build mode                          |
+| 0.5.0  | `nativeLinkReleaseFast` | `File`          | Alias for `nativeLink` using fast release build mode (2)                      |
+| 0.5.0  | `nativeLinkReleaseFull` | `File`          | Alias for `nativeLink` using full release build mode (2)                      |
 
 For the details of available `NativeConfig` options see [API](https://javadoc.io/doc/org.scala-native/tools_3/latest/scala/scalanative/build/NativeConfig.html)
 
 1.  See [Publishing](#publishing) and [Cross compilation](#cross-compilation) for details.
 2.  See [Compilation modes](#compilation-modes) for details.
-3.  See [Garbage collectors](#garbage-collectors) for details.
-4.  See [Link-Time Optimization (LTO)](#link-time-optimization-lto) for details.
 
 ## Compilation modes
 

--- a/docs/user/sbt.md
+++ b/docs/user/sbt.md
@@ -22,27 +22,21 @@ user files path, e.g /home/\<USER\>/sn-projects.
 
 
 This will:
-
 -   start sbt.
 -   prompt for a project name
--   use the [.g8
-    template](https://github.com/scala-native/scala-native.g8/tree/main/src/main/g8).
-    to generate a basic project with that name.
+-   use the [.g8 template](https://github.com/scala-native/scala-native.g8/tree/main/src/main/g8) to generate a basic project with that name.
 -   create a project sub-directory with the project name.
--   copy the contents at these template links to the corresponding
-    location in this new project sub-directory.
-    -   [project/plugins.sbt](https://github.com/scala-native/scala-native.g8/blob/main/src/main/g8/project/plugins.sbt)
-        adds the Scala Native plugin dependency and its version.
-    -   [project/build.properties](https://github.com/scala-native/scala-native.g8/blob/main/src/main/g8/project/build.properties)
-        specifies the sbt version.
-    -   [build.sbt](https://github.com/scala-native/scala-native.g8/blob/main/src/main/g8/build.sbt)
-        enables the plugin and specifies the Scala version.
-    -   [src/main/scala/Main.scala](https://github.com/scala-native/scala-native.g8/blob/main/src/main/g8/src/main/scala/Main.scala)
-        is a minimal application. :
+-   copy the contents at these template links to the corresponding location in this new project sub-directory.
+    -   [project/plugins.sbt](https://github.com/scala-native/scala-native.g8/blob/main/src/main/g8/project/plugins.sbt) adds the Scala Native plugin dependency and its version.
+    -   [project/build.properties](https://github.com/scala-native/scala-native.g8/blob/main/src/main/g8/project/build.properties) specifies the sbt version.
+    -   [build.sbt](https://github.com/scala-native/scala-native.g8/blob/main/src/main/g8/build.sbt) enables the plugin and specifies the Scala version.
+    -   [src/main/scala/Main.scala](https://github.com/scala-native/scala-native.g8/blob/main/src/main/g8/src/main/scala/Main.scala) is a minimal application. 
+        ```scala
             object Main {
               def main(args: Array[String]): Unit =
                 println("Hello, world!")
             }
+        ```
 
 To use the new project:
 
@@ -50,7 +44,6 @@ To use the new project:
     > -   For example, on linux with a project named
     >     AnswerToProjectNamePrompt, type
     >     `cd AnswerToProjectNamePrompt`.
-
 -   Type `sbt run`.
 
 This will get everything compiled and should have the expected output!
@@ -126,25 +119,16 @@ nativeConfig ~= { c =>
 | 0.1    | `package`               | `File`          | Similar to standard package with addition of NIR                              |
 | 0.1    | `publish`               | `Unit`          | Similar to standard publish with addition of NIR (1)                          |
 | 0.1    | `nativeLink`            | `File`          | Link NIR and generate native binary                                           |
-| 0.1    | `nativeClang`           | `File`          | Path to `clang` command                                                       |
-| 0.1    | `nativeClangPP`         | `File`          | Path to `clang++` command                                                     |
-| 0.1    | `nativeCompileOptions`  | `Seq[String]`   | Extra options passed to clang verbatim during compilation                     |
-| 0.1    | `nativeLinkingOptions`  | `Seq[String]`   | Extra options passed to clang verbatim during linking                         |
-| 0.1    | `nativeMode`            | `String`        | One of `"debug"`, `"release-fast"`, `"release-size"` or `"release-full"` (2)  |
-| 0.2    | `nativeGC`              | `String`        | One of `"none"`, `"boehm"`, `"immix"` or `"commix"` (3)                       |
-| 0.3.3  | `nativeLinkStubs`       | `Boolean`       | Whether to link `@stub` definitions, or to ignore them                        |
 | 0.4.0  | `nativeConfig`          | `NativeConfig`  | Configuration of the Scala Native plugin                                      |
-| 0.4.0  | `nativeLTO`             | `String`        | One of `"none"`, `"full"` or `"thin"` (4)                                     |
-| 0.4.0  | `targetTriple`          | `String`        | The platform LLVM target triple                                               |
-| 0.4.0  | `nativeCheck`           | `Boolean`       | Shall the linker check intermediate results for correctness?                  |
-| 0.4.0  | `nativeDump`            | `Boolean`       | Shall the linker dump intermediate results to disk?                           |
+| 0.5.0  | `nativeLinkReleaseFast` | `File`          | Alias for `nativeLink` using fast release build mode                          |
+| 0.5.0  | `nativeLinkReleaseFull` | `File`          | Alias for `nativeLink` using full release build mode                          |
 
-1.  See [Publishing](#publishing) and [Cross
-    compilation](#cross-compilation) for details.
+For the details of available `NativeConfig` options see [API](https://javadoc.io/doc/org.scala-native/tools_3/latest/scala/scalanative/build/NativeConfig.html)
+
+1.  See [Publishing](#publishing) and [Cross compilation](#cross-compilation) for details.
 2.  See [Compilation modes](#compilation-modes) for details.
 3.  See [Garbage collectors](#garbage-collectors) for details.
-4.  See [Link-Time Optimization (LTO)](#link-time-optimization-lto) for
-    details.
+4.  See [Link-Time Optimization (LTO)](#link-time-optimization-lto) for details.
 
 ## Compilation modes
 

--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -10,7 +10,7 @@ import util.unsupported
  *
  *  * What are the successors of given block?
  */
-object ControlFlow {
+private[scalanative] object ControlFlow {
   final case class Edge(from: Block, to: Block, next: Next)
 
   final case class Block(

--- a/nir/src/main/scala/scala/scalanative/nir/Dep.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Dep.scala
@@ -1,9 +1,0 @@
-package scala.scalanative
-package nir
-
-sealed abstract class Dep
-object Dep {
-  final case class Direct(dep: Global) extends Dep
-  final case class Conditional(dep: Global, cond: Global) extends Dep
-  final case class Weak(dep: Global) extends Dep
-}

--- a/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
@@ -27,7 +27,7 @@ object LinktimeCondition {
 
 }
 
-object Linktime {
+private[scalanative] object Linktime {
 
   final val Linktime = Global.Top("scala.scalanative.linktime")
 

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -3,7 +3,7 @@ package nir
 
 import Type._
 
-object Rt {
+private[scalanative] object Rt {
   val Object = Ref(Global.Top("java.lang.Object"))
   val Class = Ref(Global.Top("java.lang.Class"))
   val String = Ref(Global.Top("java.lang.String"))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -14,10 +14,10 @@ import ScriptedPlugin.autoImport._
 import com.jsuereth.sbtpgp.PgpKeys
 
 import scala.collection.mutable
-import scala.scalanative.build.Platform
 import MyScalaNativePlugin.isGeneratingForIDE
 
 import java.io.File
+import java.util.Locale
 
 object Settings {
   lazy val fetchScalaSource = taskKey[File](
@@ -182,7 +182,11 @@ object Settings {
       apiMappings += file("/modules/java.base") -> url(javaDocBaseURL),
       Compile / doc / sources := {
         val prev = (Compile / doc / sources).value
-        if (Platform.isWindows &&
+        val isWindows = System
+          .getProperty("os.name", "unknown")
+          .toLowerCase(Locale.ROOT)
+          .startsWith("windows")
+        if (isWindows &&
             sys.env.contains("CI") // Always present in GitHub Actions
         ) Nil
         else prev

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -1,7 +1,6 @@
 enablePlugins(ScalaNativePlugin)
 
 import scala.sys.process._
-import scala.scalanative.build.Platform.isWindows
 
 scalaVersion := {
   val scalaVersion = System.getProperty("scala.version")
@@ -54,6 +53,10 @@ Compile / compile := {
     opath
   }
 
+  val isWindows = System
+    .getProperty("os.name", "unknown")
+    .toLowerCase(Locale.ROOT)
+    .startsWith("windows")
   val libName =
     if (isWindows) "link-order-test.lib"
     else "liblink-order-test.a"

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -1,6 +1,7 @@
 enablePlugins(ScalaNativePlugin)
 
 import scala.sys.process._
+import java.util.Locale
 
 scalaVersion := {
   val scalaVersion = System.getProperty("scala.version")

--- a/tools/jvm/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/jvm/src/main/scala/scala/scalanative/build/Platform.scala
@@ -3,7 +3,7 @@ package scala.scalanative.build
 import java.util.Locale
 
 /** Utility methods indicating the platform type */
-private[scalanative] object Platform {
+private[scala] object Platform {
   final val isJVM = true
 
   private lazy val osUsed =

--- a/tools/jvm/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/jvm/src/main/scala/scala/scalanative/build/Platform.scala
@@ -3,7 +3,7 @@ package scala.scalanative.build
 import java.util.Locale
 
 /** Utility methods indicating the platform type */
-object Platform {
+private[scalanative] object Platform {
   final val isJVM = true
 
   private lazy val osUsed =

--- a/tools/native/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/native/src/main/scala/scala/scalanative/build/Platform.scala
@@ -3,7 +3,7 @@ package scala.scalanative.build
 import scala.scalanative.meta.LinktimeInfo
 
 /** Utility methods indicating the platform type */
-private[scalanative] object Platform {
+private[scala] object Platform {
   final val isJVM = false
 
   /** Test for the platform type

--- a/tools/native/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/native/src/main/scala/scala/scalanative/build/Platform.scala
@@ -3,7 +3,7 @@ package scala.scalanative.build
 import scala.scalanative.meta.LinktimeInfo
 
 /** Utility methods indicating the platform type */
-object Platform {
+private[scalanative] object Platform {
   final val isJVM = false
 
   /** Test for the platform type

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -257,7 +257,7 @@ object Build {
    *  @return
    *    the paths to the compiled objects
    */
-  def findAndCompileNativeLibraries(
+  private[scala] def findAndCompileNativeLibraries(
       config: Config,
       analysis: ReachabilityAnalysis.Result
   )(implicit ec: ExecutionContext): Future[Seq[Path]] = {

--- a/tools/src/main/scala/scala/scalanative/build/Descriptor.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Descriptor.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 import java.io.Reader
 import scala.annotation.tailrec
 
-final case class Descriptor(
+private[build] final case class Descriptor(
     organization: Option[String],
     name: Option[String],
     gcProject: Boolean,
@@ -17,7 +17,7 @@ final case class Descriptor(
     includes: List[String]
 )
 
-object Descriptor {
+private[build] object Descriptor {
 
   def load(path: Path): Try[Descriptor] = Try {
     var reader: Reader = null

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -270,7 +270,7 @@ object Discover {
     }
   }
 
-  class ContextBasedCache[Ctx, Key, Value <: AnyRef] {
+  private class ContextBasedCache[Ctx, Key, Value <: AnyRef] {
     private val cachedValues = scala.collection.mutable.Map.empty[Key, Value]
     private var lastContext: Ctx = _
     def apply[T <: Value: ClassTag](

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -485,7 +485,7 @@ object NativeConfig {
     }
   }
 
-  def checkLinktimeProperties(properties: LinktimeProperites): Unit = {
+  private[scalanative] def checkLinktimeProperties(properties: LinktimeProperites): Unit = {
     def isNumberOrString(value: Any) = {
       value match {
         case _: Boolean | _: Byte | _: Char | _: Short | _: Int | _: Long |

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -485,7 +485,9 @@ object NativeConfig {
     }
   }
 
-  private[scalanative] def checkLinktimeProperties(properties: LinktimeProperites): Unit = {
+  private[scalanative] def checkLinktimeProperties(
+      properties: LinktimeProperites
+  ): Unit = {
     def isNumberOrString(value: Any) = {
       value match {
         case _: Boolean | _: Byte | _: Char | _: Short | _: Int | _: Long |

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -3,7 +3,7 @@ package scala.scalanative.build
 import java.nio.file.Files
 
 /** Used to validate config objects */
-object Validator {
+private[build] object Validator {
 
   /** Runs all the individual private validators
    *

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -6,7 +6,9 @@ import scalanative.linker._
 import scalanative.util.partitionBy
 import scala.concurrent._
 
-private[scalanative] sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
+private[scalanative] sealed abstract class NIRCheck(implicit
+    analysis: ReachabilityAnalysis.Result
+) {
   val errors = mutable.UnrolledBuffer.empty[Check.Error]
   var name: nir.Global = nir.Global.None
   var ctx: List[String] = Nil
@@ -77,8 +79,9 @@ private[scalanative] sealed abstract class NIRCheck(implicit analysis: Reachabil
   }
 }
 
-private[scalanative] final class Check(implicit analysis: ReachabilityAnalysis.Result)
-    extends NIRCheck {
+private[scalanative] final class Check(implicit
+    analysis: ReachabilityAnalysis.Result
+) extends NIRCheck {
   val labels = mutable.Map.empty[nir.Local, Seq[nir.Type]]
   val env = mutable.Map.empty[nir.Local, nir.Type]
 
@@ -741,8 +744,9 @@ private[scalanative] final class Check(implicit analysis: ReachabilityAnalysis.R
   }
 }
 
-private[scalanative] final class QuickCheck(implicit analysis: ReachabilityAnalysis.Result)
-    extends NIRCheck {
+private[scalanative] final class QuickCheck(implicit
+    analysis: ReachabilityAnalysis.Result
+) extends NIRCheck {
   override def checkMethod(meth: Method): Unit = {
     meth.insts.foreach(checkInst)
   }

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -6,7 +6,7 @@ import scalanative.linker._
 import scalanative.util.partitionBy
 import scala.concurrent._
 
-sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
+private[scalanative] sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
   val errors = mutable.UnrolledBuffer.empty[Check.Error]
   var name: nir.Global = nir.Global.None
   var ctx: List[String] = Nil
@@ -77,7 +77,7 @@ sealed abstract class NIRCheck(implicit analysis: ReachabilityAnalysis.Result) {
   }
 }
 
-final class Check(implicit analysis: ReachabilityAnalysis.Result)
+private[scalanative] final class Check(implicit analysis: ReachabilityAnalysis.Result)
     extends NIRCheck {
   val labels = mutable.Map.empty[nir.Local, Seq[nir.Type]]
   val env = mutable.Map.empty[nir.Local, nir.Type]
@@ -741,7 +741,7 @@ final class Check(implicit analysis: ReachabilityAnalysis.Result)
   }
 }
 
-final class QuickCheck(implicit analysis: ReachabilityAnalysis.Result)
+private[scalanative] final class QuickCheck(implicit analysis: ReachabilityAnalysis.Result)
     extends NIRCheck {
   override def checkMethod(meth: Method): Unit = {
     meth.insts.foreach(checkInst)
@@ -765,7 +765,7 @@ final class QuickCheck(implicit analysis: ReachabilityAnalysis.Result)
 
 }
 
-object Check {
+private[scalanative] object Check {
   final case class Error(name: nir.Global, ctx: List[String], msg: String)
 
   private def run(

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package codegen
 
-class CommonMemoryLayouts(implicit meta: Metadata) {
+private[codegen] class CommonMemoryLayouts(implicit meta: Metadata) {
 
   sealed abstract class Layout(types: List[nir.Type]) {
     def this(types: nir.Type*) = this(types.toList)

--- a/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
@@ -3,11 +3,11 @@ package codegen
 
 import scalanative.linker.{Class, Method}
 
-object DynamicHashMap {
+private[codegen] object DynamicHashMap {
   final val ty: nir.Type = nir.Type.Ptr
 }
 
-class DynamicHashMap(cls: Class, proxies: Seq[nir.Defn])(implicit
+private[codegen] class DynamicHashMap(cls: Class, proxies: Seq[nir.Defn])(implicit
     meta: Metadata
 ) {
 

--- a/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
@@ -7,8 +7,8 @@ private[codegen] object DynamicHashMap {
   final val ty: nir.Type = nir.Type.Ptr
 }
 
-private[codegen] class DynamicHashMap(cls: Class, proxies: Seq[nir.Defn])(implicit
-    meta: Metadata
+private[codegen] class DynamicHashMap(cls: Class, proxies: Seq[nir.Defn])(
+    implicit meta: Metadata
 ) {
 
   val methods: Seq[nir.Global.Member] = {

--- a/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
@@ -3,7 +3,7 @@ package codegen
 
 import scalanative.linker.{Class, Field}
 
-class FieldLayout(cls: Class)(implicit meta: Metadata) {
+private[codegen] class FieldLayout(cls: Class)(implicit meta: Metadata) {
 
   import meta.layouts.{Object, ObjectHeader, ArrayHeader}
   import meta.platform

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -12,7 +12,7 @@ import scala.scalanative.linker.{
 import scala.scalanative.build.Logger
 
 // scalafmt: { maxColumn = 120}
-private[codegen]  object Generate {
+private[codegen] object Generate {
   private implicit val pos: nir.SourcePosition = nir.SourcePosition.NoPosition
   private implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
   import Impl._

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -12,7 +12,7 @@ import scala.scalanative.linker.{
 import scala.scalanative.build.Logger
 
 // scalafmt: { maxColumn = 120}
-object Generate {
+private[codegen]  object Generate {
   private implicit val pos: nir.SourcePosition = nir.SourcePosition.NoPosition
   private implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
   import Impl._

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 
 /** Created by lukaskellenberger on 17.12.16.
  */
-object GenerateReflectiveProxies {
+private[codegen] object GenerateReflectiveProxies {
   implicit val scopeId: nir.ScopeId = nir.ScopeId.TopLevel
 
   private def genReflProxy(defn: nir.Defn.Define): nir.Defn.Define = {

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -3,7 +3,7 @@ package codegen
 
 import scalanative.linker.{Trait, Class}
 
-class HasTraitTables(meta: Metadata) {
+private[codegen] class HasTraitTables(meta: Metadata) {
 
   private implicit val pos: nir.SourcePosition = nir.SourcePosition.NoPosition
 

--- a/tools/src/main/scala/scala/scalanative/codegen/IncrementalCodeGenContext.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/IncrementalCodeGenContext.scala
@@ -9,7 +9,7 @@ import scala.io.Source
 import scala.language.implicitConversions
 import scala.scalanative.build.Build
 
-class IncrementalCodeGenContext(config: build.Config) {
+private[codegen] class IncrementalCodeGenContext(config: build.Config) {
   private val package2hash: TrieMap[String, Long] = TrieMap[String, Long]()
   private val pack2hashPrev: TrieMap[String, Long] = TrieMap[String, Long]()
   private val changed: TrieMap[String, Long] = TrieMap[String, Long]()

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -6,7 +6,7 @@ import scalanative.util.{ScopedVar, unsupported}
 import scalanative.linker._
 import scalanative.interflow.UseDef.eliminateDeadCode
 
-object Lower {
+private[scalanative] object Lower {
 
   def apply(
       defns: Seq[nir.Defn]

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -11,7 +11,7 @@ import scala.scalanative.nir.Attr.Alignment
 import scala.scalanative.build.BuildException
 import scala.annotation.tailrec
 
-final case class MemoryLayout(
+private[codegen] final case class MemoryLayout(
     size: Long,
     tys: Seq[MemoryLayout.PositionedType]
 ) {
@@ -48,7 +48,7 @@ final case class MemoryLayout(
       .map(_.offset)
 }
 
-object MemoryLayout {
+private[scalanative] object MemoryLayout {
   final val BITS_IN_BYTE = 8
   final val BYTES_IN_LONG = 8
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -4,7 +4,7 @@ package codegen
 import scala.collection.mutable
 import scalanative.linker.{Trait, Class, ReachabilityAnalysis}
 
-private[codegen]  class Metadata(
+private[codegen] class Metadata(
     val analysis: ReachabilityAnalysis.Result,
     val buildConfig: build.Config,
     proxies: Seq[nir.Defn]

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -4,7 +4,7 @@ package codegen
 import scala.collection.mutable
 import scalanative.linker.{Trait, Class, ReachabilityAnalysis}
 
-class Metadata(
+private[codegen]  class Metadata(
     val analysis: ReachabilityAnalysis.Result,
     val buildConfig: build.Config,
     proxies: Seq[nir.Defn]

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -4,7 +4,7 @@ package codegen
 import scala.collection.mutable
 import scalanative.linker.{Trait, Class, ReachabilityAnalysis}
 
-private[codegen] class Metadata(
+private[scalanative] class Metadata(
     val analysis: ReachabilityAnalysis.Result,
     val buildConfig: build.Config,
     proxies: Seq[nir.Defn]

--- a/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
@@ -4,7 +4,7 @@ package codegen
 import scala.collection.mutable
 import scalanative.linker.Class
 
-class ModuleArray(meta: Metadata) {
+private[codegen] class ModuleArray(meta: Metadata) {
 
   val index = mutable.Map.empty[Class, Int]
   val modules = mutable.UnrolledBuffer.empty[Class]

--- a/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
@@ -6,7 +6,7 @@ import scalanative.linker.Method
 /** Implementation based on the article: 'Throw away the keys: Easy, Minimal
  *  Perfect Hashing' by Steve Hanov (http://stevehanov.ca/blog/index.php?id=119)
  */
-object PerfectHashMap {
+private[codegen] object PerfectHashMap {
 
   val MAX_D_VALUE = 10000
 
@@ -144,7 +144,7 @@ object PerfectHashMap {
 
 }
 
-class PerfectHashMap[K, V](
+private[codegen] class PerfectHashMap[K, V](
     val keys: Seq[Int],
     val values: Seq[Option[V]],
     hashFunc: (K, Int) => Int
@@ -166,7 +166,7 @@ class PerfectHashMap[K, V](
 
 }
 
-object DynmethodPerfectHashMap {
+private[codegen] object DynmethodPerfectHashMap {
 
   def apply(
       dynmethods: Seq[nir.Global.Member],

--- a/tools/src/main/scala/scala/scalanative/codegen/PlatformInfo.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PlatformInfo.scala
@@ -13,7 +13,7 @@ private[scalanative] case class PlatformInfo(
   val sizeOfPtr = if (is32Bit) 4 else 8
   val sizeOfPtrBits = sizeOfPtr * 8
 }
-object PlatformInfo {
+private[scalanative] object PlatformInfo {
   def apply(config: Config): PlatformInfo = PlatformInfo(
     targetTriple = config.compilerConfig.targetTriple,
     targetsWindows = config.targetsWindows,

--- a/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
@@ -4,7 +4,9 @@ package codegen
 import scalanative.util.unreachable
 import scalanative.linker.{ScopeInfo, Class, Trait}
 
-private[codegen] class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
+private[codegen] class RuntimeTypeInformation(info: ScopeInfo)(implicit
+    meta: Metadata
+) {
 
   import RuntimeTypeInformation._
 

--- a/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
@@ -4,7 +4,7 @@ package codegen
 import scalanative.util.unreachable
 import scalanative.linker.{ScopeInfo, Class, Trait}
 
-class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
+private[codegen] class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
 
   import RuntimeTypeInformation._
 
@@ -51,7 +51,7 @@ class RuntimeTypeInformation(info: ScopeInfo)(implicit meta: Metadata) {
   }
 }
 
-object RuntimeTypeInformation {
+private[codegen] object RuntimeTypeInformation {
 
   private val classConst =
     nir.Val.Global(

--- a/tools/src/main/scala/scala/scalanative/codegen/SourceCodeCache.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/SourceCodeCache.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable
 import scala.collection.concurrent.TrieMap
 import scala.annotation.nowarn
 
-class SourceCodeCache(config: build.Config) {
+private[codegen] class SourceCodeCache(config: build.Config) {
   lazy val sourceCodeDir = {
     val dir = config.workDir.resolve("sources")
     if (!Files.exists(dir)) Files.createDirectories(dir)

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -4,7 +4,7 @@ package codegen
 import scala.collection.mutable
 import scalanative.linker.{Method, Trait, Class}
 
-class TraitDispatchTable(meta: Metadata) {
+private[codegen] class TraitDispatchTable(meta: Metadata) {
 
   val dispatchName =
     nir.Global

--- a/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
@@ -3,7 +3,7 @@ package codegen
 
 import scala.collection.mutable
 
-class VirtualTable(cls: linker.Class)(implicit meta: Metadata) {
+private[codegen] class VirtualTable(cls: linker.Class)(implicit meta: Metadata) {
 
   private val slots: mutable.UnrolledBuffer[nir.Sig] =
     cls.parent.fold {

--- a/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
@@ -3,7 +3,9 @@ package codegen
 
 import scala.collection.mutable
 
-private[codegen] class VirtualTable(cls: linker.Class)(implicit meta: Metadata) {
+private[codegen] class VirtualTable(cls: linker.Class)(implicit
+    meta: Metadata
+) {
 
   private val slots: mutable.UnrolledBuffer[nir.Sig] =
     cls.parent.fold {

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -159,7 +159,7 @@ object CodeGen {
       llvmIRGenerators ++ maybeBuildInfoGenerator
     }
 
-  object Impl {
+  private object Impl {
     import scala.scalanative.codegen.llvm.AbstractCodeGen
     def apply(
         env: Map[nir.Global, nir.Defn],
@@ -231,7 +231,7 @@ object CodeGen {
     }
   }
 
-  def depends(implicit platform: PlatformInfo): Seq[nir.Global] = {
+  private[scalanative] def depends(implicit platform: PlatformInfo): Seq[nir.Global] = {
     val buf = mutable.UnrolledBuffer.empty[nir.Global]
     buf ++= Lower.depends
     buf ++= Generate.depends

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -231,7 +231,9 @@ object CodeGen {
     }
   }
 
-  private[scalanative] def depends(implicit platform: PlatformInfo): Seq[nir.Global] = {
+  private[scalanative] def depends(implicit
+      platform: PlatformInfo
+  ): Seq[nir.Global] = {
     val buf = mutable.UnrolledBuffer.empty[nir.Global]
     buf ++= Lower.depends
     buf ++= Generate.depends

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
@@ -4,8 +4,8 @@ package llvm
 
 import scala.language.implicitConversions
 import scala.collection.mutable
-sealed trait Metadata
-object Metadata {
+private[codegen] sealed trait Metadata
+private[codegen] object Metadata {
   case class Id(value: Int) extends AnyVal {
     def show = "!" + value.toString()
   }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -24,7 +24,7 @@ import scala.scalanative.codegen.llvm.Metadata.conversions.optionWrapper
 import scala.scalanative.nir.SourceFile.Relative
 
 // scalafmt: { maxColumn = 100}
-trait MetadataCodeGen { self: AbstractCodeGen =>
+private[codegen] trait MetadataCodeGen { self: AbstractCodeGen =>
   import MetadataCodeGen._
   import Metadata._
   import Writer._
@@ -650,7 +650,7 @@ trait MetadataCodeGen { self: AbstractCodeGen =>
   }
 }
 
-object MetadataCodeGen {
+private[codegen] object MetadataCodeGen {
   case class Context(codeGen: AbstractCodeGen, sb: ShowBuilder) {
     type WriterCache[T <: Metadata.Node] = mutable.Map[T, Metadata.Id]
     private[MetadataCodeGen] val writersCache

--- a/tools/src/main/scala/scala/scalanative/interflow/Allowlist.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Allowlist.scala
@@ -4,7 +4,7 @@ package interflow
 import scala.collection.mutable
 import scalanative.codegen.Lower
 
-object Allowlist {
+private[scalanative] object Allowlist {
 
   val constantModules = {
     val out = collection.mutable.Set.empty[nir.Global]

--- a/tools/src/main/scala/scala/scalanative/interflow/BailOut.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/BailOut.scala
@@ -1,6 +1,6 @@
 package scala.scalanative
 package interflow
 
-final case class BailOut(val msg: String)
+private[interflow] final case class BailOut(val msg: String)
     extends Exception(msg)
     with scala.util.control.NoStackTrace

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -8,7 +8,7 @@ import nir.Bin.{And => Iand, _}
 import nir.Comp._
 import nir.Conv._
 
-trait Combine { self: Interflow =>
+private[interflow] trait Combine { self: Interflow =>
 
   def combine(bin: nir.Bin, ty: nir.Type, l: nir.Val, r: nir.Val)(implicit
       state: State,

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -7,7 +7,7 @@ import scala.scalanative.linker._
 import scala.scalanative.codegen.MemoryLayout
 import scala.scalanative.util.{unreachable, And}
 
-trait Eval { self: Interflow =>
+private[interflow] trait Eval { self: Interflow =>
   def interflow: Interflow = self
   final val preserveDebugInfo: Boolean =
     self.config.compilerConfig.sourceLevelDebuggingConfig.generateLocalVariables

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -5,7 +5,7 @@ import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.linker._
 import scala.scalanative.util.unreachable
 
-trait Inline { self: Interflow =>
+private[interflow] trait Inline { self: Interflow =>
   val optimizerConfig = config.compilerConfig.optimizerConfig
   import optimizerConfig.{
     smallFunctionSize,

--- a/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
@@ -34,7 +34,8 @@ private[interflow] sealed abstract class Instance(implicit
   }
 }
 
-private[interflow] final case class EscapedInstance(val escapedValue: nir.Val)(implicit
+private[interflow] final case class EscapedInstance(val escapedValue: nir.Val)(
+    implicit
     srcPosition: nir.SourcePosition,
     scopeId: nir.ScopeId
 ) extends Instance {
@@ -42,7 +43,8 @@ private[interflow] final case class EscapedInstance(val escapedValue: nir.Val)(i
     this(escapedValue)(instance.srcPosition, instance.scopeId)
 }
 
-private[interflow] final case class DelayedInstance(val delayedOp: nir.Op)(implicit
+private[interflow] final case class DelayedInstance(val delayedOp: nir.Op)(
+    implicit
     srcPosition: nir.SourcePosition,
     scopeId: nir.ScopeId
 ) extends Instance

--- a/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
@@ -4,7 +4,7 @@ package interflow
 import java.util.Arrays
 import scalanative.linker.Class
 
-sealed abstract class Instance(implicit
+private[interflow] sealed abstract class Instance(implicit
     val srcPosition: nir.SourcePosition,
     val scopeId: nir.ScopeId
 ) extends Cloneable {
@@ -34,7 +34,7 @@ sealed abstract class Instance(implicit
   }
 }
 
-final case class EscapedInstance(val escapedValue: nir.Val)(implicit
+private[interflow] final case class EscapedInstance(val escapedValue: nir.Val)(implicit
     srcPosition: nir.SourcePosition,
     scopeId: nir.ScopeId
 ) extends Instance {
@@ -42,12 +42,12 @@ final case class EscapedInstance(val escapedValue: nir.Val)(implicit
     this(escapedValue)(instance.srcPosition, instance.scopeId)
 }
 
-final case class DelayedInstance(val delayedOp: nir.Op)(implicit
+private[interflow] final case class DelayedInstance(val delayedOp: nir.Op)(implicit
     srcPosition: nir.SourcePosition,
     scopeId: nir.ScopeId
 ) extends Instance
 
-final case class VirtualInstance(
+private[interflow] final case class VirtualInstance(
     kind: Kind,
     cls: Class,
     values: Array[nir.Val],

--- a/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
@@ -3,7 +3,7 @@ package interflow
 
 import scalanative.linker._
 
-object InstanceRef {
+private[interflow] object InstanceRef {
 
   def unapply(addr: Addr)(implicit state: State): Option[nir.Type] =
     unapply(nir.Val.Virtual(addr))
@@ -18,7 +18,7 @@ object InstanceRef {
 
 }
 
-object VirtualRef {
+private[interflow] object VirtualRef {
 
   type Extract = (Kind, Class, Array[nir.Val])
 
@@ -43,7 +43,7 @@ object VirtualRef {
 
 }
 
-object DelayedRef {
+private[interflow] object DelayedRef {
 
   def unapply(addr: Addr)(implicit state: State): Option[nir.Op] =
     unapply(nir.Val.Virtual(addr))
@@ -63,7 +63,7 @@ object DelayedRef {
 
 }
 
-object BinRef {
+private[interflow] object BinRef {
 
   type Extract = (nir.Bin, nir.Val, nir.Val)
 
@@ -85,7 +85,7 @@ object BinRef {
 
 }
 
-object ConvRef {
+private[interflow] object ConvRef {
 
   type Extract = (nir.Conv, nir.Type, nir.Val)
 
@@ -107,7 +107,7 @@ object ConvRef {
 
 }
 
-object CompRef {
+private[interflow] object CompRef {
 
   type Extract = (nir.Comp, nir.Type, nir.Val, nir.Val)
 
@@ -133,7 +133,7 @@ object CompRef {
 
 }
 
-object EscapedRef {
+private[interflow] object EscapedRef {
 
   def unapply(addr: Addr)(implicit state: State): Option[nir.Val] =
     unapply(nir.Val.Virtual(addr))

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -9,7 +9,7 @@ import scala.scalanative.util.ScopedVar
 import java.util.function.Supplier
 import scala.concurrent._
 
-class Interflow(val config: build.Config)(implicit
+private[scalanative] class Interflow(val config: build.Config)(implicit
     val analysis: ReachabilityAnalysis.Result
 ) extends Visit
     with Opt
@@ -200,7 +200,7 @@ object Interflow {
       .map(_ => interflow.result())
   }
 
-  object LLVMIntrinsics {
+  private[interflow] object LLVMIntrinsics {
     private val externAttrs = nir.Attrs(isExtern = true)
     private val LLVMI =
       nir.Global.Top("scala.scalanative.runtime.LLVMIntrinsics$")
@@ -214,7 +214,7 @@ object Interflow {
     val StackRestoreSig = nir.Type.Function(Seq(nir.Type.Ptr), nir.Type.Unit)
   }
 
-  val depends: Seq[nir.Global] = Seq(
+  private[scalanative] val depends: Seq[nir.Global] = Seq(
     LLVMIntrinsics.StackSave.name,
     LLVMIntrinsics.StackRestore.name
   )

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -200,7 +200,7 @@ object Interflow {
       .map(_ => interflow.result())
   }
 
-  private[interflow] object LLVMIntrinsics {
+  private[scalanative] object LLVMIntrinsics {
     private val externAttrs = nir.Attrs(isExtern = true)
     private val LLVMI =
       nir.Global.Top("scala.scalanative.runtime.LLVMIntrinsics$")

--- a/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
@@ -6,7 +6,7 @@ import scalanative.codegen.Lower
 import java.util.Arrays
 import scalanative.linker._
 
-trait Intrinsics { self: Interflow =>
+private[interflow] trait Intrinsics { self: Interflow =>
 
   val arrayApplyIntrinsics = Lower.arrayApply.values.toSet[nir.Global]
   val arrayUpdateIntrinsics = Lower.arrayUpdate.values.toSet[nir.Global]

--- a/tools/src/main/scala/scala/scalanative/interflow/Kind.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Kind.scala
@@ -1,8 +1,8 @@
 package scala.scalanative
 package interflow
 
-sealed abstract class Kind
-object ClassKind extends Kind
-object ArrayKind extends Kind
-object BoxKind extends Kind
-object StringKind extends Kind
+private[interflow] sealed abstract class Kind
+private[interflow] object ClassKind extends Kind
+private[interflow] object ArrayKind extends Kind
+private[interflow] object BoxKind extends Kind
+private[interflow] object StringKind extends Kind

--- a/tools/src/main/scala/scala/scalanative/interflow/Log.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Log.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package interflow
 
-trait Log { self: Interflow =>
+private[interflow] trait Log { self: Interflow =>
   private def show: Boolean =
     false
 

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -4,7 +4,10 @@ package interflow
 import scala.collection.mutable
 import scala.annotation.tailrec
 
-private[interflow] final class MergeBlock(val label: nir.Inst.Label, val id: nir.Local) {
+private[interflow] final class MergeBlock(
+    val label: nir.Inst.Label,
+    val id: nir.Local
+) {
 
   var incoming = mutable.Map.empty[nir.Local, (Seq[nir.Val], State)]
   var outgoing = mutable.Map.empty[nir.Local, MergeBlock]

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -4,7 +4,7 @@ package interflow
 import scala.collection.mutable
 import scala.annotation.tailrec
 
-final class MergeBlock(val label: nir.Inst.Label, val id: nir.Local) {
+private[interflow] final class MergeBlock(val label: nir.Inst.Label, val id: nir.Local) {
 
   var incoming = mutable.Map.empty[nir.Local, (Seq[nir.Val], State)]
   var outgoing = mutable.Map.empty[nir.Local, MergeBlock]

--- a/tools/src/main/scala/scala/scalanative/interflow/MergePhi.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergePhi.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package interflow
 
-final case class MergePhi(
+private[interflow] final case class MergePhi(
     param: nir.Val.Local,
     incoming: Seq[(nir.Local, nir.Val)]
 )

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -6,7 +6,7 @@ import scala.scalanative.util.unreachable
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.linker._
 
-final class MergeProcessor(
+private[interflow] final class MergeProcessor(
     insts: Array[nir.Inst],
     debugInfo: DebugInfo,
     blockFresh: nir.Fresh,
@@ -521,7 +521,7 @@ final class MergeProcessor(
   }
 }
 
-object MergeProcessor {
+private[interflow] object MergeProcessor {
   case object Restart extends Exception with scala.util.control.NoStackTrace
 
   /* To mitigate risk of duplicated ids each merge block uses a dedicated

--- a/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
@@ -3,7 +3,7 @@ package interflow
 
 import scalanative.linker._
 
-trait NoOpt { self: Interflow =>
+private[interflow] trait NoOpt { self: Interflow =>
 
   def noOpt(defn: nir.Defn.Define): Unit =
     noOptInsts(defn.insts)

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -6,7 +6,7 @@ import scala.scalanative.linker._
 import scala.collection.mutable
 import scala.scalanative.util.ScopedVar.scopedPushIf
 
-trait Opt { self: Interflow =>
+private[interflow] trait Opt { self: Interflow =>
 
   def shallOpt(name: nir.Global.Member): Boolean = {
     val defn =

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -4,7 +4,7 @@ package interflow
 import scala.collection.mutable
 import scalanative.linker._
 
-trait PolyInline { self: Interflow =>
+private[interflow] trait PolyInline { self: Interflow =>
 
   private def polyTargets(
       op: nir.Op.Method

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -6,8 +6,7 @@ import scalanative.util.unreachable
 import scalanative.linker._
 import scalanative.codegen.Lower
 
-final class State(val blockId: nir.Local)(preserveDebugInfo: Boolean) {
-
+private[interflow] final class State(val blockId: nir.Local)(preserveDebugInfo: Boolean) {
   var fresh = nir.Fresh(blockId.id)
   /* Performance Note: nir.OpenHashMap/LongMap/AnyRefMap have a faster clone()
    * operation. This really makes a difference on fullClone() */

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -9,7 +9,7 @@ import scalanative.codegen.Lower
 private[interflow] final class State(val blockId: nir.Local)(
     preserveDebugInfo: Boolean
 ) {
-  var fresh = nir.Fresh(block.id)
+  var fresh = nir.Fresh(blockId.id)
   /* Performance Note: nir.OpenHashMap/LongMap/AnyRefMap have a faster clone()
    * operation. This really makes a difference on fullClone() */
   var heap = mutable.LongMap.empty[Instance]

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -6,8 +6,10 @@ import scalanative.util.unreachable
 import scalanative.linker._
 import scalanative.codegen.Lower
 
-private[interflow] final class State(val blockId: nir.Local)(preserveDebugInfo: Boolean) {
-  var fresh = nir.Fresh(blockId.id)
+private[interflow] final class State(val blockId: nir.Local)(
+    preserveDebugInfo: Boolean
+) {
+  var fresh = nir.Fresh(block.id)
   /* Performance Note: nir.OpenHashMap/LongMap/AnyRefMap have a faster clone()
    * operation. This really makes a difference on fullClone() */
   var heap = mutable.LongMap.empty[Instance]

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -7,20 +7,20 @@ import scalanative.linker.Ref
 
 object UseDef {
 
-  sealed abstract class Def {
+  private sealed abstract class Def {
     def id: nir.Local
     def deps: mutable.UnrolledBuffer[Def]
     def uses: mutable.UnrolledBuffer[Def]
     var alive: Boolean = false
   }
 
-  final case class InstDef(
+  private final case class InstDef(
       id: nir.Local,
       deps: mutable.UnrolledBuffer[Def],
       uses: mutable.UnrolledBuffer[Def]
   ) extends Def
 
-  final case class BlockDef(
+  private final case class BlockDef(
       id: nir.Local,
       deps: mutable.UnrolledBuffer[Def],
       uses: mutable.UnrolledBuffer[Def],
@@ -71,7 +71,7 @@ object UseDef {
       false
   }
 
-  def apply(cfg: nir.ControlFlow.Graph): Map[nir.Local, Def] = {
+  private def apply(cfg: nir.ControlFlow.Graph): Map[nir.Local, Def] = {
     val defs = mutable.Map.empty[nir.Local, Def]
     val blocks = cfg.all
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -5,7 +5,7 @@ import scalanative.linker._
 import scala.concurrent._
 import scala.annotation.tailrec
 
-trait Visit { self: Interflow =>
+private[interflow] trait Visit { self: Interflow =>
 
   def shallVisit(name: nir.Global.Member): Boolean = {
     val orig = originalName(name)

--- a/tools/src/main/scala/scala/scalanative/interflow/package.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/package.scala
@@ -6,7 +6,8 @@ package object interflow {
 
   private[interflow] type Addr = Long
 
-  private[interflow] implicit class MutMapOps[K, V](val map: mutable.Map[K, V]) extends AnyVal {
+  private[interflow] implicit class MutMapOps[K, V](val map: mutable.Map[K, V])
+      extends AnyVal {
     def addMissing(other: Iterable[(K, V)]): Unit = other.foreach {
       case (key, value) => map.getOrElseUpdate(key, value)
     }

--- a/tools/src/main/scala/scala/scalanative/interflow/package.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/package.scala
@@ -4,9 +4,9 @@ import scala.collection.mutable
 
 package object interflow {
 
-  type Addr = Long
+  private[interflow] type Addr = Long
 
-  implicit class MutMapOps[K, V](val map: mutable.Map[K, V]) extends AnyVal {
+  private[interflow] implicit class MutMapOps[K, V](val map: mutable.Map[K, V]) extends AnyVal {
     def addMissing(other: Iterable[(K, V)]): Unit = other.foreach {
       case (key, value) => map.getOrElseUpdate(key, value)
     }

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
@@ -6,7 +6,7 @@ import scala.scalanative.util.unsupported
 import scala.scalanative.build.NativeConfig.{ServiceName, ServiceProviderName}
 import scala.scalanative.build.Logger
 
-object LinktimeIntrinsicCallsResolver {
+private[linker] object LinktimeIntrinsicCallsResolver {
   // scalafmt: { maxColumn = 120}
   final val ServiceLoader = Global.Top("java.util.ServiceLoader")
   final val ServiceLoaderModule = Global.Top("java.util.ServiceLoader$")
@@ -176,7 +176,7 @@ object LinktimeIntrinsicCallsResolver {
   }
 }
 
-trait LinktimeIntrinsicCallsResolver { self: Reach =>
+private[linker] trait LinktimeIntrinsicCallsResolver { self: Reach =>
   import self._
   import LinktimeIntrinsicCallsResolver._
 

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
@@ -6,7 +6,7 @@ import scala.scalanative.util.unsupported
 import scala.scalanative.build.NativeConfig.{ServiceName, ServiceProviderName}
 import scala.scalanative.build.Logger
 
-private[linker] object LinktimeIntrinsicCallsResolver {
+private[scala] object LinktimeIntrinsicCallsResolver {
   // scalafmt: { maxColumn = 120}
   final val ServiceLoader = Global.Top("java.util.ServiceLoader")
   final val ServiceLoaderModule = Global.Top("java.util.ServiceLoader$")

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 import scala.scalanative.build._
 import scala.scalanative.util.unsupported
 
-trait LinktimeValueResolver { self: Reach =>
+private[linker] trait LinktimeValueResolver { self: Reach =>
 
   import LinktimeValueResolver._
 

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Path, Paths}
 import scala.annotation.tailrec
 import scala.collection.mutable
 
-class Reach(
+private[linker] class Reach(
     protected val config: build.Config,
     entries: Seq[nir.Global],
     protected val loader: ClassLoader
@@ -1156,7 +1156,7 @@ class Reach(
   lazy val injects: Seq[nir.Defn] = UnsupportedFeatureExtractor.injects
 }
 
-object Reach {
+private[scalanative] object Reach {
   def apply(
       config: build.Config,
       entries: Seq[nir.Global],


### PR DESCRIPTION
Makes most of toolchain internal definitions package private and update docs to point users to NativeConfig API 