### PR TITLE
java CharSequenceTestOnJDK15 now explicitly tests against Java StringBuilder

### DIFF
--- a/unit-tests/shared/src/test/require-jdk15/org/scalanative/testsuite/javalib/lang/CharSequenceTestOnJDK15.scala
+++ b/unit-tests/shared/src/test/require-jdk15/org/scalanative/testsuite/javalib/lang/CharSequenceTestOnJDK15.scala
@@ -1,5 +1,6 @@
 package org.scalanative.testsuite.javalib.lang
 
+import java.{lang => jl}
 import java.nio.CharBuffer
 
 import org.junit.Test
@@ -45,7 +46,7 @@ class CharSequenceTestOnJDK15 {
 
   @Test def isEmptyStringBuilder(): Unit = {
     // check method inherited from CharSequence
-    val sb = new StringBuilder(64)
+    val sb = new jl.StringBuilder(64)
 
     assertTrue("empty StringBuilder", sb.isEmpty())
 


### PR DESCRIPTION
javalib unit-test `CharSequenceTestOnJDK15` was introduced in PR #4230 with the intent of 
testing the `isEmpty` method against a `java.lang.StringBuilder`, not a similar Scala StringBuilder.

In some hard to replicate cases, it appears that the latter would be used and cause the
compiler to fail, complaining that parentheses were not necessary. The Java declarations
explicitly specify the parentheses.  

The Test has been corrected to specify the `java.lang.StringBuilder`.
