### PR TITLE
Align javalib PrintStream with JDK 23

### DIFF
--- a/javalib/src/main/scala/java/io/PrintStream.scala
+++ b/javalib/src/main/scala/java/io/PrintStream.scala
@@ -4,10 +4,10 @@ import java.nio.charset.{Charset, UnsupportedCharsetException}
 import java.util.Formatter
 import java.util.Objects
 
-class PrintStream private (
-    _out: OutputStream,
-    autoFlush: Boolean,
-    charset: Charset
+class PrintStream(
+    private val _out: OutputStream,
+    private val autoFlush: Boolean,
+    private val _charset: Charset
 ) extends FilterOutputStream(_out)
     with Appendable
     with Closeable {
@@ -50,32 +50,34 @@ class PrintStream private (
       }
     )
 
-  /* The following constructors, although implemented, will not link, since
-   * File, FileOutputStream and BufferedOutputStream are not implemented.
-   * They're here just in case a third-party library on the classpath
-   * implements those.
-   */
-
-  /* Cravenly pass the possibly null, possibly unsupported charSet String
-   * through to whatever third-party software satisfies the link.
-   * Let it deal with converting UnsupportedCharsetException to
-   * UnsupportedEncodingException. Since the code will not link, there
-   * is no good way to test that conversion for these two items.
-   */
+  /** @since JDK 10 */
+//  def this(out: OutputStream, autoFlush: Boolean, charset: Charset) =
+//    this(out, autoFlush, charset)
 
   def this(file: File) =
     this(new BufferedOutputStream(new FileOutputStream(file)))
+
   def this(file: File, csn: String) =
     this(new BufferedOutputStream(new FileOutputStream(file)), false, csn)
+
+  /** @since JDK 10 */
+  def this(file: File, charset: Charset) =
+    this(new BufferedOutputStream(new FileOutputStream(file)), false, charset)
+
   def this(fileName: String) =
     this(new File(fileName))
+
   def this(fileName: String, csn: String) =
     this(new File(fileName), csn)
 
+  /** @since JDK 10 */
+  def this(fileName: String, charset: Charset) =
+    this(new File(fileName), charset)
+
   private lazy val encoder = {
     val c =
-      if (charset == null) Charset.defaultCharset()
-      else charset
+      if (_charset == null) Charset.defaultCharset()
+      else _charset
     /* We pass `this` as the output stream for the encoding writer so that
      * we can apply auto-flushing. Note that this will flush() more often
      * than required by the spec. It appears to be consistent with how the
@@ -249,4 +251,13 @@ class PrintStream private (
     if (closed) setError()
     else trapIOExceptions(body)
   }
+
+  /** @since JDK 18 */
+  def charset(): Charset =
+    this._charset
+
+  /** @since JDK 14 */
+  def writeBytes(buf: Array[Byte]): Unit =
+    this.write(buf, 0, buf.length)
+
 }

--- a/javalib/src/main/scala/java/io/PrintStream.scala
+++ b/javalib/src/main/scala/java/io/PrintStream.scala
@@ -5,32 +5,12 @@ import java.util.Formatter
 import java.util.Objects
 
 class PrintStream(
-    private val _out: OutputStream,
-    private val autoFlush: Boolean,
-    private val _charset: Charset
+    _out: OutputStream,
+    autoFlush: Boolean,
+    _charset: Charset
 ) extends FilterOutputStream(_out)
     with Appendable
     with Closeable {
-
-  /* The way we handle charsets here is a bit tricky, because we want to
-   * minimize the area of reachability for normal programs.
-   *
-   * First, if nobody uses the constructor taking an explicit encoding, we
-   * don't want to reach Charset.forName(), which pulls in all of the
-   * implemented charsets.
-   *
-   * Second, most programs will reach PrintStream only because of
-   * java.lang.System.{out,err}, which are subclasses of PrintStream that do
-   * not actually need to encode anything: they override all of PrintStream's
-   * methods to bypass the encoding altogether, and hence don't even need
-   * the default charset.
-   *
-   * This is why we have:
-   * * A private constructor taking the Charset directly, instead of its name.
-   * * Which is allowed to be `null`, which stands for the default charset.
-   * * The default charset is only loaded lazily in the initializer of the
-   *   encoder field.
-   */
 
   def this(out: OutputStream) =
     this(out, false, null: Charset)
@@ -49,10 +29,6 @@ class PrintStream(
           throw new java.io.UnsupportedEncodingException(encoding)
       }
     )
-
-  /** @since JDK 10 */
-//  def this(out: OutputStream, autoFlush: Boolean, charset: Charset) =
-//    this(out, autoFlush, charset)
 
   def this(file: File) =
     this(new BufferedOutputStream(new FileOutputStream(file)))

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -50,9 +50,9 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-pc-linux-gnu"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1066, members = 6905)
-      else if (isScala2_13) SymbolsCount(types = 1026, members = 6980)
-      else SymbolsCount(types = 1010, members = 7121)
+      if (isScala3) SymbolsCount(types = 1068, members = 6906)
+      else if (isScala2_13) SymbolsCount(types = 1028, members = 6980)
+      else SymbolsCount(types = 1010, members = 7124)
     )
 
   @Test def multithreading(): Unit =

--- a/unit-tests/shared/src/test/require-jdk10/org/scalanative/testsuite/javalib/io/PrintStreamTestOnJDK10.scala
+++ b/unit-tests/shared/src/test/require-jdk10/org/scalanative/testsuite/javalib/io/PrintStreamTestOnJDK10.scala
@@ -1,0 +1,77 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io.{File, OutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform
+
+class PrintStreamTestOnJDK10 {
+  /* Due to limited time to implement, this Class is a minimal implantation.
+   * For each of the various PrintStream constructors, it invokes that
+   * constructor and then invokes a write method on it. If it can write,
+   * it can sing!
+   *
+   * More extensive tests could be written, given extended resources and time.
+   */
+
+  final val secondComing = """
+               |""Things fall apart; the centre cannot hold;
+               |Mere anarchy is loosed upon the world,
+               """
+
+  // Do not use /dev/null on Windows. It leads to FileNotFoundException
+  final val devNull = if (Platform.isWindows) "NUL" else "/dev/null"
+
+  @Test def constructorFileCharset(): Unit = {
+    val bytesUTF_8 = secondComing.getBytes(StandardCharsets.UTF_8)
+
+    val outCharset = StandardCharsets.UTF_16LE
+    val ps = new PrintStream(new File(devNull), outCharset)
+
+    // check only that created ps is healthy enough that no Exception is thown
+    ps.write(bytesUTF_8)
+  }
+
+  @Test def constructorOutputStreamBooleanCharset(): Unit = {
+    val bytesUTF_8 = secondComing.getBytes(StandardCharsets.UTF_8)
+
+    val outStream = OutputStream.nullOutputStream()
+    val outCharset = StandardCharsets.UTF_16LE
+    val ps = new PrintStream(outStream, false, outCharset)
+
+    // check only that created ps is healthy enough that no Exception is thown
+    ps.write(bytesUTF_8)
+  }
+
+  @Test def constructorString(): Unit = {
+    val bytesUTF_8 = secondComing.getBytes(StandardCharsets.UTF_8)
+
+    val ps = new PrintStream(devNull)
+
+    // check only that created ps is healthy enough that no Exception is thown
+    ps.write(bytesUTF_8)
+  }
+
+  @Test def constructorStringCharset(): Unit = {
+    val bytesUTF_8 = secondComing.getBytes(StandardCharsets.UTF_8)
+
+    val outCharset = StandardCharsets.UTF_16LE
+    val ps = new PrintStream(devNull, outCharset)
+
+    // check only that created ps is healthy enough that no Exception is thown
+    ps.write(bytesUTF_8)
+  }
+
+  @Test def constructorStringString(): Unit = {
+    val bytesUTF_8 = secondComing.getBytes(StandardCharsets.UTF_8)
+
+    val ps = new PrintStream(devNull, "UTF_16LE")
+
+    // check only that created ps is healthy enough that no Exception is thown
+    ps.write(bytesUTF_8)
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk14/org/scalanative/testsuite/javalib/io/PrintStreamTestOnJDK14.scala
+++ b/unit-tests/shared/src/test/require-jdk14/org/scalanative/testsuite/javalib/io/PrintStreamTestOnJDK14.scala
@@ -1,0 +1,44 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
+import java.util.Arrays
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class PrintStreamTestOnJDK14 {
+  final val secondComing = """
+               |""The best lack all conviction, while the worst
+               |Are full of passionate intensity."
+               """
+
+  @Test def writeByteArray(): Unit = {
+    val bytesUTF_16 = secondComing.getBytes(StandardCharsets.UTF_16)
+    val bytesUTF_8 = secondComing.getBytes(StandardCharsets.UTF_8)
+    val bytesExpected = bytesUTF_8
+
+    val outStream = new ByteArrayOutputStream()
+
+    val ps = new PrintStream(outStream, false, StandardCharsets.UTF_16)
+
+    // The bytes should be written as given, not translated to UTF_16
+    ps.writeBytes(bytesUTF_8)
+    val bytesReceived = outStream.toByteArray()
+
+    assertEquals(
+      "size difference",
+      bytesExpected.length,
+      bytesReceived.length
+    )
+
+    val mmPos = Arrays.mismatch(bytesExpected, bytesReceived)
+    assertEquals(
+      s"expected($mmPos) != recieved(${mmPos})",
+      -1,
+      mmPos
+    )
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk18/org/scalanative/testsuite/javalib/io/PrintStreamTestOnJDK18.scala
+++ b/unit-tests/shared/src/test/require-jdk18/org/scalanative/testsuite/javalib/io/PrintStreamTestOnJDK18.scala
@@ -1,0 +1,24 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io.{OutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class PrintStreamTestOnJDK18 {
+
+  @Test def charset(): Unit = {
+    val outStream = OutputStream.nullOutputStream()
+    val expectedCharset = StandardCharsets.UTF_16LE // pick an usual one.
+    val ps = new PrintStream(outStream, false, expectedCharset)
+
+    assertEquals(
+      "charset",
+      expectedCharset,
+      ps.charset()
+    )
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/PrintStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/PrintStreamTest.scala
@@ -1,31 +1,41 @@
 package org.scalanative.testsuite.javalib.io
 
-import java.io._
+import java.io.{File, PrintStream}
+import java.nio.charset.StandardCharsets
 
 import org.junit.Test
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.Platform.isWindows
+import org.scalanative.testsuite.utils.Platform
 
 class PrintStreamTest {
 
+  final val secondComing = """
+               |""The darkness drops again; but now I know
+               """
+
+  // Do not use /dev/null on Windows. It leads to FileNotFoundException
+  final val devNull = if (Platform.isWindows) "NUL" else "/dev/null"
+
+  final val bytesUTF_8 = secondComing.getBytes(StandardCharsets.UTF_8)
+
   @Test def printStreamOutputStreamStringWithUnsupportedEncoding(): Unit = {
-    // Make sure to not use /dev/null on Windows leading to FileNotFoundException
-    // On JVM charset check happens before file exists checks
-    val devNull = if (isWindows) "NUL" else "/dev/null"
     assertThrows(
       classOf[java.io.UnsupportedEncodingException],
       new PrintStream(new File(devNull), "unsupported encoding")
     )
   }
 
-  // The careful reader would expect to see tests for the constructors
-  // PrintStream(String, String) and PrintStream(String, String) here.
-  //
-  // See the comments in PrintStream.scala for a discussion about
-  // the those constructors.
-  //
-  // They are minimally implemented and will not link, so they can not
-  // be tested here.
+  @Test def constructorString(): Unit = {
+    val ps = new PrintStream(devNull)
+    // check only that created ps is healthy enough so no Exception is thown
+    ps.write(bytesUTF_8)
+  }
 
+  @Test def constructorStringString(): Unit = {
+    val ps = new PrintStream(devNull, "UTF_16LE")
+
+    // check only that created ps is healthy enough so no Exception is thown
+    ps.write(bytesUTF_8)
+  }
 }


### PR DESCRIPTION
Implement javalib `PrintStream` methods and constructors introduced in JDK 10, JDK 14, and JDK 18 
and associated unit Tests.  

Since there were no changes to the `PrintStream` class after JDK and before and including JDK 23, this 
aligns `PrintStream` with the JDK 23.

Reviewers & readers may note that some internal technical debt has been removed.
 Those changes are not directly visible to end users but should ease future maintenance.