### PR TITLE
[fix] javalib InputStream#readNBytes(N) now returns correct number of Bytes read

### DIFF
--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -1,6 +1,8 @@
 package java.io
 
 import java.{util => ju}
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.Arrays
 
 abstract class InputStream extends Closeable {
   def read(): Int
@@ -34,43 +36,25 @@ abstract class InputStream extends Closeable {
     }
   }
 
-  // Allow obvious implementation of readAllBytes() to work on both Java 9 & 11
-  def readNBytesImpl(len: Int): Array[Byte] = {
-    if (len < 0)
-      throw new IllegalArgumentException("len < 0")
-
-    def readBytes(len: Int): ByteArrayOutputStream = {
-      val limit = Math.min(len, 1024)
-
-      val storage = new ByteArrayOutputStream(limit) // can grow itself
-      val buffer = new Array[Byte](limit)
-
-      var remaining = len
-
-      while (remaining > 0) {
-        val nRead = read(buffer, 0, limit)
-
-        if (nRead == -1) remaining = 0 // EOF
-        else {
-          storage.write(buffer, 0, nRead)
-          remaining -= nRead
-        }
-      }
-
-      storage
-    }
-
-    /* To stay within the documented 2 * len memory bound for this method,
-     * ensure that the temporary intermediate read buffer is out of scope
-     * and released before calling toByteArray().
-     */
-
-    readBytes(len).toByteArray()
-  }
-
   /** Java 9
    */
-  def readAllBytes(): Array[Byte] = readNBytesImpl(Integer.MAX_VALUE)
+  def readAllBytes(): Array[Byte] = {
+    /* Design Note:
+     *   readAllBytes() was introduced in Java 9 without any implementation
+     *   requirements. Java 11 added such a requirement:
+     *
+     *    Implementation Requirements:
+     *    This method invokes readNBytes(int) with a length of
+     *    Integer.MAX_VALUE.
+     *
+     *   The current JDK, 23, retains this requirement.
+     *
+     *   This requirement effects the way readNBytes(int) is implemented
+     *   because it implies buffered or "chunked" intermediate reads.
+     */
+
+    readNBytes(Integer.MAX_VALUE)
+  }
 
   /** Java 9
    */
@@ -105,9 +89,115 @@ abstract class InputStream extends Closeable {
     }
   }
 
+  /* Design Note:
+   * The 'streamChunkSize' "constant" must manually be kept in synch with
+   * the corresponding value in InputStreamTestOnJDK11.scala.
+   *
+   * The 4096 value is a guess at a sweet spot between memory used and
+   * number of I/Os when N is large. It is the page size on many systems.
+   * Experience and the passage of time may show that this number should be
+   * increased.
+   */
+
+  private final val streamChunkSize = 4096 // remember InputStreamTestOnJDK11
+
   /** Java 11
    */
-  def readNBytes(len: Int): Array[Byte] = readNBytesImpl(len)
+  def readNBytes(len: Int): Array[Byte] = {
+    /* Design Note:
+     *   See Design Note in method readAllBytes(). The constraint described
+     *   there leads directly to the possibility that 'len' might be
+     *   large (Integer.MAX_VALUE). This means that always blindly allocating
+     *   an Array[Byte](len) is not robust.
+     */
+
+    if (len < 0)
+      throw new IllegalArgumentException("len < 0")
+
+    def readSmallN(len: Int): Array[Byte] = {
+      /* Attempt to minimize the number of times the data is copied.
+       *
+       * When the caller has guessed correctly and len bytes are available,
+       * only one copy is needed.  When less than len bytes
+       * are available, a second is necessary.
+       *
+       * readLargeN() is likely to call readSmallN() with an exact match
+       * len argument one or more times for each call which triggers
+       * the second copy.
+       */
+
+      // caller has dispatched on argument, so OK to allocate size blindly.
+      val buffer = new Array[Byte](len)
+
+      var totalBytesRead = 0
+      var remaining = len
+
+      while (remaining > 0) {
+        val nRead = read(buffer, totalBytesRead, remaining)
+
+        if (nRead == -1) remaining = 0 // EOF
+        else {
+          remaining -= nRead
+          totalBytesRead += nRead
+        }
+      }
+
+      if (totalBytesRead == len)
+        buffer
+      else if (totalBytesRead < len)
+        Arrays.copyOfRange(buffer, 0, totalBytesRead)
+      else { // should never happen
+        throw new IOException(
+          s"total bytes read ${totalBytesRead} > len argument ${len}"
+        )
+      }
+    }
+
+    def readLargeN(len: Int): Array[Byte] = {
+      /* The byteStore is not expected to be accessed concurrently.
+       * ConcurrentedLinkedDeque is used here because the Scala Native JSR-166
+       * code is newer, more studied, and likely to execute faster
+       * than the SN LinkedListDequeue implementation. FUD, not measurement.
+       *
+       * Using a Deque rather than, say, a ByteArrayOutputStream may briefly
+       * exceed the JDK documented upper bound of (2 * len) for memory
+       * usage. Given that we are in large N territory here, it is highly
+       * likely to reduce the number of data copies.
+       */
+      val byteStore = new ConcurrentLinkedDeque[Array[Byte]]
+
+      var totalBytesRead = 0
+      var remaining = len
+
+      while (remaining > 0) {
+        val bufferSize = Math.min(remaining, streamChunkSize)
+        val buffer = readSmallN(bufferSize)
+
+        val nRead = buffer.size
+
+        if (nRead == 0) remaining = 0 /* EOF */
+        else {
+          remaining -= nRead
+          totalBytesRead += nRead
+          byteStore.addLast(buffer)
+        }
+      }
+
+      val result = new Array[Byte](totalBytesRead)
+
+      var resultPos = 0
+      byteStore.forEach(b => {
+        val n = b.size
+        System.arraycopy(b, 0, result, resultPos, n)
+        resultPos += n
+      })
+
+      result
+    }
+
+    if (len <= streamChunkSize) readSmallN(len)
+    else readLargeN(len)
+  }
 
   def skip(n: Long): Long = {
     var skipped = 0

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK11.scala
@@ -1,6 +1,7 @@
 package org.scalanative.testsuite.javalib.io
 
 import java.io._
+import java.util.Arrays
 
 import org.junit.Test
 import org.junit.Assert._
@@ -9,7 +10,7 @@ import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 
 class InputStreamTestOnJDK11 {
 
-  @Test def readNBytesLenNegativeLength(): Unit = {
+  @Test def readNBytesOneArgNegativeLength(): Unit = {
     val inputBytes =
       List(255, 254, 253, 252)
         .map(_.toByte)
@@ -23,7 +24,7 @@ class InputStreamTestOnJDK11 {
     )
   }
 
-  @Test def readNBytesLen(): Unit = {
+  @Test def readNBytesOneArgSmallN(): Unit = {
     val inputBytes =
       List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
         .map(_.toByte)
@@ -34,5 +35,52 @@ class InputStreamTestOnJDK11 {
     val result = streamIn.readNBytes(len)
 
     assertEquals("result length", len, result.length)
+    assertArrayEquals("result content", Arrays.copyOf(inputBytes, len), result)
   }
+
+  @Test def readNBytesOneArgLargeN(): Unit = {
+    /* Read more bytes than the presumably known implementation buffer size
+     * but not the entire stream.
+     */
+
+    /* This "constant" must be manually kept in sync with corresponding
+     * 'streamChunkSize' value in InputStream.scala.
+     */
+    val readNbChunkSize = 4096 // must match value in InputStream.scala
+
+    val shouldBeReadFragmentSize = 5
+    val shouldBeUnreadFragmentSize = 3
+
+    // Force read of two full internal buffers, then a partial.
+    val nToRead = (2 * readNbChunkSize) + shouldBeReadFragmentSize
+
+    // For confusion, have some unread bytes at tail end of streamIn
+    val nInputBytes = nToRead + shouldBeUnreadFragmentSize
+
+    val inputBytes = new Array[Byte](nInputBytes)
+
+    /* Place some non-zero data astride two internal chunks; some
+     * at the end of one, some at the beginning of the following chunk.
+     * Try to trip-up the buffering logic and expose any bugs.
+     */
+
+    val lookback = 2
+    val startValidData = nToRead - shouldBeReadFragmentSize - lookback
+
+    for (j <- startValidData until nToRead)
+      inputBytes(j) = j.toByte
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+
+    val result = streamIn.readNBytes(nToRead)
+
+    assertEquals("result length", nToRead, result.length)
+
+    assertArrayEquals(
+      "result content",
+      Arrays.copyOfRange(inputBytes, startValidData, nToRead),
+      Arrays.copyOfRange(result, startValidData, nToRead)
+    )
+  }
+
 }

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK9.scala
@@ -52,6 +52,8 @@ class InputStreamTestOnJDK9 {
   }
 
   @Test def readNBytesBufferOffLen(): Unit = {
+    // Read all bytes in InputStream: exactly sized receiver.
+
     val inputBytes =
       List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
 
@@ -65,7 +67,27 @@ class InputStreamTestOnJDK9 {
     assertEquals("expected content", expected, receiver(expected))
   }
 
-  @Test def transferToNullOutStream(): Unit = {
+  @Test def readNBytesBufferOffNotAllInput(): Unit = {
+    // Read fewer bytes than are available in InputStream: short receiver.
+
+    val inputBytes = (0 until 12).map(_.toByte).toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+
+    val receiverLength = inputBytes.length - 2
+    val receiver = new Array[Byte](receiverLength)
+
+    val nRead = streamIn.readNBytes(receiver, 0, receiverLength)
+
+    assertEquals("nRead", receiverLength, nRead)
+
+    val expected = 9
+    assertEquals("expected content", expected, receiver(expected))
+  }
+
+  @Test def transferToNullArg(): Unit = {
+    // Distinguish from test of Java 11 static method nullOutputStream().
+
     val inputBytes =
       List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
         .map(_.toByte)


### PR DESCRIPTION
fix #4127 

javalib `InputStream#readNBytes(N)` now more consistently returns the correct number of Bytes read.

I did not measure it, but this implementation should reduce the amount of data being copied as
a result of "growing" the previous internal array when N is large.  This should change should also benefit `readAllBytes()`,
