### PR TITLE
doc: Correct 'realloc' & 'free' package reference to libc.stdlib

### DIFF
--- a/docs/user/interop.md
+++ b/docs/user/interop.md
@@ -372,7 +372,7 @@ unmanaged memory.
 
     > Scala Native\'s library contains a bindings for a subset of the
     > standard libc functionality. This includes the trio of `malloc`,
-    > `realloc` and `free` functions that are defined in `unsafe.stdlib`
+    > `realloc` and `free` functions that are defined in `libc.stdlib`
     > extern object.
     >
     > Calling those will let you allocate memory using system\'s


### PR DESCRIPTION
[     `realloc` and `free` functions that are defined in `unsafe.stdlib`](https://github.com/scala-native/scala-native/blob/main/docs/user/interop.md?plain=1#L375)
These external functions are defined in lib.stdlib