### PR TITLE
improvement: implement java.util.BitSet#stream

### DIFF
--- a/javalib/src/main/scala/java/util/BitSet.scala
+++ b/javalib/src/main/scala/java/util/BitSet.scala
@@ -661,8 +661,12 @@ class BitSet private (private var bits: Array[Long])
       Spliterator.DISTINCT |
         Spliterator.SORTED |
         Spliterator.ORDERED |
-        Spliterator.SIZED |
-        Spliterator.SUBSIZED
+        Spliterator.SIZED
+
+    /* JVM versions around 8 seem to set Spliterator.SUBSIZED.
+     * Later versions seem to leave it clear. Follow the latter practice.
+     * At some point, may need to add some JVM version specific code here.
+     */
 
     val spliter = new AbstractIntSpliterator(size, characteristics) {
       var fromIndex = 0

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/BitSetTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/BitSetTest.scala
@@ -1550,8 +1550,7 @@ class BitSetTest {
       Spliterator.DISTINCT |
         Spliterator.SORTED |
         Spliterator.ORDERED |
-        Spliterator.SIZED |
-        Spliterator.SUBSIZED
+        Spliterator.SIZED
 
     val expectedSet = new TreeSet[Int]()
     val resultSet = new TreeSet[Int]()
@@ -1566,10 +1565,18 @@ class BitSetTest {
         bs.set(e)
       })
 
+    /* It appears that JVMs circa Java 8 set SUBSIZED and that sometime
+     * after that they stopped. Mask off that bit to avoid having JVM
+     * version specific code here. The presence or absence of the bits
+     * that are checked is far more important.
+     */
+    val resultCharacteristics =
+      bs.stream().spliterator().characteristics() & ~Spliterator.SUBSIZED
+
     assertEquals(
       "stream spliterator characteristics",
       expectedCharacteristics,
-      bs.stream().spliterator().characteristics()
+      resultCharacteristics
     )
 
     /* The values returned by stream() are _probably_ monotonically increasing


### PR DESCRIPTION
Provide javalib `java.util.BitSet#stream` method and an associated unit-test.

`BitSet` is useful with small, say <= 32 bit, sets for correct rapid prototyping.
Easy to get bit masking & shifting wrong, even if one does it every day.
`BitSet` probably has too much overhead for production use.

Where `BitSet` really comes into its own is with sets with more than 64 elements.

In either case, the `BitSet#stream` method is useful, especially for rapid prototyping.
The powerful `Collectors` methods are easy to use in Scala 3.

This PR provides another way of exercising `IntStream` 