### PR TITLE
Optimize Integer.toString

### DIFF
--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -418,9 +418,9 @@ object Integer {
   }
 
   def toString(i: scala.Int): String = {
-    if (i == 0) {"0"}
-    else if (i == java.lang.Integer.MIN_VALUE) {"-2147483648"}
-    else if (i == java.lang.Integer.MAX_VALUE) {"2147483647"}
+    if (i == 0) { "0" }
+    else if (i == java.lang.Integer.MIN_VALUE) { "-2147483648" }
+    else if (i == java.lang.Integer.MAX_VALUE) { "2147483647" }
     else {
       val negative = i < 0
       val bufferSize = if (i < 1000 && i > -1000) 4 else 11

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -168,18 +168,11 @@ final class Integer(val _value: scala.Int)
   protected def %(x: scala.Double): scala.Double = _value % x
 }
 
-private[lang] object IntegerDecimalScale {
-  private[lang] val decimalScale: Array[scala.Int] = Array(1000000000,
-    100000000, 10000000, 1000000, 100000, 10000, 1000, 100, 10, 1)
-}
-
 private[lang] object IntegerCache {
   private[lang] val cache = new Array[java.lang.Integer](256)
 }
 
 object Integer {
-  import IntegerDecimalScale.decimalScale
-
   final val TYPE = scala.Predef.classOf[scala.scalanative.runtime.PrimitiveInt]
   final val MIN_VALUE = -2147483648
   final val MAX_VALUE = 2147483647
@@ -425,113 +418,29 @@ object Integer {
   }
 
   def toString(i: scala.Int): String = {
-    if (i == 0) {
-      "0"
-    } else {
+    if (i == 0) {"0"}
+    else if (i == java.lang.Integer.MIN_VALUE) {"-2147483648"}
+    else if (i == java.lang.Integer.MAX_VALUE) {"2147483647"}
+    else {
       val negative = i < 0
-
-      if (i < 1000 && i > -1000) {
-        val buffer = new Array[Char](4)
-        val positive_value =
-          if (negative) -i
-          else i
-        var first_digit = 0
-        if (negative) {
-          buffer(0) = '-'
-          first_digit += 1
-        }
-
-        var last_digit = first_digit
-        var quot = positive_value
-        while ({
-          val res = quot / 10
-          var digit_value = quot - ((res << 3) + (res << 1))
-          digit_value += '0'
-          buffer(last_digit) = digit_value.toChar
-          last_digit += 1
-          quot = res
-          quot != 0
-        }) ()
-
-        val count = last_digit
-        last_digit -= 1
-        while ({
-          val tmp = buffer(last_digit)
-          buffer(last_digit) = buffer(first_digit)
-          last_digit -= 1
-          buffer(first_digit) = tmp
-          first_digit += 1
-          first_digit < last_digit
-        }) ()
-
-        new String(buffer, 0, count)
-      } else if (i == MIN_VALUE) {
-        "-2147483648"
-      } else {
-        val buffer = new Array[Char](11)
-        var positive_value = if (negative) -i else i
-        var first_digit = 0
-        if (negative) {
-          buffer(0) = '-'
-          first_digit += 1
-        }
-
-        var last_digit = first_digit
-        var count = 0
-        var number = 0
-        var start = false
-        var k = 0
-        while (k < 9) {
-          count = 0
-          number = decimalScale(k)
-
-          if (positive_value < number) {
-            if (start) {
-              buffer(last_digit) = '0'
-              last_digit += 1
-            }
-          } else {
-            if (k > 0) {
-              number = decimalScale(k) << 3
-              if (positive_value >= number) {
-                positive_value -= number
-                count += 8
-              }
-
-              number = decimalScale(k) << 2
-              if (positive_value >= number) {
-                positive_value -= number
-                count += 4
-              }
-            }
-            number = decimalScale(k) << 1
-            if (positive_value >= number) {
-              positive_value -= number
-              count += 2
-            }
-            if (positive_value >= decimalScale(k)) {
-              positive_value -= decimalScale(k)
-              count += 1
-            }
-            if (count > 0 && !start) {
-              start = true
-            }
-            if (start) {
-              buffer(last_digit) = (count + '0').toChar
-              last_digit += 1
-            }
-          }
-
-          k += 1
-        }
-
-        buffer(last_digit) = (positive_value + '0').toChar
-        last_digit += 1
-        count = last_digit
-        last_digit -= 1
-
-        new String(buffer, 0, count)
+      val bufferSize = if (i < 1000 && i > -1000) 4 else 11
+      val buffer = new Array[Char](bufferSize)
+      var positiveValue = Math.abs(i)
+      var offset = bufferSize - 1
+      while (positiveValue != 0 && offset > 0) {
+        val next = positiveValue / 10
+        buffer(offset) = ((positiveValue - next * 10) + '0').toChar
+        offset = offset - 1
+        positiveValue = next
       }
+
+      if (negative) {
+        buffer(offset) = '-'
+      } else {
+        offset = offset + 1
+      }
+
+      new String(buffer, offset, bufferSize - offset)
     }
   }
 


### PR DESCRIPTION
Related to #4040

Uses a simpler implementation of `Integer#toString`, which was quite faster on my benchmarks.
Maybe there's still room for optimization... The old implementation was quite complex, so I was a bit surprised that I was able to get faster results with a naive solution 🤷 

Benchmark code:
```scala
object Main {
  val numIter = 10000000

  def main(args: Array[String]): Unit = {
    println("Sanity Checks:")
    println(s"${0} / ${-123} / ${123} / ${-123456} / ${123456} / ${Int.MinValue} / ${Int.MaxValue}")

    locally {
      val start = System.currentTimeMillis()
      var res = 0
      var i = 0
      while (i < numIter) {
        res = res + s"$res".##
        i = i + 1
      }
      println("RES: " + res)
      println("Time: " + (System.currentTimeMillis() - start))
    }
  }
}
```

Results on 0.5.5:
```
Sanity Checks:
0 / -123 / 123 / -123456 / 123456 / -2147483648 / 2147483647
RES: -1548773655
Time: 1625
```

Results on 0.5.6-SNAPSHOT:
```
Sanity Checks:
0 / -123 / 123 / -123456 / 123456 / -2147483648 / 2147483647
RES: -1548773655
Time: 766
```