### PR TITLE
Improvement [Build]: Update sbt to 1.10.11

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -57,8 +57,9 @@ object ScalaVersions {
   //   1.10.0 Latest sbt version.
   //   1.10.1 Latest sbt version.
   //   1.10.7 Latest sbt version, 1.10.2 had bug, see comment in SN Issue #4126
+  //   1.10.11 Latest sbt version
 
-  val sbt10Version: String = "1.10.7"
+  val sbt10Version: String = "1.10.11"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.7
+sbt.version = 1.10.11


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.10.11.

The SBT GitHub [announcement](https://github.com/sbt/sbt/releases/tag/v1.10.11).

This PR also updates the SBT version in both project/build.properties & project/ScalaVersions.scala.

This change has been heavily exercised for two weeks on MacOS ARM.