### PR TITLE
feature [nativelib]: implement `MemoryMXBean` and `ManagementFactory`

### DIFF
--- a/javalib/src/main/scala/java/lang/management/ManagementFactory.scala
+++ b/javalib/src/main/scala/java/lang/management/ManagementFactory.scala
@@ -1,0 +1,20 @@
+package java.lang.management
+
+object ManagementFactory {
+
+  private lazy val MemoryBean = MemoryMXBean()
+
+  /** Returns the memory-specific bean.
+   *
+   *  @example
+   *    {{{
+   *  val memoryBean = getMemoryMXBean()
+   *  println(s"current heap: $${memoryBean.getHeapMemoryUsage().getUsed()}")
+   *
+   *  val list = List.fill(Short.MaxValue)(0) // allocate memory
+   *  println(s"current heap: $${memoryBean.getHeapMemoryUsage().getUsed()}")
+   *    }}}
+   */
+  def getMemoryMXBean(): MemoryMXBean = MemoryBean
+
+}

--- a/javalib/src/main/scala/java/lang/management/MemoryMXBean.scala
+++ b/javalib/src/main/scala/java/lang/management/MemoryMXBean.scala
@@ -7,9 +7,6 @@ trait MemoryMXBean {
   /** Returns the current runtime memory usage.
    *
    *  @note
-   *    the committed memory is always -1
-   *
-   *  @note
    *    the memory usage values may differ between invocations
    */
   def getHeapMemoryUsage(): MemoryUsage
@@ -27,13 +24,24 @@ object MemoryMXBean {
     new Impl
 
   private class Impl extends MemoryMXBean {
-    def getHeapMemoryUsage(): MemoryUsage =
-      new MemoryUsage(
-        GC.getInitHeapSize().toLong,
-        GC.getUsedHeapSize().toLong,
-        -1L,
-        GC.getMaxHeapSize().toLong
-      )
+
+    /** The committed memory = used memory.
+     *
+     *  By @WojciechMazur: This one might be more difficult to track. On Windows
+     *  we do manually commit memory provided by VirtualAlloc, but in the case
+     *  of Unix we typically only reserve a maximal chunk of memory using mmap
+     *  and committing is done automatically by the system on the first usage of
+     *  every page. Access to this memory is only limited by Immix/Commix Heap
+     *  blocks limit. I guess the best choice would be to fill it with usedHeap
+     *  which is still correct regarding Javadocs: committed will always be
+     *  greater than or equal to used.
+     */
+    def getHeapMemoryUsage(): MemoryUsage = {
+      val init = GC.getInitHeapSize().toLong
+      val used = GC.getUsedHeapSize().toLong
+      val max = GC.getMaxHeapSize().toLong
+      new MemoryUsage(init, used, used, max)
+    }
 
     def gc(): Unit =
       System.gc()

--- a/javalib/src/main/scala/java/lang/management/MemoryMXBean.scala
+++ b/javalib/src/main/scala/java/lang/management/MemoryMXBean.scala
@@ -1,0 +1,42 @@
+package java.lang.management
+
+import scala.scalanative.runtime.GC
+
+trait MemoryMXBean {
+
+  /** Returns the current runtime memory usage.
+   *
+   *  @note
+   *    the committed memory is always -1
+   *
+   *  @note
+   *    the memory usage values may differ between invocations
+   */
+  def getHeapMemoryUsage(): MemoryUsage
+
+  /** Runs the garbage collector.
+   *
+   *  An alias for `System.gc()`.
+   */
+  def gc(): Unit
+}
+
+object MemoryMXBean {
+
+  private[management] def apply(): MemoryMXBean =
+    new Impl
+
+  private class Impl extends MemoryMXBean {
+    def getHeapMemoryUsage(): MemoryUsage =
+      new MemoryUsage(
+        GC.getInitHeapSize().toLong,
+        GC.getUsedHeapSize().toLong,
+        -1L,
+        GC.getMaxHeapSize().toLong
+      )
+
+    def gc(): Unit =
+      System.gc()
+  }
+
+}

--- a/javalib/src/main/scala/java/lang/management/MemoryUsage.scala
+++ b/javalib/src/main/scala/java/lang/management/MemoryUsage.scala
@@ -1,0 +1,42 @@
+package java.lang.management
+
+/** Represents the runtime memory usage.
+ *
+ *  @param init
+ *    the initial amount of memory (bytes)
+ *
+ *  @param used
+ *    the currently used amount of memory (bytes)
+ *
+ *  @param committed
+ *    the currently committed amount of memory (bytes)
+ *
+ *  @param max
+ *    the maximum amount of memory that can be used (bytes)
+ */
+class MemoryUsage(init: Long, used: Long, committed: Long, max: Long) {
+  require(init >= -1, s"init ($init) must be >= -1.")
+  require(used >= -1, s"used ($used) must be >= -1")
+  require(committed >= -1, s"committed ($max) must be >= -1.")
+  require(max >= -1, s"max ($max) must be >= -1.")
+
+  /** The initial amount of memory (bytes).
+   */
+  def getInit(): Long = init
+
+  /** The currently used amount of memory (bytes).
+   */
+  def getUsed(): Long = used
+
+  /** The currently committed amount of memory (bytes)
+   */
+  def getCommitted(): Long = committed
+
+  /** The maximum amount of memory that can be used (bytes).
+   */
+  def getMax(): Long = max
+
+  override def toString(): String =
+    s"init = $init(${init >> 10}K) used = $used(${used >> 10}K) " +
+      s"committed = $committed(${committed >> 10}K) max = $max(${max >> 10}K)"
+}

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -61,6 +61,16 @@ size_t scalanative_GC_get_max_heapsize() {
     return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", heap_sz);
 }
 
+size_t scalanative_GC_get_used_heapsize() {
+    struct GC_prof_stats_s *stats =
+        (struct GC_prof_stats_s *)malloc(sizeof(struct GC_prof_stats_s));
+    GC_get_prof_stats(stats, sizeof(struct GC_prof_stats_s));
+    size_t heap_sz = stats->heapsize_full;
+    size_t unmapped_bytes = stats->unmapped_bytes;
+    free(stats);
+    return heap_sz - unmapped_bytes;
+}
+
 void scalanative_GC_collect() { GC_gcollect(); }
 
 void scalanative_GC_set_weak_references_collected_callback(

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -62,12 +62,10 @@ size_t scalanative_GC_get_max_heapsize() {
 }
 
 size_t scalanative_GC_get_used_heapsize() {
-    struct GC_prof_stats_s *stats =
-        (struct GC_prof_stats_s *)malloc(sizeof(struct GC_prof_stats_s));
-    GC_get_prof_stats(stats, sizeof(struct GC_prof_stats_s));
-    size_t heap_sz = stats->heapsize_full;
-    size_t unmapped_bytes = stats->unmapped_bytes;
-    free(stats);
+    struct GC_prof_stats_s stats = {};
+    GC_get_prof_stats(&stats, sizeof(struct GC_prof_stats_s));
+    size_t heap_sz = stats.heapsize_full;
+    size_t unmapped_bytes = stats.unmapped_bytes;
     return heap_sz - unmapped_bytes;
 }
 

--- a/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/CommixGC.c
@@ -112,6 +112,8 @@ size_t scalanative_GC_get_max_heapsize() {
     return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
 }
 
+size_t scalanative_GC_get_used_heapsize() { return Heap_getMemoryUsed(&heap); }
+
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {
     AddressRange range = {addr_low, addr_high};
     GC_Roots_Add(customRoots, range);

--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
@@ -42,6 +42,8 @@ size_t Heap_getMemoryLimit() {
     }
 }
 
+size_t Heap_getMemoryUsed(Heap *heap) { return heap->heapSize; }
+
 /**
  * Maps `MAX_SIZE` of memory and returns the first address aligned on
  * `alignement` mask

--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.h
@@ -90,5 +90,6 @@ void Heap_GrowIfNeeded(Heap *heap);
 void Heap_Grow(Heap *heap, uint32_t increment);
 void Heap_exitWithOutOfMemory(const char *details);
 size_t Heap_getMemoryLimit();
+size_t Heap_getMemoryUsed(Heap *heap);
 
 #endif // IMMIX_HEAP_H

--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
@@ -36,6 +36,8 @@ size_t Heap_getMemoryLimit() {
     }
 }
 
+size_t Heap_getMemoryUsed(Heap *heap) { return heap->heapSize; }
+
 /**
  * Maps `MAX_SIZE` of memory and returns the first address aligned on
  * `alignement` mask

--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.h
@@ -48,5 +48,6 @@ void Heap_Recycle(Heap *heap);
 void Heap_Grow(Heap *heap, uint32_t increment);
 void Heap_exitWithOutOfMemory(const char *details);
 size_t Heap_getMemoryLimit();
+size_t Heap_getMemoryUsed(Heap *heap);
 
 #endif // IMMIX_HEAP_H

--- a/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/ImmixGC.c
@@ -97,6 +97,8 @@ size_t scalanative_GC_get_max_heapsize() {
     return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", Heap_getMemoryLimit());
 }
 
+size_t scalanative_GC_get_used_heapsize() { return Heap_getMemoryUsed(&heap); }
+
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {
     AddressRange range = {addr_low, addr_high};
     GC_Roots_Add(customRoots, range);

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -52,6 +52,8 @@ size_t scalanative_GC_get_max_heapsize() {
     return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", getMemorySize());
 }
 
+size_t scalanative_GC_get_used_heapsize() { return -1L; }
+
 void Prealloc_Or_Default() {
 
     if (TO_NORMAL_MMAP == 1L) { // Check if we have prealloc env varible

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -37,7 +37,8 @@ static size_t DEFAULT_CHUNK;
 static size_t PREALLOC_CHUNK;
 static size_t CHUNK;
 static size_t TO_NORMAL_MMAP = 1L;
-static size_t DO_PREALLOC = 0L; // No Preallocation.
+static size_t DO_PREALLOC = 0L;     // No Preallocation.
+static size_t TOTAL_ALLOCATED = 0L; // Track total allocated memory
 
 static void exitWithOutOfMemory() {
     fprintf(stderr, "Out of heap space\n");
@@ -52,7 +53,7 @@ size_t scalanative_GC_get_max_heapsize() {
     return Parse_Env_Or_Default("GC_MAXIMUM_HEAP_SIZE", getMemorySize());
 }
 
-size_t scalanative_GC_get_used_heapsize() { return -1L; }
+size_t scalanative_GC_get_used_heapsize() { return TOTAL_ALLOCATED; }
 
 void Prealloc_Or_Default() {
 
@@ -110,6 +111,7 @@ void *scalanative_GC_alloc(Rtti *info, size_t size) {
         Object *alloc = (Object *)current;
         alloc->rtti = info;
         current += size;
+        TOTAL_ALLOCATED += size;
         return alloc;
     } else {
         scalanative_GC_init();
@@ -118,6 +120,7 @@ void *scalanative_GC_alloc(Rtti *info, size_t size) {
 #else
     Object *alloc = (Object *)calloc(size, 1);
     alloc->rtti = info;
+    TOTAL_ALLOCATED += size;
     return alloc;
 #endif
 }

--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -37,6 +37,7 @@ void scalanative_GC_set_weak_references_collected_callback(
 
 size_t scalanative_GC_get_init_heapsize();
 size_t scalanative_GC_get_max_heapsize();
+size_t scalanative_GC_get_used_heapsize();
 
 // Functions used to create a new thread supporting multithreading support in
 // the garbage collector. Would execute a proxy startup routine to register

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -40,6 +40,8 @@ object GC {
   def getInitHeapSize(): CSize = extern
   @name("scalanative_GC_get_max_heapsize")
   def getMaxHeapSize(): CSize = extern
+  @name("scalanative_GC_get_used_heapsize")
+  def getUsedHeapSize(): CSize = extern
 
   /*  Multithreading awareness for GC Every implementation of GC supported in
    *  ScalaNative needs to register a given thread The main thread is

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/ManagementFactoryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/ManagementFactoryTest.scala
@@ -12,6 +12,8 @@ class ManagementFactoryTest {
     val memoryUsage = bean.getHeapMemoryUsage()
 
     assertTrue(memoryUsage.getInit() >= 0L)
+    assertTrue(memoryUsage.getCommitted() >= 0L)
+    assertTrue(memoryUsage.getUsed() >= 0L)
     assertTrue(memoryUsage.getMax() >= 0L)
   }
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/ManagementFactoryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/ManagementFactoryTest.scala
@@ -1,0 +1,18 @@
+package org.scalanative.testsuite.javalib.lang.management
+
+import java.lang.management._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class ManagementFactoryTest {
+
+  @Test def getMemoryMXBean(): Unit = {
+    val bean = ManagementFactory.getMemoryMXBean
+    val memoryUsage = bean.getHeapMemoryUsage()
+
+    assertTrue(memoryUsage.getInit() >= 0L)
+    assertTrue(memoryUsage.getMax() >= 0L)
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/MemoryUsageTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/MemoryUsageTest.scala
@@ -1,0 +1,51 @@
+package org.scalanative.testsuite.javalib.lang.management
+
+import java.lang.management._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class MemoryUsageTest {
+
+  @Test def failWhenRequirementsFail(): Unit = {
+    assertThrows(
+      classOf[java.lang.IllegalArgumentException],
+      new MemoryUsage(-2L, 0L, 0L, 0L)
+    )
+
+    assertThrows(
+      classOf[java.lang.IllegalArgumentException],
+      new MemoryUsage(0L, -2L, 0L, 0L)
+    )
+
+    assertThrows(
+      classOf[java.lang.IllegalArgumentException],
+      new MemoryUsage(0L, 0L, -2L, 0L)
+    )
+
+    assertThrows(
+      classOf[java.lang.IllegalArgumentException],
+      new MemoryUsage(0L, 0L, 0L, -2L)
+    )
+  }
+
+  @Test def constructAnInstance(): Unit = {
+    val memoryUsage = new MemoryUsage(1024L, 2048L, 4096L, 8192L)
+
+    assertTrue(memoryUsage.getInit == 1024L)
+    assertTrue(memoryUsage.getUsed == 2048L)
+    assertTrue(memoryUsage.getCommitted == 4096L)
+    assertTrue(memoryUsage.getMax == 8192L)
+  }
+
+  @Test def properToString(): Unit = {
+    val memoryUsage = new MemoryUsage(1024L, 2048L, 4096L, 8192L)
+    val expected =
+      "init = 1024(1K) used = 2048(2K) committed = 4096(4K) max = 8192(8K)"
+
+    assertTrue(memoryUsage.toString == expected)
+  }
+
+}


### PR DESCRIPTION
The first step towards https://github.com/scala-native/scala-native/issues/4018.

### Scope

1) Implement `java.lang.management.MemoryMXBean`
2) Implement `java.lang.management.MemoryUsage`
3) Implement `java.lang.management.ManagementFactory.getMemoryMXBean()`