### PR TITLE
Fix #4209: implement j.l.ClassValue

### DIFF
--- a/javalib/src/main/scala/java/lang/ClassValue.scala
+++ b/javalib/src/main/scala/java/lang/ClassValue.scala
@@ -1,0 +1,34 @@
+// Ported from Scala.js commit: 5e9956b dated: 2024-11-18
+// Significantly modified for Scala Native Issue 4209
+
+package java.lang
+
+import java.util.Optional
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+
+abstract class ClassValue[T <: AnyRef] protected () {
+  private val cvMap: ConcurrentMap[Class[_], Optional[T]] =
+    new ConcurrentHashMap[Class[_], Optional[T]](64) // a guess > default 16
+
+  protected def computeValue(`type`: Class[_]): T
+
+  def get(`type`: Class[_]): T =
+    cvMap
+      .computeIfAbsent(`type`, (tpe) => Optional.ofNullable(computeValue(tpe)))
+      .orElse(null.asInstanceOf[T])
+
+  def remove(`type`: Class[_]): Unit =
+    cvMap.remove(`type`)
+}
+
+/* This companion object and, especially, its inner class are not documented
+ * in the JDK API for ClassValue. Rather they are an implementation detail.
+ *
+ * The Scala compiler used by Scala Native seems to depend on that detail.
+ * It tries and fails to resolve the inner class ClassValueMap.
+ * See Issue 4209 for a sample error log and a fuller discussion.
+ */
+
+object ClassValue {
+  class ClassValueMap {}
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ClassValueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ClassValueTest.scala
@@ -1,0 +1,67 @@
+// Ported from Scala.js commit: 3cc6db1 dated: 2020-10-28
+// Modified for Scala Native. Unit () is not an AnyRef.
+
+package org.scalanative.testsuite.javalib.lang
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.lang.ClassValue
+
+class ClassValueTest {
+  final val testVal = "Test Value"
+
+  @Test def testClassValue(): Unit = {
+    type T = AnyRef
+    val classValue = new ClassValue[T] {
+      private var counter: Int = 0
+
+      // null is the corner-case of Scala Native implementation
+      protected def computeValue(cls: Class[_]): T = {
+        counter += 1
+        cls match {
+          case Integer.TYPE           => testVal
+          case _ if cls.isPrimitive() => null.asInstanceOf[T]
+          case _                      => s"${cls.getName()} ${counter}"
+        }
+      }
+    }
+
+    assertEquals("java.lang.String 1", classValue.get(classOf[String]))
+    assertEquals("scala.Option 2", classValue.get(classOf[Option[_]]))
+    assertEquals("java.lang.String 1", classValue.get(classOf[String]))
+    assertEquals("scala.Option 2", classValue.get(classOf[Option[_]]))
+
+    assertEquals(null, classValue.get(classOf[Boolean])) // insert
+    assertEquals(
+      null,
+      classValue.get(classOf[Boolean])
+    ) // lookup, does not touch counter
+
+    assertEquals(testVal, classValue.get(classOf[Int])) // insert
+    assertEquals(
+      testVal,
+      classValue.get(classOf[Int])
+    ) // lookup, does not touch counter
+
+    // the counter was incremented exactly twice for the primitives
+    assertEquals(
+      "scala.collection.immutable.List 5",
+      classValue.get(classOf[List[_]])
+    )
+    assertEquals(
+      "scala.collection.immutable.List 5",
+      classValue.get(classOf[List[_]])
+    )
+
+    assertEquals("java.lang.String 1", classValue.get(classOf[String]))
+
+    classValue.remove(classOf[String])
+    assertEquals(
+      "scala.collection.immutable.List 5",
+      classValue.get(classOf[List[_]])
+    )
+    assertEquals("java.lang.String 6", classValue.get(classOf[String]))
+    assertEquals("java.lang.String 6", classValue.get(classOf[String]))
+  }
+}


### PR DESCRIPTION
Fix #4209 

Port javalib `java.lang.ClassValue` and its `ClassValueTest` from Scala.js, with thanks & appreciation.
Significantly modified both for Scala Native.