### PR TITLE
Implement a faster javalib String#compareTo

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -202,18 +202,12 @@ final class _String()
 
     val cmp =
       if (memcmpCount == 0) 0
-      else {
-        val data1 =
-          value
-            .at(offset)
-            .asInstanceOf[Ptr[scala.Byte]]
-        val data2 =
-          anotherString.value
-            .at(anotherString.offset)
-            .asInstanceOf[Ptr[scala.Byte]]
-
-        memcmp(data1, data2, memcmpCount.toUInt)
-      }
+      else
+        memcmp(
+          value.at(offset),
+          anotherString.value.at(anotherString.offset),
+          memcmpCount.toCSize
+        )
 
     if (cmp == 0) thisCount - thatCount
     else cmp

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -52,7 +52,7 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
     )(expected =
       if (isScala3) SymbolsCount(types = 1068, members = 6906)
       else if (isScala2_13) SymbolsCount(types = 1028, members = 6980)
-      else SymbolsCount(types = 1010, members = 7124)
+      else SymbolsCount(types = 1010, members = 7125)
     )
 
   @Test def multithreading(): Unit =

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
@@ -154,10 +154,11 @@ class StringTest {
   }
 
   @Test def compareTo(): Unit = {
-    assertTrue("test".compareTo("utest") < 0)
-    assertTrue("test".compareTo("test") == 0)
-    assertTrue("test".compareTo("stest") > 0)
-    assertTrue("test".compareTo("tess") > 0)
+    assertTrue("== 0", "test".compareTo("test") == 0)
+    assertTrue("< 0", "test".compareTo("utest") < 0)
+    assertTrue("AB prefix equal with A shorter", "test".compareTo("testX") < 0)
+    assertTrue("A > B", "test".compareTo("tess") > 0)
+    assertTrue("A shorter but greater than B", "test".compareTo("stest") > 0)
   }
 
   @Test def compareToIgnoreCase(): Unit = {


### PR DESCRIPTION
javalib `String#equals` has used  `libc.memcmp` for a number of Scala Native versions.
`String#compareTo` now also uses `libc.memcmp`.  This should give faster execution
when comparing almost all Strings.


 As always, any change brings winners and losers. Comparing tiny one or two character strings 
may see some performance regression.If this becomes noticeable or measurable, special cases can be 
added for small N. `equals()` does not special casing for tiny strings.