### PR TITLE
improvement [javalib]: simplify 'Stream#toList' implementation

### DIFF
--- a/javalib/src/main/scala/java/util/stream/Stream.scala
+++ b/javalib/src/main/scala/java/util/stream/Stream.scala
@@ -371,8 +371,17 @@ trait Stream[T] extends BaseStream[T, Stream[T]] {
   def toArray[A <: Object](generator: IntFunction[Array[A]]): Array[A]
 
   // Since: Java 16
-  def toList(): List[T] =
-    this.collect(Collectors.toUnmodifiableList())
+  def toList(): List[T] = {
+    val underlying = this.toArray().asInstanceOf[Array[T]]
+
+    new AbstractList[T] with RandomAccess {
+      def size(): Int =
+        underlying.size
+
+      def get(index: Int): T =
+        underlying(index)
+    }
+  }
 }
 
 object Stream {


### PR DESCRIPTION
Re-work the implementation of javalib `Stream#toList` to provide a shorter, and hopefully faster, execution path.