### PR TITLE
improvement [docs]: remove `$`, separate output from cli snippets

### DIFF
--- a/docs/user/profiling.md
+++ b/docs/user/profiling.md
@@ -8,7 +8,9 @@ Native binary in Linux.
 -   With the `time` command you can measure execution time:
 
 ``` shell
-$ time ./target/scala-2.13/scala-native-out
+time ./target/scala-2.13/scala-native-out
+```
+```
 real  0m0,718s
 user  0m0,419s
 sys   0m0,299s
@@ -17,8 +19,10 @@ sys   0m0,299s
 -   With the `/usr/bin/time --verbose` command you can also see memory
     consumption:
 
+```shell
+/usr/bin/time --verbose ./target/scala-2.13/scala-native-out
 ```
-$ /usr/bin/time --verbose ./target/scala-2.13/scala-native-out
+```
 Command being timed: "./target/scala-2.13/scala-native-out"
 User time (seconds): 0.49
 System time (seconds): 0.23
@@ -55,24 +59,24 @@ Follow these steps:
     already:
 
 ``` shell
-$ sudo apt update && sudo apt install linux-tools-generic
+sudo apt update && sudo apt install linux-tools-generic
 ```
 
 -   Then clone the flamegraph repository into e.g. `~/git/hub/`
 
 ``` shell
-$ cd ~ && mkdir -p git/hub && cd git/hub/
-$ git clone git@github.com:brendangregg/FlameGraph.git
+cd ~ && mkdir -p git/hub && cd git/hub/
+git clone git@github.com:brendangregg/FlameGraph.git
 ```
 
 -   Then navigate to your Scala Native project and, after building your
     binary, you can create a flamegraph like so:
 
 ``` shell
-$ sudo perf record -F 1000 -a -g ./target/scala-2.13/scala-native-out
-$ sudo perf script > out.perf
-$ ~/git/hub/FlameGraph/stackcollapse-perf.pl out.perf > out.folded
-$ ~/git/hub/FlameGraph/flamegraph.pl out.folded > kernel.svg
+sudo perf record -F 1000 -a -g ./target/scala-2.13/scala-native-out
+sudo perf script > out.perf
+~/git/hub/FlameGraph/stackcollapse-perf.pl out.perf > out.folded
+~/git/hub/FlameGraph/flamegraph.pl out.folded > kernel.svg
 ```
 
 -   Open the file `kernel.svg` in your browser and you can zoom in the

--- a/docs/user/runtime.md
+++ b/docs/user/runtime.md
@@ -68,11 +68,16 @@ examples showing some error conditions using Immix, the default GC.
 Adjust the path to your executable as needed:
 
 ``` shell
-$ export GC_INITIAL_HEAP_SIZE=64k; export GC_MAXIMUM_HEAP_SIZE=512k; sandbox/.2.13/target/scala-2.13/sandbox
+export GC_INITIAL_HEAP_SIZE=64k; export GC_MAXIMUM_HEAP_SIZE=512k; sandbox/.2.13/target/scala-2.13/sandbox
+```
+```
 GC_MAXIMUM_HEAP_SIZE too small to initialize heap.
 Minimum required: 1m
-
-$ export GC_INITIAL_HEAP_SIZE=2m; export GC_MAXIMUM_HEAP_SIZE=1m; sandbox/.2.13/target/scala-2.13/sandbox
+```
+```shell
+export GC_INITIAL_HEAP_SIZE=2m; export GC_MAXIMUM_HEAP_SIZE=1m; sandbox/.2.13/target/scala-2.13/sandbox
+```
+```
 GC_MAXIMUM_HEAP_SIZE should be at least GC_INITIAL_HEAP_SIZE
 ```
 

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -24,19 +24,19 @@ instructions for your operating system.
 **FreeBSD**
 
 ``` shell
-$ pkg install sbt
+pkg install sbt
 ```
 
 **OpenBSD**
 
 ``` shell
-$ pkg_add sbt
+pkg_add sbt
 ```
 
 **NetBSD**
 
 ``` shell
-$ pkg_add scala-sbt
+pkg_add scala-sbt
 ```
 
 ## Installing clang and runtime dependencies
@@ -66,8 +66,8 @@ Native has been used with:
 **macOS**
 
 ``` shell
-$ brew install llvm
-$ brew install bdw-gc # optional
+brew install llvm
+brew install bdw-gc # optional
 ```
 
 *Note 1:* Xcode should work as an alternative if preferred:
@@ -79,15 +79,15 @@ installation of macOS.
 **Ubuntu**
 
 ``` shell
-$ sudo apt install clang libstdc++-12-dev
-$ sudo apt install libgc-dev # optional
+sudo apt install clang libstdc++-12-dev
+sudo apt install libgc-dev # optional
 ```
 
 **Arch Linux**
 
 ``` shell
-$ sudo pacman -S llvm clang
-$ sudo pacman -S gc # optional
+sudo pacman -S llvm clang
+sudo pacman -S gc # optional
 ```
 
 *Note:* A version of zlib that is sufficiently recent comes with the
@@ -96,9 +96,9 @@ installation of Arch Linux.
 **Fedora 33**
 
 ``` shell
-$ sudo dnf install llvm clang
-$ sudo dnf groupinstall "Development Tools"
-$ sudo dnf install gc-devel zlib-devel # both optional
+sudo dnf install llvm clang
+sudo dnf groupinstall "Development Tools"
+sudo dnf install gc-devel zlib-devel # both optional
 ```
 
 **FreeBSD 12.4 and later**
@@ -109,7 +109,7 @@ $ sudo dnf install gc-devel zlib-devel # both optional
 installation of FreeBSD.
 
 ``` shell
-$ pkg install boehm-gc # optional
+pkg install boehm-gc # optional
 ```
 
 *Note 3:* Using the boehm GC with multi-threaded binaries doesn\'t work
@@ -121,7 +121,7 @@ out-of-the-box yet.
 architecture.
 
 ``` shell
-$ pkg_add boehm-gc # optional
+pkg_add boehm-gc # optional
 ```
 
 **NetBSD 9.3 and later**
@@ -130,15 +130,15 @@ $ pkg_add boehm-gc # optional
 architecture.
 
 ``` shell
-$ pkg_add clang
-$ pkg_add boehm-gc # optional
+pkg_add clang
+pkg_add boehm-gc # optional
 ```
 
 **Nix/NixOS**
 
 ``` shell
-$ wget https://raw.githubusercontent.com/scala-native/scala-native/main/scripts/scala-native.nix
-$ nix-shell scala-native.nix -A clangEnv
+wget https://raw.githubusercontent.com/scala-native/scala-native/main/scripts/scala-native.nix
+nix-shell scala-native.nix -A clangEnv
 ```
 
 **Windows**


### PR DESCRIPTION

resolves https://github.com/scala-native/scala-native/issues/4001

Improves quality of life for unix cli power users. It is obvious to the typical reader that these snippets are terminal commands so the `$` is not of much benefit, and removing it allows users to copy paste all commands in one go instead of manually copying and pasting each individual command which is a larger benefit. Separating the command outputs into their own snippets allows for easier copy pasting without accidentally selecting the output.