### PR TITLE
Optimize throwing exception to local handler as jump

### DIFF
--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -728,7 +728,7 @@ class IssuesTest {
   @Test def issue4194(): Unit = {
     var tryCounter = 0
     var finallyCounter = 0
-    var cought = false
+    var caught = false
     try {
       tryCounter += 1
       try {

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -738,20 +738,20 @@ class IssuesTest {
           try throw new RuntimeException()
           catch {
             case ex: java.io.IOException => // exception unrelated to throw one
-              fail("Should not be cought")
+              fail("Should not be caught")
           } finally {
             finallyCounter += 1
           }
         } finally {
           finallyCounter += 1
         }
-      } catch { case ex: java.lang.Throwable => cought = true }
+      } catch { case ex: java.lang.Throwable => caught = true }
     } finally {
       finallyCounter += 1
     }
     assertEquals("some finally block was skipped", 3, finallyCounter)
     assertEquals(tryCounter, finallyCounter)
-    assertTrue("exception not cought", cought)
+    assertTrue("exception not caught", caught)
   }
 
   // Based on Scala 2.13.16 fix in delambdafy https://github.com/scala/scala/pull/10831

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -725,6 +725,35 @@ class IssuesTest {
     assertEquals(result, "b")
   }
 
+  @Test def issue4194(): Unit = {
+    var tryCounter = 0
+    var finallyCounter = 0
+    var cought = false
+    try {
+      tryCounter += 1
+      try {
+        tryCounter += 1
+        try {
+          tryCounter += 1
+          try throw new RuntimeException()
+          catch {
+            case ex: java.io.IOException => // exception unrelated to throw one
+              fail("Should not be cought")
+          } finally {
+            finallyCounter += 1
+          }
+        } finally {
+          finallyCounter += 1
+        }
+      } catch { case ex: java.lang.Throwable => cought = true }
+    } finally {
+      finallyCounter += 1
+    }
+    assertEquals("some finally block was skipped", 3, finallyCounter)
+    assertEquals(tryCounter, finallyCounter)
+    assertTrue("exception not cought", cought)
+  }
+
   // Based on Scala 2.13.16 fix in delambdafy https://github.com/scala/scala/pull/10831
   @Test def partest_t13022(): Unit = {
     import t13022.StringValue


### PR DESCRIPTION
Allows to skip unwinding process and jump directly to handler if it's defined in the same scope. 

Fixes #4195 on the CodeGen side by eliminating most of unwinding calls that were failing after LTO