### PR TITLE
improvement [javalib]: Implement List static methods

### DIFF
--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -1,4 +1,11 @@
 // Ported from Scala.js commit: ad7d82f dated: 2020-10-05
+//
+// Post Java 8 Static methods on List added for Scala Native
+
+/* Some of the strange coding style, especially of specifying type
+ * parameters explicitly and not using lambdas is due to the need to
+ * support Scala versions from 2.12.19 through 3.N.
+ */
 
 package java.util
 
@@ -44,4 +51,261 @@ trait List[E] extends SequencedCollection[E] {
   def listIterator(index: Int): ListIterator[E]
   def subList(fromIndex: Int, toIndex: Int): List[E]
   def addAll(index: Int, c: Collection[_ <: E]): Boolean
+}
+
+object List {
+
+  private class UnmodifiableList[E](underlying: ArrayList[E])
+      extends AbstractList[E]
+      with RandomAccess {
+
+    /* Since 'set()' is not defined, various methods which try to
+     * mutate the list, such as subList#add or listIterator#remove,
+     * should all throw, as desired.
+     */
+
+    override def size(): Int =
+      underlying.size()
+
+    override def get(index: Int): E = {
+      underlying.get(index)
+    }
+  }
+
+  def copyOf[E](coll: Collection[? <: E]): List[E] = {
+    Objects.requireNonNull(coll)
+
+    /*  The JVM List.copyOf() doc _may_ be saying, obtusely, that if the
+     *  given collection is already an unmodifiable List then the original
+     *  will be returned and a copy will not be made.
+     *
+     *  Scala Native may differ here in that it always makes a copy because
+     *  the author saw no way to check for "already an unmodifiable list".
+     *  Scala Native may need to implement and use a private class
+     *  UnmodifiableList. A quick study of Collections.scala showed
+     *  no suitable candidate.
+     *
+     *  A future pass may want to correct this difference, if it exists.
+     *  Until then this code should provide some benefit in the by far
+     *  more likely 'normal' cases.
+     */
+
+    val listSize = coll.size()
+
+    val underlying = new ArrayList[E](listSize)
+
+    coll.forEach(e => {
+      Objects.requireNonNull(e)
+      underlying.add(e)
+    })
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](): List[E] = {
+    val listSize = 0
+
+    val underlying = new ArrayList[E](listSize)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  private def appendListOfElement[E](e: E, al: ArrayList[E]): Unit = {
+    Objects.requireNonNull(e)
+    al.add(e)
+  }
+
+  def of[E](e1: E): List[E] = {
+    val listSize = 1
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](elements: Array[Object]): List[E] = {
+    /* This overload handles varargs & must not conflict with single argument
+     * overload. That is the reason for 'Array[Object]' rather than 'Array[E]'.
+     */
+
+    Objects.requireNonNull(elements)
+
+    val listSize = elements.size
+
+    for (j <- 0 until listSize)
+      Objects.requireNonNull(elements(j))
+
+    val underlying = Arrays
+      .copyOf(elements, listSize)
+      .asInstanceOf[Array[E]]
+
+    /* It would be consistent, regular, & nice to call
+     * "new UnmodifiableList[E](underlying)" here.
+     *
+     * That is not readily available here, because 'underlying' is an
+     * Array and UnmodifiableList takes an ArrayList argument.
+     * A defensive copy of the list has already been done. Open coding
+     * the resultant list breaks regularity but avoids a costly
+     * element-by-element copy from the defensive Array to an ArrayList
+     * to use as an argument.
+     *
+     * Individual 'List.of()' methods are more likely to be used in the wild.
+     * When this varargs overload is used, there will be more than 10 elements
+     * so some efficiency will be needed.
+     */
+
+    new AbstractList[E] with RandomAccess {
+      def size(): Int =
+        listSize
+
+      def get(index: Int): E =
+        underlying(index)
+    }
+  }
+
+  def of[E](e1: E, e2: E): List[E] = {
+    val listSize = 2
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](e1: E, e2: E, e3: E): List[E] = {
+    val listSize = 3
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+    appendListOfElement[E](e3, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](e1: E, e2: E, e3: E, e4: E): List[E] = {
+    val listSize = 4
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+    appendListOfElement[E](e3, underlying)
+    appendListOfElement[E](e4, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](e1: E, e2: E, e3: E, e4: E, e5: E): List[E] = {
+    val listSize = 5
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+    appendListOfElement[E](e3, underlying)
+    appendListOfElement[E](e4, underlying)
+    appendListOfElement[E](e5, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](e1: E, e2: E, e3: E, e4: E, e5: E, e6: E): List[E] = {
+    val listSize = 6
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+    appendListOfElement[E](e3, underlying)
+    appendListOfElement[E](e4, underlying)
+    appendListOfElement[E](e5, underlying)
+    appendListOfElement[E](e6, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](e1: E, e2: E, e3: E, e4: E, e5: E, e6: E, e7: E): List[E] = {
+    val listSize = 7
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+    appendListOfElement[E](e3, underlying)
+    appendListOfElement[E](e4, underlying)
+    appendListOfElement[E](e5, underlying)
+    appendListOfElement[E](e6, underlying)
+    appendListOfElement[E](e7, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](e1: E, e2: E, e3: E, e4: E, e5: E, e6: E, e7: E, e8: E): List[E] = {
+    val listSize = 8
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+    appendListOfElement[E](e3, underlying)
+    appendListOfElement[E](e4, underlying)
+    appendListOfElement[E](e5, underlying)
+    appendListOfElement[E](e6, underlying)
+    appendListOfElement[E](e7, underlying)
+    appendListOfElement[E](e8, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](e1: E, e2: E, e3: E, e4: E, e5: E, e6: E, e7: E, e8: E, e9: E)
+      : List[E] = {
+    val listSize = 9
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+    appendListOfElement[E](e3, underlying)
+    appendListOfElement[E](e4, underlying)
+    appendListOfElement[E](e5, underlying)
+    appendListOfElement[E](e6, underlying)
+    appendListOfElement[E](e7, underlying)
+    appendListOfElement[E](e8, underlying)
+    appendListOfElement[E](e9, underlying)
+
+    new UnmodifiableList[E](underlying)
+  }
+
+  def of[E](
+      e1: E,
+      e2: E,
+      e3: E,
+      e4: E,
+      e5: E,
+      e6: E,
+      e7: E,
+      e8: E,
+      e9: E,
+      e10: E
+  ): List[E] = {
+    val listSize = 10
+
+    val underlying = new ArrayList[E](listSize)
+    appendListOfElement[E](e1, underlying)
+    appendListOfElement[E](e2, underlying)
+    appendListOfElement[E](e3, underlying)
+    appendListOfElement[E](e4, underlying)
+    appendListOfElement[E](e5, underlying)
+    appendListOfElement[E](e6, underlying)
+    appendListOfElement[E](e7, underlying)
+    appendListOfElement[E](e8, underlying)
+    appendListOfElement[E](e9, underlying)
+    appendListOfElement[E](e10, underlying)
+
+    new UnmodifiableList[E](underlying)
+    new AbstractList[E] with RandomAccess {
+      def size(): Int =
+        listSize
+
+      def get(index: Int): E =
+        underlying.get(index)
+    }
+  }
 }

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -300,12 +300,5 @@ object List {
     appendListOfElement[E](e10, underlying)
 
     new UnmodifiableList[E](underlying)
-    new AbstractList[E] with RandomAccess {
-      def size(): Int =
-        listSize
-
-      def get(index: Int): E =
-        underlying.get(index)
-    }
   }
 }

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -72,6 +72,7 @@ object List {
     }
   }
 
+  // Since: Java 10
   def copyOf[E](coll: Collection[_ <: E]): List[E] = {
     Objects.requireNonNull(coll)
 
@@ -102,6 +103,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](): List[E] = {
     val listSize = 0
 
@@ -115,6 +117,7 @@ object List {
     al.add(e)
   }
 
+  // Since: Java 9
   def of[E](e1: E): List[E] = {
     val listSize = 1
 
@@ -124,6 +127,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](elements: Array[Object]): List[E] = {
     /* This overload handles varargs & must not conflict with single argument
      * overload. That is the reason for 'Array[Object]' rather than 'Array[E]'.
@@ -164,6 +168,7 @@ object List {
     }
   }
 
+  // Since: Java 9
   def of[E](e1: E, e2: E): List[E] = {
     val listSize = 2
 
@@ -174,6 +179,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](e1: E, e2: E, e3: E): List[E] = {
     val listSize = 3
 
@@ -185,6 +191,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](e1: E, e2: E, e3: E, e4: E): List[E] = {
     val listSize = 4
 
@@ -197,6 +204,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](e1: E, e2: E, e3: E, e4: E, e5: E): List[E] = {
     val listSize = 5
 
@@ -210,6 +218,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](e1: E, e2: E, e3: E, e4: E, e5: E, e6: E): List[E] = {
     val listSize = 6
 
@@ -224,6 +233,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](e1: E, e2: E, e3: E, e4: E, e5: E, e6: E, e7: E): List[E] = {
     val listSize = 7
 
@@ -239,6 +249,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](e1: E, e2: E, e3: E, e4: E, e5: E, e6: E, e7: E, e8: E): List[E] = {
     val listSize = 8
 
@@ -255,6 +266,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](e1: E, e2: E, e3: E, e4: E, e5: E, e6: E, e7: E, e8: E, e9: E)
       : List[E] = {
     val listSize = 9
@@ -273,6 +285,7 @@ object List {
     new UnmodifiableList[E](underlying)
   }
 
+  // Since: Java 9
   def of[E](
       e1: E,
       e2: E,

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -72,7 +72,7 @@ object List {
     }
   }
 
-  def copyOf[E](coll: Collection[? <: E]): List[E] = {
+  def copyOf[E](coll: Collection[_ <: E]): List[E] = {
     Objects.requireNonNull(coll)
 
     /*  The JVM List.copyOf() doc _may_ be saying, obtusely, that if the

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/ListStaticMethodsTestOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/ListStaticMethodsTestOnJDK21.scala
@@ -350,7 +350,7 @@ class ListStaticMethodsTestOnJDK21 {
 
     val expected = new Array[String](expectedSize)
     for (j <- 0 until expectedSize)
-      expected(j) = s"ThreeArgs_${j}"
+      expected(j) = s"FourArgs_${j}"
 
     val result = ju.List.of(
       expected(0),
@@ -403,7 +403,7 @@ class ListStaticMethodsTestOnJDK21 {
 
     val expected = new Array[String](expectedSize)
     for (j <- 0 until expectedSize)
-      expected(j) = s"ThreeArgs_${j}"
+      expected(j) = s"FiveArgs_${j}"
 
     val result = ju.List.of(
       expected(0),
@@ -462,7 +462,7 @@ class ListStaticMethodsTestOnJDK21 {
 
     val expected = new Array[String](expectedSize)
     for (j <- 0 until expectedSize)
-      expected(j) = s"ThreeArgs_${j}"
+      expected(j) = s"SixArgs_${j}"
 
     val result = ju.List.of(
       expected(0),
@@ -529,7 +529,7 @@ class ListStaticMethodsTestOnJDK21 {
 
     val expected = new Array[String](expectedSize)
     for (j <- 0 until expectedSize)
-      expected(j) = s"ThreeArgs_${j}"
+      expected(j) = s"SevenArgs_${j}"
 
     val result = ju.List.of(
       expected(0),
@@ -609,7 +609,7 @@ class ListStaticMethodsTestOnJDK21 {
 
     val expected = new Array[String](expectedSize)
     for (j <- 0 until expectedSize)
-      expected(j) = s"ThreeArgs_${j}"
+      expected(j) = s"EightArgs_${j}"
 
     val result = ju.List.of(
       expected(0),
@@ -696,7 +696,7 @@ class ListStaticMethodsTestOnJDK21 {
 
     val expected = new Array[String](expectedSize)
     for (j <- 0 until expectedSize)
-      expected(j) = s"ThreeArgs_${j}"
+      expected(j) = s"NineArgs_${j}"
 
     val result = ju.List.of(
       expected(0),
@@ -789,7 +789,7 @@ class ListStaticMethodsTestOnJDK21 {
 
     val expected = new Array[String](expectedSize)
     for (j <- 0 until expectedSize)
-      expected(j) = s"ThreeArgs_${j}"
+      expected(j) = s"TenArgs_${j}"
 
     val result = ju.List.of(
       expected(0),
@@ -821,7 +821,7 @@ class ListStaticMethodsTestOnJDK21 {
 
     val expected = new Array[String](expectedSize)
     for (j <- 0 until expectedSize)
-      expected(j) = s"ThreeArgs_${j}"
+      expected(j) = s"ElevenArgs_${j}"
 
     val result = ju.List.of(
       expected(0),

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/ListStaticMethodsTestOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/ListStaticMethodsTestOnJDK21.scala
@@ -1,0 +1,846 @@
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+import java.{util => ju}
+
+/* The List.of static methods were introduced in Java 9.
+ * The List.copyOf static method was introduced in Java 10.
+ *
+ * Strictly these tests should be in require-jdk9 and require-jdk10
+ * directories. Scala Native Continuous Integration (CI) currently runs
+ * jobs using Java 8, 11, 17, and 21.  These are in 21 to increase the
+ * chances that they get run in CI.  Conflicting goals: regular & predictable
+ * location or actually being exercised.
+ *
+ * If these tests are going to be out-of-place, they might as well be
+ * located near the envisioned ListDefaultMethodsOnJDK21.scala for
+ * default methods which were introduced in Java 21.
+ */
+
+/* Some of the strange coding style, especially of specifying type
+ * parameters explicitly and not using lambdas is due to the need to
+ * support Scala versions from 2.12.19 through 3.N.
+ */
+
+class ListStaticMethodsTestOnJDK21 {
+
+  @Test def copyOf_ValidateArgs(): Unit = {
+
+    assertThrows(
+      "null argument should throw",
+      classOf[NullPointerException],
+      ju.List.copyOf(null)
+    )
+
+    val expectedSize = 4
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"copyOf_ValidateArgs_${j}"
+
+    expected(2) = null // Pick an arbitary victim
+
+    val hs = new ju.HashSet[String]()
+    for (j <- 0 until expectedSize)
+      hs.add(expected(j))
+
+    assertThrows(
+      "null collection content should throw",
+      classOf[NullPointerException],
+      ju.List.copyOf(hs)
+    )
+  }
+
+  @Test def copyOf(): Unit = {
+    val expectedSize = 10
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"copyOf_${j}"
+
+    val ts = new ju.TreeSet[String]()
+    for (j <- (expectedSize - 1) to 0 by -1)
+      ts.add(expected(j))
+
+    val result = ju.List.copyOf(ts)
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+
+    assertTrue(
+      "result is not instanceOf[RandomAccess]",
+      result.isInstanceOf[ju.RandomAccess]
+    )
+
+    assertThrows(
+      "result.remove() should throw",
+      classOf[UnsupportedOperationException],
+      result.remove(expectedSize - 1)
+    )
+  }
+
+  @Test def of_NoArg(): Unit = {
+    val expectedSize = 0
+
+    val result = ju.List.of()
+
+    assertEquals("list size", expectedSize, result.size())
+  }
+
+  @Test def of_OneArg_ValidateArgs(): Unit = {
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+  }
+
+  @Test def of_OneArg(): Unit = {
+    val expectedSize = 1
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"OneArg_${j}"
+
+    val result = ju.List.of[String](
+      expected(0)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+
+    assertTrue(
+      "result is not instanceOf[RandomAccess]",
+      result.isInstanceOf[ju.RandomAccess]
+    )
+
+    assertThrows(
+      "result.remove() should throw",
+      classOf[UnsupportedOperationException],
+      result.remove(expectedSize - 1)
+    )
+  }
+
+  @Test def of_VarArgs_ValidateArgs(): Unit = {
+
+    val varArgs = new Array[String](4)
+    varArgs(0) = "va_1"
+    varArgs(1) = "va_2"
+    varArgs(2) = null
+    varArgs(3) = "va_4"
+
+    assertThrows(
+      "null variable argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(varArgs: _*)
+    )
+  }
+
+  @Test def of_CheckUnmodifiableRobustness(): Unit = {
+    val expectedSize = 10
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"Unmodifiable_${j}"
+
+    val result = ju.List.of(expected: _*)
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+
+    assertTrue(
+      "result is not instanceOf[RandomAccess]",
+      result.isInstanceOf[ju.RandomAccess]
+    )
+
+    assertThrows(
+      "List.of() result itself should be unmodifiable",
+      classOf[UnsupportedOperationException],
+      result.remove(expectedSize - 1)
+    )
+
+    // subList
+    val fromIndex = 2
+    val toIndex = expectedSize - 1
+    val sublist = result.subList(fromIndex, toIndex)
+
+    assertThrows(
+      "subLists of List.of() should be unmodifiable - remove",
+      classOf[UnsupportedOperationException],
+      sublist.remove(4) // an arbitrary index in center of new sublist
+    )
+
+    assertThrows(
+      "subLists of List.of() should be unmodifiable - add",
+      classOf[UnsupportedOperationException],
+      sublist.add("GrochoMarx")
+    )
+
+    // ListIterator
+
+    val li = result.listIterator(3)
+
+    val unusedRemove = li.next()
+
+    assertThrows(
+      "ListIterator#remove of List.of() should be unmodifiable - remove",
+      classOf[UnsupportedOperationException],
+      li.remove()
+    )
+
+    val unusedSet1 = li.next() // skip to a position not touched above.
+    val unusedSet2 = li.next()
+
+    assertThrows(
+      "ListIterator#add of List.of() should be unmodifiable - set",
+      classOf[UnsupportedOperationException],
+      li.set("SetShouldThrow")
+    )
+  }
+
+  @Test def of_VarArgs_SmallN(): Unit = {
+    /* Does a varargs with less than 10 elements conflict with the overloads
+     * which specify one thru 10 args explicitly?  Can I break things before
+     * users do?
+     */
+
+    val expectedSize = 5
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"VarArgs_SmallN_${j}"
+
+    // 'Normal' varargs usage
+    val result = ju.List.of(expected: _*)
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_VarArgs_LargeN(): Unit = {
+
+    /* Does a varargs with more than 10 elements conflict with the overloads
+     * which specify one thru 10 args explicitly?  Can I break things before
+     * users do?
+     */
+
+    val expectedSize = 20
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"VarArgs_LargeN_${j}"
+
+    val result = ju.List.of(expected: _*)
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_TwoArgs_ValidateArgs(): Unit = {
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+  }
+
+  @Test def of_TwoArgs(): Unit = {
+    val expectedSize = 2
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"TwoArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_ThreeArgs_ValidateArgs(): Unit = {
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+
+    assertThrows(
+      "null third argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, null)
+    )
+  }
+
+  @Test def of_ThreeArgs(): Unit = {
+    val expectedSize = 3
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_FourArgs_ValidateArgs(): Unit = {
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+
+    assertThrows(
+      "null third argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, null)
+    )
+
+    assertThrows(
+      "null forth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, null)
+    )
+  }
+
+  @Test def of_FourArgs(): Unit = {
+    val expectedSize = 4
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2),
+      expected(3)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_FiveArgs_ValidateArgs(): Unit = {
+
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+
+    assertThrows(
+      "null third argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, null)
+    )
+
+    assertThrows(
+      "null forth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, null)
+    )
+
+    assertThrows(
+      "null fifth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, null)
+    )
+  }
+
+  @Test def of_FiveArgs(): Unit = {
+    val expectedSize = 5
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2),
+      expected(3),
+      expected(4)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_SixArgs_ValidateArgs(): Unit = {
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+
+    assertThrows(
+      "null third argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, null)
+    )
+
+    assertThrows(
+      "null forth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, null)
+    )
+
+    assertThrows(
+      "null fifth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, null)
+    )
+
+    assertThrows(
+      "null sixth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, null)
+    )
+  }
+
+  @Test def of_SixArgs(): Unit = {
+    val expectedSize = 6
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2),
+      expected(3),
+      expected(4),
+      expected(5)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_SevenArgs_ValidateArgs(): Unit = {
+
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+
+    assertThrows(
+      "null third argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, null)
+    )
+
+    assertThrows(
+      "null forth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, null)
+    )
+
+    assertThrows(
+      "null fifth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, null)
+    )
+
+    assertThrows(
+      "null sixth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, null)
+    )
+
+    assertThrows(
+      "null seventh argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, null)
+    )
+  }
+
+  @Test def of_SevenArgs(): Unit = {
+    val expectedSize = 7
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2),
+      expected(3),
+      expected(4),
+      expected(5),
+      expected(6)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_EightArgs_ValidateArgs(): Unit = {
+
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+
+    assertThrows(
+      "null third argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, null)
+    )
+
+    assertThrows(
+      "null forth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, null)
+    )
+
+    assertThrows(
+      "null fifth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, null)
+    )
+
+    assertThrows(
+      "null sixth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, null)
+    )
+
+    assertThrows(
+      "null sixth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, null)
+    )
+
+    assertThrows(
+      "null seventh argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, null)
+    )
+
+    assertThrows(
+      "null eigth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, 7, null)
+    )
+  }
+
+  @Test def of_EightArgs(): Unit = {
+    val expectedSize = 8
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2),
+      expected(3),
+      expected(4),
+      expected(5),
+      expected(6),
+      expected(7)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_NineArgs_ValidateArgs(): Unit = {
+
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+
+    assertThrows(
+      "null third argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, null)
+    )
+
+    assertThrows(
+      "null forth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, null)
+    )
+
+    assertThrows(
+      "null fifth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, null)
+    )
+
+    assertThrows(
+      "null sixth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, null)
+    )
+
+    assertThrows(
+      "null sixth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, null)
+    )
+
+    assertThrows(
+      "null seventh argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, null)
+    )
+
+    assertThrows(
+      "null eigth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, 7, null)
+    )
+
+    assertThrows(
+      "null ninth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, 7, 8, null)
+    )
+  }
+
+  @Test def of_NineArgs(): Unit = {
+    val expectedSize = 9
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2),
+      expected(3),
+      expected(4),
+      expected(5),
+      expected(6),
+      expected(7),
+      expected(8)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_TenArgs_ValidateArgs(): Unit = {
+    assertThrows(
+      "null first argument should throw",
+      classOf[NullPointerException],
+      ju.List.of[String](null)
+    )
+
+    assertThrows(
+      "null second argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, null)
+    )
+
+    assertThrows(
+      "null third argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, null)
+    )
+
+    assertThrows(
+      "null forth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, null)
+    )
+
+    assertThrows(
+      "null fifth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, null)
+    )
+
+    assertThrows(
+      "null sixth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, null)
+    )
+
+    assertThrows(
+      "null sixth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, null)
+    )
+
+    assertThrows(
+      "null seventh argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, null)
+    )
+
+    assertThrows(
+      "null eigth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, 7, null)
+    )
+
+    assertThrows(
+      "null ninth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, 7, 8, null)
+    )
+
+    assertThrows(
+      "null ninth argument should throw",
+      classOf[NullPointerException],
+      ju.List.of(1, 2, 3, 4, 5, 6, 7, 9, null)
+    )
+  }
+
+  @Test def of_TenArgs(): Unit = {
+    val expectedSize = 10
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2),
+      expected(3),
+      expected(4),
+      expected(5),
+      expected(6),
+      expected(7),
+      expected(8),
+      expected(9)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+  @Test def of_ElevenArgs(): Unit = {
+    /* Boundary case.
+     *  Does this fall over to using varargs on JVM? On SN?
+     *  It exceeds the number of explicitly defined .of() methods.
+     *  Answer: Appears to work fine on both JDK & Scala Native.
+     */
+
+    val expectedSize = 11
+
+    val expected = new Array[String](expectedSize)
+    for (j <- 0 until expectedSize)
+      expected(j) = s"ThreeArgs_${j}"
+
+    val result = ju.List.of(
+      expected(0),
+      expected(1),
+      expected(2),
+      expected(3),
+      expected(4),
+      expected(5),
+      expected(6),
+      expected(7),
+      expected(8),
+      expected(9),
+      expected(10)
+    )
+
+    assertEquals("list size", expectedSize, result.size())
+
+    for (j <- 0 until expectedSize)
+      assertEquals(s"contents(${j})", expected(j), result.get(j))
+  }
+
+}


### PR DESCRIPTION
This PR addresses one of the items in Issue #3991.

Java 9 added a number of `List.of()` static methods. Java 10 added the `List.copyOf()` 
static method.  Those methods and corresponding Tests are now implemented in Scala Native.