### PR TITLE
Build: Update sbt to 1.9.9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.7
+sbt.version = 1.9.9


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.9.9.

The skips the problematic sbt version 1.9.8.  I have been using this
version in heavy development for about two weeks now with no problems.

The SBT GitHub [announcement](https://github.com/sbt/sbt/releases/tag/v1.9.9)

I'll close the #3643 draft PR tombstone once this PR merges.