### PR TITLE
Reduce number of wrappers when fetching aliveThreads

### DIFF
--- a/javalib/src/main/scala/java/lang/ThreadGroup.scala
+++ b/javalib/src/main/scala/java/lang/ThreadGroup.scala
@@ -77,7 +77,7 @@ class ThreadGroup(
   def isDestroyed(): scala.Boolean = false
 
   def activeCount(): Int = {
-    NativeThread.Registry.aliveThreads
+    NativeThread.Registry.aliveThreadsIterator
       .count { nativeThread =>
         val group = nativeThread.thread.getThreadGroup()
         this.parentOf(group)
@@ -109,7 +109,7 @@ class ThreadGroup(
     if (out == null) throw new NullPointerException()
     if (out.length == 0) 0
     else {
-      val aliveThreads = NativeThread.Registry.aliveThreads.toArray
+      val aliveThreads = NativeThread.Registry.aliveThreadsIterator.toArray
       @tailrec def loop(idx: Int, included: Int): Int =
         if (idx == aliveThreads.length || included == out.length) included
         else {
@@ -153,7 +153,7 @@ class ThreadGroup(
   }
 
   final def interrupt(): Unit = {
-    for (nativeThread <- NativeThread.Registry.aliveThreads) {
+    for (nativeThread <- NativeThread.Registry.aliveThreadsIterator) {
       val thread = nativeThread.thread
       val group = thread.getThreadGroup()
       if (this.parentOf(group)) thread.interrupt()
@@ -162,7 +162,7 @@ class ThreadGroup(
 
   def list(): Unit = {
     val groupThreads = new HashMap[ThreadGroup, List[Thread]]
-    for (nativeThread <- NativeThread.Registry.aliveThreads) {
+    for (nativeThread <- NativeThread.Registry.aliveThreadsIterator) {
       val thread = nativeThread.thread
       val group = thread.getThreadGroup()
       if (this.parentOf(group)) {

--- a/javalib/src/main/scala/java/lang/ThreadGroup.scala
+++ b/javalib/src/main/scala/java/lang/ThreadGroup.scala
@@ -1,6 +1,7 @@
 package java.lang
 
 import java.util.{Arrays, Map, HashMap, List, ArrayList}
+import java.util.ScalaOps._
 import java.io.PrintStream
 import java.lang.Thread.UncaughtExceptionHandler
 import java.lang.ref.WeakReference
@@ -77,7 +78,7 @@ class ThreadGroup(
   def isDestroyed(): scala.Boolean = false
 
   def activeCount(): Int = {
-    NativeThread.Registry.aliveThreadsIterator
+    NativeThread.Registry.aliveThreadsIterator.scalaOps
       .count { nativeThread =>
         val group = nativeThread.thread.getThreadGroup()
         this.parentOf(group)
@@ -109,19 +110,18 @@ class ThreadGroup(
     if (out == null) throw new NullPointerException()
     if (out.length == 0) 0
     else {
-      val aliveThreads = NativeThread.Registry.aliveThreadsIterator.toArray
-      @tailrec def loop(idx: Int, included: Int): Int =
-        if (idx == aliveThreads.length || included == out.length) included
+      val aliveThreadsIterator = NativeThread.Registry.aliveThreadsIterator
+      @tailrec def loop(included: Int): Int =
+        if (!aliveThreadsIterator.hasNext() || included == out.length) included
         else {
-          val thread = aliveThreads(idx).thread
+          val thread = aliveThreadsIterator.next().thread
           val group = thread.getThreadGroup()
-          val nextIdx = idx + 1
           if ((group eq this) || (recurse && this.parentOf(group))) {
             out(included) = thread
-            loop(nextIdx, included + 1)
-          } else loop(nextIdx, included)
+            loop(included + 1)
+          } else loop(included)
         }
-      loop(0, 0)
+      loop(0)
     }
   }
 
@@ -153,7 +153,7 @@ class ThreadGroup(
   }
 
   final def interrupt(): Unit = {
-    for (nativeThread <- NativeThread.Registry.aliveThreadsIterator) {
+    for (nativeThread <- NativeThread.Registry.aliveThreadsIterator.scalaOps) {
       val thread = nativeThread.thread
       val group = thread.getThreadGroup()
       if (this.parentOf(group)) thread.interrupt()
@@ -162,7 +162,7 @@ class ThreadGroup(
 
   def list(): Unit = {
     val groupThreads = new HashMap[ThreadGroup, List[Thread]]
-    for (nativeThread <- NativeThread.Registry.aliveThreadsIterator) {
+    for (nativeThread <- NativeThread.Registry.aliveThreadsIterator.scalaOps) {
       val thread = nativeThread.thread
       val group = thread.getThreadGroup()
       if (this.parentOf(group)) {

--- a/javalib/src/main/scala/java/lang/management/ThreadMXBean.scala
+++ b/javalib/src/main/scala/java/lang/management/ThreadMXBean.scala
@@ -150,7 +150,9 @@ object ThreadMXBean {
         maxDepth: Int
     ): Array[ThreadInfo] = {
       checkMaxDepth(maxDepth)
-      NativeThread.Registry.aliveThreadsIterator.map(thread => ThreadInfo(thread)).toArray
+      NativeThread.Registry.aliveThreadsIterator
+        .map(thread => ThreadInfo(thread))
+        .toArray
     }
 
     @inline private def checkThreadId(id: Long): Unit =

--- a/javalib/src/main/scala/java/lang/management/ThreadMXBean.scala
+++ b/javalib/src/main/scala/java/lang/management/ThreadMXBean.scala
@@ -107,14 +107,14 @@ object ThreadMXBean {
 
   private class Impl extends ThreadMXBean {
     def getThreadCount(): Int =
-      aliveThreads.size
+      NativeThread.Registry.aliveThreadsCount
 
     def getDaemonThreadCount(): Int =
-      aliveThreads.count(_.thread.isDaemon())
+      NativeThread.Registry.aliveThreadsIterator.count(_.thread.isDaemon())
 
     @annotation.nowarn // Thread.getId is deprecated since JDK 19
     def getAllThreadIds(): Array[Long] =
-      aliveThreads.map(_.thread.getId()).toArray
+      NativeThread.Registry.aliveThreadsIterator.map(_.thread.getId()).toArray
 
     def getThreadInfo(id: Long): ThreadInfo =
       getThreadInfo(id, 0)
@@ -150,11 +150,8 @@ object ThreadMXBean {
         maxDepth: Int
     ): Array[ThreadInfo] = {
       checkMaxDepth(maxDepth)
-      aliveThreads.map(thread => ThreadInfo(thread)).toArray
+      NativeThread.Registry.aliveThreadsIterator.map(thread => ThreadInfo(thread)).toArray
     }
-
-    @inline private def aliveThreads: Iterable[NativeThread] =
-      NativeThread.Registry.aliveThreads
 
     @inline private def checkThreadId(id: Long): Unit =
       require(id > 0, s"Invalid thread ID parameter: $id")

--- a/javalib/src/main/scala/java/lang/management/ThreadMXBean.scala
+++ b/javalib/src/main/scala/java/lang/management/ThreadMXBean.scala
@@ -120,7 +120,7 @@ object ThreadMXBean {
       val builder = Array.newBuilder[Long]
       builder.sizeHint(NativeThread.Registry.aliveThreadsCount)
       NativeThread.Registry.aliveThreadsIterator.scalaOps.foreach(
-        nativeThread => builder += nativeThread.thread.getId
+        nativeThread => builder += nativeThread.thread.getId()
       )
       builder.result()
     }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -190,9 +190,8 @@ object NativeThread {
     }
 
     @nowarn
-    def aliveThreadsIterator: Iterator[NativeThread] = {
-      import scala.collection.JavaConverters._
-      _aliveThreads.values.iterator.asScala
+    def aliveThreadsIterator: java.util.Iterator[NativeThread] = {
+      _aliveThreads.values.iterator
     }
 
     @nowarn

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -194,6 +194,12 @@ object NativeThread {
       import scala.collection.JavaConverters._
       _aliveThreads.values.iterator.asScala
     }
+
+    @nowarn
+    def aliveThreads: Iterable[NativeThread] = {
+      import scala.collection.JavaConverters._
+      _aliveThreads.values.asScala
+    }
   }
 
   def threadRoutine: ThreadStartRoutine = CFuncPtr1.fromScalaFunction {

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -185,10 +185,14 @@ object NativeThread {
     def getById(id: Long): Option[NativeThread] =
       Option(_aliveThreads.get(id))
 
+    def aliveThreadsCount: Int = {
+      _aliveThreads.size
+    }
+
     @nowarn
-    def aliveThreads: Iterable[NativeThread] = {
+    def aliveThreadsIterator: Iterator[NativeThread] = {
       import scala.collection.JavaConverters._
-      _aliveThreads.values.asScala
+      _aliveThreads.values.iterator.asScala
     }
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -95,11 +95,12 @@ package object runtime {
       shutdownThread = Thread.currentThread()
       atomic_thread_fence(memory_order.memory_order_seq_cst)
     }
-    def pollNonDaemonThreads = NativeThread.Registry.aliveThreadsIterator.exists { aliveThread =>
+    def pollNonDaemonThreads =
+      NativeThread.Registry.aliveThreadsIterator.exists { aliveThread =>
         val thread = aliveThread.thread
         (thread ne shutdownThread) &&
-        !thread.isDaemon() &&
-        thread.isAlive()
+          !thread.isDaemon() &&
+          thread.isAlive()
       }
 
     def queue = concurrent.NativeExecutionContext.queueInternal

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -95,13 +95,17 @@ package object runtime {
       shutdownThread = Thread.currentThread()
       atomic_thread_fence(memory_order.memory_order_seq_cst)
     }
-    def pollNonDaemonThreads =
-      NativeThread.Registry.aliveThreadsIterator.exists { aliveThread =>
-        val thread = aliveThread.thread
-        (thread ne shutdownThread) &&
+    def pollNonDaemonThreads = {
+      val it = NativeThread.Registry.aliveThreadsIterator
+      var exists = false
+      while (!exists && it.hasNext()) {
+        val thread = it.next().thread
+        exists = (thread ne shutdownThread) &&
           !thread.isDaemon() &&
           thread.isAlive()
       }
+      exists
+    }
 
     def queue = concurrent.NativeExecutionContext.queueInternal
     def shouldWaitForThreads =

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -95,16 +95,16 @@ package object runtime {
       shutdownThread = Thread.currentThread()
       atomic_thread_fence(memory_order.memory_order_seq_cst)
     }
-    def pollNonDaemonThreads = NativeThread.Registry.aliveThreads.iterator
-      .map(_.thread)
-      .filter { thread =>
-        (thread ne shutdownThread) && !thread.isDaemon() &&
+    def pollNonDaemonThreads = NativeThread.Registry.aliveThreadsIterator.exists { aliveThread =>
+        val thread = aliveThread.thread
+        (thread ne shutdownThread) &&
+        !thread.isDaemon() &&
         thread.isAlive()
       }
 
     def queue = concurrent.NativeExecutionContext.queueInternal
     def shouldWaitForThreads =
-      if (isMultithreadingEnabled) gracefully && pollNonDaemonThreads.hasNext
+      if (isMultithreadingEnabled) gracefully && pollNonDaemonThreads
       else false
     def shouldRunQueuedTasks = gracefully && queue.nonEmpty
 


### PR DESCRIPTION
Changes `NativeThread.Registry.aliveThreads` into two methods: `NativeThread.Registry.aliveThreadsIterator` and `NativeThread.Registry.numAliveThreads`, to try to reduce the number of wrappers allocated when operating on this.

Follow up to the profile in https://profiler.firefox.com/public/xj9vrexr9t1yz0egx06sty9zhsamvphrq57t4y8/calltree/?globalTrackOrder=0w2&hiddenGlobalTracks=12&hiddenLocalTracksByPid=97759-1w7&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F0qqvz038sfbj7vinzp5a09rrfw5wsv0m5fdb253&thread=0&v=10

I see quite a few calls to allocations in `pollNonDaemonThreads`. This is called in a `while(true)` loop, so I guess it's expected that this method is called a lot.

The original method looked like:
```scala
NativeThread.Registry.aliveThreads.iterator
      .map(_.thread)
      .filter { thread =>
        (thread ne shutdownThread) && !thread.isDaemon() &&
        thread.isAlive()
      }
```

Since `aliveThreads` is a Scala wrapped over a Java collection (a [`JIterableWrapper`](https://github.com/scala/scala/blob/347341babac6a5e75c61c25fdf8b0417ad7d2188/src/library/scala/collection/convert/JavaCollectionWrappers.scala#L83-L95)) where most methods are implemented on top of [`iterator`](https://github.com/scala/scala/blob/347341babac6a5e75c61c25fdf8b0417ad7d2188/src/library/scala/collection/convert/JavaCollectionWrappers.scala#L87) this will:
- Create a Java iterator
- Create a Scala iterator wrapper
- Create an extra iterator for the map
- Create an extra iterator for the filter

Only to check an `hasNext` later.

This changes it to
```scala
def pollNonDaemonThreads = NativeThread.Registry.aliveThreadsIterator.exists { aliveThread =>
        val thread = aliveThread.thread
        (thread ne shutdownThread) &&
        !thread.isDaemon() &&
        thread.isAlive()
      }
```

Which should not allocate any object in the heap after the call to `NativeThread.Registry.aliveThreadsIterator`

Other parts of the code were also changed for similar reasons.

I did not check if some of those allocations were already optimized away by Interflow, but based on the profiler I don't think that's always the case.