### PR TITLE
fix: reduce the chance of ld complaining of no .note.GNU-stack

### DIFF
--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd32.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd32.S
@@ -137,6 +137,7 @@ __lh_get_sp:
   ret
 
 #endif
+#endif
 
 #if defined(__linux__) && defined(__ELF__)
 /* Reference:
@@ -145,5 +146,4 @@ __lh_get_sp:
 
 .section .note.GNU-stack,"",%progbits
 
-#endif
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_amd64.S
@@ -114,6 +114,7 @@ __lh_get_sp:
   ret
 
 #endif
+#endif
 
 #if defined(__linux__) && defined(__ELF__)
 /* Reference:
@@ -122,5 +123,4 @@ __lh_get_sp:
 
 .section .note.GNU-stack,"",%progbits
 
-#endif
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_arm64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_arm64.S
@@ -131,7 +131,8 @@ _lh_get_sp:
     ret
 
 #endif
-
+#endif
+	
 #if defined(__linux__) && defined(__ELF__)
 /* Reference:
  *   https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
@@ -139,5 +140,4 @@ _lh_get_sp:
 
 .section .note.GNU-stack,"",%progbits
 
-#endif
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
@@ -157,4 +157,3 @@ __lh_get_sp:
 .section .note.GNU-stack,"",%progbits
 
 #endif
-	

--- a/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
+++ b/nativelib/src/main/resources/scala-native/delimcc/setjmp_x64.S
@@ -147,6 +147,7 @@ __lh_get_sp:
   ret
 
 #endif
+#endif
 
 #if defined(__linux__) && defined(__ELF__)
 /* Reference:
@@ -156,4 +157,4 @@ __lh_get_sp:
 .section .note.GNU-stack,"",%progbits
 
 #endif
-#endif
+	


### PR DESCRIPTION
PR #3926 is a better & stronger fix.

<hr> 
Quick fix  #3916

Reduce the chance that the linux GNU `ld.bfs` linker will complain about a missing `.note.GNU-stack` section 
by ensuring that all `setjmp_*.S` files unconditionally provide such a section on linux GNU.

Traditionally GCC & Clang provided such a section for `.c` and `.cpp` files but not for `.S` files.
Current (clang >= 18 or so, perhaps gcc 13) may provide such.
Having the `setjmp_*.S` code always provide it decreases linker warnings when a compiler
which does not automagically generate such for .S files is used.

1) I _did_not_ check the various "*unwind*.S" files because I have never seen `ld.bfd` complain
    about them. They may be an issue there.

2) This PR is a 'reduction in strength" fix. It _does_ not address the `primum mobile` (prime mover; essential) 
     problem with architecture specific files being presented to the compiler.  
     See Issue #3916 for a discussion of a mid-range solution. 