### PR TITLE
Support shutdown hooks with signals

### DIFF
--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -20,6 +20,9 @@ class Runtime private () {
     stdlib.atexit(() => Runtime.getRuntime().runHooks())
   }
 
+  // https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html
+  // Currently, we use C lib signals so SIGHUP is not covered for POSIX platforms.
+
   lazy val setupSignalHandler = {
     signal.signal(signal.SIGINT, handleSignal(_))
     signal.signal(signal.SIGTERM, handleSignal(_))

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -54,7 +54,7 @@ class Runtime private () {
       .asInstanceOf[Array[Thread]]
       .sorted(Ordering.by[Thread, Int](-_.getPriority()))
     hooks.foreach { t =>
-      t.setUncaughtExceptionHandler(ShutdownHookUncoughExceptionHandler)
+      t.setUncaughtExceptionHandler(ShutdownHookUncaughtExceptionHandler)
     }
     // JDK specifies that hooks might run in any order.
     // However, for Scala Native it might be beneficial to support partial ordering
@@ -83,7 +83,7 @@ class Runtime private () {
         try t.run()
         catch {
           case ex: Throwable =>
-            ShutdownHookUncoughExceptionHandler.uncaughtException(t, ex)
+            ShutdownHookUncaughtExceptionHandler.uncaughtException(t, ex)
         }
       }
   }
@@ -123,7 +123,7 @@ class Runtime private () {
     exec(Array(cmd), envp, dir)
 }
 
-private object ShutdownHookUncoughExceptionHandler
+private object ShutdownHookUncaughtExceptionHandler
     extends Thread.UncaughtExceptionHandler {
   def uncaughtException(t: Thread, e: Throwable): Unit = {
     System.err.println(s"Shutdown hook $t failed, reason: $e")

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -27,6 +27,7 @@ class Runtime private () {
 
   private def handleSignal(sig: CInt): Unit = {
     Runtime.getRuntime().runHooks()
+    exit(0)
   }
 
   private def ensureCanModify(hook: Thread): Unit = if (shutdownStarted) {
@@ -89,9 +90,11 @@ class Runtime private () {
   private def runHooks() = {
     import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
     hooks.synchronized {
-      shutdownStarted = true
-      if (isMultithreadingEnabled) runHooksConcurrent()
-      else runHooksSequential()
+      if (!shutdownStarted) {
+        shutdownStarted = true
+        if (isMultithreadingEnabled) runHooksConcurrent()
+        else runHooksSequential()
+      }
     }
   }
 

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -17,7 +17,7 @@ class Runtime private () {
   private lazy val hooks: juSet[Thread] = new java.util.HashSet()
 
   lazy val setupAtExitHandler = {
-    stdlib.atexit(() => if (!shutdownStarted) Runtime.getRuntime().runHooks())
+    stdlib.atexit(() => Runtime.getRuntime().runHooks())
   }
 
   lazy val setupSignalHandler = {
@@ -26,7 +26,7 @@ class Runtime private () {
   }
 
   private def handleSignal(sig: CInt): Unit = {
-    if (!shutdownStarted) Runtime.getRuntime().runHooks()
+    Runtime.getRuntime().runHooks()
   }
 
   private def ensureCanModify(hook: Thread): Unit = if (shutdownStarted) {
@@ -79,7 +79,7 @@ class Runtime private () {
       .asInstanceOf[Array[Thread]]
       .sorted(Ordering.by[Thread, Int](-_.getPriority()))
       .foreach { t =>
-        try t.start()
+        try t.run()
         catch {
           case ex: Throwable =>
             ShutdownHookUncoughExceptionHandler.uncaughtException(t, ex)
@@ -93,7 +93,6 @@ class Runtime private () {
       if (isMultithreadingEnabled) runHooksConcurrent()
       else runHooksSequential()
     }
-    exit(0)
   }
 
   import Runtime.ProcessBuilderOps

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -27,7 +27,7 @@ class Runtime private () {
 
   private def handleSignal(sig: CInt): Unit = {
     Runtime.getRuntime().runHooks()
-    exit(0)
+    exit(128 + sig)
   }
 
   private def ensureCanModify(hook: Thread): Unit = if (shutdownStarted) {

--- a/javalib/src/main/scala/scala/scalanative/runtime/JoinNonDeamonThreads.scala
+++ b/javalib/src/main/scala/scala/scalanative/runtime/JoinNonDeamonThreads.scala
@@ -7,7 +7,7 @@ object JoinNonDaemonThreads {
     try
       Runtime.getRuntime().addShutdownHook {
         val t = new Thread(() => {
-          def pollDaemonThreads = Registry.aliveThreads.iterator
+          def pollNonDaemonThreads = Registry.aliveThreads.iterator
             .map(_.thread)
             .filter { thread =>
               thread != Thread.currentThread() && !thread.isDaemon() && thread
@@ -16,7 +16,7 @@ object JoinNonDaemonThreads {
 
           Registry.onMainThreadTermination()
           Iterator
-            .continually(pollDaemonThreads)
+            .continually(pollNonDaemonThreads)
             .takeWhile(_.hasNext)
             .flatten
             .foreach(_.join())

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -47,7 +47,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   @Test def multithreading(): Unit =
     checkMinimalRequiredSymbols(withMultithreading = true)(expected =
       if (isScala3) SymbolsCount(types = 1100, members = 6550)
-      else if (isScala2_13) SymbolsCount(types = 1050, members = 6600)
+      else if (isScala2_13) SymbolsCount(types = 1050, members = 6650)
       else SymbolsCount(types = 1050, members = 7050)
     )
 


### PR DESCRIPTION
Now you can use Ctrl-C or `kill -s SIGTERM <pid>` and shutdown hooks will be called and the process will exit gracefully.

Here is the `sandbox` I used - not sure how to test.
```scala
object Test {
  def main(args: Array[String]): Unit = {
    println("Shutdown test - use Ctrl-C or send SIGTERM")
    // Runtime
    //   .getRuntime()
    //   .addShutdownHook(new Thread() {
    //     override def run(): Unit = messageThread()
    //   })
    // or this
    sys.addShutdownHook(messageThread())
    while (true) {
      try Thread.sleep(1000)
      catch {
        case e: InterruptedException => {
          println("Interrupted")
        }
      }
    }
  }
  def messageThread() = (0 to 5).foreach { i =>
    println("Shutting down")
    Thread.sleep(500)
  }
}
```