### PR TITLE
improve [build]: Publish Scala 2.13 artifacts using oldest cross compiled version of Scala 2.13

### DIFF
--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test tools
         run: sbt "test-tools ${{ matrix.scala }}; toolsBenchmarks${{env.project-version}}/Jmh/compile"
 
-  tests-compile-scala3PublishVersion:
+  tests-compile-scalaPublishVersion:
     name: Compile sources with the Scala 3 version used for publishing artifacts
     if: "github.event_name == 'pull_request' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')"
     runs-on: ubuntu-20.04
@@ -46,7 +46,7 @@ jobs:
           java-version: 8
 
       - name: Compile everything
-        run: sbt "++3.1.3; Test/compile"
+        run: sbt "++2.13.8; ++3.1.3; Test/compile"
 
     
   test-scala-cross-build:

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -46,7 +46,8 @@ jobs:
           java-version: 8
 
       - name: Compile everything
-        run: sbt "++2.13.8; ++3.1.3; Test/compile"
+        # Publish 2.13.latest artifacts locally first, these are required by scalalib3
+        run: sbt "scalalib2_13/publishLocal;clean; ++2.13.8; ++3.1.3; Test/compile"
 
     
   test-scala-cross-build:

--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -185,7 +185,8 @@ object Commands {
       case (binVersion, state) =>
         val (scalaVersion, crossScalaVersions) = binVersion match {
           case "2.12" => ScalaVersions.scala212 -> ScalaVersions.crossScala212
-          case "2.13" => ScalaVersions.scala213 -> ScalaVersions.crossScala213
+          case "2.13" =>
+            ScalaVersions.scala213PublishVersion -> ScalaVersions.crossScala213
           case "3" =>
             ScalaVersions.scala3PublishVersion -> ScalaVersions.crossScala3
           case _ => sys.error(s"Invalid Scala binary version: '$binVersion'")

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -40,6 +40,7 @@ object ScalaVersions {
 
   // The latest version of minimal Scala 3 minor version used to publish artifacts
   val scala3PublishVersion = "3.1.3"
+  val scala213PublishVersion = crossScala213.head
 
   // List of nightly version can be found here: https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/
   val scala3Nightly = "3.4.0-RC1-bin-20240114-bfabc31-NIGHTLY"

--- a/tools/src/main/scala/scala/scalanative/build/Mode.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Mode.scala
@@ -19,16 +19,11 @@ sealed abstract class Mode private (val name: String) {
 }
 object Mode {
   private[scalanative] case object Debug extends Mode("debug")
-  private[scalanative] sealed trait Release
-  private[scalanative] case object ReleaseFast
-      extends Mode("release-fast")
-      with Release
-  private[scalanative] case object ReleaseSize
-      extends Mode("release-size")
-      with Release
-  private[scalanative] case object ReleaseFull
-      extends Mode("release-full")
-      with Release
+  private[scalanative] sealed abstract class Release(name: String)
+      extends Mode(name)
+  private[scalanative] case object ReleaseFast extends Release("release-fast")
+  private[scalanative] case object ReleaseSize extends Release("release-size")
+  private[scalanative] case object ReleaseFull extends Release("release-full")
 
   /** Debug compilation mode. */
   def debug: Mode = Debug


### PR DESCRIPTION
Fixes #3943 -  allows the end user to use the minimal Scala 2.13.8 version under the limitations of SIP-51