### PR TITLE
Four small improvements to java.io.InputStreamReader

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/InputStreamReaderTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/InputStreamReaderTest.scala
@@ -11,7 +11,7 @@ import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 class InputStreamReaderTest {
 
   /* Scala.js tests - Begin
-   * Ported from Scala.js commit: cbf86bb dated: 2020-10-23
+   * Ported from Scala.js commit: 11a5e4a dated: 2023-11-02
    */
 
   /* Scala.js tests - End

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/InputStreamReaderTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/InputStreamReaderTest.scala
@@ -9,6 +9,81 @@ import org.junit.Assert._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 
 class InputStreamReaderTest {
+
+  /* Scala.js tests - Begin
+   * Ported from Scala.js commit: cbf86bb dated: 2020-10-23
+   */
+
+  /* Scala.js tests - End
+   */
+  import scala.annotation.tailrec
+
+  @Test def readUTF8(): Unit = {
+
+    val buf = Array[Byte](72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100,
+      46, -29, -127, -109, -29, -126, -109, -29, -127, -85, -29, -127, -95, -29,
+      -127, -81, -26, -105, -91, -26, -100, -84, -24, -86, -98, -29, -126, -110,
+      -24, -86, -83, -29, -126, -127, -29, -127, -66, -29, -127, -103, -29,
+      -127, -117, -29, -128, -126)
+
+    val r = new InputStreamReader(new ByteArrayInputStream(buf))
+
+    def expectRead(str: String): Unit = {
+      val buf = new Array[Char](str.length)
+      @tailrec
+      def readAll(readSoFar: Int): Int = {
+        if (readSoFar == buf.length) readSoFar
+        else {
+          val newlyRead = r.read(buf, readSoFar, buf.length - readSoFar)
+          if (newlyRead == -1) readSoFar
+          else readAll(readSoFar + newlyRead)
+        }
+      }
+      assertEquals(str.length, readAll(0))
+      assertEquals(str, new String(buf))
+    }
+
+    expectRead("Hello World.")
+    expectRead("こんにちは")
+    expectRead("日本語を読めますか。")
+    assertEquals(-1, r.read())
+  }
+
+  @Test def readEOFThrows(): Unit = {
+    val data = "Lorem ipsum".getBytes()
+    val streamReader = new InputStreamReader(new ByteArrayInputStream(data))
+    val bytes = new Array[Char](11)
+
+    assertEquals(11, streamReader.read(bytes))
+    // Do it twice to check for a regression where this used to throw
+    assertEquals(-1, streamReader.read(bytes))
+    assertEquals(-1, streamReader.read(bytes))
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      streamReader.read(bytes, 10, 3)
+    )
+    assertEquals(0, streamReader.read(new Array[Char](0)))
+  }
+
+  @Test def skipReturns0AfterReachingEnd(): Unit = {
+    val data = "Lorem ipsum".getBytes()
+    val r = new InputStreamReader(new ByteArrayInputStream(data))
+    assertTrue(r.skip(100) > 0)
+    assertEquals(-1, r.read())
+
+    assertEquals(0, r.skip(100))
+    assertEquals(-1, r.read())
+  }
+
+  @Test def markThrowsNotSupported(): Unit = {
+    val data = "Lorem ipsum".getBytes()
+    val r = new InputStreamReader(new ByteArrayInputStream(data))
+    assertThrows(classOf[IOException], r.mark(0))
+  }
+
+  /* Scala Native authored tests
+   */
+
   class MockInputStream extends InputStream {
     private var _closed: Boolean = false
 


### PR DESCRIPTION
Implement four small improvements to `java.io.InputStreamReader`.    
End users may see some reduced memory use but no functional changes.

* Correct a grossly oversized initial memory allocation.

* Be less generous when re-trying with a larger buffer.

* Do not clear a buffer if a new one is going to be immediately allocated & used instead.

* Port Tests from Scala.js. 