### PR TITLE
[improve/nativelib] Better detection of `LinktimeInfo.isMac`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -21,7 +21,7 @@ object LinktimeInfo {
 
   @resolvedAtLinktime
   def isMac: Boolean =
-    (target.vendor == "apple" || target.vendor == "unknown") &&
+    target.vendor == "apple" &&
       (target.os == "darwin" || target.os == "macosx")
 
   @resolvedAtLinktime

--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -20,7 +20,9 @@ object LinktimeInfo {
   def isLinux: Boolean = target.os == "linux"
 
   @resolvedAtLinktime
-  def isMac: Boolean = target.vendor == "apple" && target.os == "darwin"
+  def isMac: Boolean =
+    (target.vendor == "apple" || target.vendor == "unknown") &&
+      (target.os == "darwin" || target.os == "macosx")
 
   @resolvedAtLinktime
   def isFreeBSD: Boolean = target.os == "freebsd"


### PR DESCRIPTION
 Support alternative 'macosx` OS naming convention. Handle `unknown` vendor for custom builds