### PR TITLE
Fix #3076: Compilation Support for native Windows toolchain

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -14,10 +14,12 @@
 typedef DWORD ThreadRoutineReturnType;
 #else
 #include <pthread.h>
+// define as nothing on non Windows
+#define WINAPI
 typedef void *ThreadRoutineReturnType;
 #endif
-
-typedef ThreadRoutineReturnType (*ThreadStartRoutine)(void *);
+// Requires WINAPI which is defined as __stdcall on Windows
+typedef ThreadRoutineReturnType(WINAPI *ThreadStartRoutine)(void *);
 typedef void *RoutineArgs;
 
 void scalanative_GC_init();


### PR DESCRIPTION
Default using MSVC tools compiles for `i686-pc-windows-msvc` (32 bit) so calling convention is important.

- [X] Fix compilation [WINAPI](https://learn.microsoft.com/en-us/cpp/cpp/stdcall?view=msvc-170)
- [ ] Fix link symbols [Linker Options](https://learn.microsoft.com/en-us/cpp/build/reference/linker-options?view=msvc-170)

Fix for https://github.com/scala-native/scala-native/issues/3076

Setup - Visual Studio 2022 Community Edition:
```sh
> where clang
> c:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\bin\clang

> clang --version
clang version 17.0.3
Target: i686-pc-windows-msvc
Thread model: posix
InstalledDir: c:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\bin\clang
```

Potential for Github action [windows-2022](https://github.com/actions/runner-images/issues/3949)