### PR TITLE
Fix scala-native#4167: javalib PipeIO output is now direct

### DIFF
--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -255,11 +255,9 @@ private[lang] object PipeIO {
 
   implicit val InputPipeIO: PipeIO[Stream] =
     new PipeIO(NullInput, (p, fd) => new StreamImpl(p, new FileInputStream(fd)))
+
   implicit val OutputPipeIO: PipeIO[OutputStream] =
-    new PipeIO(
-      NullOutput,
-      (_, fd) => new BufferedOutputStream(new FileOutputStream(fd))
-    )
+    new PipeIO(NullOutput, (_, fd) => new FileOutputStream(fd))
 
   private object NullInput extends Stream {
     @stub


### PR DESCRIPTION
Fix https://github.com/scala-native/scala-native/issues/4167

The output stream used by a javalib Process to send output to the sub-process it creates
is now direct; that is, unbuffered. This corresponds more closely with JVM practice and
with the now unbuffered equivalent input stream.

If one needs the stream to be buffered, one should wrap the result of Process.getOutputStream() in
a BufferedOutputStream or other class documented as buffered..