### PR TITLE
Address multiple concerns in ProcessTest#concurrentPipe

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -440,7 +440,7 @@ class ProcessTest {
     )
   }
 
-  /* concurrentPipe() Design Note: Issue #4164
+  /* concurrentPipe() Design Note: Issue 4164
    *
    *   This evolution of concurrentPipe() is motivated by both experience
    *   and analysis.

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -440,7 +440,7 @@ class ProcessTest {
     )
   }
 
-  /* concurrentPipe() Design Note: Issue 4164
+  /* concurrentPipe() Design Note: Issue #4164
    *
    *   This evolution of concurrentPipe() is motivated by both experience
    *   and analysis.


### PR DESCRIPTION
Any good use of concurrency demands multiple evolutions. This is the next of what will probably
be many such. `ProcessTest` itself has proven itself particularly needy and demanding.

The presenting problem is that  `ProcessTest#concurrentPipe` tends to intermittently fail in
Windows CI. Reading the code and mentally executing assuming a hostile concurrency environment
reveals additional issues.

This PR should fix #4164
 
It should also fix two issues which have not been reported and tracked:

* It makes the Test robust to a race condition where the Thread reads() before the
  child process has written to the pipe (and that message has shown up at the parent end). 
 
* It removes an prior non-obvious assumption that the Test is running on a reasonably fast
  multiprocessor or fast uniprocessor by being more generous with the overall `Await`
  timeout.  This should not cause the usual success case to take additional time but should
  avoid false failures in foreseeable scenarios.  