### PR TITLE
Fix compilation error of _CS_PATH for Termux on Android

### DIFF
--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -35,6 +35,11 @@
 #define _SC_TRACE_USER_EVENT_MAX 0
 #endif // __FreeBSD__ || __OpenBSD__ || __NetBSD__
 
+#if defined(__ANDROID__) && !defined(_CS_PATH)
+// Termux does not define _CS_PATH. We follow the same approach as BSD.
+#define _CS_PATH 0
+#endif
+
 long scalanative__posix_version() { return _POSIX_VERSION; }
 
 int scalanative__xopen_version() { return _XOPEN_VERSION; }


### PR DESCRIPTION
I followed the practice to check for __ANDROID__ and _CS_PATH macro in termux's repo: https://github.com/search?q=repo%3Atermux%2Ftermux-packages%20_CS_PATH&type=code