### PR TITLE
Implement ProcessHandle for processes started by Scala Native runtime

### DIFF
--- a/javalib/src/main/scala/java/lang/Process.scala
+++ b/javalib/src/main/scala/java/lang/Process.scala
@@ -4,6 +4,7 @@ import java.io.{InputStream, OutputStream}
 import java.util.Optional
 import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
+import java.util.concurrent.CompletableFuture
 
 abstract class Process {
 
@@ -33,10 +34,8 @@ abstract class Process {
 
   def isAlive(): scala.Boolean
 
-  // Since: JDK 9
-  // Not yet implemented - a good candidate for one of Herakles' 12 labors.
-  // import java.util.concurrent.CompletableFuture
-  // def onExit(): CompletableFuture[ProcessHandle]
+  /** @since JDK 9 */
+  def onExit(): CompletableFuture[Process]
 
   /** @since JDK 9 */
   def pid(): scala.Long =

--- a/javalib/src/main/scala/java/lang/ProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/ProcessHandle.scala
@@ -6,7 +6,7 @@ import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.stream.Stream
 
-trait ProcessHandle {
+trait ProcessHandle extends Comparable[ProcessHandle] {
 
   def children(): Stream[ProcessHandle]
 
@@ -17,10 +17,6 @@ trait ProcessHandle {
   def destroy(): scala.Boolean
 
   def destroyForcibly(): scala.Boolean
-
-  override def equals(other: Any): scala.Boolean
-
-  override def hashCode(): scala.Int
 
   def info(): ProcessHandle.Info =
     throw new UnsupportedOperationException("ProcessHandle.info()")
@@ -40,7 +36,7 @@ trait ProcessHandle {
 object ProcessHandle {
 
   trait Info {
-    def arguments(): Optional[String]
+    def arguments(): Optional[Array[String]]
 
     def command(): Optional[String]
 

--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -34,8 +34,9 @@ private object GenericProcess {
     // We don't track transitive children
     override def children(): ju.stream.Stream[ProcessHandle] =
       ju.stream.Stream.empty()
-    override def descendants(): ju.stream.Stream[ProcessHandle] = children()
-
+    override def descendants(): ju.stream.Stream[ProcessHandle] =
+      ju.stream.Stream.empty()
+    
     override def destroy(): Boolean = {
       if (isAlive()) process.destroy()
       true // all implementations are always successful

--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -63,7 +63,7 @@ private object GenericProcess {
     }
     override def equals(that: Any): Boolean = that match {
       case other: ProcessHandle => this.compareTo(other) == 0
-      case _ => false
+      case _                    => false
     }
     override def hashCode(): Int = 31 * this.pid().##
     override def toString(): String = process.pid().toString() // JVM compliance
@@ -154,8 +154,7 @@ private object GenericProcess {
             watchedProcesses.forEach { (completion, handle) =>
               if (completion.isCancelled())
                 watchedProcesses.remove(completion)
-              else if (!handle.isAlive() ||
-                  handle.process.waitFor(25, TimeUnit.MILLISECONDS)) {
+              else if (handle.process.waitFor(25, TimeUnit.MILLISECONDS)) {
                 completion.complete(handle)
                 watchedProcesses.remove(completion)
               }

--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -36,7 +36,7 @@ private object GenericProcess {
       ju.stream.Stream.empty()
     override def descendants(): ju.stream.Stream[ProcessHandle] =
       ju.stream.Stream.empty()
-    
+
     override def destroy(): Boolean = {
       if (isAlive()) process.destroy()
       true // all implementations are always successful

--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -1,7 +1,161 @@
 package java.lang.process
 
 import scala.scalanative.unsafe._
+import scala.scalanative.meta.LinktimeInfo
 
-abstract class GenericProcess extends java.lang.Process {
+import java.time.{Duration, Instant}
+import java.{util => ju}
+import ju.{Optional, Arrays}
+import ju.concurrent.{CompletableFuture, ConcurrentHashMap, TimeUnit}
+
+abstract class GenericProcess() extends java.lang.Process {
+  private lazy val handle = new GenericProcess.Handle(this)
+
   private[lang] def checkResult(): CInt
+  protected def processInfo: GenericProcess.Info
+
+  override def toHandle(): ProcessHandle = handle
+
+  override def onExit(): CompletableFuture[Process] =
+    toHandle().onExit().thenApply(_ => this)
+
+  override def info(): ProcessHandle.Info = processInfo
+  override def pid(): scala.Long = processInfo.pid
+}
+
+private object GenericProcess {
+  // Represents ProcessHandle for process started by Scala Native runtime
+  // Cannot be used with processes started by other programs
+  class Handle(val process: GenericProcess) extends ProcessHandle {
+    override def parent(): Optional[ProcessHandle] = Optional.empty()
+
+    // We don't track transitive children
+    override def children(): ju.stream.Stream[ProcessHandle] =
+      ju.stream.Stream.empty()
+    override def descendants(): ju.stream.Stream[ProcessHandle] = children()
+
+    override def destroy(): Boolean = {
+      if (isAlive()) process.destroy()
+      true // all implementations are always successful
+    }
+    override def destroyForcibly(): Boolean = {
+      if (isAlive()) process.destroyForcibly()
+      true // all implementations are always successful
+    }
+    override def supportsNormalTermination(): Boolean =
+      process.supportsNormalTermination()
+
+    override def onExit(): CompletableFuture[ProcessHandle] = {
+      val completion = new CompletableFuture[ProcessHandle]()
+      if (LinktimeInfo.isMultithreadingEnabled)
+        GenericProcess.ProcessWatcher.watchForTermination(completion, this)
+      completion
+    }
+
+    override def pid(): scala.Long = process.pid()
+    override def isAlive(): Boolean = process.isAlive()
+    override def info(): ProcessHandle.Info = process.info()
+
+    override def compareTo(other: ProcessHandle): Int = other match {
+      case handle: GenericProcess.Handle =>
+        this.process.pid().compareTo(handle.process.pid())
+      case _ => -1
+    }
+
+    override def toString(): String = process.pid().toString() // JVM compliance
+  }
+
+  object Info {
+    def create(builder: ProcessBuilder, pid: scala.Long): Info = {
+      val cmd = builder.command()
+      val cmdAsArray = cmd.toArray(new Array[String](cmd.size()))
+      val command =
+        if (cmd.isEmpty()) Optional.empty()
+        else Optional.of(cmdAsArray.head)
+      val args =
+        if (cmd.isEmpty()) Optional.empty()
+        else Optional.of(cmdAsArray.tail)
+      new Info(pid = pid, cmd = command, args = args)
+    }
+  }
+  class Info(
+      val pid: scala.Long,
+      cmd: Optional[String],
+      args: Optional[Array[String]]
+  ) extends ProcessHandle.Info {
+    override def command(): Optional[String] = cmd
+    override def arguments(): Optional[Array[String]] = args
+    override def commandLine(): Optional[String] = for {
+      cmd <- command()
+      args <- arguments()
+    } yield s"$cmd ${args.mkString(" ")}"
+
+    override def user(): Optional[String] =
+      Optional.ofNullable(System.getProperty("user.name"))
+
+    // Instant not implemented
+    override def startInstant(): Optional[Instant] = Optional.empty()
+    override def totalCpuDuration(): Optional[Duration] = Optional.empty()
+
+    override def toString(): String = {
+      val args = this
+        .arguments()
+        .orElseGet(() => Array[String]())
+        .asInstanceOf[Array[AnyRef]]
+      s"[user: ${user()}, cmd: ${{ command() }}, args: ${Arrays.toString(args)}"
+    }
+  }
+
+  object ProcessWatcher {
+    // Identity map, no valid concurrent structure
+    val watchedProcesses =
+      new ConcurrentHashMap[CompletableFuture[
+        ProcessHandle
+      ], GenericProcess.Handle]()
+
+    private val lock = new ju.concurrent.locks.ReentrantLock()
+    private val hasProcessesToWatch = lock.newCondition()
+
+    def watchForTermination(
+        completion: CompletableFuture[ProcessHandle],
+        handle: GenericProcess.Handle
+    ): Unit = {
+      watchedProcesses.put(completion, handle)
+      assert(
+        watcherThread.isAlive(),
+        "Process termination watch thread is terminated"
+      )
+      // If we cannot lock it means that watcher thread is already executing, no need to wake it up
+      if (lock.tryLock()) {
+        try hasProcessesToWatch.signal()
+        finally lock.unlock()
+      }
+    }
+
+    lazy val watcherThread: Thread = Thread
+      .ofPlatform()
+      .daemon(true)
+      .group(ThreadGroup.System)
+      .name("ScalaNative-ProcessTerminationWatcher")
+      .startInternal(() =>
+        lock.lock()
+        try {
+          while (true) try {
+            while (watchedProcesses.isEmpty()) {
+              hasProcessesToWatch.await()
+            }
+            watchedProcesses.forEach {
+              case (completion, handle) =>
+                if (completion.isCancelled())
+                  watchedProcesses.remove(completion)
+                else if (!handle.isAlive() ||
+                    handle.process.waitFor(25, TimeUnit.MILLISECONDS)) {
+                  completion.complete(handle)
+                  watchedProcesses.remove(completion)
+                }
+            }
+          } catch { case scala.util.control.NonFatal(_) => () }
+        } finally lock.unlock()
+      )
+  }
 }

--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -61,7 +61,11 @@ private object GenericProcess {
         this.process.pid().compareTo(handle.process.pid())
       case _ => -1
     }
-
+    override def equals(that: Any): Boolean = that match {
+      case other: ProcessHandle => this.compareTo(other) == 0
+      case _ => false
+    }
+    override def hashCode(): Int = 31 * this.pid().##
     override def toString(): String = process.pid().toString() // JVM compliance
   }
 

--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -161,7 +161,7 @@ private object GenericProcess {
             watchedProcesses.forEach { (completion, handle) =>
               if (completion.isCancelled())
                 watchedProcesses.remove(completion)
-              else if (handle.process.waitFor(1, TimeUnit.MILLISECONDS)) {
+              else if (handle.process.waitFor(5, TimeUnit.MILLISECONDS)) {
                 completion.complete(handle)
                 watchedProcesses.remove(completion)
               }

--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -161,11 +161,12 @@ private object GenericProcess {
             watchedProcesses.forEach { (completion, handle) =>
               if (completion.isCancelled())
                 watchedProcesses.remove(completion)
-              else if (handle.process.waitFor(25, TimeUnit.MILLISECONDS)) {
+              else if (handle.process.waitFor(1, TimeUnit.MILLISECONDS)) {
                 completion.complete(handle)
                 watchedProcesses.remove(completion)
               }
             }
+            Thread.sleep(100 /*ms*/ )
           } catch { case scala.util.control.NonFatal(_) => () }
         } finally lock.unlock()
       }

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -23,6 +23,7 @@ private[lang] class UnixProcessGen1 private (
     outfds: Ptr[CInt],
     errfds: Ptr[CInt]
 ) extends UnixProcess() {
+  override val processInfo = GenericProcess.Info.create(builder, pid = pid.toLong)
 
   override def destroy(): Unit = kill(pid, sig.SIGTERM)
 

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -23,7 +23,7 @@ private[lang] class UnixProcessGen1 private (
     outfds: Ptr[CInt],
     errfds: Ptr[CInt]
 ) extends UnixProcess() {
-  override val processInfo =
+  override private[process] val processInfo =
     GenericProcess.Info.create(builder, pid = pid.toLong)
 
   override def destroy(): Unit = kill(pid, sig.SIGTERM)

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -23,7 +23,8 @@ private[lang] class UnixProcessGen1 private (
     outfds: Ptr[CInt],
     errfds: Ptr[CInt]
 ) extends UnixProcess() {
-  override val processInfo = GenericProcess.Info.create(builder, pid = pid.toLong)
+  override val processInfo =
+    GenericProcess.Info.create(builder, pid = pid.toLong)
 
   override def destroy(): Unit = kill(pid, sig.SIGTERM)
 

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -45,6 +45,7 @@ private[lang] class UnixProcessGen2 private (
     outfds: Ptr[CInt],
     errfds: Ptr[CInt]
 ) extends UnixProcess() {
+  override val processInfo = GenericProcess.Info.create(builder, pid = pid.toLong)
 
   private var _exitValue: Option[Int] = None
 

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -45,7 +45,7 @@ private[lang] class UnixProcessGen2 private (
     outfds: Ptr[CInt],
     errfds: Ptr[CInt]
 ) extends UnixProcess() {
-  override val processInfo =
+  override private[process] val processInfo =
     GenericProcess.Info.create(builder, pid = pid.toLong)
 
   private var _exitValue: Option[Int] = None

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -45,7 +45,8 @@ private[lang] class UnixProcessGen2 private (
     outfds: Ptr[CInt],
     errfds: Ptr[CInt]
 ) extends UnixProcess() {
-  override val processInfo = GenericProcess.Info.create(builder, pid = pid.toLong)
+  override val processInfo =
+    GenericProcess.Info.create(builder, pid = pid.toLong)
 
   private var _exitValue: Option[Int] = None
 

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -35,7 +35,7 @@ private[lang] class WindowsProcess private (
 ) extends GenericProcess {
   private val winPid = GetProcessId(handle)
 
-  override val processInfo =
+  override private[process] val processInfo =
     GenericProcess.Info.create(builder, pid = winPid.toLong)
 
   private var cachedExitValue: Option[scala.Int] = None

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -34,6 +34,9 @@ private[lang] class WindowsProcess private (
     errHandle: FileDescriptor
 ) extends GenericProcess {
   private val winPid = GetProcessId(handle)
+  
+  override val processInfo = GenericProcess.Info.create(builder, pid = winPid.toLong)
+
   private var cachedExitValue: Option[scala.Int] = None
 
   override def destroy(): Unit = if (isAlive()) {

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -34,8 +34,9 @@ private[lang] class WindowsProcess private (
     errHandle: FileDescriptor
 ) extends GenericProcess {
   private val winPid = GetProcessId(handle)
-  
-  override val processInfo = GenericProcess.Info.create(builder, pid = winPid.toLong)
+
+  override val processInfo =
+    GenericProcess.Info.create(builder, pid = winPid.toLong)
 
   private var cachedExitValue: Option[scala.Int] = None
 

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -71,7 +71,8 @@ private[lang] class WindowsProcess private (
   }
 
   override def waitFor(): scala.Int = synchronized {
-    WaitForSingleObject(handle, Constants.Infinite)
+    if (isAlive())
+      WaitForSingleObject(handle, Constants.Infinite)
     exitValue()
   }
 

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
@@ -1,0 +1,137 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.util.concurrent.TimeUnit
+import java.io._
+import java.nio.file._
+import java.nio.charset.StandardCharsets
+
+import scala.io.Source
+
+import org.junit._
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Ignore
+
+import org.scalanative.testsuite.utils.Platform, Platform._
+import scala.scalanative.junit.utils.AssumesHelper._
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object ProcessTestOnJDK9 {
+  @BeforeClass
+  def checkRuntime(): Unit = {
+    assumeTrue(isMultithreadingEnabled)
+  }
+}
+
+class ProcessTestOnJDK9 {
+  import ProcessUtils._
+
+  @Test def onExitHandles(): Unit = {
+    val proc = processSleep(0.1).start()
+    val handle = proc.toHandle()
+    val f1, f2 = handle.onExit()
+    val f3, f4 = proc.onExit()
+
+    assertNotSame("each onExit invocation should return a new instance", f1, f2)
+    assertNotSame("each onExit invocation should return a new instance", f3, f4)
+    assertEquals(
+      "All completions should refer to the same pid",
+      1,
+      Seq(f1, f2, f3, f4)
+        .map(_.get())
+        .map {
+          case handle: ProcessHandle => handle.pid()
+          case proc: Process         => proc.pid()
+        }
+        .distinct
+        .size
+    )
+
+  }
+
+  @Test def onExitTerminates(): Unit = {
+    val proc = processSleep(1).start()
+    val completion = proc.onExit()
+    assertFalse(completion.isDone())
+    assertFalse(completion.isCancelled())
+
+    completion.get()
+    assertTrue(completion.isDone())
+    assertFalse(completion.isCancelled())
+    assertFalse(proc.isAlive())
+  }
+
+  // copy from ProcessTest
+  private def processForDestruction(): Process = {
+    val proc = processForCommand("ping", "-c", "2", "-i", "10", "127.0.0.1")
+      .start()
+    proc.getInputStream().read()
+    proc
+  }
+
+  @Test def processInfo(): Unit = {
+    val proc = processForDestruction()
+    try {
+      val info = proc.toHandle().info()
+      assertTrue(
+        s"command: ${info.command()}",
+        info.command().get().contains("ping")
+      )
+      assertEquals(
+        Seq("-c", "2", "-i", "10", "127.0.0.1"),
+        info.arguments().get().toSeq
+      )
+      assertTrue(
+        s"command line (cmd): ${info.commandLine()}",
+        info.commandLine().get().contains("ping")
+      )
+      assertTrue(
+        s"command line (args): ${info.commandLine()}",
+        info.commandLine().get().contains("-c")
+      )
+      // TODO not implemented:
+      // startInstant: Optional[Instant]
+      // totalCpuDuration: Optional[Duration]
+      // user: Optional[String]
+    } finally proc.destroy()
+  }
+
+  @Test def destroy(): Unit = {
+    val proc = processForDestruction()
+    val handle = proc.toHandle()
+
+    assertTrue(handle.destroy())
+
+    // Throws on timeout
+    assertFalse(
+      "process should have been terminated",
+      handle.onExit().get(500, TimeUnit.MILLISECONDS).isAlive()
+    )
+    assertEquals(
+      // SIGTERM, use unix signal 'excess 128' convention on non-Windows.
+      if (isWindows) 1 else 0x80 + 15,
+      proc.exitValue
+    )
+  }
+
+  @Test def destroyForcibly(): Unit = {
+    val proc = processForDestruction()
+    val handle = proc.toHandle()
+
+    assertTrue(handle.destroyForcibly())
+
+    // Throws on timeout
+    assertFalse(
+      "process should have been terminated",
+      handle.onExit().get(500, TimeUnit.MILLISECONDS).isAlive()
+    )
+    assertEquals(
+      // SIGKILL, use unix signal 'excess 128' convention on non-Windows.
+      if (isWindows) 1 else 0x80 + 9,
+      proc.exitValue
+    )
+  }
+
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
@@ -86,11 +86,14 @@ class ProcessTestOnJDK9 {
       }
       assertTrue(
         s"command: ${info.command()}",
-        info.command().get().contains("ping")
+        // On Windows every binary is wrapped in cmd invocation
+        Seq("ping", "cmd").exists(info.command().get().contains(_))
       )
+      // On windows first argument would be ping
+      val expectedArgs = Seq("-c", "2", "-i", "10", "127.0.0.1")
       assertEquals(
-        Seq("-c", "2", "-i", "10", "127.0.0.1"),
-        info.arguments().get().toSeq
+        expectedArgs,
+        info.arguments().get().toSeq.takeRight(expectedArgs.size)
       )
       assertTrue(
         s"command line (cmd): ${info.commandLine()}",

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
@@ -75,6 +75,15 @@ class ProcessTestOnJDK9 {
     val proc = processForDestruction()
     try {
       val info = proc.toHandle().info()
+      if (executingInJVM) {
+        // Might be empty sometimes on JVM but needs to be defined in SN runtime
+        assumeTrue(s"no command on JVM - $info", info.command().isPresent())
+        assumeTrue(s"no args on JVM - $info", info.arguments().isPresent())
+        assumeTrue(
+          s"no commandLine on JVM - $info",
+          info.commandLine().isPresent()
+        )
+      }
       assertTrue(
         s"command: ${info.command()}",
         info.command().get().contains("ping")


### PR DESCRIPTION
Fix to signatures of `Process` and `ProcesHandle` introduced in JDK 9 
Provide implementation for ProcessHandle for processes started by Scala Native. 

Partial fix for #4231 