### PR TITLE
Allow to run github action tests manually

### DIFF
--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -2,6 +2,7 @@ name: Run tests JDK compliance tests
 on:
   workflow_call:
   pull_request:
+  workflow_dispatch:
 concurrency:
   group: jdk-compliance-${{ github.head_ref }}-${{ github.event_name }}
   cancel-in-progress: true

--- a/.github/workflows/run-tests-linux-multiarch.yml
+++ b/.github/workflows/run-tests-linux-multiarch.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Every day at 2 AM UTC
     - cron: "0 2 * * *"
+  workflow_dispatch:
 concurrency:
   group: linux-multiarch-${{ github.head_ref }}-${{ github.event_name }}
   cancel-in-progress: true
@@ -13,7 +14,7 @@ jobs:
   # Build testing image that would be used to build and run against different platforms
   # Currently only Linux x64 is tested
   build-image:
-    if: "github.event_name == 'pull_request' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
+    if: "github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
     name: Build image
     runs-on: ubuntu-22.04
     outputs:

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Every day at 2 AM UTC
     - cron: "0 2 * * *"
+  workflow_dispatch:
 concurrency:
   group: linux-${{ github.head_ref }}-${{ github.event_name }}
   cancel-in-progress: true
@@ -15,7 +16,7 @@ jobs:
   # Test tools, if any of them fails, further tests will not start.
   tests-tools:
     name: Compile & test tools
-    if: "github.event_name == 'pull_request' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
+    if: "github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
     runs-on: ubuntu-22.04
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Every day at 2 AM UTC
     - cron: "0 2 * * *"
+  workflow_dispatch:
 concurrency:
   group: macOS-${{ github.head_ref }}-${{ github.event_name }}
   cancel-in-progress: true
@@ -12,7 +13,7 @@ concurrency:
 jobs:
   test-runtime:
     name: Test runtime
-    if: "github.event_name == 'pull_request' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
+    if: "github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
     runs-on: macos-12
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Every day at 2 AM UTC
     - cron: "0 2 * * *"
+  workflow_dispatch:
 concurrency:
   group: windows-${{ github.head_ref }}-${{ github.event_name }}
   cancel-in-progress: true
@@ -12,7 +13,7 @@ concurrency:
 jobs:
   test-runtime:
     name: Test runtime
-    if: "github.event_name == 'pull_request' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
+    if: "github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
     runs-on: windows-2022
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true


### PR DESCRIPTION
Right now for a contributor the only way to test his work on different platform is to create PR.

Some changes can be too early to create PR, or a kind of test.

So, here I allow to run test actions via github UI on desired branch against user's worker quota.

An example of usage:
![image](https://github.com/scala-native/scala-native/assets/37775/9be58bb3-9446-4c88-9c1a-edd1ee7381ca)
