### PR TITLE
Update javalib GZIPInputStreamTest for JDK >= 23

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/GZIPInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/GZIPInputStreamTest.scala
@@ -54,7 +54,7 @@ class GZIPInputStreamTest {
      * bytes have been read and just before the read which sets eos.
      * This shows that the read() is calculating the crc correctly
      * not leaving it zero.
-     * 
+     *
      * Another test could be written to show that the calculated crc is
      * actually being used to detect errors.  An exercise for the
      * reader.

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/GZIPInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/zip/GZIPInputStreamTest.scala
@@ -39,10 +39,44 @@ class GZIPInputStreamTest {
     var outBuf = new Array[Byte](100)
     var result = 0
     val inGZIP = new TestGZIPInputStream(new ByteArrayInputStream(gInput))
+
+    /* It appears that JDK 23 changed so that the crc is reset to 0
+     * after eos (end of string) is detected.  Previous JDKs maintained the
+     * crc value in this case.
+     *
+     * The JDK 23 (and 24) Release Notes and the Web in general is silent
+     * about this change.
+     *
+     * Scala Native preserves the traditional behavior, even on JDK >= 23.
+     */
+
+    /* On all platforms & versions, verify the crc after all expected
+     * bytes have been read and just before the read which sets eos.
+     * This shows that the read() is calculating the crc correctly
+     * not leaving it zero.
+     * 
+     * Another test could be written to show that the calculated crc is
+     * actually being used to detect errors.  An exercise for the
+     * reader.
+     */
+
     while (!inGZIP.endofInput()) {
-      result += inGZIP.read(outBuf, result, outBuf.length - result)
+      val nRead = inGZIP.read(outBuf, result, outBuf.length - result)
+      if (nRead > -1) {
+        result += nRead
+        if (result > orgBuf.length) {
+          fail(
+            s"read too many bytes, expected: ${orgBuf.length}, read ${result}"
+          )
+        } else if (result == orgBuf.length) {
+          assertEquals(
+            "checksum",
+            2074883667L /* 0x7BAC3653L */,
+            inGZIP.getChecksum().getValue()
+          )
+        } // else read more
+      }
     }
-    assertTrue(inGZIP.getChecksum().getValue() == 2074883667L)
 
     var i = 0
     while (i < orgBuf.length) {
@@ -121,22 +155,37 @@ class GZIPInputStreamTest {
       }
     }
 
-    result = -10
-    result = in.read(null, 100, 1)
-    result = in.read(outBuf, -100, 1)
-    result = in.read(outBuf, -1, 1)
+    /* Stream is at eos at this point, so some argument combinations which
+     * would throw exceptions earlier in the stream no longer do.
+     */
+
+    assertEquals("No NPE", -1, in.read(null, 100, 1))
+
+    assertEquals(
+      "No IndexOutOfBoundsException, negative origin",
+      -1,
+      in.read(outBuf, -100, 1)
+    )
+
+    assertEquals(
+      "No IndexOutOfBoundsException, negative length",
+      -1,
+      in.read(outBuf, 100, -2)
+    )
+
+    assertEquals(
+      "No IndexOutOfBoundsException, negative length",
+      -1,
+      in.read(outBuf, 1, 2 * outBuf.length)
+    )
   }
 
   @Test def close(): Unit = {
     val outBuf = new Array[Byte](100)
     var result = 0
     val inGZIP = new TestGZIPInputStream(new ByteArrayInputStream(gInput))
-    while (!inGZIP.endofInput()) {
-      result += inGZIP.read(outBuf, result, outBuf.length - result)
-    }
-    assertTrue(inGZIP.getChecksum().getValue() == 2074883667L)
-    inGZIP.close()
 
+    inGZIP.close()
     assertThrows(classOf[IOException], inGZIP.read())
   }
 


### PR DESCRIPTION
This is a partial fix for Issue https://github.com/scala-native/scala-native/issues/4171, which 
still has one failing case outstanding.

The behavior of javalib `java.util.zip.GZIPInputStream` with regards to crc handling appears to 
have changed in JDK and beyond.  A description of the change is difficult to find in the JDK 23 & 24
fine Release Notes and on the Web at large.

The change appears to be that instance variable `crc` is reset (to zero) when the instance
variable `eos` (end of stream) is `true`.

This PR reworks its `crc` test to validate its value after all the expected bytes and prior
to the read() which sets eos and on the affected JVM versions zeros the crc.  
Showing that the crc is being calculated correctly is the essence of the prior code.

The Scala Native code continues to pass without changes.  This means that the SN
code is slightly non-compliant with JVM >= 23. It errs in the helpful direction of preserving
the crc.  It is hard to understand the utility of resetting the crc on a stream after its
end because  the crc will never be used or updated again.

A section of puzzling code at the bottom of the same test has been re-written to makes its
intent & purpose easier to apprehend.