### PR TITLE
fix [javalib] Fix access to redirected output of the file directly after finishing the subprocess execution

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -311,7 +311,11 @@ object UnixProcessGen1 {
   }
 
   @inline def open(f: File, flags: CInt) = Zone.acquire { implicit z =>
-    fcntl.open(toCString(f.getAbsolutePath()), flags, 0.toUInt) match {
+    def defaultCreateMode = 0x1a4.toUInt // 0644, no octal literal in Scala
+    val mode: CUnsignedInt =
+      if ((flags & fcntl.O_CREAT) != 0) defaultCreateMode
+      else 0.toUInt
+    fcntl.open(toCString(f.getAbsolutePath()), flags, mode) match {
       case -1 => throw new IOException(s"Unable to open file $f ($errno)")
       case fd => fd
     }

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -789,7 +789,11 @@ object UnixProcessGen2 {
   }
 
   def open(f: File, flags: CInt) = Zone.acquire { implicit z =>
-    fcntl.open(toCString(f.getAbsolutePath()), flags, 0.toUInt) match {
+    def defaultCreateMode = 0x1a4.toUInt // 0644, no octal literal in Scala
+    val mode: CUnsignedInt =
+      if ((flags & fcntl.O_CREAT) != 0) defaultCreateMode
+      else 0.toUInt
+    fcntl.open(toCString(f.getAbsolutePath()), flags, mode) match {
       case -1 => throw new IOException(s"Unable to open file $f ($errno)")
       case fd => fd
     }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -2,7 +2,7 @@ package org.scalanative.testsuite.javalib.lang
 
 import java.util.concurrent.TimeUnit
 import java.io._
-import java.nio.file.Files
+import java.nio.file._
 import java.nio.charset.StandardCharsets
 
 import scala.io.Source
@@ -345,6 +345,24 @@ class ProcessTest {
         .result(Future.sequence(tasks), iterations.seconds)
         .forall(_ == true)
     )
+  }
+
+  @Test def redirectOutputAccess() = {
+    // Regression test for com-lihaoyi/os-lib
+    val out = Paths.get("all.txt")
+    val catCmd = if (isWindows) "type" else "cat"
+    val proc = new ProcessBuilder(
+      (catCmd +:
+        Files
+          .list(Path.of("."))
+          .filter(_.getFileName().toString().endsWith(".txt"))
+          .toArray()
+          .map(_.toString())): _*
+    ).redirectOutput(out.toFile())
+      .start()
+
+    assertEquals(0, proc.waitFor())
+    assertNotNull(Files.readAllLines(out).toArray())
   }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -350,9 +350,11 @@ class ProcessTest {
   @Test def redirectOutputAccess() = {
     // Regression test for com-lihaoyi/os-lib
     val out = Paths.get("all.txt")
-    val catCmd = if (isWindows) "type" else "cat"
+    val catCmd =
+      if (scala.util.Properties.isWin) List(".EXCMDE", "/C", "type")
+      else List("cat")
     val proc = new ProcessBuilder(
-      (catCmd +:
+      (catCmd ++
         Files
           .list(Path.of("."))
           .filter(_.getFileName().toString().endsWith(".txt"))

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -351,7 +351,7 @@ class ProcessTest {
     // Regression test for com-lihaoyi/os-lib
     val out = Paths.get("all.txt")
     val catCmd =
-      if (scala.util.Properties.isWin) List(".EXCMDE", "/C", "type")
+      if (scala.util.Properties.isWin) List("cmd", "/c", "type")
       else List("cat")
     val proc = new ProcessBuilder(
       (catCmd ++

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -356,7 +356,7 @@ class ProcessTest {
     val proc = new ProcessBuilder(
       (catCmd ++
         Files
-          .list(Path.of("."))
+          .list(Paths.get("."))
           .filter(_.getFileName().toString().endsWith(".txt"))
           .toArray()
           .map(_.toString())): _*


### PR DESCRIPTION
Fixes one of the bugs found in https://github.com/com-lihaoyi/os-lib/pull/274 
Previously the redirected output file was created with default mode (0), instead of 644 