### PR TITLE
fix: javalib posix fileKeys are now unique

### DIFF
--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -1,5 +1,6 @@
 package java.nio.file.attribute
 
+import java.{lang => jl}
 import java.{util => ju}
 import java.util.{HashMap, HashSet, Set}
 import java.util.concurrent.TimeUnit
@@ -86,8 +87,39 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
 
   override def readAttributes(): BasicFileAttributes = attributes
 
+  /*
+  private case class PosixFileKey(deviceId: stat.dev_t,
+                                  inodeNumber: stat.ino_t)
+   */
+
+  private class PosixFileKey(deviceId: stat.dev_t, inodeNumber: stat.ino_t) {
+
+    override def equals(that: Any): Boolean = that match {
+      case n if that == null => false
+      case that: Object      => this.hashCode() == that.hashCode()
+      case _                 => false
+    }
+
+    // This hashCode is not intended or guaranteed to match Java.
+    override def hashCode(): Int = {
+      var res = 1
+      res = 31 * res + deviceId.##
+      res = 31 * res + inodeNumber.##
+      res
+    }
+
+    override def toString(): String = {
+      /* follow JVM practice of, (hex, decimal). Who knows why they mix
+       * numeric bases.
+       */
+      // Possible truncation of ULong dev_t by .toLong OK. Top bit is always 0.
+      s"(dev=${jl.Long.toHexString(deviceId.toLong)},ino=${inodeNumber})"
+    }
+  }
+
   private def attributes =
     new PosixFileAttributes {
+      private var st_dev: stat.dev_t = _
       private var st_ino: stat.ino_t = _
       private var st_uid: stat.uid_t = _
       private var st_gid: stat.gid_t = _
@@ -101,6 +133,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
         import scala.scalanative.posix.sys.statOps.statOps
 
         // Copy only what is referenced below. Save runtime cycles.
+        st_dev = buf.st_dev
         st_ino = buf.st_ino
         st_uid = buf.st_uid
         st_gid = buf.st_gid
@@ -110,7 +143,10 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
         st_mode = buf.st_mode
       }
 
-      override def fileKey() = st_ino.asInstanceOf[Object]
+      override def fileKey(): Object = new PosixFileKey(
+        deviceId = st_dev,
+        inodeNumber = st_ino
+      )
 
       private lazy val isDir = stat.S_ISDIR(st_mode) == 1
       override def isDirectory() = isDir

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -1592,12 +1592,17 @@ class FilesTest {
       val d0isSym =
         Files.getAttribute(d0, "isSymbolicLink").asInstanceOf[Boolean]
       val d0isOth = Files.getAttribute(d0, "isOther").asInstanceOf[Boolean]
-      val d0fkey = Files.getAttribute(d0, "fileKey")
 
       assertFalse("a2", d0isReg)
       assertTrue("a3", d0isDir)
       assertFalse("a4", d0isSym)
       assertFalse("a5", d0isOth)
+
+      /* The two NotNull fileKey assertions in this Test must change if/when
+       * SN ever implements a file system which returns null fileKeys.
+       */
+      val d0fkey = Files.getAttribute(d0, "fileKey")
+      assertNotNull("fileKey: directory", d0fkey)
 
       val f0mtime =
         Files.getAttribute(f0, "lastModifiedTime").asInstanceOf[FileTime]
@@ -1612,7 +1617,6 @@ class FilesTest {
       val f0isSym =
         Files.getAttribute(f0, "isSymbolicLink").asInstanceOf[Boolean]
       val f0isOth = Files.getAttribute(f0, "isOther").asInstanceOf[Boolean]
-      val f0fkey = Files.getAttribute(f0, "fileKey")
 
       // Last 3 digits tend to be ignored by JVM
       val lastModifiedResolution = 1000
@@ -1626,6 +1630,25 @@ class FilesTest {
       assertFalse("a9", f0isDir)
       assertFalse("a10", f0isSym)
       assertFalse("a11", f0isOth)
+
+      val f0fkey1 = Files.getAttribute(f0, "fileKey")
+      assertNotNull("fileKey 1: file", f0fkey1)
+
+      // fileKeys for different files be different.
+      assertNotEquals("fileKeys should not be equal", d0fkey, f0fkey1)
+
+      val f0fkey2 = Files.getAttribute(f0, "fileKey")
+      assertNotNull("fileKey 2: file", f0fkey2)
+
+      /* fileKeys may or may not be reference equal, depending on
+       * implementaton. fileKeys should, as in _must_, have content equality.
+       */
+      assertEquals(
+        s"fileKeys should be content equal; key1: ${f0fkey1.toString()}," +
+          s" key2: ${f0fkey2.toString()}",
+        f0fkey1,
+        f0fkey2
+      )
     }
   }
 


### PR DESCRIPTION
Fix: #3905 

javalib `java.nio.file.attributes.PosixFileAttributeViewImpl` `fileKey`s now follow the JVM description
of a `fileKey`  as uniquely identifying a file. 