### PR TITLE
nix flake defined development environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "sbt": "sbt",
+        "systems": "systems"
+      }
+    },
+    "sbt": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698464090,
+        "narHash": "sha256-Pnej7WZIPomYWg8f/CZ65sfW85IfIUjYhphMMg7/LT0=",
+        "owner": "zaninime",
+        "repo": "sbt-derivation",
+        "rev": "6762cf2c31de50efd9ff905cbcc87239995a4ef9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zaninime",
+        "ref": "master",
+        "repo": "sbt-derivation",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "scala-native";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/24.05";
+
+  inputs.sbt.url = "github:zaninime/sbt-derivation/master";
+  inputs.sbt.inputs.nixpkgs.follows = "nixpkgs";
+
+  inputs.systems.url = "github:nix-systems/default";
+
+  outputs = {
+    self,
+    nixpkgs,
+    sbt,
+    systems
+  }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      devShells = eachSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+          default = (sbt.mkSbtDerivation.${system}).withOverrides({ stdenv = pkgs.llvmPackages_18.stdenv; }) {
+            pname = "scala-native";
+            version = (builtins.elemAt
+              (
+                builtins.match "^.*current: String = \"([^\"]+)\".*$" (
+                  builtins.readFile "${self}/nir/src/main/scala/scala/scalanative/nir/Versions.scala"
+                )
+              )
+              0
+            );
+            src = self;
+            # set to "" and rebuild to regenerate this.
+            depsSha256 = "sha256-xLudUMf0bi77vWBnLZvft2sALD9GSI7ezpxXObxL/rs=";
+            nativeBuildInputs = [
+              pkgs.async-profiler
+              pkgs.linuxPackages.perf
+            ];
+            buildInputs = with pkgs; [
+              boehmgc
+              libunwind
+              zlib
+            ];
+            env.NIX_CFLAGS_COMPILE = "-Wno-unused-command-line-argument";
+            hardeningDisable = [ "fortify" ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Provides a `nix develop` environment that should everything necessary to build, test and performance measure.  

This largely just replaces `scripts/scala-native.nix` with a nix flake. 

This does not define scala-native as an installable package. This only defines a `devShell` for `nix develop`.