### PR TITLE
Fix #4297: javalib charset CoderResult#toString now matches JVM

### DIFF
--- a/javalib/src/main/scala/java/nio/charset/CoderResult.scala
+++ b/javalib/src/main/scala/java/nio/charset/CoderResult.scala
@@ -24,10 +24,17 @@ class CoderResult private (kind: Int, _length: Int) {
   }
 
   def throwException(): Unit = (kind: @switch) match {
-    case Overflow   => throw new BufferOverflowException()
     case Underflow  => throw new BufferUnderflowException()
+    case Overflow   => throw new BufferOverflowException()
     case Malformed  => throw new MalformedInputException(_length)
     case Unmappable => throw new UnmappableCharacterException(_length)
+  }
+
+  override def toString(): String = (kind: @switch) match {
+    case Underflow  => "UNDERFLOW"
+    case Overflow   => "OVERFLOW"
+    case Malformed  => s"MALFORMED[${_length}]"
+    case Unmappable => s"UNMAPPABLE[${_length}]"
   }
 }
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/charset/CoderResultTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/charset/CoderResultTest.scala
@@ -1,0 +1,33 @@
+package org.scalanative.testsuite.javalib.nio.charset
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.nio.charset.CoderResult
+
+class CoderResultTest {
+
+  @Test def toString_Malformed(): Unit = {
+
+    // Scala Native Issue #4297
+    assertEquals(
+      "MALFORMED[3]",
+      CoderResult.malformedForLength(3).toString()
+    )
+
+    assertEquals(
+      "OVERFLOW",
+      CoderResult.OVERFLOW.toString()
+    )
+
+    assertEquals(
+      "UNDERFLOW",
+      CoderResult.UNDERFLOW.toString()
+    )
+
+    assertEquals(
+      "UNMAPPABLE[4]",
+      CoderResult.unmappableForLength(4).toString()
+    )
+  }
+}


### PR DESCRIPTION
Fix #4297 

 javalib `java.nio.charset` `CoderResult#toString` now matches JVM.

Thanks to JD557 for permission to use the reproducer test code in the Issue
and for discussions leading to a rapid turnaround.  

One yak shaven... Hope it has plenty of sunscreen.