### PR TITLE
Implement two JDK9 java.lang compareUnsigned methods

### DIFF
--- a/javalib/src/main/scala/java/lang/Byte.scala
+++ b/javalib/src/main/scala/java/lang/Byte.scala
@@ -186,6 +186,9 @@ object Byte {
   @inline def compare(x: scala.Byte, y: scala.Byte): scala.Int =
     x - y
 
+  @inline def compareUnsigned(x: scala.Byte, y: scala.Byte): scala.Int =
+    Integer.compareUnsigned(x, y)
+
   @inline def decode(nm: String): Byte = {
     val i = Integer.decode(nm).intValue()
     val b = i.toByte

--- a/javalib/src/main/scala/java/lang/Short.scala
+++ b/javalib/src/main/scala/java/lang/Short.scala
@@ -185,6 +185,9 @@ object Short {
   @inline def compare(x: scala.Short, y: scala.Short): scala.Int =
     x - y
 
+  @inline def compareUnsigned(x: scala.Short, y: scala.Short): scala.Int =
+    Integer.compareUnsigned(x, y)
+
   @inline def decode(nm: String): Short = {
     val i = Integer.decode(nm).intValue()
     val r = i.toShort

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ByteTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ByteTestOnJDK9.scala
@@ -1,0 +1,24 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ByteTestOnJDK9 {
+  @Test def compareUnsigned(): Unit = {
+    val byteZero = 0.toByte
+
+    assertTrue(
+      "compare signed",
+      jl.Byte.compare(jl.Byte.MIN_VALUE, byteZero) < 0
+    )
+
+    assertTrue(
+      "compare unsigned",
+      jl.Byte.compareUnsigned(jl.Byte.MIN_VALUE, byteZero) > 0
+    )
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ShortTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ShortTestOnJDK9.scala
@@ -1,0 +1,25 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ShortTestOnJDK9 {
+
+  @Test def compareUnsigned(): Unit = {
+    val shortZero = 0.toShort
+
+    assertTrue(
+      "compare signed",
+      jl.Short.compare(jl.Short.MIN_VALUE, shortZero) < 0
+    )
+
+    assertTrue(
+      "compare unsigned",
+      jl.Short.compareUnsigned(jl.Short.MIN_VALUE, shortZero) > 0
+    )
+  }
+}


### PR DESCRIPTION
Implement javalib JDK9 `java.lang` static methods `Byte.compareUnsigned(byte, byte)` and
`Short.compareUnsigned(short, short)` and associated Tests.

Observers may note that `ShortTestOnJDK9` is self-descriptive.

These methods will get more extensively exercised in the Tests for JDK9 `Arrays` methods
which are under development.