### PR TITLE
Implement `java.lang.Class.forName`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Class.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Class.scala
@@ -207,11 +207,23 @@ private[runtime] object _Class {
     false
   }
 
-  // Could be implemented via intrinsic method resolved at compile time and generating nir.Val.ClassOf(name: String)
-  // def forName(name: String): Class[_] = ???
-  // def forName(
-  //     name: String,
-  //     init: scala.Boolean,
-  //     loader: ClassLoader
-  // ): Class[_] = ???
+  def forName(name: String): Class[_] =
+    LinkedClassesRepository.byName
+      .get(name)
+      .getOrElse(throw new ClassNotFoundException(name))
+      .asInstanceOf[Class[_]]
+
+  def forName(
+      name: String,
+      init: scala.Boolean,
+      loader: ClassLoader
+  ): Class[_] = forName(name)
+}
+
+private object LinkedClassesRepository {
+  // Reachable only from `forName` method
+  @noinline private def loadAll: scala.Array[_Class[_]] = intrinsic
+  val byName: Map[String, _Class[_]] = loadAll.map { cls =>
+    cls.name -> cls
+  }.toMap
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Class.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Class.scala
@@ -222,8 +222,8 @@ private[runtime] object _Class {
 
 private object LinkedClassesRepository {
   // Reachable only from `forName` method
-  @noinline private def loadAll: scala.Array[_Class[_]] = intrinsic
-  val byName: Map[String, _Class[_]] = loadAll.map { cls =>
+  @noinline private def loadAll(): scala.Array[_Class[_]] = intrinsic
+  val byName: Map[String, _Class[_]] = loadAll().map { cls =>
     cls.name -> cls
   }.toMap
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Class.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Class.scala
@@ -222,7 +222,7 @@ private[runtime] object _Class {
 
 private object LinkedClassesRepository {
   // Reachable only from `forName` method
-  @noinline private def loadAll(): scala.Array[_Class[_]] = intrinsic
+  @nooptimize private def loadAll(): scala.Array[_Class[_]] = intrinsic
   val byName: Map[String, _Class[_]] = loadAll().map { cls =>
     cls.name -> cls
   }.toMap

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -58,7 +58,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   @Test def multithreading(): Unit =
     checkMinimalRequiredSymbols(withMultithreading = true)(expected =
       if (isScala3) SymbolsCount(types = 1100, members = 6550)
-      else if (isScala2_13) SymbolsCount(types = 1014, members = 6490)
+      else if (isScala2_13) SymbolsCount(types = 1014, members = 6500)
       else SymbolsCount(types = 1014, members = 7050)
     )
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ClassTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ClassTest.scala
@@ -249,4 +249,18 @@ class ClassTest {
 
     assertDiffClass(cls1, cls2)
   }
+
+  @Test def classForName(): Unit = {
+    val cls1 = Class.forName("java.lang.String")
+    val cls2 = classOf[String]
+    val cls3 = Class.forName("java.lang.Double")
+
+    assertEqualClass(cls1, cls2)
+    assertDiffClass(cls1, cls3)
+
+    assertThrows(
+      classOf[ClassNotFoundException],
+      () => Class.forName("not.existing.class.name")
+    )
+  }
 }


### PR DESCRIPTION
We implement `Class.forName` by constructing on demand map of all linked classes. 
We detect and intercept calls to `LinkedClassesRepository.loadAll` and create an compile time constant array filled with all reachable classes. These can be later referenced at runtime. 

If the application does not use Class.forName then there is no binary size overhead