### PR TITLE
Enhance build error handling for a build module named native

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -14,11 +14,12 @@
 typedef DWORD ThreadRoutineReturnType;
 #else
 #include <pthread.h>
-typedef WINAPI;
+// define as nothing on non Windows
+#define __stdcall
 typedef void *ThreadRoutineReturnType;
 #endif
-
-typedef ThreadRoutineReturnType(WINAPI *ThreadStartRoutine)(void *);
+// Requires WINAPI which is defined as __stdcall on Windows
+typedef ThreadRoutineReturnType(__stdcall *ThreadStartRoutine)(void *);
 typedef void *RoutineArgs;
 
 void scalanative_GC_init();

--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -12,13 +12,13 @@
 #pragma comment(lib, "kernel32.lib")
 #include <windows.h>
 typedef DWORD ThreadRoutineReturnType;
-typedef ThreadRoutineReturnType(WINAPI *ThreadStartRoutine)(void *);
 #else
 #include <pthread.h>
+typedef WINAPI;
 typedef void *ThreadRoutineReturnType;
-typedef ThreadRoutineReturnType (*ThreadStartRoutine)(void *);
 #endif
 
+typedef ThreadRoutineReturnType(WINAPI *ThreadStartRoutine)(void *);
 typedef void *RoutineArgs;
 
 void scalanative_GC_init();

--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -12,12 +12,13 @@
 #pragma comment(lib, "kernel32.lib")
 #include <windows.h>
 typedef DWORD ThreadRoutineReturnType;
+typedef ThreadRoutineReturnType(WINAPI *ThreadStartRoutine)(void *);
 #else
 #include <pthread.h>
 typedef void *ThreadRoutineReturnType;
+typedef ThreadRoutineReturnType (*ThreadStartRoutine)(void *);
 #endif
 
-typedef ThreadRoutineReturnType (*ThreadStartRoutine)(void *);
 typedef void *RoutineArgs;
 
 void scalanative_GC_init();


### PR DESCRIPTION
As discussed in Discord, when a project is named `native` on UNIX type systems the executable will be named `native` which will cause a exception thrown as shown below but it does not stop the build and the executable named `native` is put into the `native` `workDir` directory rather than in the same directory as the `workDir`.

This PR catches the exception now, and if the potential artifact will be named the same as the `workDir` by using `exists()` method then a `BuildException` with a message is output with a solution for the user to avoid the conflict. Any other exception is output with some context included. The following is an example although I am not sure why the message is printed twice (sbt?):

New Outcome:
```scala
...
[info] Linking with [pthread, dl]
[info] Total (3511 ms)
[error] Executable build module or `baseName` is named 'native'
[error] which conflicts with the compiler `workDir`.
[error] Please rename the build module or
[error] use `withBaseName` to rename the executable.
[error] Cause: java.nio.file.DirectoryNotEmptyException: /Users/eric/workspace/scala-native-bugs/native-dir/native/target/scala-3.3.4/native
[error] (native / Compile / nativeLink) Executable build module or `baseName` is named 'native'
[error] which conflicts with the compiler `workDir`.
[error] Please rename the build module or
[error] use `withBaseName` to rename the executable.
[error] Cause: java.nio.file.DirectoryNotEmptyException: /Users/eric/workspace/scala-native-bugs/native-dir/native/target/scala-3.3.4/native
[error] Total time: 4 s, completed Dec 2, 2024, 9:55:47 AM
```

Original outcome:
```scala
sbt:native-dir> native/run
[info] Linking (multithreadingEnabled=true, disable if not used) (929 ms)
[info] Discovered 884 classes and 5396 methods after classloading
[info] Checking intermediate code (quick) (48 ms)
[info] Multithreading was not explicitly enabled - initial class loading has not detected any usage of system threads. Multithreading support will be disabled to improve performance.
[info] Linking (multithreadingEnabled=false) (337 ms)
[info] Discovered 495 classes and 2485 methods after classloading
[info] Checking intermediate code (quick) (8 ms)
[info] Discovered 474 classes and 1898 methods after optimization
[info] Optimizing (debug mode) (534 ms)
[info] Produced 44 LLVM IR files
[info] Generating intermediate code (643 ms)
[info] Compiling to native code (2316 ms)
[info] Linking with [pthread, dl]
[info] Total (4687 ms)
[error] stack trace is suppressed; run last native / Compile / nativeLink for the full output
[error] (native / Compile / nativeLink) java.nio.file.DirectoryNotEmptyException: /Users/eric/workspace/scala-native-bugs/native-dir/native/target/scala-3.3.4/native
[error] Total time: 5 s, completed Dec 2, 2024, 7:42:55 AM
sbt:native-dir> clean
[success] Total time: 1 s, completed Dec 2, 2024, 8:27:35 AM
```