### PR TITLE
Fix detection of using system threads when using ThreadBuilders.start API

### DIFF
--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -402,7 +402,13 @@ object Thread {
     /** Creates a new Thread from the current state of the builder and schedules
      *  it to execute.
      */
-    def start(task: Runnable): Thread
+    def start(task: Runnable): Thread = startInternal(task)
+
+    /** Scala Native internal API Used to start thread without triggering usage
+     *  of system threads, allowing to the detection mechanism to disable
+     *  multihreading support
+     */
+    private[java] def startInternal(task: Runnable): Thread
 
     /** Sets the uncaught exception handler. */
     def uncaughtExceptionHandler(

--- a/javalib/src/main/scala/java/lang/ThreadBuilders.scala
+++ b/javalib/src/main/scala/java/lang/ThreadBuilders.scala
@@ -102,7 +102,7 @@ object ThreadBuilders {
       thread
     }
 
-    override def start(task: Runnable): Thread = {
+    override def startInternal(task: Runnable): Thread = {
       val thread = unstarted(task)
       thread.start()
       thread
@@ -131,7 +131,7 @@ object ThreadBuilders {
       thread
     }
 
-    override def start(task: Runnable): Thread = {
+    override def startInternal(task: Runnable): Thread = {
       val thread = unstarted(task)
       thread.start()
       thread

--- a/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
@@ -101,7 +101,7 @@ private[java] object WeakReferenceRegistry {
     .daemon()
     .group(ThreadGroup.System)
     .name("GC-WeakReferenceHandler")
-    .start(() =>
+    .startInternal(() =>
       while (true) {
         handleCollectedReferences()
         LockSupport.park()


### PR DESCRIPTION
These do not create a new Thread subclass and don't show any new allocation.