### PR TITLE
feature [nativelib]: partially implement `OperatingSystemMXBean`

### DIFF
--- a/javalib/src/main/scala/java/lang/management/ManagementFactory.scala
+++ b/javalib/src/main/scala/java/lang/management/ManagementFactory.scala
@@ -4,6 +4,7 @@ object ManagementFactory {
 
   private lazy val MemoryBean = MemoryMXBean()
   private lazy val ThreadBean = ThreadMXBean()
+  private lazy val OperatingSystemBean = OperatingSystemMXBean()
 
   /** Returns the memory-specific bean.
    *
@@ -27,5 +28,15 @@ object ManagementFactory {
    *    }}}
    */
   def getThreadMXBean(): ThreadMXBean = ThreadBean
+
+  /** Returns the OS-specific bean.
+   *
+   *  @example
+   *    {{{
+   *  val osBean = ManagementFactory.getOperatingSystemMXBean()
+   *  println(s"OS: $${osBean.getName()}")
+   *    }}}
+   */
+  def getOperatingSystemMXBean(): OperatingSystemMXBean = OperatingSystemBean
 
 }

--- a/javalib/src/main/scala/java/lang/management/OperatingSystemMXBean.scala
+++ b/javalib/src/main/scala/java/lang/management/OperatingSystemMXBean.scala
@@ -1,0 +1,54 @@
+package java.lang.management
+
+trait OperatingSystemMXBean {
+
+  /** Returns the name of the operating system.
+   *
+   *  The equivalent of `sys.props("os.name")`.
+   */
+  def getName(): String
+
+  /** Returns the architecture of the operating system.
+   *
+   *  The equivalent of `sys.props("os.arch")`.
+   */
+  def getArch(): String
+
+  /** Returns the version of the operating system.
+   *
+   *  The equivalent of `sys.props("os.version")`.
+   *
+   *  @note
+   *    the `null` will be returned on Windows and MacOS platforms
+   */
+  def getVersion(): String
+
+  /** Returns the number of processors available to the process, never smaller
+   *  than one.
+   *
+   *  The equivalent of `Runtime.getRuntime().availableProcessors()`.
+   */
+  def getAvailableProcessors(): Int
+
+}
+
+object OperatingSystemMXBean {
+
+  private[management] def apply(): OperatingSystemMXBean =
+    new Impl
+
+  private class Impl extends OperatingSystemMXBean {
+    def getName(): String =
+      System.getProperty("os.name")
+
+    def getArch(): String =
+      System.getProperty("os.arch")
+
+    def getVersion(): String =
+      System.getProperty("os.version")
+
+    def getAvailableProcessors(): Int =
+      Runtime.getRuntime().availableProcessors()
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/ManagementFactoryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/ManagementFactoryTest.scala
@@ -43,4 +43,16 @@ class ManagementFactoryTest {
     )
   }
 
+  @Test def getOperatingSystemMXBean(): Unit = {
+    val bean = ManagementFactory.getOperatingSystemMXBean
+
+    assertEquals(bean.getArch(), System.getProperty("os.arch"))
+    assertEquals(bean.getName(), System.getProperty("os.name"))
+    assertEquals(bean.getVersion(), System.getProperty("os.version"))
+    assertEquals(
+      bean.getAvailableProcessors(),
+      Runtime.getRuntime().availableProcessors()
+    )
+  }
+
 }


### PR DESCRIPTION
A follow-up to the #4018. 

### Scope
- Partially implement `java.lang.management.OperatingSystemMXBean` (`getSystemLoadAverage` is unimplemented)
- Implement `java.lang.management.ManagementFactory.getOperatingSystemMXBean()`