### PR TITLE
Don't wrap synchronous RPC endpoints into asynchronous ones

### DIFF
--- a/test-interface-common/src/main/scala/scala/scalanative/testinterface/common/RPCCore.scala
+++ b/test-interface-common/src/main/scala/scala/scalanative/testinterface/common/RPCCore.scala
@@ -99,6 +99,17 @@ private[testinterface] abstract class RPCCore()(implicit ec: ExecutionContext) {
               val arg = deserialize[Msg](in)
               bep.exec(arg)
 
+            case bep: BoundRPCSyncEndpoint =>
+              val callID = in.readLong()
+              val ep: bep.endpoint.type = bep.endpoint
+              import ep._
+
+              val repl = Try {
+                val req = deserialize[Req](in)
+                bep.exec(req)
+              }
+              send(makeReply(callID, repl))
+
             case bep: BoundRPCEndpoint =>
               val callID = in.readLong()
 
@@ -169,7 +180,10 @@ private[testinterface] abstract class RPCCore()(implicit ec: ExecutionContext) {
 
   /* Attaches the given method to the given (local) endpoint. */
   final def attach(ep: RPCEndpoint)(ex: ep.Req => ep.Resp): Unit = {
-    attachAsync(ep)(x => Future.fromTry(Try(ex(x))))
+    attach(new BoundRPCSyncEndpoint {
+      val endpoint: ep.type = ep
+      val exec = ex
+    })
   }
 
   /* Attaches the given method to the given (local) endpoint. */
@@ -280,6 +294,11 @@ private[testinterface] object RPCCore {
   private sealed trait BoundRPCEndpoint extends BoundEndpoint {
     val endpoint: RPCEndpoint
     val exec: endpoint.Req => Future[endpoint.Resp]
+  }
+
+  private sealed trait BoundRPCSyncEndpoint extends BoundEndpoint {
+    val endpoint: RPCEndpoint
+    val exec: endpoint.Req => endpoint.Resp
   }
 
   private trait PendingCall {

--- a/test-interface-common/src/main/scala/scala/scalanative/testinterface/common/RunMuxRPC.scala
+++ b/test-interface-common/src/main/scala/scala/scalanative/testinterface/common/RunMuxRPC.scala
@@ -44,7 +44,7 @@ private[testinterface] final class RunMuxRPC(rpc: RPCCore) {
   def attach[Req](ep: MuxRPCEndpoint[Req], runId: RunID)(
       ex: Req => ep.Resp
   ): Unit =
-    attachAsync(ep, runId)(x => Future.fromTry(Try(ex(x))))
+    attachMux(ep.opCode, runId, ex)(rpc.attach(ep))
 
   def attachAsync[Req](ep: MuxRPCEndpoint[Req], runId: RunID)(
       ex: Req => Future[ep.Resp]

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/NativeRPC.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/NativeRPC.scala
@@ -38,6 +38,7 @@ private[testinterface] class NativeRPC(clientSocket: Socket)(implicit
     } else {
       val msg = Array.fill(msgLength)(inStream.readChar).mkString
       handleMessage(msg)
+      // We don't use asynchronous RPC calls in Native client, so we can skip helpComplete
       // We cannot control which ExecutionContext implementation is used by users
       // Run the queue execution context loop just to be sure we don't create deadlock
       concurrent.NativeExecutionContext.queueInternal.helpComplete()


### PR DESCRIPTION
Before #1869 we have not needed explicit `concurrent.NativeExecutionContext.queueInternal.helpComplete()` (previously `runtime.loop()`) invocation in the `NativeRPC.loop`, becouse in the old testing infrastrucure we never spawned any Futures. 
When porting new infra from Scala.js we've also ported some of possibly not very useful implementation details. 

In Scala.js the only asynchronous RPC endpoint was used to execute the code. In Scala Native [this endpoint](https://github.com/scala-native/scala-native/blob/c7b54a18e3ff11d8b2792f16fbb6e97780314014/test-interface/src/main/scala/scala/scalanative/testinterface/TestAdapterBridge.scala#L50) was always implemented as synchronous. However, the internal implementation of the endpoint binded using `attach` was delegating the execution using `attachAsync` - this required us to pass the Execution context that would be used to create `onComplete` event.

In Scala.js infra and modified JUnitRuntime used the continuations to delay completion and notifing the JVM server until test execution has finished. It was never ported to Scala Native - the original port used a mostly synchronous variant to execute code , and last port in #2723 was rejected. 

In this PR we makes synchronous RPC endpoints truly synchronous - we no longer create dummy Futures that serve little to no real purpose. It should not negatively affect the testing infrastructure - the JVM server would wait until current execution would finish before sending a next task to execute. 


