### PR TITLE
Improve interflow inliner log messages

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -58,11 +58,13 @@ private[interflow] trait Inline { self: Interflow =>
           if (shall) {
             if (shallNot) {
               logger(s"not inlining ${name.show}, because:")
+              if (noOpt) logger("* has noopt attr")
               if (noInline) logger("* has noinline attr")
               if (isRecursive) logger("* is recursive")
               if (isDenylisted) logger("* is denylisted")
-              if (callerTooBig) logger("* caller is too big")
-              if (calleeTooBig) logger("* callee is too big")
+              if (calleeTooBig) logger(s"* callee is too big (${defn.insts.size} > $maxCalleeSize)")
+              if (callerTooBig) logger(s"* caller is too big (${mergeProcessor.currentSize()} > $maxCallerSize)")
+              if (isExtern) logger("* is an extern method")
               if (inlineDepthLimitExceeded)
                 logger("* inline depth limit exceeded")
             }

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -62,8 +62,14 @@ private[interflow] trait Inline { self: Interflow =>
               if (noInline) logger("* has noinline attr")
               if (isRecursive) logger("* is recursive")
               if (isDenylisted) logger("* is denylisted")
-              if (calleeTooBig) logger(s"* callee is too big (${defn.insts.size} > $maxCalleeSize)")
-              if (callerTooBig) logger(s"* caller is too big (${mergeProcessor.currentSize()} > $maxCallerSize)")
+              if (calleeTooBig)
+                logger(
+                  s"* callee is too big (${defn.insts.size} > $maxCalleeSize)"
+                )
+              if (callerTooBig)
+                logger(
+                  s"* caller is too big (${mergeProcessor.currentSize()} > $maxCallerSize)"
+                )
               if (isExtern) logger("* is an extern method")
               if (inlineDepthLimitExceeded)
                 logger("* inline depth limit exceeded")


### PR DESCRIPTION
Some minor nitpicks. I noticed that some checks were missing from the inliner logs, which made the message a bit confusing ("could not inline because:... chirps")

I also added some sizes to the callee/caller too big checks, as otherwise it's impossible to know if a change improved that or not.