### PR TITLE
add whitespace to exception error message

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -205,7 +205,7 @@ object Discover {
           .map(envPath => s"or via '$envPath' environment variable")
           .getOrElse("")
         throw new BuildException(
-          s"""'$binaryName' not found in PATH$envMessage.
+          s"""'$binaryName' not found in PATH $envMessage.
             |Please refer to ($docSetup)""".stripMargin
         )
       }


### PR DESCRIPTION
While trying to run scala-cli, I was hit by this error

```scala
scala-cli test.sc --native
Downloading compiler plugin org.scala-native:::nscplugin:0.4.17
Downloading Scala Native CLI
Downloading 2 dependencies
Error: scala.scalanative.build.BuildException: 'clang' not found in PATHor via 'LLVM_BIN' environment variable.
Please refer to (http://www.scala-native.org/en/latest/user/setup.html)
```
Notice the missing whitespace between "PATH" and "or"