### PR TITLE
add references to third party tools and libraries to docs

### DIFF
--- a/docs/lib/javalib.md
+++ b/docs/lib/javalib.md
@@ -18,6 +18,10 @@ details.
 [scala-java-time](https://github.com/cquiroz/scala-java-time) provides a native, JVM and JS implementation of
 the `java.time` packages
 
+The full timezone database required for `java.time` can be too large for some applications. The
+[sbt-tzdb](https://github.com/cquiroz/sbt-tzdb) `sbt` plugin can  build a custom version of tzdb, which has
+the minimal data your application needs; reducing the size of the application.
+
 ## `java.util.Locale`
 
 [scala-java-locales](https://github.com/cquiroz/scala-java-locales) provides a native, JVM and JS

--- a/docs/lib/javalib.md
+++ b/docs/lib/javalib.md
@@ -18,6 +18,10 @@ details.
 [scala-java-time](https://github.com/cquiroz/scala-java-time) provides a native, JVM and JS implementation of
 the `java.time` packages
 
+[sjavatime](https://github.com/ekrich/sjavatime) provides a native and JS implementation of the `java.time`
+API. While not yet as full features as `scala-java-time` this is useful if a minimal implementation is
+required.
+
 The full timezone database required for `java.time` can be too large for some applications. The
 [sbt-tzdb](https://github.com/cquiroz/sbt-tzdb) `sbt` plugin can  build a custom version of tzdb, which has
 the minimal data your application needs; reducing the size of the application.

--- a/docs/lib/javalib.md
+++ b/docs/lib/javalib.md
@@ -1,11 +1,27 @@
 # Java Standard Library
 
-Scala Native supports a subset of the JDK core libraries reimplemented
+Scala Native includes a subset of the JDK core libraries reimplemented
 in Scala.
 
-## Supported classes
+Third-party libraries, like `scala-java-time` and `scala-java-locales`,
+provide more complete implementations for some JDK packages.
 
-For list of currently supported Java Standard Library types and methods refer to [scaladoc package](https://www.javadoc.io/doc/org.scala-native/javalib_native0.5_2.13/latest/index.html) or consult [javalib sources](https://github.com/scala-native/scala-native/tree/main/javalib/src/main/scala/java) for details.
+## Included JDK Implementation
+
+For list of currently supported Java Standard Library types and methods refer to [scaladoc
+package](https://www.javadoc.io/doc/org.scala-native/javalib_native0.5_2.13/latest/index.html) or consult
+[javalib sources](https://github.com/scala-native/scala-native/tree/main/javalib/src/main/scala/java) for
+details.
+
+## `java.time`
+
+[scala-java-time](https://github.com/cquiroz/scala-java-time) provides a native, JVM and JS implementation of
+the `java.time` packages
+
+## `java.util.Locale`
+
+[scala-java-locales](https://github.com/cquiroz/scala-java-locales) provides a native, JVM and JS
+implementation of `java.util.Locale`
 
 ## Regular expressions (java.util.regex)
 

--- a/docs/user/profiling.md
+++ b/docs/user/profiling.md
@@ -60,7 +60,7 @@ flamegraphs to see where your program spends most of its CPU time.
 ### Use samply
 
 [samply](https://github.com/mstange/samply) is a command line CPU profiler which uses the Firefox profiler as
-its UI. Samply has support for de-mangling Scala native symbols.
+its UI. Samply has support for de-mangling Scala Native symbols.
 
 ### Use hotspot
 

--- a/docs/user/profiling.md
+++ b/docs/user/profiling.md
@@ -65,7 +65,7 @@ its UI. Samply has support for de-mangling Scala Native symbols.
 ### Use hotspot
 
 [hotspot](https://github.com/KDAB/hotspot) is a GUI for `perf` which provides a flamegraph view. As of this
-writing, hotspot does not de-mangle Scala native symbols.
+writing, hotspot does not de-mangle Scala Native symbols.
 
 ### Using using `perf` and `FlameGraph`
 

--- a/docs/user/profiling.md
+++ b/docs/user/profiling.md
@@ -3,6 +3,9 @@
 In this section you can find some tips on how to profile your Scala
 Native binary in Linux.
 
+Scala Native binaries are regular executables. Tools that works with native executables will work with Scala
+Native executables. That includes the Linux `perf` performance analysis tool.
+
 ## Measuring execution time and memory
 
 -   With the `time` command you can measure execution time:
@@ -53,6 +56,19 @@ Exit status: 0
 A [flamegraph](http://www.brendangregg.com/flamegraphs.html) is a
 visualization of the most frequent code-paths of a program. You can use
 flamegraphs to see where your program spends most of its CPU time.
+
+### Use samply
+
+[samply](https://github.com/mstange/samply) is a command line CPU profiler which uses the Firefox profiler as
+its UI. Samply has support for de-mangling Scala native symbols.
+
+### Use hotspot
+
+[hotspot](https://github.com/KDAB/hotspot) is a GUI for `perf` which provides a flamegraph view. As of this
+writing, hotspot does not de-mangle Scala native symbols.
+
+### Using using `perf` and `FlameGraph`
+
 Follow these steps:
 
 -   You need to install the `perf` command if you haven't got it


### PR DESCRIPTION
adds references to `scala-java-time`, `scala-java-locale` and a few performance tools.