### PR TITLE
Remove the unwind handler for operations that can never throw exception.

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -15,6 +15,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
   import nirAddons._
   import nirDefinitions._
   import SimpleType.{fromType, fromSymbol}
+  def nounwind = nir.Next.None
 
   sealed case class ValTree(value: nir.Val)(
       pos: global.Position = global.NoPosition
@@ -216,11 +217,11 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case nir.Val.Unit => nir.Val.Unit
         case v =>
           if (isMutable) v
-          else buf.let(namedId(fresh)(name), nir.Op.Copy(v), unwind)
+          else buf.let(namedId(fresh)(name), nir.Op.Copy(v), nounwind)
       }
       if (isMutable) {
         val slot = curMethodEnv.resolve(vd.symbol)
-        buf.varstore(slot, rhs, unwind)
+        buf.varstore(slot, rhs, nounwind)
       } else {
         curMethodEnv.enter(vd.symbol, rhs)
         nir.Val.Unit
@@ -512,7 +513,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             buf.raise(exc, unwind)
             nir.Val.Unit
           case (excty, f, pos) +: rest =>
-            val cond = buf.is(excty, exc, unwind)(pos, getScopeId)
+            val cond = buf.is(excty, exc, nounwind)(pos, getScopeId)
             genIf(
               retty,
               ValTree(f)(cond),
@@ -704,7 +705,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       implicit val pos: nir.SourcePosition =
         tree.pos.orElse(fallbackSourcePosition)
       val value = if (curMethodInfo.mutableVars.contains(sym)) {
-        buf.varload(curMethodEnv.resolve(sym), unwind)
+        buf.varload(curMethodEnv.resolve(sym), nounwind)
       } else if (sym.isModule) {
         genModule(sym)
       } else {
@@ -735,7 +736,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       } else if (owner.isStruct) {
         val index = owner.info.decls.filter(_.isField).toList.indexOf(sym)
         val qual = genExpr(qualp)
-        buf.extract(qual, Seq(index), unwind)
+        buf.extract(qual, Seq(index), nounwind)
       } else {
         val ty = genType(tree.symbol.tpe)
         val name = genFieldName(tree.symbol)
@@ -744,7 +745,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           genLoadExtern(ty, externTy, tree.symbol)
         } else {
           val qual = genExpr(qualp)
-          buf.fieldload(ty, qual, name, unwind)
+          buf.fieldload(ty, qual, name, nounwind)
         }
       }
     }
@@ -773,13 +774,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           } else {
             val ty = genType(sym.tpe)
             val qual = genExpr(qualp)
-            buf.fieldstore(ty, qual, name, rhs, unwind)
+            buf.fieldstore(ty, qual, name, rhs, nounwind)
           }
 
         case id: Ident =>
           val rhs = genExpr(rhsp)
           val slot = curMethodEnv.resolve(id.symbol)
-          buf.varstore(slot, rhs, unwind)
+          buf.varstore(slot, rhs, nounwind)
       }
     }
 
@@ -1643,13 +1644,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def negateInt(value: nir.Val)(implicit pos: nir.SourcePosition): nir.Val =
-      buf.bin(nir.Bin.Isub, value.ty, numOfType(0, value.ty), value, unwind)
+      buf.bin(nir.Bin.Isub, value.ty, numOfType(0, value.ty), value, nounwind)
     def negateFloat(value: nir.Val)(implicit pos: nir.SourcePosition): nir.Val =
-      buf.bin(nir.Bin.Fmul, value.ty, numOfType(-1, value.ty), value, unwind)
+      buf.bin(nir.Bin.Fmul, value.ty, numOfType(-1, value.ty), value, nounwind)
     def negateBits(value: nir.Val)(implicit pos: nir.SourcePosition): nir.Val =
-      buf.bin(nir.Bin.Xor, value.ty, numOfType(-1, value.ty), value, unwind)
+      buf.bin(nir.Bin.Xor, value.ty, numOfType(-1, value.ty), value, nounwind)
     def negateBool(value: nir.Val)(implicit pos: nir.SourcePosition): nir.Val =
-      buf.bin(nir.Bin.Xor, nir.Type.Bool, nir.Val.True, value, unwind)
+      buf.bin(nir.Bin.Xor, nir.Type.Bool, nir.Val.True, value, nounwind)
 
     def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type)(implicit
         pos: nir.SourcePosition
@@ -1823,7 +1824,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val right = genExpr(rightp)
       val rightcoerced = genCoercion(right, rightty, opty)
 
-      buf.let(op(opty, leftcoerced, rightcoerced), unwind)
+      buf.let(op(opty, leftcoerced, rightcoerced), nounwind)
     }
 
     private def genClassEquality(
@@ -1838,7 +1839,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val left = genExpr(leftp)
         val right = genExpr(rightp)
         val comp = if (negated) nir.Comp.Ine else nir.Comp.Ieq
-        buf.comp(comp, nir.Rt.Object, left, right, unwind)
+        buf.comp(comp, nir.Rt.Object, left, right, nounwind)
       } else genClassUniversalEquality(leftp, rightp, negated)
     }
 
@@ -1897,10 +1898,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
       else if (isNull(l)) {
         // null == expr -> expr eq null
-        buf.comp(comparator, nir.Rt.Object, genExpr(r), nir.Val.Null, unwind)
+        buf.comp(comparator, nir.Rt.Object, genExpr(r), nir.Val.Null, nounwind)
       } else if (isNull(r)) {
         // expr == null -> expr eq null
-        buf.comp(comparator, nir.Rt.Object, genExpr(l), nir.Val.Null, unwind)
+        buf.comp(comparator, nir.Rt.Object, genExpr(l), nir.Val.Null, nounwind)
       } else if (isNonNullExpr(l)) maybeNegate {
         // SI-7852 Avoid null check if L is statically non-null.
         genApplyMethod(
@@ -1917,13 +1918,19 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val mergev = nir.Val.Local(fresh(), nir.Type.Bool)
           val left = genExpr(l)
           val isnull =
-            buf.comp(nir.Comp.Ieq, nir.Rt.Object, left, nir.Val.Null, unwind)
+            buf.comp(nir.Comp.Ieq, nir.Rt.Object, left, nir.Val.Null, nounwind)
           buf.branch(isnull, nir.Next(thenn), nir.Next(elsen))
           locally {
             buf.label(thenn)
             val right = genExpr(r)
             val thenv =
-              buf.comp(nir.Comp.Ieq, nir.Rt.Object, right, nir.Val.Null, unwind)
+              buf.comp(
+                nir.Comp.Ieq,
+                nir.Rt.Object,
+                right,
+                nir.Val.Null,
+                nounwind
+              )
             buf.jump(mergen, Seq(thenv))
           }
           locally {
@@ -2235,7 +2242,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val memoryOrder =
         if (!ptrp.symbol.isVolatile) None
         else Some(nir.MemoryOrder.Acquire)
-      buf.load(ty, ptr, unwind, memoryOrder)
+      buf.load(ty, ptr, nounwind, memoryOrder)
     }
 
     def genRawPtrStoreOp(app: Apply, code: Int): nir.Val = {
@@ -2261,7 +2268,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val memoryOrder =
         if (!ptrp.symbol.isVolatile) None
         else Some(nir.MemoryOrder.Release)
-      buf.store(ty, ptr, value, unwind, memoryOrder)
+      buf.store(ty, ptr, value, nounwind, memoryOrder)
     }
 
     def genRawPtrElemOp(app: Apply, code: Int): nir.Val = {
@@ -2271,7 +2278,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val ptr = genExpr(ptrp)
       val offset = genExpr(offsetp)
 
-      buf.elem(nir.Type.Byte, ptr, Seq(offset), unwind)
+      buf.elem(nir.Type.Byte, ptr, Seq(offset), nounwind)
     }
 
     def genRawPtrCastOp(app: Apply, code: Int): nir.Val = {
@@ -2303,7 +2310,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           (nir.Type.Long, nir.Type.Size, nir.Conv.SSizeCast)
       }
 
-      buf.conv(conv, toty, rec, unwind)
+      buf.conv(conv, toty, rec, nounwind)
     }
 
     def castConv(fromty: nir.Type, toty: nir.Type): Option[nir.Conv] =
@@ -2374,7 +2381,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val getRawPtrName = selfName
         .member(nir.Sig.Field("rawptr", nir.Sig.Scope.Private(selfName)))
 
-      val target = buf.fieldload(nir.Type.Ptr, self, getRawPtrName, unwind)
+      val target = buf.fieldload(nir.Type.Ptr, self, getRawPtrName, nounwind)
       val result = buf.call(funcSig, target, args, unwind)
       if (retType != unboxedRetType)
         buf.box(retType, result, unwind)
@@ -2388,7 +2395,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     ): nir.Val =
       castConv(fromty, toty)
         .orElse(castConv(value.ty, toty))
-        .fold(value)(buf.conv(_, toty, value, unwind))
+        .fold(value)(buf.conv(_, toty, value, nounwind))
 
     private lazy val optimizedFunctions = {
       // Included functions should be pure, and should not not narrow the result type
@@ -2438,7 +2445,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             }
 
           if (unboxed.ty == nir.Type.Size) unboxed
-          else buf.conv(nir.Conv.SSizeCast, nir.Type.Size, unboxed, unwind)
+          else buf.conv(nir.Conv.SSizeCast, nir.Type.Size, unboxed, nounwind)
       }
 
     private def genStackalloc(app: Apply): nir.Val = app match {
@@ -2532,14 +2539,14 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val ty = genType(app.tpe)
           val arg = genExpr(argp)
 
-          buf.conv(nir.Conv.Zext, ty, arg, unwind)
+          buf.conv(nir.Conv.Zext, ty, arg, nounwind)
 
         case Apply(_, Seq(argp))
             if code >= UINT_TO_FLOAT && code <= ULONG_TO_DOUBLE =>
           val ty = genType(app.tpe)
           val arg = genExpr(argp)
 
-          buf.conv(nir.Conv.Uitofp, ty, arg, unwind)
+          buf.conv(nir.Conv.Uitofp, ty, arg, nounwind)
 
         case Apply(_, Seq(leftp, rightp)) =>
           val bin = code match {
@@ -2550,7 +2557,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val left = genExpr(leftp)
           val right = genExpr(rightp)
 
-          buf.bin(bin, ty, left, right, unwind)
+          buf.bin(bin, ty, left, right, nounwind)
       }
     }
 
@@ -2580,7 +2587,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         .collectFirst {
           case f if matchesName(f) && f.isVariable =>
             // Don't allow to get pointer to immutable field, as it might allow for mutation
-            buf.field(genExpr(target), genFieldName(f), unwind)
+            buf.field(genExpr(target), genFieldName(f), nounwind)
         }
         .getOrElse {
           reporter.error(
@@ -2593,10 +2600,10 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     def genSizeOf(app: Apply)(implicit pos: nir.SourcePosition): nir.Val =
-      genLayoutValueOf("sizeOf", buf.sizeOf(_, unwind))(app)
+      genLayoutValueOf("sizeOf", buf.sizeOf(_, nounwind))(app)
 
     def genAlignmentOf(app: Apply)(implicit pos: nir.SourcePosition): nir.Val =
-      genLayoutValueOf("alignmentOf", buf.alignmentOf(_, unwind))(app)
+      genLayoutValueOf("alignmentOf", buf.alignmentOf(_, nounwind))(app)
 
     // used as internal implementation of sizeOf / alignmentOf
     private def genLayoutValueOf(opType: String, toVal: nir.Type => nir.Val)(
@@ -2744,7 +2751,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case (nir.Type.Float, nir.Type.Double) =>
             nir.Conv.Fpext
         }
-        buf.conv(conv, toty, value, unwind)
+        buf.conv(conv, toty, value, nounwind)
       }
     }
 
@@ -2824,7 +2831,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       fun.symbol match {
         case Object_isInstanceOf =>
-          buf.is(boxty, boxed, unwind)
+          buf.is(boxty, boxed, nounwind)
 
         case Object_asInstanceOf =>
           (fromty, toty) match {
@@ -2835,17 +2842,17 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               val runtimeNothing = genType(RuntimeNothingClass)
               val isNullL, notNullL = fresh()
               val isNull =
-                buf.comp(nir.Comp.Ieq, boxed.ty, boxed, nir.Val.Null, unwind)
+                buf.comp(nir.Comp.Ieq, boxed.ty, boxed, nir.Val.Null, nounwind)
               buf.branch(isNull, nir.Next(isNullL), nir.Next(notNullL))
               buf.label(isNullL)
               buf.raise(nir.Val.Null, unwind)
               buf.label(notNullL)
-              buf.as(runtimeNothing, boxed, unwind)
+              buf.as(runtimeNothing, boxed, nounwind)
               buf.unreachable(unwind)
               buf.label(fresh())
               nir.Val.Zero(nir.Type.Nothing)
             case _ =>
-              val cast = buf.as(boxty, boxed, unwind)
+              val cast = buf.as(boxty, boxed, nounwind)
               unboxValue(app.tpe, partial = true, cast)(app.pos)
           }
 
@@ -2882,7 +2889,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       args.zip(argsp).zipWithIndex.foreach {
         case ((arg, argp), idx) =>
-          res = buf.insert(res, arg, Seq(idx), unwind)(argp.pos, getScopeId)
+          res = buf.insert(res, arg, Seq(idx), nounwind)(argp.pos, getScopeId)
       }
 
       res
@@ -2967,7 +2974,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       fromExtern(
         ty,
-        buf.load(externTy, name, unwind, memoryOrder)
+        buf.load(externTy, name, nounwind, memoryOrder)
       )
     }
 
@@ -2981,7 +2988,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         if (!sym.isVolatile) None
         else Some(nir.MemoryOrder.Release)
 
-      buf.store(externTy, name, externValue, unwind, memoryOrder)
+      buf.store(externTy, name, externValue, nounwind, memoryOrder)
     }
 
     def toExtern(expectedTy: nir.Type, value: nir.Val)(implicit
@@ -3121,7 +3128,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                       val conv =
                         if (isUnsigned) nir.Conv.Zext
                         else nir.Conv.Sext
-                      buf.conv(conv, nir.Type.Int, arg, unwind)
+                      buf.conv(conv, nir.Type.Int, arg, nounwind)
                     case _ => arg
                   }
                   res += promotedArg

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -24,6 +24,7 @@ private[scalanative] object Lower {
 
     val Object = analysis.infos(nir.Rt.Object.name).asInstanceOf[Class]
 
+    private def nounwind = nir.Next.None
     private val zero = nir.Val.Int(0)
     private val one = nir.Val.Int(1)
     val RttiClassIdPath = Seq(zero, nir.Val.Int(Rtti.ClassIdIdx))
@@ -416,7 +417,7 @@ private[scalanative] object Lower {
             val toty = nir.Val.Local(fresh(), nir.Type.Ptr)
 
             buf.label(slowPath, Seq(obj, toty))
-            val fromty = buf.let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
+            val fromty = buf.let(nir.Op.Load(nir.Type.Ptr, obj), nounwind)
             buf.call(
               throwClassCastTy,
               throwClassCastVal,
@@ -501,7 +502,7 @@ private[scalanative] object Lower {
       op.resty match {
         case nir.Type.Unit =>
           genOp(buf, fresh(), op)
-          buf.let(n, nir.Op.Copy(unit), unwind)
+          buf.let(n, nir.Op.Copy(unit), nounwind)
         case nir.Type.Nothing =>
           genOp(buf, fresh(), op)
           genUnreachable(buf)
@@ -577,7 +578,7 @@ private[scalanative] object Lower {
         case nir.Op.Var(_) =>
           () // Already emmited
         case nir.Op.Varload(nir.Val.Local(slot, nir.Type.Var(ty))) =>
-          buf.let(n, nir.Op.Load(ty, nir.Val.Local(slot, nir.Type.Ptr)), unwind)
+          buf.let(n, nir.Op.Load(ty, nir.Val.Local(slot, nir.Type.Ptr)), nounwind)
         case nir.Op.Varstore(nir.Val.Local(slot, nir.Type.Var(ty)), value) =>
           buf.let(
             n,
@@ -597,7 +598,7 @@ private[scalanative] object Lower {
           genStackallocOp(buf, n, op)
         case op: nir.Op.Copy =>
           val v = genVal(buf, op.value)
-          buf.let(n, nir.Op.Copy(v), unwind)
+          buf.let(n, nir.Op.Copy(v), nounwind)
         case _ =>
           buf.let(n, op, unwind)
       }
@@ -620,7 +621,7 @@ private[scalanative] object Lower {
           val isNullL =
             nullPointerSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
-          val isNull = comp(nir.Comp.Ine, v.ty, v, nir.Val.Null, unwind)
+          val isNull = comp(nir.Comp.Ine, v.ty, v, nir.Val.Null, nounwind)
           branch(isNull, nir.Next(notNullL), nir.Next(isNullL))
           label(notNullL)
 
@@ -638,9 +639,9 @@ private[scalanative] object Lower {
       val outOfBoundsL =
         outOfBoundsSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
-      val gt0 = comp(nir.Comp.Sge, nir.Type.Int, idx, zero, unwind)
-      val ltLen = comp(nir.Comp.Slt, nir.Type.Int, idx, len, unwind)
-      val inBounds = bin(nir.Bin.And, nir.Type.Bool, gt0, ltLen, unwind)
+      val gt0 = comp(nir.Comp.Sge, nir.Type.Int, idx, zero, nounwind)
+      val ltLen = comp(nir.Comp.Slt, nir.Type.Int, idx, len, nounwind)
+      val inBounds = bin(nir.Bin.And, nir.Type.Bool, gt0, ltLen, nounwind)
       branch(
         inBounds,
         nir.Next(inBoundsL),
@@ -663,7 +664,7 @@ private[scalanative] object Lower {
       val index = layout.index(fld)
 
       genGuardNotNull(buf, v)
-      elem(ty, v, Seq(zero, nir.Val.Int(index)), unwind)
+      elem(ty, v, Seq(zero, nir.Val.Int(index)), nounwind)
     }
 
     def genFieldloadOp(
@@ -722,7 +723,7 @@ private[scalanative] object Lower {
     )(implicit srcPosition: nir.SourcePosition, scopeId: nir.ScopeId) = {
       val nir.Op.Field(obj, name) = op: @unchecked
       val elem = genFieldElemOp(buf, obj, name)
-      buf.let(n, nir.Op.Copy(elem), unwind)
+      buf.let(n, nir.Op.Copy(elem), nounwind)
     }
 
     def genLoadOp(
@@ -824,7 +825,7 @@ private[scalanative] object Lower {
       val nir.Op.Comp(comp, ty, l, r) = op
       val left = genVal(buf, l)
       val right = genVal(buf, r)
-      buf.let(n, nir.Op.Comp(comp, ty, left, right), unwind)
+      buf.let(n, nir.Op.Comp(comp, ty, left, right), nounwind)
     }
 
     // Cached function
@@ -877,10 +878,10 @@ private[scalanative] object Lower {
         scopeId: nir.ScopeId
     ): nir.Val = {
       import buf._
-      val itablesPtr = let(nir.Op.Elem(ClassRtti.layout, rtti, ClassRttiItablesPath), unwind)
-      val itables = let(nir.Op.Load(nir.Type.Ptr, itablesPtr), unwind)
-      val itableIdx = let(nir.Op.Bin(nir.Bin.And, nir.Type.Int, traitId, itableSize), unwind)
-      let(nir.Op.Elem(nir.Type.StructValue(nir.Type.Int :: nir.Type.Ptr :: Nil), itables, Seq(itableIdx)), unwind)
+      val itablesPtr = let(nir.Op.Elem(ClassRtti.layout, rtti, ClassRttiItablesPath), nounwind)
+      val itables = let(nir.Op.Load(nir.Type.Ptr, itablesPtr), nounwind)
+      val itableIdx = let(nir.Op.Bin(nir.Bin.And, nir.Type.Int, traitId, itableSize), nounwind)
+      let(nir.Op.Elem(nir.Type.StructValue(nir.Type.Int :: nir.Type.Ptr :: Nil), itables, Seq(itableIdx)), nounwind)
     }
 
     type ITableLookupGenerator = (
@@ -898,8 +899,8 @@ private[scalanative] object Lower {
     ): nir.Val.Local = {
       import buf._
       val traitId = nir.Val.Int(meta.ids(trt))
-      val itableSizePtr = let(nir.Op.Elem(ClassRtti.layout, rtti, ClassRttiITableSizePath), unwind)
-      val itableSize = let(nir.Op.Load(nir.Type.Int, itableSizePtr), unwind)
+      val itableSizePtr = let(nir.Op.Elem(ClassRtti.layout, rtti, ClassRttiITableSizePath), nounwind)
+      val itableSize = let(nir.Op.Load(nir.Type.Int, itableSizePtr), nounwind)
 
       val canEmitOnlyFastPath = meta.canAlwaysUseFastITables || (!mayBeNotFound && meta.rtti(trt).canUseFastITables)
       if (canEmitOnlyFastPath) genFastPath(buf, traitId, itableSize, resultLabel.getOrElse(fresh()))
@@ -907,7 +908,7 @@ private[scalanative] object Lower {
         val onFastPath, onSlowPath, merge = fresh()
         val resultV = nir.Val.Local(resultLabel.getOrElse(fresh()), resultType)
 
-        val useFastPath = let(nir.Op.Comp(nir.Comp.Sge, nir.Type.Int, itableSize, zero), unwind)
+        val useFastPath = let(nir.Op.Comp(nir.Comp.Sge, nir.Type.Int, itableSize, zero), nounwind)
         branch(useFastPath, nir.Next.Label(onFastPath, Nil), nir.Next.Label(onSlowPath, Nil))
 
         label(onFastPath, Nil)
@@ -1025,7 +1026,7 @@ private[scalanative] object Lower {
           s"The virtual table of ${cls.name} does not contain $sig"
         )
 
-        val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
+        val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), nounwind)
         val methptrptr = let(
           nir.Op.Elem(
             rtti(cls).struct,
@@ -1035,7 +1036,7 @@ private[scalanative] object Lower {
           unwind
         )
 
-        let(n, nir.Op.Load(nir.Type.Ptr, methptrptr), unwind)
+        let(n, nir.Op.Load(nir.Type.Ptr, methptrptr), nounwind)
       }
 
       def genTraitVirtualLookup(trt: Trait): Unit = {
@@ -1044,16 +1045,16 @@ private[scalanative] object Lower {
             .indexOf(sig)
             .ensuring(_ >= 0, s"Not found ${sig.show} entry in ${trt.name.id} methods")
         )
-        val rtti = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
+        val rtti = let(nir.Op.Load(nir.Type.Ptr, obj), nounwind)
         genItableLookup(trt, buf, mayBeNotFound = false)(Some(n), rtti, nir.Type.Ptr)(
           genFastPath = (buf, traitId, itableSize, resultLabel) => {
-            val itablesPtr = let(nir.Op.Elem(ClassRtti.layout, rtti, ClassRttiItablesPath), unwind)
-            val itables = let(nir.Op.Load(nir.Type.Ptr, itablesPtr), unwind)
-            val itableIdx = let(nir.Op.Bin(nir.Bin.And, nir.Type.Int, traitId, itableSize), unwind)
-            val itablePtr = let(nir.Op.Elem(nir.Type.StructValue(nir.Type.Int :: nir.Type.Ptr :: Nil), itables, Seq(itableIdx, one)), unwind)
-            val itable = let(nir.Op.Load(nir.Type.Ptr, itablePtr), unwind)
-            val methodPtr = let(nir.Op.Elem(nir.Type.Ptr, itable, Seq(methodIdx)), unwind)
-            let(resultLabel, nir.Op.Load(nir.Type.Ptr, methodPtr), unwind)
+            val itablesPtr = let(nir.Op.Elem(ClassRtti.layout, rtti, ClassRttiItablesPath), nounwind)
+            val itables = let(nir.Op.Load(nir.Type.Ptr, itablesPtr), nounwind)
+            val itableIdx = let(nir.Op.Bin(nir.Bin.And, nir.Type.Int, traitId, itableSize), nounwind)
+            val itablePtr = let(nir.Op.Elem(nir.Type.StructValue(nir.Type.Int :: nir.Type.Ptr :: Nil), itables, Seq(itableIdx, one)), nounwind)
+            val itable = let(nir.Op.Load(nir.Type.Ptr, itablePtr), nounwind)
+            val methodPtr = let(nir.Op.Elem(nir.Type.Ptr, itable, Seq(methodIdx)), nounwind)
+            let(resultLabel, nir.Op.Load(nir.Type.Ptr, methodPtr), nounwind)
           },
           genSlowPath = (buf, traitId, itableSize, _) => {
             call(TraitDispatchSlowpathSig, TraitDispatchSlowpath, Seq(rtti, traitId, methodIdx), unwind)
@@ -1065,9 +1066,9 @@ private[scalanative] object Lower {
         scope.targets(sig).toSeq match {
           case Seq() =>
             // logger.warn(s"Unable to call ${sig.show} on instance of ${scope.name.id} in ${srcPosition.show}. It would result in NullPointerException at runtime")
-            let(n, nir.Op.Copy(nir.Val.Null), unwind)
+            let(n, nir.Op.Copy(nir.Val.Null), nounwind)
           case Seq(impl) =>
-            let(n, nir.Op.Copy(nir.Val.Global(impl, nir.Type.Ptr)), unwind)
+            let(n, nir.Op.Copy(nir.Val.Global(impl, nir.Type.Ptr)), nounwind)
           case _ =>
             obj.ty match {
               case ClassRef(cls) =>
@@ -1089,7 +1090,7 @@ private[scalanative] object Lower {
               s"Did not find the signature of method $sig in ${cls.name}"
             )
           }
-        let(n, nir.Op.Copy(nir.Val.Global(method, nir.Type.Ptr)), unwind)
+        let(n, nir.Op.Copy(nir.Val.Global(method, nir.Type.Ptr)), nounwind)
       }
 
       def staticMethodIn(cls: Class): Boolean =
@@ -1136,7 +1137,7 @@ private[scalanative] object Lower {
           noSuchMethodSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
         val condNull =
-          comp(nir.Comp.Ine, nir.Type.Ptr, value, nir.Val.Null, unwind)
+          comp(nir.Comp.Ine, nir.Type.Ptr, value, nir.Val.Null, nounwind)
         branch(
           condNull,
           nir.Next(notNullL),
@@ -1150,10 +1151,10 @@ private[scalanative] object Lower {
           meta.analysis.dynsigs.zipWithIndex.find(_._1 == sig).get._2
 
         // Load the type information pointer
-        val typeptr = load(nir.Type.Ptr, obj, unwind)
+        val typeptr = load(nir.Type.Ptr, obj, nounwind)
         // Load the dynamic hash map for given type, make sure it's not null
-        val mapelem = elem(classRttiType, typeptr, ClassRttiDynmapPath, unwind)
-        val mapptr = load(nir.Type.Ptr, mapelem, unwind)
+        val mapelem = elem(classRttiType, typeptr, ClassRttiDynmapPath, nounwind)
+        val mapptr = load(nir.Type.Ptr, mapelem, nounwind)
         // If hash map is not null, it has to contain at least one entry
         throwIfNull(mapptr)
         // Perform dynamic dispatch via dyndispatch helper
@@ -1165,7 +1166,7 @@ private[scalanative] object Lower {
         )
         // Hash map lookup can still not contain given signature
         throwIfNull(methptrptr)
-        let(n, nir.Op.Load(nir.Type.Ptr, methptrptr), unwind)
+        let(n, nir.Op.Load(nir.Type.Ptr, methptrptr), nounwind)
       }
 
       genGuardNotNull(buf, obj)
@@ -1181,7 +1182,7 @@ private[scalanative] object Lower {
 
       op match {
         case nir.Op.Is(_, nir.Val.Null | nir.Val.Zero(_)) =>
-          let(n, nir.Op.Copy(nir.Val.False), unwind)
+          let(n, nir.Op.Copy(nir.Val.False), nounwind)
 
         case nir.Op.Is(ty, v) =>
           val obj = genVal(buf, v)
@@ -1221,17 +1222,17 @@ private[scalanative] object Lower {
 
       ty match {
         case ClassRef(cls) if meta.ranges(cls).length == 1 =>
-          val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
-          let(nir.Op.Comp(nir.Comp.Ieq, nir.Type.Ptr, typeptr, rtti(cls).const), unwind)
+          val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), nounwind)
+          let(nir.Op.Comp(nir.Comp.Ieq, nir.Type.Ptr, typeptr, rtti(cls).const), nounwind)
 
         case ClassRef(cls) =>
           val range = meta.ranges(cls)
-          val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
-          val idptr = let(nir.Op.Elem(Rtti.layout, typeptr, RttiClassIdPath), unwind)
-          val id = let(nir.Op.Load(nir.Type.Int, idptr), unwind)
-          val ge = let(nir.Op.Comp(nir.Comp.Sle, nir.Type.Int, nir.Val.Int(range.start), id), unwind)
-          val le = let(nir.Op.Comp(nir.Comp.Sle, nir.Type.Int, id, nir.Val.Int(range.end)), unwind)
-          let(nir.Op.Bin(nir.Bin.And, nir.Type.Bool, ge, le), unwind)
+          val typeptr = let(nir.Op.Load(nir.Type.Ptr, obj), nounwind)
+          val idptr = let(nir.Op.Elem(Rtti.layout, typeptr, RttiClassIdPath), nounwind)
+          val id = let(nir.Op.Load(nir.Type.Int, idptr), nounwind)
+          val ge = let(nir.Op.Comp(nir.Comp.Sle, nir.Type.Int, nir.Val.Int(range.start), id), nounwind)
+          val le = let(nir.Op.Comp(nir.Comp.Sle, nir.Type.Int, id, nir.Val.Int(range.end)), nounwind)
+          let(nir.Op.Bin(nir.Bin.And, nir.Type.Bool, ge, le), nounwind)
 
         case TraitRef(trt) =>
           v.ty match {
@@ -1239,15 +1240,15 @@ private[scalanative] object Lower {
             case _             =>
           }
           val traitId = nir.Val.Int(meta.ids(trt))
-          val rtti = let(nir.Op.Load(nir.Type.Ptr, obj), unwind)
+          val rtti = let(nir.Op.Load(nir.Type.Ptr, obj), nounwind)
           genItableLookup(trt, buf, mayBeNotFound = true)(None, rtti, nir.Type.Bool)(
             genFastPath = (buf, traitId, itableSize, _) => {
-              val itablesPtr = let(nir.Op.Elem(ClassRtti.layout, rtti, ClassRttiItablesPath), unwind)
-              val itables = let(nir.Op.Load(nir.Type.Ptr, itablesPtr), unwind)
-              val itableIdx = let(nir.Op.Bin(nir.Bin.And, nir.Type.Int, traitId, itableSize), unwind)
-              val itableIdPtr = let(nir.Op.Elem(nir.Type.StructValue(nir.Type.Int :: nir.Type.Ptr :: Nil), itables, Seq(itableIdx, zero)), unwind)
-              val itableId = let(nir.Op.Load(nir.Type.Int, itableIdPtr), unwind)
-              let(nir.Op.Comp(nir.Comp.Ieq, nir.Type.Int, traitId, itableId), unwind)
+              val itablesPtr = let(nir.Op.Elem(ClassRtti.layout, rtti, ClassRttiItablesPath), nounwind)
+              val itables = let(nir.Op.Load(nir.Type.Ptr, itablesPtr), nounwind)
+              val itableIdx = let(nir.Op.Bin(nir.Bin.And, nir.Type.Int, traitId, itableSize), nounwind)
+              val itableIdPtr = let(nir.Op.Elem(nir.Type.StructValue(nir.Type.Int :: nir.Type.Ptr :: Nil), itables, Seq(itableIdx, zero)), nounwind)
+              val itableId = let(nir.Op.Load(nir.Type.Int, itableIdPtr), nounwind)
+              let(nir.Op.Comp(nir.Comp.Ieq, nir.Type.Int, traitId, itableId), nounwind)
             },
             genSlowPath = (buf, traitId, itableSize, _) => {
               call(ClassHasTraitSlowpathSig, ClassHasTraitSlowpath, Seq(rtti, traitId), unwind)
@@ -1268,14 +1269,14 @@ private[scalanative] object Lower {
 
       op match {
         case nir.Op.As(ty: nir.Type.RefKind, v) if v.ty == nir.Type.Null =>
-          let(n, nir.Op.Copy(nir.Val.Null), unwind)
+          let(n, nir.Op.Copy(nir.Val.Null), nounwind)
 
         case nir.Op.As(ty: nir.Type.RefKind, obj) if obj.ty.isInstanceOf[nir.Type.RefKind] =>
           val v = genVal(buf, obj)
           val checkIfIsInstanceOfL, castL = fresh()
           val failL = classCastSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
-          val isNull = comp(nir.Comp.Ieq, v.ty, v, nir.Val.Null, unwind)
+          val isNull = comp(nir.Comp.Ieq, v.ty, v, nir.Val.Null, nounwind)
           branch(isNull, nir.Next(castL), nir.Next(checkIfIsInstanceOfL))
 
           label(checkIfIsInstanceOfL)
@@ -1289,9 +1290,9 @@ private[scalanative] object Lower {
 
           label(castL)
           if (platform.useOpaquePointers)
-            let(n, nir.Op.Copy(v), unwind)
+            let(n, nir.Op.Copy(v), nounwind)
           else
-            let(n, nir.Op.Conv(nir.Conv.Bitcast, ty, v), unwind)
+            let(n, nir.Op.Conv(nir.Conv.Bitcast, ty, v), nounwind)
 
         case nir.Op.As(to, v) =>
           util.unsupported(s"can't cast from ${v.ty} to $to")
@@ -1314,7 +1315,7 @@ private[scalanative] object Lower {
           meta.layout(cls).size
         case _ => MemoryLayout.sizeOf(op.ty)
       }
-      buf.let(n, nir.Op.Copy(nir.Val.Size(size)), unwind)
+      buf.let(n, nir.Op.Copy(nir.Val.Size(size)), nounwind)
     }
 
     def genAlignmentOfOp(
@@ -1323,7 +1324,7 @@ private[scalanative] object Lower {
         op: nir.Op.AlignmentOf
     )(implicit srcPosition: nir.SourcePosition, scopeId: nir.ScopeId): Unit = {
       val alignment = MemoryLayout.alignmentOf(op.ty)
-      buf.let(n, nir.Op.Copy(nir.Val.Size(alignment)), unwind)
+      buf.let(n, nir.Op.Copy(nir.Val.Size(alignment)), nounwind)
     }
 
     def genClassallocOp(
@@ -1434,14 +1435,14 @@ private[scalanative] object Lower {
 
           val isNaNL, checkLessThanMinL, lessThanMinL, checkLargerThanMaxL, largerThanMaxL, inBoundsL, resultL = fresh()
 
-          val isNaN = comp(nir.Comp.Fne, v.ty, v, v, unwind)
+          val isNaN = comp(nir.Comp.Fne, v.ty, v, v, nounwind)
           branch(isNaN, nir.Next(isNaNL), nir.Next(checkLessThanMinL))
 
           label(isNaNL)
           jump(resultL, Seq(nir.Val.Zero(op.resty)))
 
           label(checkLessThanMinL)
-          val isLessThanMin = comp(nir.Comp.Fle, v.ty, v, fmin, unwind)
+          val isLessThanMin = comp(nir.Comp.Fle, v.ty, v, fmin, nounwind)
           branch(
             isLessThanMin,
             nir.Next(lessThanMinL),
@@ -1452,7 +1453,7 @@ private[scalanative] object Lower {
           jump(resultL, Seq(imin))
 
           label(checkLargerThanMaxL)
-          val isLargerThanMax = comp(nir.Comp.Fge, v.ty, v, fmax, unwind)
+          val isLargerThanMax = comp(nir.Comp.Fge, v.ty, v, fmax, nounwind)
           branch(isLargerThanMax, nir.Next(largerThanMaxL), nir.Next(inBoundsL))
 
           label(largerThanMaxL)
@@ -1465,7 +1466,7 @@ private[scalanative] object Lower {
           label(resultL, Seq(nir.Val.Local(n, op.resty)))
 
         case nir.Op.Conv(conv, ty, value) =>
-          let(n, nir.Op.Conv(conv, ty, genVal(buf, value)), unwind)
+          let(n, nir.Op.Conv(conv, ty, genVal(buf, value)), nounwind)
       }
     }
 
@@ -1489,14 +1490,14 @@ private[scalanative] object Lower {
           divisionByZeroSlowPath.getOrElseUpdate(unwindHandler, fresh())
 
         val isZero =
-          comp(nir.Comp.Ine, ty, divisor, nir.Val.Zero(ty), unwind)
+          comp(nir.Comp.Ine, ty, divisor, nir.Val.Zero(ty), nounwind)
         branch(isZero, nir.Next(succL), nir.Next(failL))
 
         label(succL)
         if (bin == nir.Bin.Srem || bin == nir.Bin.Sdiv) {
           checkDivisionOverflow(op)
         } else {
-          let(n, op, unwind)
+          let(n, op, nounwind)
         }
       }
 
@@ -1541,12 +1542,12 @@ private[scalanative] object Lower {
         }
 
         val divisorIsMinus1 =
-          let(nir.Op.Comp(nir.Comp.Ieq, ty, divisor, minus1), unwind)
+          let(nir.Op.Comp(nir.Comp.Ieq, ty, divisor, minus1), nounwind)
         branch(divisorIsMinus1, nir.Next(mayOverflowL), nir.Next(noOverflowL))
 
         label(mayOverflowL)
         val dividendIsMinValue =
-          let(nir.Op.Comp(nir.Comp.Ieq, ty, dividend, minValue), unwind)
+          let(nir.Op.Comp(nir.Comp.Ieq, ty, dividend, minValue), nounwind)
         branch(
           dividendIsMinValue,
           nir.Next(didOverflowL),
@@ -1565,7 +1566,7 @@ private[scalanative] object Lower {
         jump(resultL, Seq(overflowResult))
 
         label(noOverflowL)
-        val noOverflowResult = let(op, unwind)
+        val noOverflowResult = let(op, nounwind)
         jump(resultL, Seq(noOverflowResult))
 
         label(resultL, Seq(nir.Val.Local(n, ty)))
@@ -1583,8 +1584,8 @@ private[scalanative] object Lower {
           case _ =>
             util.unreachable
         }
-        val masked = bin(nir.Bin.And, ty, r, mask, unwind)
-        let(n, op.copy(r = masked), unwind)
+        val masked = bin(nir.Bin.And, ty, r, mask, nounwind)
+        let(n, op.copy(r = masked), nounwind)
       }
 
       op match {
@@ -1605,7 +1606,7 @@ private[scalanative] object Lower {
           maskShift(op)
 
         case op =>
-          let(n, op, unwind)
+          let(n, op, nounwind)
       }
     }
 
@@ -1672,7 +1673,7 @@ private[scalanative] object Lower {
           buf.let(
             n,
             nir.Op.Copy(nir.Val.Global(instance, nir.Type.Ptr)),
-            unwind
+            nir.Next.None
           )
 
         case _ =>
@@ -1771,8 +1772,8 @@ private[scalanative] object Lower {
       genGuardInBounds(buf, idx, nir.Val.Local(len, nir.Type.Int))
 
       val arrTy = arrayMemoryLayout(ty)
-      val elemPtr = buf.elem(arrTy, arr, arrayValuePath(idx), unwind)
-      buf.let(n, nir.Op.Load(ty, elemPtr), unwind)
+      val elemPtr = buf.elem(arrTy, arr, arrayValuePath(idx), nounwind)
+      buf.let(n, nir.Op.Load(ty, elemPtr), nounwind)
     }
 
     def genArraystoreOp(
@@ -1788,7 +1789,7 @@ private[scalanative] object Lower {
       genGuardInBounds(buf, idx, nir.Val.Local(len, nir.Type.Int))
 
       val arrTy = arrayMemoryLayout(ty)
-      val elemPtr = buf.elem(arrTy, arr, arrayValuePath(idx), unwind)
+      val elemPtr = buf.elem(arrTy, arr, arrayValuePath(idx), nounwind)
       genStoreOp(buf, n, nir.Op.Store(ty, elemPtr, value))
     }
 
@@ -1805,8 +1806,8 @@ private[scalanative] object Lower {
 
       genGuardNotNull(buf, arr)
       val lenPtr =
-        buf.elem(ArrayHeader.layout, arr, ArrayHeaderLengthPath, unwind)
-      buf.let(n, nir.Op.Load(nir.Type.Int, lenPtr), unwind)
+        buf.elem(ArrayHeader.layout, arr, ArrayHeaderLengthPath, nounwind)
+      buf.let(n, nir.Op.Load(nir.Type.Int, lenPtr), nounwind)
     }
 
     def genStackallocOp(
@@ -1832,9 +1833,9 @@ private[scalanative] object Lower {
                 case i: nir.Type.FixedSizeI =>
                   if (i.width == platform.sizeOfPtrBits) sizeV
                   else if (i.width > platform.sizeOfPtrBits)
-                    buf.conv(nir.Conv.Trunc, nir.Type.Size, sizeV, unwind)
+                    buf.conv(nir.Conv.Trunc, nir.Type.Size, sizeV, nounwind)
                   else
-                    buf.conv(nir.Conv.Zext, nir.Type.Size, sizeV, unwind)
+                    buf.conv(nir.Conv.Zext, nir.Type.Size, sizeV, nounwind)
 
                 case _ => sizeV
               }


### PR DESCRIPTION
Remove the unwind handler for operations that can never throw exception.. Would allow to remove no longer needed unwind handlers