### PR TITLE
fix[javalib]: Correct UnixProcessGen2#isAlive

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -76,7 +76,7 @@ private[lang] class UnixProcessGen2 private (
   override def getOutputStream(): OutputStream = _outputStream
 
   override def isAlive(): scala.Boolean =
-    _exitValue.isDefined || waitpidImpl(pid, options = WNOHANG) == 0
+    _exitValue.isEmpty && waitpidImpl(pid, options = WNOHANG) == 0
 
   override def toString = { // Match JVM output
     val ev = _exitValue.fold("not exited")(_.toString())


### PR DESCRIPTION
javalib `java.lang.process.UnixProcessGen2#isAlive` now correctly returns "false" when a prior C `waitpid()`
has reported the process as having exited.  That is, the cached value is respected & reported.

Previously, the incorrect inverse of the cached value was reported. Thus querying `isAlive` for a process
which had exited might lie and return "true".  No telling what havoc that might cause.