### PR TITLE
Refine when to check for StackOverflowError

### DIFF
--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -266,6 +266,7 @@ object ReachabilityAnalysis {
 
     private[scalanative] object references {
       // Currently unused, useful for debugging
+      @scala.annotation.nowarn("msg=Non local returns are no longer supported")
       def pathBetween(
           symbol: nir.Global.Member,
           from: nir.Global.Member

--- a/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -4,6 +4,8 @@ import java.util.Locale
 // Ported from Scala.js
 
 object Platform {
+  class DummyAnnotation extends scala.annotation.StaticAnnotation()
+  type nooptimize = DummyAnnotation
 
   final val executingInJVM = true
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -7,6 +7,7 @@ import scala.scalanative.buildinfo.ScalaNativeBuildInfo
 import scala.scalanative.runtime
 
 object Platform {
+  type nooptimize = scala.scalanative.annotation.nooptimize
 
   def scalaVersion: String = ScalaNativeBuildInfo.scalaVersion
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StackOverflowTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StackOverflowTest.scala
@@ -11,7 +11,9 @@ import java.io.{PrintStream, File}
 
 class StackOverflowTest {
   // Simple 1 + stackoverflow() would be optimized to be tail recursive(!?) by LLVM
-  def stackoverflow(): Int = stackoverflow() + stackoverflow()
+  @noinline()
+  @Platform.nooptimize
+  def stackoverflow(): Int = 1 + stackoverflow()
 
   @Test def catchStackOverflowError(): Unit = {
     assertThrows(classOf[StackOverflowError], () => stackoverflow())
@@ -40,6 +42,8 @@ class StackOverflowTest {
       new File(if (Platform.isWindows) "NUL" else "/dev/null")
     )
     // println uses synchronized blocks (recursively)
+    @noinline()
+    @Platform.nooptimize
     def stackoverflow(): Int = {
       devNull.println(".")
       1 + stackoverflow()
@@ -68,8 +72,10 @@ class StackOverflowTest {
     val devNull = new PrintStream(
       new File(if (Platform.isWindows) "NUL" else "/dev/null")
     )
-    // println uses synchronized blocks (recursively)
+    @noinline()
+    @Platform.nooptimize
     def stackoverflow(): Int = {
+      // println uses synchronized blocks (recursively)
       devNull.println(".")
       1 + stackoverflow()
     }


### PR DESCRIPTION
 Remove checks in performance critical paths and improve detection of self-recursive methods 
 
 Should fix problems in [test-extended] for LTO + Boehm GC tests. Previously stackoverflow methods in tests were optimized to tailrecursive versions that lead to timeouts