### PR TITLE
Implement JDK 15 jl.String#formatted

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -301,6 +301,18 @@ final class _String()
     }
   }
 
+  /** @since Java 12 */
+  def formatted(args: Array[AnyRef]): String = {
+    /* Delegating to the companion static method costs a call but
+     * preserves a Single Point of Truth and ensures identical output.
+     *
+     * Attention!: Using "String.format", no leading underbar, will
+     * use the wrong entry point and bring woe.
+     */
+
+    _String.format(this, args) // Must use underbarString.format()
+  }
+
   def getBytes(): Array[scala.Byte] = {
     val buffer =
       Charset.defaultCharset().encode(CharBuffer.wrap(value, offset, count))
@@ -577,7 +589,6 @@ final class _String()
   }
 
   /** @since JDK 11 */
-
   def lines(): jus.Stream[_String] = {
     /* Library methods are supposed to be reasonably fast.
      * The obvious implementation, which works, is

--- a/unit-tests/shared/src/test/require-jdk15/org/scalanative/testsuite/javalib/lang/StringTestOnJDK15.scala
+++ b/unit-tests/shared/src/test/require-jdk15/org/scalanative/testsuite/javalib/lang/StringTestOnJDK15.scala
@@ -1,4 +1,6 @@
 // Ported from Scala.js, revision c8ddba0 dated 4 Dec 2021
+// For Scala Native additions & changes, check GitHub history.
+
 package org.scalanative.testsuite.javalib.lang
 
 import org.junit.Test
@@ -223,6 +225,23 @@ class StringTestOnJDK15 {
     assertEquals("abcd\\", """abcd\\""".translateEscapes())
     assertEquals("\\abcd\\", """\\abcd\\""".translateEscapes())
     assertEquals("\\\\\\", """\\\\\\""".translateEscapes())
+  }
+
+  /* "formatted" test adapted from "format" test
+   *  Scala.js, commit: e10803c, dated: 2024-09-16
+   */
+  @Test def formatted(): Unit = {
+    assertEquals("5", "%d".formatted(new Integer(5)))
+    assertEquals("00005", "%05d".formatted(new Integer(5)))
+    assertEquals("0x005", "%0#5x".formatted(new Integer(5)))
+    assertEquals("  0x5", "%#5x".formatted(new Integer(5)))
+    assertEquals("  0X5", "%#5X".formatted(new Integer(5)))
+    assertEquals("  -10", "%5d".formatted(new Integer(-10)))
+    assertEquals("-0010", "%05d".formatted(new Integer(-10)))
+    assertEquals("fffffffd", "%x".formatted(new Integer(-3)))
+
+    // See note in String.scala about SN & JVM "fc" vs Scala.js "fffffffc"
+    assertEquals("fc", "%x".formatted(new java.lang.Byte(-4.toByte)))
   }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
@@ -1011,6 +1011,22 @@ class StringTest {
 
   /* selected Static methods
    */
+
+  // "format" test ported from Scala.js, commit: e10803c, dated: 2024-09-16
+  @Test def format(): Unit = {
+    assertEquals("5", String.format("%d", new Integer(5)))
+    assertEquals("00005", String.format("%05d", new Integer(5)))
+    assertEquals("0x005", String.format("%0#5x", new Integer(5)))
+    assertEquals("  0x5", String.format("%#5x", new Integer(5)))
+    assertEquals("  0X5", String.format("%#5X", new Integer(5)))
+    assertEquals("  -10", String.format("%5d", new Integer(-10)))
+    assertEquals("-0010", String.format("%05d", new Integer(-10)))
+    assertEquals("fffffffd", String.format("%x", new Integer(-3)))
+
+    // SN matches JVM (8 to 23) "fc", Scala.js original expected "fffffffc"
+    assertEquals("fc", String.format("%x", new java.lang.Byte(-4.toByte)))
+  }
+
   @Test def joinVarargs(): Unit = {
     val strings = Array("one", "two", "three")
     val delimiter = "-%-"


### PR DESCRIPTION
Implement javalib JDK 15 jl.`String#formatted` method & associated Tests.

Ported Test for static `String.format(String, Array[Object])` from Scala.js,
with thanks and appreciation, in order to establish a reference baseline,
This brings warrented belief that the output of the implemented method
matches that of the existing static method. 

The output of the Scala.js static method differs in one Test from
that of the JVM. Scala Native matches the JVM, in both the
static and instance methods. 