### PR TITLE
Optimizations for Delimited Continuations implementation

### DIFF
--- a/nativelib/src/main/resources/scala-native/delimcc.c
+++ b/nativelib/src/main/resources/scala-native/delimcc.c
@@ -384,7 +384,7 @@ void *scalanative_continuation_resume(Continuation *continuation, void *out) {
     return (void *)result;
 }
 
-#ifdef DELIMCC_DEBUG
+#ifdef SCALANATIVE_DELIMCC_DEBUG
 static void handler_free(Handlers *hs) {
     while (hs != NULL) {
         Handlers *old = hs;
@@ -398,6 +398,6 @@ void scalanative_continuation_free(Continuation *continuation) {
     free(continuation->stack);
     free(continuation);
 }
-#endif // DELIMCC_DEBUG
+#endif // SCALANATIVE_DELIMCC_DEBUG
 
 #endif

--- a/nativelib/src/main/resources/scala-native/delimcc.h
+++ b/nativelib/src/main/resources/scala-native/delimcc.h
@@ -42,11 +42,11 @@ void *scalanative_continuation_suspend(ContinuationBoundaryLabel b,
 // argument into the suspended computation and returns its result.
 void *scalanative_continuation_resume(Continuation *continuation, void *arg);
 
-#ifdef DELIMCC_DEBUG // Debug flag for delimcc
+#ifdef SCALANATIVE_DELIMCC_DEBUG // Debug flag for delimcc
 
 // Frees a continuation. Used only if malloc is used as the implementation of
 // alloc function.
 void scalanative_continuation_free(Continuation *continuation);
 
-#endif // DELIMCC_DEBUG
+#endif // SCALANATIVE_DELIMCC_DEBUG
 #endif // DELIMCC_H


### PR DESCRIPTION
- Use variable sized Continuation struct to avoid double allocation
  - Before, we make 2 allocations for each Continuation: one for the Continuation struct itself, the other for the stack fragment.
- Make handler an internal list, avoid more allocations
  - We now don't use heap-allocated linked lists for handlers, the list is maintained from within the handlers themselves.

Hammer testing on a suspend/resume loop gives me 10-20% speedup.

Misc:
- Use `SCALANATIVE_DELIMCC_DEBUG` flag consistently
