### PR TITLE
Use lower case file names on Windows

### DIFF
--- a/javalib/src/main/resources/scala-native/time_millis.c
+++ b/javalib/src/main/resources/scala-native/time_millis.c
@@ -1,7 +1,7 @@
 #include <time.h>
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #include "win_freq.h"
 #else
 #include <stdio.h>

--- a/javalib/src/main/resources/scala-native/time_nano.c
+++ b/javalib/src/main/resources/scala-native/time_nano.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #include "win_freq.h"
 #else
 #include <time.h>

--- a/javalib/src/main/resources/scala-native/win_freq.c
+++ b/javalib/src/main/resources/scala-native/win_freq.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #include "win_freq.h"
 
 static int winFreqQuadPartValue = 0;

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/utils/Time.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/utils/Time.c
@@ -4,7 +4,7 @@
 #include <time.h>
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 static int winFreqQuadPartValue = 0;
 static int winFreqQuadPart(int *quad) {

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryInfo.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryInfo.h
@@ -9,7 +9,6 @@
  */
 
 #if defined(_WIN32)
-#include <Windows.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #elif defined(__unix__) || defined(__unix) || defined(unix) ||                 \

--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -8,8 +8,8 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 // Boehm on Windows needs User32.lib linked
-#pragma comment(lib, "User32.lib")
-#pragma comment(lib, "Kernel32.lib")
+#pragma comment(lib, "user32.lib")
+#pragma comment(lib, "kernel32.lib")
 #include <windows.h>
 typedef DWORD ThreadRoutineReturnType;
 #else

--- a/nativelib/src/main/resources/scala-native/platform/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform/platform.c
@@ -1,6 +1,6 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <sys/utsname.h>
 #endif

--- a/nativelib/src/main/resources/scala-native/platform/windows/unwind.c
+++ b/nativelib/src/main/resources/scala-native/platform/windows/unwind.c
@@ -2,8 +2,8 @@
 #if defined(_WIN32)
 
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <DbgHelp.h>
+#include <windows.h>
+#include <dbghelp.h>
 #include <stdio.h>
 #include "../unwind.h"
 

--- a/posixlib/src/main/resources/scala-native/arpa/inet.c
+++ b/posixlib/src/main/resources/scala-native/arpa/inet.c
@@ -3,7 +3,7 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
-#pragma comment(lib, "Ws2_32.lib")
+#pragma comment(lib, "ws2_32.lib")
 #include <winsock2.h>
 #else
 #include <arpa/inet.h>

--- a/posixlib/src/main/resources/scala-native/arpa/inet.c
+++ b/posixlib/src/main/resources/scala-native/arpa/inet.c
@@ -4,7 +4,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #pragma comment(lib, "Ws2_32.lib")
-#include <WinSock2.h>
+#include <winsock2.h>
 #else
 #include <arpa/inet.h>
 #endif

--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -1,9 +1,9 @@
 #if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_NET_IF)
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #pragma comment(lib, "Ws2_32.lib")
-#include <Netioapi.h>
-#include <Iphlpapi.h>
+#include <netioapi.h>
+#include <iphlpapi.h>
 #pragma comment(lib, "Iphlpapi.lib")
 #else
 #include <net/if.h>

--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -1,10 +1,10 @@
 #if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_NET_IF)
 #ifdef _WIN32
 #include <winsock2.h>
-#pragma comment(lib, "Ws2_32.lib")
+#pragma comment(lib, "ws2_32.lib")
 #include <netioapi.h>
 #include <iphlpapi.h>
-#pragma comment(lib, "Iphlpapi.lib")
+#pragma comment(lib, "iphlpapi.lib")
 #else
 #include <net/if.h>
 

--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -1,8 +1,8 @@
 #if defined(SCALANATIVE_COMPILE_ALWAYS) || defined(__SCALANATIVE_POSIX_NETDB)
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #include <ws2tcpip.h> // socklen_t
-// #include <Winerror.h>
+// #include <winerror.h>
 #else // not _WIN32
 /* FreeBSD wants AF_INET, which is in <sys/socket.h>
  *

--- a/posixlib/src/main/resources/scala-native/netinet/in.h
+++ b/posixlib/src/main/resources/scala-native/netinet/in.h
@@ -7,8 +7,8 @@
 #define WIN32_LEAN_AND_MEAN
 #define WINSOCK_DEPRECATED_NO_WARNINGS
 #pragma comment(lib, "Ws2_32.lib")
-#include <WinSock2.h>
-#include <WS2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 typedef uint32_t in_addr_t;
 typedef uint16_t in_port_t;
 #else

--- a/posixlib/src/main/resources/scala-native/netinet/in.h
+++ b/posixlib/src/main/resources/scala-native/netinet/in.h
@@ -6,7 +6,7 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define WINSOCK_DEPRECATED_NO_WARNINGS
-#pragma comment(lib, "Ws2_32.lib")
+#pragma comment(lib, "ws2_32.lib")
 #include <winsock2.h>
 #include <ws2tcpip.h>
 typedef uint32_t in_addr_t;

--- a/posixlib/src/main/resources/scala-native/netinet/tcp.c
+++ b/posixlib/src/main/resources/scala-native/netinet/tcp.c
@@ -2,7 +2,7 @@
     defined(__SCALANATIVE_POSIX_NETINET_TCP)
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <WinSock2.h>
+#include <winsock2.h>
 #else
 #ifdef __OpenBSD__
 #include <sys/types.h>

--- a/posixlib/src/main/resources/scala-native/sys/ioctl.c
+++ b/posixlib/src/main/resources/scala-native/sys/ioctl.c
@@ -3,7 +3,7 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
-#pragma comment(lib, "Ws2_32.lib")
+#pragma comment(lib, "ws2_32.lib")
 #else
 #include <sys/ioctl.h>
 #endif

--- a/posixlib/src/main/resources/scala-native/sys/select.c
+++ b/posixlib/src/main/resources/scala-native/sys/select.c
@@ -7,7 +7,7 @@
 
 #ifdef _WIN32
 #pragma comment(lib, "Ws2_32.lib")
-#include <WinSock2.h>
+#include <winsock2.h>
 typedef long int suseconds_t;
 #else
 #include <sys/select.h>

--- a/posixlib/src/main/resources/scala-native/sys/select.c
+++ b/posixlib/src/main/resources/scala-native/sys/select.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 #ifdef _WIN32
-#pragma comment(lib, "Ws2_32.lib")
+#pragma comment(lib, "ws2_32.lib")
 #include <winsock2.h>
 typedef long int suseconds_t;
 #else

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -11,7 +11,7 @@
 #endif
 #ifdef _WIN32
 #include <winsock2.h>
-#pragma comment(lib, "Ws2_32.lib")
+#pragma comment(lib, "ws2_32.lib")
 typedef SSIZE_T ssize_t;
 #else
 #if defined(__FreeBSD__)

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -10,7 +10,7 @@
 #include <ws2tcpip.h>
 #endif
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #pragma comment(lib, "Ws2_32.lib")
 typedef SSIZE_T ssize_t;
 #else

--- a/scripted-tests/run/build-library-static/build.sbt
+++ b/scripted-tests/run/build-library-static/build.sbt
@@ -53,7 +53,7 @@ def compileAndTest(
     outFile: File
 ): Unit = {
   val platformLibs =
-    if (Platform.isWindows) Seq("Advapi32", "Userenv", "Dbghelp")
+    if (Platform.isWindows) Seq("advapi32", "userenv", "dbghelp")
     else Seq("pthread", "dl")
   val cmd: Seq[String] =
     Seq(

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -191,7 +191,7 @@ private[scalanative] object LLVM {
       // * libpthread for process APIs and parallel garbage collection.
       // * Dbghelp for windows implementation of unwind libunwind API
       val platformsLinks =
-        if (config.targetsWindows) Seq("Dbghelp")
+        if (config.targetsWindows) Seq("dbghelp")
         else if (config.targetsOpenBSD || config.targetsNetBSD)
           Seq("pthread")
         else Seq("pthread", "dl")

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/accessMode.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/accessMode.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <AccCtrl.h>
+#include <accctrl.h>
 
 int scalanative_not_used_access() { return NOT_USED_ACCESS; }
 int scalanative_grant_access() { return GRANT_ACCESS; }

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/securityObjectType.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/securityObjectType.c
@@ -1,6 +1,6 @@
 #if (defined(_WIN32) || defined(WIN32)) && !defined(__MINGW64__)
 #define WIN32_LEAN_AND_MEAN
-#include <AccCtrl.h>
+#include <accctrl.h>
 
 int scalanative_se_unknown_object_type() { return SE_UNKNOWN_OBJECT_TYPE; }
 int scalanative_se_file_object() { return SE_FILE_OBJECT; }

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeForm.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeForm.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <AccCtrl.h>
+#include <accctrl.h>
 
 int scalanative_trustee_is_sid() { return TRUSTEE_IS_SID; }
 int scalanative_trustee_is_name() { return TRUSTEE_IS_NAME; }

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeType.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeType.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <AccCtrl.h>
+#include <accctrl.h>
 
 int scalanative_trustee_is_unknown() { return TRUSTEE_IS_UNKNOWN; }
 int scalanative_trustee_is_user() { return TRUSTEE_IS_USER; }

--- a/windowslib/src/main/resources/scala-native/windows/console.c
+++ b/windowslib/src/main/resources/scala-native/windows/console.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 DWORD scalanative_std_input_handle() { return STD_INPUT_HANDLE; }
 DWORD scalanative_std_output_handle() { return STD_OUTPUT_HANDLE; }

--- a/windowslib/src/main/resources/scala-native/windows/constants.c
+++ b/windowslib/src/main/resources/scala-native/windows/constants.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 // Needed to find symbols from UCRT - Windows Universal C Runtime
 #pragma comment(lib, "legacy_stdio_definitions.lib")

--- a/windowslib/src/main/resources/scala-native/windows/memory.c
+++ b/windowslib/src/main/resources/scala-native/windows/memory.c
@@ -1,7 +1,7 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <Winbase.h>
+#include <winbase.h>
 
 DWORD scalanative_file_map_all_access() { return FILE_MAP_ALL_ACCESS; }
 DWORD scalanative_file_map_read() { return FILE_MAP_READ; }

--- a/windowslib/src/main/resources/scala-native/windows/securityImpersonation.c
+++ b/windowslib/src/main/resources/scala-native/windows/securityImpersonation.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 DWORD scalanative_securityanonymous() { return SecurityAnonymous; }
 DWORD scalanative_securityidentification() { return SecurityIdentification; }

--- a/windowslib/src/main/resources/scala-native/windows/winSocket.c
+++ b/windowslib/src/main/resources/scala-native/windows/winSocket.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include "Windows.h"
+#include "windows.h"
 #include <winsock2.h>
 
 #pragma comment(lib, "Ws2_32.lib")

--- a/windowslib/src/main/resources/scala-native/windows/winSocket.c
+++ b/windowslib/src/main/resources/scala-native/windows/winSocket.c
@@ -3,7 +3,7 @@
 #include "windows.h"
 #include <winsock2.h>
 
-#pragma comment(lib, "Ws2_32.lib")
+#pragma comment(lib, "ws2_32.lib")
 
 SOCKET scalanative_winsock_invalid_socket() { return INVALID_SOCKET; }
 DWORD scalanative_winsock_wsadata_size() { return sizeof(WSADATA); }

--- a/windowslib/src/main/resources/scala-native/windows/winnls.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnls.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include "Windows.h"
+#include "windows.h"
 
 PCWSTR scalanative_locale_name_invariant() { return LOCALE_NAME_INVARIANT; }
 PCWSTR scalanative_locale_name_system_default() {

--- a/windowslib/src/main/resources/scala-native/windows/winnt/accessRights.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/accessRights.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 DWORD scalanative_generic_all() { return GENERIC_ALL; }
 

--- a/windowslib/src/main/resources/scala-native/windows/winnt/accessToken.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/accessToken.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 DWORD scalanative_token_adjust_default() { return TOKEN_ADJUST_DEFAULT; }
 DWORD scalanative_token_adjust_groups() { return TOKEN_ADJUST_GROUPS; }

--- a/windowslib/src/main/resources/scala-native/windows/winnt/helpers.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/helpers.c
@@ -1,6 +1,6 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #pragma comment(lib, "Advapi32.lib")
 
 size_t scalanative_winnt_empty_priviliges_size() {

--- a/windowslib/src/main/resources/scala-native/windows/winnt/helpers.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/helpers.c
@@ -1,7 +1,7 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#pragma comment(lib, "Advapi32.lib")
+#pragma comment(lib, "advapi32.lib")
 
 size_t scalanative_winnt_empty_priviliges_size() {
     PRIVILEGE_SET privileges = {0};

--- a/windowslib/src/main/resources/scala-native/windows/winnt/sidNameUse.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/sidNameUse.c
@@ -1,7 +1,7 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <WinNT.h>
+#include <windows.h>
+#include <winnt.h>
 
 int scalanative_sidtypeuser() { return SidTypeUser; }
 int scalanative_sidtypegroup() { return SidTypeGroup; }

--- a/windowslib/src/main/resources/scala-native/windows/winnt/tokenInformationClass.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/tokenInformationClass.c
@@ -1,7 +1,7 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <WinNT.h>
+#include <windows.h>
+#include <winnt.h>
 #include <sdkddkver.h>
 
 int scalanative_tokenuser() { return TokenUser; }

--- a/windowslib/src/main/scala/scala/scalanative/windows/ProcessThreadsApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ProcessThreadsApi.scala
@@ -5,8 +5,8 @@ import scalanative.unsigned._
 import HandleApi.Handle
 import WinBaseApi.SecurityAttributes
 
-@link("Advapi32")
-@link("Kernel32")
+@link("advapi32")
+@link("kernel32")
 @extern()
 object ProcessThreadsApi {
   type StartupInfoW = CStruct18[

--- a/windowslib/src/main/scala/scala/scalanative/windows/SddlApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SddlApi.scala
@@ -2,7 +2,7 @@ package scala.scalanative.windows
 
 import scala.scalanative.unsafe._
 
-@link("Advapi32")
+@link("advapi32")
 @extern()
 object SddlApi {
   import SecurityBaseApi._

--- a/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
@@ -3,7 +3,7 @@ package scala.scalanative.windows
 import scala.scalanative.unsafe.{Word => _, _}
 import scala.scalanative.windows.HandleApi.Handle
 
-@link("Advapi32")
+@link("advapi32")
 @extern()
 object SecurityBaseApi {
   import winnt.TokenInformationClass

--- a/windowslib/src/main/scala/scala/scalanative/windows/UserEnvApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/UserEnvApi.scala
@@ -3,7 +3,7 @@ package scala.scalanative.windows
 import scala.scalanative.unsafe._
 import scala.scalanative.windows.HandleApi.Handle
 
-@link("Userenv")
+@link("userenv")
 @extern()
 object UserEnvApi {
   def GetUserProfileDirectoryA(

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -5,7 +5,7 @@ import scala.scalanative.unsigned._
 import HandleApi.Handle
 import scala.scalanative.windows.winnt._
 
-@link("Advapi32")
+@link("advapi32")
 @extern()
 object WinBaseApi {
   import SecurityBaseApi._

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinNlsApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinNlsApi.scala
@@ -3,7 +3,7 @@ package scala.scalanative.windows
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 
-@link("Kernel32")
+@link("kernel32")
 @extern()
 object WinNlsApi {
   type LCType = Int

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/AccessRights.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/AccessRights.scala
@@ -2,7 +2,7 @@ package scala.scalanative.windows.winnt
 
 import scala.scalanative.unsafe._
 
-@link("Advapi32")
+@link("advapi32")
 @extern
 object AccessRights {
   @name("scalanative_generic_all")

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/HelperMethods.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/HelperMethods.scala
@@ -5,7 +5,7 @@ import scala.scalanative.unsafe._
 
 import scala.scalanative.windows.SecurityBaseApi._
 
-@link("Advapi32")
+@link("advapi32")
 @extern
 object HelperMethods {
   @name("scalanative_winnt_setupUsersGroupSid")

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
@@ -2,7 +2,7 @@ package scala.scalanative.windows.winnt
 
 import scalanative.unsafe._
 
-@link("Advapi32")
+@link("advapi32")
 @extern
 object TokenInformationClass {
   @name("scalanative_tokenuser")


### PR DESCRIPTION
This PR changes header names in include directives and names of library names in lib pragmas to use lower case.

The reason to do this is that the header files and libraries are provided in lower case when installing a cross compiler (e.g. zig cc or llvm-mingw) on Linux targeting Windows.

Currently, as a work-around I added `-isystem src/main/c` to the compile options, with the `src/main/c` directory containing many header files looking like this:
```Windows.h
// Windows.h
#include <windows.h>
```

- Convert Windows header names to lower case
- Include windows.h after declaring `WIN32_LEAN_AND_MEAN`
- Use lower case Windows library names
