### PR TITLE
feature [nativelib]: partially implement `RuntimeMXBean`

### DIFF
--- a/javalib/src/main/scala/java/lang/management/ManagementFactory.scala
+++ b/javalib/src/main/scala/java/lang/management/ManagementFactory.scala
@@ -5,6 +5,7 @@ object ManagementFactory {
   private lazy val MemoryBean = MemoryMXBean()
   private lazy val ThreadBean = ThreadMXBean()
   private lazy val OperatingSystemBean = OperatingSystemMXBean()
+  private lazy val RuntimeBean = RuntimeMXBean()
 
   /** Returns the memory-specific bean.
    *
@@ -38,5 +39,15 @@ object ManagementFactory {
    *    }}}
    */
   def getOperatingSystemMXBean(): OperatingSystemMXBean = OperatingSystemBean
+
+  /** Returns the runtime-specific bean.
+   *
+   *  @example
+   *    {{{
+   *  val runtimeBean = ManagementFactory.getRuntimeMXBean()
+   *  println(s"pid: $${runtimeBean.getPid()}")
+   *    }}}
+   */
+  def getRuntimeMXBean(): RuntimeMXBean = RuntimeBean
 
 }

--- a/javalib/src/main/scala/java/lang/management/RuntimeMXBean.scala
+++ b/javalib/src/main/scala/java/lang/management/RuntimeMXBean.scala
@@ -1,0 +1,131 @@
+package java.lang.management
+
+trait RuntimeMXBean {
+
+  /** Returns the process ID of the running virtual machine (process).
+   *
+   *  @since 10
+   */
+  def getPid(): Long
+
+  /** Returns the name of the running virtual machine (process).
+   */
+  def getName(): String
+
+  /** Returns the name of the virtual machine implementation.
+   *
+   *  The equivalent of `sys.props("java.vm.name")`.
+   */
+  def getVmName(): String
+
+  /** Returns the vendor of the virtual machine implementation.
+   *
+   *  The equivalent of `sys.props("java.vm.vendor")`.
+   */
+  def getVmVendor(): String
+
+  /** Returns the version of the virtual machine implementation.
+   *
+   *  The equivalent of `sys.props("java.vm.version")`.
+   */
+  def getVmVersion(): String
+
+  /** Returns the name of the virtual machine specification.
+   *
+   *  The equivalent of `sys.props("java.vm.specification.name")`.
+   */
+  def getSpecName(): String
+
+  /** Returns the vendor of the virtual machine specification.
+   *
+   *  The equivalent of `sys.props("java.vm.specification.vendor")`.
+   */
+  def getSpecVendor(): String
+
+  /** Returns the version of the virtual machine specification.
+   *
+   *  The equivalent of `sys.props("java.vm.specification.version")`.
+   */
+  def getSpecVersion(): String
+
+  /** Returns the uptime of the virtual machine (process) in milliseconds.
+   */
+  def getUptime(): Long
+
+  /** Returns the start time of the virtual machine (process) in milliseconds.
+   */
+  def getStartTime(): Long
+
+  /** Returns a map of names and values of the system properties whose name and
+   *  value is represented as a string.
+   */
+  def getSystemProperties(): java.util.Map[String, String]
+}
+
+object RuntimeMXBean {
+
+  private[management] def apply(): RuntimeMXBean =
+    new Impl
+
+  private class Impl extends RuntimeMXBean {
+    import scala.scalanative.unsafe._
+    import scala.scalanative.posix._
+    import scala.scalanative.unsigned._
+
+    def getPid(): Long =
+      unistd.getpid()
+
+    def getName(): String = {
+      val pid = getPid()
+
+      // InetAddress.getLocalHost returns IP (e.g. /127.0.0.1) while we need the name
+      val hostname = {
+        val hostNameLength = unistd._SC_HOST_NAME_MAX.toCSize
+        val hostName = stackalloc[Byte](hostNameLength)
+        if (unistd.gethostname(hostName, hostNameLength) == 0) {
+          fromCString(hostName)
+        } else {
+          "localhost"
+        }
+      }
+
+      pid + "@" + hostname
+    }
+
+    def getVmName(): String =
+      System.getProperty("java.vm.name")
+
+    def getVmVendor(): String =
+      System.getProperty("java.vm.vendor")
+
+    def getVmVersion(): String =
+      System.getProperty("java.vm.version")
+
+    def getSpecName(): String =
+      System.getProperty("java.vm.specification.name")
+
+    def getSpecVendor(): String =
+      System.getProperty("java.vm.specification.vendor")
+
+    def getSpecVersion(): String =
+      System.getProperty("java.vm.specification.version")
+
+    def getUptime(): Long =
+      scalanative.runtime.uptime
+
+    def getStartTime(): Long =
+      scalanative.runtime.startTime
+
+    def getSystemProperties(): java.util.Map[String, String] = {
+      val result = new java.util.HashMap[String, String]()
+      System.getProperties().forEach { (key, value) =>
+        (key, value) match {
+          case (k: String, v: String) => result.put(k, v)
+          case _                      =>
+        }
+      }
+      result
+    }
+  }
+
+}

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -11,6 +11,8 @@ import java.util.concurrent.locks.LockSupport
 
 package object runtime {
   def filename = ExecInfo.filename
+  def startTime: Long = ExecInfo.startTime
+  def uptime: Long = System.currentTimeMillis() - startTime
 
   /** Used as a stub right hand of intrinsified methods. */
   private[scalanative] def intrinsic: Nothing = throwUndefined()
@@ -73,6 +75,7 @@ package object runtime {
     }
 
     ExecInfo.filename = fromCString(argv(0))
+    ExecInfo.startTime = System.currentTimeMillis()
     args
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.state.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.state.scala
@@ -22,4 +22,5 @@ private[scalanative] object MainThreadShutdownContext {
 
 private object ExecInfo {
   var filename: String = null
+  var startTime: Long = 0L
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/ManagementFactoryTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/management/ManagementFactoryTest.scala
@@ -55,4 +55,24 @@ class ManagementFactoryTest {
     )
   }
 
+  @Test def getRuntimeMXBean(): Unit = {
+    val bean = ManagementFactory.getRuntimeMXBean
+
+    assertEquals(bean.getVmName(), sys.props("java.vm.name"))
+    assertEquals(bean.getVmVendor(), sys.props("java.vm.vendor"))
+    assertEquals(bean.getVmVersion(), sys.props("java.vm.version"))
+    assertEquals(bean.getSpecName(), sys.props("java.vm.specification.name"))
+    assertEquals(
+      bean.getSpecVendor(),
+      sys.props("java.vm.specification.vendor")
+    )
+    assertEquals(
+      bean.getSpecVersion(),
+      sys.props("java.vm.specification.version")
+    )
+    assertTrue(bean.getUptime() > 0L)
+    assertTrue(bean.getStartTime() > 0L)
+    assertTrue(bean.getSystemProperties().size() > 0)
+  }
+
 }


### PR DESCRIPTION
A follow-up to the #4018. 

### Scope

- Extend `scalanative.runtime`: add `uptime` and `startTime`, record process start time
- Partially implement `java.lang.management.RuntimeMXBean`
- Implement `java.lang.management.ManagementFactory.getRuntimeMXBean()`