### PR TITLE
fix: Try to mitigate Windows AccessDeniedException when using `IO.deleteRecursive`

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/IO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/IO.scala
@@ -137,7 +137,7 @@ private[scalanative] object IO {
   /** Deletes recursively `directory` and all its content. */
   def deleteRecursive(directory: Path): Unit = {
     // On Windows the file permissions / locks are slow leading to AccessDeniedException
-    // we might need to revisit the directory to ensure it is deleated
+    // we might need to revisit the directory to ensure it is deleted
     var shouldRetry = false
     var remainingRetries = 3
     def tryDelete(path: Path, isRetry: Boolean = false): Unit =

--- a/tools/src/main/scala/scala/scalanative/build/IO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/IO.scala
@@ -3,6 +3,7 @@ package build
 
 import java.io.IOException
 import java.nio.file.{
+  AccessDeniedException,
   Files,
   FileSystems,
   FileVisitOption,
@@ -16,6 +17,8 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.util.EnumSet
 import java.util.zip.{ZipEntry, ZipInputStream}
 import java.security.{DigestInputStream, MessageDigest}
+import java.nio.file.attribute.DosFileAttributes
+import scala.util.control.NonFatal
 
 /** Internal I/O utilities. */
 private[scalanative] object IO {
@@ -133,7 +136,30 @@ private[scalanative] object IO {
 
   /** Deletes recursively `directory` and all its content. */
   def deleteRecursive(directory: Path): Unit = {
-    if (Files.exists(directory)) {
+    // On Windows the file permissions / locks are slow leading to AccessDeniedException
+    // we might need to revisit the directory to ensure it is deleated
+    var shouldRetry = false
+    var remainingRetries = 3
+    def tryDelete(path: Path, isRetry: Boolean = false): Unit =
+      try Files.deleteIfExists(path)
+      catch {
+        case _: AccessDeniedException if Platform.isWindows && !isRetry =>
+          if (Files.notExists(path)) ()
+          else
+            try {
+              val attrs = Files.readAttributes(path, classOf[DosFileAttributes])
+              if (attrs.isReadOnly()) {
+                Files.setAttribute(path, "dos:readonly", false)
+              }
+              tryDelete(path, isRetry = true)
+            } catch { case NonFatal(_) => shouldRetry = true }
+        case NonFatal(_) => shouldRetry = true
+      }
+
+    while (Files.exists(directory) && remainingRetries > 0) {
+      // If retrying the cleanup give OS a bit of time to close any pending locks
+      if (shouldRetry) Thread.sleep(50)
+      shouldRetry = false
       Files.walkFileTree(
         directory,
         new SimpleFileVisitor[Path]() {
@@ -141,18 +167,19 @@ private[scalanative] object IO {
               file: Path,
               attrs: BasicFileAttributes
           ): FileVisitResult = {
-            Files.delete(file)
+            tryDelete(file)
             FileVisitResult.CONTINUE
           }
           override def postVisitDirectory(
               dir: Path,
               exc: IOException
           ): FileVisitResult = {
-            Files.delete(dir)
+            tryDelete(dir)
             FileVisitResult.CONTINUE
           }
         }
       )
+      remainingRetries -= 1
     }
   }
 


### PR DESCRIPTION
Best effort fix to issue found in Bloop builds for Scala Native 0.5.: https://github.com/scalacenter/bloop/actions/runs/8224055636/job/22487426436#step:4:1004 

Related https://stackoverflow.com/questions/64090643/java-nio-file-accessdeniedexception-while-trying-to-delete-a-renamed-directoryu (see comments) 
> Windows has some unusual file locking behaviors. Deleting files shortly after using them is rarely possible to do quickly or expediently using Java on Windows, as the file locking will get in your way. Best advice is to ensure that all resources for that File/Path/Streams/etc are all closed properly before attempting to delete that file. But even so, that file can be seen by Windows as still locked and not possible to be deleted (yet)