### PR TITLE
improvement [javalib]: implement ju.LinkedHashSet#newLinkedHashSet static method

### DIFF
--- a/javalib/src/main/scala/java/util/LinkedHashSet.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashSet.scala
@@ -21,3 +21,23 @@ class LinkedHashSet[E]
   override protected val inner: mutable.Set[Box[E]] =
     new mutable.LinkedHashSet[Box[E]]()
 }
+
+object LinkedHashSet {
+
+  // Since: Java 19
+  def newLinkedHashSet[T](numElements: Int): LinkedHashSet[T] = {
+    if (numElements < 0) {
+      throw new IllegalArgumentException(
+        s"Negative number of elements: ${numElements}"
+      )
+    }
+
+    val loadFactor = 0.75f // as defined in JVM method description.
+
+    val desiredCapacity = Math.ceil(numElements * (1.0f / loadFactor)).toInt
+
+    val clampedCapacity = Math.clamp(desiredCapacity, 0, Integer.MAX_VALUE)
+
+    new LinkedHashSet[T](clampedCapacity.toInt, loadFactor)
+  }
+}


### PR DESCRIPTION
Implement the javalib `java.util.LinkedHashSet#newLinkedHashSet` static method introduced in
JDK 19.

This method is the cousin of `java.util.LinkedHashMap#newLinkedHashMap`, introduced in PR #4006.

A careful reader of Scala Native internals will note that  this method introduces the API entry point
but limitations in the current `java.util.LinkedHashSet` internals prevent the information supplied
from being used. That internal implementation is a candidate for change in a future Scala Native 0.n
release. 