### PR TITLE
Implement basic `java.lang.System.Logger`

### DIFF
--- a/javalib/src/main/scala/java/lang/ClassLoader.scala
+++ b/javalib/src/main/scala/java/lang/ClassLoader.scala
@@ -3,7 +3,7 @@ package java.lang
 class ClassLoader protected (parent: ClassLoader) {
   def this() = this(null)
   def getResourceAsStream(name: String): java.io.InputStream =
-    ClassLoader.getResourceAsStream(name)
+    this.getClass().getResourceAsStream(name)
   def getUnnamedModule(): Module = new Module(null, this)
 }
 
@@ -12,6 +12,5 @@ object ClassLoader {
   def getSystemClassLoader(): ClassLoader = NativeClassLoader
 
   private object NativeClassLoader extends ClassLoader()
-  def getResourceAsStream(name: String): java.io.InputStream =
-    classOf[NativeClassLoader.type].getResourceAsStream(name)
+
 }

--- a/javalib/src/main/scala/java/lang/ClassLoader.scala
+++ b/javalib/src/main/scala/java/lang/ClassLoader.scala
@@ -3,5 +3,15 @@ package java.lang
 class ClassLoader protected (parent: ClassLoader) {
   def this() = this(null)
   def getResourceAsStream(name: String): java.io.InputStream =
-    this.getClass().getResourceAsStream(name)
+    ClassLoader.getResourceAsStream(name)
+  def getUnnamedModule(): Module = new Module(null, this)
+}
+
+object ClassLoader {
+  def getPlatformClassLoader(): ClassLoader = NativeClassLoader
+  def getSystemClassLoader(): ClassLoader = NativeClassLoader
+
+  private object NativeClassLoader extends ClassLoader()
+  def getResourceAsStream(name: String): java.io.InputStream =
+    classOf[NativeClassLoader.type].getResourceAsStream(name)
 }

--- a/javalib/src/main/scala/java/lang/ClassLoader.scala
+++ b/javalib/src/main/scala/java/lang/ClassLoader.scala
@@ -2,4 +2,6 @@ package java.lang
 
 class ClassLoader protected (parent: ClassLoader) {
   def this() = this(null)
+  def getResourceAsStream(name: String): java.io.InputStream =
+    this.getClass().getResourceAsStream(name)
 }

--- a/javalib/src/main/scala/java/lang/Module.scala
+++ b/javalib/src/main/scala/java/lang/Module.scala
@@ -1,0 +1,44 @@
+package java.lang
+
+import java.util.{Set => JSet}
+import java.io.{InputStream, IOException}
+import java.lang.annotation.Annotation
+import java.lang.reflect.AnnotatedElement
+
+final case class Module private[lang] (
+    name: String,
+    loader: ClassLoader
+) {
+  def getName(): String = name
+  def isNamed(): scala.Boolean = name != null
+
+  def getClassLoader(): ClassLoader = loader
+
+  def getResourceAsStream(name: String): InputStream = loader match {
+    case null   => ClassLoader.getSystemClassLoader().getResourceAsStream(name)
+    case loader => loader.getResourceAsStream(name)
+  }
+
+  // def canRead(other: Module): scala.Boolean = false
+  // def addReads(other: Module): Module = this
+  // def isExported(pn: String): scala.Boolean = false
+  // def isExported(pn: String, other: Module): scala.Boolean = false
+  // def isOpen(pn: String): scala.Boolean = ???
+  // def isOpen(pn: String, other: Module): scala.Boolean = ???
+  // def addExports(pn: String, other: Module): Module = ???
+  // def addOpens(pn: String, other: Module): Module = ???
+  // def canUse(service: Class[_]): scala.Boolean = ???
+  // def addUses(service: Class[_]): Module = ???
+  // def getDescriptor(): ModuleDescriptor = null // We don't support module descriptors yet
+  // def getLayer(): ModuleLayer = null // We don't support module layers yet
+  // def getPackages(): JSet[String] = java.util.Collections.emptySet()
+  // def getAnnotation[T <: Annotation](annotationClass: Class[T]): T = null.asInstanceOf[T]
+  // def getAnnotations(): Array[Annotation] = new Array[Annotation](0)
+  // def getDeclaredAnnotations(): Array[Annotation] = new Array[Annotation](0)
+  // def isNativeAccessEnabled(): scala.Boolean = false
+
+  override def toString(): String = {
+    if (isNamed()) s"module $name"
+    else s"unnamed module @${System.identityHashCode(this).toHexString}"
+  }
+}

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -2,7 +2,8 @@ package java.lang
 
 import java.io._
 import java.nio.charset.StandardCharsets
-import java.util.{Collections, HashMap, Map, Properties, WindowsHelperMethods}
+import java.{util => ju}
+import java.util.WindowsHelperMethods
 import scala.scalanative.posix.pwdOps._
 import scala.scalanative.posix.{pwd, unistd}
 import scala.scalanative.meta.LinktimeInfo.isWindows
@@ -55,7 +56,7 @@ object System {
   def err: PrintStream = Streams.err
   def err_=(v: PrintStream) = Streams.err = v
 
-  def getProperties(): Properties = SystemProperties.getProperties()
+  def getProperties(): ju.Properties = SystemProperties.getProperties()
 
   def clearProperty(key: String): String =
     SystemProperties.remove(key).asInstanceOf[String]
@@ -72,7 +73,7 @@ object System {
   def nanoTime(): scala.Long = time.scalanative_nano_time()
   def currentTimeMillis(): scala.Long = time.scalanative_current_time_millis()
 
-  def getenv(): Map[String, String] = envVars
+  def getenv(): ju.Map[String, String] = envVars
   def getenv(key: String): String = envVars.get(key.toUpperCase())
 
   def setIn(in: InputStream): Unit =
@@ -88,17 +89,29 @@ object System {
 
   // Logger interface
   def getLogger(name: String): Logger = {
-    java.util.Objects.requireNonNull(name)
-    new impl.SimpleLogger(name)
+    ju.Objects.requireNonNull(name)
+    LoggerFinder
+      .getLoggerFinder()
+      .getLogger(
+        name,
+        ClassLoader.getSystemClassLoader().getUnnamedModule()
+      )
   }
-  def getLogger(name: String, bundle: java.util.ResourceBundle): Logger =
-    getLogger(name)
-
+  def getLogger(name: String, bundle: java.util.ResourceBundle): Logger = {
+    ju.Objects.requireNonNull(name)
+    ju.Objects.requireNonNull(bundle)
+    LoggerFinder
+      .getLoggerFinder()
+      .getLocalizedLogger(
+        name,
+        bundle,
+        ClassLoader.getSystemClassLoader().getUnnamedModule()
+      )
+  }
   trait Logger {
     def getName(): String
     def isLoggable(level: Logger.Level): scala.Boolean
 
-    // Core methods that need implementation
     def log(
         level: Logger.Level,
         bundle: java.util.ResourceBundle,
@@ -112,7 +125,6 @@ object System {
         thrown: Throwable
     ): Unit
 
-    // Default methods with implementations
     def log(level: Logger.Level, obj: Object): Unit = if (isLoggable(level)) {
       log(level, if (obj == null) "null" else obj.toString())
     }
@@ -185,6 +197,79 @@ object System {
       }
     }
   }
+
+  abstract class LoggerFinder {
+    def getLogger(name: String, module: Module): Logger
+
+    def getLocalizedLogger(
+        name: String,
+        bundle: ju.ResourceBundle,
+        module: Module
+    ): Logger = {
+      ju.Objects.requireNonNull(name)
+      ju.Objects.requireNonNull(module)
+
+      val logger = getLogger(name, module)
+      // Return a wrapper logger that handles localization
+      new Logger {
+        def getName(): String = logger.getName()
+
+        def isLoggable(level: Logger.Level): scala.Boolean =
+          logger.isLoggable(level)
+
+        override def log(level: Logger.Level, msg: String): Unit =
+          logger.log(level, bundle, msg, null: Array[Object])
+
+        override def log(
+            level: Logger.Level,
+            msg: String,
+            thrown: Throwable
+        ): Unit =
+          logger.log(level, bundle, msg, thrown)
+
+        override def log(
+            level: Logger.Level,
+            format: String,
+            params: Array[Object]
+        ): Unit =
+          logger.log(level, bundle, format, params)
+
+        override def log(
+            level: Logger.Level,
+            bundle: ju.ResourceBundle,
+            format: String,
+            params: Array[Object]
+        ): Unit =
+          logger.log(level, bundle, format, params)
+
+        override def log(
+            level: Logger.Level,
+            bundle: ju.ResourceBundle,
+            msg: String,
+            thrown: Throwable
+        ): Unit =
+          logger.log(level, bundle, msg, thrown)
+      }
+    }
+  }
+
+  object LoggerFinder {
+    // Default LoggerFinder implementation
+    private class DefaultLoggerFinder extends LoggerFinder {
+      override def getLogger(name: String, module: Module): Logger = {
+        ju.Objects.requireNonNull(name)
+        ju.Objects.requireNonNull(module)
+        new impl.SimpleLogger(name)
+      }
+    }
+
+    private lazy val loggerFinder = ju.ServiceLoader
+      .load(classOf[LoggerFinder])
+      .findFirst()
+      .orElse(new DefaultLoggerFinder())
+
+    def getLoggerFinder(): LoggerFinder = loggerFinder
+  }
 }
 
 // Extract mutable fields to custom object allowing to skip allocations of unused features
@@ -231,7 +316,7 @@ private object SystemProperties {
   private lazy val initializeUserName =
     getUserName().foreach(systemProperties.setProperty(UserNameKey, _))
 
-  def getProperties(): Properties = {
+  def getProperties(): ju.Properties = {
     // initialize all properties
     initializeCurrentDirectory
     initializeUserHomeDirectory
@@ -273,7 +358,7 @@ private object SystemProperties {
   }
 
   private def loadProperties() = {
-    val sysProps = new Properties()
+    val sysProps = new ju.Properties()
     sysProps.setProperty("java.version", "1.8")
     sysProps.setProperty("java.vm.specification.version", "1.8")
     sysProps.setProperty("java.vm.specification.vendor", "Oracle Corporation")
@@ -402,9 +487,9 @@ private object SystemProperties {
 }
 
 private object EnvVars {
-  val envVars: Map[String, String] = {
+  val envVars: ju.Map[String, String] = {
     def getEnvsUnix() = {
-      val map = new HashMap[String, String]()
+      val map = new ju.HashMap[String, String]()
       val ptr: Ptr[CString] = unistd.environ
       var i = 0
       while (ptr(i) != null) {
@@ -421,8 +506,8 @@ private object EnvVars {
       map
     }
 
-    def getEnvsWindows(): Map[String, String] = {
-      val envsMap = new HashMap[String, String]()
+    def getEnvsWindows(): ju.Map[String, String] = {
+      val envsMap = new ju.HashMap[String, String]()
       val envBlockHead = GetEnvironmentStringsW()
 
       var blockPtr = envBlockHead
@@ -444,7 +529,7 @@ private object EnvVars {
       envsMap
     }
 
-    Collections.unmodifiableMap {
+    ju.Collections.unmodifiableMap {
       if (isWindows) getEnvsWindows()
       else getEnvsUnix()
     }

--- a/javalib/src/main/scala/java/lang/impl/SimpleLogger.scala
+++ b/javalib/src/main/scala/java/lang/impl/SimpleLogger.scala
@@ -1,0 +1,104 @@
+package java.lang
+package impl
+
+import System.Logger
+import scalanative.posix.time._
+import scalanative.windows.crt.{time => winTime}
+import scalanative.unsafe._
+import scalanative.unsigned._
+import scala.scalanative.meta.LinktimeInfo.isWindows
+import scala.scalanative.runtime.javalib.Proxy
+
+// Simple default logger implementation
+private[lang] class SimpleLogger(name: String) extends Logger {
+  def getName(): String = name
+
+  def isLoggable(level: Logger.Level): scala.Boolean = level match {
+    case Logger.Level.OFF => false
+    case _                => true
+  }
+
+  override def log(
+      level: Logger.Level,
+      bundle: java.util.ResourceBundle,
+      format: String,
+      params: scala.Array[Object]
+  ): Unit = {
+    if (isLoggable(level)) {
+      val message = if (bundle != null && bundle.containsKey(format)) {
+        val pattern = bundle.getString(format)
+        String.format(pattern, params: _*)
+      } else {
+        String.format(format, params: _*)
+      }
+      doLog(level, message)
+    }
+  }
+
+  def log(
+      level: Logger.Level,
+      bundle: java.util.ResourceBundle,
+      msg: String,
+      thrown: Throwable
+  ): Unit = {
+    if (isLoggable(level)) {
+      val message = if (bundle != null && bundle.containsKey(msg)) {
+        bundle.getString(msg)
+      } else {
+        msg
+      }
+      doLog(level, message)
+      if (thrown != null) {
+        thrown.printStackTrace(System.err)
+      }
+    }
+  }
+
+  private def doLog(level: Logger.Level, message: String): Unit = {
+    System.err.println(
+      s"${currentDate()} ${currentCallsite()}\n[$level]: $message"
+    )
+  }
+
+  private def currentCallsite(): String = {
+    val callSiteFrames = Proxy
+      .stackTraceIterator()
+      .dropWhile { elem =>
+        elem.getClassName.startsWith("java.lang.")
+      }
+    if (!callSiteFrames.hasNext) {
+      return ""
+    }
+    val frame = callSiteFrames.next()
+    s"${frame.getClassName} ${frame.getMethodName}"
+  }
+
+  private def currentDate(): String = {
+    def fallback = System.currentTimeMillis().toString()
+    val milliseconds = System.currentTimeMillis()
+    val seconds = milliseconds / 1000L
+    val ttPtr = stackalloc[time_t]()
+    !ttPtr = seconds.toSize
+
+    val tmPtr = stackalloc[tm]()
+    def getLocalTime() =
+      if (isWindows) winTime.localtime_s(tmPtr, ttPtr) != 0
+      else localtime_r(ttPtr, tmPtr) == null
+
+    if (getLocalTime()) {
+      return fallback
+    }
+
+    val bufSize = 50.toUSize
+    val buf: Ptr[CChar] = stackalloc[CChar](bufSize)
+
+    val n =
+      if (isWindows)
+        winTime.strftime(buf, bufSize, c"%b %d, %Y %I:%M:%S %p", tmPtr)
+      else
+        strftime(buf, bufSize, c"%b %d, %Y %I:%M:%S %p", tmPtr)
+
+    if (n.toInt == 0) fallback
+    else fromCString(buf)
+  }
+}

--- a/javalib/src/main/scala/java/util/ResourceBundle.scala
+++ b/javalib/src/main/scala/java/util/ResourceBundle.scala
@@ -1,0 +1,172 @@
+package java.util
+
+import java.{util => ju}
+
+abstract class ResourceBundle {
+  def getKeys(): ju.Enumeration[String]
+
+  protected def handleGetObject(key: String): Object
+
+  private var parent: ResourceBundle = _
+  protected def getParent(): ResourceBundle = parent
+  def setParent(parent: ResourceBundle): Unit = {
+    this.parent = parent
+  }
+
+  def getBaseBundleName(): String = null
+
+  // private var locale: Locale = _
+  // def getLocale(): Locale = locale
+  // protected[util] def setLocale(locale: Locale): Unit = {
+  //   this.locale = locale
+  // }
+
+  def getObject(key: String): Object = {
+    Objects.requireNonNull(key)
+
+    var obj = handleGetObject(key)
+    if (obj == null) {
+      if (parent != null) {
+        obj = parent.getObject(key)
+      }
+      if (obj == null) {
+        throw new MissingResourceException(
+          s"Can't find resource for bundle $this, key $key",
+          this.getClass.getName,
+          key
+        )
+      }
+    }
+    obj
+  }
+
+  def getString(key: String): String = {
+    getObject(key) match {
+      case s: String => s
+      case obj =>
+        throw new ClassCastException(
+          s"'$key' in bundle ${this.getClass.getName} is not a string but ${obj.getClass.getName}"
+        )
+    }
+  }
+
+  def getStringArray(key: String): Array[String] = {
+    getObject(key) match {
+      case arr: Array[String] => arr
+      case obj =>
+        throw new ClassCastException(
+          s"'$key' in bundle ${this.getClass.getName} is not a string array but ${obj.getClass.getName}"
+        )
+    }
+  }
+
+  def keySet(): ju.Set[String] = {
+    val set = new ju.HashSet[String]()
+    var bundle = this
+    while (bundle != null) {
+      val keys = bundle.handleKeySet()
+      if (keys != null) {
+        set.addAll(keys)
+      }
+      bundle = bundle.parent
+    }
+    ju.Collections.unmodifiableSet(set)
+  }
+
+  def containsKey(key: String): Boolean = {
+    if (key == null) {
+      throw new NullPointerException("key is null")
+    }
+    var bundle = this
+    while (bundle != null) {
+      if (bundle.handleKeySet().contains(key)) {
+        return true
+      }
+      bundle = bundle.parent
+    }
+    false
+  }
+
+  protected def handleKeySet(): ju.Set[String] = {
+    val keys = new ju.HashSet[String]()
+    val enum_ = getKeys()
+    while (enum_.hasMoreElements()) {
+      keys.add(enum_.nextElement())
+    }
+    keys
+  }
+}
+
+object ResourceBundle {
+  // def getBundle(baseName: String): ResourceBundle = ???
+  // def getBundle(baseName: String, locale: Locale): ResourceBundle = ???
+  // def getBundle(baseName: String, control: Control): ResourceBundle = ???
+  // def getBundle(baseName: String, locale: Locale, control: Control): ResourceBundle = ???
+  // def getBundle(baseName: String, locale: Locale, loader: ClassLoader): ResourceBundle = ???
+  // def getBundle(
+  //     baseName: String,
+  //     targetLocale: Locale,
+  //     loader: ClassLoader,
+  //     control: Control
+  // ): ResourceBundle = ???
+  // def getBundle(
+  //     baseName: String,
+  //     locale: Locale,
+  //     loader: ClassLoader,
+  //     format: scala.Boolean
+  // ): ResourceBundle = ???
+
+  def clearCache(): Unit = ()
+  def clearCache(loader: ClassLoader): Unit = ()
+
+  // object Control {
+  //   final val FORMAT_DEFAULT = List.of("java.class", "java.properties")
+  //   final val FORMAT_CLASS = List.of("java.class")
+  //   final val FORMAT_PROPERTIES = List.of("java.properties")
+  //   final val TTL_DONT_CACHE: scala.Long = -1L
+  //   final val TTL_NO_EXPIRATION_CONTROL: scala.Long = -2L
+
+  //   def getControl(formats: ju.List[String]): Control
+  //   def getNoFallbackControl(formats: ju.List[String]): Control
+  // }
+
+  // abstract class Control protected () {
+  //   def getFormats(baseName: String): ju.List[String] = ???
+  //   def getCandidateLocales(
+  //       baseName: String,
+  //       locale: Locale
+  //   ): ju.List[Locale] = ???
+  //   def getFallbackLocale(
+  //       baseName: String,
+  //       locale: Locale
+  //   ): Locale = ???
+  //   def newBundle(
+  //       baseName: String,
+  //       locale: Locale,
+  //       format: String,
+  //       loader: ClassLoader,
+  //       reload: scala.Boolean
+  //   ): ResourceBundle = ???
+  //   def getTimeToLive(
+  //       baseName: String,
+  //       locale: Locale
+  //   ): scala.Long = ???
+  //   def needsReload(
+  //       baseName: String,
+  //       locale: Locale,
+  //       format: String,
+  //       loader: ClassLoader,
+  //       bundle: ResourceBundle,
+  //       loadTime: scala.Long
+  //   ): scala.Boolean = ???
+  //   def toBundleName(
+  //       baseName: String,
+  //       locale: Locale
+  //   ): String = ???
+
+  //   def toResourceName(
+  //       bundleName: String,
+  //       suffix: String
+  //   ): String = ???
+  // }
+}

--- a/javalib/src/main/scala/scala/scalanative/runtime/javalib/Proxy.scala
+++ b/javalib/src/main/scala/scala/scalanative/runtime/javalib/Proxy.scala
@@ -31,4 +31,6 @@ object Proxy {
   def stealWork(timeout: FiniteDuration): Unit =
     concurrent.NativeExecutionContext.queueInternal.stealWork(timeout)
 
+  def stackTraceIterator(): Iterator[StackTraceElement] =
+    StackTrace.stackTraceIterator()
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
@@ -7,6 +7,33 @@ import scala.scalanative.unsigned._
 import scala.scalanative.meta.LinktimeInfo
 
 private[runtime] object StackTrace {
+  @noinline def stackTraceIterator(): Iterator[StackTraceElement] = {
+    new Iterator[StackTraceElement] {
+      val tlContext = ThreadLocalContext.get()
+      implicit val localContext: Context = tlContext
+      val cursor = tlContext.unwindCursor
+      val context = tlContext.unwindContext
+      val ip = tlContext.ip
+      unwind.get_context(context)
+      unwind.init_local(cursor, context)
+
+      override def hasNext: Boolean = unwind.step(cursor) > 0
+      override def next(): StackTraceElement = {
+        unwind.get_reg(cursor, unwind.UNW_REG_IP, ip)
+        val addr =
+          Intrinsics.castRawSizeToLongUnsigned(Intrinsics.loadRawSize(ip))
+        tlContext.cache.getOrElseUpdate(
+          addr,
+          makeStackTraceElement(cursor, addr)
+        )
+      }
+    }
+      .dropWhile { elem =>
+        elem.getClassName.startsWith("scala.scalanative.runtime.") ||
+        elem.getClassName.contains(".Iterator")
+      }
+  }
+
   @noinline def currentStackTrace(): scala.Array[StackTraceElement] = {
     // Used to prevent filling stacktraces inside `currentStackTrace` which might lead to infinite loop
     val thread = NativeThread.currentNativeThread
@@ -16,10 +43,10 @@ private[runtime] object StackTrace {
       implicit val tlContext: Context = ThreadLocalContext.get()
       val cursor = tlContext.unwindCursor
       val context = tlContext.unwindContext
+      val ip = tlContext.ip
       try {
         thread.isFillingStackTrace = true
         val buffer = scala.Array.newBuilder[StackTraceElement]
-        val ip = Intrinsics.stackalloc[RawSize]()
         unwind.get_context(context)
         unwind.init_local(cursor, context)
         // JVM limit stack trace to 1024 entries
@@ -168,7 +195,8 @@ private[runtime] object StackTrace {
       MethodNameBufferOffset + MethodNameMaxLength
     final val UnwindCursorOffset = FileNameBufferOffset + FileNameMaxLength
     final val UnwindContextOffset = UnwindCursorOffset + unwind.sizeOfCursor
-    final val DataSize = UnwindContextOffset + unwind.sizeOfContext
+    final val IPOffset = UnwindContextOffset + unwind.sizeOfContext
+    final val DataSize = IPOffset + 8
   }
   private class Context(
       val cache: mutable.LongMap[StackTraceElement],
@@ -191,5 +219,6 @@ private[runtime] object StackTrace {
     def freshFileNameBuffer = freshAt(FileNameBufferOffset, FileNameMaxLength)
     def unwindCursor = data.atUnsafe(UnwindCursorOffset)
     def unwindContext = data.atUnsafe(UnwindContextOffset)
+    def ip = data.atUnsafe(IPOffset).rawptr
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
@@ -30,7 +30,7 @@ private[runtime] object StackTrace {
     }
       .dropWhile { elem =>
         elem.getClassName.startsWith("scala.scalanative.runtime.") ||
-        elem.getClassName.contains(".Iterator")
+        elem.getClassName.contains("scala.collection.")
       }
   }
 

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/SystemLoggerOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/SystemLoggerOnJDK9.scala
@@ -1,0 +1,219 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+import org.scalanative.testsuite.utils.Platform
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.lang.System.Logger
+import java.util.{ResourceBundle, MissingResourceException}
+
+class SystemLoggerTestOnJDK9 {
+
+  private def captureSystemErr(testCode: => Unit): String = {
+    val originalErr = System.err
+    val errContent = new ByteArrayOutputStream()
+    System.setErr(new PrintStream(errContent))
+
+    try {
+      testCode
+      errContent.toString
+    } finally {
+      System.setErr(originalErr)
+    }
+  }
+
+  // Basic functionality tests
+
+  @Test def testJDK9GetLogger(): Unit = {
+    val logger = System.getLogger("test.logger")
+    assertNotNull(logger)
+    assertEquals("test.logger", logger.getName())
+  }
+
+  @Test def testJDK9CachedLoggers(): Unit = {
+    val logger2 = System.getLogger("test.logger")
+    val logger1 = System.getLogger("test.logger")
+    assertNotNull(logger1)
+    assertNotNull(logger2)
+    assertNotSame(logger1, logger2)
+  }
+
+  @Test def testJDK9IsLoggable(): Unit = {
+    // On JDK9+ this is usually delegated to the underlying logging system
+    // Just verify it doesn't throw exceptions
+    val logger = System.getLogger("test.logger.levels")
+
+    // Check each level without asserting specific behavior
+    for (level <- Logger.Level.values()) {
+      // Just call the method to verify it works
+      logger.isLoggable(level)
+    }
+  }
+
+  // Logging tests
+
+  @Test def testJDK9LogWithMessage(): Unit = {
+    // Just verify it doesn't throw exceptions
+    val logger = System.getLogger("test.simple")
+    captureSystemErr {
+      logger.log(Logger.Level.INFO, "Test message")
+    }
+  }
+
+  @Test def testJDK9LogWithNullMessage(): Unit = {
+    // Just verify it doesn't throw exceptions
+    val logger = System.getLogger("test.null")
+    captureSystemErr {
+      logger.log(Logger.Level.WARNING, null: String)
+    }
+  }
+
+  @Test def testJDK9LogWithFormatAndParams(): Unit = {
+    // Just verify it doesn't throw exceptions
+    val logger = System.getLogger("test.format")
+    captureSystemErr {
+      logger.log(
+        Logger.Level.ERROR,
+        "Value: %s, Number: %d",
+        "test",
+        42
+      )
+    }
+  }
+
+  @Test def testJDK9LogWithThrowable(): Unit = {
+    // Just verify it doesn't throw exceptions
+    val logger = System.getLogger("test.exception")
+    val exception = new RuntimeException("Test exception")
+    captureSystemErr {
+      logger.log(Logger.Level.ERROR, "Error occurred", exception)
+    }
+  }
+
+  @Test def testJDK9OffLevelDoesNotLog(): Unit = {
+    val logger = System.getLogger("test.off")
+    val output = captureSystemErr {
+      logger.log(Logger.Level.OFF, "This should not be logged")
+    }
+
+    // In most implementations, OFF should not log anything
+    // but we don't assert specifics since implementations may vary
+  }
+
+  // ResourceBundle tests
+
+  @Test def testJDK9LogWithResourceBundle(): Unit = {
+    // Just verify it doesn't throw exceptions
+    val logger = System.getLogger("test.bundle")
+
+    val bundle = new ResourceBundle {
+      private val messages = Map(
+        "message.key" -> "Translated message",
+        "format.key" -> "Formatted with %s and %d"
+      )
+
+      override def handleGetObject(key: String): Object =
+        messages.getOrElse(key, null)
+
+      override def getKeys(): java.util.Enumeration[String] = {
+        val it = messages.keys.iterator
+        new java.util.Enumeration[String] {
+          override def hasMoreElements(): Boolean = it.hasNext
+          override def nextElement(): String = it.next()
+        }
+      }
+    }
+
+    captureSystemErr {
+      logger.log(Logger.Level.INFO, bundle, "message.key", null: Throwable)
+      logger.log(
+        Logger.Level.DEBUG,
+        bundle,
+        "format.key",
+        "value",
+        123
+      )
+      logger.log(Logger.Level.WARNING, bundle, "missing.key", null: Throwable)
+    }
+  }
+
+  // Supplier tests
+
+  @Test def testJDK9LogWithSupplier(): Unit = {
+    val logger = System.getLogger("test.supplier")
+    var supplierCalled = false
+
+    val msgSupplier = new java.util.function.Supplier[String] {
+      override def get(): String = {
+        supplierCalled = true
+        "Message from supplier"
+      }
+    }
+
+    captureSystemErr {
+      logger.log(Logger.Level.INFO, msgSupplier)
+    }
+
+    // Should have called the supplier
+    assertTrue("Supplier was not called", supplierCalled)
+  }
+
+  @Test def testJDK9LogWithSupplierAndThrowable(): Unit = {
+    // Just verify it doesn't throw exceptions
+    val logger = System.getLogger("test.supplier.exception")
+    val exception = new IllegalArgumentException("Supplier exception")
+
+    val msgSupplier = new java.util.function.Supplier[String] {
+      override def get(): String = "Error from supplier"
+    }
+
+    captureSystemErr {
+      logger.log(Logger.Level.ERROR, msgSupplier, exception)
+    }
+  }
+
+  // Level tests
+
+  @Test def testJDK9LoggerLevels(): Unit = {
+    // Check severity relationships between levels
+    val logger = System.getLogger("test.logger")
+    assertTrue(
+      System.Logger.Level.ERROR.getSeverity() > System.Logger.Level.WARNING
+        .getSeverity()
+    )
+    assertTrue(
+      System.Logger.Level.WARNING.getSeverity() > System.Logger.Level.INFO
+        .getSeverity()
+    )
+    assertTrue(
+      System.Logger.Level.INFO.getSeverity() > System.Logger.Level.DEBUG
+        .getSeverity()
+    )
+    assertTrue(
+      System.Logger.Level.DEBUG.getSeverity() > System.Logger.Level.TRACE
+        .getSeverity()
+    )
+    assertTrue(
+      System.Logger.Level.TRACE.getSeverity() > System.Logger.Level.ALL
+        .getSeverity()
+    )
+  }
+
+  @Test def testJDK9LoggerLevelValues(): Unit = {
+    // Verify all expected levels exist
+    val levels = Logger.Level.values()
+    assertEquals(7, levels.length)
+
+    // Verify we have all the expected levels
+    assertTrue(levels.contains(Logger.Level.ALL))
+    assertTrue(levels.contains(Logger.Level.TRACE))
+    assertTrue(levels.contains(Logger.Level.DEBUG))
+    assertTrue(levels.contains(Logger.Level.INFO))
+    assertTrue(levels.contains(Logger.Level.WARNING))
+    assertTrue(levels.contains(Logger.Level.ERROR))
+    assertTrue(levels.contains(Logger.Level.OFF))
+  }
+}


### PR DESCRIPTION
Resolves #4272

Example: 

```scala
object Test {
  def main(args: Array[String]): Unit = {
    val logger = System.getLogger("TestLogger")
    logger.log(System.Logger.Level.INFO, "Hello from logger!")
    logger.log(
      System.Logger.Level.ERROR,
      "This is an error message",
      new Exception("Test exception")
    )
  }
}
```

produces (compliant with JVM outputs): 
```
Apr 05, 2025 02:17:21 AM Test main
[INFO]: Hello from logger!
Apr 05, 2025 02:17:21 AM Test main
[ERROR]: This is an error message
java.lang.Exception: Test exception
        at Test$.main(Test.scala:3)
        at Test.main(Test.scala:3)
        at <none>.main(unknown:2)
```

Does not provide actual implementation of `ResourceBundle` <del>or `LoggerFinder`</del>