### PR TITLE
Expose API to run one iteration of event loop

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
@@ -14,8 +14,8 @@ object ExecutionContext {
 
   private val queue: ListBuffer[Runnable] = new ListBuffer
 
-  private[runtime] def loop(): Unit = {
-    while (queue.nonEmpty) {
+  private[runtime] def loopRunOnce(): Boolean = {
+    if (queue.nonEmpty) {
       val runnable = queue.remove(0)
       try {
         runnable.run()
@@ -23,6 +23,13 @@ object ExecutionContext {
         case t: Throwable =>
           QueueExecutionContext.reportFailure(t)
       }
+    }
+    queue.nonEmpty
+  }
+
+  private[runtime] def loop(): Unit = {
+    while (loopRunOnce()) {
+      // iterates until queue is empty
     }
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -119,6 +119,11 @@ package object runtime {
    */
   @noinline def loop(): Unit = ExecutionContext.loop()
 
+  /** Run the runtime's event loop once and return true when internal queue has
+   *  more Runnable to run.
+   */
+  @noinline def loopRunOnce(): Boolean = ExecutionContext.loopRunOnce()
+
   /** Called by the generated code in case of division by zero. */
   @noinline
   private[scalanative] def throwDivisionByZero(): Nothing =


### PR DESCRIPTION
This API should be used to mix Scala-Native's event loop with external one like `select`, `poll`, etc or a wraper from `libub` or `libev` and so on.

Right now such integration requires quite ugly and very frigiel hack which grand access to the queue via `RawPtr`.

We had a few PRs with attemt to implement in, for example see: https://github.com/scala-native/scala-native/pull/1852

So, here I made things quite trivial and without any refactoring.