### PR TITLE
fix: Files#move now handles target directories which are populated

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -580,7 +580,7 @@ object Files {
           }
 
         if (mustDeleteTarget)
-          Files.delete(target)
+          Files.delete(target) // will detect & throw if target is not empty.
       }
 
       if (isWindows) {


### PR DESCRIPTION
Fix #3900 

javalib `Files#move` now throws a `DirectoryNotEmptyException` when attempting to remove an existing directory
which contains files.  This follows the JVM description & practice.