### PR TITLE
fix[javalib]:Runtime#availableProcessors now respects cpuset on small Linux systems

### DIFF
--- a/javalib/src/main/resources/scala-native/sys/linux_sched.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_sched.c
@@ -21,7 +21,7 @@ int scalanative_sched_cpuset_cardinality() {
      * logical processes configured for the system (_SC_NPROCESSORS).
      *
      * Note that OpenMP environment variables are neither consulted nor used.
-     * This consistent with Java.
+     * This is consistent with Java.
      *
      * Large systems:
      *   This implementation will return -1 if the number of logical processors

--- a/javalib/src/main/resources/scala-native/sys/linux_sched.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_sched.c
@@ -1,0 +1,48 @@
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_JAVALIB_SYS_LINUX_SCHED_H) && defined(__linux__)
+
+/* Define _GNU_SOURCE to make the CPU_* macros available.
+ * This file is already GNU Linux specific, so adding more GNU does not
+ * add impurity. What is a bit of GNU amoung friends?
+ *
+ * Those macros greatly ease this implementation.
+ */
+#define _GNU_SOURCE
+#include <sched.h>
+
+int scalanative_sched_cpuset_cardinality() {
+
+    /* On error, return -1. Let caller handle errors.
+     *
+     * On success, return the number of logical processors available to
+     * the process. Due to taskset, cpuset, and such, this may be
+     * less than sysconf number of online logical processes
+     * (_SC_NPROCESSORS_ONLN) which may be less than the total number of
+     * logical processes configured for the system (_SC_NPROCESSORS).
+     *
+     * Note that OpenMP environment variables are neither consulted nor used.
+     * This consistent with Java.
+     *
+     * Large systems:
+     *   This implementation will return -1 if the number of logical processors
+     *   available to the process is greater than sizeof[cpu_set_t]
+     *   (CPU_SETSIZE == 1024, circa 2024). The caller will probably fall
+     *   back to reporting sysconf(_SC_NPROCESSORS_ONLN) as a best guess.
+     *
+     *   Someday there could be a fallback "slow" path which
+     *   tried used CPU_*S macros to dynamically try larger sizes.
+     *   Send me a CPU with that many logical processors with a large check to
+     *   cover the electricity and air conditioning and I will code that
+     *   up right away.
+     */
+
+    cpu_set_t cpuset;
+
+    CPU_ZERO(&cpuset);
+
+    int status = sched_getaffinity(0, sizeof(cpu_set_t), &cpuset);
+
+    return (status < 0) ? -1 : CPU_COUNT(&cpuset);
+}
+
+#endif // __linux__

--- a/javalib/src/main/scala/java/lang/RuntimeLinuxOsSpecific.scala
+++ b/javalib/src/main/scala/java/lang/RuntimeLinuxOsSpecific.scala
@@ -1,0 +1,12 @@
+package java.lang
+
+import scala.scalanative.unsafe._
+
+@define("__SCALANATIVE_JAVALIB_SYS_LINUX_SCHED_H")
+@extern
+object RuntimeLinuxOsSpecific {
+
+  // @blocking considered but not used.
+  @name("scalanative_sched_cpuset_cardinality")
+  def sched_cpuset_cardinality(): CInt = extern
+}

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/RuntimeOsTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/lang/RuntimeOsTest.scala
@@ -1,0 +1,47 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.lang._
+
+import java.util.concurrent.TimeUnit
+import java.io.File
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalanative.junit.utils.AssumesHelper._
+
+import scala.scalanative.meta.LinktimeInfo
+
+import scala.scalanative.posix.unistd.{sysconf, _SC_NPROCESSORS_CONF}
+
+class RuntimeOsTest {
+
+  // See also the major /unit-tests/shared RuntimeTest.scala
+  @Test def availableProcessors(): Unit = {
+    val available = Runtime.getRuntime().availableProcessors()
+
+    assertTrue(s"${available} < 1", available >= 1)
+
+    /* Do a coherence check of 'available' against an upper bound. Is it
+     * in a believable closed range?
+     *
+     * A tight upper bound is desirable but problematic.
+     * 'available' should match the number of online processors,
+     * _SC_NPROCESSORS_ONLN exactly. Since the value fetch and comparison
+     * are not atomic, there is a race, albeit tortoise slow.
+     *
+     * Check against the number of configured processors, _SC_NPROCESSORS_CONF.
+     * It gives a higher ceiling but fewer chances intermittent errors.
+     */
+
+    if (LinktimeInfo.isLinux) {
+      val nprocConf = sysconf(_SC_NPROCESSORS_CONF).toInt
+      assertTrue(
+        "available > sysconf(_SC_NPROCESSORS_CONF): " +
+          s"${available} > ${nprocConf}",
+        available <= nprocConf
+      )
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/RuntimeTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/RuntimeTest.scala
@@ -67,6 +67,10 @@ class RuntimeTest {
     assertEquals(Scripts.values.map(_.filename), out.split(EOL).toSet)
   }
 
+  /* See also /unit-tests/native RuntimeOsTest.scala, which checks the
+   * upper bound on specific operating systems, currently Linux only.
+   */
+
   @Test def availableProcessors(): Unit = {
     assertTrue(Runtime.getRuntime().availableProcessors() >= 1)
   }


### PR DESCRIPTION
Weakly fixes #3963 

`Runtime#availableProcessors` on small Linux systems now reports the number of logical processors allow
 by the process `cpuset`. 

This number may be smaller than that reported by `sysconf(_SC_NPROCESSORS_ONLN)` due to various
Linux mechanisms: cgroups, taskset, cpuset, etc.

'small' is defined as less than or equal to, currently, 1024. Above that limit `sysconf(_SC_NPROCESSORS_ONLN)` is
reported, same as before this PR.

See Issue for discussion and manual testing instructions (next sprint). Most notably, OpenMP variables are not considered.