### PR TITLE
Add `chroot` syscall

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -50,6 +50,7 @@ object unistd {
   def alarm(seconds: CUnsignedInt): CUnsignedInt = extern
 
   def chdir(path: CString): CInt = extern
+  def chroot(path: CString): CInt = extern
   def chown(path: CString, owner: uid_t, group: gid_t): CInt = extern
   def close(fildes: CInt): CInt = extern
   def confstr(name: CInt, buf: Ptr[CChar], len: size_t): size_t = extern


### PR DESCRIPTION
The `chroot()` system call first appeared in Version 7 AT&T UNIX. I assume that every posix system which can run Scala-Native has it.

Unfortently I have no idea how to test it without root / sudo.