### PR TITLE
Fix `unsafe.toCWideString` was returning a double pointer to a string

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -206,7 +206,7 @@ package object unsafe extends unsafe.UnsafePackageCompat {
   @alwaysinline
   def toCWideString(str: String, charset: Charset = StandardCharsets.UTF_16LE)(
       implicit z: Zone
-  ): Ptr[CWideString] = {
+  ): CWideString = {
     toCWideStringImpl(str, charset, WideCharSize)
   }
 
@@ -241,7 +241,7 @@ package object unsafe extends unsafe.UnsafePackageCompat {
         !(cstrEnd + c) = 0.toByte
         c += 1
       }
-      cstr.asInstanceOf[Ptr[CWideString]]
+      cstr.asInstanceOf[CWideString]
     }
   }
 


### PR DESCRIPTION
Previously `toCWideString` returns `Ptr[CWideString]` = `Ptr[Ptr[CWideChar]]`.

This would not be what we expect, nor consistent with `toCWideStringUTF16LE` which returns `Ptr[CChar16]`.