### PR TITLE
[fix] Always use RuntimeNothing and RuntimeNull types in method parameters and return types

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
@@ -35,7 +35,9 @@ private[scalanative] object Linktime {
   // Takes Global for constant struct describing linktime property.
   // Replaced with resolved value at link-time.
   final val PropertyResolveFunctionName: Global.Member =
-    Linktime.member(Sig.Method("resolveProperty", Seq(Rt.String, Type.Nothing)))
+    Linktime.member(
+      Sig.Method("resolveProperty", Seq(Rt.String, Rt.RuntimeNothing))
+    )
 
   final def PropertyResolveFunctionTy(retty: Type): Type.Function =
     Type.Function(Seq(Rt.String), retty)

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -233,6 +233,11 @@ object Type {
   def isUnsignedType(ty: Type): Boolean =
     unsigned.values.contains(normalize(ty))
 
+  def isNothing(ty: Type): Boolean =
+    ty == nir.Type.Nothing || normalize(ty) == nir.Rt.RuntimeNothing
+  def isNull(ty: Type): Boolean =
+    ty == nir.Type.Null || normalize(ty) == nir.Rt.RuntimeNull
+
   def normalize(ty: Type): Type = ty match {
     case ArrayValue(ty, n)          => ArrayValue(normalize(ty), n)
     case StructValue(tys)           => StructValue(tys.map(normalize))

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -233,10 +233,24 @@ object Type {
   def isUnsignedType(ty: Type): Boolean =
     unsigned.values.contains(normalize(ty))
 
-  def isNothing(ty: Type): Boolean =
-    ty == nir.Type.Nothing || normalize(ty) == nir.Rt.RuntimeNothing
-  def isNull(ty: Type): Boolean =
-    ty == nir.Type.Null || normalize(ty) == nir.Rt.RuntimeNull
+  object NothingType {
+    def unapply(v: nir.Type): Option[nir.Type] =
+      if (isNothing(v)) Some(v) else None
+  }
+  def isNothing(ty: Type): Boolean = ty match {
+    case nir.Type.Nothing         => true
+    case nir.Type.Ref(name, _, _) => name == nir.Rt.RuntimeNothing.name
+    case _                        => false
+  }
+  object NullType {
+    def unapply(v: nir.Type): Option[nir.Type] =
+      if (isNull(v)) Some(v) else None
+  }
+  def isNull(ty: Type): Boolean = ty match {
+    case nir.Type.Null            => true
+    case nir.Type.Ref(name, _, _) => name == nir.Rt.RuntimeNull.name
+    case _                        => false
+  }
 
   def normalize(ty: Type): Type = ty match {
     case ArrayValue(ty, n)          => ArrayValue(normalize(ty), n)

--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -22,7 +22,7 @@ object Versions {
    * new version of the toolchain.
    */
   final val compat: Int = 6 // a.k.a. MAJOR version
-  final val revision: Int = 10 // a.k.a. MINOR version
+  final val revision: Int = 11 // a.k.a. MINOR version
   case class Version(compat: Int, revision: Int)
 
   /* Current public release version of Scala Native. */

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -354,9 +354,9 @@ final class BinaryDeserializer(buffer: ByteBuffer, nirSource: NIRSource) {
 
   private def getSig(): Sig = {
     val sig = new Sig(getString())
-    if (prelude.requiresParamTypeAdaption && (sig.isMethod || sig.isCtor)) {
+    if (prelude.requiresParamTypeOrReturnTypeAdaption && (sig.isMethod || sig.isCtor)) {
       sig.unmangled match {
-        case sig @ Sig.Method(_, tps, _) => sig.copy(types = tps.init.map(adaptParamType) :+ tps.last).mangled
+        case sig @ Sig.Method(_, tps, _) => sig.copy(types = tps.map(adaptParamType)).mangled
         case sig @ Sig.Ctor(tps)         => sig.copy(types = tps.map(adaptParamType)).mangled
         case sig                         => sig
       }
@@ -437,10 +437,10 @@ final class BinaryDeserializer(buffer: ByteBuffer, nirSource: NIRSource) {
         Type.Function(
           args = {
             val types = getTypes()
-            if (prelude.requiresParamTypeAdaption) types.map(adaptParamType)
+            if (prelude.requiresParamTypeOrReturnTypeAdaption) types.map(adaptParamType)
             else types
           },
-          ret = getType()
+          ret = adaptParamType(getType())
         )
 
       case T.NullType    => Type.Null

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Prelude.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Prelude.scala
@@ -20,6 +20,8 @@ case class Prelude(
     sections = sections,
     hasEntryPoints = hasEntryPoints
   )
+
+  private[scalanative] val requiresParamTypeAdaption = revision < 11
 }
 
 object Prelude {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Prelude.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Prelude.scala
@@ -21,7 +21,11 @@ case class Prelude(
     hasEntryPoints = hasEntryPoints
   )
 
-  private[scalanative] val requiresParamTypeAdaption = revision < 11
+  /* Until Scala Native 0.5.6 we were incorrectly using nir.Type.Null | nir.Type.Nothing for method parameter and return types
+   * This lead to uncorrect handling of method dispatch on their instances.
+   * hese should be always emitted as scala.runtime.RuntimeNothing$ | scala.runtime.RuntimeNull$
+   */
+  private[scalanative] val requiresParamTypeOrReturnTypeAdaption = revision < 11
 }
 
 object Prelude {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -55,7 +55,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
       super.+=(inst)
       inst match {
-        case nir.Inst.Let(_, op, _) if op.resty == nir.Type.Nothing =>
+        case nir.Inst.Let(_, op, _) if nir.Type.isNothing(op.resty) =>
           unreachable(unwind)
           label(fresh())
         case _ =>
@@ -710,7 +710,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       } else {
         curMethodEnv.resolve(sym)
       }
-      if(value.ty == nir.Type.Nothing) {
+      if (nir.Type.isNothing(value.ty)) {
         // Short circuit the generated code for phantom value
         // scala.runtime.Nothing$ extends Throwable so it's safe to throw
         buf.raise(value, unwind)
@@ -849,15 +849,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       // enclosing class `this` reference + capture symbols
       val captureSymsWithEnclThis = curClassSym.get +: captureSyms
 
-      val captureTypes = captureSymsWithEnclThis.map(sym => toParamRefType(genType(sym.tpe)))
-      val captureNames =
+      val (captureTypes, captureNames) =
         captureSymsWithEnclThis.zipWithIndex.map {
           case (sym, idx) =>
             val name = anonName.member(nir.Sig.Field("capture" + idx))
-            val ty = genType(sym.tpe)
+            val ty = toParamRefType(genType(sym.tpe))
             statBuf += nir.Defn.Var(nir.Attrs.None, name, ty, nir.Val.Zero(ty))
-            name
-        }
+            (ty, name)
+        }.unzip
 
       // Generate an anonymous class constructor that initializes all the fields.
 
@@ -934,7 +933,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                     case ErasedValueType(valueClazz, underlying) =>
                       val unboxMethod = valueClazz.derivedValueClassUnbox
                       val casted =
-                        buf.genCastOp(value.ty, genType(valueClazz), value)
+                        buf.genCastOp(value.ty, genRefType(valueClazz), value)
                       val unboxed = buf.genApplyMethod(
                         sym = unboxMethod,
                         statically = false,
@@ -944,13 +943,21 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                       if (unboxMethod.tpe.resultType == underlying)
                         unboxed
                       else
-                        buf.genCastOp(unboxed.ty, genType(underlying), unboxed)
+                        buf.genCastOp(
+                          unboxed.ty,
+                          genRefType(underlying),
+                          unboxed
+                        )
 
                     case _ =>
                       val unboxed =
                         buf.unboxValue(sym.tpe, partial = true, value)
                       if (unboxed == value) // no need to or cannot unbox, we should cast
-                        buf.genCastOp(genType(sym.tpe), genType(arg.tpe), value)
+                        buf.genCastOp(
+                          genRefType(sym.tpe),
+                          genRefType(arg.tpe),
+                          value
+                        )
                       else unboxed
                   }
                 curMethodEnv.enter(sym, result)
@@ -1057,7 +1064,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case tpe: ErasedValueType =>
           val valueClass = tpe.valueClazz
           val unboxMethod = treeInfo.ValueClass.valueUnbox(tpe)
-          val castedValue = buf.genCastOp(value.ty, genType(valueClass), value)
+          val castedValue =
+            buf.genCastOp(value.ty, genRefType(valueClass), value)
           buf.genApplyMethod(
             sym = unboxMethod,
             statically = false,
@@ -1068,7 +1076,11 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case tpe =>
           val unboxed = buf.unboxValue(tpe, partial = true, value)
           if (unboxed == value) // no need to or cannot unbox, we should cast
-            buf.genCastOp(genType(tpeEnteringPosterasure), genType(tpe), value)
+            buf.genCastOp(
+              genRefType(tpeEnteringPosterasure),
+              genRefType(tpe),
+              value
+            )
           else unboxed
       }
     }
@@ -2374,7 +2386,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genCastOp(fromty: nir.Type, toty: nir.Type, value: nir.Val)(implicit
         pos: nir.SourcePosition
     ): nir.Val =
-      castConv(fromty, toty).fold(value)(buf.conv(_, toty, value, unwind))
+      castConv(fromty, toty)
+        .orElse(castConv(value.ty, toty))
+        .fold(value)(buf.conv(_, toty, value, unwind))
 
     private lazy val optimizedFunctions = {
       // Included functions should be pure, and should not not narrow the result type
@@ -2689,9 +2703,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genCoercion(value: nir.Val, fromty: nir.Type, toty: nir.Type)(implicit
         pos: nir.SourcePosition
     ): nir.Val = {
-      if (fromty == toty) {
-        value
-      } else {
+      if (fromty == toty) value
+      else if (nir.Type.isNothing(fromty) || nir.Type.isNothing(toty)) value
+      else {
         val conv = (fromty, toty) match {
           case (nir.Type.Ptr, _: nir.Type.RefKind) =>
             nir.Conv.Bitcast
@@ -2817,7 +2831,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             case (_: nir.Type.PrimitiveKind, _: nir.Type.PrimitiveKind) =>
               genCoercion(value, fromty, toty)
             case _ if boxed.ty =?= boxty => boxed
-            case (_, nir.Type.Nothing) =>
+            case _ if nir.Type.isNothing(toty) =>
               val runtimeNothing = genType(RuntimeNothingClass)
               val isNullL, notNullL = fresh()
               val isNull =

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -92,7 +92,7 @@ trait NirGenName[G <: Global with Singleton] {
         nir.Sig.Scope.Private(owner)
       else nir.Sig.Scope.Public
 
-    val paramTypes = tpe.params.toSeq.map(p => genType(p.info))
+    val paramTypes = tpe.params.toSeq.map(p => toParamRefType(genType(p.info)))
 
     def isExtern = sym.isExtern
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -92,7 +92,7 @@ trait NirGenName[G <: Global with Singleton] {
         nir.Sig.Scope.Private(owner)
       else nir.Sig.Scope.Public
 
-    val paramTypes = tpe.params.toSeq.map(p => toParamRefType(genType(p.info)))
+    val paramTypes = tpe.params.toSeq.map(p => genParamOrReturnType(p.info))
 
     def isExtern = sym.isExtern
 
@@ -103,7 +103,7 @@ trait NirGenName[G <: Global with Singleton] {
     else if (sym.name == nme.CONSTRUCTOR)
       owner.member(nir.Sig.Ctor(paramTypes))
     else {
-      val retType = genType(tpe.resultType)
+      val retType = genParamOrReturnType(tpe.resultType)
       owner.member(nir.Sig.Method(id, paramTypes :+ retType, scope))
     }
   }
@@ -140,8 +140,8 @@ trait NirGenName[G <: Global with Singleton] {
       else nir.Sig.Scope.PublicStatic
 
     val tpe = sym.tpe.widen
-    val paramTypes = tpe.params.toSeq.map(p => toParamRefType(genType(p.info)))
-    val retType = genType(fromType(sym.info.resultType))
+    val paramTypes = tpe.params.toSeq.map(p => genParamOrReturnType(p.info))
+    val retType = genParamOrReturnType(fromType(sym.info.resultType))
 
     val name = sym.name
     val sig = nir.Sig.Method(id, paramTypes :+ retType, scope)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -140,7 +140,7 @@ trait NirGenName[G <: Global with Singleton] {
       else nir.Sig.Scope.PublicStatic
 
     val tpe = sym.tpe.widen
-    val paramTypes = tpe.params.toSeq.map(p => genType(p.info))
+    val paramTypes = tpe.params.toSeq.map(p => toParamRefType(genType(p.info)))
     val retType = genType(fromType(sym.info.resultType))
 
     val name = sym.name

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -1043,7 +1043,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val ty = genType(curClassSym.tpe)
           nir.Val.Local(namedId(fresh)("this"), ty)
         case Some(sym) =>
-          val ty = genType(sym.tpe)
+          val ty = toParamRefType(genType(sym.tpe))
           val name = genLocalName(sym)
           val param = nir.Val.Local(namedId(fresh)(name), ty)
           curMethodEnv.enter(sym, param)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -1043,7 +1043,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val ty = genType(curClassSym.tpe)
           nir.Val.Local(namedId(fresh)("this"), ty)
         case Some(sym) =>
-          val ty = toParamRefType(genType(sym.tpe))
+          val ty = genParamOrReturnType(sym.tpe)
           val name = genLocalName(sym)
           val param = nir.Val.Local(namedId(fresh)(name), ty)
           curMethodEnv.enter(sym, param)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -260,7 +260,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     val params = sym.tpe.params
     val isExtern = isExternHint || sym.isExtern
     if (!isExtern)
-      params.map { p => genType(p.tpe) }
+      params.map { p => toParamRefType(genType(p.tpe)) }
     else {
       val wereRepeated = exitingPhase(currentRun.typerPhase) {
         for {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -134,6 +134,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     case UnitClass        => nir.Type.Unit
     case BoxedUnitClass   => nir.Rt.BoxedUnit
     case NullClass        => genRefType(RuntimeNullClass)
+    case NothingClass     => genRefType(RuntimeNothingClass)
     case ArrayClass       => nir.Type.Array(genType(st.targs.head))
     case _ if st.isStruct => genStruct(st)
     case _ if deconstructValueTypes =>
@@ -144,6 +145,17 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
         nir.Type.unbox.getOrElse(nir.Type.normalize(ref), ref)
       }
     case _ => nir.Type.Ref(genTypeName(st.sym))
+  }
+
+  /** Adapts the possibly primitive NIR type to reference type required by
+   *  method parameters or result types Method param types should never contain
+   *  primitive null or nothing types. Instead, similary to JVM we should only
+   *  emit synthetic scala.runtime types
+   */
+  def toParamRefType(tpe: nir.Type): nir.Type = tpe match {
+    case nir.Type.Null    => nir.Rt.RuntimeNull
+    case nir.Type.Nothing => nir.Rt.RuntimeNothing
+    case ty               => ty
   }
 
   def genFixedSizeArray(st: SimpleType): nir.Type = {
@@ -262,7 +274,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
       params.map { p =>
         if (isExtern && wereRepeated(p.name)) nir.Type.Vararg
         else if (isExtern) genExternType(p.tpe)
-        else genType(p.tpe)
+        else toParamRefType(genType(p.tpe))
       }
     }
   }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -151,10 +151,10 @@ trait NirGenExpr(using Context) {
       val Assign(lhsp, rhsp) = tree
       given nir.SourcePosition = tree.span
 
-      desugarTree(lhsp) match {
-        case sel @ Select(qualp, _) =>
+      lhsp match {
+        case DesugaredSelect(qualp, _) =>
           def rhs = genExpr(rhsp)
-          val sym = sel.symbol
+          val sym = lhsp.symbol
           val name = genFieldName(sym)
           if (sym.isExtern) {
             // Ignore intrinsic call to extern in class constructor
@@ -164,14 +164,14 @@ trait NirGenExpr(using Context) {
                 rhsp.symbol == defnNir.UnsafePackage_extern
             if (shouldIgnoreAssign) nir.Val.Unit
             else {
-              val externTy = genExternType(sel.tpe)
+              val externTy = genExternType(lhsp.tpe)
               genStoreExtern(externTy, sym, rhs)
             }
           } else {
             val qual =
               if (sym.isStaticMember) genModule(qualp.symbol)
               else genExpr(qualp)
-            val ty = genType(sel.tpe)
+            val ty = genType(lhsp.tpe)
             buf.fieldstore(ty, qual, name, rhs, unwind)
           }
 
@@ -262,7 +262,7 @@ trait NirGenExpr(using Context) {
             case _          => genType(tree.tpe)
           }
           name = anonClassName.member(nir.Sig.Field(s"capture$idx"))
-        yield (tpe, name)
+        yield (toParamRefType(tpe), name)
       }
       val (captureTypes, captureNames) = captureTypesAndNames.unzip
 
@@ -448,19 +448,24 @@ trait NirGenExpr(using Context) {
     }
 
     def genIdent(tree: Ident): nir.Val =
-      desugarIdent(tree) match {
-        case Ident(_) =>
+      tree match {
+        case DesugaredSelect(_, _) =>
+          genSelect(DesugaredSelect.desugared)
+        case _ =>
           val sym = tree.symbol
           given nir.SourcePosition = tree.span
-          if (curMethodInfo.mutableVars.contains(sym))
-            buf.varload(curMethodEnv.resolve(sym), unwind)
-          else if (sym.is(Module))
-            genModule(sym)
-          else curMethodEnv.resolve(sym)
-        case desuagred: Select =>
-          genSelect(desuagred.withSpan(tree.span))
-        case tree =>
-          throw FatalError(s"Unsupported desugared ident tree: $tree")
+          val value =
+            if (sym.is(Module))
+              genModule(sym)
+            else if (curMethodInfo.mutableVars.contains(sym))
+              buf.varload(curMethodEnv.resolve(sym), unwind)
+            else curMethodEnv.resolve(sym)
+          if value.ty == nir.Type.Nothing then
+            // Short circuit the generated code for phantom value
+            // scala.runtime.Nothing$ extends Throwable so it's safe to throw
+            buf.raise(value, unwind)
+            buf.unreachable(unwind)
+          value
       }
 
     def genIf(tree: If): nir.Val = {
@@ -1101,8 +1106,7 @@ trait NirGenExpr(using Context) {
       import NirPrimitives._
       import dotty.tools.backend.ScalaPrimitivesOps._
       given nir.SourcePosition = app.span
-      val Apply(fun, args) = app
-      val Select(receiver, _) = desugarTree(fun): @unchecked
+      val Apply(fun @ DesugaredSelect(receiver, _), args) = app: @unchecked
 
       val sym = app.symbol
       val code = nirPrimitives.getPrimitive(app, receiver.tpe)
@@ -1181,8 +1185,10 @@ trait NirGenExpr(using Context) {
     }
 
     private def genApplyTypeApply(app: Apply): nir.Val = {
-      val Apply(tApply @ TypeApply(fun, targs), argsp) = app: @unchecked
-      val Select(receiverp, _) = desugarTree(fun): @unchecked
+      val Apply(
+        tApply @ TypeApply(fun @ DesugaredSelect(receiverp, _), targs),
+        argsp
+      ) = app: @unchecked
       given nir.SourcePosition = app.span
 
       val funSym = fun.symbol
@@ -1381,7 +1387,7 @@ trait NirGenExpr(using Context) {
             s"Too many arguments for primitive function: $app",
             app.sourcePos
           )
-          nir.Val.Null
+          nir.Val.Zero(retty)
       }
     }
 
@@ -1467,7 +1473,7 @@ trait NirGenExpr(using Context) {
                 s"Unknown floating point type binary operation code: $code",
                 right.sourcePos
               )
-              nir.Val.Null
+              nir.Val.Zero(retty)
           }
         case nir.Type.Bool | _: nir.Type.I =>
           code match {
@@ -1498,7 +1504,7 @@ trait NirGenExpr(using Context) {
                 s"Unknown integer type binary operation code: $code",
                 right.sourcePos
               )
-              nir.Val.Null
+              nir.Val.Zero(retty)
           }
         case _: nir.Type.RefKind =>
           def genEquals(ref: Boolean, negated: Boolean) = (left, right) match {
@@ -1521,7 +1527,7 @@ trait NirGenExpr(using Context) {
                 s"Unknown reference type binary operation code: $code",
                 right.sourcePos
               )
-              nir.Val.Null
+              nir.Val.Zero(retty)
           }
         case nir.Type.Ptr =>
           code match {
@@ -1533,7 +1539,7 @@ trait NirGenExpr(using Context) {
             s"Unknown binary operation type: $ty",
             right.sourcePos
           )
-          nir.Val.Null
+          nir.Val.Zero(retty)
       }
 
       genCoercion(binres, binres.ty, retty)(using right.span)
@@ -2044,7 +2050,9 @@ trait NirGenExpr(using Context) {
     def genCastOp(from: nir.Type, to: nir.Type, value: nir.Val)(using
         nir.SourcePosition
     ): nir.Val =
-      castConv(from, to).fold(value)(buf.conv(_, to, value, unwind))
+      castConv(from, to)
+      .orElse(castConv(value.ty, to))
+      .fold(value)(buf.conv(_, to, value, unwind))
 
     private def genCoercion(app: Apply, receiver: Tree, code: Int): nir.Val = {
       given nir.SourcePosition = app.span
@@ -2244,7 +2252,7 @@ trait NirGenExpr(using Context) {
         case ErasedValueType(valueClass, _) =>
           val boxedClass = valueClass.typeSymbol.asClass
           val unboxMethod = ValueClasses.valueClassUnbox(boxedClass)
-          val castedValue = buf.genCastOp(value.ty, genType(valueClass), value)
+          val castedValue = buf.genCastOp(value.ty, genRefType(valueClass), value)
           buf.genApplyMethod(
             sym = unboxMethod,
             statically = false,
@@ -2255,7 +2263,7 @@ trait NirGenExpr(using Context) {
         case tpe =>
           val unboxed = buf.unboxValue(tpe, partial = true, value)
           if (unboxed == value) // no need to or cannot unbox, we should cast
-            buf.genCastOp(genType(tpeEnteringPosterasure), genType(tpe), value)
+            buf.genCastOp(genRefType(tpeEnteringPosterasure), genRefType(tpe), value)
           else unboxed
       }
     }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -79,6 +79,7 @@ trait NirGenName(using Context) {
     def paramTypes = sym.info.paramInfoss.flatten
       .map(fromType)
       .map(genType(_))
+      .map(toParamRefType)
 
     if (sym == defn.`String_+`) genMethodName(defnNir.String_concat)
     else if (sym.isExtern) owner.member(genExternSigImpl(sym, id))
@@ -130,6 +131,7 @@ trait NirGenName(using Context) {
     val paramTypes = sym.info.paramInfoss.flatten
       .map(fromType)
       .map(genType(_))
+      .map(toParamRefType)
     val retType = genType(fromType(sym.info.resultType))
 
     val sig = nir.Sig.Method(id, paramTypes :+ retType, scope)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -78,8 +78,7 @@ trait NirGenName(using Context) {
 
     def paramTypes = sym.info.paramInfoss.flatten
       .map(fromType)
-      .map(genType(_))
-      .map(toParamRefType)
+      .map(genParamOrReturnType(_))
 
     if (sym == defn.`String_+`) genMethodName(defnNir.String_concat)
     else if (sym.isExtern) owner.member(genExternSigImpl(sym, id))
@@ -88,7 +87,7 @@ trait NirGenName(using Context) {
     else if (sym.name == nme.TRAIT_CONSTRUCTOR)
       owner.member(nir.Sig.Method(id, Seq(nir.Type.Unit), scope))
     else
-      val retType = genType(fromType(sym.info.resultType))
+      val retType = genParamOrReturnType(fromType(sym.info.resultType))
       owner.member(nir.Sig.Method(id, paramTypes :+ retType, scope))
   }
 
@@ -130,9 +129,8 @@ trait NirGenName(using Context) {
 
     val paramTypes = sym.info.paramInfoss.flatten
       .map(fromType)
-      .map(genType(_))
-      .map(toParamRefType)
-    val retType = genType(fromType(sym.info.resultType))
+      .map(genParamOrReturnType)
+    val retType = genParamOrReturnType(fromType(sym.info.resultType))
 
     val sig = nir.Sig.Method(id, paramTypes :+ retType, scope)
     owner.member(sig)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -385,7 +385,7 @@ trait NirGenStat(using Context) {
     } yield param.symbol
     val argParams = argParamSyms.map { sym =>
       val tpe = sym.info.resultType
-      val ty = toParamRefType(genType(tpe))
+      val ty = genParamOrReturnType(tpe)
       val name = genLocalName(sym)
       val param = nir.Val.Local(fresh.namedId(genLocalName(sym)), ty)
       curMethodEnv.enter(sym, param)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -385,7 +385,7 @@ trait NirGenStat(using Context) {
     } yield param.symbol
     val argParams = argParamSyms.map { sym =>
       val tpe = sym.info.resultType
-      val ty = genType(tpe)
+      val ty = toParamRefType(genType(tpe))
       val name = genLocalName(sym)
       val param = nir.Val.Local(fresh.namedId(genLocalName(sym)), ty)
       curMethodEnv.enter(sym, param)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -229,7 +229,7 @@ trait NirGenType(using Context) {
    *  primitive null or nothing types. Instead, similary to JVM we should only
    *  emit synthetic scala.runtime types
    */
-  def toParamRefType(tpe: nir.Type): nir.Type = tpe match {
+  def genParamOrReturnType(st: SimpleType): nir.Type = genType(st) match {
     case nir.Type.Null    => nir.Rt.RuntimeNull
     case nir.Type.Nothing => nir.Rt.RuntimeNothing
     case ty               => ty
@@ -349,7 +349,7 @@ trait NirGenType(using Context) {
       val retty =
         if (sym.isConstructor) nir.Type.Unit
         else if (isExtern) genExternType(resultType)
-        else genType(resultType)
+        else genParamOrReturnType(resultType)
       nir.Type.Function(selfty ++: paramtys, retty)
     }
 
@@ -388,7 +388,7 @@ trait NirGenType(using Context) {
       def isRepeated = repeatedParams.getOrElse(paramName, false)
       if (isExtern && isRepeated) nir.Type.Vararg
       else if (isExtern) genExternType(paramType)
-      else toParamRefType(genType(paramType))
+      else genParamOrReturnType(paramType)
     }
   }
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -211,6 +211,7 @@ trait NirGenType(using Context) {
     else if (sym == defn.UnitClass) nir.Type.Unit
     else if (sym == defn.BoxedUnitClass) nir.Rt.BoxedUnit
     else if (sym == defn.NullClass) nir.Rt.RuntimeNull
+    else if (sym == defn.NothingClass) nir.Rt.RuntimeNothing
     else if (sym == defn.ArrayClass) nir.Type.Array(genType(targs.head))
     else if (sym.isStruct) genStruct(st)
     else if (deconstructValueTypes) {
@@ -221,6 +222,17 @@ trait NirGenType(using Context) {
         nir.Type.unbox.getOrElse(nir.Type.normalize(ref), ref)
       }
     } else nir.Type.Ref(genTypeName(sym))
+  }
+
+  /** Adapts the possibly primitive NIR type to reference type required by
+   *  method parameters or result types
+   *  Method param types should never contain primitive null or nothing types. 
+   *  Instead, similary to JVM we should only emit synthetic scala.runtime types
+   */
+  def toParamRefType(tpe: nir.Type): nir.Type = tpe match {
+    case nir.Type.Null    => nir.Rt.RuntimeNull
+    case nir.Type.Nothing => nir.Rt.RuntimeNothing
+    case ty               => ty
   }
 
   def genTypeValue(st: SimpleType): nir.Val =
@@ -376,7 +388,7 @@ trait NirGenType(using Context) {
       def isRepeated = repeatedParams.getOrElse(paramName, false)
       if (isExtern && isRepeated) nir.Type.Vararg
       else if (isExtern) genExternType(paramType)
-      else genType(paramType)
+      else toParamRefType(genType(paramType))
     }
   }
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -225,9 +225,9 @@ trait NirGenType(using Context) {
   }
 
   /** Adapts the possibly primitive NIR type to reference type required by
-   *  method parameters or result types
-   *  Method param types should never contain primitive null or nothing types. 
-   *  Instead, similary to JVM we should only emit synthetic scala.runtime types
+   *  method parameters or result types Method param types should never contain
+   *  primitive null or nothing types. Instead, similary to JVM we should only
+   *  emit synthetic scala.runtime types
    */
   def toParamRefType(tpe: nir.Type): nir.Type = tpe match {
     case nir.Type.Null    => nir.Rt.RuntimeNull

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -289,7 +289,8 @@ private[scalanative] final class Check(implicit
       ty match {
         case _: nir.Type.ValueKind =>
           ok
-        case nir.Type.Ptr | nir.Type.Nothing | nir.Type.Null | nir.Type.Unit =>
+        case nir.Type.Ptr | nir.Type.Unit | nir.Type.NothingType(_) |
+            nir.Type.NullType(_) =>
           ok
         case ScopeRef(kind) =>
           kind match {
@@ -303,7 +304,8 @@ private[scalanative] final class Check(implicit
       ty match {
         case _: nir.Type.ValueKind =>
           ok
-        case nir.Type.Ptr | nir.Type.Nothing | nir.Type.Null | nir.Type.Unit =>
+        case nir.Type.Ptr | nir.Type.Unit | nir.Type.NothingType(_) |
+            nir.Type.NullType(_) =>
           ok
         case ScopeRef(kind) =>
           kind match {

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -480,7 +480,7 @@ private[scalanative] object Lower {
         case nir.Type.Unit =>
           genOp(buf, fresh(), op)
           buf.let(n, nir.Op.Copy(unit), unwind)
-        case nir.Type.Nothing =>
+        case ty if nir.Type.isNothing(ty) =>
           genOp(buf, fresh(), op)
           genUnreachable(buf)
           buf.label(fresh(), Seq(nir.Val.Local(n, op.resty)))
@@ -1973,7 +1973,7 @@ private[scalanative] object Lower {
   val unit = nir.Val.Global(unitInstance, nir.Type.Ptr)
 
   val throwName = extern("scalanative_throw")
-  val throwSig = nir.Type.Function(Seq(nir.Type.Ptr), nir.Type.Nothing)
+  val throwSig = nir.Type.Function(Seq(nir.Type.Ptr), nir.Rt.RuntimeNothing)
   val throw_ = nir.Val.Global(throwName, nir.Type.Ptr)
 
   val arrayHeapAlloc = nir.Type.typeToArray.map {
@@ -2079,11 +2079,11 @@ private[scalanative] object Lower {
     )
 
   val throwDivisionByZeroTy =
-    nir.Type.Function(Seq(nir.Rt.Runtime), nir.Type.Nothing)
+    nir.Type.Function(Seq(nir.Rt.Runtime), nir.Rt.RuntimeNothing)
   val throwDivisionByZero =
     nir.Global.Member(
       nir.Rt.Runtime.name,
-      nir.Sig.Method("throwDivisionByZero", Seq(nir.Type.Nothing))
+      nir.Sig.Method("throwDivisionByZero", Seq(nir.Rt.RuntimeNothing))
     )
   val throwDivisionByZeroVal =
     nir.Val.Global(throwDivisionByZero, nir.Type.Ptr)
@@ -2091,35 +2091,35 @@ private[scalanative] object Lower {
   val throwClassCastTy =
     nir.Type.Function(
       Seq(nir.Rt.Runtime, nir.Type.Ptr, nir.Type.Ptr),
-      nir.Type.Nothing
+      nir.Rt.RuntimeNothing
     )
   val throwClassCast =
     nir.Global.Member(
       nir.Rt.Runtime.name,
       nir.Sig.Method(
         "throwClassCast",
-        Seq(nir.Type.Ptr, nir.Type.Ptr, nir.Type.Nothing)
+        Seq(nir.Type.Ptr, nir.Type.Ptr, nir.Rt.RuntimeNothing)
       )
     )
   val throwClassCastVal =
     nir.Val.Global(throwClassCast, nir.Type.Ptr)
 
   val throwNullPointerTy =
-    nir.Type.Function(Seq(nir.Rt.Runtime), nir.Type.Nothing)
+    nir.Type.Function(Seq(nir.Rt.Runtime), nir.Rt.RuntimeNothing)
   val throwNullPointer =
     nir.Global.Member(
       nir.Rt.Runtime.name,
-      nir.Sig.Method("throwNullPointer", Seq(nir.Type.Nothing))
+      nir.Sig.Method("throwNullPointer", Seq(nir.Rt.RuntimeNothing))
     )
   val throwNullPointerVal =
     nir.Val.Global(throwNullPointer, nir.Type.Ptr)
 
   val throwUndefinedTy =
-    nir.Type.Function(Seq(nir.Type.Ptr), nir.Type.Nothing)
+    nir.Type.Function(Seq(nir.Type.Ptr), nir.Rt.RuntimeNothing)
   val throwUndefined =
     nir.Global.Member(
       nir.Rt.Runtime.name,
-      nir.Sig.Method("throwUndefined", Seq(nir.Type.Nothing))
+      nir.Sig.Method("throwUndefined", Seq(nir.Rt.RuntimeNothing))
     )
   val throwUndefinedVal =
     nir.Val.Global(throwUndefined, nir.Type.Ptr)
@@ -2127,25 +2127,26 @@ private[scalanative] object Lower {
   val throwOutOfBoundsTy =
     nir.Type.Function(
       Seq(nir.Type.Ptr, nir.Type.Int, nir.Type.Int),
-      nir.Type.Nothing
+      nir.Rt.RuntimeNothing
     )
   val throwOutOfBounds =
     nir.Global.Member(
       nir.Rt.Runtime.name,
       nir.Sig.Method(
         "throwOutOfBounds",
-        Seq(nir.Type.Int, nir.Type.Int, nir.Type.Nothing)
+        Seq(nir.Type.Int, nir.Type.Int, nir.Rt.RuntimeNothing)
       )
     )
   val throwOutOfBoundsVal =
     nir.Val.Global(throwOutOfBounds, nir.Type.Ptr)
 
   val throwNoSuchMethodTy =
-    nir.Type.Function(Seq(nir.Type.Ptr, nir.Type.Ptr), nir.Type.Nothing)
+    nir.Type.Function(Seq(nir.Type.Ptr, nir.Type.Ptr), nir.Rt.RuntimeNothing)
   val throwNoSuchMethod =
     nir.Global.Member(
       nir.Rt.Runtime.name,
-      nir.Sig.Method("throwNoSuchMethod", Seq(nir.Rt.String, nir.Type.Nothing))
+      nir.Sig
+        .Method("throwNoSuchMethod", Seq(nir.Rt.String, nir.Rt.RuntimeNothing))
     )
   val throwNoSuchMethodVal =
     nir.Val.Global(throwNoSuchMethod, nir.Type.Ptr)

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -768,7 +768,7 @@ private[codegen] abstract class AbstractCodeGen(
   ): Unit = {
     import sb._
     def isVoid(ty: nir.Type): Boolean =
-      ty == nir.Type.Unit || ty == nir.Type.Nothing
+      ty == nir.Type.Unit || nir.Type.isNothing(ty)
 
     val op = inst.op
     val id = inst.id

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -85,8 +85,8 @@ private[codegen] trait MetadataCodeGen { self: AbstractCodeGen =>
     dbg("", v)
 
   private def canHaveDebugValue(ty: nir.Type) = ty match {
-    case nir.Type.Unit | nir.Type.Nothing => false
-    case _                                => true
+    case nir.Type.Unit | nir.Type.NothingType(_) => false
+    case _                                       => true
   }
 
   def dbgLocalValue(id: nir.Local, ty: nir.Type, argIdx: Option[Int] = None)(

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -61,7 +61,7 @@ private[interflow] trait Eval { self: Interflow =>
               case _ => ()
             }
           }
-          if (value.ty == nir.Type.Nothing) {
+          if (nir.Type.isNothing(value.ty)) {
             return nir.Inst.Unreachable(unwind)(inst.pos)
           } else {
             val ty = value match {

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -87,7 +87,7 @@ private[interflow] trait Opt { self: Interflow =>
 
       // If any of the argument types is nothing, this method
       // is never going to be called, so we don't have to visit it.
-      if (args.exists(_.ty == nir.Type.Nothing)) {
+      if (args.exists(arg => nir.Type.isNothing(arg.ty))) {
         val insts = Seq(
           nir.Inst.Label(nir.Local(0), args),
           nir.Inst.Unreachable(nir.Next.None)

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -41,7 +41,10 @@ object Sub {
         true
       case (nir.Type.NullType(_), (nir.Type.Ptr | _: nir.Type.RefKind)) =>
         true
-      case (nir.Type.NothingType(_), (_: nir.Type.ValueKind | _: nir.Type.RefKind)) =>
+      case (
+            nir.Type.NothingType(_),
+            (_: nir.Type.ValueKind | _: nir.Type.RefKind)
+          ) =>
         true
       case (_: nir.Type.RefKind, nir.Rt.Object) =>
         true

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -39,9 +39,9 @@ object Sub {
     (l, r) match {
       case (l, r) if l == r =>
         true
-      case (nir.Type.Null, (nir.Type.Ptr | _: nir.Type.RefKind)) =>
+      case (nir.Type.NullType(_), (nir.Type.Ptr | _: nir.Type.RefKind)) =>
         true
-      case (nir.Type.Nothing, (_: nir.Type.ValueKind | _: nir.Type.RefKind)) =>
+      case (nir.Type.NothingType(_), (_: nir.Type.ValueKind | _: nir.Type.RefKind)) =>
         true
       case (_: nir.Type.RefKind, nir.Rt.Object) =>
         true
@@ -80,17 +80,17 @@ object Sub {
     (lty, rty) match {
       case _ if lty == rty =>
         lty
-      case (ty, nir.Type.Nothing) =>
+      case (ty, nir.Type.NothingType(_)) =>
         ty
-      case (nir.Type.Nothing, ty) =>
+      case (nir.Type.NothingType(_), ty) =>
         ty
-      case (nir.Type.Ptr, nir.Type.Null) =>
+      case (nir.Type.Ptr, nir.Type.NullType(_)) =>
         nir.Type.Ptr
-      case (nir.Type.Null, nir.Type.Ptr) =>
+      case (nir.Type.NullType(_), nir.Type.Ptr) =>
         nir.Type.Ptr
-      case (refty: nir.Type.RefKind, nir.Type.Null) =>
+      case (refty: nir.Type.RefKind, nir.Type.NullType(_)) =>
         nir.Type.Ref(refty.className, refty.isExact, nullable = true)
-      case (nir.Type.Null, refty: nir.Type.RefKind) =>
+      case (nir.Type.NullType(_), refty: nir.Type.RefKind) =>
         nir.Type.Ref(refty.className, refty.isExact, nullable = true)
       case (lty: nir.Type.RefKind, rty: nir.Type.RefKind) =>
         val ScopeRef(linfo) = lty: @unchecked

--- a/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
@@ -174,4 +174,14 @@ class IssuesSpec extends LinkerSpec {
     }
   }
 
+  // https://github.com/scala-native/scala-native/issues/4039
+  @Test def issue4039(): Unit = checkNoLinkageErrors {
+    """
+    |object Test {
+    |  def main(args: Array[String]): Unit = {
+    |    Seq.empty[Nothing].forall(_ == Int.box(0))
+    |  }
+    |}
+    |"""
+  }
 }


### PR DESCRIPTION
Fixes #4039 

We're using incorrect signatures for methods having parameter or return types set to `Nothing` or `Null` - we should have always used `scala.runtime.Nothing$` and `scala.runtime.Null$` instances. These are emitted by both JVM and Scala.js. 

This change breaks the binary compatibility of NIR. For backward compatibility, it adopts the signatures produced by the pre 0.5.6 compiler.  
Due to broken forward compatibility it probably should not be merged in 0.5.x series and we should fix issue #4039 in some other way.