### PR TITLE
improvement [toolchain]: Ignore incompatible NIR files when checking for entrypoints

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -23,6 +23,7 @@ object Versions {
    */
   final val compat: Int = 6 // a.k.a. MAJOR version
   final val revision: Int = 10 // a.k.a. MINOR version
+  case class Version(compat: Int, revision: Int)
 
   /* Current public release version of Scala Native. */
   final val current: String = "0.5.2-SNAPSHOT"

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
@@ -29,4 +29,14 @@ package object serialization {
       ).deserialize()
     }
   }
+
+  abstract class NirDeserializationException(message: String)
+      extends IllegalStateException(message)
+  object UnknownFormat
+      extends NirDeserializationException("Can't read non-NIR file")
+  class IncompatibleVersion(version: Versions.Version, fileName: String)
+      extends NirDeserializationException(
+        s"Can't read binary-incompatible version of NIR from '$fileName': expected (compat=${Versions.compat}, revision=${Versions.revision}), got (compat=${version.compat}, revision=${version.revision})."
+      )
+
 }

--- a/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
@@ -4,6 +4,7 @@ package linker
 import scala.collection.mutable
 import scalanative.io.VirtualDirectory
 import scalanative.util.Scope
+import scala.scalanative.build.Logger
 
 sealed abstract class ClassLoader {
 
@@ -19,7 +20,7 @@ object ClassLoader {
 
   def fromDisk(config: build.Config)(implicit in: Scope): ClassLoader = {
     val classpath = config.classPath.map { path =>
-      ClassPath(VirtualDirectory.real(path))
+      ClassPath(VirtualDirectory.real(path), config.logger)
     }
     new FromDisk(classpath)
   }


### PR DESCRIPTION
Resolves #3881 

When scanning for entry-points ignore unreadable/incompatible NIR files. These files can be present when publishing artifact with stale 0.4.x NIR files