### PR TITLE
fix: Deadlocks in singlethreaded execution context

### DIFF
--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -572,8 +572,8 @@ object Thread {
     else if (NativeExecutionContext.queue.nonEmpty) {
       val now = System.nanoTime()
       val timeout = millis.millis + nanos.nanos
-      val deadline = now + timeout.toNanos
       Proxy.stealWork(timeout)
+      val deadline = now + timeout.toNanos
       val remainingNanos = deadline - System.nanoTime()
       if (remainingNanos > 0) {
         doSleep(remainingNanos / 1000000, (remainingNanos % 1000000).toInt)

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -16,6 +16,8 @@ import scala.scalanative.runtime.NativeThread.State._
 import scala.scalanative.libc.stdatomic.{AtomicLongLong, atomic_thread_fence}
 import scala.scalanative.libc.stdatomic.memory_order._
 import scala.scalanative.runtime.UnsupportedFeature
+import scala.concurrent.duration._
+import scala.scalanative.concurrent.NativeExecutionContext
 
 class Thread private[lang] (
     @volatile private var name: String,
@@ -555,18 +557,35 @@ object Thread {
       throw new IllegalArgumentException("millis must be >= 0")
     if (nanos < 0 || nanos > 999999)
       throw new IllegalArgumentException("nanos value out of range")
-
     val nativeThread = nativeCompanion.currentNativeThread()
-    if (millis == 0) nativeThread.sleepNanos(nanos)
-    else
-      nativeThread.sleep(nanos match {
-        case 0 => millis
-        case _ => millis + 1
-      })
+
+    def doSleep(millis: scala.Long, nanos: Int) = {
+      if (millis == 0) nativeThread.sleepNanos(nanos)
+      else
+        nativeThread.sleep(nanos match {
+          case 0 => millis
+          case _ => millis + 1
+        })
+    }
+
+    if (isMultithreadingEnabled) doSleep(millis, nanos)
+    else if (NativeExecutionContext.queue.isWorkStealingPossible) {
+      val now = System.nanoTime()
+      val timeout = millis.millis + nanos.nanos
+      val deadline = now + timeout.toNanos
+      NativeExecutionContext.queue.stealWork(timeout)
+      val remainingNanos = deadline - System.nanoTime()
+      if (remainingNanos > 0) {
+        doSleep(remainingNanos / 1000000, (remainingNanos % 1000000).toInt)
+      }
+    } else doSleep(millis, nanos)
+
     if (interrupted()) throw new InterruptedException()
   }
 
-  @alwaysinline def `yield`(): Unit = nativeCompanion.yieldThread()
+  @alwaysinline def `yield`(): Unit =
+    if (isMultithreadingEnabled) nativeCompanion.yieldThread()
+    else NativeExecutionContext.queue.stealWork(1)
 
   // Since JDK 19
   @throws[InterruptedException](

--- a/javalib/src/main/scala/scala/scalanative/runtime/Proxy.scala
+++ b/javalib/src/main/scala/scala/scalanative/runtime/Proxy.scala
@@ -1,6 +1,8 @@
-package scala.scalanative.runtime
+package scala.scalanative
+package runtime
 
 import scala.scalanative.annotation.alwaysinline
+import scala.concurrent.duration.FiniteDuration
 
 object Proxy {
   @alwaysinline
@@ -22,4 +24,10 @@ object Proxy {
 
   def disableGracefullShutdown(): Unit =
     MainThreadShutdownContext.gracefully = false
+
+  def stealWork(maxSteals: Int): Unit =
+    concurrent.NativeExecutionContext.queueInternal.stealWork(maxSteals)
+  def stealWork(timeout: FiniteDuration): Unit =
+    concurrent.NativeExecutionContext.queueInternal.stealWork(timeout)
+
 }

--- a/nativelib/src/main/scala/scala/scalanative/concurrent/QueueExecutionContextImpl.scala
+++ b/nativelib/src/main/scala/scala/scalanative/concurrent/QueueExecutionContextImpl.scala
@@ -67,8 +67,8 @@ private[concurrent] class QueueExecutionContextImpl()
   override def stealWork(timeout: FiniteDuration): Unit =
     if (timeout > Duration.Zero) {
       var clock = nowMillis()
-      val deadline = clock + timeout.toMillis
-      while (nonEmpty && clock < deadline) {
+      val deadline = clock + timeout.toMillis + 1
+      while (nonEmpty && clock <= deadline) {
         doStealWork()
         clock = nowMillis()
       }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -45,12 +45,12 @@ trait NativeThread {
   @alwaysinline
   final def park(): Unit =
     if (isMultithreadingEnabled) park(0, isAbsolute = false)
-    else NativeExecutionContext.queue.helpComplete()
+    else NativeExecutionContext.queueInternal.helpComplete()
 
   @alwaysinline
   final def parkNanos(nanos: Long): Unit = if (nanos > 0) {
     if (isMultithreadingEnabled) park(nanos, isAbsolute = false)
-    else NativeExecutionContext.queue.stealWork(nanos.nanos)
+    else NativeExecutionContext.queueInternal.stealWork(nanos.nanos)
   }
 
   @alwaysinline
@@ -58,7 +58,7 @@ trait NativeThread {
     if (isMultithreadingEnabled) park(deadlineEpoch, isAbsolute = true)
     else {
       val timeout = (deadlineEpoch - System.currentTimeMillis()).millis
-      NativeExecutionContext.queue.stealWork(timeout)
+      NativeExecutionContext.queueInternal.stealWork(timeout)
     }
 
   @alwaysinline

--- a/scripted-tests/run/execution-context/build.sbt
+++ b/scripted-tests/run/execution-context/build.sbt
@@ -60,3 +60,13 @@ testEventLoop := Def.taskDyn {
       assert(finished)
     }
 }.value
+
+lazy val testIssue3859 = taskKey[Unit]("...")
+testIssue3859 := {
+  import java.util.concurrent.TimeUnit
+  val bin = (Compile / nativeLink).value
+  val proc = new ProcessBuilder(bin.getAbsolutePath).start()
+  val finished = proc.waitFor(1, TimeUnit.SECONDS)
+  if (!finished) proc.destroyForcibly()
+  assert(finished)
+}

--- a/scripted-tests/run/execution-context/test
+++ b/scripted-tests/run/execution-context/test
@@ -6,3 +6,6 @@ $ copy-file variants/QueueExecutionContext2.scala src/main/scala/Main.scala
 
 $ copy-file variants/EventLoop.scala src/main/scala/Main.scala
 > testEventLoop
+
+$ copy-file variants/Issue3859.scala src/main/scala/Main.scala
+> testIssue3859

--- a/scripted-tests/run/execution-context/variants/Issue3859.scala
+++ b/scripted-tests/run/execution-context/variants/Issue3859.scala
@@ -1,0 +1,11 @@
+import scala.concurrent._
+import scala.concurrent.duration._
+
+// Issue https://github.com/scala-native/scala-native/issues/3859
+object Test {
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  def main(args: Array[String]): Unit = {
+    Await.result(Future.successful(1) map (_ + 1), Duration.Inf)
+  }
+}


### PR DESCRIPTION
Fixes #3859 
Based on work in #3853, kept as draft until deciding the new API for Native ExecutionContext

The only changes related to this fix are in the commit 516444b03f14f2ebc546b2753ef9b523fc674bb2