### PR TITLE
fix [javalib] - Improve handling of symbolic links in `java.nio.file.Files`

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -255,25 +255,9 @@ object Files {
           }
         } else created
       } else {
-        val targetFilename = toCString(target.toAbsolutePath().toString())
-        val linkFilename = toCString(link.toAbsolutePath().toString())
-        if (link.getNameCount() == 1)
-          unistd.symlink(targetFilename, linkFilename) == 0
-        else {
-          val parentDir = link.toAbsolutePath().getParent()
-          createDirectories(parentDir, Array.empty)
-          val dirFD =
-            fcntl.open(toCString(parentDir.toString()), fcntl.O_RDONLY)
-          dirFD > 0 && {
-            try
-              unistd.symlinkat(
-                targetFilename,
-                dirFD,
-                toCString(link.getFileName().toString())
-              ) == 0
-            finally unistd.close(dirFD)
-          }
-        }
+        val targetFilename = toCString(target.toString())
+        val linkFilename = toCString(link.toString())
+        unistd.symlink(targetFilename, linkFilename) == 0
       }
     }
 

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -969,9 +969,7 @@ object Files {
           }
           fromCString(buf)
         }
-        val target = Paths.get(name, Array.empty)
-        if (Files.isSymbolicLink(target)) readSymbolicLink(target)
-        else target
+        Paths.get(name, Array.empty)
       }
 
   def setAttribute(

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -99,7 +99,7 @@ object Files {
     if (attrs.isSymbolicLink() &&
         options.contains(LinkOption.NOFOLLOW_LINKS)) {
       if (targetExists) Files.delete(target)
-      createSymbolicLink(target, source, Array.empty)
+      createSymbolicLink(target, readSymbolicLink(source), Array.empty)
     } else if (isDirectory(source, Array.empty)) {
       createDirectory(target, Array.empty)
     } else {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -920,7 +920,7 @@ class FilesTest {
       val link1 = Files.createSymbolicLink(dir.resolve("link1"), file)
       val link2 = Files.createSymbolicLink(dir.resolve("link2"), link1)
       val link3 =
-        Files.createSymbolicLink(dir.resolve("link3"), Path.of("./link2"))
+        Files.createSymbolicLink(dir.resolve("link3"), Paths.get("./link2"))
 
       assertTrue("a1", Files.exists(file))
       assertTrue("a2", Files.exists(link1))
@@ -929,7 +929,7 @@ class FilesTest {
       assertEquals("read 2", link1, Files.readSymbolicLink(link2))
       assertEquals(
         "read 3",
-        Path.of(".", "link2"),
+        Paths.get(".", "link2"),
         Files.readSymbolicLink(link3)
       )
     }
@@ -1103,9 +1103,12 @@ class FilesTest {
       val link3 =
         Files.copy(link2, dir.resolve("link3"), LinkOption.NOFOLLOW_LINKS)
       val link4 =
-        Files.createSymbolicLink(dir.resolve("link4"), Path.of(".", "link2"))
+        Files.createSymbolicLink(dir.resolve("link4"), Paths.get(".", "link2"))
       val link5 =
-        Files.createSymbolicLink(dir2.resolve("link5"), Path.of("..", "link2"))
+        Files.createSymbolicLink(
+          dir2.resolve("link5"),
+          Paths.get("..", "link2")
+        )
       val link6 = Files.createSymbolicLink(dir.resolve("link6"), link5)
 
       val links = Seq(link1, link2, link3, link4, link5, link6)
@@ -2123,9 +2126,12 @@ class FilesTest {
       val link3 =
         Files.copy(link2, dir.resolve("link3"), LinkOption.NOFOLLOW_LINKS)
       val link4 =
-        Files.createSymbolicLink(dir.resolve("link4"), Path.of(".", "link2"))
+        Files.createSymbolicLink(dir.resolve("link4"), Paths.get(".", "link2"))
       val link5 =
-        Files.createSymbolicLink(dir2.resolve("link5"), Path.of("..", "link2"))
+        Files.createSymbolicLink(
+          dir2.resolve("link5"),
+          Paths.get("..", "link2")
+        )
       val link6 = Files.createSymbolicLink(dir.resolve("link6"), link5)
       Seq(file, link1, link2, link3, link4, link5, link6).foreach { path =>
         assertTrue(s"exists $path", Files.exists(path))


### PR DESCRIPTION
* Use attributes to check for `isDirectory`, `isRegularFile`, `isSymbolicLink` - deduplicates logic 
* Revert special handling in `createSymbolicLink` for relative paths with multiple segments introduced in #3913  - redundant
* Revert fully resolving symbolic link targets in `readSymblicLink` introduced in #3913 - not JVM compiant
* Resolve relative symbolic link targets before checking for their existance - fixes issues when symlink is a relative path with different base then current working directory 
* Skip cycle detection in `Files.walk` if not follow links - not possible to create a cycle without symlinks 
* Fix cycle detection - consider only visited directories