### PR TITLE
fix[toolchain]: Generate GC yield instructions when looping on the same block

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -252,7 +252,7 @@ private[scalanative] object Lower {
           implicit val pos: nir.SourcePosition = inst.pos
           // Generate GC yield points before backward jumps, eg. in loops
           next match {
-            case nir.Next.Label(target, _) if labelPositions(target) < currentBlockPosition =>
+            case nir.Next.Label(target, _) if labelPositions(target) <= currentBlockPosition =>
               genGCYieldpoint(buf)
             case _ => ()
           }


### PR DESCRIPTION
Generate GC yield instructions when looping on the same block (eg.`while(true) i ++ 1`). Previously, these would lead to deadlock if other thread would try to perform GC