### PR TITLE
Fix missing space in printed exceptions

### DIFF
--- a/javalib/src/main/scala/java/lang/ThreadGroup.scala
+++ b/javalib/src/main/scala/java/lang/ThreadGroup.scala
@@ -222,7 +222,7 @@ class ThreadGroup(
         Thread.getDefaultUncaughtExceptionHandler() match {
           case null =>
             val threadName = "\"" + thread.getName() + "\""
-            System.err.print(s"Exception in thread $threadName")
+            System.err.print(s"Exception in thread $threadName ")
             throwable.printStackTrace(System.err)
           case handler =>
             Proxy.executeUncaughtExceptionHandler(handler, thread, throwable)


### PR DESCRIPTION
Should add a space after "main" in below snippet
```
user@laptop:~$ cat exception.scala 
@main
def main(): Unit = {
  throw new Exception("Error")
}

user@laptop:~$ scala-cli exception.scala 
<omitted>
Exception in thread "main" java.lang.Exception: Error
        at exception$package$.main(exception.scala:3)
        at main.main(exception.scala:1)
user@laptop:~$ scala-cli --native exception.scala 
<omitted>
Exception in thread "main"java.lang.Exception: Error
        at exception$package$.main(Unknown Source)
        at main.main(Unknown Source)
        at <none>.main(Unknown Source)
        at <none>.(Unknown Source)
        at <none>.__libc_start_main(Unknown Source)
        at <none>._start(Unknown Source)
```