### PR TITLE
Faster UTF-8 decoding from mixed buffers

### DIFF
--- a/javalib/src/main/scala/niocharset/UTF_8.scala
+++ b/javalib/src/main/scala/niocharset/UTF_8.scala
@@ -210,32 +210,32 @@ private[niocharset] object UTF_8
               fail(CoderResult.malformedForLength(1))
             } else {
               val decoded = {
-                if (in.hasRemaining()) {
+                if (!in.hasRemaining()) {
+                  DecodedMultiByte(CoderResult.UNDERFLOW)
+                } else {
                   val b2 = in.get()
                   if (isInvalidNextByte(b2)) {
                     DecodedMultiByte(CoderResult.malformedForLength(1))
                   } else if (length == 2) {
                     decode2(leading, b2)
-                  } else if (in.hasRemaining()) {
+                  } else if (!in.hasRemaining()) {
+                    DecodedMultiByte(CoderResult.UNDERFLOW)
+                  } else {
                     val b3 = in.get()
                     if (isInvalidNextByte(b3)) {
                       DecodedMultiByte(CoderResult.malformedForLength(2))
                     } else if (length == 3) {
                       decode3(leading, b2, b3)
-                    } else if (in.hasRemaining()) {
+                    } else if (!in.hasRemaining()) {
+                      DecodedMultiByte(CoderResult.UNDERFLOW)
+                    } else {
                       val b4 = in.get()
                       if (isInvalidNextByte(b4))
                         DecodedMultiByte(CoderResult.malformedForLength(3))
                       else
                         decode4(leading, b2, b3, b4)
-                    } else {
-                      DecodedMultiByte(CoderResult.UNDERFLOW)
                     }
-                  } else {
-                    DecodedMultiByte(CoderResult.UNDERFLOW)
                   }
-                } else {
-                  DecodedMultiByte(CoderResult.UNDERFLOW)
                 }
               }
 
@@ -325,8 +325,9 @@ private[niocharset] object UTF_8
 
   private class Encoder extends CharsetEncoder(UTF_8, 1.1f, 3.0f) {
     def encodeLoop(in: CharBuffer, out: ByteBuffer): CoderResult = {
-      if (in.hasArray() && out.hasArray())
+      if (in.hasArray() && out.hasArray()) {
         encodeLoopArray(in, out)
+      }
       else
         encodeLoopNoArray(in, out)
     }

--- a/javalib/src/main/scala/niocharset/UTF_8.scala
+++ b/javalib/src/main/scala/niocharset/UTF_8.scala
@@ -102,8 +102,7 @@ private[niocharset] object UTF_8
             } else {
               if (outArray != null) {
                 outArray(outPos) = leading.toChar
-              }
-              else {
+              } else {
                 out.put(outPos, leading.toChar)
               }
               loop(inPos + 1, outPos + 1)
@@ -159,8 +158,7 @@ private[niocharset] object UTF_8
                 else {
                   if (outArray != null) {
                     outArray(outPos) = decoded.high
-                  }
-                  else {
+                  } else {
                     out.put(outPos, decoded.high)
                   }
                   loop(inPos + length, outPos + 1)
@@ -173,8 +171,7 @@ private[niocharset] object UTF_8
                   if (outArray != null) {
                     outArray(outPos) = decoded.high
                     outArray(outPos + 1) = decoded.low
-                  }
-                  else {
+                  } else {
                     out.put(outPos, decoded.high)
                     out.put(outPos + 1, decoded.low)
                   }
@@ -249,8 +246,7 @@ private[niocharset] object UTF_8
     def encodeLoop(in: CharBuffer, out: ByteBuffer): CoderResult = {
       if (in.hasArray() && out.hasArray()) {
         encodeLoopArray(in, out)
-      }
-      else
+      } else
         encodeLoopNoArray(in, out)
     }
 


### PR DESCRIPTION
Part of https://github.com/scala-native/scala-native/issues/4280

UTF-8 decoding had two implementations, a naive `decodeLoopNoArray` and an optimized `decodeLoopArray` (for when both Buffers are backed by an array).

In real world applications it's to use the buffers as a bridge between the "Native" and "Scala" worlds, so one of the buffers is backed by pointers, while another is backed by arrays (e.g. in `fromCString`). This case was not being optimized.

This PR merges both implementations into a single one, so that `Ptr->Array` and `Array->Ptr` conversions are also optimized. This also opens the door for future optimizations using the extended`Buffer#hasPointer(): Boolean` / `Buffer#pointer(): unsafe.Ptr[Byte]` operations.

While this adds a few extra ifs in the `ArrayBuffer->ArrayBuffer` conversion, I didn't see any meaningful performance degradation, so I just removed the specialized method, but it would be trivial to add it back again.

I used the following naive code for benchmarks:

```scala
package example

import java.nio.*
import java.nio.charset.Charset
import scala.util.Random
import scala.scalanative.memory.PointerBuffer
import scalanative.unsafe.*

object Main {
  val charset = Charset.forName("UTF-8")
  val encoder = charset.newEncoder()
  val decoder = charset.newDecoder()

  def time[T](task: String)(f: => T): T =
    println(s"Starting $task")
    val start = System.currentTimeMillis()
    val res = f
    println(s"Done in ${System.currentTimeMillis() - start}ms")
    res

  @main def run() = {
    val data: Array[Byte] =
      time("fill array")(("TEST: 👍 | " + Random.alphanumeric.take(20 * 1024 * 1024).mkString).getBytes(charset))

    val ptr = data.at(0)

    val arrRes = time("decode array"){
      val inputBuffer = ByteBuffer.wrap(data, 0, data.size)
      decoder.decode(inputBuffer)
    }

    val ptrRes = time("decode ptr"){
      val inputBuffer = PointerBuffer.wrap(ptr, data.size)
      decoder.decode(inputBuffer)
    }

    // I had some issues running the unit tests locally, so I added some sanity checks here.
    // Hopefully, the CI will be green.
    println(arrRes.array().mkString("") == ptrRes.array().mkString(""))
    println(arrRes.array().mkString("").take(16))
  }
}
```

On 0.5.7:
```
Starting fill array
Done in 12127ms
Starting decode array
Done in 25ms
Starting decode ptr
Done in 88ms
true
TEST: 👍 | 5HIw5
```

With this PR:
```
Starting fill array
Done in 12092ms
Starting decode array
Done in 27ms
Starting decode ptr
Done in 36ms
true
TEST: 👍 | dHrUG
```