### PR TITLE
Fallback to C++ exceptions when using LTO or explicitly enabled

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -197,8 +197,14 @@ sealed trait Config {
       case _ => false
     }
 
-  private[scalanative] def usingCppExceptions: Boolean =
-    targetsWindows
+  private[scalanative] lazy val usingCppExceptions: Boolean =
+    targetsWindows || {
+      val disabled = compileOptions.contains("-fno-cxx-exceptions")
+      val enabled = compileOptions.contains("-fcxx-exceptions")
+      // New EH does not work good with LTO https://github.com/scala-native/scala-native/issues/4190
+      val enabledLTO = compilerConfig.lto != build.LTO.none
+      !disabled && (enabled || enabledLTO)
+    }
 }
 
 /** Factory to create [[#empty]] [[Config]] objects */

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -341,10 +341,10 @@ object NativeConfig {
       copy(clangPP = value)
 
     def withLinkingOptions(update: Mapping[Seq[String]]): NativeConfig =
-      copy(linkingOptions = update(linkingOptions))
+      copy(linkingOptions = update(linkingOptions).map(_.trim()))
 
     def withCompileOptions(update: Mapping[Seq[String]]): NativeConfig =
-      copy(compileOptions = update(compileOptions))
+      copy(compileOptions = update(compileOptions).map(_.trim()))
 
     def withTargetTriple(value: Option[String]): NativeConfig = {
       val propertyName = "target.triple"

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/compat/os/UnixCompat.scala
@@ -13,14 +13,18 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
   import codegen.{pointerType => ptrT}
 
   val excRecTy = s"{ $ptrT, i32 }"
-  val scalaNativeCatch = "@scalanative_catch"
-  val catchSig =
-    if (useOpaquePointers) s"$ptrT null"
-    else s"i8* null"
-  val landingpad =
-    s"landingpad $excRecTy catch $catchSig"
 
-  protected val osPersonalityType: String = "@scalanative_personality"
+  final val scalanativeCatch = "@scalanative_catch"
+
+  final val cppExceptionWrapperTy = "@_ZTIN11scalanative16ExceptionWrapperE"
+  final val cxaBeginCatch = "@__cxa_begin_catch"
+  final val cxaEndCatch = "@__cxa_end_catch"
+
+  val usingCppExceptions = codegen.meta.buildConfig.usingCppExceptions
+
+  protected val osPersonalityType: String =
+    if (usingCppExceptions) "@__gxx_personality_v0"
+    else "@scalanative_personality"
 
   override def genBlockAlloca(block: nir.ControlFlow.Block)(implicit
       sb: ShowBuilder
@@ -49,27 +53,80 @@ private[codegen] class UnixCompat(codegen: AbstractCodeGen)
 
     def line(s: String) = { newline(); str(s) }
 
-    line(s"$excpad:")
-    indent()
-    line(s"$rec = $landingpad")
-    line(s"$r0 = extractvalue $excRecTy $rec, 0")
-    line(s"br label %$excsucc")
-    unindent()
+    def genScalaNativeLandingPad(): Unit = {
+      line(s"$excpad:")
+      indent()
+      // Catch all exception
+      line(s"$rec = landingpad $excRecTy catch $ptrT null")
+      line(s"$r0 = extractvalue $excRecTy $rec, 0")
+      line(s"br label %$excsucc")
+      unindent()
 
-    line(s"$excsucc:")
-    indent()
+      line(s"$excsucc:")
+      indent()
+      line(s"$exc = call $ptrT $scalanativeCatch($ptrT $r0)")
+      codegen.dbg(",", codegen.toDILocation(pos, scopeId))
+      line("br ")
+      codegen.genNext(next)
+      unindent()
+    }
 
-    line(s"$exc = call $ptrT $scalaNativeCatch($ptrT $r0)")
-    codegen.dbg(",", codegen.toDILocation(pos, scopeId))
-    line("br ")
-    codegen.genNext(next)
-    unindent()
+    def genCppLandingPad(): Unit = {
+      val catchSig =
+        if (useOpaquePointers) s"$ptrT $cppExceptionWrapperTy"
+        else s"i8* bitcast ({ i8*, i8*, i8* }* $cppExceptionWrapperTy to i8*)"
+      val r1, cmp = "%_" + fresh().id
+      val excfail = excpad + ".fail"
+
+      line(s"$excpad:")
+      indent()
+      line(s"$rec = landingpad $excRecTy catch $catchSig")
+      line(s"$r0 = extractvalue $excRecTy $rec, 0")
+      line(s"$r1 = extractvalue $excRecTy $rec, 1")
+      line(s"$id = call i32 @llvm.eh.typeid.for($catchSig)")
+      line(s"$cmp = icmp eq i32 $r1, $id")
+      line(s"br i1 $cmp, label %$excsucc, label %$excfail")
+      unindent()
+
+      line(s"$excsucc:")
+      indent()
+      line(s"$w0 = call $ptrT $cxaBeginCatch($ptrT $r0)")
+      if (useOpaquePointers) {
+        line(s"$w2 = getelementptr ptr, ptr $w0, i32 1")
+        line(s"$exc = load ptr, ptr $w2")
+      } else {
+        line(s"$w1 = bitcast i8* $w0 to i8**")
+        line(s"$w2 = getelementptr i8*, i8** $w1, i32 1")
+        line(s"$exc = load i8*, i8** $w2")
+      }
+      line(s"call void $cxaEndCatch()")
+      str("br ")
+      codegen.genNext(next)
+      unindent()
+
+      line(s"$excfail:")
+      indent()
+      line(s"resume $excRecTy $rec")
+      unindent()
+    }
+
+    if (usingCppExceptions) genCppLandingPad()
+    else genScalaNativeLandingPad()
   }
 
   def genPrelude()(implicit builder: ShowBuilder): Unit = {
     import builder._
     line(s"declare i32 $osPersonalityType(...)")
-    line(s"declare $ptrT $scalaNativeCatch($ptrT)")
+    if (usingCppExceptions) {
+      line(s"declare i32 @llvm.eh.typeid.for($ptrT)")
+      line(s"declare $ptrT $cxaBeginCatch($ptrT)")
+      line(s"declare void $cxaEndCatch()")
+      line(
+        s"$cppExceptionWrapperTy = external constant { $ptrT, $ptrT, $ptrT }"
+      )
+    } else {
+      line(s"declare $ptrT $scalanativeCatch($ptrT)")
+    }
   }
 
 }


### PR DESCRIPTION
Workarounds #4190 problems by using C++ exception handlings as a fallback. The new EH mechanism would still be used by default on Unix, unless LTO is enabled or compile options contains (`-fcxx-exceptions`). 
The compile option `-fno-cxx-exceptions` would always allow to use only new EH. 
This should introduce a healthy default behaviour

We don't introduce a new options to `NativeConfig` becouse we want it to be temporal solution. At some point we'd like to use only our own EH mechanism without C++ dependency


[test-extended]