### PR TITLE
Add missing dbg metadata to generated `scalanative_catch` calls

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/OsCompat.scala
@@ -20,7 +20,10 @@ private[codegen] abstract class OsCompat(
   )(implicit
       fresh: nir.Fresh,
       pos: nir.SourcePosition,
-      sb: ShowBuilder
+      scopeId: nir.ScopeId,
+      sb: ShowBuilder,
+      metaCtx: MetadataCodeGen.Context,
+      scopes: MetadataCodeGen.DefnScopes
   ): Unit
   def genBlockAlloca(block: nir.ControlFlow.Block)(implicit
       sb: ShowBuilder

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -60,7 +60,7 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
     indent()
 
     line(s"$exc = call $ptrT $scalaNativeCatch($ptrT $r0)")
-    codegen.dbg(",",codegen.toDILocation(pos, scopeId))
+    codegen.dbg(",", codegen.toDILocation(pos, scopeId))
     line("br ")
     codegen.genNext(next)
     unindent()

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -5,6 +5,7 @@ package compat.os
 import scala.scalanative.codegen.llvm.AbstractCodeGen
 import scala.scalanative.nir.Defn.Define.DebugInfo
 import scala.scalanative.util.ShowBuilder
+import scala.scalanative.codegen.llvm.Metadata.DILocation
 
 private[codegen] class UnixCompat(codegen: AbstractCodeGen)
     extends OsCompat(codegen) {
@@ -31,7 +32,10 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
   )(implicit
       fresh: nir.Fresh,
       pos: nir.SourcePosition,
-      sb: ShowBuilder
+      scopeId: nir.ScopeId,
+      sb: ShowBuilder,
+      metaCtx: MetadataCodeGen.Context,
+      scopes: MetadataCodeGen.DefnScopes
   ): Unit = {
     import sb._
     val nir.Next.Unwind(nir.Val.Local(excname, _), next) = unwind
@@ -54,7 +58,9 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
 
     line(s"$excsucc:")
     indent()
+
     line(s"$exc = call $ptrT $scalaNativeCatch($ptrT $r0)")
+    codegen.dbg(",",codegen.toDILocation(pos, scopeId))
     line("br ")
     codegen.genNext(next)
     unindent()

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsCompat.scala
@@ -56,7 +56,10 @@ private[codegen] class WindowsCompat(codegen: AbstractCodeGen)
   )(implicit
       fresh: nir.Fresh,
       pos: nir.SourcePosition,
-      sb: ShowBuilder
+      scopeId: nir.ScopeId,
+      sb: ShowBuilder,
+      metaCtx: MetadataCodeGen.Context,
+      scopes: MetadataCodeGen.DefnScopes
   ): Unit = {
     import codegen._
     import sb._

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsGnuCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/WindowsGnuCompat.scala
@@ -39,7 +39,10 @@ private[codegen] class WindowsGnuCompat(codegen: AbstractCodeGen)
   )(implicit
       fresh: nir.Fresh,
       pos: nir.SourcePosition,
-      sb: ShowBuilder
+      scopeId: nir.ScopeId,
+      sb: ShowBuilder,
+      metaCtx: MetadataCodeGen.Context,
+      scopes: MetadataCodeGen.DefnScopes
   ): Unit = {
     import sb._
     val nir.Next.Unwind(nir.Val.Local(excname, _), next) = unwind


### PR DESCRIPTION
Based on issues in the extendended (nightly) CI builds https://github.com/scala-native/scala-native/actions/runs/12960925473/job/36156529063#step:5:148 
Required a small refactor in the codegen