### PR TITLE
Dead-code eliminate unused boxes runtime methods

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -2285,8 +2285,6 @@ private[scalanative] object Lower {
     buf += BoxesRunTime
     buf += RuntimeBoxes
     buf += unitName
-    buf ++= BoxTo.values
-    buf ++= UnboxTo.values
     buf += arrayLength
     buf ++= arrayHeapAlloc.values
     buf ++= arrayZoneAlloc.values


### PR DESCRIPTION
`scala.scalanative.runtime.Boxes` and `scala.runtime.BoxesRunTime` were kept regardless of usage.
This treats them as any other object by reaching their methods when a `nir.Op.Box` or `nir.Op.Unbox` operation happens.