### PR TITLE
Preliminary support of OpenBSD/amd64

### DIFF
--- a/clib/src/main/resources/scala-native/locale.c
+++ b/clib/src/main/resources/scala-native/locale.c
@@ -136,7 +136,7 @@ _Static_assert(offsetof(struct scalanative_lconv, int_p_cs_precedes) ==
                    offsetof(struct lconv, int_p_cs_precedes),
                "Unexpected offset: scalanative_lconv.int_p_cs_precedes");
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__OpenBSD__)
 _Static_assert(offsetof(struct scalanative_lconv, int_n_cs_precedes) ==
                    offsetof(struct lconv, int_n_cs_precedes),
                "Unexpected offset: scalanative_lconv.int_n_cs_precedes");

--- a/clib/src/main/scala/scala/scalanative/libc/locale.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/locale.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package libc
 
 import scalanative.unsafe._
-import scalanative.meta.LinktimeInfo.isLinux
+import scalanative.meta.LinktimeInfo.{isLinux, isOpenBSD}
 
 /** ISO/IEC C definitions for locale.h
  *
@@ -105,11 +105,11 @@ object localeOpsImpl {
   def n_sign_posn(ptr: Ptr[lconv]): CChar = ptr._18
   def int_p_cs_precedes(ptr: Ptr[lconv]): CChar = ptr._19._1
   def int_p_sep_by_space(ptr: Ptr[lconv]): CChar =
-    if (isLinux) ptr._19._2
+    if (isLinux || isOpenBSD) ptr._19._2
     else ptr._19._3 // macOS & probably BSDs
 
   def int_n_cs_precedes(ptr: Ptr[lconv]): CChar =
-    if (isLinux) ptr._19._3
+    if (isLinux || isOpenBSD) ptr._19._3
     else ptr._19._2 // macOS & probably BSDs
 
   def int_n_sep_by_space(ptr: Ptr[lconv]): CChar = ptr._19._4

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -27,6 +27,12 @@ instructions for your operating system.
 $ pkg install sbt
 ```
 
+**OpenBSD**
+
+``` shell
+$ pkg_add sbt
+```
+
 ## Installing clang and runtime dependencies
 
 Scala Native requires Clang, which is part of the
@@ -102,6 +108,15 @@ $ pkg install boehm-gc # optional
 
 *Note 3:* Using the boehm GC with multi-threaded binaries doesn\'t work
 out-of-the-box yet.
+
+**OpenBSD 7.5 and later**
+
+*Note 1:* OpenBSD support is experimental and limited to only AMD64
+architecture.
+
+``` shell
+$ pkg_add boehm-gc # optional
+```
 
 **Nix/NixOS**
 

--- a/javalib/src/main/resources/scala-native/net/if_dl.c
+++ b/javalib/src/main/resources/scala-native/net/if_dl.c
@@ -4,8 +4,8 @@
 // Does not exist on Linux, so no check
 #else // macOS, FreeBSD, etc.
 
-#if defined(__FreeBSD__)
-// Make u_* types required/used by FreeBSD net/if_dl.h available
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+// Make u_* types required/used by FreeBSD / OpenBSD net/if_dl.h available
 #undef __BSD_VISIBLE
 #define __BSD_VISIBLE 1
 #include <sys/types.h> // size_t

--- a/javalib/src/main/resources/scala-native/time_nano.c
+++ b/javalib/src/main/resources/scala-native/time_nano.c
@@ -37,9 +37,11 @@ long long scalanative_nano_time() {
 #else
 #if defined(__FreeBSD__)
     int clock = CLOCK_MONOTONIC_PRECISE; // OS has no CLOCK_MONOTONIC_RAW
+#elif defined(__OpenBSD__)
+    int clock = CLOCK_MONOTONIC; // OpenBSD has only CLOCK_MONOTONIC
 #else  // Linux, macOS
     int clock = CLOCK_MONOTONIC_RAW;
-#endif // !FreeBSD
+#endif // !FreeBSD || !OpenBSD
 
     // return value of 0 is success
     struct timespec ts;

--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -15,8 +15,8 @@
 #if defined(__aarch64__) // ARM64
 #define ASM_JMPBUF_SIZE 192
 #define JMPBUF_STACK_POINTER_OFFSET (104 / 8)
-#elif defined(__x86_64__) &&                                                   \
-    (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
+#elif defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) ||      \
+                              defined(__FreeBSD__) || defined(__OpenBSD__))
 #define ASM_JMPBUF_SIZE 72
 #define JMPBUF_STACK_POINTER_OFFSET (16 / 8)
 #elif defined(__i386__) &&                                                     \

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
@@ -1,4 +1,4 @@
-#if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
+#if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__))
 
 /* ----------------------------------------------------------------------------
   Copyright (c) 2016, Microsoft Research, Daan Leijen

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/utils/Time.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/utils/Time.c
@@ -82,9 +82,11 @@ long long Time_current_nanos() {
 #else
 #if defined(__FreeBSD__)
     int clock = CLOCK_MONOTONIC_PRECISE; // OS has no CLOCK_MONOTONIC_RAW
+#elif defined(__OpenBSD__)
+    int clock = CLOCK_MONOTONIC; // OpenBSD has only CLOCK_MONOTONIC
 #else  // Linux, macOS
     int clock = CLOCK_MONOTONIC_RAW;
-#endif // !FreeBSD
+#endif // !FreeBSD || !OpenBSD
 
     // return value of 0 is success
     struct timespec ts;

--- a/nativelib/src/main/resources/scala-native/platform/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform/platform.c
@@ -20,6 +20,14 @@ int scalanative_platform_is_freebsd() {
 #endif
 }
 
+int scalanative_platform_is_openbsd() {
+#if defined(__OpenBSD__)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 int scalanative_platform_is_linux() {
 #ifdef __linux__
     return 1;

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -25,6 +25,9 @@ object LinktimeInfo {
   @resolvedAtLinktime
   def isFreeBSD: Boolean = target.os == "freebsd"
 
+  @resolvedAtLinktime
+  def isOpenBSD: Boolean = target.os == "openbsd"
+
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.is32BitPlatform")
   def is32BitPlatform: Boolean = resolved
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -10,6 +10,9 @@ object Platform {
   @name("scalanative_platform_is_freebsd")
   def isFreeBSD(): Boolean = extern
 
+  @name("scalanative_platform_is_openbsd")
+  def isOpenBSD(): Boolean = extern
+
   @name("scalanative_platform_is_linux")
   def isLinux(): Boolean = extern
 

--- a/posixlib/src/main/resources/scala-native/dirent.c
+++ b/posixlib/src/main/resources/scala-native/dirent.c
@@ -21,7 +21,13 @@ int scalanative_dt_blk() { return DT_BLK; }
 int scalanative_dt_reg() { return DT_REG; }
 int scalanative_dt_lnk() { return DT_LNK; }
 int scalanative_dt_sock() { return DT_SOCK; }
-int scalanative_dt_wht() { return DT_WHT; }
+int scalanative_dt_wht() {
+#ifdef DW_WHT
+    return DT_WHT;
+#else
+    return 0;
+#endif
+}
 
 DIR *scalanative_opendir(const char *name) { return opendir(name); }
 

--- a/posixlib/src/main/resources/scala-native/errno.c
+++ b/posixlib/src/main/resources/scala-native/errno.c
@@ -112,7 +112,13 @@ int scalanative_enoexec() { return ENOEXEC; }
 
 int scalanative_enolck() { return ENOLCK; }
 
-int scalanative_enolink() { return ENOLINK; }
+int scalanative_enolink() {
+#ifdef ENOLINK
+    return ENOLINK;
+#else
+    return 0;
+#endif
+}
 
 int scalanative_enomem() { return ENOMEM; }
 

--- a/posixlib/src/main/resources/scala-native/langinfo.c
+++ b/posixlib/src/main/resources/scala-native/langinfo.c
@@ -63,6 +63,14 @@
 #define CRNCYSTR -1
 #endif // _WIN32
 
+#if defined(__OpenBSD__)
+#define ERA -1
+#define ERA_D_FMT -1
+#define ERA_D_T_FMT -1
+#define ERA_T_FMT -1
+#define ALT_DIGITS -1
+#endif // OpenBSD
+
 int scalanative_codeset() { return CODESET; };
 
 int scalanative_d_t_fmt() { return D_T_FMT; };

--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -99,9 +99,21 @@ int scalanative_ai_numerichost() { return AI_NUMERICHOST; }
 
 int scalanative_ai_numericserv() { return AI_NUMERICSERV; }
 
-int scalanative_ai_v4mapped() { return AI_V4MAPPED; }
+int scalanative_ai_v4mapped() {
+#ifdef AI_V4MAPPED
+    return AI_V4MAPPED;
+#else
+    return 0;
+#endif
+}
 
-int scalanative_ai_all() { return AI_ALL; }
+int scalanative_ai_all() {
+#ifdef AI_ALL
+    return AI_ALL;
+#else
+    return 0;
+#endif
+}
 
 int scalanative_ai_addrconfig() { return AI_ADDRCONFIG; }
 

--- a/posixlib/src/main/resources/scala-native/netinet/tcp.c
+++ b/posixlib/src/main/resources/scala-native/netinet/tcp.c
@@ -2,6 +2,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <WinSock2.h>
 #else
+#ifdef __OpenBSD__
+#include <sys/types.h>
+#endif
 #include <netinet/tcp.h>
 #endif
 

--- a/posixlib/src/main/resources/scala-native/signal.c
+++ b/posixlib/src/main/resources/scala-native/signal.c
@@ -2,6 +2,31 @@
     (defined(__APPLE__) && defined(__MACH__))
 #include <signal.h>
 
+#ifdef __OpenBSD__
+
+// OpenBSD doesn't implenent SIGEB_ signals, use 0 instead
+#define SIGEV_NONE 0
+#define SIGEV_SIGNAL 0
+#define SIGEV_THREAD 0
+
+// nor SIGPOLL
+#define POLL_IN 0
+#define POLL_OUT 0
+#define POLL_MSG 0
+#define POLL_ERR 0
+#define POLL_PRI 0
+#define POLL_HUP 0
+#define NSIGPOLL 0
+
+// nor SIGPROF
+#define PROF_SIG 0
+#define NSIGPROF 0
+
+// SI_ASYNCIO and SI_MESGQ are missed as well
+#define SI_ASYNCIO 0
+#define SI_MESGQ 0
+#endif
+
 // symbolic constants -  see signal.scala
 // some missing are deprecated or not supported
 // others missing can be found in clib

--- a/posixlib/src/main/resources/scala-native/sys/resource.c
+++ b/posixlib/src/main/resources/scala-native/sys/resource.c
@@ -83,7 +83,13 @@ rlim_t scalanative_rlim_saved_cur() { return RLIM_SAVED_CUR; };
 
 rlim_t scalanative_rlim_saved_max() { return RLIM_SAVED_MAX; };
 
-int scalanative_rlimit_as() { return RLIMIT_AS; };
+int scalanative_rlimit_as() {
+#ifdef RLIMIT_AS
+    return RLIMIT_AS;
+#else
+    return 0;
+#endif
+};
 
 int scalanative_rlimit_core() { return RLIMIT_CORE; };
 

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -56,7 +56,7 @@ struct scalanative_sockaddr_storage {
     scalanative_sa_family_t ss_family;
     unsigned short __opaquePadTo32;
     unsigned int __opaquePadTo64;
-    unsigned long long __opaqueAlignStructure[15];
+    unsigned long long __opaqueAlignStructure[31];
 };
 
 // Also verifies that Scala Native sa_family field has the traditional size.
@@ -67,8 +67,13 @@ _Static_assert(offsetof(struct scalanative_sockaddr, sa_data) ==
                    offsetof(struct sockaddr, sa_data),
                "offset mismatch: sockaddr sa_data");
 
+#if defined(__OpenBSD__)
+_Static_assert(sizeof(struct sockaddr_storage) == 256,
+               "unexpected size for sockaddr_storage");
+#else
 _Static_assert(sizeof(struct sockaddr_storage) == 128,
                "unexpected size for sockaddr_storage");
+#endif
 
 // struct msghdr - POSIX 48 byte (padding) on 64 bit machines, 28 on 32 bit.
 struct scalanative_msghdr {

--- a/posixlib/src/main/resources/scala-native/syslog.c
+++ b/posixlib/src/main/resources/scala-native/syslog.c
@@ -22,7 +22,13 @@ int scalanative_log_debug() { return LOG_DEBUG; }
 int scalanative_log_primask() { return LOG_PRIMASK; }
 
 int scalanative_log_pri(int p) { return LOG_PRI(p); }
-int scalanative_log_makepri(int fac, int pri) { return LOG_MAKEPRI(fac, pri); }
+int scalanative_log_makepri(int fac, int pri) {
+#ifdef LOG_MAKEPRI
+    return LOG_MAKEPRI(fac, pri);
+#else
+    return fac | pri;
+#endif
+}
 
 int scalanative_log_kern() { return LOG_KERN; }
 int scalanative_log_user() { return LOG_USER; }

--- a/posixlib/src/main/resources/scala-native/termios.c
+++ b/posixlib/src/main/resources/scala-native/termios.c
@@ -10,6 +10,26 @@
 #define VTDLY VTDELAY
 #endif
 
+#if defined(__OpenBSD__)
+// OpenBSD has missed some constatn, use 0 instead
+#define NLDLY 0
+#define CRDLY 0
+#define BSDLY 0
+#define VTDLY 0
+#define BS0 0
+#define BS1 0
+#define CR0 0
+#define CR1 0
+#define CR2 0
+#define CR3 0
+#define FF0 0
+#define FF1 0
+#define NL0 0
+#define NL1 0
+#define TAB1 0
+#define TAB2 0
+#endif
+
 // symbolic constants for use as subscripts for the array c_cc
 
 int scalanative_termios_veof() { return VEOF; }

--- a/posixlib/src/main/resources/scala-native/time.c
+++ b/posixlib/src/main/resources/scala-native/time.c
@@ -127,10 +127,10 @@ static void scalanative_tm_init(struct scalanative_tm *scala_tm,
 int scalanative_clock_nanosleep(clockid_t clockid, int flags,
                                 struct timespec *request,
                                 struct timespec *remain) {
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__OpenBSD__)
     return clock_nanosleep(clockid, flags, request, remain);
 #else
-    errno = ENOTSUP; // No clock_nanosleep() on Apple.
+    errno = ENOTSUP; // No clock_nanosleep() on Apple or OpenBSD.
     return ENOTSUP;
 #endif
 }

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -7,7 +7,7 @@
 #include <unistd.h>
 #include "types.h" // scalanative_* types, not <sys/types.h>
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 
 /* Apply a Pareto cost/benefit analysis here.
  *
@@ -32,7 +32,7 @@
 #define _SC_TRACE_NAME_MAX 0
 #define _SC_TRACE_SYS_MAX 0
 #define _SC_TRACE_USER_EVENT_MAX 0
-#endif // __FreeBSD__
+#endif // __FreeBSD__ || __OpenBSD__
 
 long scalanative__posix_version() { return _POSIX_VERSION; }
 

--- a/posixlib/src/main/resources/scala-native/wordexp.c
+++ b/posixlib/src/main/resources/scala-native/wordexp.c
@@ -1,5 +1,6 @@
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
+#ifndef __OpenBSD__
 
 #include <stddef.h>
 #include <wordexp.h>
@@ -39,9 +40,10 @@ _Static_assert(offsetof(struct scalanative_wordexp_t, we_offs) ==
                "offset mismatch: wordexp_t we_offs");
 
 #endif // __STDC_VERSION__
+#endif // !OpenBSD
 #endif // Unix or Mac OS
 
-#if defined(_WIN32) // bogus values to keep linker happy
+#if defined(_WIN32) || defined(__OpenBSD__) // bogus values to keep linker happy
 #define WRDE_APPEND -1
 #define WRDE_DOOFFS -1
 #define WRDE_NOCMD -1

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -15,7 +15,7 @@ import scalanative.meta.LinktimeInfo._
 @extern
 object socket {
   type _14 = Nat.Digit2[Nat._1, Nat._4]
-  type _15 = Nat.Digit2[Nat._1, Nat._5]
+  type _31 = Nat.Digit2[Nat._3, Nat._1]
 
   /* Design Note:
    *  C11 _Static_assert() statements in socket.c check that the
@@ -57,14 +57,14 @@ object socket {
     CArray[CChar, _14] // sa_data, size = 14 in OS X and Linux
   ]
 
-  /* The declaration of sockaddr_storage should yield 128 bytes,
-   * with an overall alignment so that pointers have natural (64 )alignment.
+  /* The declaration of sockaddr_storage should yield 256 bytes,
+   * with an overall alignment so that pointers have natural (64) alignment.
    */
   type sockaddr_storage = CStruct4[
     sa_family_t, // ss_family, // ss_family, sa_len is synthesized if needed
     CUnsignedShort, // __opaquePadTo32
     CUnsignedInt, // opaque, __opaquePadTo64
-    CArray[CUnsignedLongLong, _15] // __opaqueAlignStructure to 8 bytes.
+    CArray[CUnsignedLongLong, _31] // __opaqueAlignStructure to 8 bytes.
   ]
 
   /* This is the POSIX 2018 & prior definition. Because SN 'naturally'
@@ -396,7 +396,7 @@ object socketOps {
   // Also used by posixlib netinet/in.scala
   @resolvedAtLinktime
   def useSinXLen = !isLinux &&
-    (isMac || isFreeBSD)
+    (isMac || isFreeBSD || isOpenBSD)
 
   implicit class sockaddrOps(val ptr: Ptr[sockaddr]) extends AnyVal {
     def sa_len: uint8_t = if (!useSinXLen) {

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
@@ -35,7 +35,7 @@ object unOps {
 
   @resolvedAtLinktime
   def useSinXLen = !isLinux &&
-    (isMac || isFreeBSD)
+    (isMac || isFreeBSD || isOpenBSD)
 
   implicit class sockaddr_unOps(val ptr: Ptr[sockaddr_un]) extends AnyVal {
     def sun_len: uint8_t = if (!useSinXLen) {

--- a/tools/jvm/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/jvm/src/main/scala/scala/scalanative/build/Platform.scala
@@ -44,6 +44,13 @@ private[scala] object Platform {
    */
   lazy val isFreeBSD: Boolean = osUsed.contains("freebsd")
 
+  /** Test for the platform type
+   *
+   *  @return
+   *    true if `OpenBSD`, false otherwise
+   */
+  lazy val isOpenBSD: Boolean = osUsed.contains("openbsd")
+
   /** Test for the target type
    *
    *  @return

--- a/tools/native/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/native/src/main/scala/scala/scalanative/build/Platform.scala
@@ -42,6 +42,13 @@ private[scala] object Platform {
    */
   lazy val isFreeBSD: Boolean = LinktimeInfo.isFreeBSD
 
+  /** Test for the platform type
+   *
+   *  @return
+   *    true if `OpenBSD`, false otherwise
+   */
+  lazy val isOpenBSD: Boolean = LinktimeInfo.isOpenBSD
+
   /** Test for the target type
    *
    *  @return

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -174,6 +174,11 @@ sealed trait Config {
       Seq("linux").exists(customTriple.contains(_))
     }
 
+  private[scalanative] lazy val targetsOpenBSD: Boolean =
+    compilerConfig.targetTriple.fold(Platform.isOpenBSD) { customTriple =>
+      Seq("openbsd").exists(customTriple.contains(_))
+    }
+
   // see https://no-color.org/
   private[scalanative] lazy val noColor: Boolean = sys.env.contains("NO_COLOR")
 

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -192,6 +192,7 @@ private[scalanative] object LLVM {
       // * Dbghelp for windows implementation of unwind libunwind API
       val platformsLinks =
         if (config.targetsWindows) Seq("Dbghelp")
+        else if (config.targetsOpenBSD) Seq("pthread")
         else Seq("pthread", "dl")
       platformsLinks ++ srclinks ++ gclinks
     }.distinct

--- a/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -29,6 +29,7 @@ object Platform {
 
   private val osNameProp = System.getProperty("os.name")
   final val isFreeBSD = osNameProp.equals("FreeBSD")
+  final val isOpenBSD = osNameProp.equals("OpenBSD")
   final val isLinux = osNameProp.toLowerCase.contains("linux")
   final val isMacOs = osNameProp.toLowerCase.contains("mac")
   final val isWindows = osNameProp.toLowerCase.startsWith("windows")

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LanginfoTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LanginfoTest.scala
@@ -5,7 +5,12 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.{BeforeClass, AfterClass}
 
-import scala.scalanative.meta.LinktimeInfo.{isLinux, isMac, isWindows}
+import scala.scalanative.meta.LinktimeInfo.{
+  isLinux,
+  isMac,
+  isWindows,
+  isOpenBSD
+}
 
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
@@ -101,7 +106,7 @@ class LanginfoTest {
     if (!isWindows) {
       val osSharedItems = Array(
         LanginfoItem("CODESET", CODESET, "UTF-8"),
-        LanginfoItem("D_FMT", D_FMT, "%m/%d/%Y"),
+        LanginfoItem("D_FMT", D_FMT, if (isOpenBSD) "%m/%d/%y" else "%m/%d/%Y"),
         LanginfoItem("T_FMT_AMPM", T_FMT_AMPM, "%I:%M:%S %p"),
         LanginfoItem("AM_STR", AM_STR, "AM"),
         LanginfoItem("PM_STR", PM_STR, "PM"),
@@ -143,17 +148,21 @@ class LanginfoTest {
         LanginfoItem("ABMON_10", ABMON_10, "Oct"),
         LanginfoItem("ABMON_11", ABMON_11, "Nov"),
         LanginfoItem("ABMON_12", ABMON_12, "Dec"),
-        LanginfoItem("ERA", ERA, ""),
-        LanginfoItem("ERA_D_FMT", ERA_D_FMT, ""),
-        LanginfoItem("ERA_D_T_FMT", ERA_D_T_FMT, ""),
-        LanginfoItem("ERA_T_FMT", ERA_T_FMT, ""),
         LanginfoItem("ALT_DIGITS", ALT_DIGITS, ""),
-        LanginfoItem("RADIXCHAR", RADIXCHAR, "."),
-        LanginfoItem("THOUSEP", THOUSEP, ","), // linux
-        LanginfoItem("CRNCYSTR", CRNCYSTR, "-$")
+        LanginfoItem("RADIXCHAR", RADIXCHAR, ".")
       )
 
       osSharedItems.foreach(verify(_))
+
+      if (!isWindows && !isOpenBSD)
+        Array(
+          LanginfoItem("ERA", ERA, ""),
+          LanginfoItem("ERA_D_FMT", ERA_D_FMT, ""),
+          LanginfoItem("ERA_D_T_FMT", ERA_D_T_FMT, ""),
+          LanginfoItem("ERA_T_FMT", ERA_T_FMT, ""),
+          LanginfoItem("THOUSEP", THOUSEP, ","), // linux
+          LanginfoItem("CRNCYSTR", CRNCYSTR, "-$")
+        ).foreach(verify(_))
 
       if (isLinux) {
         Array(

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LocaleTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LocaleTest.scala
@@ -82,7 +82,10 @@ class LocaleTest {
       savedLocale.isDefined
     )
 
-    if (!LinktimeInfo.isWindows) {
+    // OpenBSD support of locale quite incomplete, it never changes
+    // LC_NUMERIC and LC_MONETARY that means that it always returns
+    // the smae value with C locale.
+    if (!LinktimeInfo.isWindows && !LinktimeInfo.isOpenBSD) {
       val currentLconv = localeconv() // documented as always succeeds.
 
       assertEquals(

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/MonetaryTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/MonetaryTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.BeforeClass
 
-import scala.scalanative.meta.LinktimeInfo.isWindows
+import scala.scalanative.meta.LinktimeInfo._
 
 /* Using both LinktimeInfo & runtime.Platform looks strange.
  * It is a workaround to let this test run whilst I a suspected bug
@@ -25,8 +25,8 @@ object MonetaryTest {
   @BeforeClass
   def beforeClass(): Unit = {
     assumeTrue(
-      "monetary.scala is not implemented on Windows",
-      !isWindows
+      "monetary.scala is not implemented on Windows and OpenBSD",
+      !isWindows && !isOpenBSD
     )
   }
 }
@@ -34,7 +34,7 @@ object MonetaryTest {
 class MonetaryTest {
 
   @Test def strfmon_l_Using_en_US(): Unit =
-    if (!isWindows) {
+    if (!isWindows && !isOpenBSD) {
       errno = 0
 
       val locale = {

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
@@ -534,10 +534,11 @@ class TimeTest {
        */
     } else if (result == EINTR) {
       // EINTR means sleep was interrupted, clock_nanosleep() executed.
-    } else if (Platform.isMacOs) {
-      // No macOS clock_nanosleep(). time.c stub should always return ENOTSUP.
+    } else if (Platform.isMacOs || Platform.isOpenBSD) {
+      // No macOS and OpenBSD clock_nanosleep().
+      // time.c stub should always return ENOTSUP.
       assumeTrue(
-        s"macOS clock_nanosleep failed with return code: ${result}",
+        s"macOS or OpenBSD clock_nanosleep failed with return code: ${result}",
         result == ENOTSUP
       )
     } else {

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/WordexpTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/WordexpTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import scala.scalanative.meta.LinktimeInfo.isWindows
+import scala.scalanative.meta.LinktimeInfo._
 
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
@@ -32,10 +32,10 @@ class WordexpTest {
 
   @Test def wordexpExpectBadcharError(): Unit = {
     assumeTrue(
-      "wordexp.scala is not implemented on Windows",
-      !isWindows
+      "wordexp.scala is not implemented on Windows or OpenBSD",
+      !isWindows && !isOpenBSD
     )
-    if (!isWindows) Zone.acquire { implicit z =>
+    if (!isWindows && !isOpenBSD) Zone.acquire { implicit z =>
       val wrdeP = stackalloc[wordexp_t]()
 
       /* wordexp is defined as using the sh shell. That shell does not
@@ -55,11 +55,11 @@ class WordexpTest {
 
   @Test def wordexpTildeExpansion: Unit = {
     assumeTrue(
-      "wordexp.scala is not implemented on Windows",
-      !isWindows
+      "wordexp.scala is not implemented on Windows or OpenBSD",
+      !isWindows && !isOpenBSD
     )
 
-    if (!isWindows) Zone.acquire { implicit z =>
+    if (!isWindows && !isOpenBSD) Zone.acquire { implicit z =>
       val wrdeP = stackalloc[wordexp_t]()
 
       val pattern = "~"
@@ -80,13 +80,13 @@ class WordexpTest {
       } finally {
         wordfree(wrdeP)
       }
-    } // !isWindows
+    } // !isWindows && !isOpenBSD
   }
 
   @Test def wordexpVariableSubstitution: Unit = {
     assumeTrue(
-      "wordexp.scala is not implemented on Windows",
-      !isWindows
+      "wordexp.scala is not implemented on Windows or OpenBSD",
+      !isWindows && !isOpenBSD
     )
 
     /* The environment variable $HOME may not exist on all non-CI systems.
@@ -102,7 +102,7 @@ class WordexpTest {
       hasHomeEnvvar != null
     )
 
-    if (!isWindows) Zone.acquire { implicit z =>
+    if (!isWindows && !isOpenBSD) Zone.acquire { implicit z =>
       val wrdeP = stackalloc[wordexp_t]()
 
       val pattern = "Phil $HOME Ochs"
@@ -123,6 +123,6 @@ class WordexpTest {
       } finally {
         wordfree(wrdeP)
       }
-    } // !isWindows
+    } // !isWindows && !isOpenBSD
   }
 }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/ResourceTest.scala
@@ -51,7 +51,8 @@ class ResourceTest {
 
     // Most operating systems will return EINVAL. Handle corner cases here.
     if (errno != EINVAL) {
-      if (!(Platform.isLinux() || Platform.isFreeBSD())) {
+      if (!(Platform.isLinux() || Platform.isFreeBSD() || Platform
+            .isOpenBSD())) {
         assertEquals("unexpected errno", EINVAL, errno)
       } else if (errno != 0) { // Linux, FreeBSD
         // A pid of UInt.MaxValue is highly unlikely but, by one reading,

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/StatTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/StatTest.scala
@@ -253,11 +253,15 @@ class StatTest {
         stat.S_ISDIR(dirStatFromPath.st_mode)
       )
 
-      assertEquals(
-        s"st_rdev must be ${expectedRdev} for dir file",
-        expectedRdev,
-        dirStatFromPath.st_rdev
-      )
+      /* OpenBSD returns some vlaue as st_rdev for directory,
+       * which seems to be related to inode => we can't predict it */
+      if (!LinktimeInfo.isOpenBSD) {
+        assertEquals(
+          s"st_rdev must be ${expectedRdev} for dir file",
+          expectedRdev,
+          dirStatFromPath.st_rdev
+        )
+      }
 
       assert(
         dirStatFromPath.st_nlink.toInt >= 2

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -29,6 +29,7 @@ object Platform {
   private val osNameProp = System.getProperty("os.name")
 
   final val isFreeBSD = runtime.Platform.isFreeBSD()
+  final val isOpenBSD = runtime.Platform.isOpenBSD()
   final val isLinux = runtime.Platform.isLinux()
   final val isMacOs = runtime.Platform.isMac()
   final val isWindows = runtime.Platform.isWindows()

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/net/NetworkInterfaceTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/net/NetworkInterfaceTestOnJDK9.scala
@@ -19,10 +19,15 @@ class NetworkInterfaceTestOnJDK9 {
     else "lo0"
 
   val osIPv6LoopbackSuffix =
-    s":0:0:0:0:0:0:1%${localhostIf}"
+    if (Platform.isOpenBSD && Platform.executingInScalaNative)
+      s":3:0:0:0:0:0:1%${localhostIf}"
+    else
+      s":0:0:0:0:0:0:1%${localhostIf}"
 
   val osIPv6LoopbackAddress =
     if (Platform.isMacOs) s"fe80${osIPv6LoopbackSuffix}"
+    else if (Platform.isOpenBSD && Platform.executingInScalaNative)
+      s"fe80${osIPv6LoopbackSuffix}"
     else s"0${osIPv6LoopbackSuffix}"
 
 // Test instance method(s)
@@ -58,9 +63,12 @@ class NetworkInterfaceTestOnJDK9 {
     /* Out-of-the-box Linux tends to have two addresses, one IPv4 & one IPv6.
      * macOS has three. It adds a link local (fe80) address.
      * Of course, a user may configure their system differently and
-     * break this test.
+     * break this test. Thus, OpenBSD has only one IPv4 address by default.
      */
-    assertTrue("count ${count} not >= 2", count >= 2)
+    val atLeast =
+      if (Platform.isOpenBSD) 1
+      else 2
+    assertTrue(s"count ${count} not >= ${atLeast}", count >= atLeast)
   }
 
 }

--- a/unit-tests/shared/src/test/resources/process/unix/ls
+++ b/unit-tests/shared/src/test/resources/process/unix/ls
@@ -1,3 +1,12 @@
 #!/bin/sh
 
+# /bin/sh can be a symlink to some shell, this some shell
+# may not have printf command. OpenBSD uses ksh without printf
+# for example. Instead it expects to run /usr/bin/printf on that case.
+#
+# Test may reset PATH variable, add /bin and /usr/bin to make this test
+# works again on edge case like OpenBSD's ksh
+
+export PATH=$PATH:/bin:/usr/bin
+
 printf 1

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/InterfaceAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/InterfaceAddressTest.scala
@@ -34,17 +34,21 @@ class InterfaceAddressTest {
 
   val loopbackIfIndex =
     if (Platform.isFreeBSD) 2
+    else if (Platform.isOpenBSD) 3
     else 1
 
   val osIPv6PrefixLength =
-    if ((Platform.isMacOs) || (Platform.isFreeBSD)) 64
+    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD)) 64
     else 128
 
   val osIPv6LoopbackSuffix =
-    s":0:0:0:0:0:0:1%${loopbackIfName}"
+    if (Platform.isOpenBSD)
+      s":3:0:0:0:0:0:1%${loopbackIfName}"
+    else
+      s":0:0:0:0:0:0:1%${loopbackIfName}"
 
   val osIPv6LoopbackAddress =
-    if ((Platform.isMacOs) || (Platform.isFreeBSD))
+    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD))
       s"fe80${osIPv6LoopbackSuffix}"
     else
       s"0${osIPv6LoopbackSuffix}"

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/NetworkInterfaceTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/NetworkInterfaceTest.scala
@@ -37,13 +37,17 @@ class NetworkInterfaceTest {
 
   val loopbackIfIndex =
     if (Platform.isFreeBSD) 2
+    else if (Platform.isOpenBSD) 3
     else 1
 
   val osIPv6LoopbackSuffix =
-    s":0:0:0:0:0:0:1%${loopbackIfName}"
+    if (Platform.isOpenBSD)
+      s":3:0:0:0:0:0:1%${loopbackIfName}"
+    else
+      s":0:0:0:0:0:0:1%${loopbackIfName}"
 
   val osIPv6LoopbackAddress =
-    if ((Platform.isMacOs) || (Platform.isFreeBSD))
+    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD))
       s"fe80${osIPv6LoopbackSuffix}"
     else
       s"0${osIPv6LoopbackSuffix}"
@@ -69,6 +73,7 @@ class NetworkInterfaceTest {
 
     val sought =
       if (Platform.isFreeBSD) "em0"
+      else if (Platform.isOpenBSD) "iwx0"
       else loopbackIfName
     val ifName = netIf.getName()
     assertEquals("a2", sought, ifName)
@@ -205,7 +210,8 @@ class NetworkInterfaceTest {
     assertNotNull(lbIf)
 
     val expected =
-      if ((Platform.isMacOs) || (Platform.isFreeBSD)) true
+      if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD))
+        true
       else false // Linux
 
     assertEquals("a1", expected, lbIf.supportsMulticast())


### PR DESCRIPTION
This commit allows to run `sandbox3/run` on OpenBSD-7.5 which should be released soon. With probability almost 1 it should run on 7.4 and OpenBSD before than.

Regarding testing:
 - `sbt test-sandbox-gc` works;
 - `sbt test-runtime` works as well.