### PR TITLE
Fix signaturs of java.lang.{Math,Runtime} methods

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -198,7 +198,10 @@ object Math {
   @alwaysinline def hypot(a: scala.Double, b: scala.Double): scala.Double =
     cmath.hypot(a, b)
 
-  @alwaysinline def IEEEremainder(f1: scala.Double, f2: scala.Double): scala.Double =
+  @alwaysinline def IEEEremainder(
+      f1: scala.Double,
+      f2: scala.Double
+  ): scala.Double =
     cmath.remainder(f1, f2)
 
   @alwaysinline def incrementExact(a: scala.Int): scala.Int =

--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -192,13 +192,13 @@ object Math {
   @alwaysinline def getExponent(a: scala.Float): scala.Int =
     cmath.ilogbf(a)
 
-  @alwaysinline def getExponent(a: scala.Double): scala.Long =
+  @alwaysinline def getExponent(a: scala.Double): scala.Int =
     cmath.ilogb(a)
 
   @alwaysinline def hypot(a: scala.Double, b: scala.Double): scala.Double =
     cmath.hypot(a, b)
 
-  @alwaysinline def IEEEremainder(f1: scala.Double, f2: scala.Double): Double =
+  @alwaysinline def IEEEremainder(f1: scala.Double, f2: scala.Double): scala.Double =
     cmath.remainder(f1, f2)
 
   @alwaysinline def incrementExact(a: scala.Int): scala.Int =

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -44,7 +44,7 @@ class Runtime private () {
     setupSignalHandler
   }
 
-  def removeShutdownHook(thread: Thread): Boolean = hooks.synchronized {
+  def removeShutdownHook(thread: Thread): scala.Boolean = hooks.synchronized {
     ensureCanModify(thread)
     hooks.remove(thread)
   }

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -58,7 +58,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   @Test def multithreading(): Unit =
     checkMinimalRequiredSymbols(withMultithreading = true)(expected =
       if (isScala3) SymbolsCount(types = 1100, members = 6550)
-      else if (isScala2_13) SymbolsCount(types = 1014, members = 6490)
+      else if (isScala2_13) SymbolsCount(types = 1014, members = 6500)
       else SymbolsCount(types = 1014, members = 7050)
     )
 


### PR DESCRIPTION
These were interpreted as java.lang.{Int, Double, Boolean} instead of primitive types