### PR TITLE
Implement two JDK 9 & 16 java.lang IndexOutOfBoundsExceptions

### DIFF
--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -394,7 +394,9 @@ class IllegalThreadStateException(s: String)
 }
 
 class IndexOutOfBoundsException(s: String) extends RuntimeException(s) {
-  def this() = this(null)
+  def this(index: scala.Long) = this(s"Index out of range: ${index}") // JDK 16
+  def this(index: Int) = this(index.toLong) // JDK 9
+  def this() = this(null.asInstanceOf[String])
 }
 
 class InstantiationException(s: String)

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/lang/ThrowablesTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/lang/ThrowablesTestOnJDK16.scala
@@ -1,0 +1,24 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.{lang => jl}
+import java.util.Objects
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ThrowablesTestOnJDK16 {
+
+  @Test def indexOutOfBoundsException_Long(): Unit = {
+    val ioobExc = new IndexOutOfBoundsException(jl.Long.MAX_VALUE)
+    Objects.requireNonNull(ioobExc, "Long index")
+
+    // Check Exception message visually, since can rightly vary across JVMs.
+    assertThrows(
+      "IndexOutOfBounds Long",
+      classOf[java.lang.IndexOutOfBoundsException],
+      throw ioobExc
+    )
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ThrowablesTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ThrowablesTestOnJDK9.scala
@@ -1,0 +1,23 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.util.Objects
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ThrowablesTestOnJDK9 {
+
+  @Test def indexOutOfBoundsException_Int(): Unit = {
+    val ioobExc = new IndexOutOfBoundsException(66)
+    Objects.requireNonNull(ioobExc, "Int index")
+
+    // Check Exception message visually, since can rightly vary across JVMs.
+    assertThrows(
+      "IndexOutOfBounds Int",
+      classOf[java.lang.IndexOutOfBoundsException],
+      throw ioobExc
+    )
+  }
+}


### PR DESCRIPTION
Implement  javalib `java.lang` JDK 9 `IndexOutOfBoundsException(int)`  and
JDK 16 `IndexOutOfBoundsException(long)`.