### PR TITLE
chore: Support Scala 3.4.2 and 3.5.0-RC1

### DIFF
--- a/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -20,6 +20,7 @@ class ScalaNativeJUnitPlugin extends StandardPlugin {
   val name: String = "scalanative-junit"
   val description: String = "Makes JUnit test classes invokable in Scala Native"
 
-  def init(options: List[String]): List[PluginPhase] =
+  @annotation.nowarn("cat=deprecation")
+  override def init(options: List[String]): List[PluginPhase] =
     ScalaNativeJUnitBootstrappers() :: Nil
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PostInlineNativeInterop.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PostInlineNativeInterop.scala
@@ -74,7 +74,7 @@ class PostInlineNativeInterop extends PluginPhase with NativeInteropUtil {
         }
         val tpeSym = tpe.typeSymbol
         if (tpe.isAny || tpe.isNothingType || tpe.isNullType ||
-            tpeSym.isAbstractType && !tpeSym.isAllOf(DeferredType | TypeParam))
+            tpeSym.is(DeferredType, butNot = TypeParam))
           report.error(
             s"Stackalloc requires concrete type but ${tpe.show} found",
             tree.srcPos

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -7,6 +7,7 @@ import java.net.URI
 import java.net.URISyntaxException
 import dotty.tools.dotc.core.Contexts.Context
 import java.nio.file.Paths
+import scala.annotation.nowarn
 
 class ScalaNativePlugin extends StandardPlugin:
   val name: String = "scalanative"
@@ -30,6 +31,7 @@ class ScalaNativePlugin extends StandardPlugin:
       |     If none of the patches matches path would be relative to -sourcepath if defined or -sourceroot otherwise.
       """.stripMargin)
 
+  @nowarn("cat=deprecation")
   override def init(options: List[String]): List[PluginPhase] = {
     val genNirSettings = options
       .foldLeft(GenNIR.Settings()) {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -502,7 +502,8 @@ object Build {
     publishSettings(Some(VersionScheme.BreakOnMajor)),
     name := "javalib-intf",
     crossPaths := false,
-    autoScalaLibrary := false
+    autoScalaLibrary := false,
+    scalaVersion := scala3
   )
 
   lazy val javalibExtDummies =

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -21,13 +21,17 @@ object ScalaVersions {
   val crossScala212 = crossScalaVersions("2.12.", 14 to 19)
   val crossScala213 = crossScalaVersions("2.13.", 8 to 14)
   val crossScala3 = List(
+    extraCrossScalaVersion("3.").toList,
+    scala3RCVersions,
     // windowslib fails to compile with 3.1.{0-1}
     (2 to 3).map(v => s"3.1.$v"),
     (0 to 2).map(v => s"3.2.$v"),
     (0 to 3).map(v => s"3.3.$v"),
-    (0 to 1).map(v => s"3.4.$v"),
-    extraCrossScalaVersion("3.").toList
+    (0 to 2).map(v => s"3.4.$v")
   ).flatten.distinct
+
+  // Tested in scheduled nightly CI to check compiler plugins
+  lazy val scala3RCVersions = List("3.5.0-RC1")
 
   // Scala versions used for publishing libraries
   val scala212: String = crossScala212.last

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -599,7 +599,8 @@ object Settings {
     libraryDependencies ++= Deps.compilerPluginDependencies(scalaVersion.value),
     publishSettings(None),
     mavenPublishSettings,
-    exportJars := true
+    exportJars := true,
+    scalacOptions --= Seq("-deprecation", "-Xfatal-warnings")
   )
 
   lazy val sbtPluginSettings = Def.settings(
@@ -734,6 +735,7 @@ object Settings {
         scalaNativeCompilerOptions(
           s"positionRelativizationPaths:${crossTarget.value / "patched"};${(fetchScalaSource / artifactPath).value}"
         ),
+      scalacOptions --= Seq("-deprecation", "-Xfatal-warnings"),
       // Scala.js original comment modified to clarify issue is Scala.js.
       /* Work around for https://github.com/scala-js/scala-js/issues/2649
        * We would like to always use `update`, but

--- a/scalalib/overrides-3.4/scala/runtime/LazyVals.scala.patch
+++ b/scalalib/overrides-3.4/scala/runtime/LazyVals.scala.patch
@@ -1,4 +1,4 @@
---- 3.5.0-RC1/scala/runtime/LazyVals.scala
+--- 3.4.0/scala/runtime/LazyVals.scala
 +++ overrides-3/scala/runtime/LazyVals.scala
 @@ -4,44 +4,15 @@
  
@@ -13,7 +13,7 @@
   */
  object LazyVals {
 -  @nowarn
--  private val unsafe: sun.misc.Unsafe = {
+-  private[this] val unsafe: sun.misc.Unsafe = {
 -    def throwInitializationException() =
 -      throw new ExceptionInInitializerError(
 -        new IllegalStateException("Can't find instance of sun.misc.Unsafe")

--- a/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
@@ -97,10 +97,10 @@ private[codegen] object PerfectHashMap {
 
           Some(
             buckets
-              .filter(bucket => bucket.size == 1)
+              .collect { case Seq(elem) => elem }
               .zip(freeList)
               .foldLeft((keys, values)) {
-                case ((accKeys, accValues), (Seq(elem), freeValue)) =>
+                case ((accKeys, accValues), (elem, freeValue)) =>
                   val keyIndex = mod(hashFunc(elem, 0), hashMapSize)
                   val keyValue = -freeValue - 1
                   val valueIndex = freeValue


### PR DESCRIPTION
* Add Scala 3.4.2 to build (default Scala 3 version).
* Test next major Scala 3 version in CI.
* Ignore compilation warnings in scalalib and nscplugin
* Update scaallib patches for Scala 3.5