### PR TITLE
HttpCookie and its tests

### DIFF
--- a/javalib/src/main/scala/java/net/HttpCookie.scala
+++ b/javalib/src/main/scala/java/net/HttpCookie.scala
@@ -1,0 +1,374 @@
+package java.net
+
+import java.util.ArrayList
+
+object HttpCookie {
+
+  def domainMatches(domain: String, host: String): Boolean = {
+    val effectiveHost = if (host.indexOf('.') == -1) {
+      host + ".local"
+    } else
+      host
+
+    val domainL = domain.toLowerCase
+    val hostL = host.toLowerCase
+
+    val exactMatch = domainL == hostL
+    // a host is a subdomain if it ends with the domain, and
+    // the character preceeding the domain suffix is a dot
+    val hostIsSubdomain = hostL.endsWith("." + domainL)
+
+    domainL == hostL || hostIsSubdomain
+
+  }
+
+  private[HttpCookie] val Discard = "Discard"
+  private[HttpCookie] val Comment = "Comment"
+  private[HttpCookie] val CommentURL = "CommentURL"
+  private[HttpCookie] val Domain = "Domain"
+  private[HttpCookie] val MaxAge = "Max-Age"
+  private[HttpCookie] val Path = "Path"
+  private[HttpCookie] val Port = "Port"
+  private[HttpCookie] val Secure = "Secure"
+  private[HttpCookie] val Version = "Version"
+  private[HttpCookie] val HttpOnly = "HttpOnly"
+
+  def parse(header: String): java.util.List[HttpCookie] = {
+
+    val cookies = new ArrayList[HttpCookie]()
+
+    if (header == null)
+      throw new NullPointerException()
+    else if (header == "")
+      cookies
+    else {
+
+      val nameless =
+        if (header.regionMatches(false, 0, "set-cookie2:", 0, 12)) {
+          header.substring(12)
+        } else if (header.regionMatches(false, 0, "set-cookie:", 0, 11))
+          header.substring(11)
+        else
+          header
+
+      val unprocessed = splitUnquotedAt(nameless, ',')
+
+      var i = 0
+      while (i < unprocessed.size) {
+        val kv = unprocessed.get(i)
+        val eqIndex = kv.indexOf("=")
+        val name = kv.substring(0, eqIndex)
+        val value = kv.substring(eqIndex + 1)
+
+        val cookie = parseValue(name.trim(), unquote(value.trim()))
+        if (cookie != null) {
+          cookies.add(cookie)
+        }
+
+        i += 1
+
+      }
+
+    }
+
+    cookies
+
+  }
+
+  // Splits the string at the given character,
+  // however it also respects quoted strings, i.e.
+  // occurences of the separator inside quoted strings
+  // won't trigger a split
+  // backslash also escapes double quotes inside the string
+  private def splitUnquotedAt(
+      in: String,
+      separator: Char
+  ): java.util.List[String] = {
+
+    val res = new ArrayList[String]()
+    if (in == "") {
+      res
+    } else {
+
+      var i = 0
+      var begin = 0
+      var inQuotes = false
+      var escaping = false
+
+      while (i < in.length()) {
+
+        val char = in.charAt(i)
+
+        if (char == separator && !inQuotes) {
+          res.add(in.substring(begin, i))
+          begin = i + 1
+        } else if (char == '\\' && inQuotes && !escaping) {
+          escaping = true
+        } else if (char == '"' && inQuotes && !escaping) {
+          inQuotes = false
+        } else if (char == '"' && !inQuotes) {
+          inQuotes = true
+        }
+
+        i += 1
+
+      }
+
+      res.add(in.substring(begin))
+
+      res
+    }
+  }
+
+  private def unquote(in: String): String = {
+    if (in.charAt(0) == '"' && in.charAt(in.length() - 1) == '"') {
+      in.substring(1, in.length() - 1)
+    } else in
+  }
+
+  private def parseValue(name: String, value: String): HttpCookie = {
+
+    val attrs = splitUnquotedAt(value, ';')
+
+    if (attrs.size() == 0) {
+      new HttpCookie(name, "")
+    } else {
+
+      val value = attrs.get(0)
+
+      val cookie = new HttpCookie(name, unquote(value.trim()))
+
+      var i = 1
+      while (i < attrs.size()) {
+
+        val prop = attrs.get(i).trim()
+
+        val sep = prop.indexOf('=')
+
+        val propValue: String = if (sep == -1) {
+          null
+        } else {
+          unquote(prop.substring(sep + 1).trim())
+        }
+
+        val propName =
+          if (sep == -1)
+            prop
+          else {
+            prop.substring(0, sep).trim()
+          }
+
+        if (propName.regionMatches(true, 0, Discard, 0, Discard.length())) {
+          cookie.setDiscard(true)
+
+          // We have to check commenturl before comment because comment matches commenturl
+        } else if (propName.regionMatches(
+              true,
+              0,
+              CommentURL,
+              0,
+              CommentURL.length()
+            )) {
+          cookie.setCommentURL(propValue)
+        } else if (propName.regionMatches(
+              true,
+              0,
+              Comment,
+              0,
+              Comment.length()
+            )) {
+          cookie.setComment(propValue)
+        } else if (propName.regionMatches(
+              true,
+              0,
+              Domain,
+              0,
+              Domain.length()
+            )) {
+          cookie.setDomain(propValue)
+        } else if (propName.regionMatches(
+              true,
+              0,
+              MaxAge,
+              0,
+              MaxAge.length()
+            )) {
+          try {
+            cookie.setMaxAge(java.lang.Long.valueOf(propValue))
+          } catch {
+            case _: NumberFormatException =>
+              throw new IllegalArgumentException(
+                "Illegal cookie max-age attribute"
+              )
+          }
+        } else if (propName.regionMatches(true, 0, Path, 0, Path.length())) {
+          cookie.setPath(propValue)
+        } else if (propName.regionMatches(true, 0, Port, 0, Port.length())) {
+          cookie.setPortlist(propValue)
+        } else if (propName.regionMatches(
+              true,
+              0,
+              Secure,
+              0,
+              Secure.length()
+            )) {
+          cookie.setSecure(true)
+        } else if (propName.regionMatches(
+              true,
+              0,
+              HttpOnly,
+              0,
+              HttpOnly.length()
+            )) {
+          cookie.setHttpOnly(true)
+        } else if (propName.regionMatches(
+              true,
+              0,
+              Version,
+              0,
+              Version.length()
+            )) {
+          try {
+            cookie.setVersion(java.lang.Integer.valueOf(propValue))
+          } catch {
+            case _: NumberFormatException =>
+              throw new IllegalArgumentException(
+                "Illegal cookie max-age attribute"
+              )
+          }
+        }
+
+        i += 1
+
+      }
+
+      cookie
+
+    }
+
+  }
+
+  // NAME = attr
+  // attr = token
+  // token = 1*<any CHAR except CTLs or separators>
+  // separators = "(" | ")" | "<" | ">" | "@"
+  //                | "," | ";" | ":" | "\" | <">
+  //                | "/" | "[" | "]" | "?" | "="
+  //                | "{" | "}" | SP | HT
+  // CHAR = <any US-ASCII character (octets 0 - 127)>
+  // CTL = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+  private def validateName(name: String): String = {
+    if (name.length == 0)
+      throw new IllegalArgumentException("Illegal cookie name")
+
+    var i = 0
+    while (i < name.length()) {
+      val char = name.charAt(i)
+      if (char < 32 || // CTL
+          char == 127 || // CTL
+          char == '(' ||
+          char == ')' ||
+          char == '<' ||
+          char == '>' ||
+          char == '@' ||
+          char == ',' ||
+          char == ';' ||
+          char == ':' ||
+          char == '\\' ||
+          char == '"' ||
+          char == '/' ||
+          char == '[' ||
+          char == ']' ||
+          char == '?' ||
+          char == '=' ||
+          char == '{' ||
+          char == '}' ||
+          char == ' ' ||
+          char == '\t') {
+        throw new IllegalArgumentException("Illegal cookie name")
+      }
+
+      i += 1
+    }
+
+    name
+
+  }
+
+}
+
+final class HttpCookie private (
+    private var _comment: String = null,
+    private var _commentURL: String = null,
+    private var _httpOnly: Boolean = false,
+    private var _discard: Boolean = false,
+    private var _domain: String = null,
+    private var _maxAge: Long = -1,
+    private var _name: String = null,
+    private var _path: String = null,
+    private var _portlist: String = null,
+    private var _secure: Boolean = false,
+    private var _value: String = null,
+    private var _version: Int = 1
+) extends Cloneable {
+
+  def this(name: String, value: String) = {
+    this(
+      _name =
+        (if (name.length() == 0) {
+           throw new IllegalArgumentException("Illegal cookie name")
+         } else
+           HttpCookie.validateName(name)),
+      _value = value
+    )
+  }
+
+  override def equals(obj: Any): Boolean = {
+
+    if (obj.isInstanceOf[HttpCookie]) {
+      val other = obj.asInstanceOf[HttpCookie]
+      this.getComment().equals(other.getComment()) &&
+        this.getCommentURL().equals(other.getCommentURL()) &&
+        this.isHttpOnly().equals(other.isHttpOnly()) &&
+        this.getDiscard().equals(other.getDiscard()) &&
+        this.getDomain().equals(other.getDomain()) &&
+        this.getMaxAge().equals(other.getMaxAge()) &&
+        this.getName().equals(other.getName()) &&
+        this.getPath().equals(other.getPath()) &&
+        this.getPortlist().equals(other.getPortlist()) &&
+        this.getSecure().equals(other.getSecure()) &&
+        this.getValue().equals(other.getValue()) &&
+        this.getVersion().equals(other.getVersion())
+    } else {
+      false
+    }
+
+  }
+
+  def getComment(): String = this._comment
+  def getCommentURL(): String = this._commentURL
+  def getDiscard(): Boolean = this._discard
+  def getDomain(): String = this._domain
+  def getMaxAge(): Long = this._maxAge
+  def getName(): String = this._name
+  def getPath(): String = this._path
+  def getPortlist(): String = this._portlist
+  def getSecure(): Boolean = this._secure
+  def getValue(): String = this._value
+  def getVersion(): Int = this._version
+  def hasExpired(): Boolean = this._maxAge == 0
+  override def hashCode(): Int = toString().hashCode()
+  def isHttpOnly(): Boolean = this._httpOnly
+  def setComment(purpose: String): Unit = this._comment = purpose
+  def setCommentURL(purpose: String): Unit = this._commentURL = purpose
+  def setDiscard(discard: Boolean): Unit = this._discard = discard
+  def setDomain(pattern: String): Unit = this._domain = pattern
+  def setHttpOnly(httpOnly: Boolean): Unit = this._httpOnly = httpOnly
+  def setMaxAge(expiry: Long): Unit = this._maxAge = expiry
+  def setPath(uri: String): Unit = this._path = uri
+  def setPortlist(ports: String): Unit = this._portlist = ports
+  def setSecure(flag: Boolean): Unit = this._secure = flag
+  def setValue(newValue: String): Unit = this._value = newValue
+  def setVersion(v: Int): Unit = this._version = v
+  override def toString(): String = _name + "=" + _value
+}

--- a/javalib/src/main/scala/java/net/HttpCookie.scala
+++ b/javalib/src/main/scala/java/net/HttpCookie.scala
@@ -1,6 +1,9 @@
 package java.net
 
 import java.util.ArrayList
+import java.util.Arrays
+import scala.annotation.switch
+import java.util.Collections
 
 object HttpCookie {
 
@@ -16,32 +19,19 @@ object HttpCookie {
     val exactMatch = domainL == hostL
     // a host is a subdomain if it ends with the domain, and
     // the character preceeding the domain suffix is a dot
-    val hostIsSubdomain = hostL.endsWith("." + domainL)
+    def hostIsSubdomain = hostL.endsWith("." + domainL)
 
-    domainL == hostL || hostIsSubdomain
+    exactMatch || hostIsSubdomain
 
   }
 
-  private final val Discard = "Discard"
-  private final val Comment = "Comment"
-  private final val CommentURL = "CommentURL"
-  private final val Domain = "Domain"
-  private final val MaxAge = "Max-Age"
-  private final val Path = "Path"
-  private final val Port = "Port"
-  private final val Secure = "Secure"
-  private final val Version = "Version"
-  private final val HttpOnly = "HttpOnly"
-
   def parse(header: String): java.util.List[HttpCookie] = {
-
-    val cookies = new ArrayList[HttpCookie]()
-
     if (header == null)
       throw new NullPointerException()
     else if (header == "")
-      cookies
+      Collections.emptyList()
     else {
+      val cookies = new ArrayList[HttpCookie]()
 
       val nameless =
         if (header.regionMatches(false, 0, "set-cookie2:", 0, 12)) {
@@ -53,10 +43,10 @@ object HttpCookie {
 
       val unprocessed = splitUnquotedAt(nameless, ',')
 
-      var i = 0
-      while (i < unprocessed.size()) {
-        val kv = unprocessed.get(i)
+      unprocessed.forEach { kv =>
+
         val eqIndex = kv.indexOf("=")
+        require(eqIndex >= 0, "Invalid cookie name-value pair")
         val name = kv.substring(0, eqIndex)
         val value = kv.substring(eqIndex + 1)
 
@@ -64,15 +54,10 @@ object HttpCookie {
         if (cookie != null) {
           cookies.add(cookie)
         }
-
-        i += 1
-
       }
 
+      cookies
     }
-
-    cookies
-
   }
 
   // Splits the string at the given character,
@@ -102,11 +87,18 @@ object HttpCookie {
         if (char == separator && !inQuotes) {
           res.add(in.substring(begin, i))
           begin = i + 1
-        } else if (char == '\\' && inQuotes && !escaping) {
-          escaping = true
-        } else if (char == '"' && inQuotes && !escaping) {
-          inQuotes = false
-        } else if (char == '"' && !inQuotes) {
+        } else if (inQuotes) {
+          if (!escaping) {
+            char match {
+              case '\\' => escaping = true
+              case '"'  => inQuotes = false
+              case _    => ()
+            }
+          } else {
+            escaping = false
+          }
+
+        } else if (char == '"') {
           inQuotes = true
         }
 
@@ -114,7 +106,8 @@ object HttpCookie {
 
       }
 
-      res.add(in.substring(begin))
+      if (begin < in.length())
+        res.add(in.substring(begin))
 
       res
     }
@@ -144,10 +137,10 @@ object HttpCookie {
     } else {
 
       val value = attrs.get(0)
-
       val cookie = new HttpCookie(name, unquote(value.trim()))
 
       var i = 1
+
       while (i < attrs.size()) {
 
         val prop = attrs.get(i).trim()
@@ -167,100 +160,49 @@ object HttpCookie {
             prop.substring(0, sep).trim()
           }
 
-        if (propName.regionMatches(true, 0, Discard, 0, Discard.length())) {
-          cookie.setDiscard(true)
-
-          // We have to check commenturl before comment because comment matches commenturl
-        } else if (propName.regionMatches(
-              true,
-              0,
-              CommentURL,
-              0,
-              CommentURL.length()
-            )) {
-          cookie.setCommentURL(propValue)
-        } else if (propName.regionMatches(
-              true,
-              0,
-              Comment,
-              0,
-              Comment.length()
-            )) {
-          cookie.setComment(propValue)
-        } else if (propName.regionMatches(
-              true,
-              0,
-              Domain,
-              0,
-              Domain.length()
-            )) {
-          cookie.setDomain(propValue)
-        } else if (propName.regionMatches(
-              true,
-              0,
-              MaxAge,
-              0,
-              MaxAge.length()
-            )) {
-          try {
-            cookie.setMaxAge(java.lang.Long.valueOf(propValue))
-          } catch {
-            case _: NumberFormatException =>
-              throw new IllegalArgumentException(
-                "Illegal cookie max-age attribute"
-              )
-          }
-        } else if (propName.regionMatches(true, 0, Path, 0, Path.length())) {
-          cookie.setPath(propValue)
-        } else if (propName.regionMatches(true, 0, Port, 0, Port.length())) {
-          cookie.setPortlist(propValue)
-        } else if (propName.regionMatches(
-              true,
-              0,
-              Secure,
-              0,
-              Secure.length()
-            )) {
-          cookie.setSecure(true)
-        } else if (propName.regionMatches(
-              true,
-              0,
-              HttpOnly,
-              0,
-              HttpOnly.length()
-            )) {
-          cookie.setHttpOnly(true)
-        } else if (propName.regionMatches(
-              true,
-              0,
-              Version,
-              0,
-              Version.length()
-            )) {
-          try {
-            val value = java.lang.Integer.valueOf(propValue)
-            if (value != 0 && value != 1) {
-              throw new IllegalArgumentException(
-                "cookie version should be 0 or 1"
-              )
+        propName.toLowerCase() match {
+          case "discard" =>
+            cookie.setDiscard(true)
+          case "comment" =>
+            cookie.setComment(propValue)
+          case "commenturl" =>
+            cookie.setCommentURL(propValue)
+          case "domain" =>
+            cookie.setDomain(propValue)
+          case "max-age" =>
+            try {
+              cookie.setMaxAge(java.lang.Long.valueOf(propValue))
+            } catch {
+              case _: NumberFormatException =>
+                throw new IllegalArgumentException(
+                  "Illegal cookie max-age attribute"
+                )
             }
-            cookie.setVersion(value)
-          } catch {
-            case _: NumberFormatException =>
-              throw new IllegalArgumentException(
-                "Illegal cookie max-age attribute"
-              )
-          }
+          case "path" =>
+            cookie.setPath(propValue)
+          case "port" =>
+            cookie.setPortlist(propValue)
+          case "secure" =>
+            cookie.setSecure(true)
+          case "version" =>
+            try {
+              val value = java.lang.Integer.valueOf(propValue)
+              cookie.setVersion(value)
+            } catch {
+              case _: NumberFormatException =>
+                throw new IllegalArgumentException(
+                  "Illegal cookie max-age attribute"
+                )
+            }
+          case "httponly" =>
+            cookie.setHttpOnly(true)
+          case _ => ()
         }
 
         i += 1
-
       }
-
       cookie
-
     }
-
   }
 
   // NAME = attr
@@ -274,76 +216,47 @@ object HttpCookie {
   // CTL = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
   //
   // stricter than the JVM, for better or worse
-  private def validateName(name: String): String = {
+  private def validateName(name: String): Unit = {
     // Testing the $ as that's what the JVM
     // seems to do
     if (name.length == 0 || name.charAt(0) == '$')
       throw new IllegalArgumentException("Illegal cookie name")
 
-    var i = 0
-    while (i < name.length()) {
-      val char = name.charAt(i)
-      if (char < 32 || // CTL
-          char == 127 || // CTL
-          char == '(' ||
-          char == ')' ||
-          char == '<' ||
-          char == '>' ||
-          char == '@' ||
-          char == ',' ||
-          char == ';' ||
-          char == ':' ||
-          char == '\\' ||
-          char == '"' ||
-          char == '/' ||
-          char == '[' ||
-          char == ']' ||
-          char == '?' ||
-          char == '=' ||
-          char == '{' ||
-          char == '}' ||
-          char == ' ' ||
-          char == '\t') {
-        throw new IllegalArgumentException("Illegal cookie name")
+    name.foreach { char =>
+      val isIllegal = (char: @switch) match {
+        case 127 | '(' | ')' | '<' | '>' | '@' | ',' | ';' | ':' | '\\' | '"' |
+            '/' | '[' | ']' | '?' | '=' | '{' | '}' | ' ' | '\t' =>
+          true
+        case char => char < 32
       }
-
-      i += 1
+      if (isIllegal) throw new IllegalArgumentException("Illegal cookie name")
     }
-
-    name
-
   }
 
 }
 
 /** HttpCookie */
 final class HttpCookie private (
-    private val createdAtEpochSecond: Long,
-    private var _comment: String = null,
-    private var _commentURL: String = null,
-    private var _httpOnly: Boolean = false,
-    private var _discard: Boolean = false,
-    private var _domain: String = null,
-    private var _maxAge: Long = -1,
-    private var _name: String = null,
-    private var _path: String = null,
-    private var _portlist: String = null,
-    private var _secure: Boolean = false,
-    private var _value: String = null,
-    private var _version: Int = 1
+    private val _name: String = null,
+    private var _value: String = null
 ) extends Cloneable {
 
-  def this(name: String, value: String) = {
-    this(
-      System.currentTimeMillis() % 1000,
-      _name =
-        (if (name.length() == 0) {
-           throw new IllegalArgumentException("Illegal cookie name")
-         } else
-           HttpCookie.validateName(name)),
-      _value = value
-    )
-  }
+  if (_name.isEmpty())
+    throw new IllegalArgumentException("Illegal cookie name")
+
+  HttpCookie.validateName(_name)
+
+  private val createdAtEpochMillis: Long = System.currentTimeMillis()
+  private var _comment: String = null
+  private var _commentURL: String = null
+  private var _httpOnly: Boolean = false
+  private var _discard: Boolean = false
+  private var _domain: String = null
+  private var _maxAge: Long = -1
+  private var _path: String = null
+  private var _portlist: String = null
+  private var _secure: Boolean = false
+  private var _version: Int = 1
 
   def canEqual(other: Any): Boolean =
     other.isInstanceOf[HttpCookie]
@@ -364,20 +277,9 @@ final class HttpCookie private (
   override def equals(obj: Any): Boolean =
     obj match {
       case other: HttpCookie =>
-        super.equals(other) &&
-          canEqual(other) &&
-          this.getName() == other.getName() &&
-          this.getValue() == other.getValue() &&
-          this.getComment() == other.getComment() &&
-          this.getCommentURL() == other.getCommentURL() &&
-          this.isHttpOnly() == other.isHttpOnly() &&
-          this.getDiscard() == other.getDiscard() &&
-          this.getDomain() == other.getDomain() &&
-          this.getMaxAge() == other.getMaxAge() &&
-          this.getPath() == other.getPath() &&
-          this.getPortlist() == other.getPortlist() &&
-          this.getSecure() == other.getSecure() &&
-          this.getVersion() == other.getVersion()
+        this.getName().equalsIgnoreCase(other.getName()) &&
+          this.getDomain().equalsIgnoreCase(other.getDomain()) &&
+          this.getPath().equalsIgnoreCase(other.getPath())
 
       case _ => false
     }
@@ -393,21 +295,29 @@ final class HttpCookie private (
   def getSecure(): Boolean = this._secure
   def getValue(): String = this._value
   def getVersion(): Int = this._version
-  def hasExpired(): Boolean = {
-    _maxAge >= 0 && ((System
-      .currentTimeMillis() % 1000) >= (createdAtEpochSecond + _maxAge))
-  }
+  def hasExpired(): Boolean =
+    _maxAge >= 0 &&
+      (_maxAge == 0 || System
+        .currentTimeMillis() >= createdAtEpochMillis + _maxAge * 1000)
+
   def isHttpOnly(): Boolean = this._httpOnly
   def setComment(purpose: String): Unit = this._comment = purpose
   def setCommentURL(purpose: String): Unit = this._commentURL = purpose
   def setDiscard(discard: Boolean): Unit = this._discard = discard
-  def setDomain(pattern: String): Unit = this._domain = pattern
+  def setDomain(pattern: String): Unit = this._domain = pattern.toLowerCase()
   def setHttpOnly(httpOnly: Boolean): Unit = this._httpOnly = httpOnly
   def setMaxAge(expiry: Long): Unit = this._maxAge = expiry
   def setPath(uri: String): Unit = this._path = uri
   def setPortlist(ports: String): Unit = this._portlist = ports
   def setSecure(flag: Boolean): Unit = this._secure = flag
   def setValue(newValue: String): Unit = this._value = newValue
-  def setVersion(v: Int): Unit = this._version = v
+  def setVersion(v: Int): Unit = {
+    if (v != 0 && v != 1) {
+      throw new IllegalArgumentException(
+        "cookie version should be 0 or 1"
+      )
+    }
+    this._version = v
+  }
 
 }

--- a/javalib/src/main/scala/java/net/HttpCookie.scala
+++ b/javalib/src/main/scala/java/net/HttpCookie.scala
@@ -120,23 +120,21 @@ object HttpCookie {
     }
   }
 
-  /**
-  * If the string begins and ends with quotes - remove them,
-  * otherwise return the input
-  */
+  /** If the string begins and ends with quotes - remove them, otherwise return
+   *  the input
+   */
   private def unquote(in: String): String = {
     if (in.charAt(0) == '"' && in.charAt(in.length() - 1) == '"') {
       in.substring(1, in.length() - 1)
     } else in
   }
 
-  /**
-  * performs parsing on the section of the cookie following the cookie name,
-  * and constructs the resulting cookie.
-  * If the given value contains multiple cookies - this method will break,
-  * so any input into this method must be pre-processed such that  
-  * only the section that pertains to a single cookie is fed into this method
-  */
+  /** performs parsing on the section of the cookie following the cookie name,
+   *  and constructs the resulting cookie. If the given value contains multiple
+   *  cookies - this method will break, so any input into this method must be
+   *  pre-processed such that only the section that pertains to a single cookie
+   *  is fed into this method
+   */
   private def parseValue(name: String, value: String): HttpCookie = {
 
     val attrs = splitUnquotedAt(value, ';')
@@ -240,9 +238,11 @@ object HttpCookie {
               Version.length()
             )) {
           try {
-            val value =  java.lang.Integer.valueOf(propValue)
+            val value = java.lang.Integer.valueOf(propValue)
             if (value != 0 && value != 1) {
-              throw new IllegalArgumentException("cookie version should be 0 or 1")
+              throw new IllegalArgumentException(
+                "cookie version should be 0 or 1"
+              )
             }
             cookie.setVersion(value)
           } catch {
@@ -330,7 +330,7 @@ final class HttpCookie private (
     private var _portlist: String = null,
     private var _secure: Boolean = false,
     private var _value: String = null,
-    private var _version: Int = 1,
+    private var _version: Int = 1
 ) extends Cloneable {
 
   def this(name: String, value: String) = {
@@ -345,7 +345,7 @@ final class HttpCookie private (
     )
   }
 
-  def canEqual(other: Any): Boolean = 
+  def canEqual(other: Any): Boolean =
     other.isInstanceOf[HttpCookie]
 
   override def hashCode(): Int = {
@@ -361,9 +361,9 @@ final class HttpCookie private (
   }
 
   override def toString(): String = _name + "=" + _value
-  override def equals(obj: Any): Boolean = 
+  override def equals(obj: Any): Boolean =
     obj match {
-      case other: HttpCookie => 
+      case other: HttpCookie =>
         super.equals(other) &&
           canEqual(other) &&
           this.getName() == other.getName() &&
@@ -394,7 +394,8 @@ final class HttpCookie private (
   def getValue(): String = this._value
   def getVersion(): Int = this._version
   def hasExpired(): Boolean = {
-    _maxAge >= 0 && ((System.currentTimeMillis() % 1000) >= (createdAtEpochSecond + _maxAge))
+    _maxAge >= 0 && ((System
+      .currentTimeMillis() % 1000) >= (createdAtEpochSecond + _maxAge))
   }
   def isHttpOnly(): Boolean = this._httpOnly
   def setComment(purpose: String): Unit = this._comment = purpose

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/HttpCookieTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/HttpCookieTest.scala
@@ -48,6 +48,22 @@ class HttpCookieTest {
   }
 
   @Test
+  def stringEscapingTest(): Unit = {
+    val out =
+      HttpCookie.parse("set-cookie2:potato=\"toma\\\"t,o=asdf\",second=second")
+    assertEquals("number of cookies", out.size(), 2)
+    val cookieOne = out.get(0)
+    assertCookie(
+      cookieOne,
+      "cookie one",
+      name = "potato",
+      value = "toma\\\"t,o=asdf"
+    )
+    val cookieTwo = out.get(1)
+    assertCookie(cookieTwo, "cookie two", name = "second", value = "second")
+  }
+
+  @Test
   def attributeTest(): Unit = {
     val out = HttpCookie.parse("""set-cookie2: 
                                |potato = tomato ; 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/HttpCookieTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/HttpCookieTest.scala
@@ -10,8 +10,8 @@ import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 class HttpCookieTest {
 
   // label parameter gets added to the clue field on assertions
-    def assertCookie(
-    testSubject: HttpCookie,
+  def assertCookie(
+      testSubject: HttpCookie,
       label: String,
       name: String,
       value: String,
@@ -23,9 +23,9 @@ class HttpCookieTest {
       path: String = null,
       portlist: String = null,
       secure: Boolean = false,
-      version: Int = 1 
-          ): Unit = {
-              
+      version: Int = 1
+  ): Unit = {
+
     assertEquals(s"$label: name", name, testSubject.getName())
     assertEquals(s"$label: value", value, testSubject.getValue())
     assertEquals(s"$label: comment", comment, testSubject.getComment())
@@ -37,8 +37,7 @@ class HttpCookieTest {
     assertEquals(s"$label: portlist", portlist, testSubject.getPortlist())
     assertEquals(s"$label: secure", secure, testSubject.getSecure())
     assertEquals(s"$label: version", version, testSubject.getVersion())
-            }
-
+  }
 
   @Test
   def basicParseTest(): Unit = {
@@ -72,8 +71,8 @@ class HttpCookieTest {
       value = "tomato",
       comment = "This is a comment",
       discard = true,
-      commentUrl =  "https://definitely.real.website.cool/",
-      domain =  "definitely.real.webiste.cool",
+      commentUrl = "https://definitely.real.website.cool/",
+      domain = "definitely.real.webiste.cool",
       maxAge = 123,
       path = "/potato/tomato",
       portlist = "123 456 789",
@@ -85,14 +84,17 @@ class HttpCookieTest {
 
   @Test
   def multipleCookieTest(): Unit = {
-    val out = HttpCookie.parse("""set-cookie2: 
+    val out = HttpCookie.parse(
+      """set-cookie2: 
                                |potato = tomato ; 
                                |comment = "This is a comment"; 
                                |discard,
                                |second="second";
                                |secure,
                                |third=third;
-                               |comment = "This is the third cookie" """.stripMargin.replaceAll("\n", ""))
+                               |comment = "This is the third cookie" """.stripMargin
+        .replaceAll("\n", "")
+    )
 
     assertEquals("number of cookies", out.size(), 3)
     assertCookie(
@@ -148,7 +150,7 @@ class HttpCookieTest {
       classOf[IllegalArgumentException],
       HttpCookie.parse("set-cookie2:potato=tomato;max-age=bad")
     )
-    
+
     assertThrows(
       "Version must be a number",
       classOf[IllegalArgumentException],
@@ -178,10 +180,22 @@ class HttpCookieTest {
 
   @Test
   def domainMatchTest: Unit = {
-    assertTrue("equal domains should match", HttpCookie.domainMatches("website.com", "website.com"))
-    assertTrue("should match if host is a subdomain", HttpCookie.domainMatches("website.com", "www.website.com"))
-    assertFalse("if domain is subdomain of host - should not match", HttpCookie.domainMatches("www.website.com", "website.com"))
-    assertFalse("non-subdomain host whose suffix is the domain should not match", HttpCookie.domainMatches("website.com", "awebsite.com"))
+    assertTrue(
+      "equal domains should match",
+      HttpCookie.domainMatches("website.com", "website.com")
+    )
+    assertTrue(
+      "should match if host is a subdomain",
+      HttpCookie.domainMatches("website.com", "www.website.com")
+    )
+    assertFalse(
+      "if domain is subdomain of host - should not match",
+      HttpCookie.domainMatches("www.website.com", "website.com")
+    )
+    assertFalse(
+      "non-subdomain host whose suffix is the domain should not match",
+      HttpCookie.domainMatches("website.com", "awebsite.com")
+    )
   }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/HttpCookieTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/HttpCookieTest.scala
@@ -1,0 +1,73 @@
+package org.scalanative.testsuite.javalib.net
+
+import java.net._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class HttpCookieTest {
+
+  @Test
+  def basicParseTest(): Unit = {
+
+    val out = HttpCookie.parse("set-cookie2:potato=tomato")
+    assertEquals(out.size(), 1)
+    val cookie = out.get(0)
+    assertEquals("potato", cookie.getName())
+    assertEquals("tomato", cookie.getValue())
+    assertEquals(null, cookie.getComment())
+    assertEquals(false, cookie.getDiscard())
+    assertEquals(null, cookie.getCommentURL())
+    assertEquals(null, cookie.getDomain())
+    assertEquals(-1, cookie.getMaxAge())
+    assertEquals(null, cookie.getPath())
+    assertEquals(null, cookie.getPortlist())
+    assertEquals(false, cookie.getSecure())
+    assertEquals(1, cookie.getVersion)
+
+  }
+
+  @Test
+  def attributeTest(): Unit = {
+    val out = HttpCookie.parse("""set-cookie2: 
+                               |potato = tomato ; 
+                               |comment = "This is a comment"; 
+                               |discard;
+                               |commenturl= https://definitely.real.website.cool/;
+                               |domain=definitely.real.webiste.cool;
+                               |max-age=123;
+                               |path=/potato/tomato;
+                               |port="123 456 789";
+                               |secure;
+                               |version=1""".stripMargin.replaceAll("\n", ""))
+
+    assertEquals(out.size(), 1)
+    val cookie = out.get(0)
+    assertEquals("potato", cookie.getName())
+    assertEquals("tomato", cookie.getValue())
+    assertEquals("This is a comment", cookie.getComment())
+    assertEquals(true, cookie.getDiscard())
+    assertEquals(
+      "https://definitely.real.website.cool/",
+      cookie.getCommentURL()
+    )
+    assertEquals("definitely.real.webiste.cool", cookie.getDomain())
+    assertEquals(123, cookie.getMaxAge())
+    assertEquals("/potato/tomato", cookie.getPath())
+    assertEquals("123 456 789", cookie.getPortlist())
+    assertEquals(true, cookie.getSecure())
+    assertEquals(1, cookie.getVersion)
+
+  }
+
+  @Test
+  def domainMatchTest: Unit = {
+    assert(HttpCookie.domainMatches("website.com", "website.com"))
+    assert(HttpCookie.domainMatches("website.com", "www.website.com"))
+    assert(!HttpCookie.domainMatches("www.website.com", "website.com"))
+    assert(!HttpCookie.domainMatches("website.com", "awebsite.com"))
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/HttpCookieTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/HttpCookieTest.scala
@@ -9,24 +9,43 @@ import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 
 class HttpCookieTest {
 
+  // label parameter gets added to the clue field on assertions
+    def assertCookie(
+    testSubject: HttpCookie,
+      label: String,
+      name: String,
+      value: String,
+      comment: String = null,
+      discard: Boolean = false,
+      commentUrl: String = null,
+      domain: String = null,
+      maxAge: Int = -1,
+      path: String = null,
+      portlist: String = null,
+      secure: Boolean = false,
+      version: Int = 1 
+          ): Unit = {
+              
+    assertEquals(s"$label: name", name, testSubject.getName())
+    assertEquals(s"$label: value", value, testSubject.getValue())
+    assertEquals(s"$label: comment", comment, testSubject.getComment())
+    assertEquals(s"$label: discard", discard, testSubject.getDiscard())
+    assertEquals(s"$label: commentURL", commentUrl, testSubject.getCommentURL())
+    assertEquals(s"$label: domain", domain, testSubject.getDomain())
+    assertEquals(s"$label: maxAge", maxAge, testSubject.getMaxAge())
+    assertEquals(s"$label: path", path, testSubject.getPath())
+    assertEquals(s"$label: portlist", portlist, testSubject.getPortlist())
+    assertEquals(s"$label: secure", secure, testSubject.getSecure())
+    assertEquals(s"$label: version", version, testSubject.getVersion())
+            }
+
+
   @Test
   def basicParseTest(): Unit = {
-
     val out = HttpCookie.parse("set-cookie2:potato=tomato")
-    assertEquals(out.size(), 1)
+    assertEquals("number of cookies", out.size(), 1)
     val cookie = out.get(0)
-    assertEquals("potato", cookie.getName())
-    assertEquals("tomato", cookie.getValue())
-    assertEquals(null, cookie.getComment())
-    assertEquals(false, cookie.getDiscard())
-    assertEquals(null, cookie.getCommentURL())
-    assertEquals(null, cookie.getDomain())
-    assertEquals(-1, cookie.getMaxAge())
-    assertEquals(null, cookie.getPath())
-    assertEquals(null, cookie.getPortlist())
-    assertEquals(false, cookie.getSecure())
-    assertEquals(1, cookie.getVersion)
-
+    assertCookie(cookie, "cookie", name = "potato", value = "tomato")
   }
 
   @Test
@@ -43,31 +62,126 @@ class HttpCookieTest {
                                |secure;
                                |version=1""".stripMargin.replaceAll("\n", ""))
 
-    assertEquals(out.size(), 1)
+    assertEquals("number of cookies", out.size(), 1)
     val cookie = out.get(0)
-    assertEquals("potato", cookie.getName())
-    assertEquals("tomato", cookie.getValue())
-    assertEquals("This is a comment", cookie.getComment())
-    assertEquals(true, cookie.getDiscard())
-    assertEquals(
-      "https://definitely.real.website.cool/",
-      cookie.getCommentURL()
+
+    assertCookie(
+      cookie,
+      "Cookie",
+      name = "potato",
+      value = "tomato",
+      comment = "This is a comment",
+      discard = true,
+      commentUrl =  "https://definitely.real.website.cool/",
+      domain =  "definitely.real.webiste.cool",
+      maxAge = 123,
+      path = "/potato/tomato",
+      portlist = "123 456 789",
+      secure = true,
+      version = 1
     )
-    assertEquals("definitely.real.webiste.cool", cookie.getDomain())
-    assertEquals(123, cookie.getMaxAge())
-    assertEquals("/potato/tomato", cookie.getPath())
-    assertEquals("123 456 789", cookie.getPortlist())
-    assertEquals(true, cookie.getSecure())
-    assertEquals(1, cookie.getVersion)
 
   }
 
   @Test
+  def multipleCookieTest(): Unit = {
+    val out = HttpCookie.parse("""set-cookie2: 
+                               |potato = tomato ; 
+                               |comment = "This is a comment"; 
+                               |discard,
+                               |second="second";
+                               |secure,
+                               |third=third;
+                               |comment = "This is the third cookie" """.stripMargin.replaceAll("\n", ""))
+
+    assertEquals("number of cookies", out.size(), 3)
+    assertCookie(
+      out.get(0),
+      "Cookie 0",
+      name = "potato",
+      value = "tomato",
+      discard = true,
+      comment = "This is a comment"
+    )
+
+    assertCookie(
+      out.get(1),
+      "Cookie 1",
+      name = "second",
+      value = "second",
+      secure = true
+    )
+
+    assertCookie(
+      out.get(2),
+      "Cookie 2",
+      name = "third",
+      value = "third",
+      comment = "This is the third cookie"
+    )
+
+  }
+
+  @Test
+  def illegalCookieNameTest: Unit = {
+    assertThrows(
+      "Names containing special characters should not be allowed",
+      classOf[IllegalArgumentException],
+      new HttpCookie("a\u0000", "")
+    )
+    assertThrows(
+      "Names are not allowed to start with a '$' character'",
+      classOf[IllegalArgumentException],
+      new HttpCookie("$$$$", "")
+    )
+    assertThrows(
+      "Empty names should not be allowed",
+      classOf[IllegalArgumentException],
+      new HttpCookie("", "")
+    )
+  }
+
+  @Test
+  def illegalAttributeTest: Unit = {
+    assertThrows(
+      "Max-age must be a number",
+      classOf[IllegalArgumentException],
+      HttpCookie.parse("set-cookie2:potato=tomato;max-age=bad")
+    )
+    
+    assertThrows(
+      "Version must be a number",
+      classOf[IllegalArgumentException],
+      HttpCookie.parse("set-cookie2:potato=tomato;version=bad")
+    )
+    assertThrows(
+      "Version must be 0 or 1",
+      classOf[IllegalArgumentException],
+      HttpCookie.parse("set-cookie2:potato=tomato;version=123")
+    )
+  }
+
+  @Test
+  def testExpiration: Unit = {
+    assertFalse(
+      "Cookies without max-age set should be never expired",
+      new HttpCookie("potato", "tomato").hasExpired()
+    )
+
+    val expiredCookie = new HttpCookie("potato", "tomato")
+    expiredCookie.setMaxAge(0)
+    assertTrue(
+      "Cookies with max-age set should be compared with the time they were created at",
+      expiredCookie.hasExpired()
+    )
+  }
+
+  @Test
   def domainMatchTest: Unit = {
-    assert(HttpCookie.domainMatches("website.com", "website.com"))
-    assert(HttpCookie.domainMatches("website.com", "www.website.com"))
-    assert(!HttpCookie.domainMatches("www.website.com", "website.com"))
-    assert(!HttpCookie.domainMatches("website.com", "awebsite.com"))
+    assertTrue("equal domains should match", HttpCookie.domainMatches("website.com", "website.com"))
+    assertTrue("should match if host is a subdomain", HttpCookie.domainMatches("website.com", "www.website.com"))
+    assertFalse("if domain is subdomain of host - should not match", HttpCookie.domainMatches("www.website.com", "website.com"))
+    assertFalse("non-subdomain host whose suffix is the domain should not match", HttpCookie.domainMatches("website.com", "awebsite.com"))
   }
 
 }


### PR DESCRIPTION
Fixes #3921 

Not a very strict implementation of the RFCs, but I find that it largely matches how the JVM behaves. I tried copying from netty at first (as netty is also apache 2.0), but ultimately found that implementing this was more about matching the quirks of the JVM rather the RFCs, so I ended up implementing something from scratch.

I'll add some more tests, but given that this is my first PR to the project I wanted to make sure that the PR is in order. As such let me know if there's anything else needed here!