### PR TITLE
feature [javalib]: 0.6.n: javalib Random now inherits from RandomAccess

### DIFF
--- a/javalib/src/main/scala/java/util/Collections.scala
+++ b/javalib/src/main/scala/java/util/Collections.scala
@@ -148,63 +148,18 @@ object Collections {
   }
 
   def shuffle(list: List[_]): Unit =
-    shuffle(list, new Random)
+    shuffleImpl(list, new Random)
 
-  def shuffle(list: List[_], rndg: RandomGenerator): Unit = {
-    /* This implementation is coyote ugly but avoids breaking binary
-     * compatibility in the Scala Native 0.5.n series.
-     *
-     * When Scala Native 0.6.n opens for changes, Random can be changed
-     * to follow the Java 17 class hierarchy where it extends the
-     * RandomGenerator interface.
-     *
-     * The the shuffleImpl() declaration can be changed to something like:
-     *   private def shuffleImpl[T, R <: RandomGenerator](
-     *      list: List[T], rng: R): Unit = {
-     *
-     * It probably makes sense to remove the "@inline" from shuffleImple().
-     * the method is large enough that one would hope that the compiler
-     * ignores the hint anyway.
-     *
-     * Lastly, the use of Random() can be removed here. Easy Peasy.
-     */
-    val rnd = new Random { // implement just enough for shuffleImpl().
-      override def nextInt(): Int =
-        (rndg.nextLong() >> 32).toInt
-
-      override def nextInt(bound: Int): Int = {
-        // Algorithm adapted from java.util.concurrent.ThreadLocalRandom.
-        if (bound <= 0)
-          throw new IllegalArgumentException("bound must be positive")
-
-        var r = nextInt()
-        val m = bound - 1
-
-        if ((bound & m) == 0) { // power of two
-          r &= m
-        } else { // reject over-represented candidates
-          var u = r >>> 1
-          while ({
-            r = u % bound
-            (u + m - r) < 0
-          }) {
-            u = nextInt() >>> 1
-          }
-        }
-
-        r
-      }
-    }
-
-    shuffle(list, rnd)
-  }
-
-  @noinline
   def shuffle(list: List[_], rnd: Random): Unit =
     shuffleImpl(list, rnd)
 
-  @inline
-  private def shuffleImpl[T](list: List[T], rnd: Random): Unit = {
+  def shuffle(list: List[_], rndg: RandomGenerator): Unit =
+    shuffleImpl(list, rndg)
+
+  private def shuffleImpl[T, R <: RandomGenerator](
+      list: List[T],
+      rng: R
+  ): Unit = {
     def shuffleInPlace(list: List[T] with RandomAccess): Unit = {
       @inline
       def swap(i1: Int, i2: Int): Unit = {
@@ -215,7 +170,7 @@ object Collections {
 
       var n = list.size()
       while (n > 1) {
-        val k = rnd.nextInt(n)
+        val k = rng.nextInt(n)
         swap(n - 1, k)
         n -= 1
       }

--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -2,6 +2,7 @@ package java.util
 
 import java.{lang => jl}
 import java.util.function.{DoubleConsumer, IntConsumer, LongConsumer}
+import java.util.random.RandomGenerator
 import java.util.stream.StreamSupport
 import java.util.stream.{DoubleStream, IntStream, LongStream}
 
@@ -10,7 +11,10 @@ import scala.annotation.tailrec
 /** Ported from Apache Harmony and described by Donald E. Knuth in The Art of
  *  Computer Programming, Volume 2: Seminumerical Algorithms, section 3.2.1.
  */
-class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
+class Random(seed_in: Long)
+    extends AnyRef
+    with RandomGenerator
+    with java.io.Serializable {
 
   private var seed: Long = calcSeed(seed_in)
 
@@ -41,9 +45,9 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
 
   def nextBoolean(): Boolean = next(1) != 0
 
-  def nextInt(): Int = next(32)
+  override def nextInt(): Int = next(32)
 
-  def nextInt(n: Int): Int = {
+  override def nextInt(n: Int): Int = {
     if (n <= 0)
       throw new IllegalArgumentException("n must be positive")
 

--- a/javalib/src/main/scala/java/util/SplittableRandom.scala
+++ b/javalib/src/main/scala/java/util/SplittableRandom.scala
@@ -1,4 +1,5 @@
 // Ported from Scala.js, revision c473689, dated 3 May 2021
+// Contains Scala Native specific changes, see repository commit history.
 
 /*
  * Scala.js (https://www.scala-js.org/)
@@ -113,9 +114,9 @@ final class SplittableRandom private (private var seed: Long, gamma: Long)
     seed
   }
 
-  def nextInt(): Int = mix32(nextSeed())
+  override def nextInt(): Int = mix32(nextSeed())
 
-  // def nextInt(bound: Int): Int
+  // def nextInt(bound: Int): Int // SN uses RandomGenerator default method
 
   // def nextInt(origin: Int, bound: Int): Int
 

--- a/javalib/src/main/scala/java/util/random/RandomGenerator.scala
+++ b/javalib/src/main/scala/java/util/random/RandomGenerator.scala
@@ -1,5 +1,34 @@
 package java.util.random
 
 trait RandomGenerator {
+
   def nextLong(): Long // Abstract
+
+  // Incomplete implementation. Needs population.
+
+  def nextInt(): Int =
+    (nextLong() >> 32).toInt
+
+  def nextInt(bound: Int): Int = {
+    // Algorithm adapted from java.util.concurrent.ThreadLocalRandom.
+    if (bound <= 0)
+      throw new IllegalArgumentException("bound must be positive")
+
+    var r = nextInt()
+    val m = bound - 1
+
+    if ((bound & m) == 0) { // power of two
+      r &= m
+    } else { // reject over-represented candidates
+      var u = r >>> 1
+      while ({
+        r = u % bound
+        (u + m - r) < 0
+      }) {
+        u = nextInt() >>> 1
+      }
+    }
+
+    r
+  }
 }


### PR DESCRIPTION
Fix #4003

##### Prologue
It is too early (and expensive) for a 0.6.n now. I am creating this PR for review and in case I get
hit by the proverbial bus (or hurricane). I'm marking it Draft until either 0.6.0 opens or somebody
who knows can reassure me that it does not break binary compatibility (color me chicken).

##### Release Note
Following Java 17 practice, the javalib `java.util.Random` now implements (extends) the  `RandomGenerator`
interface.  The `RandomGenerator` interface is incomplete and a work-in-progress. This PR changes
the `Random` class definition in a minor (0.N.0) , so that later changes in patch versions (0.5.n)  do not change it
in a way that breaks binary compatibility or user expectations.

##### Epilogue
This PR passes `test-mima` (thank you, Ekrich) but I do not know enough Scala Native internals to feel confident that
it does not break backward binary compatibility. This is caution due to lack of knowledge, rather
than knowledge of any breakage.

Over the course of time, I may peck away adding additional definitions to `RandomGenerator` to
make it more useful.