### PR TITLE
Chasing Windows ProcessTest intermittent failure

### DIFF
--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -255,9 +255,11 @@ private[lang] object PipeIO {
 
   implicit val InputPipeIO: PipeIO[Stream] =
     new PipeIO(NullInput, (p, fd) => new StreamImpl(p, new FileInputStream(fd)))
-
   implicit val OutputPipeIO: PipeIO[OutputStream] =
-    new PipeIO(NullOutput, (_, fd) => new FileOutputStream(fd))
+    new PipeIO(
+      NullOutput,
+      (_, fd) => new BufferedOutputStream(new FileOutputStream(fd))
+    )
 
   private object NullInput extends Stream {
     @stub

--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -220,7 +220,7 @@ private[lang] object PipeIO {
         if (avail <= 0) PipeIO.NullInput
         else new ByteArrayInputStream(src.readNBytes(avail))
 
-      // release JVM FileDescriptor and, especially, its OS fd. 
+      // release JVM FileDescriptor and, especially, its OS fd.
       src.close()
 
       src = newSrc

--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -220,7 +220,7 @@ private[lang] object PipeIO {
         if (avail <= 0) PipeIO.NullInput
         else new ByteArrayInputStream(src.readNBytes(avail))
 
-      // release JVM FileDescriptor and, especially, its OS fd.
+      // release JVM FileDescriptor and, especially, its OS fd. 
       src.close()
 
       src = newSrc

--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -255,11 +255,9 @@ private[lang] object PipeIO {
 
   implicit val InputPipeIO: PipeIO[Stream] =
     new PipeIO(NullInput, (p, fd) => new StreamImpl(p, new FileInputStream(fd)))
+
   implicit val OutputPipeIO: PipeIO[OutputStream] =
-    new PipeIO(
-      NullOutput,
-      (_, fd) => new BufferedOutputStream(new FileOutputStream(fd))
-    )
+    new PipeIO(NullOutput, (_, fd) => new FileOutputStream(fd))
 
   private object NullInput extends Stream {
     @stub


### PR DESCRIPTION
The original PR is described below the horizontal line.  That content is now in
PR #4174.

This PR involved into yet another evolution of my attempt to understand the
apparent intermittent failure in `ProcessTest` `concurrentTest`.  I am trying
to tease apart a concurrency defect in the test as written from the way
Scala Native is handling EOF on an apparently empty pipe.  

Is SN not blocking when it should?  Is output from the child process getting
lost (that is, output happens but child closes pipe, so EOF is real).  The latter
may be why intermittent seems to be only/more_frequent on Windows.

I would like to understand this intermittent better before I go off and
fix the concurrency logic and read-framing errors in the test.

<hr>
Fix  NNNN

The output stream used by a javalib `Process` to send output to the sub-process it creates
is now direct; that is, unbuffered.  This corresponds more closely with JVM practice and
with the now unbuffered equivalent input stream.


If one needs the stream to be buffered, one should wrap the result of `Process.getOutputStream()` in
a `BufferedOutputStream` or other class documented as buffered..