### PR TITLE
fix: provide POSIX dirent#readdir  & deprecate non-POSIX prior

### DIFF
--- a/docs/changelog/0.5.x/0.5.2-SNAPSHOT.md
+++ b/docs/changelog/0.5.x/0.5.2-SNAPSHOT.md
@@ -1,0 +1,15 @@
+
+# 0.5.2-SNAPSHOT (2024-04-27)
+
+We're happy to announce the release of Scala Native v0.5.2-SNAPSHOT. 
+
+This patch release is focused on <To be specified>
+
+## Deprecated definitions 
+
+### Introduced in this version
+All newly deprecated declarations are subject to removal in the future.
+
+* posixlib dirent.scala 'readdir(dirp: Ptr[DIR], buf: Ptr[dirent]): CInt'
+  is now deprecated because it is not part of the POSIX 2018 standard.
+  Suggested replacement: 'readdir(dirp: Ptr[DIR]): Ptr[dirent]'.

--- a/docs/changelog/0.5.x/index.rst
+++ b/docs/changelog/0.5.x/index.rst
@@ -6,6 +6,7 @@
 .. toctree::
   :maxdepth: 1
 
+  0.5.2-SNAPSHOT
   0.5.1
   0.5.0
   0.5.0-RC3

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -3,6 +3,7 @@ package scala.scalanative.nio.fs
 import scalanative.unsigned._
 import scalanative.libc._
 import scalanative.posix.dirent._
+import scalanative.posix.DirentImpl.scalanative_readdirImpl
 
 // Import posix name errno as variable, not class or type.
 import scalanative.posix.{errno => posixErrno}, posixErrno._
@@ -75,7 +76,8 @@ object FileHelpers {
         Zone.acquire { implicit z =>
           var elem = alloc[dirent]()
           var res = 0
-          while ({ res = readdir(dir, elem); res == 0 }) {
+          // Avoid deprecated non-POSIX method by using private implementation.
+          while ({ res = scalanative_readdirImpl(dir, elem); res == 0 }) {
             val name = fromCString(elem._2.at(0))
             val fileType = FileType.unixFileType(elem._3)
             collectFile(name, fileType)

--- a/posixlib/src/main/resources/scala-native/dirent.c
+++ b/posixlib/src/main/resources/scala-native/dirent.c
@@ -6,7 +6,44 @@
 #include <stdio.h>
 #include <errno.h>
 
-#define NAME_MAX 255
+// Check consistency of Scala Native and operating system definitions.
+
+_Static_assert(sizeof(ino_t) <= 64,
+               "os ino_t does not match Scala Native dirent");
+
+_Static_assert(sizeof(((struct dirent *)0)->d_type) <= 2,
+               "os dirent.d_type does not match Scala Native dirent");
+
+#ifdef NAME_MAX
+/* TL;DR - The Scala Native d_name definition should be changed to CString
+ *         as soon as breaking changes are allowed. That punts allocation
+ *         of storage with sufficient size for a file name to the
+ *         operating system, which knows best.
+ *
+ *         Scala Native can always to a strlen/strnlen of the returned
+ *         string and allocate, at its level, the exact required size.
+ *         Scala Native code while almost always be copying the os d_name
+ *         to a Scala 'String'. fromCString(os_d_name) can be done
+ *         directly, and does not require an intermediate allocation and
+ *         copy
+ *
+ * In 2024 and possibly much earlier, linux & FreeBSD  "getconf NAME_MAX /"
+ * return 255 for the file systems the most commonly used on those operating
+ * systems. They may or may not define NAME_MAX and readdir() may or
+ * may not return strings longer that that; long story.
+ *
+ * macOS limits need to be explored. It specifies a max of 255 UTF-8
+ * characters. Since each UTF-8 character can be up to 5 bytes long,
+ * a 255 UTF-8 characters could be (255 * 5 == 1275) bytes.
+ *
+ * Then again, there are file systems, such as Amazon S3 which has a
+ * file name length limit of 1024 characters)
+ *
+ */
+_Static_assert(NAME_MAX <= 255, "NAME_MAX does not match Scala Native dirent");
+#else
+#define NAME_MAX 255 // manually match dirent.scala definition
+#endif
 
 struct scalanative_dirent {
     unsigned long long d_ino;  /** file serial number */
@@ -35,13 +72,17 @@ DIR *scalanative_opendir(const char *name) { return opendir(name); }
 void scalanative_dirent_init(struct dirent *dirent,
                              struct scalanative_dirent *my_dirent) {
     my_dirent->d_ino = dirent->d_ino;
+
+    // Note: code will _silently_ truncate any long d_name returned by OS.
     strncpy(my_dirent->d_name, dirent->d_name, NAME_MAX);
     my_dirent->d_name[NAME_MAX] = '\0';
     my_dirent->d_type = dirent->d_type;
 }
 
+// This function is for Scala Native internal use only.
+
 // returns 0 in case of success, -1 in case of empty dir, errno otherwise
-int scalanative_readdir(DIR *dirp, struct scalanative_dirent *buf) {
+int scalanative_readdirImpl(DIR *dirp, struct scalanative_dirent *buf) {
     errno = 0;
     struct dirent *orig_buf = readdir(dirp);
     int result = 0;
@@ -54,6 +95,17 @@ int scalanative_readdir(DIR *dirp, struct scalanative_dirent *buf) {
         result = errno;
 
     return result;
+}
+/* This function is for Scala Native internal use only.
+ * It is provided to preserve the entry point and prevent a breaking
+ * change in 0.5.2. To reduce enduring & compounding complexity, it should
+ * be removed for 0.6.0.
+ *
+ * No Scala Native code defines or calls it.
+ */
+
+int scalanative_readdir(DIR *dirp, struct scalanative_dirent *buf) {
+    scalanative_readdirImpl(dirp, buf);
 }
 
 int scalanative_closedir(DIR *dirp) { return closedir(dirp); }

--- a/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
@@ -1,42 +1,127 @@
 package scala.scalanative
 package posix
 
+import scalanative.posix.sys.types.ino_t
+
 import scala.scalanative.unsafe._, Nat._
 
-@extern
-@define("__SCALANATIVE_POSIX_DIRENT")
-object dirent {
+object DirentTypes {
+  type _256 = Digit3[_2, _5, _6] // see comment above 'type dirent' below.
 
-  type _256 = Digit3[_2, _5, _6]
-  type DIR = CStruct0
+  type DIR = CStruct0 // An opaque structure from os. Deconstruct a your peril.
+
+  /* Use "glue" is here because Direct call through to the operating
+   * system is beyond the scope of time available. Linux, FreeBSD and,
+   * macOS appear to use different layouts, possibly containing padding.
+   */
+
+  /* The second field, d_name, is suspect and should be changed to CString
+   * as soon as breaking changes are allowed after 0.5.0.
+   *
+   * The handling of d_name across operating systems is complex. All, so far,
+   * agree that the field is a null-terminated array of characters, a.k.a
+   * CString.
+   *
+   * Guarantees of the allocated size of that CString are stated but
+   * unreliable.  Some operating systems do not specify NAME_MAX.
+   * Some specify it as 255 but can return a string longer that that.
+   * macOS specifies 255 UTF-8 characters. Since each UTF-8 character
+   * can be up to, currently, 5 bytes long, the total size can
+   * exceed the _256 here.
+   *
+   * Using a CString here, follows the Open Group 'char   d_name[]'.
+   * By C rules, that is equivalent to 'char *', a.k.a CString.
+   */
+
+  /* Code in dirent.c manually checks that the sizes & declarations
+   * of this structure are compatible with the operating system definitions.
+   * Devo: if you change anything here, please examine the  dirent.c checks.
+   */
+
   type dirent =
-    CStruct3[CUnsignedLongLong, CArray[CChar, _256], CShort]
+    CStruct3[ino_t, CArray[CChar, _256], CShort]
+}
 
-  @name("scalanative_opendir")
-  def opendir(name: CString): Ptr[DIR] = extern
+// not __SCALANATIVE_POSIX_DIRENTIMPL for historical/version_compatibility.
+@define("__SCALANATIVE_POSIX_DIRENT")
+@extern
+private[scalanative] object DirentImpl {
+  import DirentTypes._
 
-  @name("scalanative_readdir")
-  def readdir(dirp: Ptr[DIR], buf: Ptr[dirent]): CInt = extern
+  type DIR = DirentTypes.DIR
 
-  @name("scalanative_closedir")
-  def closedir(dirp: Ptr[DIR]): CInt = extern
+  def scalanative_closedir(dirp: Ptr[DIR]): CInt = extern
 
-  @name("scalanative_dt_unknown")
-  def DT_UNKNOWN: CInt = extern
-  @name("scalanative_dt_fifo")
-  def DT_FIFO: CInt = extern
-  @name("scalanative_dt_chr")
-  def DT_CHR: CInt = extern
-  @name("scalanative_dt_dir")
-  def DT_DIR: CInt = extern
-  @name("scalanative_dt_blk")
-  def DT_BLK: CInt = extern
-  @name("scalanative_dt_reg")
-  def DT_REG: CInt = extern
-  @name("scalanative_dt_lnk")
-  def DT_LNK: CInt = extern
-  @name("scalanative_dt_sock")
-  def DT_SOCK: CInt = extern
-  @name("scalanative_dt_wht")
-  def DT_WHT: CInt = extern
+  def scalanative_opendir(name: CString): Ptr[DIR] = extern
+
+  def scalanative_readdir(dirp: Ptr[DIR]): CInt = extern
+
+  // Not POSIX, javalib internal use only.
+  def scalanative_readdirImpl(dirp: Ptr[DIR], buf: Ptr[dirent]): CInt = extern
+
+  def scalanative_dt_unknown: CInt = extern
+  def scalanative_dt_fifo: CInt = extern
+  def scalanative_dt_chr: CInt = extern
+  def scalanative_dt_dir: CInt = extern
+  def scalanative_dt_blk: CInt = extern
+  def scalanative_dt_reg: CInt = extern
+  def scalanative_dt_lnk: CInt = extern
+  def scalanative_dt_sock: CInt = extern
+  def scalanative_dt_wht: CInt = extern
+}
+
+object dirent {
+  import DirentTypes._
+  import DirentImpl._
+
+  type DIR = DirentTypes.DIR
+  type dirent = DirentTypes.dirent
+
+  def closedir(dirp: Ptr[DIR]): CInt = scalanative_closedir(dirp)
+
+  def opendir(name: CString): Ptr[DIR] = scalanative_opendir(name)
+
+  def readdir(dirp: Ptr[DIR]): Ptr[dirent] = {
+    val entry = new Array[Byte](sizeOf[dirent]).at(0).asInstanceOf[Ptr[dirent]]
+
+    if (DirentImpl.scalanative_readdirImpl(dirp, entry) != 0) null
+    else entry
+  }
+
+  @deprecated(
+    "Not POSIX, subject to removal in the future. Use readdir(dirp) instead.",
+    since = "posixlib 0.5.2"
+  )
+  // Not to be confused with POSIX readdir_r().
+  def readdir(dirp: Ptr[DIR], buf: Ptr[dirent]): CInt =
+    DirentImpl.scalanative_readdirImpl(dirp, buf)
+
+  /* readdir_r() is specified in Open Group 2018 version, and probably earlier.
+   *
+   * macOS allows the function but Linux & FreeBSD describe it a "deprecated"
+   * and recommend using a current thread-safe version of 'readdir()'.
+   * For one discussion, see:
+   *  https://man7.org/linux/man-pages/man3/readdir_r.3.html
+   *
+   * Not implemented to avoid spending time on complexity to no good end.
+   */
+  // def readdir_r(/* three arguments */)
+
+  def DT_UNKNOWN: CInt = scalanative_dt_unknown
+
+  def DT_FIFO: CInt = scalanative_dt_fifo
+
+  def DT_CHR: CInt = scalanative_dt_chr
+
+  def DT_DIR: CInt = scalanative_dt_dir
+
+  def DT_BLK: CInt = scalanative_dt_blk
+
+  def DT_REG: CInt = scalanative_dt_reg
+
+  def DT_LNK: CInt = scalanative_dt_lnk
+
+  def DT_SOCK: CInt = scalanative_dt_sock
+
+  def DT_WHT: CInt = scalanative_dt_wht
 }


### PR DESCRIPTION
fix Issue #3892.

1. Implement a posixlib `dirent#readdir` method which follows the Open Group 2018 (aka POSIX) specification.

2. Deprecate the prior non-POSIX two argument method.

3. Modify `FileHelpers#list#listUnix` to no longer use the now deprecated two argument form. 

Note Well:   

- `dirent.scala` is still missing a number of declarations from the Open Group 2018 specification.

- The declaration of the `dirent` structure in `dirent.scala` should be changed so that  `d_name`
   is a `CString` and not a `CArray`. This will allow better handling of large file names across 
   multiple operating systems.  Since this is a breaking change, it can/should not be done before
   SN 0.6.0.