### PR TITLE
Improvement [Build]: Update sbt to 1.10.0

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -50,8 +50,9 @@ object ScalaVersions {
   //   1.9.0 is required in order to use Java >= 21
   //   1.9.4 fixes (Common Vulnerabilities and Exposures) CVE-2022-46751
   //   1.9.7 fixes sbt IO.unzip vulnerability described in sbt release notes.
+  //   1.10.0 Latest sbt version.
 
-  val sbt10Version: String = "1.9.7"
+  val sbt10Version: String = "1.10.0"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.9
+sbt.version = 1.10.0


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.10.0.

 I have been using this version in heavy development for about two weeks now with no problems.

The SBT GitHub [announcement](https://github.com/sbt/sbt/releases/tag/v1.10.0).

This PR also updates the SBT version in both `project/build.properties & `project/ScalaVersions.scala`.