### PR TITLE
fix[javalib]:  Use FunctionalInterface annotation consistently 

### DIFF
--- a/javalib/src/main/scala/java/util/function/BiConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/BiConsumer.scala
@@ -1,6 +1,7 @@
 // Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
+@FunctionalInterface
 trait BiConsumer[T, U] {
   def accept(t: T, u: U): Unit
 

--- a/javalib/src/main/scala/java/util/function/BiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/BiFunction.scala
@@ -1,6 +1,7 @@
 // Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
+@FunctionalInterface
 trait BiFunction[T, U, R] {
   def apply(t: T, u: U): R
 

--- a/javalib/src/main/scala/java/util/function/BiPredicate.scala
+++ b/javalib/src/main/scala/java/util/function/BiPredicate.scala
@@ -1,6 +1,7 @@
 // Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
+@FunctionalInterface
 trait BiPredicate[T, U] {
   def test(t: T, u: U): Boolean
 

--- a/javalib/src/main/scala/java/util/function/BinaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/BinaryOperator.scala
@@ -3,6 +3,7 @@ package java.util.function
 
 import java.util.Comparator
 
+@FunctionalInterface
 trait BinaryOperator[T] extends BiFunction[T, T, T]
 
 object BinaryOperator {

--- a/javalib/src/main/scala/java/util/function/Function.scala
+++ b/javalib/src/main/scala/java/util/function/Function.scala
@@ -1,6 +1,7 @@
 // Ported from Scala.js, commit SHA: 7b4e8a80b dated: 2022-12-06
 package java.util.function
 
+@FunctionalInterface
 trait Function[T, R] {
   def apply(t: T): R
 

--- a/javalib/src/main/scala/java/util/function/Supplier.scala
+++ b/javalib/src/main/scala/java/util/function/Supplier.scala
@@ -1,6 +1,7 @@
 // Ported from Scala.js, commit SHA: 5df5a4142 dated: 2020-09-06
 package java.util.function
 
+@FunctionalInterface
 trait Supplier[T] {
   def get(): T
 }

--- a/javalib/src/main/scala/java/util/function/UnaryOperator.scala
+++ b/javalib/src/main/scala/java/util/function/UnaryOperator.scala
@@ -1,6 +1,7 @@
 // Ported from Scala.js, commit SHA: 4a394815e dated: 2020-09-06
 package java.util.function
 
+@FunctionalInterface
 trait UnaryOperator[T] extends Function[T, T]
 
 object UnaryOperator {


### PR DESCRIPTION
All files in javalib `java.util.function` now use the FunctionalInterface annotation, as described in
the corresponding JDK documentation.

Previously, 7 of the 43 files did not have the annotation. For example, `Consumer.scala` had
the annotation but `BiConsumer.scala` did not.  

Merit to Aly on Scala Native Discourse for information which facilitated this PR; all defects
remain my original work.