### PR TITLE
fix[javalib]: Fix calculation of initial maximal load of ThreadLocal.Values table

### DIFF
--- a/javalib/src/main/scala/java/lang/ThreadLocal.scala
+++ b/javalib/src/main/scala/java/lang/ThreadLocal.scala
@@ -45,11 +45,11 @@ object ThreadLocal {
 
     /** Size must always be a power of 2.
      */
-    private val INITIAL_SIZE = 16
+    private final val INITIAL_SIZE = 16
 
-    private def DefaultCapacity = INITIAL_SIZE << 1
-    private def DefaultMask = DefaultCapacity - 1
-    private def DefaultMaximumLoad = DefaultCapacity * 2 / 3
+    private final val DefaultCapacity = INITIAL_SIZE << 1
+    private final val DefaultMask = DefaultCapacity - 1
+    private final val DefaultMaximumLoad = INITIAL_SIZE * 2 / 3
 
     /** Placeholder for deleted entries. */
     private case object TOMBSTONE
@@ -132,7 +132,7 @@ object ThreadLocal {
       this.table = new Array[AnyRef](capacity << 1)
       this.mask = table.length - 1
       this.clean = 0
-      this.maximumLoad = capacity * 2 / 3 // 2/3
+      this.maximumLoad = capacity * 2 / 3
     }
 
     /** Cleans up after garbage-collected thread locals.

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThreadLocalTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ThreadLocalTest.scala
@@ -77,4 +77,14 @@ class ThreadLocalTest extends JSR166Test {
     progenitor.join()
     for (i <- 0 until threadCount) { assertEquals(i, x(i)) }
   }
+
+  @Test def issue3956(): Unit = {
+    // Ensure ThreadLocal values table can grow over the initial size of 16 entries
+    0.until(1024).foreach { _ =>
+      val tl = new ThreadLocal[String]() {
+        override def initialValue: String = "foo"
+      }
+      assertSame(tl.get(), "foo")
+    }
+  }
 }


### PR DESCRIPTION
Was incorrectly using the doubled size as a base thus preventing growing the table entry over the INITIAL_SIZE=16 
Fixes #3956 