### PR TITLE
fix: javalib SimpleFileVisitor#visitFileFailed now matches JVM

### DIFF
--- a/javalib/src/main/scala/java/nio/file/FileVisitor.scala
+++ b/javalib/src/main/scala/java/nio/file/FileVisitor.scala
@@ -31,6 +31,6 @@ class SimpleFileVisitor[T] protected () extends FileVisitor[T] {
     FileVisitResult.CONTINUE
 
   override def visitFileFailed(file: T, error: IOException): FileVisitResult =
-    FileVisitResult.CONTINUE
+    throw error
 
 }


### PR DESCRIPTION
The javalib `SimpleFileVisitor#visitFileFailed` method now rethrows the exception passed to it.
It behavior now matches the documented and runtime JVM behavior. 

After the change of this PR, the reproducer program in Issue #3879 gives the same results
on Scala Native and the JVM.

While the presenting problem of Issue #3879 no longer shows,
I'd like to keep that PR open and not call it fixed because I need to convince myself that 
this is a fix by understanding, rather than by lucky happenstance.

<hr>

Tested manually, the reproducer code from Issue #3879.

In a better world, a standalone test run every six months or so might repay its carbon footprint.
This bug has existed for 7+ years. I hope the fix lasts at least as long.

The eventual resolution of Issue #3879 should exercise this code in CI.