### PR TITLE
Fix #4171: Update javalib ZIPEntryTest for JDK >= 23

### DIFF
--- a/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -21,6 +21,13 @@ object Platform {
   final val executingInJVMOnLowerThanJDK17 = jdkVersion < 17
   final val executingInJVMOnJDK17 = jdkVersion == 17
 
+  // current usage, adapted from: Scala.js commit: b38201c dated: 2025-02-06
+  def executingInJVMOnLowerThanJDK(version: Int): Boolean =
+    jdkVersion < version
+
+  def executingInJVMWithJDKIn(range: Range): Boolean =
+    range.contains(jdkVersion)
+
   private lazy val jdkVersion = {
     val v = System.getProperty("java.version")
     if (v.startsWith("1.")) Integer.parseInt(v.drop(2).takeWhile(_.isDigit))

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -19,11 +19,17 @@ object Platform {
 
   final val hasCompliantArrayIndexOutOfBounds = true
 
+  // historical usage, kept to avoid cascading changes.
   final val executingInJVMOnJDK8OrLower = false
   final val executingInJVMOnLowerThenJDK11 = false
   final val executingInJVMOnLowerThanJDK15 = false
   final val executingInJVMOnLowerThanJDK17 = false
   final val executingInJVMOnJDK17 = false
+
+  // current usage, adapted from: Scala.js commit: b38201c dated: 2025-02-06
+  def executingInJVMOnLowerThanJDK(version: Int): Boolean = false
+
+  def executingInJVMWithJDKIn(range: Range): Boolean = false
 
   final val hasCompliantAsInstanceOfs = true
 


### PR DESCRIPTION
This is the third and final of three PRs which, taken together,  fix #4171.

JDK 23 introduced stricter argument checking for three javalib `j.u.zip.ZipEntry`  methods.

`ZipEntryTest` continues to use the looser JDK 8 to 22, inclusive, and reports non-compliance
when running on JVM greater than or equal to 23. Scala Native is based on Java 8, so 
it continues to use and be tested using the Java 8 specification.

The non-compliance here is one of those "minor unless it happens to you" cases where
JVM 23+ detects and throws if the sum of various fields exceeds a given limit.

The Java < 23 behavior is to silently truncate upon writing out  ZIP file.