### PR TITLE
Implement compliant but minimal JDK 9 Process & ProcessHandle changes.

### DIFF
--- a/javalib/src/main/scala/java/lang/Process.scala
+++ b/javalib/src/main/scala/java/lang/Process.scala
@@ -1,12 +1,23 @@
 package java.lang
 
 import java.io.{InputStream, OutputStream}
+import java.util.Optional
 import java.util.concurrent.TimeUnit
+import java.util.stream.Stream
 
 abstract class Process {
+
+  /** @since JDK 9 */
+  def children(): Stream[ProcessHandle] =
+    toHandle().children()
+
+  /** @since JDK 9 */
+  def descendants(): Stream[ProcessHandle] =
+    toHandle().descendants()
+
   def destroy(): Unit
 
-  def destroyForcibly(): Process
+  def destroyForcibly(): Process // See SN Issue 4233, should be concrete.
 
   def exitValue(): Int
 
@@ -16,7 +27,30 @@ abstract class Process {
 
   def getOutputStream(): OutputStream
 
+  /** @since JDK 9 */
+  def info(): ProcessHandle.Info =
+    toHandle().info()
+
   def isAlive(): scala.Boolean
+
+  // Since: JDK 9
+  // Not yet implemented - a good candidate for one of Herakles' 12 labors.
+  // import java.util.concurrent.CompletableFuture
+  // def onExit(): CompletableFuture[ProcessHandle]
+
+  /** @since JDK 9 */
+  def pid(): scala.Long =
+    toHandle().pid()
+
+  /** @since JDK 9 */
+  def supportsNormalTermination(): scala.Boolean =
+    throw new UnsupportedOperationException(
+      "Process.supportsNormalTermination()"
+    )
+
+  /** @since JDK 9 */
+  def toHandle(): ProcessHandle =
+    throw new UnsupportedOperationException("Process.toHandle()")
 
   def waitFor(): Int
 

--- a/javalib/src/main/scala/java/lang/ProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/ProcessHandle.scala
@@ -1,0 +1,65 @@
+package java.lang
+
+import java.time.{Duration, Instant}
+
+import java.util.Optional
+import java.util.concurrent.CompletableFuture
+import java.util.stream.Stream
+
+trait ProcessHandle {
+
+  def children(): Stream[ProcessHandle]
+
+  def compareTo(other: ProcessHandle): scala.Int
+
+  def descendants(): Stream[ProcessHandle]
+
+  def destroy(): scala.Boolean
+
+  def destroyForcibly(): scala.Boolean
+
+  override def equals(other: Any): scala.Boolean
+
+  override def hashCode(): scala.Int
+
+  def info(): ProcessHandle.Info =
+    throw new UnsupportedOperationException("ProcessHandle.info()")
+
+  def isAlive(): scala.Boolean
+
+  def onExit(): CompletableFuture[ProcessHandle]
+
+  def parent(): Optional[ProcessHandle]
+
+  def pid(): scala.Long =
+    throw new UnsupportedOperationException("ProcessHandle.pid()")
+
+  def supportsNormalTermination(): scala.Boolean
+}
+
+object ProcessHandle {
+
+  trait Info {
+    def arguments(): Optional[String]
+
+    def command(): Optional[String]
+
+    def commandLine(): Optional[String]
+
+    def startInstant(): Optional[Instant]
+
+    def totalCpuDuration(): Optional[Duration]
+
+    def user(): Optional[String]
+
+  }
+
+  def allProcesses(): Stream[ProcessHandle] =
+    throw new UnsupportedOperationException("ProcessHandle.allProcesses()")
+
+  def current(): Stream[ProcessHandle] =
+    throw new UnsupportedOperationException("ProcessHandle.current()")
+
+  def of(pid: scala.Long): Optional[ProcessHandle] =
+    throw new UnsupportedOperationException("ProcessHandle.of()")
+}

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -33,7 +33,7 @@ private[lang] class WindowsProcess private (
     outHandle: FileDescriptor,
     errHandle: FileDescriptor
 ) extends GenericProcess {
-  private val pid = GetProcessId(handle)
+  private val winPid = GetProcessId(handle)
   private var cachedExitValue: Option[scala.Int] = None
 
   override def destroy(): Unit = if (isAlive()) {
@@ -49,7 +49,7 @@ private[lang] class WindowsProcess private (
     checkExitValue
       .getOrElse(
         throw new IllegalThreadStateException(
-          s"Process $pid has not exited yet"
+          s"Process $winPid has not exited yet"
         )
       )
   }
@@ -63,7 +63,7 @@ private[lang] class WindowsProcess private (
   override def isAlive(): scala.Boolean = checkExitValue.isEmpty
 
   override def toString = {
-    s"Process[pid=$pid, exitValue=${checkExitValue.getOrElse("\"not exited\"")}"
+    s"Process[pid=$winPid, exitValue=${checkExitValue.getOrElse("\"not exited\"")}"
   }
 
   override def waitFor(): scala.Int = synchronized {

--- a/unit-tests/shared/src/test/require-jdk15/org/scalanative/testsuite/javalib/lang/CharSequenceTestOnJDK15.scala
+++ b/unit-tests/shared/src/test/require-jdk15/org/scalanative/testsuite/javalib/lang/CharSequenceTestOnJDK15.scala
@@ -1,5 +1,6 @@
 package org.scalanative.testsuite.javalib.lang
 
+import java.{lang => jl}
 import java.nio.CharBuffer
 
 import org.junit.Test
@@ -45,7 +46,7 @@ class CharSequenceTestOnJDK15 {
 
   @Test def isEmptyStringBuilder(): Unit = {
     // check method inherited from CharSequence
-    val sb = new StringBuilder(64)
+    val sb = new jl.StringBuilder(64)
 
     assertTrue("empty StringBuilder", sb.isEmpty())
 


### PR DESCRIPTION
Fix #4231 

Java 9 introduced  `java.lang.ProcessHandle` and related changes to  `Process` to use it.

This PR implements most of the introduced methods, with the noticeable exception of
`Process``def onExit(): CompletableFuture[ProcessHandle]`.  

The Java 9 description of "factory" methods states that they may throw `UnsupportedOperationException`.
This implementation throws that exception for all of the factory methods described.  This makes
the implementation compliant with the letter of the specification, but of limited utility in the Real World.

A future evolution can provide a more useful implementation, given this façade.
