### PR TITLE
Fix #3878: javalib Files symlink deletion now matches JVM

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -367,7 +367,7 @@ object Files {
   }
 
   def delete(path: Path): Unit = {
-    if (!exists(path, Array.empty)) {
+    if (!exists(path, Array(LinkOption.NOFOLLOW_LINKS))) {
       throw new NoSuchFileException(path.toString)
     } else if (isWindows) {
       windowsDeletePath(path)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -695,6 +695,39 @@ class FilesTest {
     }
   }
 
+  // I3874
+  @Test def filesDeleteDoesNotFollowUnbrokenSymlinks(): Unit = {
+    assumeShouldTestSymlinks()
+
+    withTemporaryDirectory { dirFile =>
+      val dir = dirFile.toPath()
+      val unbrokenLink = dir.resolve("unbroken-link")
+      val linkTarget = dir.resolve("link-target")
+
+      Files.createFile(linkTarget)
+      assertTrue("link target should exist", Files.exists(linkTarget))
+
+      Files.createSymbolicLink(unbrokenLink, linkTarget)
+      Files.delete(unbrokenLink)
+
+      // deleted symlink but not its target
+      assertFalse("symlink was not deleted", Files.exists(unbrokenLink))
+      assertTrue("target was deleted", Files.exists(linkTarget))
+    }
+  }
+
+  // I3874
+  @Test def filesDeleteDoesNotFollowBrokenSymlinks(): Unit = {
+    assumeShouldTestSymlinks()
+
+    withTemporaryDirectory { dirFile =>
+      val dir = dirFile.toPath()
+      val brokenLink = dir.resolve("broken-link")
+      Files.createSymbolicLink(brokenLink, dir.resolve("doesnt-exist"))
+      Files.delete(brokenLink)
+    }
+  }
+
   @Test def filesDeleteThrowsWhenDeletingNonExistingFile(): Unit = {
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -695,7 +695,7 @@ class FilesTest {
     }
   }
 
-  // I3874
+  // I3878
   @Test def filesDeleteDoesNotFollowUnbrokenSymlinks(): Unit = {
     assumeShouldTestSymlinks()
 
@@ -716,7 +716,7 @@ class FilesTest {
     }
   }
 
-  // I3874
+  // I3878
   @Test def filesDeleteDoesNotFollowBrokenSymlinks(): Unit = {
     assumeShouldTestSymlinks()
 


### PR DESCRIPTION
fix #3878

javalib Files symlink deletion now matches JVM. 
Deleting an existing symlink deletes the symlink, not its target.
Deleting a non-existing symlink does not throw an Exception because
the code no longer attempts to follow the broken link.

