### PR TITLE
Preliminary support of NetBSD/amd64

### DIFF
--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -33,6 +33,12 @@ $ pkg install sbt
 $ pkg_add sbt
 ```
 
+**NetBSD**
+
+``` shell
+$ pkg_add scala-sbt
+```
+
 ## Installing clang and runtime dependencies
 
 Scala Native requires Clang, which is part of the
@@ -115,6 +121,16 @@ out-of-the-box yet.
 architecture.
 
 ``` shell
+$ pkg_add boehm-gc # optional
+```
+
+**NetBSD 9.3 and later**
+
+*Note 1:* NetBSD support is experimental and limited to only AMD64
+architecture.
+
+``` shell
+$ pkg_add clang
 $ pkg_add boehm-gc # optional
 ```
 

--- a/javalib/src/main/resources/scala-native/net/if_dl.c
+++ b/javalib/src/main/resources/scala-native/net/if_dl.c
@@ -1,7 +1,12 @@
 #ifdef _WIN32
 // NO Windows support
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__NetBSD__)
 // Does not exist on Linux, so no check
+// Does exist on NetBSD but it has defines:
+//   #define sdl_type        sdl_addr.dl_type
+//   #define sdl_nlen        sdl_addr.dl_nlen
+//   ...
+// what requires to rewrite whole file from scratch
 #else // macOS, FreeBSD, etc.
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__)

--- a/javalib/src/main/resources/scala-native/time_nano.c
+++ b/javalib/src/main/resources/scala-native/time_nano.c
@@ -37,7 +37,7 @@ long long scalanative_nano_time() {
 #else
 #if defined(__FreeBSD__)
     int clock = CLOCK_MONOTONIC_PRECISE; // OS has no CLOCK_MONOTONIC_RAW
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
     int clock = CLOCK_MONOTONIC; // OpenBSD has only CLOCK_MONOTONIC
 #else  // Linux, macOS
     int clock = CLOCK_MONOTONIC_RAW;

--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -15,8 +15,9 @@
 #if defined(__aarch64__) // ARM64
 #define ASM_JMPBUF_SIZE 192
 #define JMPBUF_STACK_POINTER_OFFSET (104 / 8)
-#elif defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) ||      \
-                              defined(__FreeBSD__) || defined(__OpenBSD__))
+#elif defined(__x86_64__) &&                                                   \
+    (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) ||       \
+     defined(__OpenBSD__) || defined(__NetBSD__))
 #define ASM_JMPBUF_SIZE 72
 #define JMPBUF_STACK_POINTER_OFFSET (16 / 8)
 #elif defined(__i386__) &&                                                     \

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
@@ -1,4 +1,4 @@
-#if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__))
+#if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__))
 
 /* ----------------------------------------------------------------------------
   Copyright (c) 2016, Microsoft Research, Daan Leijen

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/utils/Time.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/utils/Time.c
@@ -82,8 +82,8 @@ long long Time_current_nanos() {
 #else
 #if defined(__FreeBSD__)
     int clock = CLOCK_MONOTONIC_PRECISE; // OS has no CLOCK_MONOTONIC_RAW
-#elif defined(__OpenBSD__)
-    int clock = CLOCK_MONOTONIC; // OpenBSD has only CLOCK_MONOTONIC
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
+    int clock = CLOCK_MONOTONIC; // OpenBSD and NetBSD has only CLOCK_MONOTONIC
 #else  // Linux, macOS
     int clock = CLOCK_MONOTONIC_RAW;
 #endif // !FreeBSD || !OpenBSD

--- a/nativelib/src/main/resources/scala-native/platform/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform/platform.c
@@ -28,6 +28,14 @@ int scalanative_platform_is_openbsd() {
 #endif
 }
 
+int scalanative_platform_is_netbsd() {
+#if defined(__NetBSD__)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 int scalanative_platform_is_linux() {
 #ifdef __linux__
     return 1;

--- a/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
+++ b/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
@@ -135,11 +135,12 @@ void scalanative_process_monitor_init() {
     // on M1 chips) leading to deadlocks
     char semaphoreName[SEM_MAX_LENGTH];
 
-#if defined(__FreeBSD__)
-#define SEM_NAME_PREFIX "/" // FreeBSD semaphore names must start with '/'
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+#define SEM_NAME_PREFIX                                                        \
+    "/" // FreeBSD and NetBSD semaphore names must start with '/'
 #else
 #define SEM_NAME_PREFIX ""
-#endif // __FreeBSD__
+#endif // __FreeBSD__ || __NetBSD__
 
     snprintf(semaphoreName, SEM_MAX_LENGTH,
              SEM_NAME_PREFIX "__sn_%d-process-monitor", getpid());

--- a/nativelib/src/main/resources/scala-native/platform/posix/unwind.c
+++ b/nativelib/src/main/resources/scala-native/platform/posix/unwind.c
@@ -4,26 +4,52 @@
 #include "../unwind.h"
 #include "libunwind/libunwind.h"
 
+// The unwinding on NetBSD is unstable, they don't provide CFI
+// annotations for most of libc and other places, nor for the signal
+// trampoline. So it can't work properly, and probably leads to
+// segmentation errors. To minimize the impact, I allow to get context
+// and initialize unwind, but cursor returns nothing.
+
 int scalanative_unwind_get_context(void *context) {
+#ifdef __NetBSD__
+    return 0;
+#else
     return unw_getcontext((unw_context_t *)context);
+#endif
 }
 
 int scalanative_unwind_init_local(void *cursor, void *context) {
+#ifdef __NetBSD__
+    return 0;
+#else
     return unw_init_local((unw_cursor_t *)cursor, (unw_context_t *)context);
+#endif
 }
 
 int scalanative_unwind_step(void *cursor) {
+#ifdef __NetBSD__
+    return 0;
+#else
     return unw_step((unw_cursor_t *)cursor);
+#endif
 }
 
 int scalanative_unwind_get_proc_name(void *cursor, char *buffer, size_t length,
                                      void *offset) {
+#ifdef __NetBSD__
+    return UNW_EUNSPEC;
+#else
     return unw_get_proc_name((unw_cursor_t *)cursor, buffer, length,
                              (unw_word_t *)offset);
+#endif
 }
 
 int scalanative_unwind_get_reg(void *cursor, int regnum, size_t *valp) {
+#ifdef __NetBSD__
+    return UNW_EUNSPEC;
+#else
     return unw_get_reg((unw_cursor_t *)cursor, regnum, (unw_word_t *)valp);
+#endif
 }
 
 int scalanative_unw_reg_ip() { return UNW_REG_IP; }

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -28,6 +28,9 @@ object LinktimeInfo {
   @resolvedAtLinktime
   def isOpenBSD: Boolean = target.os == "openbsd"
 
+  @resolvedAtLinktime
+  def isNetBSD: Boolean = target.os == "netbsd"
+
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.is32BitPlatform")
   def is32BitPlatform: Boolean = resolved
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -13,6 +13,9 @@ object Platform {
   @name("scalanative_platform_is_openbsd")
   def isOpenBSD(): Boolean = extern
 
+  @name("scalanative_platform_is_netbsd")
+  def isNetBSD(): Boolean = extern
+
   @name("scalanative_platform_is_linux")
   def isLinux(): Boolean = extern
 

--- a/posixlib/src/main/resources/scala-native/errno.c
+++ b/posixlib/src/main/resources/scala-native/errno.c
@@ -152,7 +152,13 @@ int scalanative_enotdir() { return ENOTDIR; }
 
 int scalanative_enotempty() { return ENOTEMPTY; }
 
-int scalanative_enotrecoverable() { return ENOTRECOVERABLE; }
+int scalanative_enotrecoverable() {
+#ifdef ENOTRECOVERABLE
+    return ENOTRECOVERABLE;
+#else
+    return 0;
+#endif
+}
 
 int scalanative_enotsock() { return ENOTSOCK; }
 
@@ -166,7 +172,13 @@ int scalanative_eopnotsupp() { return EOPNOTSUPP; }
 
 int scalanative_eoverflow() { return EOVERFLOW; }
 
-int scalanative_eownerdead() { return EOWNERDEAD; }
+int scalanative_eownerdead() {
+#ifdef EOWNERDEAD
+    return EOWNERDEAD;
+#else
+    return 0;
+#endif
+}
 
 int scalanative_eperm() { return EPERM; }
 

--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -51,7 +51,8 @@ _Static_assert(offsetof(struct scalanative_addrinfo, ai_addrlen) ==
                    offsetof(struct addrinfo, ai_addrlen),
                "Unexpected offset: scalanative_addrinfo.ai_addrlen");
 
-#if !(defined(__APPLE__) || defined(__FreeBSD__) || defined(_WIN32))
+#if !(defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) ||     \
+      defined(_WIN32))
 // Linux, etc.
 
 _Static_assert(offsetof(struct scalanative_addrinfo, ai_addr) ==
@@ -70,7 +71,8 @@ _Static_assert(offsetof(struct scalanative_addrinfo, ai_canonname) ==
                    offsetof(struct addrinfo, ai_addr),
                "Unexpected offset: BSD addrinfo ai_canonname fixup");
 
-#endif // (defined(__APPLE__) || defined(__FreeBSD__) || defined(_WIN32))
+#endif // (defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) ||
+       // defined(_WIN32))
 
 _Static_assert(offsetof(struct scalanative_addrinfo, ai_next) ==
                    offsetof(struct addrinfo, ai_next),

--- a/posixlib/src/main/resources/scala-native/sys/times.c
+++ b/posixlib/src/main/resources/scala-native/sys/times.c
@@ -12,7 +12,7 @@
 // 2023-01-03 FIXME -- need to fuss with timesOps in times.scala
 // 2023-01-03 FIXME -- need to explain here the useful lie.
 
-#if !defined(__FreeBSD__)
+#if !defined(__FreeBSD__) && !defined(__NetBSD__)
 // C long will mirror machine architecture: 64 bits or 32 bit.
 typedef long scalanative_clock_t;
 #else // __FreeBSD
@@ -26,10 +26,10 @@ typedef long scalanative_clock_t;
  */
 #import <sys/types.h>
 typedef __int32_t scalanative_clock_t;
-#endif // __FreeBSD__
+#endif // __FreeBSD__ || __NetBSD__
 
 struct scalanative_tms {
-    scalanative_clock_t tms_utime;  //  User CPU time
+    scalanative_clock_t tms_utime;  // User CPU time
     scalanative_clock_t tms_stime;  // System CPU time
     scalanative_clock_t tms_cutime; // User CPU time terminated children
     scalanative_clock_t tms_cstime; // System CPU time of terminated children

--- a/posixlib/src/main/resources/scala-native/termios.c
+++ b/posixlib/src/main/resources/scala-native/termios.c
@@ -10,8 +10,8 @@
 #define VTDLY VTDELAY
 #endif
 
-#if defined(__OpenBSD__)
-// OpenBSD has missed some constatn, use 0 instead
+#if defined(__OpenBSD__) || defined(__NetBSD__)
+// OpenBSD and NetBSD has missed some constatn, use 0 instead
 #define NLDLY 0
 #define CRDLY 0
 #define BSDLY 0
@@ -28,7 +28,15 @@
 #define NL1 0
 #define TAB1 0
 #define TAB2 0
-#endif
+
+// NetBSD requires a few more
+#ifdef __NetBSD__
+#define TABDLY 0
+#define TAB0 0
+#define TAB3 0
+#endif // NetBSD
+
+#endif // OpenBSD || NetBSD
 
 // symbolic constants for use as subscripts for the array c_cc
 

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -7,7 +7,7 @@
 #include <unistd.h>
 #include "types.h" // scalanative_* types, not <sys/types.h>
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 
 /* Apply a Pareto cost/benefit analysis here.
  *
@@ -32,7 +32,7 @@
 #define _SC_TRACE_NAME_MAX 0
 #define _SC_TRACE_SYS_MAX 0
 #define _SC_TRACE_USER_EVENT_MAX 0
-#endif // __FreeBSD__ || __OpenBSD__
+#endif // __FreeBSD__ || __OpenBSD__ || __NetBSD__
 
 long scalanative__posix_version() { return _POSIX_VERSION; }
 
@@ -101,9 +101,21 @@ int scalanative__cs_path() { return _CS_PATH; };
 
 int scalanative__pc_2_symlinks() { return _PC_2_SYMLINKS; };
 
-int scalanative__pc_alloc_size_min() { return _PC_ALLOC_SIZE_MIN; };
+int scalanative__pc_alloc_size_min() {
+#ifdef _PC_ALLOC_SIZE_MIN
+    return _PC_ALLOC_SIZE_MIN;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__pc_async_io() { return _PC_ASYNC_IO; };
+int scalanative__pc_async_io() {
+#ifdef _PC_ASYNC_IO
+    return _PC_ASYNC_IO;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__pc_chown_restricted() { return _PC_CHOWN_RESTRICTED; };
 
@@ -123,15 +135,45 @@ int scalanative__pc_path_max() { return _PC_PATH_MAX; };
 
 int scalanative__pc_pipe_buf() { return _PC_PIPE_BUF; };
 
-int scalanative__pc_prio_io() { return _PC_PRIO_IO; };
+int scalanative__pc_prio_io() {
+#ifdef _PC_PRIO_IO
+    return _PC_PRIO_IO;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__pc_rec_incr_xfer_size() { return _PC_REC_INCR_XFER_SIZE; };
+int scalanative__pc_rec_incr_xfer_size() {
+#ifdef _PC_REC_INCR_XFER_SIZE
+    return _PC_REC_INCR_XFER_SIZE;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__pc_rec_max_xfer_size() { return _PC_REC_MAX_XFER_SIZE; };
+int scalanative__pc_rec_max_xfer_size() {
+#ifdef _PC_REC_MAX_XFER_SIZE
+    return _PC_REC_MAX_XFER_SIZE;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__pc_rec_min_xfer_size() { return _PC_REC_MIN_XFER_SIZE; };
+int scalanative__pc_rec_min_xfer_size() {
+#ifdef _PC_REC_MIN_XFER_SIZE
+    return _PC_REC_MIN_XFER_SIZE;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__pc_rec_xfer_align() { return _PC_REC_XFER_ALIGN; };
+int scalanative__pc_rec_xfer_align() {
+#ifdef _PC_REC_XFER_ALIGN
+    return _PC_REC_XFER_ALIGN;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__pc_symlink_max() { return _PC_SYMLINK_MAX; };
 
@@ -175,13 +217,25 @@ int scalanative__sc_2_upe() { return _SC_2_UPE; };
 
 int scalanative__sc_2_version() { return _SC_2_VERSION; };
 
-int scalanative__sc_advisory_info() { return _SC_ADVISORY_INFO; };
+int scalanative__sc_advisory_info() {
+#ifdef _SC_ADVISORY_INFO
+    return _SC_ADVISORY_INFO;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_aio_listio_max() { return _SC_AIO_LISTIO_MAX; };
 
 int scalanative__sc_aio_max() { return _SC_AIO_MAX; };
 
-int scalanative__sc_aio_prio_delta_max() { return _SC_AIO_PRIO_DELTA_MAX; };
+int scalanative__sc_aio_prio_delta_max() {
+#ifdef _SC_AIO_PRIO_DELTA_MAX
+    return _SC_AIO_PRIO_DELTA_MAX;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_arg_max() { return _SC_ARG_MAX; };
 
@@ -223,7 +277,13 @@ int scalanative__sc_host_name_max() { return _SC_HOST_NAME_MAX; };
 
 int scalanative__sc_iov_max() { return _SC_IOV_MAX; };
 
-int scalanative__sc_ipv6() { return _SC_IPV6; };
+int scalanative__sc_ipv6() {
+#ifdef _SC_IPV6
+    return _SC_IPV6;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_job_control() { return _SC_JOB_CONTROL; };
 
@@ -259,11 +319,23 @@ int scalanative__sc_page_size() { return _SC_PAGE_SIZE; };
 
 int scalanative__sc_pagesize() { return _SC_PAGESIZE; };
 
-int scalanative__sc_prioritized_io() { return _SC_PRIORITIZED_IO; };
+int scalanative__sc_prioritized_io() {
+#ifdef _SC_PRIORITIZED_IO
+    return _SC_PRIORITIZED_IO;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_priority_scheduling() { return _SC_PRIORITY_SCHEDULING; };
 
-int scalanative__sc_raw_sockets() { return _SC_RAW_SOCKETS; };
+int scalanative__sc_raw_sockets() {
+#ifdef _SC_RAW_SOCKETS
+    return _SC_RAW_SOCKETS;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_re_dup_max() { return _SC_RE_DUP_MAX; };
 
@@ -273,13 +345,25 @@ int scalanative__sc_realtime_signals() { return _SC_REALTIME_SIGNALS; };
 
 int scalanative__sc_regexp() { return _SC_REGEXP; };
 
-int scalanative__sc_rtsig_max() { return _SC_RTSIG_MAX; };
+int scalanative__sc_rtsig_max() {
+#ifdef _SC_RTSIG_MAX
+    return _SC_RTSIG_MAX;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_saved_ids() { return _SC_SAVED_IDS; };
 
 int scalanative__sc_sem_nsems_max() { return _SC_SEM_NSEMS_MAX; };
 
-int scalanative__sc_sem_value_max() { return _SC_SEM_VALUE_MAX; };
+int scalanative__sc_sem_value_max() {
+#ifdef _SC_SEM_VALUE_MAX
+    return _SC_SEM_VALUE_MAX;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_semaphores() { return _SC_SEMAPHORES; };
 
@@ -295,7 +379,13 @@ int scalanative__sc_spawn() { return _SC_SPAWN; };
 
 int scalanative__sc_spin_locks() { return _SC_SPIN_LOCKS; };
 
-int scalanative__sc_sporadic_server() { return _SC_SPORADIC_SERVER; };
+int scalanative__sc_sporadic_server() {
+#ifdef _SC_SPORADIC_SERVER
+    return _SC_SPORADIC_SERVER;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_ss_repl_max() { return _SC_SS_REPL_MAX; };
 
@@ -344,7 +434,11 @@ int scalanative__sc_thread_safe_functions() {
 };
 
 int scalanative__sc_thread_sporadic_server() {
+#ifdef _SC_THREAD_SPORADIC_SERVER
     return _SC_THREAD_SPORADIC_SERVER;
+#else
+    return 0;
+#endif
 };
 
 int scalanative__sc_thread_stack_min() { return _SC_THREAD_STACK_MIN; };
@@ -353,21 +447,51 @@ int scalanative__sc_thread_threads_max() { return _SC_THREAD_THREADS_MAX; };
 
 int scalanative__sc_threads() { return _SC_THREADS; };
 
-int scalanative__sc_timeouts() { return _SC_TIMEOUTS; };
+int scalanative__sc_timeouts() {
+#ifdef _SC_TIMEOUTS
+    return _SC_TIMEOUTS;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_timer_max() { return _SC_TIMER_MAX; };
 
 int scalanative__sc_timers() { return _SC_TIMERS; };
 
-int scalanative__sc_trace() { return _SC_TRACE; };
+int scalanative__sc_trace() {
+#ifdef _SC_TRACE
+    return _SC_TRACE;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__sc_trace_event_filter() { return _SC_TRACE_EVENT_FILTER; };
+int scalanative__sc_trace_event_filter() {
+#ifdef _SC_TRACE_EVENT_FILTER
+    return _SC_TRACE_EVENT_FILTER;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_trace_event_name_max() { return _SC_TRACE_EVENT_NAME_MAX; };
 
-int scalanative__sc_trace_inherit() { return _SC_TRACE_INHERIT; };
+int scalanative__sc_trace_inherit() {
+#ifdef _SC_TRACE_INHERIT
+    return _SC_TRACE_INHERIT;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__sc_trace_log() { return _SC_TRACE_LOG; };
+int scalanative__sc_trace_log() {
+#ifdef _SC_TRACE_LOG
+    return _SC_TRACE_LOG;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_trace_name_max() { return _SC_TRACE_NAME_MAX; };
 
@@ -377,7 +501,13 @@ int scalanative__sc_trace_user_event_max() { return _SC_TRACE_USER_EVENT_MAX; };
 
 int scalanative__sc_tty_name_max() { return _SC_TTY_NAME_MAX; };
 
-int scalanative__sc_typed_memory_objects() { return _SC_TYPED_MEMORY_OBJECTS; };
+int scalanative__sc_typed_memory_objects() {
+#ifdef _SC_TYPED_MEMORY_OBJECTS
+    return _SC_TYPED_MEMORY_OBJECTS;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_tzname_max() { return _SC_TZNAME_MAX; };
 
@@ -390,26 +520,66 @@ int scalanative__sc_tzname_max() { return _SC_TZNAME_MAX; };
 
 int scalanative__sc_version() { return _SC_VERSION; };
 
-int scalanative__sc_xopen_crypt() { return _SC_XOPEN_CRYPT; };
+int scalanative__sc_xopen_crypt() {
+#ifdef _SC_XOPEN_CRYPT
+    return _SC_XOPEN_CRYPT;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__sc_xopen_enh_i18n() { return _SC_XOPEN_ENH_I18N; };
+int scalanative__sc_xopen_enh_i18n() {
+#ifdef _SC_XOPEN_ENH_I18N
+    return _SC_XOPEN_ENH_I18N;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__sc_xopen_realtime() { return _SC_XOPEN_REALTIME; };
+int scalanative__sc_xopen_realtime() {
+#ifdef _SC_XOPEN_REALTIME
+    return _SC_XOPEN_REALTIME;
+#else
+    return 0;
+#endif
+};
 
 int scalanative__sc_xopen_realtime_threads() {
+#ifdef _SC_XOPEN_REALTIME_THREADS
     return _SC_XOPEN_REALTIME_THREADS;
+#else
+    return 0;
+#endif
 };
 
 int scalanative__sc_xopen_shm() { return _SC_XOPEN_SHM; };
 
-int scalanative__sc_xopen_streams() { return _SC_XOPEN_STREAMS; };
+int scalanative__sc_xopen_streams() {
+#ifdef _SC_XOPEN_STREAMS
+    return _SC_XOPEN_STREAMS;
+#else
+    return 0;
+#endif
+};
 
-int scalanative__sc_xopen_unix() { return _SC_XOPEN_UNIX; };
+int scalanative__sc_xopen_unix() {
+#ifdef _SC_XOPEN_UNIX
+    return _SC_XOPEN_UNIX;
+#else
+    return 0;
+#endif
+};
 
 /* Not implemented, not defined on Linux.
  *	_SC_XOPEN_UUCP
  */
 
-int scalanative__sc_xopen_version() { return _SC_XOPEN_VERSION; };
+int scalanative__sc_xopen_version() {
+#ifdef _SC_XOPEN_VERSION
+    return _SC_XOPEN_VERSION;
+#else
+    return 0;
+#endif
+};
 
 #endif // Unix or Mac OS

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -151,6 +151,7 @@ object netdbOps {
   @resolvedAtLinktime
   def useBsdAddrinfo = (LinktimeInfo.isMac ||
     LinktimeInfo.isFreeBSD ||
+    LinktimeInfo.isNetBSD ||
     LinktimeInfo.isWindows)
 
   implicit class addrinfoOps(private val ptr: Ptr[addrinfo]) extends AnyVal {

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -396,7 +396,7 @@ object socketOps {
   // Also used by posixlib netinet/in.scala
   @resolvedAtLinktime
   def useSinXLen = !isLinux &&
-    (isMac || isFreeBSD || isOpenBSD)
+    (isMac || isFreeBSD || isOpenBSD || isNetBSD)
 
   implicit class sockaddrOps(val ptr: Ptr[sockaddr]) extends AnyVal {
     def sa_len: uint8_t = if (!useSinXLen) {

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMain.scala
@@ -51,7 +51,7 @@ object TestMain {
      * See: https://github.com/scala-native/scala-native/issues/3630
      */
 
-    if (!LinktimeInfo.isFreeBSD && !LinktimeInfo.isOpenBSD)
+    if (!LinktimeInfo.isFreeBSD && !LinktimeInfo.isOpenBSD && !LinktimeInfo.isNetBSD)
       return
 
     System.setProperty("java.net.preferIPv4Stack", "true")

--- a/tools/jvm/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/jvm/src/main/scala/scala/scalanative/build/Platform.scala
@@ -51,6 +51,13 @@ private[scala] object Platform {
    */
   lazy val isOpenBSD: Boolean = osUsed.contains("openbsd")
 
+  /** Test for the platform type
+   *
+   *  @return
+   *    true if `OpenBSD`, false otherwise
+   */
+  lazy val isNetBSD: Boolean = osUsed.contains("netbsd")
+
   /** Test for the target type
    *
    *  @return

--- a/tools/native/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/native/src/main/scala/scala/scalanative/build/Platform.scala
@@ -49,6 +49,13 @@ private[scala] object Platform {
    */
   lazy val isOpenBSD: Boolean = LinktimeInfo.isOpenBSD
 
+  /** Test for the platform type
+   *
+   *  @return
+   *    true if `NetBSD`, false otherwise
+   */
+  lazy val isNetBSD: Boolean = LinktimeInfo.isNetBSD
+
   /** Test for the target type
    *
    *  @return

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -179,6 +179,11 @@ sealed trait Config {
       Seq("openbsd").exists(customTriple.contains(_))
     }
 
+  private[scalanative] lazy val targetsNetBSD: Boolean =
+    compilerConfig.targetTriple.fold(Platform.isNetBSD) { customTriple =>
+      Seq("netbsd").exists(customTriple.contains(_))
+    }
+
   // see https://no-color.org/
   private[scalanative] lazy val noColor: Boolean = sys.env.contains("NO_COLOR")
 

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -192,7 +192,8 @@ private[scalanative] object LLVM {
       // * Dbghelp for windows implementation of unwind libunwind API
       val platformsLinks =
         if (config.targetsWindows) Seq("Dbghelp")
-        else if (config.targetsOpenBSD) Seq("pthread")
+        else if (config.targetsOpenBSD || config.targetsNetBSD)
+          Seq("pthread")
         else Seq("pthread", "dl")
       platformsLinks ++ srclinks ++ gclinks
     }.distinct

--- a/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -30,6 +30,7 @@ object Platform {
   private val osNameProp = System.getProperty("os.name")
   final val isFreeBSD = osNameProp.equals("FreeBSD")
   final val isOpenBSD = osNameProp.equals("OpenBSD")
+  final val isNetBSD = osNameProp.equals("NetBSD")
   final val isLinux = osNameProp.toLowerCase.contains("linux")
   final val isMacOs = osNameProp.toLowerCase.contains("mac")
   final val isWindows = osNameProp.toLowerCase.startsWith("windows")

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/GlobTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/GlobTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.{BeforeClass, AfterClass}
 
-import scala.scalanative.meta.LinktimeInfo.isWindows
+import scala.scalanative.meta.LinktimeInfo.{isWindows, isNetBSD}
 
 import java.nio.file.{Path, Paths}
 import java.nio.file.Files
@@ -101,7 +101,12 @@ class GlobTest {
       !isWindows
     )
 
-    if (!isWindows) Zone.acquire { implicit z =>
+    assumeTrue(
+      "glob seems doesn't work on NetBSD",
+      !isNetBSD
+    )
+
+    if (!isWindows && !isNetBSD) Zone.acquire { implicit z =>
       val globP = stackalloc[glob_t]()
 
       val wdAbsP = workDir.toAbsolutePath()

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LanginfoTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LanginfoTest.scala
@@ -9,7 +9,8 @@ import scala.scalanative.meta.LinktimeInfo.{
   isLinux,
   isMac,
   isWindows,
-  isOpenBSD
+  isOpenBSD,
+  isNetBSD
 }
 
 import scala.scalanative.unsafe._
@@ -106,7 +107,13 @@ class LanginfoTest {
     if (!isWindows) {
       val osSharedItems = Array(
         LanginfoItem("CODESET", CODESET, "UTF-8"),
-        LanginfoItem("D_FMT", D_FMT, if (isOpenBSD) "%m/%d/%y" else "%m/%d/%Y"),
+        LanginfoItem(
+          "D_FMT",
+          D_FMT,
+          if (isOpenBSD) "%m/%d/%y"
+          else if (isNetBSD) "%m/%e/%y"
+          else "%m/%d/%Y"
+        ),
         LanginfoItem("T_FMT_AMPM", T_FMT_AMPM, "%I:%M:%S %p"),
         LanginfoItem("AM_STR", AM_STR, "AM"),
         LanginfoItem("PM_STR", PM_STR, "PM"),
@@ -160,7 +167,11 @@ class LanginfoTest {
           LanginfoItem("ERA_D_FMT", ERA_D_FMT, ""),
           LanginfoItem("ERA_D_T_FMT", ERA_D_T_FMT, ""),
           LanginfoItem("ERA_T_FMT", ERA_T_FMT, ""),
-          LanginfoItem("THOUSEP", THOUSEP, ","), // linux
+          LanginfoItem("THOUSEP", THOUSEP, ",") // linux
+        ).foreach(verify(_))
+
+      if (!isWindows && !isOpenBSD && !isNetBSD)
+        Array(
           LanginfoItem("CRNCYSTR", CRNCYSTR, "-$")
         ).foreach(verify(_))
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LocaleTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LocaleTest.scala
@@ -107,7 +107,7 @@ class LocaleTest {
        * bug ever gets fixed.
        */
 
-      if (!LinktimeInfo.isFreeBSD) {
+      if (!LinktimeInfo.isFreeBSD && !LinktimeInfo.isNetBSD) {
         // Expect three byte-integers 3, 3, 0  meaning infinite group-by-three
         assertEquals(
           "US grouping",
@@ -142,7 +142,7 @@ class LocaleTest {
 
       // See "skip "FreeBSD"" comment before US grouping check above.
 
-      if (!LinktimeInfo.isFreeBSD) {
+      if (!LinktimeInfo.isFreeBSD && !LinktimeInfo.isNetBSD) {
         // Expect three byte-integers 3, 3, 0, meaning infinite group-by-3
         assertEquals(
           "US mon_grouping",

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/ResourceTest.scala
@@ -52,7 +52,7 @@ class ResourceTest {
     // Most operating systems will return EINVAL. Handle corner cases here.
     if (errno != EINVAL) {
       if (!(Platform.isLinux() || Platform.isFreeBSD() || Platform
-            .isOpenBSD())) {
+            .isOpenBSD() || Platform.isNetBSD())) {
         assertEquals("unexpected errno", EINVAL, errno)
       } else if (errno != 0) { // Linux, FreeBSD
         // A pid of UInt.MaxValue is highly unlikely but, by one reading,

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/StatTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/StatTest.scala
@@ -84,7 +84,8 @@ class StatTest {
       )
 
       val expectedRdev =
-        if (!LinktimeInfo.isFreeBSD) 0.toUSize // Linux, macOS
+        if (!LinktimeInfo.isFreeBSD && !LinktimeInfo.isNetBSD)
+          0.toUSize // Linux, macOS
         else ULong.MaxValue.toUSize
 
       assertEquals(

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/TimesTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/TimesTest.scala
@@ -8,6 +8,7 @@ import org.junit.Assume._
 import scala.scalanative.meta.LinktimeInfo.{
   is32BitPlatform,
   isFreeBSD,
+  isNetBSD,
   isWindows
 }
 
@@ -133,7 +134,7 @@ class TimesTest {
       !isWindows
     )
 
-    if (!isWindows && !isFreeBSD) {
+    if (!isWindows && !isFreeBSD && !isNetBSD) {
       /* Test the 'natural' cases where there is no FreeBSD64 overlay
        * of tms fields. Here each of those fields is a Scala Size, 64
        * or 32 bits as appropriate to the architecture.
@@ -169,8 +170,8 @@ class TimesTest {
     }
   }
 
-  @Test def freeBSD64TimesOpsShouldGetAndSetFields(): Unit = {
-    if (isFreeBSD && !is32BitPlatform) {
+  @Test def use32BitOn64BitTimesOpsShouldGetAndSetFields(): Unit = {
+    if ((isFreeBSD || isNetBSD) && !is32BitPlatform) {
       val timesBuf = stackalloc[tms]()
 
       val expectedUTime = 222L.toSize

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -30,6 +30,7 @@ object Platform {
 
   final val isFreeBSD = runtime.Platform.isFreeBSD()
   final val isOpenBSD = runtime.Platform.isOpenBSD()
+  final val isNetBSD = runtime.Platform.isNetBSD()
   final val isLinux = runtime.Platform.isLinux()
   final val isMacOs = runtime.Platform.isMac()
   final val isWindows = runtime.Platform.isWindows()

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/net/NetworkInterfaceTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/net/NetworkInterfaceTestOnJDK9.scala
@@ -21,12 +21,16 @@ class NetworkInterfaceTestOnJDK9 {
   val osIPv6LoopbackSuffix =
     if (Platform.isOpenBSD && Platform.executingInScalaNative)
       s":3:0:0:0:0:0:1%${localhostIf}"
+    else if (Platform.isNetBSD && Platform.executingInScalaNative)
+      s":2:0:0:0:0:0:1%${localhostIf}"
     else
       s":0:0:0:0:0:0:1%${localhostIf}"
 
   val osIPv6LoopbackAddress =
     if (Platform.isMacOs) s"fe80${osIPv6LoopbackSuffix}"
     else if (Platform.isOpenBSD && Platform.executingInScalaNative)
+      s"fe80${osIPv6LoopbackSuffix}"
+    else if (Platform.isNetBSD && Platform.executingInScalaNative)
       s"fe80${osIPv6LoopbackSuffix}"
     else s"0${osIPv6LoopbackSuffix}"
 
@@ -66,7 +70,7 @@ class NetworkInterfaceTestOnJDK9 {
      * break this test. Thus, OpenBSD has only one IPv4 address by default.
      */
     val atLeast =
-      if (Platform.isOpenBSD) 1
+      if (Platform.isOpenBSD || Platform.isNetBSD) 1
       else 2
     assertTrue(s"count ${count} not >= ${atLeast}", count >= atLeast)
   }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThrowablesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThrowablesTest.scala
@@ -373,7 +373,7 @@ class ThrowablesTest {
   }
 
   @Test def setStackTraceStackTraceWriteToReturnedStack(): Unit = {
-    assumeNotASAN()
+    assumeSupportsStackTraces()
     val throwable = new Throwable()
     val trace1 = throwable.getStackTrace()
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/InterfaceAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/InterfaceAddressTest.scala
@@ -33,22 +33,25 @@ class InterfaceAddressTest {
     else "lo0"
 
   val loopbackIfIndex =
-    if (Platform.isFreeBSD) 2
+    if (Platform.isFreeBSD || Platform.isNetBSD) 2
     else if (Platform.isOpenBSD) 3
     else 1
 
   val osIPv6PrefixLength =
-    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD)) 64
+    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD) || (Platform.isNetBSD))
+      64
     else 128
 
   val osIPv6LoopbackSuffix =
     if (Platform.isOpenBSD)
       s":3:0:0:0:0:0:1%${loopbackIfName}"
+    else if (Platform.isNetBSD)
+      s":2:0:0:0:0:0:1%${loopbackIfName}"
     else
       s":0:0:0:0:0:0:1%${loopbackIfName}"
 
   val osIPv6LoopbackAddress =
-    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD))
+    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD) || (Platform.isNetBSD))
       s"fe80${osIPv6LoopbackSuffix}"
     else
       s"0${osIPv6LoopbackSuffix}"

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/NetworkInterfaceTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/NetworkInterfaceTest.scala
@@ -36,18 +36,20 @@ class NetworkInterfaceTest {
     else "lo0"
 
   val loopbackIfIndex =
-    if (Platform.isFreeBSD) 2
+    if (Platform.isFreeBSD || Platform.isNetBSD) 2
     else if (Platform.isOpenBSD) 3
     else 1
 
   val osIPv6LoopbackSuffix =
     if (Platform.isOpenBSD)
       s":3:0:0:0:0:0:1%${loopbackIfName}"
+    else if (Platform.isNetBSD)
+      s":2:0:0:0:0:0:1%${loopbackIfName}"
     else
       s":0:0:0:0:0:0:1%${loopbackIfName}"
 
   val osIPv6LoopbackAddress =
-    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD))
+    if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD) || (Platform.isNetBSD))
       s"fe80${osIPv6LoopbackSuffix}"
     else
       s"0${osIPv6LoopbackSuffix}"
@@ -74,6 +76,7 @@ class NetworkInterfaceTest {
     val sought =
       if (Platform.isFreeBSD) "em0"
       else if (Platform.isOpenBSD) "iwx0"
+      else if (Platform.isNetBSD) "wm0"
       else loopbackIfName
     val ifName = netIf.getName()
     assertEquals("a2", sought, ifName)
@@ -210,7 +213,7 @@ class NetworkInterfaceTest {
     assertNotNull(lbIf)
 
     val expected =
-      if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD))
+      if ((Platform.isMacOs) || (Platform.isFreeBSD) || (Platform.isOpenBSD) || (Platform.isNetBSD))
         true
       else false // Linux
 

--- a/unit-tests/shared/src/test/scala/utils/AssumesHelper.scala
+++ b/unit-tests/shared/src/test/scala/utils/AssumesHelper.scala
@@ -28,6 +28,11 @@ object AssumesHelper {
     )
 
   def assumeSupportsStackTraces() = {
+    Assume.assumeFalse(
+      "NetBSD doesn't work well with unwind, disable stacktrace tests",
+      Platform.isNetBSD
+    )
+
     // On Windows linking with LTO Full does not provide debug symbols, even
     // if flag -g is used. Becouse of that limitation StackTraces do not work.
     // If env variable exists and is set to true don't run tests in this file


### PR DESCRIPTION
This commit allows to use Scala-Native on NetBSD-9.3. Probably on something before that, which I haven't tested.

Regarding testing:
 - `sbt test-sandbox-gc` works;
 - `sbt test-runtime` works as well.