### PR TITLE
fix: Enable skipped concurrent tests and fix underlying hidden bugs

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -56,8 +56,11 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
     findAndRemove(iterator())
   }
 
-  def containsAll(c: Collection[_]): Boolean =
-    c.scalaOps.forall(this.contains(_))
+  def containsAll(c: Collection[_]): Boolean = {
+    var it = c.iterator()
+    while (it.hasNext()) if (!contains(it.next())) return false
+    true
+  }
 
   def addAll(c: Collection[_ <: E]): Boolean =
     c.scalaOps.foldLeft(false)((prev, elem) => add(elem) || prev)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
@@ -12,6 +12,7 @@ import java.util.{Arrays, Collection, NoSuchElementException, Queue}
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import org.junit.Assert._
+import org.junit._
 
 object ConcurrentLinkedQueueTest {
   import JSR166Test._
@@ -37,13 +38,13 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** new queue is empty
    */
-  def testConstructor1(): Unit = {
+  @Test def testConstructor1(): Unit = {
     mustEqual(0, new ConcurrentLinkedQueue[Item]().size)
   }
 
   /** Initializing from null Collection throws NPE
    */
-  def testConstructor3(): Unit = {
+  @Test def testConstructor3(): Unit = {
     try {
       new ConcurrentLinkedQueue[Item](null.asInstanceOf[Collection[Item]])
       shouldThrow()
@@ -54,7 +55,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** Initializing from Collection of null elements throws NPE
    */
-  def testConstructor4(): Unit = {
+  @Test def testConstructor4(): Unit = {
     try {
       new ConcurrentLinkedQueue[Item](Arrays.asList(new Array[Item](SIZE): _*))
       shouldThrow()
@@ -66,7 +67,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** Initializing from Collection with some null elements throws NPE
    */
-  def testConstructor5(): Unit = {
+  @Test def testConstructor5(): Unit = {
     val items: Array[Item] = new Array[Item](2)
     items(0) = zero
     try {
@@ -80,7 +81,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** Queue contains all elements of collection used to initialize
    */
-  def testConstructor6(): Unit = {
+  @Test def testConstructor6(): Unit = {
     val items: Array[Item] = defaultItems
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue(
       Arrays.asList(items: _*)
@@ -94,7 +95,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** isEmpty is true before add, false after
    */
-  def testEmpty(): Unit = {
+  @Test def testEmpty(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     assertTrue(q.isEmpty)
     q.add(one)
@@ -107,7 +108,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** size changes when elements added and removed
    */
-  def testSize(): Unit = {
+  @Test def testSize(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     var i: Int = 0
@@ -128,7 +129,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** offer(null) throws NPE
    */
-  def testOfferNull(): Unit = {
+  @Test def testOfferNull(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     try {
       q.offer(null)
@@ -141,7 +142,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** add(null) throws NPE
    */
-  def testAddNull(): Unit = {
+  @Test def testAddNull(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     try {
       q.add(null)
@@ -154,7 +155,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** Offer returns true
    */
-  def testOffer(): Unit = {
+  @Test def testOffer(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     assertTrue(q.offer(zero))
     assertTrue(q.offer(one))
@@ -162,7 +163,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** add returns true
    */
-  def testAdd(): Unit = {
+  @Test def testAdd(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     var i: Int = 0
     while (i < SIZE) {
@@ -175,7 +176,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** addAll(null) throws NullPointerException
    */
-  def testAddAll1(): Unit = {
+  @Test def testAddAll1(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     try {
       q.addAll(null)
@@ -188,7 +189,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** addAll(this) throws IllegalArgumentException
    */
-  def testAddAllSelf(): Unit = {
+  @Test def testAddAllSelf(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     try {
@@ -202,7 +203,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** addAll of a collection with null elements throws NullPointerException
    */
-  def testAddAll2(): Unit = {
+  @Test def testAddAll2(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     try {
       q.addAll(Arrays.asList(new Array[Item](SIZE): _*))
@@ -216,7 +217,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
   /** addAll of a collection with any null elements throws NPE after possibly
    *  adding some elements
    */
-  def testAddAll3(): Unit = {
+  @Test def testAddAll3(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     val items: Array[Item] = new Array[Item](2)
     items(0) = zero
@@ -231,7 +232,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** Queue contains all elements, in traversal order, of successful addAll
    */
-  def testAddAll5(): Unit = {
+  @Test def testAddAll5(): Unit = {
     val empty: Array[Item] = new Array[Item](0)
     val items: Array[Item] = defaultItems
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
@@ -246,7 +247,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** poll succeeds unless empty
    */
-  def testPoll(): Unit = {
+  @Test def testPoll(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     var i: Int = 0
@@ -260,7 +261,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** peek returns next element, or null if empty
    */
-  def testPeek(): Unit = {
+  @Test def testPeek(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     var i: Int = 0
@@ -276,7 +277,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** element returns next element, or throws NSEE if empty
    */
-  def testElement(): Unit = {
+  @Test def testElement(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     var i: Int = 0
@@ -297,7 +298,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** remove removes next element, or throws NSEE if empty
    */
-  def testRemove(): Unit = {
+  @Test def testRemove(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     var i: Int = 0
@@ -317,7 +318,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** remove(x) removes x and returns true if present
    */
-  def testRemoveElement(): Unit = {
+  @Test def testRemoveElement(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     var i: Int = 1
@@ -344,7 +345,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** contains(x) reports true when elements added but not yet removed
    */
-  def testContains(): Unit = {
+  @Test def testContains(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     var i: Int = 0
@@ -359,7 +360,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** clear removes all elements
    */
-  def testClear(): Unit = {
+  @Test def testClear(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     q.clear()
@@ -373,7 +374,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** containsAll(c) is true when c contains a subset of elements
    */
-  def testContainsAll(): Unit = {
+  @Test def testContainsAll(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     val p: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
@@ -390,7 +391,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** retainAll(c) retains only those elements of c and reports true if change
    */
-  def testRetainAll(): Unit = {
+  @Test def testRetainAll(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     val p: ConcurrentLinkedQueue[Item] =
@@ -413,7 +414,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** removeAll(c) removes only those elements of c and reports true if changed
    */
-  def testRemoveAll(): Unit = {
+  @Test def testRemoveAll(): Unit = {
     var i: Int = 1
     while (i < SIZE) {
       val q: ConcurrentLinkedQueue[Item] =
@@ -433,7 +434,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** toArray contains all elements in FIFO order
    */
-  def testToArray(): Unit = {
+  @Test def testToArray(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     val a: Array[AnyRef] = q.toArray
@@ -446,7 +447,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** toArray(a) contains all elements in FIFO order
    */
-  def testToArray2(): Unit = {
+  @Test def testToArray2(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     val items: Array[Item] = new Array[Item](SIZE)
@@ -460,7 +461,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** toArray(null) throws NullPointerException
    */
-  def testToArray_NullArg(): Unit = {
+  @Test def testToArray_NullArg(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     try {
@@ -474,9 +475,8 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** toArray(incompatible array type) throws ArrayStoreException
    */
-  @SuppressWarnings(
-    Array("CollectionToArraySafeParameter")
-  ) def testToArray_incompatibleArrayType(): Unit = {
+  @Ignore("No array object exact element type information in SN runtime")
+  @Test def testToArray_incompatibleArrayType(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     try {
@@ -484,13 +484,12 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
       shouldThrow()
     } catch {
       case success: ArrayStoreException =>
-
     }
   }
 
   /** iterator iterates through all elements
    */
-  def testIterator(): Unit = {
+  @Test def testIterator(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     val it: java.util.Iterator[_ <: Item] = q.iterator()
@@ -506,13 +505,13 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** iterator of empty collection has no elements
    */
-  def testEmptyIterator(): Unit = {
+  @Test def testEmptyIterator(): Unit = {
     assertIteratorExhausted(new ConcurrentLinkedQueue[AnyRef]().iterator)
   }
 
   /** iterator ordering is FIFO
    */
-  def testIteratorOrdering(): Unit = {
+  @Test def testIteratorOrdering(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     q.add(one)
     q.add(two)
@@ -532,7 +531,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** Modifications do not cause iterators to fail
    */
-  def testWeaklyConsistentIteration(): Unit = {
+  @Test def testWeaklyConsistentIteration(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
     q.add(one)
     q.add(two)
@@ -547,23 +546,23 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** iterator.remove removes current element
    */
-  def testIteratorRemove(): Unit = {
+  @Test def testIteratorRemove(): Unit = {
     val q: ConcurrentLinkedQueue[Item] = new ConcurrentLinkedQueue[Item]
-    q.add(one)
-    q.add(two)
-    q.add(three)
+    q.add(itemFor(one))
+    q.add(itemFor(two))
+    q.add(itemFor(three))
     var it: java.util.Iterator[_ <: Item] = q.iterator
     it.next
     it.remove()
     it = q.iterator
-    assertSame(it.next, two)
-    assertSame(it.next, three)
+    assertSame(it.next, itemFor(two))
+    assertSame(it.next, itemFor(three))
     assertFalse(it.hasNext)
   }
 
   /** toString contains toStrings of elements
    */
-  def testToString(): Unit = {
+  @Test def testToString(): Unit = {
     val q: ConcurrentLinkedQueue[Item] =
       ConcurrentLinkedQueueTest.populatedQueue(SIZE)
     val s: String = q.toString
@@ -596,7 +595,7 @@ class ConcurrentLinkedQueueTest extends JSR166Test {
 
   /** remove(null), contains(null) always return false
    */
-  def testNeverContainsNull(): Unit = {
+  @Test def testNeverContainsNull(): Unit = {
     val qs: Array[Collection[_]] = Array(
       new ConcurrentLinkedQueue[AnyRef],
       ConcurrentLinkedQueueTest.populatedQueue(2)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/RecursiveActionTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/RecursiveActionTest.scala
@@ -239,7 +239,7 @@ class RecursiveActionTest extends JSR166Test {
    *  isCancelled return false for normally completed tasks. getRawResult of a
    *  RecursiveAction returns null;
    */
-  def testInvoke(): Unit = {
+  @Test def testInvoke(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -255,7 +255,7 @@ class RecursiveActionTest extends JSR166Test {
    *  isCompletedAbnormally and isCancelled return false for normally completed
    *  tasks
    */
-  def testQuietlyInvoke(): Unit = {
+  @Test def testQuietlyInvoke(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -269,7 +269,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** join of a forked task returns when task completes
    */
-  def testForkJoin(): Unit = {
+  @Test def testForkJoin(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -284,7 +284,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** join/quietlyJoin of a forked task succeeds in the presence of interrupts
    */
-  def testJoinIgnoresInterrupts(): Unit = {
+  @Test def testJoinIgnoresInterrupts(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         var f = new FibAction(8)
@@ -352,7 +352,7 @@ class RecursiveActionTest extends JSR166Test {
   /** join/quietlyJoin of a forked task when not in ForkJoinPool succeeds in the
    *  presence of interrupts
    */
-  def testJoinIgnoresInterruptsOutsideForkJoinPool(): Unit = {
+  @Test def testJoinIgnoresInterruptsOutsideForkJoinPool(): Unit = {
     val sq = new SynchronousQueue[Array[FibAction]]
     val a = new CheckedRecursiveAction() {
       @throws[InterruptedException]
@@ -436,7 +436,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** get of a forked task returns when task completes
    */
-  def testForkGet(): Unit = {
+  @Test def testForkGet(): Unit = {
     val a = new CheckedRecursiveAction() {
       @throws[Exception]
       protected def realCompute(): Unit = {
@@ -452,7 +452,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** timed get of a forked task returns when task completes
    */
-  def testForkTimedGet(): Unit = {
+  @Test def testForkTimedGet(): Unit = {
     val a = new CheckedRecursiveAction() {
       @throws[Exception]
       protected def realCompute(): Unit = {
@@ -468,7 +468,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** timed get with null time unit throws NPE
    */
-  def testForkTimedGetNPE(): Unit = {
+  @Test def testForkTimedGetNPE(): Unit = {
     val a = new CheckedRecursiveAction() {
       @throws[Exception]
       protected def realCompute(): Unit = {
@@ -488,7 +488,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** quietlyJoin of a forked task returns when task completes
    */
-  def testForkQuietlyJoin(): Unit = {
+  @Test def testForkQuietlyJoin(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -504,7 +504,7 @@ class RecursiveActionTest extends JSR166Test {
   /** helpQuiesce returns when tasks are complete. getQueuedTaskCount returns 0
    *  when quiescent
    */
-  def testForkHelpQuiesce(): Unit = {
+  @Test def testForkHelpQuiesce(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -522,7 +522,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invoke task throws exception when task completes abnormally
    */
-  def testAbnormalInvoke(): Unit = {
+  @Test def testAbnormalInvoke(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new RecursiveActionTest.FailingFibAction(8)
@@ -540,7 +540,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** quietlyInvoke task returns when task completes abnormally
    */
-  def testAbnormalQuietlyInvoke(): Unit = {
+  @Test def testAbnormalQuietlyInvoke(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new RecursiveActionTest.FailingFibAction(8)
@@ -554,7 +554,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** join of a forked task throws exception when task completes abnormally
    */
-  def testAbnormalForkJoin(): Unit = {
+  @Test def testAbnormalForkJoin(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new RecursiveActionTest.FailingFibAction(8)
@@ -573,7 +573,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** get of a forked task throws exception when task completes abnormally
    */
-  def testAbnormalForkGet(): Unit = {
+  @Test def testAbnormalForkGet(): Unit = {
     val a = new CheckedRecursiveAction() {
       @throws[Exception]
       protected def realCompute(): Unit = {
@@ -595,7 +595,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** timed get of a forked task throws exception when task completes abnormally
    */
-  def testAbnormalForkTimedGet(): Unit = {
+  @Test def testAbnormalForkTimedGet(): Unit = {
     val a = new CheckedRecursiveAction() {
       @throws[Exception]
       protected def realCompute(): Unit = {
@@ -617,7 +617,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** quietlyJoin of a forked task returns when task completes abnormally
    */
-  def testAbnormalForkQuietlyJoin(): Unit = {
+  @Test def testAbnormalForkQuietlyJoin(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new RecursiveActionTest.FailingFibAction(8)
@@ -632,7 +632,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invoke task throws exception when task cancelled
    */
-  def testCancelledInvoke(): Unit = {
+  @Test def testCancelledInvoke(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -651,7 +651,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** join of a forked task throws exception when task cancelled
    */
-  def testCancelledForkJoin(): Unit = {
+  @Test def testCancelledForkJoin(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -671,7 +671,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** get of a forked task throws exception when task cancelled
    */
-  def testCancelledForkGet(): Unit = {
+  @Test def testCancelledForkGet(): Unit = {
     val a = new CheckedRecursiveAction() {
       @throws[Exception]
       protected def realCompute(): Unit = {
@@ -692,7 +692,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** timed get of a forked task throws exception when task cancelled
    */
-  def testCancelledForkTimedGet(): Unit = {
+  @Test def testCancelledForkTimedGet(): Unit = {
     val a = new CheckedRecursiveAction() {
       @throws[Exception]
       protected def realCompute(): Unit = {
@@ -713,7 +713,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** quietlyJoin of a forked task returns when task cancelled
    */
-  def testCancelledForkQuietlyJoin(): Unit = {
+  @Test def testCancelledForkQuietlyJoin(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -728,7 +728,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** getPool of executing task returns its pool
    */
-  def testGetPool(): Unit = {
+  @Test def testGetPool(): Unit = {
     val mainPool = RecursiveActionTest.mainPool
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = { assertSame(mainPool, getPool) }
@@ -738,7 +738,8 @@ class RecursiveActionTest extends JSR166Test {
 
   /** getPool of non-FJ task returns null
    */
-  def testGetPool2(): Unit = {
+  @Ignore("All Scala Native tests are exuected in the pool")
+  @Test def testGetPool2(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = { assertNull(getPool) }
     }
@@ -747,7 +748,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** inForkJoinPool of executing task returns true
    */
-  def testInForkJoinPool(): Unit = {
+  @Test def testInForkJoinPool(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = { assertTrue(inForkJoinPool) }
     }
@@ -756,7 +757,8 @@ class RecursiveActionTest extends JSR166Test {
 
   /** inForkJoinPool of non-FJ task returns false
    */
-  def testInForkJoinPool2(): Unit = {
+  @Ignore("All Scala Native etests are exuected in the pool")
+  @Test def testInForkJoinPool2(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = { assertFalse(inForkJoinPool) }
     }
@@ -765,7 +767,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** getPool of current thread in pool returns its pool
    */
-  def testWorkerGetPool(): Unit = {
+  @Test def testWorkerGetPool(): Unit = {
     val mainPool = RecursiveActionTest.mainPool
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
@@ -778,7 +780,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** getPoolIndex of current thread in pool returns 0 <= value < poolSize
    */
-  def testWorkerGetPoolIndex(): Unit = {
+  @Test def testWorkerGetPoolIndex(): Unit = {
     val mainPool = RecursiveActionTest.mainPool
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
@@ -793,7 +795,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** setRawResult(null) succeeds
    */
-  def testSetRawResult(): Unit = {
+  @Test def testSetRawResult(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         setRawResult(null)
@@ -805,7 +807,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** A reinitialized normally completed task may be re-invoked
    */
-  def testReinitialize(): Unit = {
+  @Test def testReinitialize(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -824,7 +826,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** A reinitialized abnormally completed task may be re-invoked
    */
-  def testReinitializeAbnormal(): Unit = {
+  @Test def testReinitializeAbnormal(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new RecursiveActionTest.FailingFibAction(8)
@@ -847,7 +849,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invoke task throws exception after invoking completeExceptionally
    */
-  def testCompleteExceptionally(): Unit = {
+  @Test def testCompleteExceptionally(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -866,7 +868,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invoke task suppresses execution invoking complete
    */
-  def testComplete(): Unit = {
+  @Test def testComplete(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -881,7 +883,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(t1, t2) invokes all task arguments
    */
-  def testInvokeAll2(): Unit = {
+  @Test def testInvokeAll2(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -898,7 +900,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(tasks) with 1 argument invokes task
    */
-  def testInvokeAll1(): Unit = {
+  @Test def testInvokeAll1(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -912,7 +914,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(tasks) with > 2 argument invokes tasks
    */
-  def testInvokeAll3(): Unit = {
+  @Test def testInvokeAll3(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -935,7 +937,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(collection) invokes all tasks in the collection
    */
-  def testInvokeAllCollection(): Unit = {
+  @Test def testInvokeAllCollection(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -962,7 +964,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(tasks) with any null task throws NPE
    */
-  def testInvokeAllNPE(): Unit = {
+  @Test def testInvokeAllNPE(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -982,7 +984,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(t1, t2) throw exception if any task does
    */
-  def testAbnormalInvokeAll2(): Unit = {
+  @Test def testAbnormalInvokeAll2(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -1001,7 +1003,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(tasks) with 1 argument throws exception if task does
    */
-  def testAbnormalInvokeAll1(): Unit = {
+  @Test def testAbnormalInvokeAll1(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val g = new RecursiveActionTest.FailingFibAction(9)
@@ -1019,7 +1021,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(tasks) with > 2 argument throws exception if any task does
    */
-  def testAbnormalInvokeAll3(): Unit = {
+  @Test def testAbnormalInvokeAll3(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new FibAction(8)
@@ -1039,7 +1041,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** invokeAll(collection) throws exception if any task does
    */
-  def testAbnormalInvokeAllCollection(): Unit = {
+  @Test def testAbnormalInvokeAllCollection(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val f = new RecursiveActionTest.FailingFibAction(8)
@@ -1064,7 +1066,7 @@ class RecursiveActionTest extends JSR166Test {
   /** tryUnfork returns true for most recent unexecuted task, and suppresses
    *  execution
    */
-  def testTryUnfork(): Unit = {
+  @Test def testTryUnfork(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val g = new FibAction(9)
@@ -1083,7 +1085,7 @@ class RecursiveActionTest extends JSR166Test {
   /** getSurplusQueuedTaskCount returns > 0 when there are more tasks than
    *  threads
    */
-  def testGetSurplusQueuedTaskCount(): Unit = {
+  @Test def testGetSurplusQueuedTaskCount(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val h = new FibAction(7)
@@ -1105,7 +1107,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** peekNextLocalTask returns most recent unexecuted task.
    */
-  def testPeekNextLocalTask(): Unit = {
+  @Test def testPeekNextLocalTask(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val g = new FibAction(9)
@@ -1125,7 +1127,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** pollNextLocalTask returns most recent unexecuted task without executing it
    */
-  def testPollNextLocalTask(): Unit = {
+  @Test def testPollNextLocalTask(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val g = new FibAction(9)
@@ -1143,7 +1145,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** pollTask returns an unexecuted task without executing it
    */
-  def testPollTask(): Unit = {
+  @Test def testPollTask(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val g = new FibAction(9)
@@ -1161,7 +1163,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** peekNextLocalTask returns least recent unexecuted task in async mode
    */
-  def testPeekNextLocalTaskAsync(): Unit = {
+  @Test def testPeekNextLocalTaskAsync(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val g = new FibAction(9)
@@ -1181,7 +1183,7 @@ class RecursiveActionTest extends JSR166Test {
   /** pollNextLocalTask returns least recent unexecuted task without executing
    *  it, in async mode
    */
-  def testPollNextLocalTaskAsync(): Unit = {
+  @Test def testPollNextLocalTaskAsync(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val g = new FibAction(9)
@@ -1199,7 +1201,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** pollTask returns an unexecuted task without executing it, in async mode
    */
-  def testPollTaskAsync(): Unit = {
+  @Test def testPollTaskAsync(): Unit = {
     val a = new CheckedRecursiveAction() {
       protected def realCompute(): Unit = {
         val g = new FibAction(9)
@@ -1217,7 +1219,7 @@ class RecursiveActionTest extends JSR166Test {
 
   /** SortTask demo works as advertised
    */
-  def testSortTaskDemo(): Unit = {
+  @Test def testSortTaskDemo(): Unit = {
     val rnd = ThreadLocalRandom.current
     val array = new Array[Long](1007)
     for (i <- 0 until array.length) { array(i) = rnd.nextLong }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/RecursiveTaskTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/RecursiveTaskTest.scala
@@ -260,7 +260,7 @@ class RecursiveTaskTest extends JSR166Test {
 
   /** get of a forked task returns when task completes
    */
-  def testForkGet(): Unit = {
+  @Test def testForkGet(): Unit = {
     val a = new CheckedRecursiveTask[Integer] {
       protected def realCompute(): Integer = {
         val f = new FibTask(8)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/SemaphoreTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/SemaphoreTest.scala
@@ -635,7 +635,7 @@ class SemaphoreTest extends JSR166Test {
       AcquireMethod.acquireUninterruptibly
     )
   }
-  def testReleaseAcquireDifferentThreads_acquireUninterruptiblyN_fair()
+  @Test def testReleaseAcquireDifferentThreads_acquireUninterruptiblyN_fair()
       : Unit = {
     testReleaseAcquireDifferentThreads(
       true,

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/LongAdderTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/LongAdderTest.scala
@@ -122,20 +122,22 @@ class LongAdderTest extends JSR166Test {
   /** adds by multiple threads produce correct sum
    */
   @throws[Throwable]
-  def testAddAndSumMT(): Unit = {
+  @Test def testAddAndSumMT(): Unit = {
     val incs = 1000000
     val nthreads = 4
     val pool = Executors.newCachedThreadPool()
-    val a = new LongAdder
-    val barrier = new CyclicBarrier(nthreads + 1)
-    for (i <- 0 until nthreads) {
-      pool.execute(new AdderTask(a, barrier, incs))
+    usingPoolCleaner(pool) { _ =>
+      val a = new LongAdder
+      val barrier = new CyclicBarrier(nthreads + 1)
+      for (i <- 0 until nthreads) {
+        pool.execute(new AdderTask(a, barrier, incs))
+      }
+      barrier.await
+      barrier.await
+      val total = nthreads.toLong * incs
+      val sum = a.sum
+      assertEquals(sum, total)
     }
-    barrier.await
-    barrier.await
-    val total = nthreads.toLong * incs
-    val sum = a.sum
-    assertEquals(sum, total)
     pool.shutdown()
   }
   final class AdderTask(


### PR DESCRIPTION
Fixes #3874 

When porting `ConcurrentLinkedQueue` and other tests from JSR-166 we've skipped adding `@Test` annotations. This lead to skipping `ConcurrentLinkedQueue` runtime tests. During the audit we've also found other tests that were skipped. All of these tests are now enabled and we've fixed the bugs in: 
 - `j.u.c.ConcurrentLinkedQueue` - missing `Collection[T]` constructor, infinite iterators and to array conversions 
 - `j.u.c.atomic.LongAdder` 
 - `j.u.c.atomic.Stripped64`
 - `j.u.AbstractCollection.containsAll`