### PR TITLE
Grouped linking of compilated object files

### DIFF
--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/PartestTask.scala
@@ -139,7 +139,7 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
   def precompileLibs(
       options: ScalaNativePartestOptions,
       forkedClasspath: Seq[java.nio.file.Path]
-  ): Seq[java.nio.file.Path] = {
+  ): Seq[Seq[java.nio.file.Path]] = {
     val config = Defaults.config
       .withBaseDir(Defaults.workDir())
       .withClassPath(options.nativeClasspath ++ forkedClasspath)

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativePartestOptions.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativePartestOptions.scala
@@ -8,7 +8,7 @@ import scalanative.build
 case class ScalaNativePartestOptions private (
     testFilter: ScalaNativePartestOptions.TestFilter,
     nativeClasspath: Seq[Path],
-    precompiledLibrariesPaths: Seq[Path],
+    precompiledLibrariesPaths: Seq[Seq[Path]],
     parallelism: Option[Int],
     shouldPrecompileLibraries: Boolean,
     showDiff: Boolean,

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -250,7 +250,7 @@ object Build {
    *  @return
    *    the paths to the compiled objects
    */
-  private[scalanative] def findAndCompileNativeLibraries(
+  private[scala] def findAndCompileNativeLibraries(
       config: Config,
       analysis: ReachabilityAnalysis.Result
   )(implicit ec: ExecutionContext): Future[Seq[CompilationOutputs]] = {

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -127,7 +127,9 @@ object Build {
             .flatMap { irGenerators =>
               compile(config, linkerResult, irGenerators)
             }
-            .map(compilationOutputs => link(config, linkerResult, compilationOutputs))
+            .map(compilationOutputGroups =>
+              link(config, linkerResult, compilationOutputGroups)
+            )
             .map(artifact => postProcess(config, artifact))
         }
         .andThen { case Success(_) => dumpUserConfigHash(config) }

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -317,9 +317,9 @@ private[scalanative] object LLVM {
       try {
         flags.foreach(add)
         groupedCompilationOutputs.foreach { objectPaths =>
-          if(usingLLD) add("-Wl,--start-lib")
+          if (usingLLD) add("-Wl,--start-lib")
           objectPaths.foreach(path => add(path.abs))
-          if(usingLLD) add("-Wl,--end-lib")
+          if (usingLLD) add("-Wl,--end-lib")
         }
         linkopts.foreach(add)
       } finally pw.close()


### PR DESCRIPTION
LLVM.link now takes a `Seq[Seq[Path]]` allowing us to specify a groups of related files to link. We use it wrap each group  in `-Wl,--start-lib`, `Wl,--end-lib` groups to fix #4159 