### PR TITLE
improvement [javalib]: AbstractSet#equals now matches other Sets only

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractSet.scala
+++ b/javalib/src/main/scala/java/util/AbstractSet.scala
@@ -10,7 +10,7 @@ abstract class AbstractSet[E] protected ()
     if (that.asInstanceOf[AnyRef] eq this) true
     else {
       that match {
-        case that: Collection[_] =>
+        case that: Set[_] =>
           that.size() == this.size() && containsAll(that)
         case _ => false
       }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/SetTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/SetTest.scala
@@ -1,4 +1,6 @@
 // Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+//
+// 'equalsOnlyOtherSets' Test added for Scala Native.
 
 package org.scalanative.testsuite.javalib.util
 
@@ -187,6 +189,42 @@ trait SetTest extends CollectionTest {
     assertEquals(3, hs.size)
 
     assertIteratorSameElementsAsSet(l: _*)(hs.iterator())
+  }
+
+  @Test def equalsOnlyOtherSets(): Unit = {
+    val hsUut = factory.empty[String] // Unit under test
+    val hsMatch = factory.empty[String]
+    val hsNoMatch = factory.empty[String]
+
+    val l = {
+      if (factory.allowsNullElement)
+        List("ONE", "TWO", null)
+      else
+        List("ONE", "TWO", "THREE")
+    }
+
+    val coll = TrivialImmutableCollection(l: _*)
+    assertTrue(hsUut.addAll(coll))
+    assertEquals(3, hsUut.size)
+
+    assertTrue(hsMatch.addAll(coll))
+    assertEquals(hsUut.size, hsMatch.size)
+
+    assertTrue(hsNoMatch.addAll(coll))
+    assertTrue(hsNoMatch.add("MISMATCH"))
+    assertEquals(hsUut.size + 1, hsNoMatch.size)
+
+    assertTrue("should match other content-equal set", hsUut.equals(hsMatch))
+
+    assertFalse(
+      "should not match other content-not-equal set",
+      hsUut.equals(hsNoMatch)
+    )
+
+    assertFalse(
+      "should not match other content-equal not-Set Collection",
+      hsUut.equals(coll)
+    )
   }
 }
 


### PR DESCRIPTION
Fix: #3995 

javalib `AbstractSet#equals` now follows its JVM description and only content-equals matches other 
classes which implement the `Set` interface.

Previously, that method would, incorrectly, allow content-equals  matches with general `Collections`.