### PR TITLE
[fix] Teach NIR subtyping to treat `scala.runtime.Nothing$` in the same way a `nir.Type.Nothing`

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -233,6 +233,25 @@ object Type {
   def isUnsignedType(ty: Type): Boolean =
     unsigned.values.contains(normalize(ty))
 
+  object NothingType {
+    def unapply(v: nir.Type): Option[nir.Type] =
+      if (isNothing(v)) Some(v) else None
+  }
+  def isNothing(ty: Type): Boolean = ty match {
+    case nir.Type.Nothing         => true
+    case nir.Type.Ref(name, _, _) => name == nir.Rt.RuntimeNothing.name
+    case _                        => false
+  }
+  object NullType {
+    def unapply(v: nir.Type): Option[nir.Type] =
+      if (isNull(v)) Some(v) else None
+  }
+  def isNull(ty: Type): Boolean = ty match {
+    case nir.Type.Null            => true
+    case nir.Type.Ref(name, _, _) => name == nir.Rt.RuntimeNull.name
+    case _                        => false
+  }
+
   def normalize(ty: Type): Type = ty match {
     case ArrayValue(ty, n)          => ArrayValue(normalize(ty), n)
     case StructValue(tys)           => StructValue(tys.map(normalize))

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -849,15 +849,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       // enclosing class `this` reference + capture symbols
       val captureSymsWithEnclThis = curClassSym.get +: captureSyms
 
-      val captureTypes = captureSymsWithEnclThis.map(sym => genType(sym.tpe))
-      val captureNames =
+      val (captureTypes, captureNames) =
         captureSymsWithEnclThis.zipWithIndex.map {
           case (sym, idx) =>
             val name = anonName.member(nir.Sig.Field("capture" + idx))
             val ty = genType(sym.tpe)
             statBuf += nir.Defn.Var(nir.Attrs.None, name, ty, nir.Val.Zero(ty))
-            name
-        }
+            (ty, name)
+        }.unzip
 
       // Generate an anonymous class constructor that initializes all the fields.
 
@@ -934,7 +933,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                     case ErasedValueType(valueClazz, underlying) =>
                       val unboxMethod = valueClazz.derivedValueClassUnbox
                       val casted =
-                        buf.genCastOp(value.ty, genType(valueClazz), value)
+                        buf.genCastOp(value.ty, genRefType(valueClazz), value)
                       val unboxed = buf.genApplyMethod(
                         sym = unboxMethod,
                         statically = false,
@@ -944,13 +943,21 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                       if (unboxMethod.tpe.resultType == underlying)
                         unboxed
                       else
-                        buf.genCastOp(unboxed.ty, genType(underlying), unboxed)
+                        buf.genCastOp(
+                          unboxed.ty,
+                          genRefType(underlying),
+                          unboxed
+                        )
 
                     case _ =>
                       val unboxed =
                         buf.unboxValue(sym.tpe, partial = true, value)
                       if (unboxed == value) // no need to or cannot unbox, we should cast
-                        buf.genCastOp(genType(sym.tpe), genType(arg.tpe), value)
+                        buf.genCastOp(
+                          genRefType(sym.tpe),
+                          genRefType(arg.tpe),
+                          value
+                        )
                       else unboxed
                   }
                 curMethodEnv.enter(sym, result)
@@ -1057,7 +1064,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case tpe: ErasedValueType =>
           val valueClass = tpe.valueClazz
           val unboxMethod = treeInfo.ValueClass.valueUnbox(tpe)
-          val castedValue = buf.genCastOp(value.ty, genType(valueClass), value)
+          val castedValue =
+            buf.genCastOp(value.ty, genRefType(valueClass), value)
           buf.genApplyMethod(
             sym = unboxMethod,
             statically = false,
@@ -1068,7 +1076,11 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case tpe =>
           val unboxed = buf.unboxValue(tpe, partial = true, value)
           if (unboxed == value) // no need to or cannot unbox, we should cast
-            buf.genCastOp(genType(tpeEnteringPosterasure), genType(tpe), value)
+            buf.genCastOp(
+              genRefType(tpeEnteringPosterasure),
+              genRefType(tpe),
+              value
+            )
           else unboxed
       }
     }
@@ -2374,7 +2386,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genCastOp(fromty: nir.Type, toty: nir.Type, value: nir.Val)(implicit
         pos: nir.SourcePosition
     ): nir.Val =
-      castConv(fromty, toty).fold(value)(buf.conv(_, toty, value, unwind))
+      castConv(fromty, toty)
+        .orElse(castConv(value.ty, toty))
+        .fold(value)(buf.conv(_, toty, value, unwind))
 
     private lazy val optimizedFunctions = {
       // Included functions should be pure, and should not not narrow the result type
@@ -2689,9 +2703,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genCoercion(value: nir.Val, fromty: nir.Type, toty: nir.Type)(implicit
         pos: nir.SourcePosition
     ): nir.Val = {
-      if (fromty == toty) {
-        value
-      } else {
+      if (fromty == toty) value
+      else if (nir.Type.isNothing(fromty) || nir.Type.isNothing(toty)) value
+      else {
         val conv = (fromty, toty) match {
           case (nir.Type.Ptr, _: nir.Type.RefKind) =>
             nir.Conv.Bitcast

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -703,13 +703,20 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val sym = tree.symbol
       implicit val pos: nir.SourcePosition =
         tree.pos.orElse(fallbackSourcePosition)
-      if (curMethodInfo.mutableVars.contains(sym)) {
+      val value = if (curMethodInfo.mutableVars.contains(sym)) {
         buf.varload(curMethodEnv.resolve(sym), unwind)
       } else if (sym.isModule) {
         genModule(sym)
       } else {
         curMethodEnv.resolve(sym)
       }
+      if (nir.Type.isNothing(value.ty)) {
+        // Short circuit the generated code for phantom value
+        // scala.runtime.Nothing$ extends Throwable so it's safe to throw
+        buf.raise(value, unwind)
+        buf.unreachable(unwind)
+      }
+      value
     }
 
     def genSelect(tree: Select): nir.Val = {

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -134,6 +134,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     case UnitClass        => nir.Type.Unit
     case BoxedUnitClass   => nir.Rt.BoxedUnit
     case NullClass        => genRefType(RuntimeNullClass)
+    case NothingClass     => genRefType(RuntimeNothingClass)
     case ArrayClass       => nir.Type.Array(genType(st.targs.head))
     case _ if st.isStruct => genStruct(st)
     case _ if deconstructValueTypes =>

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -151,10 +151,10 @@ trait NirGenExpr(using Context) {
       val Assign(lhsp, rhsp) = tree
       given nir.SourcePosition = tree.span
 
-      desugarTree(lhsp) match {
-        case sel @ Select(qualp, _) =>
+      lhsp match {
+        case DesugaredSelect(qualp, _) =>
           def rhs = genExpr(rhsp)
-          val sym = sel.symbol
+          val sym = lhsp.symbol
           val name = genFieldName(sym)
           if (sym.isExtern) {
             // Ignore intrinsic call to extern in class constructor
@@ -164,14 +164,14 @@ trait NirGenExpr(using Context) {
                 rhsp.symbol == defnNir.UnsafePackage_extern
             if (shouldIgnoreAssign) nir.Val.Unit
             else {
-              val externTy = genExternType(sel.tpe)
+              val externTy = genExternType(lhsp.tpe)
               genStoreExtern(externTy, sym, rhs)
             }
           } else {
             val qual =
               if (sym.isStaticMember) genModule(qualp.symbol)
               else genExpr(qualp)
-            val ty = genType(sel.tpe)
+            val ty = genType(lhsp.tpe)
             buf.fieldstore(ty, qual, name, rhs, unwind)
           }
 
@@ -1105,8 +1105,7 @@ trait NirGenExpr(using Context) {
       import NirPrimitives._
       import dotty.tools.backend.ScalaPrimitivesOps._
       given nir.SourcePosition = app.span
-      val Apply(fun, args) = app
-      val Select(receiver, _) = desugarTree(fun): @unchecked
+      val Apply(fun @ DesugaredSelect(receiver, _), args) = app: @unchecked
 
       val sym = app.symbol
       val code = nirPrimitives.getPrimitive(app, receiver.tpe)
@@ -1185,8 +1184,10 @@ trait NirGenExpr(using Context) {
     }
 
     private def genApplyTypeApply(app: Apply): nir.Val = {
-      val Apply(tApply @ TypeApply(fun, targs), argsp) = app: @unchecked
-      val Select(receiverp, _) = desugarTree(fun): @unchecked
+      val Apply(
+        tApply @ TypeApply(fun @ DesugaredSelect(receiverp, _), targs),
+        argsp
+      ) = app: @unchecked
       given nir.SourcePosition = app.span
 
       val funSym = fun.symbol
@@ -1385,7 +1386,7 @@ trait NirGenExpr(using Context) {
             s"Too many arguments for primitive function: $app",
             app.sourcePos
           )
-          nir.Val.Null
+          nir.Val.Zero(retty)
       }
     }
 
@@ -1471,7 +1472,7 @@ trait NirGenExpr(using Context) {
                 s"Unknown floating point type binary operation code: $code",
                 right.sourcePos
               )
-              nir.Val.Null
+              nir.Val.Zero(retty)
           }
         case nir.Type.Bool | _: nir.Type.I =>
           code match {
@@ -1502,7 +1503,7 @@ trait NirGenExpr(using Context) {
                 s"Unknown integer type binary operation code: $code",
                 right.sourcePos
               )
-              nir.Val.Null
+              nir.Val.Zero(retty)
           }
         case _: nir.Type.RefKind =>
           def genEquals(ref: Boolean, negated: Boolean) = (left, right) match {
@@ -1525,7 +1526,7 @@ trait NirGenExpr(using Context) {
                 s"Unknown reference type binary operation code: $code",
                 right.sourcePos
               )
-              nir.Val.Null
+              nir.Val.Zero(retty)
           }
         case nir.Type.Ptr =>
           code match {
@@ -1537,7 +1538,7 @@ trait NirGenExpr(using Context) {
             s"Unknown binary operation type: $ty",
             right.sourcePos
           )
-          nir.Val.Null
+          nir.Val.Zero(retty)
       }
 
       genCoercion(binres, binres.ty, retty)(using right.span)
@@ -2048,7 +2049,9 @@ trait NirGenExpr(using Context) {
     def genCastOp(from: nir.Type, to: nir.Type, value: nir.Val)(using
         nir.SourcePosition
     ): nir.Val =
-      castConv(from, to).fold(value)(buf.conv(_, to, value, unwind))
+      castConv(from, to)
+        .orElse(castConv(value.ty, to))
+        .fold(value)(buf.conv(_, to, value, unwind))
 
     private def genCoercion(app: Apply, receiver: Tree, code: Int): nir.Val = {
       given nir.SourcePosition = app.span
@@ -2248,7 +2251,8 @@ trait NirGenExpr(using Context) {
         case ErasedValueType(valueClass, _) =>
           val boxedClass = valueClass.typeSymbol.asClass
           val unboxMethod = ValueClasses.valueClassUnbox(boxedClass)
-          val castedValue = buf.genCastOp(value.ty, genType(valueClass), value)
+          val castedValue =
+            buf.genCastOp(value.ty, genRefType(valueClass), value)
           buf.genApplyMethod(
             sym = unboxMethod,
             statically = false,
@@ -2259,7 +2263,11 @@ trait NirGenExpr(using Context) {
         case tpe =>
           val unboxed = buf.unboxValue(tpe, partial = true, value)
           if (unboxed == value) // no need to or cannot unbox, we should cast
-            buf.genCastOp(genType(tpeEnteringPosterasure), genType(tpe), value)
+            buf.genCastOp(
+              genRefType(tpeEnteringPosterasure),
+              genRefType(tpe),
+              value
+            )
           else unboxed
       }
     }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -450,7 +450,7 @@ trait NirGenExpr(using Context) {
     def genIdent(tree: Ident): nir.Val =
       tree match {
         case DesugaredSelect(_, _) =>
-          genSelect(DesugaredSelect.desugared)
+          genSelect(DesugaredSelect.desugared.withSpan(tree.span))
         case _ =>
           val sym = tree.symbol
           given nir.SourcePosition = tree.span

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -448,19 +448,23 @@ trait NirGenExpr(using Context) {
     }
 
     def genIdent(tree: Ident): nir.Val =
-      desugarIdent(tree) match {
-        case Ident(_) =>
+      tree match {
+        case DesugaredSelect(_, _) =>
+          genSelect(DesugaredSelect.desugared)
+        case _ =>
           val sym = tree.symbol
           given nir.SourcePosition = tree.span
-          if (curMethodInfo.mutableVars.contains(sym))
-            buf.varload(curMethodEnv.resolve(sym), unwind)
-          else if (sym.is(Module))
-            genModule(sym)
-          else curMethodEnv.resolve(sym)
-        case desuagred: Select =>
-          genSelect(desuagred.withSpan(tree.span))
-        case tree =>
-          throw FatalError(s"Unsupported desugared ident tree: $tree")
+          val value =
+            if sym.is(Module) then genModule(sym)
+            else if (curMethodInfo.mutableVars.contains(sym))
+              buf.varload(curMethodEnv.resolve(sym), unwind)
+            else curMethodEnv.resolve(sym)
+          if nir.Type.isNothing(value.ty) then
+            // Short circuit the generated code for phantom value
+            // scala.runtime.Nothing$ extends Throwable so it's safe to throw
+            buf.raise(value, unwind)
+            buf.unreachable(unwind)
+          value
       }
 
     def genIf(tree: If): nir.Val = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -211,6 +211,7 @@ trait NirGenType(using Context) {
     else if (sym == defn.UnitClass) nir.Type.Unit
     else if (sym == defn.BoxedUnitClass) nir.Rt.BoxedUnit
     else if (sym == defn.NullClass) nir.Rt.RuntimeNull
+    else if (sym == defn.NothingClass) nir.Rt.RuntimeNothing
     else if (sym == defn.ArrayClass) nir.Type.Array(genType(targs.head))
     else if (sym.isStruct) genStruct(st)
     else if (deconstructValueTypes) {

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -39,16 +39,21 @@ object Sub {
     (l, r) match {
       case (l, r) if l == r =>
         true
-      case (nir.Type.Null, (nir.Type.Ptr | _: nir.Type.RefKind)) =>
+      case (nir.Type.NullType(_), (nir.Type.Ptr | _: nir.Type.RefKind)) =>
         true
-      case (nir.Type.Nothing, (_: nir.Type.ValueKind | _: nir.Type.RefKind)) =>
+      case (
+            nir.Type.NothingType(_),
+            (_: nir.Type.ValueKind | _: nir.Type.RefKind)
+          ) =>
         true
       case (_: nir.Type.RefKind, nir.Rt.Object) =>
         true
       case (ScopeRef(linfo), ScopeRef(rinfo)) =>
         linfo.is(rinfo)
-      case _ =>
-        false
+      // FIXME: Workaround for method/return types not being defined as scala.runtime.Nothing$|Null$
+      case (nir.Type.NothingType(_), nir.Type.NothingType(_)) => true
+      case (nir.Type.NullType(_), nir.Type.NullType(_))       => true
+      case _                                                  => false
     }
   }
 
@@ -80,17 +85,17 @@ object Sub {
     (lty, rty) match {
       case _ if lty == rty =>
         lty
-      case (ty, nir.Type.Nothing) =>
+      case (ty, nir.Type.NothingType(_)) =>
         ty
-      case (nir.Type.Nothing, ty) =>
+      case (nir.Type.NothingType(_), ty) =>
         ty
-      case (nir.Type.Ptr, nir.Type.Null) =>
+      case (nir.Type.Ptr, nir.Type.NullType(_)) =>
         nir.Type.Ptr
-      case (nir.Type.Null, nir.Type.Ptr) =>
+      case (nir.Type.NullType(_), nir.Type.Ptr) =>
         nir.Type.Ptr
-      case (refty: nir.Type.RefKind, nir.Type.Null) =>
+      case (refty: nir.Type.RefKind, nir.Type.NullType(_)) =>
         nir.Type.Ref(refty.className, refty.isExact, nullable = true)
-      case (nir.Type.Null, refty: nir.Type.RefKind) =>
+      case (nir.Type.NullType(_), refty: nir.Type.RefKind) =>
         nir.Type.Ref(refty.className, refty.isExact, nullable = true)
       case (lty: nir.Type.RefKind, rty: nir.Type.RefKind) =>
         val ScopeRef(linfo) = lty: @unchecked

--- a/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
@@ -174,4 +174,14 @@ class IssuesSpec extends LinkerSpec {
     }
   }
 
+  // https://github.com/scala-native/scala-native/issues/4039
+  @Test def issue4039(): Unit = checkNoLinkageErrors {
+    """
+    |object Test {
+    |  def main(args: Array[String]): Unit = {
+    |    Seq.empty[Nothing].forall(_ == Int.box(0))
+    |  }
+    |}
+    |"""
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/scala-native/scala-native/issues/4039

We're using incorrect signatures for methods having parameter or return types set to Nothing or Null - we should have always used scala.runtime.Nothing$ and scala.runtime.Null$ instances. These are emitted by both JVM and Scala.js.

Alternative to #4064 which does not require breaking binary compatibility of NIR - changes treatment of scala.runtime.Nothing$/Null$ in the NIR subtyping to be matching nir.Type.Nothing/Null