### PR TITLE
Various ByteBufferTest classes now pass on JDK >= 23

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/ByteBufferTest.scala.template
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/ByteBufferTest.scala.template
@@ -1467,7 +1467,14 @@ abstract class ByteBufferTest extends BaseBufferTest {
         )) {
       val buf = allocBuffer(capacity)
       def getAlignmentOffset() = buf.alignmentOffset(capacity, unitSize)
-      if (buf.isDirect() || unitSize <= 8) {
+
+      /* Test the JDK >= 23 behavior of allowing only byte alignment for
+       * non-direct buffers.
+       *
+       * When "alignmentOffset(capacity, unitSize)" was introduced in
+       * JDK 9, it allowed the unitSizes now tested only for direct buffers.
+       */
+      if (buf.isDirect() || (unitSize == 1)) {
         val alignment = getAlignmentOffset()
         assertTrue(s"$input", alignment >= 0 && alignment < unitSize)
       } else {
@@ -1490,7 +1497,14 @@ abstract class ByteBufferTest extends BaseBufferTest {
         )) {
       val buf = withContent(capacity, elemRange(1, capacity): _*)
       def getAlignmentSlice() = buf.alignedSlice(unitSize)
-      if (buf.isDirect() || unitSize <= 8) {
+
+      /* Test the JDK >= 23 behavior of allowing only byte alignment for
+       * non-direct buffers.
+       *
+       * When "alignedSlice(unitSize)" was introduced in
+       * JDK 9, it allowed the unitSizes now tested only for direct buffers.
+       */
+      if (buf.isDirect() || (unitSize == 1)) {
         val alignBuf = getAlignmentSlice()
         assertEquals(0, alignBuf.limit() % unitSize)
         assertEquals(0, alignBuf.capacity() % unitSize)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/ByteBufferTest.scala.template
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/ByteBufferTest.scala.template
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform
 
 abstract class ByteBufferTest extends BaseBufferTest {
   type Factory = BufferFactory.ByteBufferFactory
@@ -1474,7 +1475,8 @@ abstract class ByteBufferTest extends BaseBufferTest {
        * When "alignmentOffset(capacity, unitSize)" was introduced in
        * JDK 9, it allowed the unitSizes now tested only for direct buffers.
        */
-      if (buf.isDirect() || (unitSize == 1)) {
+      val maxSize = if (Platform.executingInJVMOnLowerThanJDK(23)) 8 else 1 
+      if (buf.isDirect() || (unitSize <= maxSize)) {
         val alignment = getAlignmentOffset()
         assertTrue(s"$input", alignment >= 0 && alignment < unitSize)
       } else {
@@ -1504,7 +1506,8 @@ abstract class ByteBufferTest extends BaseBufferTest {
        * When "alignedSlice(unitSize)" was introduced in
        * JDK 9, it allowed the unitSizes now tested only for direct buffers.
        */
-      if (buf.isDirect() || (unitSize == 1)) {
+      val maxSize = if (Platform.executingInJVMOnLowerThanJDK(23)) 8 else 1 
+      if (buf.isDirect() || (unitSize <= maxSize)) {
         val alignBuf = getAlignmentSlice()
         assertEquals(0, alignBuf.limit() % unitSize)
         assertEquals(0, alignBuf.capacity() % unitSize)


### PR DESCRIPTION
Final fix #4171  

Various classes generated from javalib `nio.ByteBufferTest.template` now pass when
run on a JDK greater than or equal to JDK 23, including the recently released JDK 24.

JDK >= 23 now allows only byte alignment for non-direct buffers.  The original JDK 9
description was pretty vague.

The Scala Native code continues to pass without changes.