### PR TITLE
Improve ZLib error messages in the inflater

### DIFF
--- a/javalib/src/main/scala/java/util/zip/Inflater.scala
+++ b/javalib/src/main/scala/java/util/zip/Inflater.scala
@@ -179,7 +179,7 @@ class Inflater(noHeader: Boolean) {
         val totalOut = stream.totalOut
         (totalOut - sout).toInt
       } else {
-        throw new DataFormatException(err.toString)
+        throw new DataFormatException(Inflater.zlibStatusToString(err))
       }
     } else {
       val totalIn = stream.totalIn
@@ -209,4 +209,20 @@ private object Inflater {
     }
     stream
   }
+
+  private[Inflater] def zlibStatusToString(status: Int): String = {
+    val errorName =
+      if (status == zlib.Z_OK) " (Z_OK)"
+      else if (status == zlib.Z_STREAM_END) " (Z_STREAM_END)"
+      else if (status == zlib.Z_NEED_DICT) " (Z_NEED_DICT)"
+      else if (status == zlib.Z_ERRNO) " (Z_ERRNO)"
+      else if (status == zlib.Z_STREAM_ERROR) " (Z_STREAM_ERROR)"
+      else if (status == zlib.Z_DATA_ERROR) " (Z_DATA_ERROR)"
+      else if (status == zlib.Z_MEM_ERROR) " (Z_MEM_ERROR)"
+      else if (status == zlib.Z_BUF_ERROR) " (Z_BUF_ERROR)"
+      else if (status == zlib.Z_VERSION_ERROR) " (Z_VERSION_ERROR)"
+      else ""
+    s"zlib status $status$errorName"
+  }
+
 }

--- a/javalib/src/main/scala/java/util/zip/Inflater.scala
+++ b/javalib/src/main/scala/java/util/zip/Inflater.scala
@@ -183,7 +183,9 @@ class Inflater(noHeader: Boolean) {
         throw new DataFormatException(
           Inflater.zlibStatusToString(
             err,
-            Option(stream.msg).map(cstr => fromCString(cstr, StandardCharsets.UTF_8)).filter(_.nonEmpty)
+            Option(stream.msg)
+              .map(cstr => fromCString(cstr, StandardCharsets.UTF_8))
+              .filter(_.nonEmpty)
           )
         )
       }


### PR DESCRIPTION
Slightly related to https://github.com/scala-native/scala-native/issues/4071

I don't know how to fix the issue, but at least I think this will make it easier to debug issues like that.

In this particular case, instead of `Caused by: java.util.zip.DataFormatException: -3`, the GZIPInputStream will fail with `Caused by: java.util.zip.DataFormatException: zlib status -3 (Z_DATA_ERROR) - invalid distance too far back`