### PR TITLE
improvement [javalib]: add required override for Set#spliterator

### DIFF
--- a/javalib/src/main/scala/java/util/Set.scala
+++ b/javalib/src/main/scala/java/util/Set.scala
@@ -19,4 +19,13 @@ trait Set[E] extends Collection[E] {
   // def toArray[T](array: Array[T]): Array[T]
   // def contains(coll: Collection[_]): scala.Boolean
   // def equals(obj: Any): scala.Boolean
+
+  override def spliterator(): Spliterator[E] = {
+    Spliterators.spliterator[E](
+      this,
+      Spliterator.SIZED |
+        Spliterator.SUBSIZED |
+        Spliterator.DISTINCT
+    )
+  }
 }


### PR DESCRIPTION
The spliterator returned from javalib `Set#spliterator` now properly returns the `Spliterator.DISTINCT` 
characteristic required by its JVM description in addition to the previous, and also required,
 `Spliterator.SIZED` and  `Spliterator.SUBSIZED` characteristics.
