### PR TITLE
Add `pledge` and `unveil`

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -216,6 +216,10 @@ object unistd {
 
   @blocking def write(fildes: CInt, buf: CVoidPtr, nbyte: CSize): CInt = extern
 
+  def pledge(promises: CString, execpromises: CString): CInt = extern
+
+  def unveil(path: CString, permissions: CString): CInt = extern
+
 // Symbolic constants
 
   // NULL, see POSIX stddef


### PR DESCRIPTION
`pledge` is using to restrict system operations, and `unveil` to unveil parts of a restricted filesystem view.

Both of them available at OpenBSD for years. Anyway some work to port it to Linux is onging but it far from the end, and the best status is Justine's work to port it into cosmopolitan libc.