### PR TITLE
Better encoding for `unsafe.Nat` to be optimized away

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CArray.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CArray.scala
@@ -37,6 +37,11 @@ final class CArray[T, N <: Nat] private[scalanative] (
     ptr(idx) = value
   }
 
+  @alwaysinline def length(implicit natValue: NatValue[N]): Int = {
+    natValue.value
+  }
+
+  @deprecated("Use overload which takes natValue: NatValue[N]", since = "0.5.7")
   @alwaysinline def length(implicit tag: Tag[N]): Int = {
     tag.asInstanceOf[Tag.NatTag].toInt
   }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/NatValue.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/NatValue.scala
@@ -1,0 +1,171 @@
+// format: off
+
+// BEWARE: This file is generated - direct edits will be lost.
+// Do not edit this it directly other than to remove
+// personally identifiable information in sourceLocation lines.
+// All direct edits to this file will be lost the next time it
+// is generated.
+//
+// See nativelib runtime/Arrays.scala.gyb for details.
+
+package scala.scalanative
+package unsafe
+
+import scalanative.annotation.alwaysinline
+
+private[unsafe] abstract class NatValue[T <: Nat] {
+  @alwaysinline def value: Int
+}
+
+private[unsafe] object NatValue {
+  abstract class NatBaseValue[T <: Nat.Base] extends NatValue[T] {
+    @alwaysinline def value: Int
+  }
+
+  object Nat0 extends NatBaseValue[unsafe.Nat._0] {
+    @alwaysinline def value: Int = 0
+  }
+
+  object Nat1 extends NatBaseValue[unsafe.Nat._1] {
+    @alwaysinline def value: Int = 1
+  }
+
+  object Nat2 extends NatBaseValue[unsafe.Nat._2] {
+    @alwaysinline def value: Int = 2
+  }
+
+  object Nat3 extends NatBaseValue[unsafe.Nat._3] {
+    @alwaysinline def value: Int = 3
+  }
+
+  object Nat4 extends NatBaseValue[unsafe.Nat._4] {
+    @alwaysinline def value: Int = 4
+  }
+
+  object Nat5 extends NatBaseValue[unsafe.Nat._5] {
+    @alwaysinline def value: Int = 5
+  }
+
+  object Nat6 extends NatBaseValue[unsafe.Nat._6] {
+    @alwaysinline def value: Int = 6
+  }
+
+  object Nat7 extends NatBaseValue[unsafe.Nat._7] {
+    @alwaysinline def value: Int = 7
+  }
+
+  object Nat8 extends NatBaseValue[unsafe.Nat._8] {
+    @alwaysinline def value: Int = 8
+  }
+
+  object Nat9 extends NatBaseValue[unsafe.Nat._9] {
+    @alwaysinline def value: Int = 9
+  }
+
+
+  @alwaysinline implicit def materializeNat0NatBaseValue: NatBaseValue[unsafe.Nat._0] =
+    Nat0
+  @alwaysinline implicit def materializeNat1NatBaseValue: NatBaseValue[unsafe.Nat._1] =
+    Nat1
+  @alwaysinline implicit def materializeNat2NatBaseValue: NatBaseValue[unsafe.Nat._2] =
+    Nat2
+  @alwaysinline implicit def materializeNat3NatBaseValue: NatBaseValue[unsafe.Nat._3] =
+    Nat3
+  @alwaysinline implicit def materializeNat4NatBaseValue: NatBaseValue[unsafe.Nat._4] =
+    Nat4
+  @alwaysinline implicit def materializeNat5NatBaseValue: NatBaseValue[unsafe.Nat._5] =
+    Nat5
+  @alwaysinline implicit def materializeNat6NatBaseValue: NatBaseValue[unsafe.Nat._6] =
+    Nat6
+  @alwaysinline implicit def materializeNat7NatBaseValue: NatBaseValue[unsafe.Nat._7] =
+    Nat7
+  @alwaysinline implicit def materializeNat8NatBaseValue: NatBaseValue[unsafe.Nat._8] =
+    Nat8
+  @alwaysinline implicit def materializeNat9NatBaseValue: NatBaseValue[unsafe.Nat._9] =
+    Nat9
+
+  @alwaysinline implicit def materializeNatDigit2NatValue[N1 <: Nat.Base : NatBaseValue, N2 <: Nat.Base : NatBaseValue]: NatValue[Nat.Digit2[N1, N2]] =
+    new NatValue[Nat.Digit2[N1, N2]] {
+      @alwaysinline def value: Int = {
+        10 * implicitly[NatBaseValue[N1]].value +
+          implicitly[NatBaseValue[N2]].value
+      }
+    }
+  @alwaysinline implicit def materializeNatDigit3NatValue[N1 <: Nat.Base : NatBaseValue, N2 <: Nat.Base : NatBaseValue, N3 <: Nat.Base : NatBaseValue]: NatValue[Nat.Digit3[N1, N2, N3]] =
+    new NatValue[Nat.Digit3[N1, N2, N3]] {
+      @alwaysinline def value: Int = {
+        100 * implicitly[NatBaseValue[N1]].value +
+          10 * implicitly[NatBaseValue[N2]].value +
+          implicitly[NatBaseValue[N3]].value
+      }
+    }
+  @alwaysinline implicit def materializeNatDigit4NatValue[N1 <: Nat.Base : NatBaseValue, N2 <: Nat.Base : NatBaseValue, N3 <: Nat.Base : NatBaseValue, N4 <: Nat.Base : NatBaseValue]: NatValue[Nat.Digit4[N1, N2, N3, N4]] =
+    new NatValue[Nat.Digit4[N1, N2, N3, N4]] {
+      @alwaysinline def value: Int = {
+        1000 * implicitly[NatBaseValue[N1]].value +
+          100 * implicitly[NatBaseValue[N2]].value +
+          10 * implicitly[NatBaseValue[N3]].value +
+          implicitly[NatBaseValue[N4]].value
+      }
+    }
+  @alwaysinline implicit def materializeNatDigit5NatValue[N1 <: Nat.Base : NatBaseValue, N2 <: Nat.Base : NatBaseValue, N3 <: Nat.Base : NatBaseValue, N4 <: Nat.Base : NatBaseValue, N5 <: Nat.Base : NatBaseValue]: NatValue[Nat.Digit5[N1, N2, N3, N4, N5]] =
+    new NatValue[Nat.Digit5[N1, N2, N3, N4, N5]] {
+      @alwaysinline def value: Int = {
+        10000 * implicitly[NatBaseValue[N1]].value +
+          1000 * implicitly[NatBaseValue[N2]].value +
+          100 * implicitly[NatBaseValue[N3]].value +
+          10 * implicitly[NatBaseValue[N4]].value +
+          implicitly[NatBaseValue[N5]].value
+      }
+    }
+  @alwaysinline implicit def materializeNatDigit6NatValue[N1 <: Nat.Base : NatBaseValue, N2 <: Nat.Base : NatBaseValue, N3 <: Nat.Base : NatBaseValue, N4 <: Nat.Base : NatBaseValue, N5 <: Nat.Base : NatBaseValue, N6 <: Nat.Base : NatBaseValue]: NatValue[Nat.Digit6[N1, N2, N3, N4, N5, N6]] =
+    new NatValue[Nat.Digit6[N1, N2, N3, N4, N5, N6]] {
+      @alwaysinline def value: Int = {
+        100000 * implicitly[NatBaseValue[N1]].value +
+          10000 * implicitly[NatBaseValue[N2]].value +
+          1000 * implicitly[NatBaseValue[N3]].value +
+          100 * implicitly[NatBaseValue[N4]].value +
+          10 * implicitly[NatBaseValue[N5]].value +
+          implicitly[NatBaseValue[N6]].value
+      }
+    }
+  @alwaysinline implicit def materializeNatDigit7NatValue[N1 <: Nat.Base : NatBaseValue, N2 <: Nat.Base : NatBaseValue, N3 <: Nat.Base : NatBaseValue, N4 <: Nat.Base : NatBaseValue, N5 <: Nat.Base : NatBaseValue, N6 <: Nat.Base : NatBaseValue, N7 <: Nat.Base : NatBaseValue]: NatValue[Nat.Digit7[N1, N2, N3, N4, N5, N6, N7]] =
+    new NatValue[Nat.Digit7[N1, N2, N3, N4, N5, N6, N7]] {
+      @alwaysinline def value: Int = {
+        1000000 * implicitly[NatBaseValue[N1]].value +
+          100000 * implicitly[NatBaseValue[N2]].value +
+          10000 * implicitly[NatBaseValue[N3]].value +
+          1000 * implicitly[NatBaseValue[N4]].value +
+          100 * implicitly[NatBaseValue[N5]].value +
+          10 * implicitly[NatBaseValue[N6]].value +
+          implicitly[NatBaseValue[N7]].value
+      }
+    }
+  @alwaysinline implicit def materializeNatDigit8NatValue[N1 <: Nat.Base : NatBaseValue, N2 <: Nat.Base : NatBaseValue, N3 <: Nat.Base : NatBaseValue, N4 <: Nat.Base : NatBaseValue, N5 <: Nat.Base : NatBaseValue, N6 <: Nat.Base : NatBaseValue, N7 <: Nat.Base : NatBaseValue, N8 <: Nat.Base : NatBaseValue]: NatValue[Nat.Digit8[N1, N2, N3, N4, N5, N6, N7, N8]] =
+    new NatValue[Nat.Digit8[N1, N2, N3, N4, N5, N6, N7, N8]] {
+      @alwaysinline def value: Int = {
+        10000000 * implicitly[NatBaseValue[N1]].value +
+          1000000 * implicitly[NatBaseValue[N2]].value +
+          100000 * implicitly[NatBaseValue[N3]].value +
+          10000 * implicitly[NatBaseValue[N4]].value +
+          1000 * implicitly[NatBaseValue[N5]].value +
+          100 * implicitly[NatBaseValue[N6]].value +
+          10 * implicitly[NatBaseValue[N7]].value +
+          implicitly[NatBaseValue[N8]].value
+      }
+    }
+  @alwaysinline implicit def materializeNatDigit9NatValue[N1 <: Nat.Base : NatBaseValue, N2 <: Nat.Base : NatBaseValue, N3 <: Nat.Base : NatBaseValue, N4 <: Nat.Base : NatBaseValue, N5 <: Nat.Base : NatBaseValue, N6 <: Nat.Base : NatBaseValue, N7 <: Nat.Base : NatBaseValue, N8 <: Nat.Base : NatBaseValue, N9 <: Nat.Base : NatBaseValue]: NatValue[Nat.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9]] =
+    new NatValue[Nat.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9]] {
+      @alwaysinline def value: Int = {
+        100000000 * implicitly[NatBaseValue[N1]].value +
+          10000000 * implicitly[NatBaseValue[N2]].value +
+          1000000 * implicitly[NatBaseValue[N3]].value +
+          100000 * implicitly[NatBaseValue[N4]].value +
+          10000 * implicitly[NatBaseValue[N5]].value +
+          1000 * implicitly[NatBaseValue[N6]].value +
+          100 * implicitly[NatBaseValue[N7]].value +
+          10 * implicitly[NatBaseValue[N8]].value +
+          implicitly[NatBaseValue[N9]].value
+      }
+    }
+}

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/NatValue.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/NatValue.scala.gyb
@@ -1,0 +1,54 @@
+// format: off
+
+// BEWARE: This file is generated - direct edits will be lost.
+// Do not edit this it directly other than to remove
+// personally identifiable information in sourceLocation lines.
+// All direct edits to this file will be lost the next time it
+// is generated.
+//
+// See nativelib runtime/Arrays.scala.gyb for details.
+
+package scala.scalanative
+package unsafe
+
+import scalanative.annotation.alwaysinline
+
+private[unsafe] abstract class NatValue[T <: Nat] {
+  @alwaysinline def value: Int
+}
+
+private[unsafe] object NatValue {
+  abstract class NatBaseValue[T <: Nat.Base] extends NatValue[T] {
+    @alwaysinline def value: Int
+  }
+
+  % for N in range(0, 10):
+  object Nat${N} extends NatBaseValue[unsafe.Nat._${N}] {
+    @alwaysinline def value: Int = ${N}
+  }
+
+  % end
+
+  % for N in range(0, 10):
+  @alwaysinline implicit def materializeNat${N}NatBaseValue: NatBaseValue[unsafe.Nat._${N}] =
+    Nat${N}
+  % end
+
+  % for N in range(2, 10):
+  %   Ns      = ["N" + str(i) for i in range(1, N + 1)]
+  %   BoundNs = "[" + ", ".join(N + " <: Nat.Base : NatBaseValue" for N in Ns) + "]"
+  %   JustNs  = "[" + ", ".join(Ns) + "]"
+  %   nats    = ", ".join("implicitly[NatBaseValue[{}]]".format(N) for N in Ns)
+  @alwaysinline implicit def materializeNatDigit${N}NatValue${BoundNs}: NatValue[Nat.Digit${N}${JustNs}] =
+    new NatValue[Nat.Digit${N}${JustNs}] {
+      @alwaysinline def value: Int = {
+        % for i in range(1, N + 1):
+        % Base = "1" + "0" * (N-i) + " * " if i < N else ""
+        % Spaces = "" if i == 1 else "  "
+        % Plus = " +" if i < N else ""
+        ${Spaces}${Base}implicitly[NatBaseValue[N${i}]].value${Plus}
+        % end
+      }
+    }
+  % end
+}

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
@@ -207,66 +207,77 @@ object Tag {
     def toCSSize: CSSize = toInt.toCSSize
   }
 
+  @deprecated("Use NatValue.Nat0 instead", since = "0.5.7")
   object Nat0 extends Tag[unsafe.Nat._0] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 0
   }
 
+  @deprecated("Use NatValue.Nat1 instead", since = "0.5.7")
   object Nat1 extends Tag[unsafe.Nat._1] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 1
   }
 
+  @deprecated("Use NatValue.Nat2 instead", since = "0.5.7")
   object Nat2 extends Tag[unsafe.Nat._2] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 2
   }
 
+  @deprecated("Use NatValue.Nat3 instead", since = "0.5.7")
   object Nat3 extends Tag[unsafe.Nat._3] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 3
   }
 
+  @deprecated("Use NatValue.Nat4 instead", since = "0.5.7")
   object Nat4 extends Tag[unsafe.Nat._4] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 4
   }
 
+  @deprecated("Use NatValue.Nat5 instead", since = "0.5.7")
   object Nat5 extends Tag[unsafe.Nat._5] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 5
   }
 
+  @deprecated("Use NatValue.Nat6 instead", since = "0.5.7")
   object Nat6 extends Tag[unsafe.Nat._6] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 6
   }
 
+  @deprecated("Use NatValue.Nat7 instead", since = "0.5.7")
   object Nat7 extends Tag[unsafe.Nat._7] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 7
   }
 
+  @deprecated("Use NatValue.Nat8 instead", since = "0.5.7")
   object Nat8 extends Tag[unsafe.Nat._8] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 8
   }
 
+  @deprecated("Use NatValue.Nat9 instead", since = "0.5.7")
   object Nat9 extends Tag[unsafe.Nat._9] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
     @alwaysinline def toInt: Int = 9
   }
 
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit2[N1 <: Nat.Base, N2 <: Nat.Base](_1: Tag[N1], _2: Tag[N2])
       extends Tag[unsafe.Nat.Digit2[N1, N2]]
       with NatTag {
@@ -280,6 +291,7 @@ object Tag {
     }
   }
 
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit3[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3])
       extends Tag[unsafe.Nat.Digit3[N1, N2, N3]]
       with NatTag {
@@ -294,6 +306,7 @@ object Tag {
     }
   }
 
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit4[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4])
       extends Tag[unsafe.Nat.Digit4[N1, N2, N3, N4]]
       with NatTag {
@@ -309,6 +322,7 @@ object Tag {
     }
   }
 
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit5[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5])
       extends Tag[unsafe.Nat.Digit5[N1, N2, N3, N4, N5]]
       with NatTag {
@@ -325,6 +339,7 @@ object Tag {
     }
   }
 
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit6[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5], _6: Tag[N6])
       extends Tag[unsafe.Nat.Digit6[N1, N2, N3, N4, N5, N6]]
       with NatTag {
@@ -342,6 +357,7 @@ object Tag {
     }
   }
 
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit7[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5], _6: Tag[N6], _7: Tag[N7])
       extends Tag[unsafe.Nat.Digit7[N1, N2, N3, N4, N5, N6, N7]]
       with NatTag {
@@ -360,6 +376,7 @@ object Tag {
     }
   }
 
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit8[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base, N8 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5], _6: Tag[N6], _7: Tag[N7], _8: Tag[N8])
       extends Tag[unsafe.Nat.Digit8[N1, N2, N3, N4, N5, N6, N7, N8]]
       with NatTag {
@@ -379,6 +396,7 @@ object Tag {
     }
   }
 
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit9[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base, N8 <: Nat.Base, N9 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5], _6: Tag[N6], _7: Tag[N7], _8: Tag[N8], _9: Tag[N9])
       extends Tag[unsafe.Nat.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9]]
       with NatTag {
@@ -4207,41 +4225,59 @@ object Tag {
     Float
   @alwaysinline implicit def materializeDoubleTag: Tag[scala.Double] =
     Double
-  @alwaysinline implicit def materializeNat0Tag: Tag[unsafe.Nat._0] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat0Tag: Tag[unsafe.Nat._0] =
     Nat0
-  @alwaysinline implicit def materializeNat1Tag: Tag[unsafe.Nat._1] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat1Tag: Tag[unsafe.Nat._1] =
     Nat1
-  @alwaysinline implicit def materializeNat2Tag: Tag[unsafe.Nat._2] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat2Tag: Tag[unsafe.Nat._2] =
     Nat2
-  @alwaysinline implicit def materializeNat3Tag: Tag[unsafe.Nat._3] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat3Tag: Tag[unsafe.Nat._3] =
     Nat3
-  @alwaysinline implicit def materializeNat4Tag: Tag[unsafe.Nat._4] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat4Tag: Tag[unsafe.Nat._4] =
     Nat4
-  @alwaysinline implicit def materializeNat5Tag: Tag[unsafe.Nat._5] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat5Tag: Tag[unsafe.Nat._5] =
     Nat5
-  @alwaysinline implicit def materializeNat6Tag: Tag[unsafe.Nat._6] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat6Tag: Tag[unsafe.Nat._6] =
     Nat6
-  @alwaysinline implicit def materializeNat7Tag: Tag[unsafe.Nat._7] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat7Tag: Tag[unsafe.Nat._7] =
     Nat7
-  @alwaysinline implicit def materializeNat8Tag: Tag[unsafe.Nat._8] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat8Tag: Tag[unsafe.Nat._8] =
     Nat8
-  @alwaysinline implicit def materializeNat9Tag: Tag[unsafe.Nat._9] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat9Tag: Tag[unsafe.Nat._9] =
     Nat9
-  @alwaysinline implicit def materializeNatDigit2Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag]: Tag.Digit2[N1, N2] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit2Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag]: Tag.Digit2[N1, N2] =
     Tag.Digit2(implicitly[Tag[N1]], implicitly[Tag[N2]])
-  @alwaysinline implicit def materializeNatDigit3Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag]: Tag.Digit3[N1, N2, N3] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit3Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag]: Tag.Digit3[N1, N2, N3] =
     Tag.Digit3(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]])
-  @alwaysinline implicit def materializeNatDigit4Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag]: Tag.Digit4[N1, N2, N3, N4] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit4Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag]: Tag.Digit4[N1, N2, N3, N4] =
     Tag.Digit4(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]])
-  @alwaysinline implicit def materializeNatDigit5Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag]: Tag.Digit5[N1, N2, N3, N4, N5] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit5Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag]: Tag.Digit5[N1, N2, N3, N4, N5] =
     Tag.Digit5(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]])
-  @alwaysinline implicit def materializeNatDigit6Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag]: Tag.Digit6[N1, N2, N3, N4, N5, N6] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit6Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag]: Tag.Digit6[N1, N2, N3, N4, N5, N6] =
     Tag.Digit6(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]], implicitly[Tag[N6]])
-  @alwaysinline implicit def materializeNatDigit7Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag]: Tag.Digit7[N1, N2, N3, N4, N5, N6, N7] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit7Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag]: Tag.Digit7[N1, N2, N3, N4, N5, N6, N7] =
     Tag.Digit7(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]], implicitly[Tag[N6]], implicitly[Tag[N7]])
-  @alwaysinline implicit def materializeNatDigit8Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag, N8 <: Nat.Base : Tag]: Tag.Digit8[N1, N2, N3, N4, N5, N6, N7, N8] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit8Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag, N8 <: Nat.Base : Tag]: Tag.Digit8[N1, N2, N3, N4, N5, N6, N7, N8] =
     Tag.Digit8(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]], implicitly[Tag[N6]], implicitly[Tag[N7]], implicitly[Tag[N8]])
-  @alwaysinline implicit def materializeNatDigit9Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag, N8 <: Nat.Base : Tag, N9 <: Nat.Base : Tag]: Tag.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit9Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag, N8 <: Nat.Base : Tag, N9 <: Nat.Base : Tag]: Tag.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9] =
     Tag.Digit9(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]], implicitly[Tag[N6]], implicitly[Tag[N7]], implicitly[Tag[N8]], implicitly[Tag[N9]])
   @alwaysinline implicit def materializeCStruct0Tag: Tag.CStruct0 =
     Tag.CStruct0()
@@ -4289,8 +4325,24 @@ object Tag {
     Tag.CStruct21(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]], implicitly[Tag[T17]], implicitly[Tag[T18]], implicitly[Tag[T19]], implicitly[Tag[T20]], implicitly[Tag[T21]])
   @alwaysinline implicit def materializeCStruct22Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag, T20: Tag, T21: Tag, T22: Tag]: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22] =
     Tag.CStruct22(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]], implicitly[Tag[T17]], implicitly[Tag[T18]], implicitly[Tag[T19]], implicitly[Tag[T20]], implicitly[Tag[T21]], implicitly[Tag[T22]])
-  @alwaysinline implicit def materializeCArrayTag[T: Tag, N <: unsafe.Nat: Tag]: Tag.CArray[T, N] =
+  @deprecated("Use overload taking NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeCArrayTag[T: Tag, N <: unsafe.Nat: Tag]: Tag.CArray[T, N] =
     Tag.CArray(implicitly[Tag[T]], implicitly[Tag[N]])
+  @alwaysinline implicit def materializeCArray[T: Tag, N <: unsafe.Nat: NatValue]: Tag[unsafe.CArray[T, N]] = new Tag[unsafe.CArray[T, N]] {
+    @alwaysinline def size: Int = implicitly[Tag[T]].size * implicitly[NatValue[N]].value
+    @alwaysinline def alignment: Int = implicitly[Tag[T]].alignment
+    @alwaysinline override def offset(idx: Int): Int = implicitly[Tag[T]].size * idx
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CArray[T, N] = {
+      new unsafe.CArray[T, N](rawptr)
+    }
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CArray[T, N]): Unit = {
+      val dst = rawptr
+      if (value != null) {
+        val src = value.rawptr
+        ffi.memcpy(dst, src, castIntToRawSizeUnsigned(size))
+      } else storeRawPtr(dst, null)
+    }
+  }
 
   @alwaysinline implicit def materializeCFuncPtr0[R: Tag]: CFuncPtrTag[unsafe.CFuncPtr0[R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr0[R]] {

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
@@ -117,6 +117,7 @@ object Tag {
   }
 
   % for N in range(0, 10):
+  @deprecated("Use NatValue.Nat${N} instead", since = "0.5.7")
   object Nat${N} extends Tag[unsafe.Nat._${N}] with NatTag {
     @noinline def size: Int = throwUndefined()
     @noinline def alignment: Int = throwUndefined()
@@ -130,6 +131,7 @@ object Tag {
   %   JustNs  = "[" + ", ".join(Ns) + "]"
   %   TagNs   = ["Tag[{}]".format(n) for n in Ns]
   %   args    = ", ".join("_{}: {}".format(i + 1, T) for (i, T) in enumerate(TagNs))
+  @deprecated("Use NatValue instead", since = "0.5.7")
   final case class Digit${N}${BoundNs}(${args})
       extends Tag[unsafe.Nat.Digit${N}${JustNs}]
       with NatTag {
@@ -261,7 +263,8 @@ object Tag {
     ${name}
   % end
   % for N in range(0, 10):
-  @alwaysinline implicit def materializeNat${N}Tag: Tag[unsafe.Nat._${N}] =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNat${N}Tag: Tag[unsafe.Nat._${N}] =
     Nat${N}
   % end
   % for N in range(2, 10):
@@ -269,7 +272,8 @@ object Tag {
   %   BoundNs = "[" + ", ".join(N + " <: Nat.Base : Tag" for N in Ns) + "]"
   %   JustNs  = "[" + ", ".join(Ns) + "]"
   %   tags    = ", ".join("implicitly[Tag[{}]]".format(N) for N in Ns)
-  @alwaysinline implicit def materializeNatDigit${N}Tag${BoundNs}: Tag.Digit${N}${JustNs} =
+  @deprecated("Use NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeNatDigit${N}Tag${BoundNs}: Tag.Digit${N}${JustNs} =
     Tag.Digit${N}(${tags})
   % end
   % for N in range(0, 23):
@@ -280,8 +284,24 @@ object Tag {
   @alwaysinline implicit def materializeCStruct${N}Tag${BoundTs}: Tag.CStruct${N}${JustTs} =
     Tag.CStruct${N}(${tags})
   % end
-  @alwaysinline implicit def materializeCArrayTag[T: Tag, N <: unsafe.Nat: Tag]: Tag.CArray[T, N] =
+  @deprecated("Use overload taking NatValue instead", since = "0.5.7")
+  @alwaysinline def materializeCArrayTag[T: Tag, N <: unsafe.Nat: Tag]: Tag.CArray[T, N] =
     Tag.CArray(implicitly[Tag[T]], implicitly[Tag[N]])
+  @alwaysinline implicit def materializeCArray[T: Tag, N <: unsafe.Nat: NatValue]: Tag[unsafe.CArray[T, N]] = new Tag[unsafe.CArray[T, N]] {
+    @alwaysinline def size: Int = implicitly[Tag[T]].size * implicitly[NatValue[N]].value
+    @alwaysinline def alignment: Int = implicitly[Tag[T]].alignment
+    @alwaysinline override def offset(idx: Int): Int = implicitly[Tag[T]].size * idx
+    @alwaysinline private[unsafe] override def load(rawptr: RawPtr): unsafe.CArray[T, N] = {
+      new unsafe.CArray[T, N](rawptr)
+    }
+    @alwaysinline private[unsafe] override def store(rawptr: RawPtr, value: unsafe.CArray[T, N]): Unit = {
+      val dst = rawptr
+      if (value != null) {
+        val src = value.rawptr
+        ffi.memcpy(dst, src, castIntToRawSizeUnsigned(size))
+      } else storeRawPtr(dst, null)
+    }
+  }
   % for N in range(0, 23):
   %   tps     = ", ".join(["T" + str(i)                for i in range(1, N+1)] + ["R"])
   %   tpsDecl = ", ".join(["T" + str(i) + ": Tag"      for i in range(1, N+1)] + ["R: Tag"])


### PR DESCRIPTION
The previous implementation overloaded `Tag` for `Nat` implementing a trait `NatTag` which added a `def toInt: Int` method. The fact that Tag.DigitN both extended `NatTag` and received `NatTag` made its `def toInt: Int` method recursive in the terms of interflow. Interflow was unable to optimize the dynamic dispatch away and the `NatN` classes were materialized even in release-full mode. A new encoding is proposed which adds a new `abstract class NatValue` which has a single `def value: Int` method.
A second `abstract class NatBaseValue` is used to avoid the recursion for `Digit`s. Moreover, instead of creating classes for Digit, which Interflow can't optimize away, we implement the `toInt` on the fly via an anonimous instance which uses `implicitly[NatValue[N]].value` to get the value for the single digits.
Also, instead of using a `var` we inline the sum of powers, which, together with the other techniques used, allows interflow to inline the final value as a int.

```scala
println(implicitly[Tag[CArray[Int, Nat.Digit5[Nat._1, Nat._2, Nat._5, Nat._8, Nat._2]]]].size)
```

now generates the literal result value `50328` (`12582 * 4`) in the NIR:
```
1: %3000007 = box[@"T17java.lang.Integer"] int 50328
```

The result is backward binary compatible since all previous definitions are maintained and marked as `@deprecated` which changed to not have the `implicit` keyword, so the Scala compiler will not choose them anymore.