### PR TITLE
feature [nativelib]: add `runtimeVersion` to the `LinktimeInfo`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -60,6 +60,11 @@ object LinktimeInfo {
   )
   def contendedPaddingWidth: Int = resolved
 
+  @resolvedAtLinktime(
+    "scala.scalanative.meta.linktimeinfo.runtimeVersion"
+  )
+  def runtimeVersion: String = resolved
+
   object target {
     @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.target.arch")
     def arch: String = resolved

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -33,6 +33,7 @@ private[linker] trait LinktimeValueResolver { self: Reach =>
         .getOrElse(""),
       s"$linktimeInfo.isMsys" -> Platform.isMsys,
       s"$linktimeInfo.isCygwin" -> Platform.isCygwin,
+      s"$linktimeInfo.runtimeVersion" -> nir.Versions.current,
       s"$linktimeInfo.target.arch" -> triple.arch,
       s"$linktimeInfo.target.vendor" -> triple.vendor,
       s"$linktimeInfo.target.os" -> triple.os,

--- a/unit-tests/native/src/test/scala/scala/scalanative/meta/LinktimeInfoTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/meta/LinktimeInfoTest.scala
@@ -1,5 +1,6 @@
 package scala.scalanative.meta
 
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo
 import scala.scalanative.runtime.Platform
 
 import org.junit.Test
@@ -9,6 +10,10 @@ class LinktimeInfoTest {
 
   @Test def testMode(): Unit = {
     assertEquals(LinktimeInfo.debugMode, !LinktimeInfo.releaseMode)
+  }
+
+  @Test def testVersion(): Unit = {
+    assertEquals(LinktimeInfo.runtimeVersion, ScalaNativeBuildInfo.version)
   }
 
   @Test def testOS(): Unit = {


### PR DESCRIPTION
### Motivation

The `runtimeVersion` is a handy attribute to add to the metrics. For example, otel4s can use this property while providing [runtime attributes](https://github.com/typelevel/otel4s/blob/ebb319a02dc418054c3b265965e8a7ecf8fe4acf/sdk/common/native/src/main/scala/org/typelevel/otel4s/sdk/resource/ProcessRuntimeDetectorPlatform.scala#L37).

### Why don't use a `BuildInfo` plugin to get the Scala Native version? 

The compiler and runtime versions may differ. For example, the `otel4s` library can be compiled with Scala Native `0.5.1`, while the executable (application) will be compiled with `0.5.3`. 
