### PR TITLE
improvement: Limit amount of compiled code, restrict glue layer only referenced files.

### DIFF
--- a/auxlib/src/main/scala/scala/runtime/Statics.scala
+++ b/auxlib/src/main/scala/scala/runtime/Statics.scala
@@ -2,6 +2,7 @@ package scala.runtime
 
 import scala.scalanative.libc.stdatomic._
 import scala.scalanative.libc.stdatomic.memory_order._
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 
 /** Not for public consumption. Usage by the runtime only.
  */
@@ -89,7 +90,8 @@ object Statics {
 
   private object PFMarker
 
-  @inline def releaseFence(): Unit = atomic_thread_fence(memory_order_release)
+  @inline def releaseFence(): Unit =
+    if (isMultithreadingEnabled) atomic_thread_fence(memory_order_release)
 
   /** Just throws an exception.
    *

--- a/clib/src/main/resources/scala-native/complex.c
+++ b/clib/src/main/resources/scala-native/complex.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_C_COMPLEX)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_C_COMPLEX)
 #include <complex.h>
 
 #if defined(_WIN32)

--- a/clib/src/main/resources/scala-native/complex.c
+++ b/clib/src/main/resources/scala-native/complex.c
@@ -1,3 +1,4 @@
+#if defined(__SCANATIVE_C_COMPLEX)
 #include <complex.h>
 
 #if defined(_WIN32)
@@ -201,3 +202,4 @@ float scalanative_crealf(float snfc[2]) { return crealf(toFloatComplex(snfc)); }
 double scalanative_creal(double sndc[2]) {
     return creal(toDoubleComplex(sndc));
 }
+#endif

--- a/clib/src/main/resources/scala-native/complex.c
+++ b/clib/src/main/resources/scala-native/complex.c
@@ -1,4 +1,4 @@
-#if defined(__SCANATIVE_C_COMPLEX)
+#if defined(__SCALANATIVE_C_COMPLEX)
 #include <complex.h>
 
 #if defined(_WIN32)

--- a/clib/src/main/resources/scala-native/fenv.c
+++ b/clib/src/main/resources/scala-native/fenv.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_C_FENV)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_C_FENV)
 #include <fenv.h>
 
 int scalanative_fe_divbyzero() { return FE_DIVBYZERO; }

--- a/clib/src/main/resources/scala-native/fenv.c
+++ b/clib/src/main/resources/scala-native/fenv.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_C_FENV)
 #include <fenv.h>
 
 int scalanative_fe_divbyzero() { return FE_DIVBYZERO; }
@@ -10,3 +11,4 @@ int scalanative_fe_downward() { return FE_DOWNWARD; }
 int scalanative_fe_tonearest() { return FE_TONEAREST; }
 int scalanative_fe_towardzero() { return FE_TOWARDZERO; }
 int scalanative_fe_upward() { return FE_UPWARD; }
+#endif

--- a/clib/src/main/resources/scala-native/locale.c
+++ b/clib/src/main/resources/scala-native/locale.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_C_LOCALE)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_C_LOCALE)
 #ifdef _WIN32
 // No Windows support
 #else

--- a/clib/src/main/resources/scala-native/locale.c
+++ b/clib/src/main/resources/scala-native/locale.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_C_LOCALE)
 #ifdef _WIN32
 // No Windows support
 #else
@@ -182,3 +183,4 @@ int scalanative_lc_time() { return LC_TIME; }
 
 #endif // POSIX
 #endif // ! _WIN32
+#endif

--- a/clib/src/main/resources/scala-native/stdatomic.c
+++ b/clib/src/main/resources/scala-native/stdatomic.c
@@ -1,5 +1,5 @@
 // clang-format off
-#if defined(__SCALANATIVE_C_STDATOMIC)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_C_STDATOMIC)
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -277,4 +277,4 @@ intptr_t scalanative_atomic_fetch_or_intptr(_Atomic(intptr_t)* atm, intptr_t val
 intptr_t scalanative_atomic_fetch_or_explicit_intptr(_Atomic(intptr_t)* atm, intptr_t val, memory_order memoryOrder) { return atomic_fetch_or_explicit(atm, val, memoryOrder);}
 intptr_t scalanative_atomic_fetch_xor_intptr(_Atomic(intptr_t)* atm, intptr_t val) { return atomic_fetch_xor(atm, val);}
 intptr_t scalanative_atomic_fetch_xor_explicit_intptr(_Atomic(intptr_t)* atm, intptr_t val, memory_order memoryOrder) { return atomic_fetch_xor_explicit(atm, val, memoryOrder);}
-#endif // defined(__SCALANATIVE_C_STDATOMIC)
+#endif // defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_C_STDATOMIC)

--- a/clib/src/main/resources/scala-native/stdatomic.c
+++ b/clib/src/main/resources/scala-native/stdatomic.c
@@ -1,5 +1,5 @@
 // clang-format off
-
+#if defined(__SCALANATIVE_C_STDATOMIC)
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -277,3 +277,4 @@ intptr_t scalanative_atomic_fetch_or_intptr(_Atomic(intptr_t)* atm, intptr_t val
 intptr_t scalanative_atomic_fetch_or_explicit_intptr(_Atomic(intptr_t)* atm, intptr_t val, memory_order memoryOrder) { return atomic_fetch_or_explicit(atm, val, memoryOrder);}
 intptr_t scalanative_atomic_fetch_xor_intptr(_Atomic(intptr_t)* atm, intptr_t val) { return atomic_fetch_xor(atm, val);}
 intptr_t scalanative_atomic_fetch_xor_explicit_intptr(_Atomic(intptr_t)* atm, intptr_t val, memory_order memoryOrder) { return atomic_fetch_xor_explicit(atm, val, memoryOrder);}
+#endif // defined(__SCALANATIVE_C_STDATOMIC)

--- a/clib/src/main/resources/scala-native/stdatomic.c.gyb
+++ b/clib/src/main/resources/scala-native/stdatomic.c.gyb
@@ -1,5 +1,5 @@
 // clang-format off
-
+#if defined(__SCALANATIVE_C_STDATOMIC)
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -47,3 +47,4 @@ ${T} scalanative_atomic_fetch_${op}_${N}(_Atomic(${T})* atm, ${T} val) { return 
 ${T} scalanative_atomic_fetch_${op}_explicit_${N}(_Atomic(${T})* atm, ${T} val, memory_order memoryOrder) { return atomic_fetch_${op}_explicit(atm, val, memoryOrder);}
 % end
 % end
+#endif // defined(__SCALANATIVE_C_STDATOMIC)

--- a/clib/src/main/resources/scala-native/stdatomic.c.gyb
+++ b/clib/src/main/resources/scala-native/stdatomic.c.gyb
@@ -1,5 +1,5 @@
 // clang-format off
-#if defined(__SCALANATIVE_C_STDATOMIC)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_C_STDATOMIC)
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -47,4 +47,4 @@ ${T} scalanative_atomic_fetch_${op}_${N}(_Atomic(${T})* atm, ${T} val) { return 
 ${T} scalanative_atomic_fetch_${op}_explicit_${N}(_Atomic(${T})* atm, ${T} val, memory_order memoryOrder) { return atomic_fetch_${op}_explicit(atm, val, memoryOrder);}
 % end
 % end
-#endif // defined(__SCALANATIVE_C_STDATOMIC)
+#endif // defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_C_STDATOMIC)

--- a/clib/src/main/scala/scala/scalanative/libc/complex.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/complex.scala
@@ -24,7 +24,7 @@ import scalanative.unsafe._
 @extern object complex extends complex
 
 @extern
-@define("__SCANATIVE_C_COMPLEX")
+@define("__SCALANATIVE_C_COMPLEX")
 private[scalanative] trait complex {
   type CFloatComplex = CStruct2[CFloat, CFloat]
   type CDoubleComplex = CStruct2[CDouble, CDouble]

--- a/clib/src/main/scala/scala/scalanative/libc/complex.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/complex.scala
@@ -23,7 +23,9 @@ import scalanative.unsafe._
  */
 @extern object complex extends complex
 
-@extern private[scalanative] trait complex {
+@extern
+@define("__SCANATIVE_C_COMPLEX")
+private[scalanative] trait complex {
   type CFloatComplex = CStruct2[CFloat, CFloat]
   type CDoubleComplex = CStruct2[CDouble, CDouble]
 

--- a/clib/src/main/scala/scala/scalanative/libc/fenv.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/fenv.scala
@@ -5,7 +5,9 @@ import scala.scalanative.unsafe._
 
 @extern object fenv extends fenv
 
-@extern private[scalanative] trait fenv {
+@extern
+@define("__SCALANATIVE_C_FENV")
+private[scalanative] trait fenv {
   type fexcept_t = CStruct0
   type fenv_t = CStruct0
 

--- a/clib/src/main/scala/scala/scalanative/libc/locale.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/locale.scala
@@ -11,7 +11,9 @@ import scalanative.meta.LinktimeInfo.{isLinux, isOpenBSD}
 @extern object locale extends locale
 
 /** Definitions shared with POSIX */
-@extern private[scalanative] trait locale {
+@extern
+@define("__SCALANATIVE_C_LOCALE")
+private[scalanative] trait locale {
 
   // CStruct is limited to 22 fields, lconv wants 24, so group int_* & use Ops
 

--- a/clib/src/main/scala/scala/scalanative/libc/signal.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/signal.scala
@@ -5,7 +5,9 @@ import scalanative.unsafe._
 
 @extern object signal extends signal
 
-@extern private[scalanative] trait signal {
+@extern
+@define("__SCALANATIVE_POSIX_SIGNAL")
+private[scalanative] trait signal {
 
   // Signals
   def signal(sig: CInt, handler: CFuncPtr1[CInt, Unit]): CFuncPtr1[CInt, Unit] =

--- a/clib/src/main/scala/scala/scalanative/libc/stdatomic.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdatomic.scala
@@ -7,7 +7,9 @@ import scala.scalanative.unsigned._
 import scala.language.implicitConversions
 
 
-@extern object stdatomic extends stdatomicExt {
+@extern
+@define("__SCALANATIVE_C_STDATOMIC")
+object stdatomic extends stdatomicExt {
 
   type atomic_bool = Boolean
   type atomic_char = Byte

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_JAVALIB_IFADDRS)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_JAVALIB_IFADDRS)
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
 int getifaddrs(void *dummy) { return -1; };
@@ -86,4 +87,5 @@ _Static_assert(offsetof(struct scalanative_ifaddrs, ifa_data) ==
 
 #endif
 #endif // not _WIN32
-#endif // defined(__SCALANATIVE_JAVALIB_IFADDRS)
+#endif // defined(SCALANATIVE_COMPILE_ALWAYS) ||
+       // defined(__SCALANATIVE_JAVALIB_IFADDRS)

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_JAVALIB_IFADDRS)
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
 int getifaddrs(void *dummy) { return -1; };
@@ -85,3 +86,4 @@ _Static_assert(offsetof(struct scalanative_ifaddrs, ifa_data) ==
 
 #endif
 #endif // not _WIN32
+#endif // defined(__SCALANATIVE_JAVALIB_IFADDRS)

--- a/javalib/src/main/resources/scala-native/net/if_dl.c
+++ b/javalib/src/main/resources/scala-native/net/if_dl.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_JAVALIB_NET_IF_DL)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_JAVALIB_NET_IF_DL)
 #ifdef _WIN32
 // NO Windows support
 #elif defined(__linux__) || defined(__NetBSD__)

--- a/javalib/src/main/resources/scala-native/net/if_dl.c
+++ b/javalib/src/main/resources/scala-native/net/if_dl.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_JAVALIB_NET_IF_DL)
 #ifdef _WIN32
 // NO Windows support
 #elif defined(__linux__) || defined(__NetBSD__)
@@ -92,3 +93,4 @@ _Static_assert(offsetof(struct scalanative_sockaddr_dl, sdl_data) ==
                "Unexpected offset: ifaddrs sdl_data");
 #endif
 #endif // not _WIN32
+#endif // __SCALANATIVE_JAVALIB_NET_IF_DL

--- a/javalib/src/main/resources/scala-native/netinet/in6.c
+++ b/javalib/src/main/resources/scala-native/netinet/in6.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_JAVALIB_NETINET_IN6)
 #ifndef _WIN32
 #include <netinet/in.h>
 #endif
@@ -23,3 +24,4 @@ int scalanative_ipv6_tclass() {
     return IPV6_TCLASS;
 #endif
 }
+#endif

--- a/javalib/src/main/resources/scala-native/netinet/in6.c
+++ b/javalib/src/main/resources/scala-native/netinet/in6.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_JAVALIB_NETINET_IN6)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_JAVALIB_NETINET_IN6)
 #ifndef _WIN32
 #include <netinet/in.h>
 #endif

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_JAVALIB_NETINET_UNIXIF)
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
 int scalanative_iff_loopback() { return 0; }
@@ -53,3 +54,4 @@ int scalanative_siocgifmtu() { return SIOCGIFMTU; }
 int scalanative_iff_up() { return IFF_UP; }
 
 #endif // !_WIN32
+#endif // defined(__SCALANATIVE_JAVALIB_NETINET_UNIXIF)

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_JAVALIB_NETINET_UNIXIF)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_JAVALIB_NETINET_UNIXIF)
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
 int scalanative_iff_loopback() { return 0; }
@@ -54,4 +55,5 @@ int scalanative_siocgifmtu() { return SIOCGIFMTU; }
 int scalanative_iff_up() { return IFF_UP; }
 
 #endif // !_WIN32
-#endif // defined(__SCALANATIVE_JAVALIB_NETINET_UNIXIF)
+#endif // defined(SCALANATIVE_COMPILE_ALWAYS) ||
+       // defined(__SCALANATIVE_JAVALIB_NETINET_UNIXIF)

--- a/javalib/src/main/resources/scala-native/process_monitor.cpp
+++ b/javalib/src/main/resources/scala-native/process_monitor.cpp
@@ -1,5 +1,6 @@
 // This mechanism is only used in POSIX compliant platforms.
 // On Windows other build in approach is used.
+#if defined(__SCALANATIVE_PROCESS_MONITOR)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <memory>
@@ -156,3 +157,4 @@ void scalanative_process_monitor_init() {
 }
 
 #endif // Unix or Mac OS
+#endif // __SCALANATIVE_PROCESS_MONITOR

--- a/javalib/src/main/resources/scala-native/process_monitor.cpp
+++ b/javalib/src/main/resources/scala-native/process_monitor.cpp
@@ -1,6 +1,7 @@
 // This mechanism is only used in POSIX compliant platforms.
 // On Windows other build in approach is used.
-#if defined(__SCALANATIVE_PROCESS_MONITOR)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_JAVALIB_PROCESS_MONITOR)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <memory>

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -1,4 +1,4 @@
-#if defined(__linux__)
+#if defined(__SCALANATIVE_JAVALIB_SYS_LINUX_SYSCALL) && defined(__linux__)
 
 #if __has_include(<sys/syscall.h>) // Should almost always be true
 #include <sys/syscall.h>

--- a/javalib/src/main/resources/scala-native/sys/linux_syscall.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_syscall.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_JAVALIB_SYS_LINUX_SYSCALL) && defined(__linux__)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_JAVALIB_SYS_LINUX_SYSCALL) && defined(__linux__)
 
 #if __has_include(<sys/syscall.h>) // Should almost always be true
 #include <sys/syscall.h>

--- a/javalib/src/main/resources/scala-native/z.c
+++ b/javalib/src/main/resources/scala-native/z.c
@@ -1,4 +1,4 @@
-#ifdef SCALANATIVE_Z
+#ifdef __SCALANATIVE_JAVALIB_Z
 
 #include <zlib.h>
 

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -495,14 +495,15 @@ object Thread {
   final val MIN_PRIORITY = 1
   final val NORM_PRIORITY = 5
 
-  final val MainThread = new Thread(
-    name = "main",
-    platformCtx = PlatformThreadContext(
-      group = new ThreadGroup(ThreadGroup.System, "main"),
-      task = null: Runnable,
-      stackSize = 0L
-    )
-  ) {
+  object MainThread
+      extends Thread(
+        name = "main",
+        platformCtx = PlatformThreadContext(
+          group = new ThreadGroup(ThreadGroup.System, "main"),
+          task = null: Runnable,
+          stackSize = 0L
+        )
+      ) {
     override protected val tid: scala.Long = 0L
     inheritableThreadLocals = new ThreadLocal.Values()
     platformCtx.nativeThread = nativeCompanion.create(this, 0L)
@@ -600,10 +601,14 @@ object Thread {
   // Counter used to generate thread's ID, 0 resevered for main
   sealed abstract class Numbering {
     final protected var cursor = 1L
-    final protected val cursorRef = new AtomicLongLong(
+    @inline def cursorRef = new AtomicLongLong(
       fromRawPtr(classFieldRawPtr(this, "cursor"))
     )
-    def next(): scala.Long = cursorRef.fetchAdd(1L)
+    def next(): scala.Long =
+      if (isMultithreadingEnabled) cursorRef.fetchAdd(1L)
+      else
+        try cursor
+        finally cursor += 1L
   }
   object ThreadNamesNumbering extends Numbering
   object ThreadIdentifiers extends Numbering

--- a/javalib/src/main/scala/java/lang/impl/PosixThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/PosixThread.scala
@@ -27,7 +27,7 @@ private[java] class PosixThread(val thread: Thread, stackSize: Long)
   import NativeThread._
   import PosixThread._
 
-  private val _state = new scala.Array[scala.Byte](StateSize)
+  private lazy val _state = new scala.Array[scala.Byte](StateSize)
   @volatile private[impl] var sleepInterruptEvent: CInt = UnsetEvent
   @volatile private var counter: Int = 0
   // index of currently used condition
@@ -360,7 +360,7 @@ private[java] class PosixThread(val thread: Thread, stackSize: Long)
 private[lang] object PosixThread extends NativeThread.Companion {
   override type Impl = PosixThread
 
-  private val _state = new scala.Array[scala.Byte](CompanionStateSize)
+  private lazy val _state = new scala.Array[scala.Byte](CompanionStateSize)
 
   if (isMultithreadingEnabled) {
     checkStatus("relative-time conditions attrs init") {

--- a/javalib/src/main/scala/java/lang/invoke/VarHandle.scala
+++ b/javalib/src/main/scala/java/lang/invoke/VarHandle.scala
@@ -3,15 +3,18 @@ package java.lang.invoke
 import scala.scalanative.libc.stdatomic._
 import scala.scalanative.libc.stdatomic.memory_order._
 import scala.scalanative.annotation._
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 
 class VarHandle {}
 
 object VarHandle {
   @alwaysinline
-  private def loadFence(): Unit = atomic_thread_fence(memory_order_acquire)
+  private def loadFence(): Unit =
+    if (isMultithreadingEnabled) atomic_thread_fence(memory_order_acquire)
 
   @alwaysinline
-  private def storeFence(): Unit = atomic_thread_fence(memory_order_release)
+  private def storeFence(): Unit =
+    if (isMultithreadingEnabled) atomic_thread_fence(memory_order_release)
 
   /** Ensures that loads before the fence will not be reordered with loads and
    *  stores after the fence.
@@ -29,7 +32,8 @@ object VarHandle {
    *  loads and stores after the fence.
    */
   @alwaysinline
-  def fullFence(): Unit = atomic_thread_fence(memory_order_seq_cst)
+  def fullFence(): Unit =
+    if (isMultithreadingEnabled) atomic_thread_fence(memory_order_seq_cst)
 
   /** Ensures that loads before the fence will not be reordered with loads after
    *  the fence.

--- a/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
+++ b/javalib/src/main/scala/java/lang/process/LinuxOsSpecific.scala
@@ -17,6 +17,7 @@ object LinuxOsSpecific {
   def hasPidfdOpen(): Boolean = _hasPidfdOpen
 
   @extern
+  @define("__SCALANATIVE_JAVALIB_SYS_LINUX_SYSCALL")
   object Extern {
     @name("scalanative_linux_has_pidfd_open")
     def linux_has_pidfd_open(): CBool = extern

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -134,6 +134,7 @@ private[lang] class UnixProcessGen1 private (
 object UnixProcessGen1 {
   @link("pthread")
   @extern
+  @define("__SCALANATIVE_JAVALIB_PROCESS_MONITOR")
   private object ProcessMonitor {
     @name("scalanative_process_monitor_notify")
     def notifyMonitor(): Unit = extern

--- a/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
@@ -29,12 +29,13 @@ private[java] object WeakReferenceRegistry {
       current: WeakReference[_],
       prev: WeakReference[_]
   ): (WeakReference[Any], WeakReference[Any]) =
-    if (current == null)
+    if (current == null) {
+      val tail = if (prev != null) prev else head
       (
         head.asInstanceOf[WeakReference[Any]],
-        prev.asInstanceOf[WeakReference[Any]]
+        tail.asInstanceOf[WeakReference[Any]]
       )
-    else
+    } else
       current.get() match {
         case collected @ null =>
           current.enqueue()
@@ -81,6 +82,7 @@ private[java] object WeakReferenceRegistry {
 
       // Reattach the weak refs list to the possibly updated head
       if (newDetachedHead != null) while ({
+        assert(detachedTail != null)
         val currentHead = weakRefsHead
         !expected = currentHead
         detachedTail.nextReference = currentHead

--- a/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
@@ -10,6 +10,8 @@ import scala.scalanative.runtime.Intrinsics.classFieldRawPtr
 import scala.scalanative.annotation.alwaysinline
 import scala.util.control.NonFatal
 import java.util.concurrent.locks.LockSupport
+import scala.annotation.tailrec
+import scala.scalanative.runtime.Proxy.GCWeakReferencesCollectedCallback
 
 /* Should always be treated as a module by the compiler.
  * _gc_modified_postGCControlField is explicitly acccessed
@@ -22,51 +24,73 @@ private[java] object WeakReferenceRegistry {
     classFieldRawPtr(this, "weakRefsHead")
   )
 
-  private def handleCollectedReferences() = {
+  @tailrec private def enqueueCollectedReferences(
+      head: WeakReference[_],
+      current: WeakReference[_],
+      prev: WeakReference[_]
+  ): (WeakReference[Any], WeakReference[Any]) =
+    if (current == null)
+      (
+        head.asInstanceOf[WeakReference[Any]],
+        prev.asInstanceOf[WeakReference[Any]]
+      )
+    else
+      current.get() match {
+        case collected @ null =>
+          current.enqueue()
+          val handler = current.postGCHandler
+          if (handler != null) {
+            try handler()
+            catch {
+              case NonFatal(err) =>
+                val thread = Thread.currentThread()
+                thread
+                  .getUncaughtExceptionHandler()
+                  .uncaughtException(thread, err)
+            }
+          }
+          if (prev == null)
+            enqueueCollectedReferences(
+              current.nextReference,
+              current.nextReference,
+              current
+            )
+          else {
+            prev.nextReference = current.nextReference
+            enqueueCollectedReferences(head, current.nextReference, current)
+          }
+        case _ => enqueueCollectedReferences(head, current.nextReference, prev)
+      }
+  private def handleCollectedReferences(): Unit = {
     // This method is designed for calls from C and therefore should not include
     // non statically reachable fields or methods.
+    if (!isMultithreadingEnabled) {
+      enqueueCollectedReferences(weakRefsHead, weakRefsHead, null)
+    } else {
+      // Detach current weak refs linked-list to allow for unsynchronized updated
+      val expected = stackalloc[WeakReference[_]]()
+      var detached = null.asInstanceOf[WeakReference[_]]
+      while ({
+        detached = weakRefsHead
+        !expected = detached
+        !atomic_compare_exchange_strong(weakRefsHeadPtr, expected, null)
+      }) ()
 
-    // Detach current weak refs linked-list to allow for unsynchronized updated
-    val expected = stackalloc[WeakReference[_]]()
-    var detached = null.asInstanceOf[WeakReference[_]]
-    while ({
-      detached = weakRefsHead
-      !expected = detached
-      !atomic_compare_exchange_strong(weakRefsHeadPtr, expected, null)
-    }) ()
+      val (newDetachedHead, detachedTail) =
+        enqueueCollectedReferences(detached, detached, null)
 
-    var current = detached
-    var prev = null.asInstanceOf[WeakReference[_]]
-    while (current != null) {
-      // Actual post GC logic
-      val wasCollected = current.get() == null
-      if (wasCollected) {
-        current.enqueue()
-        val handler = current.postGCHandler
-        if (handler != null) {
-          try handler()
-          catch {
-            case NonFatal(err) =>
-              val thread = Thread.currentThread()
-              thread
-                .getUncaughtExceptionHandler()
-                .uncaughtException(thread, err)
-          }
-        }
-        // Update the detached linked list
-        if (prev == null) detached = current.nextReference
-        else prev.nextReference = current.nextReference
-      } else prev = current
-      current = current.nextReference
+      // Reattach the weak refs list to the possibly updated head
+      if (newDetachedHead != null) while ({
+        val currentHead = weakRefsHead
+        !expected = currentHead
+        detachedTail.nextReference = currentHead
+        !atomic_compare_exchange_strong(
+          weakRefsHeadPtr,
+          expected,
+          newDetachedHead
+        )
+      }) ()
     }
-
-    // Reattach the weak refs list to the possibly updated head
-    if (detached != null) while ({
-      val currentHead = weakRefsHead
-      !expected = currentHead
-      prev.nextReference = currentHead
-      !atomic_compare_exchange_strong(weakRefsHeadPtr, expected, detached)
-    }) ()
   }
 
   private lazy val referenceHandlerThread = Thread
@@ -92,16 +116,21 @@ private[java] object WeakReferenceRegistry {
     if (isWeakReferenceSupported) {
       assert(weakRef.nextReference == null)
       var head = weakRefsHead
-      val expected = stackalloc[WeakReference[_]]()
-      !expected = null
-      if (atomic_compare_exchange_weak(weakRefsHeadPtr, expected, weakRef)) ()
-      else
-        while ({
-          var currentHead = !expected
-          weakRef.nextReference = currentHead
-          !expected = currentHead
-          !atomic_compare_exchange_weak(weakRefsHeadPtr, expected, weakRef)
-        }) ()
+      if (!isMultithreadingEnabled) {
+        weakRef.nextReference = head
+        weakRefsHead = weakRef
+      } else {
+        val expected = stackalloc[WeakReference[_]]()
+        !expected = null
+        if (atomic_compare_exchange_weak(weakRefsHeadPtr, expected, weakRef)) ()
+        else
+          while ({
+            var currentHead = !expected
+            weakRef.nextReference = currentHead
+            !expected = currentHead
+            !atomic_compare_exchange_weak(weakRefsHeadPtr, expected, weakRef)
+          }) ()
+      }
     }
 
   // Scala Native javalib exclusive functionality.

--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -870,6 +870,7 @@ object NetworkInterface {
 }
 
 @extern
+@define("__SCALANATIVE_JAVALIB_IFADDRS")
 private object unixIfaddrs {
   /* Reference: man getifaddrs
    *            #include <ifaddrs.h>
@@ -912,6 +913,7 @@ private object unixIfaddrsOps {
 }
 
 @extern
+@define("__SCALANATIVE_JAVALIB_NETINET_UNIXIF")
 private object unixIf {
   /* Reference: man 7 netdevice
    *            #include <net/if.h>
@@ -1015,6 +1017,7 @@ private object macOsIf {
   // ifi fields read-only fields in use, so no Ops here to set them.
 }
 
+@define("__SCALANATIVE_JAVALIB_NET_IF_DL")
 private object macOsIfDl {
   /*  Scala sockaddr_dl & corresponding sockaddrDlOps definitions are not
    *  complete. They are only what NetworkInterface uses.

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -497,9 +497,11 @@ private[net] object ipOps {
  */
 @extern
 private[net] object ip6 {
+  @define("__SCALANATIVE_JAVALIB_NETINET_IN6")
   @name("scalanative_ipv6_tclass")
   def IPV6_TCLASS: CInt = extern
 
-  @name("scalanative_ipv6_multicast_hops")
-  def IPV6_MULTICAST_HOPS: CInt = extern
+  implicit class ip6Extension(self: ip6.type) {
+    def IPV6_MULTICAST_HOPS: CInt = in.IPV6_MULTICAST_HOPS
+  }
 }

--- a/javalib/src/main/scala/scala/scalanative/ffi/zlib.scala
+++ b/javalib/src/main/scala/scala/scalanative/ffi/zlib.scala
@@ -18,7 +18,7 @@ private[ffi] object zlibPlatformCompat {
     else zlibDefault
 }
 
-@define("SCALANATIVE_Z")
+@define("__SCALANATIVE_JAVALIB_Z")
 @extern
 trait zlib {
   import zlibOps.{z_stream, gz_header}

--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_DELIMCC)
 #include "delimcc.h"
 #include <stddef.h>
 #include <stdio.h>
@@ -397,3 +398,5 @@ void scalanative_continuation_free(Continuation *continuation) {
     free(continuation);
 }
 #endif // DELIMCC_DEBUG
+
+#endif

--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_DELIMCC)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_DELIMCC)
 #include "delimcc.h"
 #include <stddef.h>
 #include <stdio.h>

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd32.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd32.S
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_DELIMCC)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_DELIMCC)
 #if defined(__i386__) && (defined(__linux__) || defined(__APPLE__))
 
 /* ----------------------------------------------------------------------------

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd32.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd32.S
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_DELIMCC)
 #if defined(__i386__) && (defined(__linux__) || defined(__APPLE__))
 
 /* ----------------------------------------------------------------------------
@@ -144,4 +145,5 @@ __lh_get_sp:
 
 .section .note.GNU-stack,"",%progbits
 
+#endif
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_DELIMCC)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_DELIMCC)
 #if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__))
 
 /* ----------------------------------------------------------------------------

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_DELIMCC)
 #if defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__))
 
 /* ----------------------------------------------------------------------------
@@ -121,4 +122,5 @@ __lh_get_sp:
 
 .section .note.GNU-stack,"",%progbits
 
+#endif
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_arm64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_arm64.S
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_DELIMCC)
 #if defined(__aarch64__)
 /* ----------------------------------------------------------------------------
   Copyright (c) 2016, 2017, Microsoft Research, Daan Leijen
@@ -138,4 +139,5 @@ _lh_get_sp:
 
 .section .note.GNU-stack,"",%progbits
 
+#endif
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_arm64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_arm64.S
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_DELIMCC)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_DELIMCC)
 #if defined(__aarch64__)
 /* ----------------------------------------------------------------------------
   Copyright (c) 2016, 2017, Microsoft Research, Daan Leijen

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_DELIMCC)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_DELIMCC)
 #if defined(__x86_64__) && defined(_WIN64)
 /* ----------------------------------------------------------------------------
   Copyright (c) 2016, Microsoft Research, Daan Leijen

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_DELIMCC)
 #if defined(__x86_64__) && defined(_WIN64)
 /* ----------------------------------------------------------------------------
   Copyright (c) 2016, Microsoft Research, Daan Leijen
@@ -154,4 +155,5 @@ __lh_get_sp:
 
 .section .note.GNU-stack,"",%progbits
 
+#endif
 #endif

--- a/nativelib/src/main/resources/scala-native/platform/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform/platform.c
@@ -6,49 +6,50 @@
 #endif
 
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 
 #ifdef __APPLE__
 #include <sys/sysctl.h>
 #endif
 
-int scalanative_platform_is_freebsd() {
+bool scalanative_platform_is_freebsd() {
 #if defined(__FreeBSD__)
-    return 1;
+    return true;
 #else
-    return 0;
+    return false;
 #endif
 }
 
-int scalanative_platform_is_openbsd() {
+bool scalanative_platform_is_openbsd() {
 #if defined(__OpenBSD__)
-    return 1;
+    return true;
 #else
-    return 0;
+    return false;
 #endif
 }
 
-int scalanative_platform_is_netbsd() {
+bool scalanative_platform_is_netbsd() {
 #if defined(__NetBSD__)
-    return 1;
+    return true;
 #else
-    return 0;
+    return false;
 #endif
 }
 
-int scalanative_platform_is_linux() {
+bool scalanative_platform_is_linux() {
 #ifdef __linux__
-    return 1;
+    return true;
 #else
-    return 0;
+    return false;
 #endif
 }
 
-int scalanative_platform_is_mac() {
+bool scalanative_platform_is_mac() {
 #ifdef __APPLE__
-    return 1;
+    return true;
 #else
-    return 0;
+    return false;
 #endif
 }
 
@@ -93,26 +94,26 @@ int scalanative_platform_probe_mac_x8664_is_arm64() {
     return translated;
 }
 
-int scalanative_platform_is_windows() {
+bool scalanative_platform_is_windows() {
 #ifdef _WIN32
-    return 1;
+    return true;
 #else
-    return 0;
+    return false;
 #endif
 }
 
-int scalanative_platform_is_msys() {
+bool scalanative_platform_is_msys() {
 #ifdef __MSYS__
-    return 1;
+    return true;
 #else
-    return 0;
+    return false;
 #endif
 }
 
 // See http://stackoverflow.com/a/4181991
-int scalanative_little_endian() {
+bool scalanative_little_endian() {
     int n = 1;
-    return (*(char *)&n);
+    return (bool)(*(char *)&n);
 }
 
 void scalanative_set_os_props(void (*add_prop)(const char *, const char *)) {

--- a/nativelib/src/main/resources/scala-native/vmoffset.c
+++ b/nativelib/src/main/resources/scala-native/vmoffset.c
@@ -1,4 +1,6 @@
-#if (defined(__SCALANATIVE_VMOFFSET) && defined(__APPLE__) && defined(__MACH__))
+#if (defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_VMOFFSET) && \
+                                                defined(__APPLE__) &&          \
+                                                defined(__MACH__))
 #include <mach-o/dyld.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/nativelib/src/main/resources/scala-native/vmoffset.c
+++ b/nativelib/src/main/resources/scala-native/vmoffset.c
@@ -1,4 +1,4 @@
-#if (defined(__APPLE__) && defined(__MACH__))
+#if (defined(__SCALANATIVE_VMOFFSET) && defined(__APPLE__) && defined(__MACH__))
 #include <mach-o/dyld.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/nativelib/src/main/resources/scala-native/zone/LargeMemoryPool.c
+++ b/nativelib/src/main/resources/scala-native/zone/LargeMemoryPool.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_MEMORY_SAFEZONE)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_MEMORY_SAFEZONE)
 #include <stdio.h>
 #include <stdlib.h>
 #include "LargeMemoryPool.h"

--- a/nativelib/src/main/resources/scala-native/zone/LargeMemoryPool.c
+++ b/nativelib/src/main/resources/scala-native/zone/LargeMemoryPool.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_MEMORY_SAFEZONE)
 #include <stdio.h>
 #include <stdlib.h>
 #include "LargeMemoryPool.h"
@@ -84,3 +85,4 @@ void LargeMemoryPool_close(LargeMemoryPool *largePool) {
     // Free the pool.
     free(largePool);
 }
+#endif

--- a/nativelib/src/main/resources/scala-native/zone/MemoryPool.c
+++ b/nativelib/src/main/resources/scala-native/zone/MemoryPool.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_MEMORY_SAFEZONE)
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>
@@ -85,3 +86,4 @@ void MemoryPool_close(MemoryPool *pool) {
     // Free the pool.
     free(pool);
 }
+#endif

--- a/nativelib/src/main/resources/scala-native/zone/MemoryPool.c
+++ b/nativelib/src/main/resources/scala-native/zone/MemoryPool.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_MEMORY_SAFEZONE)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_MEMORY_SAFEZONE)
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>

--- a/nativelib/src/main/resources/scala-native/zone/Util.c
+++ b/nativelib/src/main/resources/scala-native/zone/Util.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_MEMORY_SAFEZONE)
 #include <stdio.h>
 #include <stdlib.h>
 #include "Util.h"
@@ -9,3 +10,4 @@ size_t Util_pad(size_t addr, size_t alignment) {
                          : (alignment - (addr & alignment_mask));
     return addr + padding;
 }
+#endif

--- a/nativelib/src/main/resources/scala-native/zone/Util.c
+++ b/nativelib/src/main/resources/scala-native/zone/Util.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_MEMORY_SAFEZONE)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_MEMORY_SAFEZONE)
 #include <stdio.h>
 #include <stdlib.h>
 #include "Util.h"

--- a/nativelib/src/main/resources/scala-native/zone/Zone.c
+++ b/nativelib/src/main/resources/scala-native/zone/Zone.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_MEMORY_SAFEZONE)
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -65,3 +66,4 @@ void *scalanative_zone_alloc(void *_zone, void *info, size_t size) {
     }
     return (void *)alloc;
 }
+#endif

--- a/nativelib/src/main/resources/scala-native/zone/Zone.c
+++ b/nativelib/src/main/resources/scala-native/zone/Zone.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_MEMORY_SAFEZONE)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_MEMORY_SAFEZONE)
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/Continuations.scala
@@ -142,7 +142,7 @@ object Continuations:
   ): Ptr[?] = continuation.alloc(size)
 
   /** Continuations implementation imported from C (see `delimcc.h`) */
-  @extern private object Impl:
+  @extern @define("__SCALANATIVE_DELIMCC") private object Impl:
     private type ContinuationLabel = CUnsignedLong
     type BoundaryLabel = ContinuationLabel
 

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
@@ -3,9 +3,10 @@ package scala.scalanative.runtime
 import scala.scalanative.annotation._
 import scala.runtime.LazyVals.{BITS_PER_LAZY_VAL, STATE}
 import scala.scalanative.runtime.ffi._
+import scala.scalanative.runtime.ffi.stdatomic._
+import scala.scalanative.runtime.ffi.stdatomic.memory_order._
 import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 import scala.scalanative.runtime.Intrinsics._
-import scala.scalanative.runtime.ffi.memory_order._
 
 // Factored out LazyVals immutable state, allowing to treat LazyVals as constant module,
 // alowing to skip loading of the module on each call to its methods

--- a/nativelib/src/main/scala-next/scala/scalanative/runtime/SafeZoneAllocator.scala
+++ b/nativelib/src/main/scala-next/scala/scalanative/runtime/SafeZoneAllocator.scala
@@ -13,7 +13,7 @@ import scala.scalanative.unsafe._
 object SafeZoneAllocator {
   def allocate[T](sz: SafeZone^, obj: T): T^{sz} = intrinsic
 
-  @extern object Impl{
+  @extern @define("__SCALANATIVE_MEMORY_SAFEZONE") object Impl{
     @name("scalanative_zone_open")
     def open(): RawPtr = extern
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Backtrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Backtrace.scala
@@ -15,6 +15,9 @@ import scala.annotation.tailrec
 
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
+import java.util.HashMap
+import java.util.AbstractMap
 
 private[runtime] object Backtrace {
   private sealed trait Format
@@ -38,7 +41,9 @@ private[runtime] object Backtrace {
   private val MACHO_MAGIC = "cffaedfe"
   private val ELF_MAGIC = "7f454c46"
 
-  private val cache = new ConcurrentHashMap[String, Option[DwarfInfo]]
+  private val cache: AbstractMap[String, Option[DwarfInfo]] =
+    if (isMultithreadingEnabled) new ConcurrentHashMap
+    else new HashMap
   case class Position(filename: String, line: Int)
   object Position {
     final val empty = Position(null, 0)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -5,8 +5,8 @@ import scala.scalanative.runtime.GC.{ThreadRoutineArg, ThreadStartRoutine}
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.unsafe._
 import scala.scalanative.meta.LinktimeInfo.{isMultithreadingEnabled, isWindows}
-import scala.scalanative.runtime.ffi.atomic_thread_fence
-import scala.scalanative.runtime.ffi.memory_order._
+import scala.scalanative.runtime.ffi.stdatomic.atomic_thread_fence
+import scala.scalanative.runtime.ffi.stdatomic.memory_order._
 import scala.annotation.nowarn
 
 import java.util.concurrent.ConcurrentHashMap

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Throwables.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Throwables.scala
@@ -1,6 +1,8 @@
 package scala.scalanative
 package runtime
 
+import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
+
 /** An exception that is thrown whenever an undefined behavior happens in a
  *  checked mode.
  */
@@ -16,9 +18,12 @@ import scala.scalanative.meta.LinktimeInfo
 import scala.scalanative.runtime.ffi.{malloc, calloc, free}
 
 import java.util.concurrent.ConcurrentHashMap
+import java.{util => ju}
 
 object StackTrace {
-  private val cache = new ConcurrentHashMap[CUnsignedLong, StackTraceElement]
+  private val cache: ju.AbstractMap[CUnsignedLong, StackTraceElement] =
+    if (isMultithreadingEnabled) new ConcurrentHashMap
+    else new ju.HashMap
 
   @noinline def currentStackTrace(): scala.Array[StackTraceElement] = {
     // Used to prevent filling stacktraces inside `currentStackTrace` which might lead to infinite loop

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ffi.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ffi.scala
@@ -31,58 +31,62 @@ object ffi {
   def atexit(func: CFuncPtr0[Unit]): CInt = extern
 
   // Glue layer defined in libc
-  @name("scalanative_atomic_compare_exchange_strong_byte")
-  private[runtime] def atomic_compare_exchange_byte(
-      ptr: RawPtr,
-      expected: RawPtr,
-      desired: Byte
-  ): CBool = extern
-
-  @name("scalanative_atomic_compare_exchange_strong_llong")
-  private[runtime] def atomic_compare_exchange_llong(
-      ptr: RawPtr,
-      expected: RawPtr,
-      desired: Long
-  ): CBool = extern
-
-  @name("scalanative_atomic_compare_exchange_strong_intptr")
-  private[runtime] def atomic_compare_exchange_intptr(
-      ptr: RawPtr,
-      expected: RawPtr,
-      desired: RawPtr
-  ): CBool = extern
-
-  @name("scalanative_atomic_load_explicit_llong")
-  private[runtime] def atomic_load_llong(
-      ptr: RawPtr,
-      memoryOrder: memory_order
-  ): Long = extern
-
-  @name("scalanative_atomic_load_explicit_intptr")
-  private[runtime] def atomic_load_intptr(
-      ptr: RawPtr,
-      memoryOrder: memory_order
-  ): RawPtr = extern
-
-  @name("scalanative_atomic_store_explicit_intptr")
-  private[runtime] def atomic_store_intptr(
-      ptr: RawPtr,
-      v: RawPtr,
-      memoryOrder: memory_order
-  ): Unit = extern
-
-  @name("scalanative_atomic_thread_fence")
-  private[runtime] final def atomic_thread_fence(order: memory_order): Unit =
-    extern
-
-  private[runtime] type memory_order = Int
   @extern
-  private[runtime] object memory_order {
-    @name("scalanative_atomic_memory_order_acquire")
-    final def memory_order_acquire: memory_order = extern
-    @name("scalanative_atomic_memory_order_release")
-    final def memory_order_release: memory_order = extern
-    @name("scalanative_atomic_memory_order_seq_cst")
-    final def memory_order_seq_cst: memory_order = extern
+  @define("__SCALANATIVE_C_STDATOMIC")
+  object stdatomic {
+    @name("scalanative_atomic_compare_exchange_strong_byte")
+    private[runtime] def atomic_compare_exchange_byte(
+        ptr: RawPtr,
+        expected: RawPtr,
+        desired: Byte
+    ): CBool = extern
+
+    @name("scalanative_atomic_compare_exchange_strong_llong")
+    private[runtime] def atomic_compare_exchange_llong(
+        ptr: RawPtr,
+        expected: RawPtr,
+        desired: Long
+    ): CBool = extern
+
+    @name("scalanative_atomic_compare_exchange_strong_intptr")
+    private[runtime] def atomic_compare_exchange_intptr(
+        ptr: RawPtr,
+        expected: RawPtr,
+        desired: RawPtr
+    ): CBool = extern
+
+    @name("scalanative_atomic_load_explicit_llong")
+    private[runtime] def atomic_load_llong(
+        ptr: RawPtr,
+        memoryOrder: memory_order
+    ): Long = extern
+
+    @name("scalanative_atomic_load_explicit_intptr")
+    private[runtime] def atomic_load_intptr(
+        ptr: RawPtr,
+        memoryOrder: memory_order
+    ): RawPtr = extern
+
+    @name("scalanative_atomic_store_explicit_intptr")
+    private[runtime] def atomic_store_intptr(
+        ptr: RawPtr,
+        v: RawPtr,
+        memoryOrder: memory_order
+    ): Unit = extern
+
+    @name("scalanative_atomic_thread_fence")
+    private[runtime] final def atomic_thread_fence(order: memory_order): Unit =
+      extern
+
+    private[runtime] type memory_order = Int
+    @extern
+    private[runtime] object memory_order {
+      @name("scalanative_atomic_memory_order_acquire")
+      final def memory_order_acquire: memory_order = extern
+      @name("scalanative_atomic_memory_order_release")
+      final def memory_order_release: memory_order = extern
+      @name("scalanative_atomic_memory_order_seq_cst")
+      final def memory_order_seq_cst: memory_order = extern
+    }
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
@@ -7,7 +7,8 @@ import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.unsafe.{stackalloc => _, _}
 import scala.scalanative.runtime.Intrinsics._
 import scala.scalanative.runtime.ffi._
-import scala.scalanative.runtime.ffi.memory_order._
+import scala.scalanative.runtime.ffi.stdatomic._
+import scala.scalanative.runtime.ffi.stdatomic.memory_order._
 import scala.scalanative.meta.LinktimeInfo.{is32BitPlatform => is32bit}
 
 /** Lightweight monitor used for single-threaded execution, upon detection of

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
@@ -5,7 +5,8 @@ import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.runtime.Intrinsics._
 import scala.scalanative.runtime.{RawPtr, NativeThread, Intrinsics}
 import scala.scalanative.runtime.ffi._
-import scala.scalanative.runtime.ffi.memory_order._
+import scala.scalanative.runtime.ffi.stdatomic._
+import scala.scalanative.runtime.ffi.stdatomic.memory_order._
 import scala.scalanative.unsafe.{stackalloc => _, sizeOf => _, _}
 import java.util.concurrent.locks.LockSupport
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/vmoffset.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/vmoffset.scala
@@ -3,6 +3,7 @@ package scala.scalanative.runtime
 import scalanative.unsafe._
 
 @extern
+@define("__SCALANATIVE_VMOFFSET")
 private[runtime] object vmoffset {
 
   /** Get the image offset of this executable.

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -726,7 +726,11 @@ trait NirGenExpr(using Context) {
     }
 
     def genModule(sym: Symbol)(using nir.SourcePosition): nir.Val = {
-      val moduleSym = if (sym.isTerm) sym.moduleClass else sym
+      val moduleSym = if (sym.isTerm) sym.moduleClass match {
+        case NoSymbol  => sym.info.typeSymbol
+        case moduleCls => moduleCls
+      }
+      else sym
       val name = genModuleName(moduleSym)
       buf.module(name, unwind)
     }

--- a/posixlib/src/main/resources/scala-native/arpa/inet.c
+++ b/posixlib/src/main/resources/scala-native/arpa/inet.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_ARPA_INET)
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
@@ -12,3 +13,4 @@ char *scalanative_inet_ntoa(struct scalanative_in_addr *in) {
     // _Static_assert code in netinet/in.c allow this transform to be valid.
     return inet_ntoa(*((struct in_addr *)in));
 }
+#endif

--- a/posixlib/src/main/resources/scala-native/arpa/inet.c
+++ b/posixlib/src/main/resources/scala-native/arpa/inet.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_ARPA_INET)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_ARPA_INET)
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define _WINSOCK_DEPRECATED_NO_WARNINGS

--- a/posixlib/src/main/resources/scala-native/cpio.c
+++ b/posixlib/src/main/resources/scala-native/cpio.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_CPIO)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <cpio.h>
@@ -26,3 +27,4 @@ unsigned short scalanative_c_ixoth() { return C_IXOTH; }
 const char *scalanative_magic() { return MAGIC; }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/cpio.c
+++ b/posixlib/src/main/resources/scala-native/cpio.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_CPIO)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_CPIO)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <cpio.h>

--- a/posixlib/src/main/resources/scala-native/dirent.c
+++ b/posixlib/src/main/resources/scala-native/dirent.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_DIRENT)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_DIRENT)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <dirent.h>

--- a/posixlib/src/main/resources/scala-native/dirent.c
+++ b/posixlib/src/main/resources/scala-native/dirent.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_DIRENT)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <dirent.h>
@@ -58,3 +59,4 @@ int scalanative_readdir(DIR *dirp, struct scalanative_dirent *buf) {
 int scalanative_closedir(DIR *dirp) { return closedir(dirp); }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/dlfcn.c
+++ b/posixlib/src/main/resources/scala-native/dlfcn.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_DLFCN)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 
@@ -12,3 +13,4 @@ int scalanative_rtld_global() { return RTLD_GLOBAL; };
 int scalanative_rtld_local() { return RTLD_LOCAL; };
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/dlfcn.c
+++ b/posixlib/src/main/resources/scala-native/dlfcn.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_DLFCN)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_DLFCN)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 

--- a/posixlib/src/main/resources/scala-native/errno.c
+++ b/posixlib/src/main/resources/scala-native/errno.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_ERRNO)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_ERRNO)
 #include <errno.h>
 
 // Omitting EDOM EILSEQ and ERANGE since they are in clib.

--- a/posixlib/src/main/resources/scala-native/errno.c
+++ b/posixlib/src/main/resources/scala-native/errno.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_ERRNO)
 #include <errno.h>
 
 // Omitting EDOM EILSEQ and ERANGE since they are in clib.
@@ -219,3 +220,4 @@ int scalanative_etxtbsy() { return ETXTBSY; }
 int scalanative_ewouldblock() { return EWOULDBLOCK; }
 
 int scalanative_exdev() { return EXDEV; }
+#endif

--- a/posixlib/src/main/resources/scala-native/fcntl.c
+++ b/posixlib/src/main/resources/scala-native/fcntl.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_FCNTL)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <fcntl.h>
@@ -86,3 +87,4 @@ int scalanative_open_m(const char *pathname, int flags, mode_t mode) {
 }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/fcntl.c
+++ b/posixlib/src/main/resources/scala-native/fcntl.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_FCNTL)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_FCNTL)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <fcntl.h>

--- a/posixlib/src/main/resources/scala-native/fnmatch.c
+++ b/posixlib/src/main/resources/scala-native/fnmatch.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_FNMATCH)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_FNMATCH)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 

--- a/posixlib/src/main/resources/scala-native/fnmatch.c
+++ b/posixlib/src/main/resources/scala-native/fnmatch.c
@@ -1,15 +1,8 @@
+#if defined(__SCALANATIVE_POSIX_FNMATCH)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 
 #include <fnmatch.h>
-#endif // Unix or Mac OS
-
-#if defined(_WIN32) // bogus values to keep linker happy
-#define FNM_NOMATCH -1
-#define FNM_PATHNAME -1
-#define FNM_PERIOD -1
-#define FNM_NOESCAPE -1
-#endif // _WIN32
 
 int scalanative_fnm_nomatch() { return FNM_NOMATCH; };
 
@@ -18,3 +11,6 @@ int scalanative_fnm_pathname() { return FNM_PATHNAME; };
 int scalanative_fnm_period() { return FNM_PERIOD; };
 
 int scalanative_fnm_noescape() { return FNM_NOESCAPE; };
+
+#endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/glob.c
+++ b/posixlib/src/main/resources/scala-native/glob.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_FNMATCH)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_FNMATCH)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 

--- a/posixlib/src/main/resources/scala-native/glob.c
+++ b/posixlib/src/main/resources/scala-native/glob.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_FNMATCH)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 
@@ -42,22 +43,8 @@ _Static_assert(offsetof(struct scalanative_glob_t, gl_pathv) ==
                "offset mismatch: glob_t gl_pathv");
 #endif // __APPLE__
 #endif // __STDC_VERSION__
-#endif // Unix or Mac OS
 
-#if defined(_WIN32) // bogus values to keep linker happy
-#define GLOB_APPEND -1
-#define GLOB_DOOFFS -1
-#define GLOB_ERR -1
-#define GLOB_MARK -1
-#define GLOB_NOCHECK -1
-#define GLOB_NOESCAPE -1
-#define GLOB_NOSORT -1
-#define GLOB_ABORTED -1
-#define GLOB_NOMATCH -1
-#define GLOB_NOSPACE -1
-#endif // _WIN32
 // flags
-
 int scalanative_glob_append() { return GLOB_APPEND; };
 
 int scalanative_glob_dooffs() { return GLOB_DOOFFS; };
@@ -78,3 +65,6 @@ int scalanative_glob_aborted() { return GLOB_ABORTED; };
 int scalanative_glob_nomatch() { return GLOB_NOMATCH; };
 
 int scalanative_glob_nospace() { return GLOB_NOSPACE; };
+
+#endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/grp.c
+++ b/posixlib/src/main/resources/scala-native/grp.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_GRP)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <stdlib.h>
@@ -39,3 +40,4 @@ int scalanative_getgrnam(char *name, struct scalanative_group *buf) {
 }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/grp.c
+++ b/posixlib/src/main/resources/scala-native/grp.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_GRP)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_GRP)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <stdlib.h>

--- a/posixlib/src/main/resources/scala-native/langinfo.c
+++ b/posixlib/src/main/resources/scala-native/langinfo.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_LANGINFO)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_LANGINFO)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 

--- a/posixlib/src/main/resources/scala-native/langinfo.c
+++ b/posixlib/src/main/resources/scala-native/langinfo.c
@@ -1,67 +1,8 @@
+#if defined(__SCALANATIVE_POSIX_LANGINFO)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 
 #include <langinfo.h>
-
-#endif // Unix or Mac OS
-
-#if defined(_WIN32) // bogus values to keep compiler happy
-#define CODESET -1
-#define D_T_FMT -1
-#define D_FMT -1
-#define T_FMT -1
-#define T_FMT_AMPM -1
-#define AM_STR -1
-#define PM_STR -1
-#define DAY_1 -1
-#define DAY_2 -1
-#define DAY_3 -1
-#define DAY_4 -1
-#define DAY_5 -1
-#define DAY_6 -1
-#define DAY_7 -1
-#define ABDAY_1 -1
-#define ABDAY_2 -1
-#define ABDAY_3 -1
-#define ABDAY_4 -1
-#define ABDAY_5 -1
-#define ABDAY_6 -1
-#define ABDAY_7 -1
-#define MON_1 -1
-#define MON_2 -1
-#define MON_3 -1
-#define MON_4 -1
-#define MON_5 -1
-#define MON_6 -1
-#define MON_7 -1
-#define MON_8 -1
-#define MON_9 -1
-#define MON_10 -1
-#define MON_11 -1
-#define MON_12 -1
-#define ABMON_1 -1
-#define ABMON_2 -1
-#define ABMON_3 -1
-#define ABMON_4 -1
-#define ABMON_5 -1
-#define ABMON_6 -1
-#define ABMON_7 -1
-#define ABMON_8 -1
-#define ABMON_9 -1
-#define ABMON_10 -1
-#define ABMON_11 -1
-#define ABMON_12 -1
-#define ERA -1
-#define ERA_D_FMT -1
-#define ERA_D_T_FMT -1
-#define ERA_T_FMT -1
-#define ALT_DIGITS -1
-#define RADIXCHAR -1
-#define THOUSEP -1
-#define YESEXPR -1
-#define NOEXPR -1
-#define CRNCYSTR -1
-#endif // _WIN32
 
 #if defined(__OpenBSD__)
 #define ERA -1
@@ -180,3 +121,6 @@ int scalanative_yesexpr() { return YESEXPR; };
 int scalanative_noexpr() { return NOEXPR; };
 
 int scalanative_crncystr() { return CRNCYSTR; };
+
+#endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/limits.c
+++ b/posixlib/src/main/resources/scala-native/limits.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_LIMITS)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <limits.h>
@@ -5,3 +6,4 @@
 int scalanative_path_max() { return NAME_MAX; }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/limits.c
+++ b/posixlib/src/main/resources/scala-native/limits.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_LIMITS)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_LIMITS)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <limits.h>

--- a/posixlib/src/main/resources/scala-native/locale.c
+++ b/posixlib/src/main/resources/scala-native/locale.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_LOCALE)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_LOCALE)
 #ifdef _WIN32
 // No Windows support
 #else

--- a/posixlib/src/main/resources/scala-native/locale.c
+++ b/posixlib/src/main/resources/scala-native/locale.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_LOCALE)
 #ifdef _WIN32
 // No Windows support
 #else
@@ -35,3 +36,4 @@ int scalanative_lc_time_mask() { return (1 << LC_TIME); }
 
 #endif // POSIX
 #endif // ! _WIN32
+#endif

--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_NET_IF)
 #ifdef _WIN32
 #include <WinSock2.h>
 #pragma comment(lib, "Ws2_32.lib")
@@ -49,3 +50,4 @@ _Static_assert(offsetof(struct scalanative_if_nameindex, if_name) ==
  * buffer overrun defects.
  */
 int scalanative_if_namesize() { return IF_NAMESIZE + 1; }
+#endif

--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_NET_IF)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_NET_IF)
 #ifdef _WIN32
 #include <WinSock2.h>
 #pragma comment(lib, "Ws2_32.lib")

--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_NETDB)
 #ifdef _WIN32
 #include <WinSock2.h>
 #include <ws2tcpip.h> // socklen_t
@@ -197,3 +198,4 @@ int scalanative_eai_system() { return -1; }
 int scalanative_eai_overflow() { return -1; }
 
 #endif // _Win32
+#endif

--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_NETDB)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_NETDB)
 #ifdef _WIN32
 #include <WinSock2.h>
 #include <ws2tcpip.h> // socklen_t

--- a/posixlib/src/main/resources/scala-native/netinet/in.c
+++ b/posixlib/src/main/resources/scala-native/netinet/in.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_NETINET_IN)
 #include <stddef.h>
 #include <string.h>
 #include "in.h"
@@ -155,3 +156,4 @@ int scalanative_in6_is_addr_mc_orglocal(struct scalanative_in6_addr *arg) {
 int scalanative_in6_is_addr_mc_global(struct scalanative_in6_addr *arg) {
     return IN6_IS_ADDR_MC_GLOBAL((struct in6_addr *)arg);
 }
+#endif

--- a/posixlib/src/main/resources/scala-native/netinet/in.c
+++ b/posixlib/src/main/resources/scala-native/netinet/in.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_NETINET_IN)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_NETINET_IN)
 #include <stddef.h>
 #include <string.h>
 #include "in.h"

--- a/posixlib/src/main/resources/scala-native/netinet/tcp.c
+++ b/posixlib/src/main/resources/scala-native/netinet/tcp.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_NETINET_TCP)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_NETINET_TCP)
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <WinSock2.h>

--- a/posixlib/src/main/resources/scala-native/netinet/tcp.c
+++ b/posixlib/src/main/resources/scala-native/netinet/tcp.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_NETINET_TCP)
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <WinSock2.h>
@@ -9,3 +10,4 @@
 #endif
 
 int scalanative_tcp_nodelay() { return TCP_NODELAY; }
+#endif

--- a/posixlib/src/main/resources/scala-native/nl_types.c
+++ b/posixlib/src/main/resources/scala-native/nl_types.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_NL_TYPES)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_NL_TYPES)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 

--- a/posixlib/src/main/resources/scala-native/nl_types.c
+++ b/posixlib/src/main/resources/scala-native/nl_types.c
@@ -1,14 +1,10 @@
+#if defined(__SCALANATIVE_POSIX_NL_TYPES)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 
 #include <nl_types.h>
 
-#endif // Unix or Mac OS
-
-#if defined(_WIN32) // bogus values to keep linker happy
-#define NL_SETD -1
-#define NL_CAT_LOCALE -1
-#endif // _WIN32
-
 int scalanative_nl_setd() { return NL_SETD; };
 int scalanative_nl_cat_locale() { return NL_CAT_LOCALE; };
+#endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/pthread.c
+++ b/posixlib/src/main/resources/scala-native/pthread.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_PTHREAD)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <pthread.h>
@@ -71,3 +72,4 @@ size_t scalanative_pthread_mutexattr_t_size() {
 }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/pthread.c
+++ b/posixlib/src/main/resources/scala-native/pthread.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_PTHREAD)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_PTHREAD)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <pthread.h>

--- a/posixlib/src/main/resources/scala-native/pwd.c
+++ b/posixlib/src/main/resources/scala-native/pwd.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_PWD)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_PWD)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <stdlib.h>

--- a/posixlib/src/main/resources/scala-native/pwd.c
+++ b/posixlib/src/main/resources/scala-native/pwd.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_PWD)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <stdlib.h>
@@ -49,3 +50,4 @@ int scalanative_getpwnam(char *name, struct scalanative_passwd *buf) {
 }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/sched.c
+++ b/posixlib/src/main/resources/scala-native/sched.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SCHED)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 
@@ -42,3 +43,4 @@ int scalanative_sched_deadline() {
 }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/sched.c
+++ b/posixlib/src/main/resources/scala-native/sched.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_SCHED)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_SCHED)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 

--- a/posixlib/src/main/resources/scala-native/signal.c
+++ b/posixlib/src/main/resources/scala-native/signal.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SIGNAL)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <signal.h>
@@ -113,3 +114,4 @@ int scalanative_si_timer() { return SI_TIMER; }
 int scalanative_si_asyncio() { return SI_ASYNCIO; }
 int scalanative_si_mesgq() { return SI_MESGQ; }
 #endif // is Unix or MacOS
+#endif

--- a/posixlib/src/main/resources/scala-native/signal.c
+++ b/posixlib/src/main/resources/scala-native/signal.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_SIGNAL)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_SIGNAL)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <signal.h>

--- a/posixlib/src/main/resources/scala-native/spawn.c
+++ b/posixlib/src/main/resources/scala-native/spawn.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_SPAWN)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_SPAWN)
 #if !defined(_WIN32)
 
 #include <spawn.h>

--- a/posixlib/src/main/resources/scala-native/spawn.c
+++ b/posixlib/src/main/resources/scala-native/spawn.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SPAWN)
 #if !defined(_WIN32)
 
 #include <spawn.h>
@@ -51,3 +52,4 @@ int scalanative_posix_spawn_setsigdef() { return POSIX_SPAWN_SETSIGDEF; }
 int scalanative_posix_spawn_setsigmask() { return POSIX_SPAWN_SETSIGMASK; }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/statvfs.c
+++ b/posixlib/src/main/resources/scala-native/statvfs.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_STATVFS)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_STATVFS)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <stdlib.h>

--- a/posixlib/src/main/resources/scala-native/statvfs.c
+++ b/posixlib/src/main/resources/scala-native/statvfs.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_STATVFS)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <stdlib.h>
@@ -62,3 +63,4 @@ unsigned long scalanative_st_rdonly() { return ST_RDONLY; }
 unsigned long scalanative_st_nosuid() { return ST_NOSUID; }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/stdio.c
+++ b/posixlib/src/main/resources/scala-native/stdio.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_STDIO)
 #include <stdio.h>
 
 #if !defined(L_ctermid)
@@ -16,3 +17,4 @@
 
 // CX extension
 int scalanative_l_ctermid() { return L_ctermid; }
+#endif

--- a/posixlib/src/main/resources/scala-native/stdio.c
+++ b/posixlib/src/main/resources/scala-native/stdio.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_STDIO)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_STDIO)
 #include <stdio.h>
 
 #if !defined(L_ctermid)

--- a/posixlib/src/main/resources/scala-native/sys/ioctl.c
+++ b/posixlib/src/main/resources/scala-native/sys/ioctl.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_SYS_IOCTL)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_SYS_IOCTL)
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>

--- a/posixlib/src/main/resources/scala-native/sys/ioctl.c
+++ b/posixlib/src/main/resources/scala-native/sys/ioctl.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYS_IOCTL)
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
@@ -15,3 +16,4 @@ int scalanative_ioctl(int fd, long int request, void *argp) {
 }
 
 long int scalanative_fionread() { return FIONREAD; }
+#endif

--- a/posixlib/src/main/resources/scala-native/sys/mman.c
+++ b/posixlib/src/main/resources/scala-native/sys/mman.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_SYS_MMAN)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_SYS_MMAN)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 

--- a/posixlib/src/main/resources/scala-native/sys/mman.c
+++ b/posixlib/src/main/resources/scala-native/sys/mman.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYS_MMAN)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 
@@ -17,3 +18,4 @@ int scalanative_ms_async() { return MS_ASYNC; }
 int scalanative_ms_invalidate() { return MS_INVALIDATE; }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/sys/resource.c
+++ b/posixlib/src/main/resources/scala-native/sys/resource.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_SYS_RESOURCE)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_SYS_RESOURCE)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 // The Open Group Base Specifications Issue 7, 2018 edition

--- a/posixlib/src/main/resources/scala-native/sys/resource.c
+++ b/posixlib/src/main/resources/scala-native/sys/resource.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYS_RESOURCE)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 // The Open Group Base Specifications Issue 7, 2018 edition
@@ -108,3 +109,4 @@ int scalanative_rusage_children() { return RUSAGE_CHILDREN; };
 int scalanative_rusage_self() { return RUSAGE_SELF; };
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/sys/select.c
+++ b/posixlib/src/main/resources/scala-native/sys/select.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYS_SELECT)
 #include <stdbool.h>
 #include <errno.h>
 #include <stddef.h>
@@ -86,3 +87,4 @@ int scalanative_select(int nfds, struct scalanative_fd_set *readfds,
 
     return status;
 }
+#endif

--- a/posixlib/src/main/resources/scala-native/sys/select.c
+++ b/posixlib/src/main/resources/scala-native/sys/select.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_SYS_SELECT)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_SYS_SELECT)
 #include <stdbool.h>
 #include <errno.h>
 #include <stddef.h>

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_SYS_SOCKET)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_SYS_SOCKET)
 #include <string.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYS_SOCKET)
 #include <string.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -426,3 +427,4 @@ int scalanative_socketpair(int domain, int type, int protocol, int *sv) {
     return socketpair(domain, type, protocol, sv);
 #endif
 }
+#endif

--- a/posixlib/src/main/resources/scala-native/sys/stat.c
+++ b/posixlib/src/main/resources/scala-native/sys/stat.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYS_STAT)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include "../types.h"
@@ -129,3 +130,4 @@ int scalanative_s_islnk(mode_t mode) { return S_ISLNK(mode); }
 int scalanative_s_issock(mode_t mode) { return S_ISSOCK(mode); }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/sys/stat.c
+++ b/posixlib/src/main/resources/scala-native/sys/stat.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_SYS_STAT)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_SYS_STAT)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include "../types.h"

--- a/posixlib/src/main/resources/scala-native/sys/times.c
+++ b/posixlib/src/main/resources/scala-native/sys/times.c
@@ -1,5 +1,6 @@
 
-#if !defined(_WIN32) && defined(__SCALANATIVE_POSIX_SYS_TIMES)
+#if !defined(_WIN32) && defined(SCALANATIVE_COMPILE_ALWAYS) ||                 \
+    defined(__SCALANATIVE_POSIX_SYS_TIMES)
 #if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
 #ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
 #warning "Size and order of C structures are not checked when -std < c11."

--- a/posixlib/src/main/resources/scala-native/sys/times.c
+++ b/posixlib/src/main/resources/scala-native/sys/times.c
@@ -1,6 +1,5 @@
-#ifdef _WIN32
-// No Windows support
-#else
+
+#if !defined(_WIN32) && defined(__SCALANATIVE_POSIX_SYS_TIMES)
 #if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
 #ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
 #warning "Size and order of C structures are not checked when -std < c11."

--- a/posixlib/src/main/resources/scala-native/sys/uio.c
+++ b/posixlib/src/main/resources/scala-native/sys/uio.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYS_UIO)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <sys/types.h>
@@ -22,3 +23,4 @@ _Static_assert(offsetof(struct scalanative_iovec, iov_len) ==
                "Unexpected offset: iov_len");
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/sys/uio.c
+++ b/posixlib/src/main/resources/scala-native/sys/uio.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_SYS_UIO)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_SYS_UIO)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <sys/types.h>

--- a/posixlib/src/main/resources/scala-native/sys/un.c
+++ b/posixlib/src/main/resources/scala-native/sys/un.c
@@ -1,4 +1,5 @@
-#if !defined(_WIN32) && defined(__SCALANATIVE_POSIX_SYS_UN)
+#if !defined(_WIN32) && defined(SCALANATIVE_COMPILE_ALWAYS) ||                 \
+    defined(__SCALANATIVE_POSIX_SYS_UN)
 #include <sys/socket.h>
 #if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
 #ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING

--- a/posixlib/src/main/resources/scala-native/sys/un.c
+++ b/posixlib/src/main/resources/scala-native/sys/un.c
@@ -1,7 +1,4 @@
-#ifdef _WIN32
-// Recent Windows has <afunix.h>, which uses 108 for sun_path.
-// No code here to assure that.
-#else
+#if !defined(_WIN32) && defined(__SCALANATIVE_POSIX_SYS_UN)
 #include <sys/socket.h>
 #if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
 #ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING

--- a/posixlib/src/main/resources/scala-native/sys/utsname.c
+++ b/posixlib/src/main/resources/scala-native/sys/utsname.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_SYS_UTSNAME)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_SYS_UTSNAME)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <sys/utsname.h>

--- a/posixlib/src/main/resources/scala-native/sys/utsname.c
+++ b/posixlib/src/main/resources/scala-native/sys/utsname.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYS_UTSNAME)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <sys/utsname.h>
@@ -56,3 +57,4 @@ int scalanative_uname(struct scalanative_utsname *scalanative_utsname) {
 #undef SIZEOF_FIELD
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/sys/wait.c
+++ b/posixlib/src/main/resources/scala-native/sys/wait.c
@@ -1,4 +1,5 @@
-#if !defined(_WIN32) && defined(__SCALANATIVE_POSIX_SYS_WAIT)
+#if !defined(_WIN32) && defined(SCALANATIVE_COMPILE_ALWAYS) ||                 \
+    defined(__SCALANATIVE_POSIX_SYS_WAIT)
 
 #include <stdbool.h>
 #include <sys/types.h>

--- a/posixlib/src/main/resources/scala-native/sys/wait.c
+++ b/posixlib/src/main/resources/scala-native/sys/wait.c
@@ -1,4 +1,4 @@
-#if !defined(_WIN32)
+#if !defined(_WIN32) && defined(__SCALANATIVE_POSIX_SYS_WAIT)
 
 #include <stdbool.h>
 #include <sys/types.h>

--- a/posixlib/src/main/resources/scala-native/syslog.c
+++ b/posixlib/src/main/resources/scala-native/syslog.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_SYSLOG)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <syslog.h>
@@ -68,3 +69,4 @@ int scalanative_log_nowait() { return LOG_NOWAIT; }
 int scalanative_log_perror() { return LOG_PERROR; }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/syslog.c
+++ b/posixlib/src/main/resources/scala-native/syslog.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_SYSLOG)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_SYSLOG)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <syslog.h>

--- a/posixlib/src/main/resources/scala-native/termios.c
+++ b/posixlib/src/main/resources/scala-native/termios.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_TERMIOS)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_TERMIOS)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <termios.h>

--- a/posixlib/src/main/resources/scala-native/termios.c
+++ b/posixlib/src/main/resources/scala-native/termios.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_TERMIOS)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #include <termios.h>
@@ -196,3 +197,4 @@ int scalanative_termios_tcooff() { return TCOOFF; }
 int scalanative_termios_tcoon() { return TCOON; }
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/time.c
+++ b/posixlib/src/main/resources/scala-native/time.c
@@ -1,4 +1,4 @@
-#if !defined(_WIN32)
+#if defined(__SCALANATIVE_POSIX_TIME) && !defined(_WIN32)
 
 // X/Open System Interfaces (XSI), also sets _POSIX_C_SOURCE.
 // Partial, but useful, implementation of X/Open 7, incorporating Posix 2008.

--- a/posixlib/src/main/resources/scala-native/time.c
+++ b/posixlib/src/main/resources/scala-native/time.c
@@ -1,4 +1,5 @@
-#if defined(__SCALANATIVE_POSIX_TIME) && !defined(_WIN32)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_POSIX_TIME) && !defined(_WIN32)
 
 // X/Open System Interfaces (XSI), also sets _POSIX_C_SOURCE.
 // Partial, but useful, implementation of X/Open 7, incorporating Posix 2008.

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_UNISTD)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 
@@ -583,3 +584,4 @@ int scalanative__sc_xopen_version() {
 };
 
 #endif // Unix or Mac OS
+#endif

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_UNISTD)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_UNISTD)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 

--- a/posixlib/src/main/resources/scala-native/utime.c
+++ b/posixlib/src/main/resources/scala-native/utime.c
@@ -1,8 +1,0 @@
-#if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
-    (defined(__APPLE__) && defined(__MACH__))
-#include <utime.h>
-
-int scalanative_utime(char *path, struct utimbuf *times) {
-    return utime(path, times);
-}
-#endif // Unix or Mac OS

--- a/posixlib/src/main/resources/scala-native/wordexp.c
+++ b/posixlib/src/main/resources/scala-native/wordexp.c
@@ -1,4 +1,4 @@
-#if defined(__SCALANATIVE_POSIX_WORDEXP)
+#if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_WORDEXP)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #ifndef __OpenBSD__

--- a/posixlib/src/main/resources/scala-native/wordexp.c
+++ b/posixlib/src/main/resources/scala-native/wordexp.c
@@ -1,3 +1,4 @@
+#if defined(__SCALANATIVE_POSIX_WORDEXP)
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
 #ifndef __OpenBSD__
@@ -43,22 +44,8 @@ _Static_assert(offsetof(struct scalanative_wordexp_t, we_offs) ==
 #endif // !OpenBSD
 #endif // Unix or Mac OS
 
-#if defined(_WIN32) || defined(__OpenBSD__) // bogus values to keep linker happy
-#define WRDE_APPEND -1
-#define WRDE_DOOFFS -1
-#define WRDE_NOCMD -1
-#define WRDE_REUSE -1
-#define WRDE_SHOWERR -1
-#define WRDE_UNDEF -1
-#define WRDE_BADCHAR -1
-#define WRDE_BADVAL -1
-#define WRDE_CMDSUB -1
-#define WRDE_NOSPACE -1
-#define WRDE_SYNTAX -1
-#endif // _WIN32
-
 // flags
-
+#if !defined(__OpenBSD__)
 int scalanative_wrde_append() { return WRDE_APPEND; };
 
 int scalanative_wrde_dooffs() { return WRDE_DOOFFS; };
@@ -81,3 +68,7 @@ int scalanative_wrde_cmdsub() { return WRDE_CMDSUB; };
 int scalanative_wrde_nospace() { return WRDE_NOSPACE; };
 
 int scalanative_wrde_syntax() { return WRDE_SYNTAX; };
+
+#endif // not bsd
+
+#endif // __SCALANATIVE_POSIX_WORDEXP

--- a/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
@@ -8,6 +8,7 @@ import scalanative.posix.sys.socket.socklen_t
 import scalanative.posix.netinet.in.{in_addr, in_addr_t}
 
 @extern
+@define("__SCALANATIVE_POSIX_ARPA_INET")
 object inet {
   /* Declarations where the arguments are passed to and from the
    * implementing extern code do not need "@name" intermediate code.

--- a/posixlib/src/main/scala/scala/scalanative/posix/cpio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/cpio.scala
@@ -4,6 +4,7 @@ package posix
 import scalanative.unsafe._
 
 @extern
+@define("__SCALANATIVE_POSIX_CPIO")
 object cpio {
   @name("scalanative_c_issock")
   def C_ISSOCK: CUnsignedShort = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
@@ -4,6 +4,7 @@ package posix
 import scala.scalanative.unsafe._, Nat._
 
 @extern
+@define("__SCALANATIVE_POSIX_DIRENT")
 object dirent {
 
   type _256 = Digit3[_2, _5, _6]

--- a/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dlfcn.scala
@@ -10,7 +10,9 @@ import scala.scalanative.unsafe._
  */
 
 @link("dl")
-@extern object dlfcn {
+@extern
+@define("__SCALANATIVE_POSIX_DLFCN")
+object dlfcn {
 
 // Symbolic constants
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
@@ -1,11 +1,13 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe.{CInt, extern, name}
+import scalanative.unsafe._
 
 @extern object errno extends errno
 
-@extern trait errno extends libc.errno {
+@extern
+@define("__SCALANATIVE_POSIX_ERRNO")
+trait errno extends libc.errno {
 
   // Macros
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -7,6 +7,7 @@ import scala.scalanative.posix.unistd.off_t
 import scala.scalanative.posix.sys.types.pid_t
 
 @extern
+@define("__SCALANATIVE_POSIX_FCNTL")
 object fcntl {
 
   def open(pathname: CString, flags: CInt): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/fnmatch.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fnmatch.scala
@@ -10,6 +10,7 @@ import scalanative.unsafe._
  */
 
 @extern
+@define("__SCALANATIVE_POSIX_FNMATCH")
 object fnmatch {
   // Symbolic constants
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/glob.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/glob.scala
@@ -14,6 +14,7 @@ import scalanative.posix.sys.types
  */
 
 @extern
+@define("__SCALANATIVE_POSIX_FNMATCH")
 object glob {
 
   type size_t = types.size_t

--- a/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
@@ -1,10 +1,11 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe.{CInt, CString, CStruct3, extern, name, Ptr}
+import scalanative.unsafe._
 import scalanative.posix.sys.types.gid_t
 
 @extern
+@define("__SCALANATIVE_POSIX_GRP")
 object grp {
   type group = CStruct3[
     CString, // gr_name

--- a/posixlib/src/main/scala/scala/scalanative/posix/langinfo.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/langinfo.scala
@@ -9,7 +9,9 @@ import scala.scalanative.unsafe._
  *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
  */
 
-@extern object langinfo {
+@extern
+@define("__SCALANATIVE_POSIX_LANGINFO")
+object langinfo {
 
   type locale_t = locale.locale_t
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/limits.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/limits.scala
@@ -1,9 +1,10 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe.{CSize, extern, name}
+import scalanative.unsafe._
 
 @extern
+@define("__SCALANATIVE_POSIX_LIMITS")
 object limits {
   @name("scalanative_path_max")
   def PATH_MAX: CSize = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
@@ -12,7 +12,9 @@ import scala.scalanative.unsafe._
  *  described by POSIX as being a CX extension.
  */
 
-@extern object locale extends libc.locale {
+@extern
+@define("__SCALANATIVE_POSIX_LOCALE")
+object locale extends libc.locale {
 
   type locale_t = CVoidPtr // CX, so can get no simpler.
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/net/if.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/net/if.scala
@@ -9,7 +9,9 @@ import scalanative.unsafe._
  *  The Open Group Base Specifications
  *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
  */
-@extern object `if` {
+@extern
+@define("__SCALANATIVE_POSIX_NET_IF")
+object `if` {
 
   type if_nameindex = CStruct2[
     CUnsignedInt, // if_index

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -11,6 +11,7 @@ import scala.scalanative.meta.LinktimeInfo
  *    [[https://scala-native.readthedocs.io/en/latest/lib/posixlib.html]]
  */
 @extern
+@define("__SCALANATIVE_POSIX_NETDB")
 object netdb {
   /* This is the Linux layout. FreeBSD, macOS, and Windows have the same
    * size but swap ai_addr and ai_canonname. FreeBSD & Windows document this.

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
@@ -9,6 +9,7 @@ import scalanative.posix.sys.socket
 import scalanative.posix.sys.socketOps
 
 @extern
+@define("__SCALANATIVE_POSIX_NETINET_IN")
 object in {
   type _8 = Nat._8
   type _16 = Nat.Digit2[Nat._1, Nat._6]

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/tcp.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/tcp.scala
@@ -3,6 +3,7 @@ package scala.scalanative.posix.netinet
 import scalanative.unsafe._
 
 @extern
+@define("__SCALANATIVE_POSIX_NETINET_TCP")
 object tcp {
 
   @name("scalanative_tcp_nodelay")

--- a/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/nl_types.scala
@@ -9,7 +9,9 @@ import scala.scalanative.unsafe._
  *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
  */
 
-@extern object nl_types {
+@extern
+@define("__SCALANATIVE_POSIX_NL_TYPES")
+object nl_types {
 
   type nl_catd = CVoidPtr // Scala Native idiom for void *.
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -10,6 +10,7 @@ import scala.scalanative.posix.sys.types._
 // see http://pubs.opengroup.org/onlinepubs/007908799/xsh/threads.html
 
 @link("pthread")
+@define("__SCALANATIVE_POSIX_PTHREAD")
 @extern
 object pthread {
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
@@ -1,10 +1,11 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe.{CInt, CString, CStruct5, extern, name, Ptr}
+import scalanative.unsafe._
 import scalanative.posix.sys.types.{uid_t, gid_t}
 
 @extern
+@define("__SCALANATIVE_POSIX_PWD")
 object pwd {
 
   type passwd = CStruct5[

--- a/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
@@ -5,6 +5,7 @@ import scala.scalanative.posix.time.timespec
 import scala.scalanative.posix.sys.types.pid_t
 
 @extern
+@define("__SCALANATIVE_POSIX_SCHED")
 object sched {
 
   def sched_setparam(pid: pid_t, param: Ptr[sched_param]): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
@@ -14,6 +14,7 @@ import scala.scalanative.posix.sys.types
  *  "Process Scheduling", not base POSIX.
  */
 @extern
+@define("__SCALANATIVE_POSIX_SPAWN")
 object spawn {
 
   /* posix_spawnattr_t & posix_spawn_file_actions_t are opaque bulk storage

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
@@ -28,6 +28,7 @@ import scalanative.posix.sys.types, types.{off_t, size_t}
    * files.
    */
   @name("scalanative_l_ctermid")
+  @define("__SCALANATIVE_POSIX_STDIO")
   def L_ctermid: CUnsignedInt = extern
 
 // Methods

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/ioctl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/ioctl.scala
@@ -3,6 +3,7 @@ package scala.scalanative.posix.sys
 import scalanative.unsafe._
 
 @extern
+@define("__SCALANATIVE_POSIX_SYS_IOCTL")
 object ioctl {
 
   @name("scalanative_ioctl")

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
@@ -7,6 +7,7 @@ import scala.scalanative.unsafe.extern
 import scala.scalanative.posix.sys.types._
 
 @extern
+@define("__SCALANATIVE_POSIX_SYS_MMAN")
 object mman {
   def mmap(
       addr: CVoidPtr,

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
@@ -10,9 +10,10 @@ package sys
 //   Method argument names come from Ubuntu 19.04 linux man pages.
 //   Open Group seems to no longer suggest them.
 
-import scalanative.unsafe.{CInt, CStruct2, CUnsignedLongInt, Ptr, name, extern}
+import scalanative.unsafe._
 
 @extern
+@define("__SCALANATIVE_POSIX_SYS_RESOURCE")
 object resource {
 
   type id_t = sys.types.id_t

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
@@ -13,6 +13,7 @@ import scalanative.unsafe.Nat._
  *    edition.
  */
 @extern
+@define("__SCALANATIVE_POSIX_SYS_SELECT")
 object select {
 
   // Use single points of truth for types required by POSIX specification.

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -13,6 +13,7 @@ import scalanative.meta.LinktimeInfo._
  *    [[https://scala-native.readthedocs.io/en/latest/lib/posixlib.html]]
  */
 @extern
+@define("__SCALANATIVE_POSIX_SYS_SOCKET")
 object socket {
   type _14 = Nat.Digit2[Nat._1, Nat._4]
   type _31 = Nat.Digit2[Nat._3, Nat._1]

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -7,6 +7,7 @@ import scalanative.posix.time._
 import scalanative.posix.sys.types._
 
 @extern
+@define("__SCALANATIVE_POSIX_SYS_STAT")
 object stat {
 
   /* This file is incomplete and DOES NOT comply with POSIX 2018.

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/statvfs.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/statvfs.scala
@@ -5,6 +5,7 @@ package sys
 import scalanative.unsafe._
 
 @extern
+@define("__SCALANATIVE_POSIX_STATVFS")
 object statvfs {
 
   type fsblkcnt_t = CUnsignedLong

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/times.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/times.scala
@@ -13,6 +13,7 @@ import scalanative.meta.LinktimeInfo.{is32BitPlatform, isFreeBSD, isNetBSD}
  */
 
 @extern
+@define("__SCALANATIVE_POSIX_SYS_TIMES")
 object times {
 
   /* The 'tms' structure below is defined in a way which allows fast

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
@@ -5,6 +5,7 @@ package sys
 import scalanative.unsafe._
 
 @extern
+@define("__SCALANATIVE_POSIX_SYS_UIO")
 object uio {
   type iovec = CStruct2[
     Ptr[Byte], // iov_base

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/un.scala
@@ -11,6 +11,7 @@ import scalanative.meta.LinktimeInfo._
  */
 
 @extern
+@define("__SCALANATIVE_POSIX_SYS_UN")
 object un {
   type _108 = Nat.Digit3[Nat._1, Nat._0, Nat._8]
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/utsname.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/utsname.scala
@@ -4,6 +4,7 @@ import scala.scalanative.unsafe._
 import scala.scalanative.unsafe.Nat._
 
 @extern
+@define("__SCALANATIVE_POSIX_SYS_UTSNAME")
 object utsname {
   /* Design notes:
    * 1) The 256 "magic"" number appears to be the macOS macro _SYS_NAMELEN.

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
@@ -27,6 +27,7 @@ import scalanative.unsafe._
  *  your variable. val status = Wait.wait(Ptr[CInt])
  */
 @extern
+@define("__SCALANATIVE_POSIX_SYS_WAIT")
 object wait {
   type id_t = types.id_t
   type pid_t = types.pid_t

--- a/posixlib/src/main/scala/scala/scalanative/posix/syslog.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/syslog.scala
@@ -18,6 +18,7 @@ import scalanative.posix.stdio.va_list
  */
 
 @extern
+@define("__SCALANATIVE_POSIX_SYSLOG")
 object syslog {
   @name("scalanative_closelog")
   @blocking def closelog(): Unit = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/termios.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/termios.scala
@@ -1,21 +1,12 @@
 package scala.scalanative
 package posix
 
-import scalanative.unsafe.{
-  CArray,
-  CChar,
-  CInt,
-  CLong,
-  CStruct7,
-  Nat,
-  Ptr,
-  extern,
-  name
-}
+import scalanative.unsafe._
 import scalanative.unsafe.Nat._
 import posix.sys.types.pid_t
 
 @extern
+@define("__SCALANATIVE_POSIX_TERMIOS")
 object termios {
 
   // types

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -10,7 +10,9 @@ import scala.scalanative.posix.signal.sigevent
 
 @extern object time extends time
 
-@extern trait time extends libc.time {
+@extern
+@define("__SCALANATIVE_POSIX_TIME")
+trait time extends libc.time {
 
   type clock_t = types.clock_t
   type clockid_t = types.clockid_t

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -9,6 +9,7 @@ import scalanative.posix.sys.types
  *    [[https://scala-native.readthedocs.io/en/latest/lib/posixlib.html]]
  */
 @extern
+@define("__SCALANATIVE_POSIX_UNISTD")
 object unistd {
 
   type gid_t = types.gid_t

--- a/posixlib/src/main/scala/scala/scalanative/posix/utime.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/utime.scala
@@ -10,6 +10,5 @@ object utime {
     time.time_t // modtime
   ]
 
-  @name("scalanative_utime")
   def utime(path: CString, times: Ptr[utimbuf]): CInt = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/wordexp.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/wordexp.scala
@@ -13,6 +13,7 @@ import scalanative.posix.sys.types.size_t
  */
 
 @extern
+@define("__SCALANATIVE_POSIX_WORDEXP")
 object wordexp {
 
   type wordexp_t = CStruct5[

--- a/scala-partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/scala-partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -48,15 +48,6 @@ class MainGenericRunner {
             )
             .withGC(loadSetting("gc", Discover.GC())(GC.apply))
             .withLTO(loadSetting("lto", Discover.LTO())(LTO(_)))
-            .withLinkingOptions {
-              // If we precompile libs we need to make sure, that we link libraries needed by Scala Native
-              Defaults.config.linkingOptions ++
-                Option(System.getProperty("scalanative.build.paths.libobj"))
-                  .filter(_.nonEmpty)
-                  .fold(Seq.empty[String]) { _ =>
-                    Defaults.links.map(_.name).map("-l" + _)
-                  }
-            }
             .withBaseName("output")
         }
         .withClassPath {

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativePartestOptions.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativePartestOptions.scala
@@ -22,8 +22,7 @@ case class ScalaNativePartestOptions private (
     s"-Dscalanative.partest.mode=${buildMode.name}",
     s"-Dscalanative.partest.gc=${gc.name}",
     s"-Dscalanative.partest.lto=${lto.name}",
-    s"-Dscalanative.partest.nativeCp=${nativeClasspath.mkString(pathSeparator)}",
-    s"-Dscalanative.build.paths.libobj=${precompiledLibrariesPaths.mkString(pathSeparator)}"
+    s"-Dscalanative.partest.nativeCp=${nativeClasspath.mkString(pathSeparator)}"
   )
 
   def show: String =

--- a/scalalib/overrides-3.3/scala/runtime/LazyVals.scala.patch
+++ b/scalalib/overrides-3.3/scala/runtime/LazyVals.scala.patch
@@ -1,5 +1,5 @@
---- 3.3.0-RC4/scala/runtime/LazyVals.scala
-+++ overrides-3/scala/runtime/LazyVals.scala
+--- 3.3.0/scala/runtime/LazyVals.scala
++++ overrides-3.3/scala/runtime/LazyVals.scala
 @@ -4,44 +4,13 @@
  
  import scala.annotation.*
@@ -47,7 +47,19 @@
  
    /* ------------- Start of public API ------------- */
  
-@@ -70,94 +39,47 @@
+@@ -52,7 +21,10 @@
+    * Used to indicate the state of a lazy val that is being
+    * evaluated and of which other threads await the result.
+    */
+-  final class Waiting extends CountDownLatch(1) with LazyValControlState
++  final class Waiting extends CountDownLatch(1) with LazyValControlState {
++    override def countDown(): Unit = if(isMultithreadingEnabled) super.countDown()
++    override def await(): Unit =  if(isMultithreadingEnabled) super.await()
++  }
+ 
+   /**
+    * Used to indicate the state of a lazy val that is currently being
+@@ -70,94 +42,47 @@
  
    def STATE(cur: Long, ord: Int): Long = {
      val r = (cur >> (ord * BITS_PER_LAZY_VAL)) & LAZY_VAL_MASK

--- a/scalalib/overrides-3/scala/runtime/LazyVals.scala.patch
+++ b/scalalib/overrides-3/scala/runtime/LazyVals.scala.patch
@@ -1,10 +1,12 @@
---- 3.4.0-RC1/scala/runtime/LazyVals.scala
+--- 3.4.0/scala/runtime/LazyVals.scala
 +++ overrides-3/scala/runtime/LazyVals.scala
-@@ -4,44 +4,13 @@
+@@ -4,44 +4,15 @@
  
  import scala.annotation.*
  
 +import scala.scalanative.runtime.*
++import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
++import java.util.concurrent.TimeUnit
 +
  /**
   * Helper methods used in thread-safe lazy vals.
@@ -47,7 +49,19 @@
  
    /* ------------- Start of public API ------------- */
  
-@@ -70,94 +39,47 @@
+@@ -52,7 +23,10 @@
+    * Used to indicate the state of a lazy val that is being
+    * evaluated and of which other threads await the result.
+    */
+-  final class Waiting extends CountDownLatch(1) with LazyValControlState
++  final class Waiting extends CountDownLatch(1) with LazyValControlState {
++    override def countDown(): Unit = if(isMultithreadingEnabled) super.countDown()
++    override def await(): Unit =  if(isMultithreadingEnabled) super.await()
++  }
+ 
+   /**
+    * Used to indicate the state of a lazy val that is currently being
+@@ -70,94 +44,47 @@
  
    def STATE(cur: Long, ord: Int): Long = {
      val r = (cur >> (ord * BITS_PER_LAZY_VAL)) & LAZY_VAL_MASK

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -149,25 +149,10 @@ object Build {
           )
         }
 
-      /* Used to pass alternative paths of compiled native (lib) sources,
-       * eg: reused native sources used in partests.
+      /* Finds all the libraries on the classpath that contain native
+       * code and then compiles them.
        */
-      val compileNativeLibs = {
-        Properties.propOrNone("scalanative.build.paths.libobj") match {
-          case None =>
-            /* Finds all the libraries on the classpath that contain native
-             * code and then compiles them.
-             */
-            findAndCompileNativeLibraries(config, analysis)
-          case Some(libObjectPaths) =>
-            Future.successful {
-              libObjectPaths
-                .split(java.io.File.pathSeparatorChar)
-                .toSeq
-                .map(Paths.get(_))
-            }
-        }
-      }
+      val compileNativeLibs = findAndCompileNativeLibraries(config, analysis)
 
       Future.reduceLeft(
         immutable.Seq(compileGeneratedIR, compileNativeLibs)

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -323,8 +323,11 @@ private[scalanative] object LLVM {
    *  @return
    *    true if it needs compiling false otherwise.
    */
-  @inline private def needsCompiling(in: Path, out: Path): Boolean = {
-    in.toFile().lastModified() > out.toFile().lastModified()
+  @inline private def needsCompiling(in: Path, out: Path)(implicit
+      config: Config
+  ): Boolean = {
+    in.toFile().lastModified() > out.toFile().lastModified() ||
+    Build.userConfigHasChanged(config)
   }
 
   /** Looks at all the object files to see if one is newer than the output

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -21,16 +21,16 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   def isScala2_12 = ScalaNativeBuildInfo.scalaVersion.startsWith("2.12")
 
   @Test def default(): Unit = checkMinimalRequiredSymbols()(expected =
-    if (isScala3) SymbolsCount(types = 710, members = 3650)
-    else if (isScala2_13) SymbolsCount(types = 630, members = 3400)
-    else SymbolsCount(types = 700, members = 4300)
+    if (isScala3) SymbolsCount(types = 650, members = 3000)
+    else if (isScala2_13) SymbolsCount(types = 600, members = 3000)
+    else SymbolsCount(types = 700, members = 4000)
   )
 
   @Test def debugMetadata(): Unit =
     checkMinimalRequiredSymbols(withDebugMetadata = true)(expected =
-      if (isScala3) SymbolsCount(types = 710, members = 3650)
-      else if (isScala2_13) SymbolsCount(types = 630, members = 3400)
-      else SymbolsCount(types = 700, members = 4300)
+      if (isScala3) SymbolsCount(types = 650, members = 3000)
+      else if (isScala2_13) SymbolsCount(types = 600, members = 3000)
+      else SymbolsCount(types = 700, members = 4000)
     )
 
   // Only MacOS uses DWARF metadata currently
@@ -39,9 +39,9 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-apple-darwin22.6.0"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1630, members = 12000)
-      else if (isScala2_13) SymbolsCount(types = 1500, members = 11700)
-      else SymbolsCount(types = 1610, members = 13150)
+      if (isScala3) SymbolsCount(types = 1450, members = 10500)
+      else if (isScala2_13) SymbolsCount(types = 1400, members = 11000)
+      else SymbolsCount(types = 1400, members = 11300)
     )
 
   @Test def multithreading(): Unit =


### PR DESCRIPTION
By using `@define` annotation we can limit amount of glue layer that needs to be compiled - we add an entry for potentially optional bindings and guard the glue-layer with `#if defined(x)` preprocesor conditions. This should allow to lower number of compilation errors in non-posix compliant systems, especially on 32-bit architectures.

The need of controlling the amount of C glue layer files on non-compatible runtimes was already needed in the WASM/WASI prototype https://github.com/WojciechMazur/scala-native/tree/scala-wasm and when targeting Playdate devices (arm v7, limited C/POSIX stdlib) https://github.com/kubukoz/scala-native/pull/1 

Based on these changes we're removing usages of `stdatomic` in minimal single-threaded execution