### PR TITLE
[fix/sbt-plugin] Always override default build target in Test scope to `application`

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -346,6 +346,7 @@ object ScalaNativePluginInternal {
     scalaNativeConfigSettings(true) ++
       Seq(
         mainClass := Some("scala.scalanative.testinterface.TestMain"),
+        nativeConfig ~= { _.withBuildTarget(build.BuildTarget.application) },
         loadedTestFrameworks := {
           val configName = configuration.value.name
 


### PR DESCRIPTION
Fixes #4049