### PR TITLE
Improve detection when system threads are used.

### DIFF
--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -67,7 +67,7 @@ class Runtime private () {
       val groupStart = idx
       val groupPriority = hooks(groupStart).getPriority()
       while (idx < limit && hooks(idx).getPriority() == groupPriority) {
-        hooks(idx).start()
+        hooks(idx).startInternal()
         idx += 1
       }
       for (i <- groupStart until limit) {

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -248,7 +248,10 @@ class Thread private[lang] (
     if (task != null) task.run()
   }
 
-  def start(): Unit = synchronized {
+  def start(): Unit = startInternal()
+
+  // Internal variant that does not trigger explicit need to enable multithreading
+  def startInternal(): Unit = synchronized {
     if (!isMultithreadingEnabled) UnsupportedFeature.threads()
     if (isVirtual())
       throw new UnsupportedOperationException(

--- a/javalib/src/main/scala/java/lang/ThreadBuilders.scala
+++ b/javalib/src/main/scala/java/lang/ThreadBuilders.scala
@@ -104,7 +104,7 @@ object ThreadBuilders {
 
     override def startInternal(task: Runnable): Thread = {
       val thread = unstarted(task)
-      thread.start()
+      thread.startInternal()
       thread
     }
 
@@ -133,7 +133,7 @@ object ThreadBuilders {
 
     override def startInternal(task: Runnable): Thread = {
       val thread = unstarted(task)
-      thread.start()
+      thread.startInternal()
       thread
     }
 

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -189,18 +189,12 @@ object Build {
         // format: off
         val jlRunnable = nir.Global.Top("java.lang.Runnable")
         val jlThread = nir.Global.Top("java.lang.Thread")
-        val jlMainThread = nir.Global.Top("java.lang.Thread$MainThread$")
-        val jlVirtualThread = nir.Global.Top("java.lang.VirtualThread")
         val jlThreadBuildersOfPlatform = nir.Global.Top("java.lang.ThreadBuilders$PlatformThreadBuilder")
         val jlThreadBuildersOfPlatformStart = jlThreadBuildersOfPlatform.member(nir.Sig.Method("start", Seq(jlRunnable, jlThread).map(nir.Type.Ref(_))))
+        val jlThreadStart = jlThread.member(nir.Sig.Method("start", Seq(nir.Type.Unit)))
         val usesSystemThreads = 
           analysis.infos.get(jlThreadBuildersOfPlatformStart).isDefined ||
-          analysis.infos.get(jlThread).collect{
-          case cls: linker.Class =>
-            cls.subclasses.size > 2 ||
-            cls.subclasses.map(_.name).diff(Set(jlMainThread, jlVirtualThread)).nonEmpty || 
-            cls.allocations > 4 // minimal number of allocations
-        }.getOrElse(false)
+          analysis.infos.get(jlThreadStart).isDefined
         // format: on
         if (!usesSystemThreads) {
           config.logger.info(


### PR DESCRIPTION
 Use internal variant of Thread.start to not trigger threading requirement