### PR TITLE
Fix [javalib]: POSIX readAttributes() now links

### DIFF
--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeView.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeView.scala
@@ -6,6 +6,7 @@ trait PosixFileAttributeView
     extends BasicFileAttributeView
     with FileOwnerAttributeView {
   def name(): String
+  def readAttributes(): PosixFileAttributes
   def setGroup(group: GroupPrincipal): Unit
   def setPermissions(perms: Set[PosixFilePermission]): Unit
 }

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -85,7 +85,10 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       }
     }
 
-  override def readAttributes(): BasicFileAttributes = attributes
+//  override def readAttributes(): BasicFileAttributes = attributes
+//  override def readAttributes(): PosixFileAttributes = attributes
+
+  def readAttributes(): PosixFileAttributes = attributes
 
   private class PosixFileKey(deviceId: stat.dev_t, inodeNumber: stat.ino_t) {
 

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/attribute/PosixFileAttributeViewTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/attribute/PosixFileAttributeViewTestOnJDK11.scala
@@ -14,7 +14,6 @@ import org.junit.BeforeClass
 
 import org.scalanative.testsuite.utils.Platform
 
-
 /* The code under test should work on Java 8 through latest (currently 23).
  * It is tested on JDK11 because that version introduces "Path.of()".
  * In some later JVM versions, "Paths.get()" becomes deprecated. No sense

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/attribute/PosixFileAttributeViewTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/attribute/PosixFileAttributeViewTestOnJDK11.scala
@@ -1,0 +1,55 @@
+package org.scalanative.testsuite.javalib.nio.file.attribute
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import java.nio.file.attribute.PosixFileAttributes
+import java.nio.file.attribute.PosixFileAttributeView
+import java.nio.file.attribute.PosixFilePermission
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.BeforeClass
+
+import org.scalanative.testsuite.utils.Platform
+
+
+/* The code under test should work on Java 8 through latest (currently 23).
+ * It is tested on JDK11 because that version introduces "Path.of()".
+ * In some later JVM versions, "Paths.get()" becomes deprecated. No sense
+ * writing new code which uses it.
+ */
+
+object PosixFileAttributeViewTestOnJDK11 {
+
+  @BeforeClass def posixOnly(): Unit = {
+    assumeTrue("Not implemented in Windows", !Platform.isWindows)
+  }
+}
+
+class PosixFileAttributeViewTestOnJDK11 {
+
+  // Issue 4067
+  @Test def readPosixFileAttributes(): Unit = {
+    val path = Path.of(".")
+
+    val posixAttrView =
+      Files.getFileAttributeView(path, classOf[PosixFileAttributeView])
+
+    val posixAttrs = posixAttrView.readAttributes()
+
+    assertNotNull("unexpected Null POSIX file attributes", posixAttrs)
+
+    // Permissions is a POSIX attribute;
+    val permissions = posixAttrs.permissions()
+    assertTrue("expected number of permissons > 0", permissions.size() > 0)
+
+    // quick consistency check.
+    assertTrue(
+      "dot should have at least owner:read permission",
+      permissions.contains(PosixFilePermission.OWNER_READ)
+    )
+  }
+
+}


### PR DESCRIPTION
Fix #4067 

Correct the signature of Javalib `PosixFileAttributeView#readAttributes()`. This allows the linker
to find it.

This PR introduces a binary incompatibility. Normally, this would mean that it would only be allowed
in a minor version update (0.6.n).  I believe it is a good candidate for a patch version (0.5.n) for
two reasons:
1) The  code before this is hard broken. It appears to have been that way for 7 or so years.
2) Since that code is broken, there is almost certainly no one using it and relying on a stable signature.