### PR TITLE
Fix #4221: Make two java.net Socket tests more robust to use outside CI

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/DatagramSocketTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/DatagramSocketTest.scala
@@ -430,10 +430,38 @@ class DatagramSocketTest {
 
           val result =
             new DatagramPacket(Array.ofDim[Byte](bytes.length), bytes.length)
-          ds2.receive(result)
+          try {
+            ds2.receive(result)
 
-          val receivedData = new String(result.getData())
-          assertEquals("Received incorrect data", data, receivedData)
+            val receivedData = new String(result.getData())
+            assertEquals("Received incorrect data", data, receivedData)
+          } catch {
+            /* DatagramSockets use UDP transport, which is "send-and-pray".
+             *
+             * This Test is designed for the Scala Native Continuous
+             * Integration environment, where it passes.
+             *
+             * In other environments a timeout may be due to a number
+             * of causes. Some, not all, possibilities. It might be:
+             *
+             *   - Today is not the day for answered prayers.
+             *
+             *   - Today is just a slow day, packets would have been received
+             *     if the timeout was longer.
+             *
+             *   - This Test is validly detecting lost packets, say send
+             *     and receive addresses not matching up.
+             *
+             *   - A defect in this Test, attempting to send or receive
+             *     on an interface where wither or both are disabled.
+             *
+             *   - A firewall or other intermediate is routing the
+             *     sent packages to a black hole sink, so they never
+             *     arrive.
+             */
+            case ex: SocketTimeoutException =>
+              fail("receive timed out, check network & firewall configuration")
+          }
         } finally {
           ds1.close()
           ds2.close()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/DatagramSocketTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/DatagramSocketTest.scala
@@ -395,6 +395,26 @@ class DatagramSocketTest {
   }
 
   @Test def sendReceiveBroadcast(): Unit = {
+    /* Issue 4221
+     *   This Test should be run only in environments where:
+     *   1) It is responsible to broadcast packets to every node on net.
+     *   2) The network configuration, possible firewalls, and routers
+     *      allow broadcasting.
+     *
+     *   This is true in the Scala Native Continuous Integration environment
+     *   but may not be in more general work environments.
+     *
+     *   Network developers will need to bypass this check and run the
+     *   test manually.
+     */
+    assumeTrue(
+      "Advanced and/or CI-only test",
+      ju.Optional
+        .ofNullable(System.getenv("GITHUB_ACTIONS"))
+        .orElse("false")
+        .equalsIgnoreCase("true")
+    )
+
     // NetworkInterface.getNetworkInterfaces is not implemented in Windows
     assumeFalse("Not implemented in Windows", Platform.isWindows)
     assumeNotRoot()

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/SocketTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/net/SocketTest.scala
@@ -227,7 +227,8 @@ class SocketTest {
     try {
       assertThrows(
         classOf[SocketTimeoutException],
-        s.connect(new InetSocketAddress("123.123.123.123", 12341), 100)
+        // Use a document-only Internet address and very short timeout.
+        s.connect(new InetSocketAddress("203.0.113.1", 12341), 2)
       )
     } finally {
       s.close()


### PR DESCRIPTION

Fix #4221 

Modify  two `java.net` `SocketTest` and `DatagramSocketTest` Tests so that they
are more robust and/or informative when used outside the Scala Native
CI (Continuous Integration) environment. 

Network firewalls in particular,  especially highly restrictive firewalls, can
invalidate assumptions in the Test suite about the network environment.

This an instance of the overall discussion of the proper balance 
between the sensitivity and generality of Tests: [ROC curve](https://en.wikipedia.org/wiki/Receiver_operating_characteristic).