### PR TITLE
Try optimize collection of stacktraces

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Throwables.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Throwables.scala
@@ -15,7 +15,6 @@ import scala.collection.mutable
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.meta.LinktimeInfo
-import scala.scalanative.runtime.ffi
 
 object StackTrace {
   @noinline def currentStackTrace(): scala.Array[StackTraceElement] = {
@@ -163,11 +162,11 @@ object StackTrace {
     override protected def initialValue(): Context =
       new Context(mutable.LongMap.empty, ByteArray.alloc(Context.DataSize))
 
-    override protected def childValue(fromParent: Context): Context =
-      new Context(
-        mutable.LongMap.from(fromParent.cache),
-        ByteArray.alloc(Context.DataSize)
-      )
+    override def childValue(fromParent: Context): Context = {
+      val cache = mutable.LongMap.empty[StackTraceElement]
+      cache ++= fromParent.cache
+      new Context(cache, ByteArray.alloc(Context.DataSize))
+    }
   }
   private object Context {
     final val SymbolMaxLength = 512

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Throwables.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Throwables.scala
@@ -1,13 +1,13 @@
+// scalafmt: { maxColumn = 120}
+
 package scala.scalanative
 package runtime
 
 import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 
-/** An exception that is thrown whenever an undefined behavior happens in a
- *  checked mode.
+/** An exception that is thrown whenever an undefined behavior happens in a checked mode.
  */
-final class UndefinedBehaviorError(message: String)
-    extends java.lang.Error(message) {
+final class UndefinedBehaviorError(message: String) extends java.lang.Error(message) {
   def this() = this(null)
 }
 
@@ -15,35 +15,37 @@ import scala.collection.mutable
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.meta.LinktimeInfo
-import scala.scalanative.runtime.ffi.{malloc, calloc, free, strncmp}
-
-import java.util.concurrent.ConcurrentHashMap
-import java.{util => ju}
+import scala.scalanative.runtime.ffi
 
 object StackTrace {
-  private val cache: ju.AbstractMap[CUnsignedLong, StackTraceElement] =
-    if (isMultithreadingEnabled) new ConcurrentHashMap
-    else new ju.HashMap
-
   @noinline def currentStackTrace(): scala.Array[StackTraceElement] = {
     // Used to prevent filling stacktraces inside `currentStackTrace` which might lead to infinite loop
     val thread = NativeThread.currentNativeThread
     if (thread.isFillingStackTrace) scala.Array.empty
     else if (LinktimeInfo.asanEnabled) scala.Array.empty
     else {
-      val cursor = fromRawPtr(malloc(unwind.sizeOfCursor))
-      val context = fromRawPtr(malloc(unwind.sizeOfContext))
+      implicit val tlContext: Context = ThreadLocalContext.get()
+      val cursor = tlContext.unwindCursor
+      val context = tlContext.unwindContext
       try {
         thread.isFillingStackTrace = true
         val buffer = scala.Array.newBuilder[StackTraceElement]
-        val ip = fromRawPtr[CSize](Intrinsics.stackalloc[CSize]())
+        val ip = Intrinsics.stackalloc[RawSize]()
         var foundCurrentStackTrace = false
         var afterFillInStackTrace = false
         unwind.get_context(context)
         unwind.init_local(cursor, context)
         while (unwind.step(cursor) > 0) {
           unwind.get_reg(cursor, unwind.UNW_REG_IP, ip)
-          val elem = cachedStackTraceElement(cursor, !ip)
+          val addr = Intrinsics.castRawSizeToLongUnsigned(Intrinsics.loadRawSize(ip))
+          /* Creates a stack trace element in given unwind context. Finding a
+           *  name of the symbol for current function is expensive, so we cache
+           *  stack trace elements based on current instruction pointer.
+           */
+          val elem = tlContext.cache.getOrElseUpdate(
+            addr,
+            makeStackTraceElement(cursor, addr)
+          )
           buffer += elem
 
           // Look for intrinsic stack frames and remove them to not polute stack traces
@@ -69,8 +71,6 @@ object StackTrace {
         buffer.result()
       } finally {
         thread.isFillingStackTrace = false
-        free(cursor)
-        free(context)
       }
     }
   }
@@ -83,46 +83,42 @@ object StackTrace {
 
   private def makeStackTraceElement(
       cursor: CVoidPtr,
-      ip: CUnsignedLong
-  ): StackTraceElement = {
+      ip: Long
+  )(implicit tlContext: Context): StackTraceElement = {
 
     val position =
-      if (hasDebugInfo) Backtrace.decodePosition(ip.toLong)
+      if (hasDebugInfo) Backtrace.decodePosition(ip)
       else Backtrace.Position.empty
 
     def withNameFromDWARF() = {
       // linkageName has an extra "_" that we don't want in stack traces
       def isScalaNativeMangledName =
-        strncmp(position.linkageName, c"__SM", 4.toCSize) == 0
-      val name =
+        ffi.strncmp(position.linkageName, c"__SM", Intrinsics.castIntToRawSize(4)) == 0
+      val symbol =
         if (isScalaNativeMangledName)
           // skip first `_`
           position.linkageName + 1
         else position.linkageName
 
-      StackTraceElement(name, position)
+      parseStackTraceElement(symbol, position)
     }
 
     def withNameFromUnwind() = {
-      val nameMax = 1024
-      val name = fromRawPtr[CChar](
-        calloc(
-          Intrinsics.castIntToRawSizeUnsigned(nameMax),
-          Intrinsics.sizeOf[CChar]
-        )
+      import Context._
+      val symbol = tlContext.freshSymbolBuffer
+      val offset = Intrinsics.stackalloc[Long]()
+      unwind.get_proc_name(
+        cursor,
+        symbol,
+        Intrinsics.castIntToRawSize(SymbolMaxLength),
+        offset
       )
-      try {
-        val offset = fromRawPtr[Long](Intrinsics.stackalloc[Long]())
+      // Make sure the name is definitely 0-terminated.
+      // Unmangler is going to use strlen on this name and it's
+      // behavior is not defined for non-zero-terminated strings.
+      symbol(SymbolMaxLength - 1) = 0.toByte
 
-        unwind.get_proc_name(cursor, name, nameMax.toUSize, offset)
-
-        // Make sure the name is definitely 0-terminated.
-        // Unmangler is going to use strlen on this name and it's
-        // behavior is not defined for non-zero-terminated strings.
-        name(nameMax - 1) = 0.toByte
-
-        StackTraceElement(name, position)
-      } finally free(name)
+      parseStackTraceElement(symbol, position)
     }
 
     if (hasDebugInfo) {
@@ -131,35 +127,14 @@ object StackTrace {
     } else withNameFromUnwind()
   }
 
-  /** Creates a stack trace element in given unwind context. Finding a name of
-   *  the symbol for current function is expensive, so we cache stack trace
-   *  elements based on current instruction pointer.
-   */
-  private def cachedStackTraceElement(
-      cursor: CVoidPtr,
-      ip: CUnsignedLong
-  ): StackTraceElement =
-    cache.computeIfAbsent(ip, makeStackTraceElement(cursor, _))
-
-}
-
-private object StackTraceElement {
-  // ScalaNative specific
-  def apply(
+  private def parseStackTraceElement(
       sym: CString,
       position: Backtrace.Position
-  ): StackTraceElement = {
-    val className: Ptr[CChar] = fromRawPtr(
-      Intrinsics.stackalloc[CChar](Intrinsics.castIntToRawSizeUnsigned(512))
-    )
-    val methodName: Ptr[CChar] = fromRawPtr(
-      Intrinsics.stackalloc[CChar](Intrinsics.castIntToRawSizeUnsigned(256))
-    )
+  )(implicit tlContext: Context): StackTraceElement = {
+    val className: Ptr[CChar] = tlContext.freshClassNameBuffer
+    val methodName: Ptr[CChar] = tlContext.freshMethodNameBuffer
     val fileName: Ptr[CChar] =
-      if (LinktimeInfo.isWindows)
-        fromRawPtr(
-          Intrinsics.stackalloc[CChar](Intrinsics.castIntToRawSizeUnsigned(512))
-        )
+      if (LinktimeInfo.isWindows) tlContext.freshFileNameBuffer
       else null
     val lineOut: Ptr[Int] = fromRawPtr(Intrinsics.stackalloc[Int]())
     SymbolFormatter.asyncSafeFromSymbol(
@@ -182,5 +157,50 @@ private object StackTraceElement {
       filename,
       line
     )
+  }
+
+  private object ThreadLocalContext extends InheritableThreadLocal[Context] {
+    override protected def initialValue(): Context =
+      new Context(mutable.LongMap.empty, ByteArray.alloc(Context.DataSize))
+
+    override protected def childValue(fromParent: Context): Context =
+      new Context(
+        mutable.LongMap.from(fromParent.cache),
+        ByteArray.alloc(Context.DataSize)
+      )
+  }
+  private object Context {
+    final val SymbolMaxLength = 512
+    final val ClassNameMaxLength = 256
+    final val MethodNameMaxLength = 256
+    final val FileNameMaxLength = 512
+
+    final val SymbolBufferOffset = 0
+    final val ClassNameBufferOffset = SymbolBufferOffset + SymbolMaxLength
+    final val MethodNameBufferOffset = ClassNameBufferOffset + ClassNameMaxLength
+    final val FileNameBufferOffset = MethodNameBufferOffset + MethodNameMaxLength
+    final val UnwindCursorOffset = FileNameBufferOffset + FileNameMaxLength
+    final val UnwindContextOffset = UnwindCursorOffset + unwind.sizeOfCursor
+    final val DataSize = UnwindContextOffset + unwind.sizeOfContext
+  }
+  private class Context(
+      val cache: mutable.LongMap[StackTraceElement],
+      val data: ByteArray
+  ) {
+    def freshAt(offset: Int, size: Int): Ptr[Byte] = {
+      ffi.memset(
+        data.atRawUnsafe(offset),
+        0,
+        Intrinsics.castIntToRawSizeUnsigned(size)
+      )
+      data.atUnsafe(offset)
+    }
+    import Context._
+    def freshSymbolBuffer = freshAt(SymbolBufferOffset, SymbolMaxLength)
+    def freshClassNameBuffer = freshAt(ClassNameBufferOffset, ClassNameMaxLength)
+    def freshMethodNameBuffer = freshAt(MethodNameBufferOffset, MethodNameMaxLength)
+    def freshFileNameBuffer = freshAt(FileNameBufferOffset, FileNameMaxLength)
+    def unwindCursor = data.atUnsafe(UnwindCursorOffset)
+    def unwindContext = data.atUnsafe(UnwindContextOffset)
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ffi.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ffi.scala
@@ -20,7 +20,7 @@ object ffi {
   def wcslen(str: CWideString): CSize = extern
   def strncpy(dest: CString, src: CString, count: RawSize): CString = extern
   def strcpy(dest: CString, src: CString): CString = extern
-  def strncmp(lhs: CString, rhs: CString, count: CSize): CInt = extern
+  def strncmp(lhs: CString, rhs: CString, count: RawSize): CInt = extern
   def strcat(dest: CString, src: CString): CString = extern
   def memcpy(dst: CVoidPtr, src: CVoidPtr, count: CSize): RawPtr = extern
   def memcpy(dst: RawPtr, src: RawPtr, count: RawSize): RawPtr = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -15,22 +15,22 @@ private[runtime] object unwind {
   def get_proc_name(
       cursor: CVoidPtr,
       buffer: CString,
-      length: CSize,
-      offset: Ptr[Long]
+      length: RawSize,
+      offset: RawPtr
   ): CInt = extern
   @name("scalanative_unwind_get_reg")
   def get_reg(
       cursor: CVoidPtr,
       reg: CInt,
-      valp: Ptr[CSize]
+      valp: RawPtr
   ): CInt = extern
 
   @name("scalanative_unw_reg_ip")
   def UNW_REG_IP: CInt = extern
 
   @name("scalanative_unwind_sizeof_context")
-  def sizeOfContext: CSize = extern
+  def sizeOfContext: Int = extern
 
   @name("scalanative_unwind_sizeof_cursor")
-  def sizeOfCursor: CSize = extern
+  def sizeOfCursor: Int = extern
 }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -46,7 +46,8 @@ object BinaryIncompatibilities {
   final val NativeLib = Seq(
     exclude[MissingClassProblem]("scala.scalanative.runtime.rtti*"),
     exclude[Problem]("scala.scalanative.runtime.Backtrace*"),
-    exclude[Problem]("scala.scalanative.runtime.dwarf.DWARF*")
+    exclude[Problem]("scala.scalanative.runtime.dwarf.DWARF*"),
+    exclude[Problem]("scala.scalanative.runtime.StackTraceElement*")
   )
   final val CLib: Filters = Nil
   final val PosixLib: Filters = Seq.empty

--- a/test-interface/src/main/scala/scala/scalanative/runtime/testinterface/signalhandling/SignalConfig.scala
+++ b/test-interface/src/main/scala/scala/scalanative/runtime/testinterface/signalhandling/SignalConfig.scala
@@ -80,16 +80,17 @@ private[scalanative] object SignalConfig {
     unwind.init_local(cursor, context)
 
     while (unwind.step(cursor) > 0) {
-      val offset = stackalloc[Long]()
-      val pc = stackalloc[CSize]()
+      val offset = Intrinsics.stackalloc[Long]()
+      val pc = Intrinsics.stackalloc[RawSize]()
       unwind.get_reg(cursor, unwind.UNW_REG_IP, pc)
-      if (!pc == 0) return
+      val addr = Intrinsics.loadRawSize(pc)
+      if (Intrinsics.castRawSizeToInt(addr) == 0) return
       val symMax = 1024
       val sym: Ptr[CChar] = stackalloc[CChar](symMax)
       if (unwind.get_proc_name(
             cursor,
             sym,
-            sizeof[CChar] * symMax.toUInt,
+            Intrinsics.castIntToRawSizeUnsigned(sizeOf[CChar] * symMax),
             offset
           ) == 0) {
         sym(symMax - 1) = 0.toByte

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -58,7 +58,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   @Test def multithreading(): Unit =
     checkMinimalRequiredSymbols(withMultithreading = true)(expected =
       if (isScala3) SymbolsCount(types = 1100, members = 6550)
-      else if (isScala2_13) SymbolsCount(types = 1014, members = 6490)
+      else if (isScala2_13) SymbolsCount(types = 1020, members = 6560)
       else SymbolsCount(types = 1014, members = 7050)
     )
 

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -50,9 +50,9 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-pc-linux-gnu"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1047, members = 6783)
-      else if (isScala2_13) SymbolsCount(types = 1006, members = 6857)
-      else SymbolsCount(types = 988, members = 6961)
+      if (isScala3) SymbolsCount(types = 1050, members = 6850)
+      else if (isScala2_13) SymbolsCount(types = 1010, members = 6920)
+      else SymbolsCount(types = 995, members = 7065)
     )
 
   @Test def multithreading(): Unit =


### PR DESCRIPTION
Preallocate memory and get rid of redundant boxing. 
Replaces shared ConcurrentHashMap cache with simpler inheritable thread local OpenHashMap

We now gain 2-4% faster collection of stacktraces - tested with 64 levels of recursion, releaseFast mode. 