### PR TITLE
Implement java.util.Objects methods up to JDK 19, inclusive

### DIFF
--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -2,10 +2,14 @@
  * Ported from Scala.js
  *   commit SHA1: 558e8a0
  *   dated: 2020-10-20
+ *
+ * Contains additions for Scala Native. See GitHub history.
+ * Current to JDK 23.
  */
 
 package java.util
 
+import java.{lang => jl}
 import java.util.function.Supplier
 
 object Objects {
@@ -93,7 +97,7 @@ object Objects {
   def checkFromIndexSize(fromIndex: Int, size: Int, length: Int): Int = {
     if ((length | fromIndex | size) < 0 || size > length - fromIndex) {
       throw new IndexOutOfBoundsException(
-        s"Range [$fromIndex, $fromIndex + $size] out of bounds for length $length"
+        s"Range [$fromIndex, $fromIndex + $size) out of bounds for length $length"
       )
     }
     fromIndex
@@ -103,9 +107,78 @@ object Objects {
   def checkFromIndexSize(fromIndex: Long, size: Long, length: Long): Long = {
     if ((length | fromIndex | size) < 0L || size > length - fromIndex) {
       throw new IndexOutOfBoundsException(
-        s"Range [$fromIndex, $fromIndex + $size] out of bounds for length $length"
+        s"Range [$fromIndex, $fromIndex + $size) out of bounds for length $length"
       )
     }
     fromIndex
+  }
+
+  /** since JDK9 */
+  def checkFromToIndex(fromIndex: Int, toIndex: Int, length: Int): Int = {
+    if ((fromIndex < 0) || (fromIndex > toIndex) || (toIndex > length)) {
+      throw new IndexOutOfBoundsException(
+        s"Range [$fromIndex, $toIndex) out of bounds for length $length"
+      )
+    }
+
+    fromIndex
+  }
+
+  /** since JDK16 */
+  def checkFromToIndex(fromIndex: Long, toIndex: Long, length: Long): Long = {
+    if ((fromIndex < 0L) || (fromIndex > toIndex) || (toIndex > length)) {
+      throw new IndexOutOfBoundsException(
+        s"Range [$fromIndex, $toIndex) out of bounds for length $length"
+      )
+    }
+
+    fromIndex
+  }
+
+  /** since JDK9 */
+  def checkIndex(index: Int, length: Int): Int = {
+    if ((index < 0) || (index >= length)) {
+      throw new IndexOutOfBoundsException(
+        s"Index $index out of bounds for length $length"
+      )
+    }
+
+    index
+  }
+
+  /** since JDK16 */
+  def checkIndex(index: Long, length: Long): Long = {
+    if ((index < 0L) || (index >= length)) {
+      throw new IndexOutOfBoundsException(
+        s"Index $index out of bounds for length $length"
+      )
+    }
+
+    index
+  }
+
+  /** since JDK9 */
+  def requireNonNullElse[T](obj: T, defaultObj: T): T = {
+    if (obj != null) obj
+    else Objects.requireNonNull[T](defaultObj, "defaultObj")
+  }
+
+  /** since JDK9 */
+  def requireNonNullElseGet[T](obj: T, supplier: Supplier[_ <: T]): T = {
+    if (obj != null) obj
+    else {
+      Objects.requireNonNull(supplier, "supplier")
+      Objects.requireNonNull(supplier.get(), "supplier.get()")
+    }
+  }
+
+  /** since JDK19 */
+  def toIdentityString(o: Object): String = {
+    Objects.requireNonNull(o)
+
+    new jl.StringBuilder(o.getClass().getName())
+      .append('@')
+      .append(Integer.toHexString(System.identityHashCode(o)))
+      .toString()
   }
 }

--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -93,7 +93,8 @@ object Objects {
    *  @throws java.lang.IndexOutOfBoundsException
    *    if not in subrange
    *
-   *  @since JDK9
+   *  @since JDK
+   *    9
    */
   def checkFromIndexSize(fromIndex: Int, size: Int, length: Int): Int = {
     if ((length | fromIndex | size) < 0 || size > length - fromIndex) {
@@ -104,7 +105,7 @@ object Objects {
     fromIndex
   }
 
-  /** @since JDK16 */
+  /** @since JDK 16 */
   def checkFromIndexSize(fromIndex: Long, size: Long, length: Long): Long = {
     if ((length | fromIndex | size) < 0L || size > length - fromIndex) {
       throw new IndexOutOfBoundsException(
@@ -114,7 +115,7 @@ object Objects {
     fromIndex
   }
 
-  /** @since JDK9 */
+  /** @since JDK 9 */
   def checkFromToIndex(fromIndex: Int, toIndex: Int, length: Int): Int = {
     if ((fromIndex < 0) || (fromIndex > toIndex) || (toIndex > length)) {
       throw new IndexOutOfBoundsException(
@@ -125,7 +126,7 @@ object Objects {
     fromIndex
   }
 
-  /** @since JDK16 */
+  /** @since JDK 16 */
   def checkFromToIndex(fromIndex: Long, toIndex: Long, length: Long): Long = {
     if ((fromIndex < 0L) || (fromIndex > toIndex) || (toIndex > length)) {
       throw new IndexOutOfBoundsException(
@@ -136,7 +137,7 @@ object Objects {
     fromIndex
   }
 
-  /** @since JDK9 */
+  /** @since JDK 9 */
   def checkIndex(index: Int, length: Int): Int = {
     if ((index < 0) || (index >= length)) {
       throw new IndexOutOfBoundsException(
@@ -147,7 +148,7 @@ object Objects {
     index
   }
 
-  /** @since JDK16 */
+  /** @since JDK 16 */
   def checkIndex(index: Long, length: Long): Long = {
     if ((index < 0L) || (index >= length)) {
       throw new IndexOutOfBoundsException(
@@ -158,13 +159,13 @@ object Objects {
     index
   }
 
-  /** @since JDK9 */
+  /** @since JDK 9 */
   def requireNonNullElse[T](obj: T, defaultObj: T): T = {
     if (obj != null) obj
     else Objects.requireNonNull[T](defaultObj, "defaultObj")
   }
 
-  /** @since JDK9 */
+  /** @since JDK 9 */
   def requireNonNullElseGet[T](obj: T, supplier: Supplier[_ <: T]): T = {
     if (obj != null) obj
     else {
@@ -173,7 +174,7 @@ object Objects {
     }
   }
 
-  /** @since JDK19 */
+  /** @since JDK 19 */
   def toIdentityString(o: Object): String = {
     Objects.requireNonNull(o)
 

--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -85,7 +85,6 @@ object Objects {
     if (obj == null) throw new NullPointerException(messageSupplier.get())
     else obj
 
-  // since JDK9
   /** Checks if subrange <fromIndex, {fromIndex+size}) is withing the bounds of
    *  range <0, length)
    *
@@ -93,6 +92,8 @@ object Objects {
    *    fromIndex argument
    *  @throws java.lang.IndexOutOfBoundsException
    *    if not in subrange
+   *
+   *  @since JDK9
    */
   def checkFromIndexSize(fromIndex: Int, size: Int, length: Int): Int = {
     if ((length | fromIndex | size) < 0 || size > length - fromIndex) {
@@ -103,7 +104,7 @@ object Objects {
     fromIndex
   }
 
-  // since JDK16
+  /** @since JDK16 */
   def checkFromIndexSize(fromIndex: Long, size: Long, length: Long): Long = {
     if ((length | fromIndex | size) < 0L || size > length - fromIndex) {
       throw new IndexOutOfBoundsException(
@@ -113,7 +114,7 @@ object Objects {
     fromIndex
   }
 
-  /** since JDK9 */
+  /** @since JDK9 */
   def checkFromToIndex(fromIndex: Int, toIndex: Int, length: Int): Int = {
     if ((fromIndex < 0) || (fromIndex > toIndex) || (toIndex > length)) {
       throw new IndexOutOfBoundsException(
@@ -124,7 +125,7 @@ object Objects {
     fromIndex
   }
 
-  /** since JDK16 */
+  /** @since JDK16 */
   def checkFromToIndex(fromIndex: Long, toIndex: Long, length: Long): Long = {
     if ((fromIndex < 0L) || (fromIndex > toIndex) || (toIndex > length)) {
       throw new IndexOutOfBoundsException(
@@ -135,7 +136,7 @@ object Objects {
     fromIndex
   }
 
-  /** since JDK9 */
+  /** @since JDK9 */
   def checkIndex(index: Int, length: Int): Int = {
     if ((index < 0) || (index >= length)) {
       throw new IndexOutOfBoundsException(
@@ -146,7 +147,7 @@ object Objects {
     index
   }
 
-  /** since JDK16 */
+  /** @since JDK16 */
   def checkIndex(index: Long, length: Long): Long = {
     if ((index < 0L) || (index >= length)) {
       throw new IndexOutOfBoundsException(
@@ -157,13 +158,13 @@ object Objects {
     index
   }
 
-  /** since JDK9 */
+  /** @since JDK9 */
   def requireNonNullElse[T](obj: T, defaultObj: T): T = {
     if (obj != null) obj
     else Objects.requireNonNull[T](defaultObj, "defaultObj")
   }
 
-  /** since JDK9 */
+  /** @since JDK9 */
   def requireNonNullElseGet[T](obj: T, supplier: Supplier[_ <: T]): T = {
     if (obj != null) obj
     else {
@@ -172,7 +173,7 @@ object Objects {
     }
   }
 
-  /** since JDK19 */
+  /** @since JDK19 */
   def toIdentityString(o: Object): String = {
     Objects.requireNonNull(o)
 

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/ObjectsTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/ObjectsTestOnJDK16.scala
@@ -1,0 +1,106 @@
+package org.scalanative.testsuite.javalib.util
+
+import java.{lang => jl}
+import java.{util => ju}
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ObjectsTestOnJDK16 {
+
+  @Test def testCheckFromIndexSizeLong(): Unit = {
+
+    assertThrows(
+      "fromIndex < 0",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromIndexSize(-1L, 2L, 3L)
+    )
+
+    assertThrows(
+      "size < 0",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromIndexSize(1L, -1L, jl.Long.MAX_VALUE - 1)
+    )
+
+    assertThrows(
+      "fromIndex + size > length",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromIndexSize(
+        jl.Integer.MAX_VALUE + 2L,
+        5L,
+        jl.Integer.MAX_VALUE + 1L
+      )
+    )
+
+    val expected = jl.Integer.MAX_VALUE + 1L
+    assertEquals(
+      "invalid return value",
+      expected,
+      ju.Objects.checkFromIndexSize(expected, 5L, expected + 6L)
+    )
+  }
+
+  @Test def testCheckFromToIndexLong(): Unit = {
+    assertThrows(
+      "fromIndex < 0",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromToIndex(-1L, 2L, 3L)
+    )
+
+    assertThrows(
+      "fromIndex > toIndex",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromToIndex(
+        jl.Integer.MAX_VALUE + 5L,
+        jl.Integer.MAX_VALUE + 1L,
+        3L
+      )
+    )
+
+    assertThrows(
+      "toIndex > length",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromToIndex(2, 4, 3)
+    )
+
+    assertThrows(
+      "toIndex > length",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromToIndex(
+        jl.Integer.MAX_VALUE + 2L,
+        jl.Integer.MAX_VALUE + 4L,
+        3L
+      )
+    )
+
+    val expected = jl.Integer.MAX_VALUE + 2L
+    assertEquals(
+      "invalid return value",
+      expected,
+      ju.Objects.checkFromToIndex(expected, expected + 4L, expected + 6L)
+    )
+  }
+
+  @Test def testCheckIndexLong(): Unit = {
+    assertThrows(
+      "index < 0",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkIndex(-1L, 2L)
+    )
+
+    assertThrows(
+      "index >= length",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkIndex(jl.Integer.MAX_VALUE + 2, jl.Integer.MAX_VALUE + 2)
+    )
+
+    val expected = jl.Integer.MAX_VALUE + 4L
+    assertEquals(
+      "invalid return value",
+      expected,
+      ju.Objects.checkIndex(expected, expected + 1L)
+    )
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/util/ObjectsTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/util/ObjectsTestOnJDK19.scala
@@ -1,0 +1,34 @@
+package org.scalanative.testsuite.javalib.util
+
+import java.{lang => jl}
+import java.{util => ju}
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ObjectsTestOnJDK19 {
+
+  @Test def testToIdendityString(): Unit = {
+
+    assertThrows(
+      "null arg",
+      classOf[NullPointerException],
+      ju.Objects.toIdentityString(null.asInstanceOf[String])
+    )
+
+    val src = "Mut"
+
+    val expected = new jl.StringBuilder(src.getClass().getName())
+      .append('@')
+      .append(Integer.toHexString(System.identityHashCode(src)))
+      .toString()
+
+    assertEquals(
+      "invalid return value",
+      expected,
+      ju.Objects.toIdentityString(src)
+    )
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/ObjectsTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/ObjectsTestOnJDK9.scala
@@ -1,0 +1,149 @@
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ObjectsTestOnJDK9 {
+
+  @Test def testCheckFromIndexSizeInt(): Unit = {
+    assertThrows(
+      "fromIndex < 0",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromIndexSize(-1, 2, 3)
+    )
+
+    assertThrows(
+      "size < 0",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromIndexSize(1, -1, 4)
+    )
+
+    assertThrows(
+      "fromIndex + size > length",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromIndexSize(1, 5, 5)
+    )
+
+    val expected = 1
+    assertEquals(
+      "invalid return value",
+      expected,
+      ju.Objects.checkFromIndexSize(expected, 5, 6)
+    )
+  }
+
+  @Test def testCheckFromToIndexInt(): Unit = {
+
+    assertThrows(
+      "fromIndex < 0",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromToIndex(-1, 2, 3)
+    )
+
+    assertThrows(
+      "fromIndex > toIndex",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromToIndex(2, 1, 3)
+    )
+
+    assertThrows(
+      "toIndex > length",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkFromToIndex(2, 4, 3)
+    )
+
+    val expected = 2
+    assertEquals(
+      "invalid return value",
+      expected,
+      ju.Objects.checkFromToIndex(expected, 4, 5)
+    )
+  }
+
+  @Test def testCheckIndexInt(): Unit = {
+
+    assertThrows(
+      "index < 0",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkIndex(-1, 2)
+    )
+
+    assertThrows(
+      "index >= length",
+      classOf[IndexOutOfBoundsException],
+      ju.Objects.checkIndex(2, 2)
+    )
+
+    val expected = 4
+    assertEquals(
+      "invalid return value",
+      expected,
+      ju.Objects.checkIndex(expected, 5)
+    )
+  }
+
+  @Test def testRequireNonNullElse(): Unit = {
+    val obj = "obj"
+    val defaultObj = "defaultObj"
+
+    assertThrows(
+      "both args null",
+      classOf[NullPointerException],
+      ju.Objects.requireNonNullElse(null, null)
+    )
+
+    assertEquals(
+      "expect obj",
+      obj,
+      ju.Objects.requireNonNullElse(obj, null)
+    )
+
+    assertEquals(
+      "expect defaultObj",
+      defaultObj,
+      ju.Objects.requireNonNullElse(null, defaultObj)
+    )
+  }
+
+  @Test def testRequireNonNullElseGet(): Unit = {
+
+    val message = "This too shall pass"
+
+    val supplierOfMessage = new ju.function.Supplier[String] {
+      def get(): String = message
+    }
+
+    val supplierOfNulls = new ju.function.Supplier[String] {
+      def get(): String = null
+    }
+
+    assertThrows(
+      "both args null",
+      classOf[NullPointerException],
+      ju.Objects.requireNonNullElseGet(null, null)
+    )
+
+    assertThrows(
+      "supplierOfNulls",
+      classOf[NullPointerException],
+      ju.Objects.requireNonNullElseGet(null, supplierOfNulls)
+    )
+
+    val expected = "Amenirdis"
+    assertEquals(
+      "expect obj",
+      expected,
+      ju.Objects.requireNonNullElseGet(expected, null)
+    )
+
+    assertEquals(
+      "test supplierOfMessage",
+      message,
+      ju.Objects.requireNonNullElseGet(null, supplierOfMessage)
+    )
+  }
+}


### PR DESCRIPTION
Implement `java.util.Objects` methods added in JDK 9, JDK 16, and JDK 19 and associated tests.
Any methods still missing are unintentional and a defect.

These changes align javalib `Objects` with JDK 23, since no new methods were added >19 & <= 23.

Also corrected/updated some error message string to follow JDK practice of indicating  semi-closed ranges 
 `java.lang.IndexOutOfBoundsException: Range [-1, 2) out of bounds for length 3`.

The additions in this PR include several particularly useful index and bounds checking methods.
A Single Point of Truth to get checking and resultant message text correct & consistent.