### PR TITLE
feature [javalib]: Implement java.io null{In, Out}putStream 

### DIFF
--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -212,7 +212,7 @@ abstract class InputStream extends Closeable {
   def mark(readlimit: Int): Unit = ()
 
   def reset(): Unit =
-    throw new IOException("Reset not supported")
+    throw new IOException("mark/reset not supported")
 
   def markSupported(): Boolean = false
 
@@ -235,5 +235,54 @@ abstract class InputStream extends Closeable {
     }
 
     nTransferred
+  }
+}
+
+/** Java 11
+ */
+object InputStream {
+
+  /** Java 11
+   */
+  def nullInputStream(): InputStream = {
+    new InputStream() {
+      private var closed = false
+
+      private def checkClosed(): Unit = {
+        if (closed)
+          throw new IOException("Stream closed")
+      }
+      private def nullRead(): Int = {
+        checkClosed()
+        -1
+      }
+
+      override def available(): Int = {
+        checkClosed()
+        0
+      }
+
+      override def close(): Unit =
+        closed = true
+
+      def read(): Int =
+        nullRead()
+
+      override def read(b: Array[Byte]): Int =
+        nullRead()
+
+      override def read(b: Array[Byte], off: Int, len: Int): Int =
+        nullRead()
+
+      override def readAllBytes(): Array[Byte] = {
+        checkClosed()
+        new Array[Byte](0)
+      }
+
+      override def readNBytes(buffer: Array[Byte], off: Int, len: Int): Int = {
+        checkClosed()
+        0
+      }
+    }
   }
 }

--- a/javalib/src/main/scala/java/io/OutputStream.scala
+++ b/javalib/src/main/scala/java/io/OutputStream.scala
@@ -23,3 +23,34 @@ abstract class OutputStream extends Object with Closeable with Flushable {
 
   def close(): Unit = ()
 }
+
+/** Java 11
+ */
+object OutputStream {
+
+  /** Java 11
+   */
+  def nullOutputStream(): OutputStream = {
+    new OutputStream() {
+      private var closed = false
+
+      private def nullWrite(): Unit = {
+        if (closed)
+          throw new IOException("Stream closed")
+        // else silently do nothing
+      }
+
+      override def close(): Unit =
+        closed = true
+
+      override def write(b: Array[Byte]): Unit =
+        nullWrite()
+
+      override def write(b: Array[Byte], off: Int, len: Int): Unit =
+        nullWrite()
+
+      def write(b: Int): Unit =
+        nullWrite()
+    }
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK11.scala
@@ -83,4 +83,130 @@ class InputStreamTestOnJDK11 {
     )
   }
 
+  @Test def nullInputStreamWhenOpen(): Unit = {
+    val streamIn = InputStream.nullInputStream()
+    val streamOut = new ByteArrayOutputStream()
+
+    val buffer = new Array[Byte](8)
+
+    assertEquals("available()", 0, streamIn.available())
+
+    assertEquals("markSupported()", false, streamIn.markSupported())
+
+    streamIn.mark(1) // should do nothing.
+
+    assertEquals("read()", -1, streamIn.read())
+
+    assertEquals("read(buffer)", -1, streamIn.read(buffer))
+
+    assertEquals(
+      "read(buffer, off, len)",
+      -1,
+      streamIn.read(buffer, 1, buffer.length - 2)
+    )
+
+    assertEquals("readAllBytes()", 0, streamIn.readAllBytes().length)
+
+    assertEquals(
+      "readNBytes(buffer, off, len)",
+      0,
+      streamIn.readNBytes(buffer, 2, buffer.length - 3)
+    )
+
+    assertEquals(
+      "readNBytes(len)",
+      0,
+      streamIn.readNBytes(buffer.length - 3).length
+    )
+
+    assertThrows(
+      "reset()",
+      classOf[IOException],
+      streamIn.reset()
+    )
+
+    assertEquals("skip(len)", 0L, streamIn.skip(buffer.length - 3))
+
+    assertEquals("transferTo(streamOut)", 0L, streamIn.transferTo(streamOut))
+    assertEquals("streamOut.length)", 0L, streamOut.size())
+
+    streamIn.close() // close of open stream should succeed
+  }
+
+  @Test def nullInputStreamWhenClosed(): Unit = {
+    val streamIn = InputStream.nullInputStream()
+    val streamOut = new ByteArrayOutputStream()
+
+    val buffer = new Array[Byte](8)
+
+    streamIn.close()
+
+    assertThrows(
+      "available()",
+      classOf[IOException],
+      streamIn.available()
+    )
+
+    assertEquals("markSupported()", false, streamIn.markSupported())
+
+    streamIn.mark(1) // should do nothing.
+
+    assertThrows(
+      "read()",
+      classOf[IOException],
+      streamIn.read()
+    )
+
+    assertThrows(
+      "read(buffer)",
+      classOf[IOException],
+      streamIn.read(buffer)
+    )
+
+    assertThrows(
+      "read(buffer, off, len)",
+      classOf[IOException],
+      streamIn.read(buffer, 1, buffer.length - 2)
+    )
+
+    assertThrows(
+      "readAllBytes()",
+      classOf[IOException],
+      streamIn.readAllBytes()
+    )
+
+    assertThrows(
+      "readNBytes(buffer, off, len)",
+      classOf[IOException],
+      streamIn.readNBytes(buffer, 2, buffer.length - 3)
+    )
+
+    assertThrows(
+      "readNBytes(len)",
+      classOf[IOException],
+      streamIn.readNBytes(buffer.length - 3).length
+    )
+
+    // reset() has same behavior, open or closed.
+    assertThrows(
+      "reset()",
+      classOf[IOException],
+      streamIn.reset()
+    )
+
+    assertThrows(
+      "skip(len)",
+      classOf[IOException],
+      streamIn.skip(buffer.length - 3)
+    )
+
+    assertThrows(
+      "transferTo(streamOut)",
+      classOf[IOException],
+      streamIn.transferTo(streamOut)
+    )
+
+    streamIn.close() // close of closed stream should succeed
+  }
+
 }

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/OutputStreamTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/OutputStreamTestOnJDK11.scala
@@ -1,0 +1,68 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class OutputStreamTestOnJDK11 {
+
+  @Test def nullOutputStreamWhenOpen(): Unit = {
+    val streamOut = OutputStream.nullOutputStream()
+
+    val outputBytes =
+      List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    // Exercise each API method. Expect that no method will throw
+
+    streamOut.flush() // empty stream
+
+    streamOut.write(outputBytes)
+
+    streamOut.write(outputBytes, 2, outputBytes.length - 2)
+
+    streamOut.write(255)
+
+    streamOut.flush() // flush again with something in stream.
+
+    streamOut.close()
+  }
+
+  @Test def nullOutputStreamWhenClosed(): Unit = {
+    val streamOut = OutputStream.nullOutputStream()
+
+    streamOut.close() // Expect no Exception thrown
+
+    streamOut.flush() // Expect no Exception thrown
+
+    val outputBytes =
+      List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    assertThrows(
+      "write(Array[Byte])",
+      classOf[IOException],
+      streamOut.write(outputBytes)
+    )
+
+    assertThrows(
+      "write(Array[Byte], off, len)",
+      classOf[IOException],
+      streamOut.write(outputBytes, 2, outputBytes.length - 2)
+    )
+
+    assertThrows(
+      "write(Int)",
+      classOf[IOException],
+      streamOut.write(255)
+    )
+
+    streamOut.close() // close() of closed steam should be silent
+  }
+
+}


### PR DESCRIPTION
Fix #4133 

Implement two static methods added to `java.io` in Java 11: `InputStream.nullInputStream()` 
and `OutputStream.nullOutputStream()' and their associated unit-tests.