### PR TITLE
fix: javalib many Files.copy methods now use multi-byte I/O

### DIFF
--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -129,7 +129,7 @@ abstract class InputStream extends Closeable {
   /** Java 9
    */
   def transferTo(out: OutputStream): Long = {
-    val limit = 1024
+    val limit = 4096 // sector & page sizes on most architectures circa 2024
     val buffer = new Array[Byte](limit)
 
     var nTransferred = 0L

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -138,17 +138,8 @@ object Files {
     target
   }
 
-  private def copy(in: InputStream, out: OutputStream): Long = {
-    var written: Long = 0L
-    var value: Int = 0
-
-    while ({ value = in.read(); value != -1 }) {
-      out.write(value)
-      written += 1
-    }
-
-    written
-  }
+  private def copy(in: InputStream, out: OutputStream): Long =
+    in.transferTo(out)
 
   def createDirectories(dir: Path, attrs: Array[FileAttribute[_]]): Path =
     if (exists(dir, Array.empty) && !isDirectory(dir, Array.empty))


### PR DESCRIPTION
fix #3914 

* Many javalib `java.nio.file.Files.copy` methods now do multi-byte (bulk) reads and writes. This should lead
   to increased performance and reduced resource when copying files larger than a few bytes.

* The size of an internal buffer in `java.io.InputStream` was increased to correspond to the most prevalent
   disk and page size on hardware architectures circa 2024. This larger buffer allows more bytes can be read or written
   at once, reducing costs.