### PR TITLE
Improvement [Build]: Update sbt to 1.10.7

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -56,8 +56,9 @@ object ScalaVersions {
   //   1.9.7 fixes sbt IO.unzip vulnerability described in sbt release notes.
   //   1.10.0 Latest sbt version.
   //   1.10.1 Latest sbt version.
+  //   1.10.7 Latest sbt version, 1.10.2 had bug, see comment in SN Issue #4126
 
-  val sbt10Version: String = "1.10.2"
+  val sbt10Version: String = "1.10.7"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.2
+sbt.version = 1.10.7


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.10.7.

The SBT GitHub [announcement](https://github.com/sbt/sbt/releases/tag/v1.10.7).

This PR also updates the SBT version in both `project/build.properties` & `project/ScalaVersions.scala`.

### NB: 

Scala Native Issue #4126 reports a problem with SN 0.5.6 when running tests twice.  A comment from
Ekrich in that Issue and followup isolated the problem to a known, to some, issue with sbt 1.10.2.

I am submitting this PR after having used sbt 1.10.7 in private development for a long day instead of
my usual two week "early mortality" interval in order to catch the SN 0.5.7 if it is leaving soon.