### PR TITLE
Fix #4193: java.io.InputStreamReader reads after EOF are now a better  match to JVM

### DIFF
--- a/javalib/src/main/scala/java/io/InputStreamReader.scala
+++ b/javalib/src/main/scala/java/io/InputStreamReader.scala
@@ -20,8 +20,7 @@ class InputStreamReader(
    *  Class invariant: contains bytes already read from `in` but not yet
    *  decoded.
    */
-  private var inBuf: ByteBuffer = ByteBuffer.allocate(4096)
-  inBuf.limit(0)
+  private var inBuf: ByteBuffer = ByteBuffer.allocate(4096).limit(0)
 
   /** Tells whether the end of the underlying input stream has been reached.
    *  Class invariant: if true, then `in.read()` has returned -1.
@@ -179,10 +178,13 @@ class InputStreamReader(
         // Flush
         if (decoder.flush(out).isOverflow()) {
           InputStreamReader.Overflow
+        } else if (out.position() != initPos) {
+          out.position() - initPos
         } else {
-          // Done
-          if (out.position() == initPos) -1
-          else out.position() - initPos
+          // End-of-File for now; prepare for any subsequent reads after EOF
+          endOfInput = false
+          decoder.reset()
+          -1
         }
       } else {
         // We need to read more from the underlying input stream


### PR DESCRIPTION
Fix #4193

The JVM allows reads by an  InputStreamReader after it had detected End-of-File up
as long as the underlying stream is still open. Any characters which may have become
available are returned.


Scala Native `java.io.InputStreamReader` reads after End-of-File are now a better  match to the
JVM behavior.

"better match" because it is hard to determine _exactly_  what the JVM does when the EOF
occurs after one or more bytes of a multibyte UTF-8 character is read but not enough bytes
are read before EOF to decode the entire character or characters. Supplemental (two UTF-16) chars
may have the a similar issue with a high surrogate before the EOF and the low surrogate after.
These are probably both "MalformedInputException" cases.

Both cases depend upon the timing and "chunking" of the input. It is the responsibility of the
application developer to manage that timing.

Reading single byte UTF-8 characters after EOF should present no problems. 

