### PR TITLE
Fix #4026 Fix negative byte to hex conversion in LLVM IR codegen

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -607,7 +607,7 @@ private[codegen] abstract class AbstractCodeGen(
     bytes.foreach {
       case '\\' => str("\\\\")
       case c if c < 0x20 || c == '"' || c >= 0x7f =>
-        val hex = Integer.toHexString(c)
+        val hex = Integer.toHexString(c & 0xff)
         str {
           if (hex.length < 2) "\\0" + hex
           else "\\" + hex

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
@@ -136,4 +136,13 @@ class CStringTest {
       assertEquals(!(cstr1 + 5), 0)
     }
   }
+
+  @Test def cStringNonASCII(): Unit = {
+    // note: `fromCString` is needed to trigger compilation errors against malformed literals
+    fromCString(c"日本語")
+    fromCString(c"język polski")
+    fromCString(c"한국어")
+
+    fromCString(c"🚂🚀🚁🍔")
+  }
 }


### PR DESCRIPTION
Previously, we generated invalid LLVM IR code for `CString` that contained non-ASCII characters.

For instance, the UTF-8 representation of the character "本" (which means "book" in Japanese) is `e6 9c ac`. The byte `0xe6` in an 8-bit signed value (Byte) is `-26`. When this byte (`-26`) is widened to an integer for the `toHexString` method, it applies sign extension, filling the upper 24 bits with 1s to preserve the negative value. This results in the 32-bit integer `0xffffffe6`.

This commit updates the `genByteString` method in `AbstractCodeGen` to mask the byte to its lowest 8 bits. This ensures that the signed byte is correctly converted to its unsigned equivalent in the range of 0-255.