### PR TITLE
Improvement[javalib]: rework skipping bytes in java.io.InputStream

### DIFF
--- a/unit-tests/shared/src/test/require-jdk12/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK12.scala
+++ b/unit-tests/shared/src/test/require-jdk12/org/scalanative/testsuite/javalib/io/InputStreamTestOnJDK12.scala
@@ -1,0 +1,95 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io._
+import java.util.Arrays
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class InputStreamTestOnJDK12 {
+
+  @Test def skipNBytesZeroN(): Unit = {
+    val inputBytes =
+      List(255, 254, 253, 252)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+
+    streamIn.skipNBytes(0)
+    val result = streamIn.readAllBytes()
+
+    // Assert zero bytes were skipped
+    assertEquals("result length", inputBytes.length, result.length)
+  }
+
+  @Test def skipNBytesNegativeN(): Unit = {
+    val inputBytes =
+      List(255, 254, 253, 252)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+
+    streamIn.skipNBytes(-2)
+    val result = streamIn.readAllBytes()
+
+    // Assert zero bytes were skipped
+    assertEquals("result length", inputBytes.length, result.length)
+  }
+
+  @Test def skipNBytesSmallN(): Unit = {
+    val inputBytes =
+      List(255, 254, 253, 252, 251, 128, 127, 2, 1, 0)
+        .map(_.toByte)
+        .toArray[Byte]
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+
+    // avoid starting skip at index 0 in case that index is special.
+    val discardedLen = 1
+    val discarded = streamIn.readNBytes(discardedLen)
+    assertEquals("discarded length", discardedLen, discarded.length)
+
+    val skipLen = 3
+    streamIn.skipNBytes(skipLen)
+
+    val remainingBytes = streamIn.readAllBytes()
+
+    val expected = inputBytes.length - discardedLen - skipLen
+    assertEquals("result length", expected, remainingBytes.length)
+  }
+
+  @Test def skipNBytesLargeN(): Unit = {
+    /* Skip an arbitrarily "large" number of Bytes where this test
+     * does not "know" if the implementation is buffered or not.
+     */
+
+    val shouldBeSkippedFragmentSize = 3
+    val remainingFragmentSize = 5
+
+    val nToSkip = 8192 + shouldBeSkippedFragmentSize
+
+    val inputBytes = new Array[Byte](nToSkip + remainingFragmentSize)
+
+    for (j <- 0 until remainingFragmentSize)
+      inputBytes(nToSkip + j) = (j + 1).toByte
+
+    val streamIn = new ByteArrayInputStream(inputBytes)
+
+    // Start skipping at index 0 in order to exercise "no prior read()" case.
+    streamIn.skipNBytes(nToSkip)
+
+    val remainingBytes = streamIn.readAllBytes()
+
+    assertEquals("result length", remainingFragmentSize, remainingBytes.length)
+
+    val expectedBytes =
+      Arrays.copyOfRange(inputBytes, nToSkip, inputBytes.length)
+
+    assertArrayEquals("result content", expectedBytes, remainingBytes)
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/InputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/InputStreamTest.scala
@@ -1,0 +1,80 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io._
+import java.util.Arrays
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class InputStreamTest {
+
+  class MockInputStreamForSkipping(buf: Array[Byte]) extends InputStream {
+    var pos = 0
+    val count = buf.length
+
+    def read(): Int = {
+      if (pos >= count) -1
+      else {
+        val index = pos
+        pos += 1
+        buf(index).toByte
+      }
+    }
+
+    /* To reduce CI time, use a clone of ByteArrayInputStream code for bulk
+     * read(b, off, len) instead of the single character read() based
+     * implementation in the InputStream base class.
+     */
+
+    override def read(b: Array[Byte], off: Int, reqLen: Int): Int = {
+      if (off < 0 || reqLen < 0 || reqLen > b.length - off)
+        throw new IndexOutOfBoundsException
+
+      val len = Math.min(reqLen, count - pos)
+
+      if (reqLen == 0)
+        0 // 0 requested, 0 returned
+      else if (len == 0)
+        -1 // nothing to read at all
+      else {
+        System.arraycopy(buf, pos, b, off, len)
+        pos += len
+        len
+      }
+    }
+  }
+
+  @Test def skipLargeN(): Unit = {
+
+    val shouldBeSkippedFragmentSize = 3
+    val remainingFragmentSize = 5
+
+    val nToSkip = 8192 + shouldBeSkippedFragmentSize
+
+    val inputBytes = new Array[Byte](nToSkip + remainingFragmentSize)
+
+    for (j <- 0 until remainingFragmentSize)
+      inputBytes(nToSkip + j) = (j + 1).toByte
+
+    // Ensure skip() implementation of base class is used, not an override
+    val streamIn = new MockInputStreamForSkipping(inputBytes)
+
+    // Start skipping at index 0 in order to exercise "no prior read()" case.
+    val nActuallySkipped = streamIn.skip(nToSkip)
+    assertEquals("n skipped", nToSkip, nActuallySkipped)
+
+    val remainingBytes = new Array[Byte](remainingFragmentSize)
+
+    val nRemainingBytes = streamIn.read(remainingBytes)
+
+    assertEquals("result length", remainingFragmentSize, nRemainingBytes)
+
+    val expectedBytes =
+      Arrays.copyOfRange(inputBytes, nToSkip, inputBytes.length)
+
+    assertArrayEquals("result content", expectedBytes, remainingBytes)
+  }
+
+}


### PR DESCRIPTION
Improvements in `java.io.InputStream`:

1) implement Java 12 method `skipNBytes(n)` & associated unit-tests

2) rework implementation of `skip(n)` :

     a. The code now matches the Java 8 (thru JDK 23) description of the method implementation 
         as  using bulk, not single Byte, reads.

     b.  The prior code had an integer overflow bug, `var skipped = 0` should have compared to the
           Long `0L`, causing `skipped` to be a Long. The new code does not have this bug.