### PR TITLE
fix [compiler-plugin]: Fix generation of match default case in if-else chain

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1840,11 +1840,16 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           platform.isMaybeBoxed(l.tpe.typeSymbol) &&
           platform.isMaybeBoxed(r.tpe.typeSymbol)
       }
-      def isNull(t: Tree) = PartialFunction.cond(t) {
-        case Literal(Constant(null)) => true
+      def isNull(t: Tree) = t match {
+        case Literal(Constant(null))   => true
+        case ValTree(nir.Val.Null)     => true
+        case ValTree(nir.Val.Zero(ty)) => nir.Type.isPtrType(ty)
+        case _                         => false
       }
-      def isLiteral(t: Tree) = PartialFunction.cond(t) {
-        case Literal(_) => true
+      def isLiteral(t: Tree) = t match {
+        case Literal(_)      => true
+        case ValTree(nirVal) => nirVal.isLiteral
+        case _               => false
       }
       def isNonNullExpr(t: Tree) =
         isLiteral(t) || ((t.symbol ne null) && t.symbol.isModule)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1638,12 +1638,19 @@ trait NirGenExpr(using Context) {
           isMaybeBoxed(l.tpe.typeSymbol) &&
           isMaybeBoxed(r.tpe.typeSymbol)
       }
-      def isNull(t: Tree): Boolean = t match {
-        case Literal(Constant(null)) => true
-        case _                       => false
+      def isNull(t: Tree) = t match {
+        case Literal(Constant(null))   => true
+        case ValTree(nir.Val.Null)     => true
+        case ValTree(nir.Val.Zero(ty)) => nir.Type.isPtrType(ty)
+        case _                         => false
+      }
+      def isLiteral(t: Tree) = t match {
+        case Literal(_)      => true
+        case ValTree(nirVal) => nirVal.isLiteral
+        case _               => false
       }
       def isNonNullExpr(t: Tree): Boolean =
-        t.isInstanceOf[Literal] || ((t.symbol ne null) && t.symbol.is(Module))
+        isLiteral(t) || ((t.symbol ne null) && t.symbol.is(Module))
 
       def comparator = if (negated) nir.Comp.Ine else nir.Comp.Ieq
       def maybeNegate(v: nir.Val): nir.Val =

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -693,6 +693,16 @@ class IssuesTest {
     val names = Names.single[Foo](x => x)
     assertEquals("foo", names.mkString)
   }
+
+  @Test def issue3987(): Unit = {
+    // ensure does not hang
+    def is211 = false
+    val result = "scala-2.10" match {
+      case "scala-2.10" if is211 => "a"
+      case _                     => "b"
+    }
+    assertEquals(result, "b")
+  }
 }
 
 package issue1090 {


### PR DESCRIPTION
Fixes #3987 
Also optimizes univeral equality when comparing with non-nullable or literal types