### PR TITLE
fix [javalib]: Fix passing arguments to fallback `/bin/sh -c` command script in Unix process builders

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -209,7 +209,8 @@ object UnixProcessGen1 {
           val bin = toCString(b)
           if (unistd.execve(bin, argv, envp) == -1 && errno == e.ENOEXEC) {
             val al = new ArrayList[String](3)
-            al.add("/bin/sh"); al.add("-c"); al.add(b)
+            al.add("/bin/sh"); al.add("-c");
+            al.add(cmd.scalaOps.mkString(sep = " "))
             val newArgv = nullTerminate(al)
             unistd.execve(c"/bin/sh", newArgv, envp)
           }

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -435,7 +435,8 @@ object UnixProcessGen2 {
           val bin = toCString(b)
           if (unistd.execve(bin, argv, envp) == -1 && errno == ENOEXEC) {
             val al = new ArrayList[String](3)
-            al.add("/bin/sh"); al.add("-c"); al.add(b)
+            al.add("/bin/sh"); al.add("-c")
+            al.add(cmd.scalaOps.mkString(sep = " "))
             val newArgv = nullTerminate(al)
             unistd.execve(c"/bin/sh", newArgv, envp)
           }
@@ -545,7 +546,8 @@ object UnixProcessGen2 {
           unistd.STDERR_FILENO
         )
 
-        val parentFds = new ArrayList[CInt] // No Scala Collections in javalib
+        // No Scala Collections in javalib
+        val parentFds = new ArrayList[CInt](3)
         parentFds.add(!(infds + 1)) // parent's stdout - write, in child
         parentFds.add(!outfds) // parent's stdin - read, in child
         if (!builder.redirectErrorStream())
@@ -580,7 +582,7 @@ object UnixProcessGen2 {
           val fallbackCmd = new ArrayList[String](3)
           fallbackCmd.add("/bin/sh")
           fallbackCmd.add("-c")
-          fallbackCmd.add(exec)
+          fallbackCmd.add(localCmd.scalaOps.mkString(sep = " "))
 
           spawnCommand(builder, fallbackCmd, attempt = 2)
         }

--- a/javalib/src/main/scala/java/util/ScalaOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaOps.scala
@@ -90,7 +90,11 @@ private[java] object ScalaOps {
     @inline def reduceLeft[B >: A](f: (B, A) => B): B =
       __self.iterator().scalaOps.reduceLeft(f)
 
-    @inline def mkString(start: String, sep: String, end: String): String =
+    @inline def mkString(
+        start: String = "",
+        sep: String = "",
+        end: String = ""
+    ): String =
       __self.iterator().scalaOps.mkString(start, sep, end)
   }
 


### PR DESCRIPTION
Fix passing arguments to fallback `/bin/sh -c` command script in Unix `java.lang.Process` implementations. When using `/bin/sh -c` there should be only 1 additional argument. Previously the argument list was discarded