### PR TITLE
feature: Allow to enable strict semantic of extern function calls.

### DIFF
--- a/docs/user/lang.md
+++ b/docs/user/lang.md
@@ -37,6 +37,11 @@ Scala Native ensures that all class field operations would be executed
 atomically, but does not impose any synchronization or happens-before
 guarantee.
 
+ When executing extern functions Garbage Collector needs to be notified about the internal state of the calling thread. This notification is required to correctly track reachable objects and skip waiting for threads executing unmanged code - these may block (e.g. waiting on socket connection) for long time leading to deadlocks during GC. 
+ By default only calls to methods annotated with `@scala.scalanative.unsafe.blocking` would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
+ This behaviour can be changed by enabling `NativeConfig.strictExternCallSemantics`. Under this mode every invocation of foreign function would notify the GC about the thread state which guarantess no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
+
+
 ## Finalization
 
 Finalize method from `java.lang.Object` is never called in Scala Native.

--- a/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
@@ -3,33 +3,63 @@ package scala.scalanative.build
 /** An object describing configuration of the Scala Native semantics. */
 sealed trait SemanticsConfig {
 //format: off
-  /** Describes Behaviour of final fields and their complaince with the Java Memory Model. 
+  /** Controls behaviour of final fields and their complaince with the Java Memory Model. 
    *  The outputs of the program would depend of compliance level:
    *  - [[JVMMemoryModelCompliance.Strict]] all final fields are synchronized - ensures safe publication,but it might lead to runtime performance overhead.
    *  - [[JVMMemoryModelCompliance.None]] final fields are never synchronized - no runtime overhead when accessing final fields, but it might lead to unexpected state in highly concurrent programs.
    *  - [[JVMMemoryModelCompliance.Relaxed]] (default) only fields marked with scala.scalanative.annotation.safePublish are synchronized.
    */
   def finalFields: JVMMemoryModelCompliance
-// format: on
+  /** Sets the behaviour of final fields and their complaince with the Java Memory Model
+   *   The outputs of the program would depend of compliance level:
+   *  - [[JVMMemoryModelCompliance.Strict]] all final fields are synchronized - ensures safe publication,but it might lead to runtime performance overhead.
+   *  - [[JVMMemoryModelCompliance.None]] final fields are never synchronized - no runtime overhead when accessing final fields, but it might lead to unexpected state in highly concurrent programs.
+   *  - [[JVMMemoryModelCompliance.Relaxed]] (default) only fields marked with scala.scalanative.annotation.safePublish are synchronized.
+   */
   def withFinalFields(value: JVMMemoryModelCompliance): SemanticsConfig
+
+  /**
+    * Controls behaviour of calls to extern methods when executing in multithreading mode.
+    * When executing extern functions Garbage Collector needs to be notified about the internal state of thread, it's required to correctly track reachable objects and skip waiting for threads executing unmanged code.
+    * When disabled (default) only calls to methods annotated with [[scala.scalanative.unsafe.blocking]] would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
+    * When enabled every invocation of foreign function would notify the GC about the thread state which guarantess no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
+    */
+  def strictExternCallSemantics: Boolean
+  /**
+    * Sets behaviour of calls to extern methods when executing in multithreading mode.
+    * When executing extern functions Garbage Collector needs to be notified about the internal state of thread, it's required to correctly track reachable objects and skip waiting for threads executing unmanged code.
+    * When disabled only calls to methods annotated with [[scala.scalanative.unsafe.blocking]] would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
+    * When enabled every invocation of foreign function would notify the GC about the thread state which guarantess no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
+    */
+  def withStrictExternCallSemantics(value: Boolean): SemanticsConfig
+// format: on
 
   private[scalanative] def show(indent: String): String
 }
 
 object SemanticsConfig {
   val default: SemanticsConfig =
-    Impl(finalFields = JVMMemoryModelCompliance.Relaxed)
+    Impl(
+      finalFields = JVMMemoryModelCompliance.Relaxed,
+      strictExternCallSemantics = false
+    )
 
-  private[build] case class Impl(finalFields: JVMMemoryModelCompliance)
-      extends SemanticsConfig {
+  private[build] case class Impl(
+      finalFields: JVMMemoryModelCompliance,
+      strictExternCallSemantics: Boolean
+  ) extends SemanticsConfig {
     override def withFinalFields(
         value: JVMMemoryModelCompliance
     ): SemanticsConfig = copy(finalFields = value)
+    override def withStrictExternCallSemantics(
+        value: Boolean
+    ): SemanticsConfig = copy(strictExternCallSemantics = value)
 
     override def toString: String = show(indent = " ")
     override private[scalanative] def show(indent: String): String = {
       s"""SemanticsConfig(
           |$indent- finalFields: ${finalFields}
+          |$indent- strictExternCallSemantics: ${strictExternCallSemantics}
           |$indent)""".stripMargin
     }
   }

--- a/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
@@ -21,14 +21,14 @@ sealed trait SemanticsConfig {
   /**
     * Controls behaviour of calls to extern methods when executing in multithreading mode.
     * When executing extern functions Garbage Collector needs to be notified about the internal state of thread, it's required to correctly track reachable objects and skip waiting for threads executing unmanged code.
-    * When disabled (default) only calls to methods annotated with [[scala.scalanative.unsafe.blocking]] would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
+    * When disabled (default) only calls to methods annotated with `scala.scalanative.unsafe.blocking` would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
     * When enabled every invocation of foreign function would notify the GC about the thread state which guarantess no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
     */
   def strictExternCallSemantics: Boolean
   /**
     * Sets behaviour of calls to extern methods when executing in multithreading mode.
     * When executing extern functions Garbage Collector needs to be notified about the internal state of thread, it's required to correctly track reachable objects and skip waiting for threads executing unmanged code.
-    * When disabled only calls to methods annotated with [[scala.scalanative.unsafe.blocking]] would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
+    * When disabled only calls to methods annotated with `scala.scalanative.unsafe.blocking` would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
     * When enabled every invocation of foreign function would notify the GC about the thread state which guarantess no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
     */
   def withStrictExternCallSemantics(value: Boolean): SemanticsConfig


### PR DESCRIPTION
 Under strict mode all extern calls (with exception of few well known ones for performance reasons) are treated as blocking and would notify GC about executing unmanaged code.