### PR TITLE
Try to fix exceptions during main thread initialization

### DIFF
--- a/nativelib/src/main/resources/scala-native/stackOverflowGuards.c
+++ b/nativelib/src/main/resources/scala-native/stackOverflowGuards.c
@@ -113,7 +113,8 @@ static bool tryGrowStack() {
 
         volatile char *cursor = currentThreadInfo.stackTop;
         while ((void *)cursor > newStackTop) {
-            *cursor = 0; // Write to the memory to force allocation
+            char value = *cursor;
+            *cursor = value; // Write to the memory to force allocation
             cursor -= resolvePageSize();
         }
         currentThreadInfo.stackSize = newSize;

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Backtrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Backtrace.scala
@@ -166,7 +166,7 @@ private[runtime] object Backtrace {
   private final val ELF_MAGIC = 0x7f454c46
 
   private def processFile(): Option[DwarfInfo] = {
-    implicit val bf: BinaryFile = new BinaryFile(new File(filename))
+    implicit val bf: BinaryFile = new BinaryFile(new File(ExecInfo.filename))
     val head = bf.position()
     val magic = bf.readInt()
     bf.seek(head)
@@ -176,12 +176,12 @@ private[runtime] object Backtrace {
         if (magic == MACHO_MAGIC) {
           val macho = MachO.parse(bf)
           processMacho(macho).orElse {
-            val basename = new File(filename).getName()
+            val basename = new File(ExecInfo.filename).getName()
             // dsymutil `foo` will assemble the debug information into `foo.dSYM/Contents/Resources/DWARF/foo`.
             // Coulnt't find the official source, but at least libbacktrace locate the dSYM file from this location.
             // https://github.com/ianlancetaylor/libbacktrace/blob/cdb64b688dda93bbbacbc2b1ccf50ce9329d4748/macho.c#L908
             val dSymPath =
-              s"$filename.dSYM/Contents/Resources/DWARF/${basename}"
+              s"${ExecInfo.filename}.dSYM/Contents/Resources/DWARF/${basename}"
             if (new File(dSymPath).exists()) {
               val dSYMBin: BinaryFile = new BinaryFile(
                 new File(dSymPath)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
@@ -22,7 +22,10 @@ private[runtime] object StackTrace {
         val ip = Intrinsics.stackalloc[RawSize]()
         unwind.get_context(context)
         unwind.init_local(cursor, context)
-        while (unwind.step(cursor) > 0) {
+        // JVM limit stack trace to 1024 entries
+        var frames = 0
+        while (unwind.step(cursor) > 0 && frames < 1024) {
+          frames += 1
           unwind.get_reg(cursor, unwind.UNW_REG_IP, ip)
           val addr =
             Intrinsics.castRawSizeToLongUnsigned(Intrinsics.loadRawSize(ip))

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -58,7 +58,7 @@ package object runtime {
       rawargv: RawPtr
   ): scala.Array[String] = {
     NativeThread.TLS.setupCurrentThreadInfo(
-      stackBottom = rawargv,
+      stackBottom = Intrinsics.stackalloc[Byte](),
       isMainThread = true,
       stackSize = 0 /* detect */
     )
@@ -75,15 +75,13 @@ package object runtime {
     val argv = fromRawPtr[CString](rawargv)
     val args = new scala.Array[String](argc - 1)
 
-    // skip the executable name in argv(0)
+    ExecInfo.filename = fromCString(argv(0))
     var c = 0
     while (c < argc - 1) {
       // use the default Charset (UTF_8 atm)
       args(c) = fromCString(argv(c + 1))
       c += 1
     }
-
-    ExecInfo.filename = fromCString(argv(0))
     ExecInfo.startTime = System.currentTimeMillis()
     args
   }


### PR DESCRIPTION
I've observed that `argv[0]` when parsing sometimes contained a garbage or null values. I suspect the data was overriden when growing stack in stackOverflowGuards.c 

Also some other changes: 
* Limit StackTrace to 1024 entries - that's what JVM does
* Refer to filename using ExecInfo