### PR TITLE
Port JDK 1-dot-1 java.io CharArrayReader & CharArrayWriter from Scala.js

### DIFF
--- a/javalib/src/main/scala/java/io/CharArrayReader.scala
+++ b/javalib/src/main/scala/java/io/CharArrayReader.scala
@@ -1,0 +1,89 @@
+// Ported from Scala.js, commit: c473689, dated 2021-05-06
+
+package java.io
+
+class CharArrayReader(protected var buf: Array[Char], offset: Int, length: Int)
+    extends Reader {
+  if (offset < 0 || offset > buf.length || length < 0 || offset + length < 0)
+    throw new IllegalArgumentException
+
+  protected var pos: Int = offset
+  protected var markedPos: Int = offset
+
+  // count is actually the "end" index
+  protected var count: Int = Math.min(offset + length, buf.length)
+
+  def this(buf: Array[Char]) = this(buf, 0, buf.length)
+
+  override def close(): Unit = this.buf = null
+
+  override def mark(readAheadLimit: Int): Unit = {
+    ensureOpen()
+
+    // The parameter readAheadLimit is ignored for CharArrayReaders
+    this.markedPos = this.pos
+  }
+
+  override def markSupported(): Boolean = true
+
+  override def read(): Int = {
+    ensureOpen()
+
+    if (this.pos == this.count) {
+      -1
+    } else {
+      this.pos += 1
+      buf(this.pos - 1)
+    }
+  }
+
+  override def read(buffer: Array[Char], offset: Int, len: Int): Int = {
+    if (offset < 0 || offset > buffer.length)
+      throw new ArrayIndexOutOfBoundsException(
+        "Offset out of bounds : " + offset
+      )
+
+    if (len < 0 || len > buffer.length - offset)
+      throw new ArrayIndexOutOfBoundsException("Length out of bounds : " + len)
+
+    ensureOpen()
+
+    if (this.pos < this.count) {
+      val bytesRead = Math.min(len, this.count - this.pos)
+      System.arraycopy(this.buf, this.pos, buffer, offset, bytesRead)
+      this.pos += bytesRead
+      bytesRead
+    } else {
+      -1
+    }
+  }
+
+  override def ready(): Boolean = {
+    ensureOpen()
+
+    /* JDK spec says "Character-array readers are always ready to be read."
+     * However, testing shows it returns false when pos == count
+     */
+    this.pos != this.count
+  }
+
+  override def reset(): Unit = {
+    ensureOpen()
+
+    this.pos = this.markedPos
+  }
+
+  override def skip(n: Long): Long = {
+    ensureOpen()
+
+    val available: Long = (this.count - this.pos).toLong
+    val skipped: Long = Math.max(0L, Math.min(n, available))
+    this.pos += skipped.toInt
+    skipped
+  }
+
+  private def ensureOpen(): Unit = {
+    if (this.buf == null)
+      throw new IOException("CharArrayReader is closed.")
+  }
+}

--- a/javalib/src/main/scala/java/io/CharArrayWriter.scala
+++ b/javalib/src/main/scala/java/io/CharArrayWriter.scala
@@ -1,0 +1,86 @@
+// Ported from Scala.js, commit: 4abf96a, dated 2020-09-09
+
+package java.io
+
+class CharArrayWriter(initialSize: Int) extends Writer {
+  if (initialSize < 0)
+    throw new IllegalArgumentException("size must be >= 0")
+
+  protected var buf: Array[Char] = new Array[Char](initialSize)
+  protected var count: Int = 0
+
+  def this() = this(32)
+
+  override def close(): Unit = ()
+
+  private def ensureCapacity(i: Int): Unit = {
+    if (i > this.buf.length - this.count) {
+      val newLen = Math.max(2 * this.buf.length, this.count + i)
+      // If newLen is negative due to (integer) overflow, copyOf will throw.
+      this.buf = java.util.Arrays.copyOf(this.buf, newLen)
+    }
+  }
+
+  override def flush(): Unit = ()
+
+  def reset(): Unit = this.count = 0
+
+  def size(): Int = this.count
+
+  def toCharArray(): Array[Char] = java.util.Arrays.copyOf(buf, count)
+
+  override def toString(): String = new String(this.buf, 0, this.count)
+
+  override def write(c: Array[Char], offset: Int, len: Int): Unit = {
+    if (offset < 0 || offset > c.length || len < 0 || len > c.length - offset)
+      throw new IndexOutOfBoundsException
+
+    ensureCapacity(len)
+    System.arraycopy(c, offset, this.buf, this.count, len)
+    this.count += len
+  }
+
+  override def write(oneChar: Int): Unit = {
+    ensureCapacity(1)
+    this.buf(this.count) = oneChar.toChar
+    this.count += 1
+  }
+
+  override def write(str: String, offset: Int, len: Int): Unit = {
+    if (offset < 0 || offset > str.length || len < 0 || len > str.length - offset)
+      throw new StringIndexOutOfBoundsException
+
+    ensureCapacity(len)
+    str.getChars(offset, offset + len, this.buf, this.count)
+    this.count += len
+  }
+
+  def writeTo(out: Writer): Unit = out.write(this.buf, 0, count)
+
+  override def append(c: Char): CharArrayWriter = {
+    write(c)
+    this
+  }
+
+  override def append(csq: CharSequence): CharArrayWriter = {
+    if (csq == null)
+      write("null")
+    else
+      write(csq.toString())
+
+    this
+  }
+
+  override def append(
+      csq: CharSequence,
+      start: Int,
+      end: Int
+  ): CharArrayWriter = {
+    if (csq == null)
+      write("null", start, end)
+    else
+      write(csq.subSequence(start, end).toString())
+
+    this
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/CharArrayReaderTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/CharArrayReaderTest.scala
@@ -1,0 +1,182 @@
+// Ported from Scala.js, commit: c473689, dated 2021-05-06
+
+package org.scalanative.testsuite.javalib.io
+
+import java.io._
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class CharArrayReaderTest {
+  private val hw: Array[Char] =
+    Array('H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd')
+
+  private def withClose[T <: AutoCloseable](
+      closeable: T
+  )(fn: T => Unit): Unit = {
+    fn(closeable)
+
+    if (closeable != null)
+      closeable.close()
+  }
+
+  @Test def ctorCharArray(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      assertTrue("Failed to create reader", cr.ready())
+    }
+  }
+
+  @Test def ctorCharArrayWithOffsetAndLength(): Unit = {
+    // CharArrayReader for "Worl"
+    withClose(new CharArrayReader(hw, 5, 4)) { cr =>
+      assertTrue("Failed to create reader", cr.ready())
+      val c = new Array[Char](10)
+      // Doesn't read past length & starts at offset
+      val bytesRead: Int = cr.read(c, 0, 10)
+      assertEquals(4, bytesRead)
+      assertArrayEquals(
+        "Worl".toCharArray,
+        java.util.Arrays.copyOf(c, bytesRead)
+      )
+      assertEquals(-1, cr.read())
+      assertFalse(cr.ready())
+    }
+  }
+
+  @Test def ctorCharArrayWithOffsetAndLargerLength(): Unit = {
+    // CharArrayReader for "World"
+    withClose(new CharArrayReader(hw, 5, 100)) { cr =>
+      assertTrue("Failed to create reader", cr.ready())
+      val c = new Array[Char](100)
+      // Doesn't read past buffer length
+      val bytesRead: Int = cr.read(c, 0, 100)
+      assertEquals(5, bytesRead)
+      assertArrayEquals(
+        "World".toCharArray,
+        java.util.Arrays.copyOf(c, bytesRead)
+      )
+      assertEquals(-1, cr.read())
+      assertFalse(cr.ready())
+    }
+  }
+
+  @Test def readThrowsIOExceptionAfterClose(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      cr.close()
+      assertThrows(classOf[IOException], cr.read())
+    }
+  }
+
+  @Test def markSupported(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      assertTrue("markSupported returned false", cr.markSupported)
+    }
+  }
+
+  @Test def readChar(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      assertEquals("Read returned incorrect char", 'H', cr.read())
+    }
+
+    withClose(new CharArrayReader(Array[Char]('\u8765'))) { cr =>
+      assertEquals("Incorrect double byte char", '\u8765', cr.read())
+    }
+  }
+
+  @Test def readCharArray(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      val c = new Array[Char](11)
+      cr.read(c, 1, 10)
+      assertArrayEquals(Array(0.toChar) ++ hw, c)
+    }
+  }
+
+  @Test def readyThrowsIOException(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      assertTrue("ready returned false", cr.ready())
+      cr.skip(1000L)
+      assertTrue("ready returned true", !cr.ready())
+      cr.close()
+
+      assertThrows(classOf[IOException], cr.ready())
+    }
+
+    withClose(new CharArrayReader(hw)) { cr =>
+      cr.close()
+      assertThrows(classOf[IOException], cr.ready())
+    }
+  }
+
+  @Test def resetAfterMark(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      cr.skip(5L)
+      // Mark current position
+      cr.mark(100)
+      assertEquals("Reset failed to return to marker position", 'W', cr.read())
+      // Reset back  to 'W'
+      cr.reset()
+      assertEquals("Reset failed to return to marker position", 'W', cr.read())
+    }
+  }
+
+  @Test def markLimitMinusOneIgnored(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      cr.skip(5L)
+      // Mark current position
+      cr.mark(-1)
+      val c = new Array[Char](5)
+      cr.read(c, 0, 5)
+      assertArrayEquals(
+        "Mark read limit should be ignored",
+        "World".toCharArray,
+        c
+      )
+
+      // Reset back  to 'W'
+      cr.reset()
+      assertEquals("Reset failed to return to marker position", 'W', cr.read())
+    }
+  }
+
+  @Test def skipNegative(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      assertEquals("Negative skip values should return zero", 0, cr.skip(-1L))
+    }
+  }
+
+  @Test def skipZero(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      assertEquals("Zero skip value should return zero", 0, cr.skip(0L))
+    }
+  }
+
+  @Test def skipReturnsArraySizeWhenGreater(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      assertEquals("Skip didn't return array size", 10L, cr.skip(1000L))
+    }
+  }
+
+  @Test def resetFromOffsetReader(): Unit = {
+    val data = "offsetHello world!".toCharArray
+    val offsetLength = 6
+    val length = data.length - offsetLength
+
+    withClose(new CharArrayReader(data, offsetLength, length)) { cr =>
+      cr.reset()
+      for (i <- 0 until length) {
+        assertEquals(data(offsetLength + i), cr.read().toChar)
+      }
+      // Verify EOF
+      assertEquals(-1, cr.read())
+    }
+  }
+
+  @Test def skip(): Unit = {
+    withClose(new CharArrayReader(hw)) { cr =>
+      val skipped = cr.skip(5L)
+      assertEquals("Failed to skip correct number of chars", 5L, skipped)
+      assertEquals("Skip skipped wrong chars", 'W', cr.read())
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/CharArrayWriterTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/CharArrayWriterTest.scala
@@ -1,0 +1,158 @@
+// Ported from Scala.js, commit: c473689, dated 2021-05-06
+
+package org.scalanative.testsuite.javalib.io
+
+import java.io.{CharArrayWriter, StringWriter}
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class CharArrayWriterTest {
+  private val hw: Array[Char] =
+    Array('H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd')
+
+  private def withClose[T <: AutoCloseable](
+      closeable: T
+  )(fn: T => Unit): Unit = {
+    fn(closeable)
+
+    if (closeable != null)
+      closeable.close()
+  }
+
+  @Test def ctorSize: Unit = {
+    withClose(new CharArrayWriter(90)) { cw =>
+      assertEquals(0, cw.size)
+    }
+  }
+
+  @Test def ctorSizeNegativeThrows(): Unit = {
+    assertThrows(classOf[IllegalArgumentException], new CharArrayWriter(-1))
+  }
+
+  @Test def ctorSizeDefault(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      assertEquals(0, cw.size)
+    }
+  }
+
+  @Test def close(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.close()
+      cw.close() // no-op
+      assertEquals(0, cw.size)
+    }
+  }
+
+  @Test def flush(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.flush()
+    }
+  }
+
+  @Test def reset(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.write("HelloWorld", 5, 5)
+      cw.reset()
+      cw.write("HelloWorld", 0, 5)
+
+      assertArrayEquals("Hello".toCharArray, cw.toCharArray)
+    }
+  }
+
+  @Test def size(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      assertEquals(0, cw.size)
+      cw.write(hw, 5, 5)
+      assertEquals(5, cw.size)
+    }
+  }
+
+  @Test def toCharArray(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.write("HelloWorld", 0, 10)
+      assertArrayEquals("HelloWorld".toCharArray, cw.toCharArray)
+    }
+  }
+
+  @Test def testToString(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.write("HelloWorld", 5, 5)
+      assertEquals("World", cw.toString)
+    }
+  }
+
+  @Test def writeSubArrayToCharArray(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.write(hw, 5, 5)
+      assertEquals("World", cw.toString)
+      assertArrayEquals("World".toCharArray, cw.toCharArray)
+    }
+  }
+
+  @Test def throwsIndexOutOfBoundsException(): Unit = {
+    withClose(new CharArrayWriter) { obj =>
+      assertThrows(
+        classOf[IndexOutOfBoundsException],
+        obj.write(Array[Char]('0'), 0, -1)
+      )
+    }
+  }
+
+  @Test def writeChar(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.write('T')
+      assertEquals("T", cw.toString)
+      assertArrayEquals(Array('T'), cw.toCharArray)
+    }
+  }
+
+  @Test def writeString(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.write("HelloWorld", 5, 5)
+      assertEquals("World", cw.toString)
+      assertArrayEquals("World".toCharArray, cw.toCharArray)
+    }
+  }
+
+  @Test def writeToStringWriter(): Unit = {
+    withClose(new CharArrayWriter) { cw =>
+      cw.write("HelloWorld", 0, 10)
+      withClose(new StringWriter) { sw =>
+        cw.writeTo(sw)
+        assertEquals("HelloWorld", sw.toString)
+      }
+    }
+  }
+
+  @Test def appendChar(): Unit = {
+    withClose(new CharArrayWriter(10)) { cw =>
+      val testChar = ' '
+      cw.append(testChar)
+      cw.flush()
+      assertEquals(String.valueOf(testChar), cw.toString)
+      assertArrayEquals(Array(testChar), cw.toCharArray)
+    }
+  }
+
+  @Test def appendCharSequence(): Unit = {
+    withClose(new CharArrayWriter(10)) { cw =>
+      val testString: CharSequence = "My Test String"
+      cw.append(testString)
+      cw.flush()
+      assertEquals("My Test String", cw.toString)
+      assertArrayEquals("My Test String".toCharArray, cw.toCharArray)
+    }
+  }
+
+  @Test def appendCharSequenceWithOffset(): Unit = {
+    withClose(new CharArrayWriter(10)) { cw =>
+      val testString: String = "My Test String"
+      cw.append(testString, 1, 3)
+      cw.flush()
+      assertEquals(testString.substring(1, 3), cw.toString)
+      assertArrayEquals(testString.substring(1, 3).toCharArray, cw.toCharArray)
+    }
+  }
+}


### PR DESCRIPTION
With appreciation & thanksgiving, ported JDK 1-dot-1 `java.io` `CharArrayReader`, `CharArrayWriter`, 
and associated unit-tests from Scala.js.
