### PR TITLE
Improve NixOS setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,10 +10,10 @@ RUN git clone https://github.com/scala-native/scala-native.git native
 
 WORKDIR /tmp/native
 
-RUN  nix-shell scripts/scala-native.nix -A clangEnv --run "echo 'clangEnv installed'"
+RUN  nix-shell scripts/scala-native.nix --run "echo 'clangEnv installed'"
 
-RUN  nix-shell scripts/scala-native.nix -A clangEnv --run "cd .. && sbt scalaVersion"
+RUN  nix-shell scripts/scala-native.nix --run "cd .. && sbt scalaVersion"
 
-RUN  nix-shell scripts/scala-native.nix -A clangEnv --run "sbt scalalib/package"
+RUN  nix-shell scripts/scala-native.nix --run "sbt scalalib/package"
 
 CMD ["/bin/bash"]

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -144,7 +144,7 @@ $ nix-shell scala-native.nix
 You can also use [flakes](https://nixos.wiki/wiki/flakes):
 
 ``` shell
-$ nix develop github:scala-native/scala-native?dir=scripts
+$ nix develop --no-write-lock-file github:scala-native/scala-native?dir=scripts
 ```
 
 **Windows**

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -138,7 +138,13 @@ $ pkg_add boehm-gc # optional
 
 ``` shell
 $ wget https://raw.githubusercontent.com/scala-native/scala-native/main/scripts/scala-native.nix
-$ nix-shell scala-native.nix -A clangEnv
+$ nix-shell scala-native.nix
+```
+
+You can also use [flakes](https://nixos.wiki/wiki/flakes):
+
+``` shell
+$ nix develop github:scala-native/scala-native?dir=scripts
 ```
 
 **Windows**

--- a/scripts/flake.nix
+++ b/scripts/flake.nix
@@ -1,0 +1,11 @@
+{
+  description = "Scala Native environment";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShells.default = pkgs.callPackage (import ./scala-native.nix) { };
+      });
+}

--- a/scripts/nix-run
+++ b/scripts/nix-run
@@ -2,4 +2,4 @@
 
 HERE="`dirname $0`"
 
-nix-shell $HERE/scala-native.nix -A clangEnv
+nix-shell $HERE/scala-native.nix

--- a/scripts/scala-native.nix
+++ b/scripts/scala-native.nix
@@ -1,21 +1,6 @@
-let
-  pkgs = import <nixpkgs> {};
-  stdenv = pkgs.stdenv;
-in rec {
-  clangEnv = stdenv.mkDerivation rec {
-    name = "clang-env";
-    shellHook = ''
-    alias cls=clear
-    '';
-    LLVM_BIN = pkgs.clang + "/bin";
-    buildInputs = with pkgs; [
-      stdenv
-      sbt
-      openjdk
-      boehmgc
-      libunwind
-      clang
-      zlib
-    ];
-  };
-} 
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell {
+  name = "clang-env";
+  hardeningDisable = [ "fortify" ];
+  buildInputs = with pkgs; [ boehmgc clang libunwind openjdk sbt ];
+}


### PR DESCRIPTION
Setup instructions for Nix/NixOS haen't been updated for a while and no longer work correctly. NixOS now defaults to `-D_FORTIFY_SOURCE=2` which makes scala native issue tons of warnings when compiling a project.

In addition, this PR adds support for setting up enviromment via [nix flakes](https://nixos.wiki/wiki/flakes) which seem to be preffered by many.