### PR TITLE
Fix #4071: java.io.InflaterInputStream#skip can now handle large N bytes

### DIFF
--- a/javalib/src/main/scala/java/util/zip/InflaterInputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/InflaterInputStream.scala
@@ -108,16 +108,19 @@ class InflaterInputStream private (
     }
   }
 
+  /* Fix Issue 4071. Make only required minimal changes so as to
+   * not disturb the dead hand of the past.
+   */
+
   override def skip(nbytes: Long): Long = {
-    if (nbytes >= 0) {
-      if (buf == null) {
-        buf =
-          new Array[Byte](Math.min(nbytes, InflaterInputStream.BUF_SIZE).toInt)
-      }
+    if (nbytes >= 0L) {
+      val skipBuffer =
+        new Array[Byte](Math.min(nbytes, InflaterInputStream.BUF_SIZE).toInt)
+
       var count, rem: Long = 0L
       while (count < nbytes) {
         val x = read(
-          buf,
+          skipBuffer,
           0,
           if ({ rem = nbytes - count; rem > buf.length })
             buf.length


### PR DESCRIPTION
Fix #4071

Issue #4071 reported problems in `java.io.GZIPInputStream`. This PR addresses 
the `java.util.zip.DataFormatException: -3` defect by correcting `java.io.InflaterInputStream#skip`
so that it correctly handles skipping large number of bytes. 

Where '"large" is defined as a number greater that 126 or so.  200 certainly triggered the Exception
in development code.

The "large N" case for this PR has been manually tested using private code derived, with permission & appreciation,
 from the reproduction code posted in the Issue.

