### PR TITLE
fix [javalib]: BaseStream & its split/iterators are now type invariant

### DIFF
--- a/javalib/src/main/scala/java/util/stream/BaseStream.scala
+++ b/javalib/src/main/scala/java/util/stream/BaseStream.scala
@@ -3,13 +3,14 @@ package java.util.stream
 import java.util.Iterator
 import java.util.Spliterator
 
-trait BaseStream[+T, +S <: BaseStream[T, S]] extends AutoCloseable {
+// trait BaseStream[+T, +S <: BaseStream[T, S]] extends AutoCloseable {
+trait BaseStream[T, S <: BaseStream[T, S]] extends AutoCloseable {
   def close(): Unit
   def isParallel(): Boolean
-  def iterator(): Iterator[_ <: T]
+  def iterator(): Iterator[T]
   def onClose(closeHandler: Runnable): S
   def parallel(): S
   def sequential(): S
-  def spliterator(): Spliterator[_ <: T]
+  def spliterator(): Spliterator[T]
   def unordered(): S
 }

--- a/javalib/src/main/scala/java/util/stream/BaseStream.scala
+++ b/javalib/src/main/scala/java/util/stream/BaseStream.scala
@@ -3,7 +3,6 @@ package java.util.stream
 import java.util.Iterator
 import java.util.Spliterator
 
-// trait BaseStream[+T, +S <: BaseStream[T, S]] extends AutoCloseable {
 trait BaseStream[T, S <: BaseStream[T, S]] extends AutoCloseable {
   def close(): Unit
   def isParallel(): Boolean

--- a/javalib/src/main/scala/java/util/stream/StreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamImpl.scala
@@ -151,7 +151,7 @@ private[stream] class StreamImpl[T](
     this
   }
 
-  def spliterator(): Spliterator[_ <: T] = {
+  def spliterator(): Spliterator[T] = {
     commenceOperation()
     _spliter
   }


### PR DESCRIPTION
Fix #3948

Make several javalib `BaseStream` declarations invariant.  

This removes a group of quirks from the set of them that javalib developers
need to know.

The change should not be visible outside of the Scala Native build.

This change will and has been exercised by some Work-in-Progress changes to 
javalib `Files#walk`, `Files#find`, and `Files#walkFileTree`.