### PR TITLE
fix[compiler-plugin] Intrinisic ClassFieldRawPtr should always mangle symbol names when comparing symbols

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2541,7 +2541,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val classInfo = target.tpe.finalResultType
       val classInfoSym = classInfo.typeSymbol.asClass
       def matchesName(f: Symbol) = {
-        f.nameString == TermName(fieldNameId).toString()
+        f.nameString == fieldNameId
       }
 
       val candidates =

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2650,7 +2650,7 @@ trait NirGenExpr(using Context) {
       val classInfo = target.tpe.finalResultType
       val classInfoSym = classInfo.typeSymbol.asClass
       def matchesName(f: SingleDenotation) =
-        f.name.mangled == termName(fieldNameId).mangled
+        f.name.mangledString == fieldNameId
       def isImmutableField(f: SymDenotation) = {
         // If `val` was defined in trait it would be internally mutable, but with stable accessors
         !f.is(Mutable) || classInfoSym.parentSyms.exists(s =>

--- a/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -786,7 +786,7 @@ class NIRCompilerTest {
     // Unable to compile lazy val in trait
     NIRCompiler(_.compile("""
       |trait Source { 
-      |  lazy val (lineStarts, charCount, lineCount) = ???
+      |  lazy val (lineStarts, charCount, lineCount) = (1, 2, 3)
       |}
       | 
       |class StringSource extends Source

--- a/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -782,4 +782,14 @@ class NIRCompilerTest {
     )
   }
 
+  @Test def issue4044(): Unit = {
+    // Unable to compile lazy val in trait
+    NIRCompiler(_.compile("""
+      |trait Source { 
+      |  lazy val (lineStarts, charCount, lineCount) = ???
+      |}
+      | 
+      |class StringSource extends Source
+      |""".stripMargin))
+  }
 }


### PR DESCRIPTION
Fixes #4044 