### PR TITLE
Improvement [Build]: Update sbt to 1.10.2

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -59,7 +59,7 @@ object ScalaVersions {
   //   1.10.0 Latest sbt version.
   //   1.10.1 Latest sbt version.
 
-  val sbt10Version: String = "1.10.1"
+  val sbt10Version: String = "1.10.2"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.1
+sbt.version = 1.10.2


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.10.2.

The SBT GitHub [announcement](https://github.com/sbt/sbt/releases/tag/v1.10.2).

This PR also updates the SBT version in both `project/build.properties` & `project/ScalaVersions.scala`.