### PR TITLE
Fix not inititalizied Posix thread state of Main thread

### DIFF
--- a/javalib/src/main/scala/java/lang/impl/PosixThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/PosixThread.scala
@@ -33,29 +33,31 @@ private[java] class PosixThread(val thread: Thread, stackSize: Long)
   // index of currently used condition
   @volatile private var conditionIdx = ConditionUnset
 
+  // Init locks/conditions before starting the thread
+  checkStatus("mutex init") {
+    pthread_mutex_init(lock, mutexAttr)
+  }
+  checkStatus("relative time condition init") {
+    pthread_cond_init(
+      condition(ConditionRelativeIdx),
+      conditionRelativeCondAttr
+    )
+  }
+  checkStatus("absolute time condition init") {
+    pthread_cond_init(condition(ConditionAbsoluteIdx), null)
+  }
+
   private val handle: pthread_t =
-    if (isMainThread) 0.toUSize // main thread
-    else if (!isMultithreadingEnabled) {
+    if (!isMultithreadingEnabled)
       throw new LinkageError(
         "Multithreading support disabled - cannot create new threads"
       )
-    } else {
+    else if (isMainThread) 0.toUSize // main thread
+    else {
       val id = stackalloc[pthread_t]()
       val attrs = stackalloc[Byte](pthread_attr_t_size)
         .asInstanceOf[Ptr[pthread_attr_t]]
 
-      checkStatus("mutex init") {
-        pthread_mutex_init(lock, mutexAttr)
-      }
-      checkStatus("relative time condition init") {
-        pthread_cond_init(
-          condition(ConditionRelativeIdx),
-          conditionRelativeCondAttr
-        )
-      }
-      checkStatus("absolute time condition init") {
-        pthread_cond_init(condition(ConditionAbsoluteIdx), null)
-      }
       checkStatus("thread attrs init") {
         pthread_attr_init(attrs)
       }

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -58,7 +58,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   @Test def multithreading(): Unit =
     checkMinimalRequiredSymbols(withMultithreading = true)(expected =
       if (isScala3) SymbolsCount(types = 1100, members = 6550)
-      else if (isScala2_13) SymbolsCount(types = 1014, members = 6490)
+      else if (isScala2_13) SymbolsCount(types = 1014, members = 6500)
       else SymbolsCount(types = 1014, members = 7050)
     )
 


### PR DESCRIPTION
The lock/conditions fields were never initialized in the main thread. This would lead to invalid behaviour when in synchronized blocks or explicit `LockSupport.park` calls by resuming execution too early. 
It was never detected by our CI, becouse by default all the tests were executed using ForkJoinPool, while main thread was only handling the RPC communication with the JVM. 
