### PR TITLE
Align j.l.StringBuilder & StringBuffer with JDK24

### DIFF
--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -33,7 +33,7 @@ import scala.scalanative.unsafe.UnsafeRichArray
 protected abstract class AbstractStringBuilder private (unit: Unit) {
   import AbstractStringBuilder._
 
-  protected var value: Array[Char] = _
+  protected var value: Array[scala.Char] = _
   protected var count: scala.Int = _
   protected var shared: scala.Boolean = _
 
@@ -85,7 +85,7 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
     count += 1
   }
 
-  protected final def append0(chars: Array[Char]): Unit = {
+  protected final def append0(chars: Array[scala.Char]): Unit = {
     val newSize = count + chars.length
     if (newSize > value.length) {
       enlargeBuffer(newSize)
@@ -95,7 +95,7 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
   }
 
   protected final def append0(
-      chars: Array[Char],
+      chars: Array[scala.Char],
       offset: scala.Int,
       length: scala.Int
   ): Unit = {
@@ -211,28 +211,13 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
     return value(index)
   }
 
-  protected def compareTo0(another: AbstractStringBuilder): Int = {
+  protected def compareTo0(that: AbstractStringBuilder): Int = {
     Objects.requireNonNull(
-      another,
+      that,
       """Cannot read field "value" because "another" is null"""
     )
 
-    val thisCount = this.count
-    val thatCount = another.count
-
-    val memcmpCount = Math.min(thisCount, thatCount) * 2 // Bytes
-
-    val cmp =
-      if (memcmpCount == 0) 0
-      else
-        libc.string.memcmp(
-          value.at(0),
-          another.value.at(0),
-          memcmpCount.toCSize
-        )
-
-    if (cmp == 0) thisCount - thatCount
-    else cmp
+    Arrays.compare(value, 0, this.count, that.value, 0, that.count)
   }
 
   protected final def delete0(start: scala.Int, _end: scala.Int): Unit = {
@@ -293,7 +278,7 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
   def getChars(
       start: scala.Int,
       end: scala.Int,
-      dest: Array[Char],
+      dest: Array[scala.Char],
       destStart: scala.Int
   ): Unit = {
     if (start > count || end > count || start > end) {
@@ -302,7 +287,10 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
     System.arraycopy(value, start, dest, destStart, end - start)
   }
 
-  protected final def insert0(index: scala.Int, chars: Array[Char]): Unit = {
+  protected final def insert0(
+      index: scala.Int,
+      chars: Array[scala.Char]
+  ): Unit = {
     if (0 > index || index > count) {
       throw new StringIndexOutOfBoundsException(index)
     }
@@ -315,7 +303,7 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
 
   protected final def insert0(
       index: scala.Int,
-      chars: Array[Char],
+      chars: Array[scala.Char],
       start: scala.Int,
       length: scala.Int
   ): Unit = {

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -212,16 +212,27 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
   }
 
   protected def compareTo0(another: AbstractStringBuilder): Int = {
-    Objects.requireNonNull(another, "another")
-    if (this.count != another.count) {
-      this.count - another.count
-    } else {
-      libc.string.memcmp(
-        this.value.at(0),
-        another.value.at(0),
-        (this.count * 2).toCSize
-      )
-    }
+    Objects.requireNonNull(
+      another,
+      """Cannot read field "value" because "another" is null"""
+    )
+
+    val thisCount = this.count
+    val thatCount = another.count
+
+    val memcmpCount = Math.min(thisCount, thatCount) * 2 // Bytes
+
+    val cmp =
+      if (memcmpCount == 0) 0
+      else
+        libc.string.memcmp(
+          value.at(0),
+          another.value.at(0),
+          memcmpCount.toCSize
+        )
+
+    if (cmp == 0) thisCount - thatCount
+    else cmp
   }
 
   protected final def delete0(start: scala.Int, _end: scala.Int): Unit = {

--- a/javalib/src/main/scala/java/lang/StringBuffer.scala
+++ b/javalib/src/main/scala/java/lang/StringBuffer.scala
@@ -7,8 +7,9 @@ import AbstractStringBuilder.INITIAL_CAPACITY
 final class StringBuffer
     extends AbstractStringBuilder
     with Appendable
-    with Serializable
-    with CharSequence {
+    with CharSequence
+    with Comparable[StringBuffer]
+    with Serializable {
 
   def this(capacity: scala.Int) = {
     this()
@@ -144,6 +145,10 @@ final class StringBuffer
       super.codePointCount(beginIndex, endIndex)
     }
 
+  def compareTo(another: StringBuffer): Int = synchronized {
+    compareTo0(another)
+  }
+
   def delete(start: scala.Int, end: scala.Int): StringBuffer =
     synchronized {
       delete0(start, end)
@@ -253,9 +258,18 @@ final class StringBuffer
       return super.offsetByCodePoints(index, codePointOffset)
     }
 
+  def repeat(codePoint: Int, count: Int): StringBuffer = {
+    repeat0(codePoint, count)
+    this
+  }
+
+  def repeat(cs: CharSequence, count: Int): StringBuffer = synchronized {
+    repeat0(cs, count)
+    this
+  }
+
   def replace(start: scala.Int, end: scala.Int, string: String): StringBuffer =
     synchronized {
-
       replace0(start, end, string)
       return this
     }

--- a/javalib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/StringBuilder.scala
@@ -6,6 +6,7 @@ final class StringBuilder
     extends AbstractStringBuilder
     with Appendable
     with CharSequence
+    with Comparable[StringBuilder]
     with Serializable {
   def this(capacity: Int) = {
     this()
@@ -113,6 +114,9 @@ final class StringBuilder
     this
   }
 
+  def compareTo(another: StringBuilder): Int =
+    compareTo0(another)
+
   def delete(start: scala.Int, end: scala.Int): StringBuilder = {
     delete0(start, end)
     this
@@ -190,6 +194,16 @@ final class StringBuilder
       end: scala.Int
   ): StringBuilder = {
     insert0(offset, seq, start, end)
+    this
+  }
+
+  def repeat(codePoint: Int, count: Int): StringBuilder = {
+    repeat0(codePoint, count)
+    this
+  }
+
+  def repeat(cs: CharSequence, count: Int): StringBuilder = {
+    repeat0(cs, count)
     this
   }
 

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -50,9 +50,9 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-pc-linux-gnu"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1074, members = 6940)
-      else if (isScala2_13) SymbolsCount(types = 1033, members = 7011)
-      else SymbolsCount(types = 1015, members = 7156)
+      if (isScala3) SymbolsCount(types = 1076, members = 6945)
+      else if (isScala2_13) SymbolsCount(types = 1036, members = 7023)
+      else SymbolsCount(types = 1018, members = 7168)
     )
 
   @Test def multithreading(): Unit =

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBufferTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBufferTestOnJDK11.scala
@@ -16,13 +16,13 @@ class StringBufferTestOnJDK11 {
     val bufrAClone = new StringBuffer(dataA)
 
     val alteredA = "abcdef"
-    val bufrB = StringBuffer(alteredA)
+    val bufrB = new StringBuffer(alteredA)
 
     val shortenedA = "abcDe"
-    val bufrC = StringBuffer(shortenedA)
+    val bufrC = new StringBuffer(shortenedA)
 
     val shortenedAndChangedA = "abcde"
-    val bufrD = StringBuffer(shortenedAndChangedA)
+    val bufrD = new StringBuffer(shortenedAndChangedA)
 
     assertThrows(
       classOf[NullPointerException],

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBufferTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBufferTestOnJDK11.scala
@@ -1,0 +1,46 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.lang.StringBuilder
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class StringBufferTestOnJDK11 {
+
+  @Test def compareTo(): Unit = {
+
+    val dataA = "abcDef"
+    val bufrA = new StringBuilder(dataA)
+    val bufrAClone = new StringBuilder(dataA)
+
+    val alteredA = "abcdef"
+    val bufrB = StringBuilder(alteredA)
+
+    val shortenedA = "abcDe"
+    val bufrC = StringBuilder(shortenedA)
+
+    assertThrows(
+      classOf[NullPointerException],
+      bufrA.compareTo(null)
+    )
+
+    /* StringBuffer extends Object and does not override equals
+     * so == and .eq both use reference equality.
+     * The intent here is to prove reference inequality. Use .eq to make
+     * that intent evident to the hasty or novice reader.
+     */
+    assertFalse("eq", bufrA.eq(bufrAClone))
+
+    // Compare contents
+    assertTrue("A == A", bufrAClone.compareTo(bufrA) == 0) // reflexive
+    assertTrue("A == AClone", bufrA.compareTo(bufrAClone) == 0)
+
+    assertTrue("A < B", bufrA.compareTo(bufrB) < 0) // symmetrical
+    assertTrue("B > A", bufrB.compareTo(bufrA) > 0)
+
+    assertTrue("A > C", bufrA.compareTo(bufrC) > 0)
+    assertTrue("B > C", bufrB.compareTo(bufrC) > 0) // transitive
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBufferTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBufferTestOnJDK11.scala
@@ -12,14 +12,17 @@ class StringBufferTestOnJDK11 {
   @Test def compareTo(): Unit = {
 
     val dataA = "abcDef"
-    val bufrA = new StringBuilder(dataA)
-    val bufrAClone = new StringBuilder(dataA)
+    val bufrA = new StringBuffer(dataA)
+    val bufrAClone = new StringBuffer(dataA)
 
     val alteredA = "abcdef"
-    val bufrB = StringBuilder(alteredA)
+    val bufrB = StringBuffer(alteredA)
 
     val shortenedA = "abcDe"
-    val bufrC = StringBuilder(shortenedA)
+    val bufrC = StringBuffer(shortenedA)
+
+    val shortenedAndChangedA = "abcde"
+    val bufrD = StringBuffer(shortenedAndChangedA)
 
     assertThrows(
       classOf[NullPointerException],
@@ -42,5 +45,7 @@ class StringBufferTestOnJDK11 {
 
     assertTrue("A > C", bufrA.compareTo(bufrC) > 0)
     assertTrue("B > C", bufrB.compareTo(bufrC) > 0) // transitive
+
+    assertTrue("D shorter but greater than A", bufrD.compareTo(bufrA) > 0)
   }
 }

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBuilderTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBuilderTestOnJDK11.scala
@@ -1,0 +1,47 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.lang.StringBuilder
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class StringBuilderTestOnJDK11 {
+
+  @Test def compareTo(): Unit = {
+
+    val dataA = "abcDef"
+    val bldrA = new StringBuilder(dataA)
+    val bldrAClone = new StringBuilder(dataA)
+
+    val alteredA = "abcdef"
+    val bldrB = StringBuilder(alteredA)
+
+    val shortenedA = "abcDe"
+    val bldrC = StringBuilder(shortenedA)
+
+    assertThrows(
+      "null argument",
+      classOf[NullPointerException],
+      bldrA.compareTo(null)
+    )
+
+    /* StringBuilder extends Object and does not override equals
+     * so == and .eq both use reference equality.
+     * The intent here is to prove reference inequality. Use .eq to make
+     * that intent evident to the hasty or novice reader.
+     */
+    assertFalse("eq", bldrA.eq(bldrAClone))
+
+    // Compare contents
+    assertTrue("A == A", bldrAClone.compareTo(bldrA) == 0) // reflexive
+    assertTrue("A == AClone", bldrA.compareTo(bldrAClone) == 0)
+
+    assertTrue("A < B", bldrA.compareTo(bldrB) < 0) // symmetrical
+    assertTrue("B > A", bldrB.compareTo(bldrA) > 0)
+
+    assertTrue("A > C", bldrA.compareTo(bldrC) > 0)
+    assertTrue("B > C", bldrB.compareTo(bldrC) > 0) // transitive
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBuilderTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBuilderTestOnJDK11.scala
@@ -21,6 +21,9 @@ class StringBuilderTestOnJDK11 {
     val shortenedA = "abcDe"
     val bldrC = StringBuilder(shortenedA)
 
+    val shortenedAndChangedA = "abcde"
+    val bldrD = StringBuilder(shortenedAndChangedA)
+
     assertThrows(
       "null argument",
       classOf[NullPointerException],
@@ -43,5 +46,7 @@ class StringBuilderTestOnJDK11 {
 
     assertTrue("A > C", bldrA.compareTo(bldrC) > 0)
     assertTrue("B > C", bldrB.compareTo(bldrC) > 0) // transitive
+
+    assertTrue("D shorter but greater than A", bldrD.compareTo(bldrA) > 0)
   }
 }

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBuilderTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/lang/StringBuilderTestOnJDK11.scala
@@ -16,13 +16,13 @@ class StringBuilderTestOnJDK11 {
     val bldrAClone = new StringBuilder(dataA)
 
     val alteredA = "abcdef"
-    val bldrB = StringBuilder(alteredA)
+    val bldrB = new StringBuilder(alteredA)
 
     val shortenedA = "abcDe"
-    val bldrC = StringBuilder(shortenedA)
+    val bldrC = new StringBuilder(shortenedA)
 
     val shortenedAndChangedA = "abcde"
-    val bldrD = StringBuilder(shortenedAndChangedA)
+    val bldrD = new StringBuilder(shortenedAndChangedA)
 
     assertThrows(
       "null argument",

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/lang/StringBufferTestOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/lang/StringBufferTestOnJDK21.scala
@@ -1,0 +1,64 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.lang.StringBuffer
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class StringBufferTestOnJDK21 {
+
+  @Test def repeatCharSequenceCheckArgs(): Unit = {
+    val bldr = new StringBuffer()
+
+    assertThrows(
+      "negative count",
+      classOf[IllegalArgumentException],
+      bldr.repeat("Y", -3)
+    )
+  }
+
+  @Test def repeatCharSequence(): Unit = {
+    val prefix = "0123"
+    val stem = "Díkē"
+    val suffix = "89AB"
+
+    val expected = s"${prefix}${stem}${stem}${stem}${suffix}"
+
+    val bldr = new StringBuffer(prefix)
+    bldr.repeat(stem, 3).append(suffix)
+
+    assertEquals("repeat", expected, bldr.toString())
+  }
+
+  @Test def repeatCodePointCheckArgs(): Unit = {
+    val bldr = new StringBuffer()
+
+    assertThrows(
+      "non-Unicode codePoint",
+      classOf[IllegalArgumentException],
+      bldr.repeat(-1, 3)
+    )
+
+    assertThrows(
+      "negative count",
+      classOf[IllegalArgumentException],
+      bldr.repeat("Y", -3)
+    )
+  }
+
+  @Test def repeatCodePoint(): Unit = {
+    val prefix = "abcd"
+    val cp = '*'
+    val stem = s"${cp}${cp}${cp}${cp}${cp}"
+    val suffix = "wxyz"
+
+    val expected = s"${prefix}${stem}${suffix}"
+
+    val bldr = new StringBuffer(prefix)
+    bldr.repeat(cp, stem.length).append(suffix)
+
+    assertEquals("repeat", expected, bldr.toString())
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/lang/StringBuilderTestOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/lang/StringBuilderTestOnJDK21.scala
@@ -1,0 +1,64 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.lang.StringBuilder
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class StringBuilderTestOnJDK21 {
+
+  @Test def repeatCharSequenceCheckArgs(): Unit = {
+    val bldr = new StringBuilder()
+
+    assertThrows(
+      "negative count",
+      classOf[IllegalArgumentException],
+      bldr.repeat("Y", -3)
+    )
+  }
+
+  @Test def repeatCharSequence(): Unit = {
+    val prefix = "0123"
+    val stem = "Díkē"
+    val suffix = "89AB"
+
+    val expected = s"${prefix}${stem}${stem}${stem}${suffix}"
+
+    val bldr = new StringBuilder(prefix)
+    bldr.repeat(stem, 3).append(suffix)
+
+    assertEquals("repeat", expected, bldr.toString())
+  }
+
+  @Test def repeatCodePointCheckArgs(): Unit = {
+    val bldr = new StringBuilder()
+
+    assertThrows(
+      "non-Unicode codePoint",
+      classOf[IllegalArgumentException],
+      bldr.repeat(-1, 3)
+    )
+
+    assertThrows(
+      "negative count",
+      classOf[IllegalArgumentException],
+      bldr.repeat("Y", -3)
+    )
+  }
+
+  @Test def repeatCodePoint(): Unit = {
+    val prefix = "abcd"
+    val cp = '*'
+    val stem = s"${cp}${cp}${cp}${cp}${cp}"
+    val suffix = "wxyz"
+
+    val expected = s"${prefix}${stem}${suffix}"
+
+    val bldr = new StringBuilder(prefix)
+    bldr.repeat(cp, stem.length).append(suffix)
+
+    assertEquals("repeat", expected, bldr.toString())
+  }
+}


### PR DESCRIPTION
Make javalib `java.lang` `StringBuilder` and `StringBuffer` current with JDK 24 and implement associated
tests.

Java 11 changed both of those classes to extend `Comparable[self]` and to require a `compareTo(other)`
method.

Java 21 added two `repeat()` methods in each of the classes.

There have been no changes to this classes since Java 21, so both are now aligned with JVM 24.
At least that part was easy.