### PR TITLE
Reduce allocations in fromCString

### DIFF
--- a/javalib-intf/src/main/java/scala/scalanative/javalibintf/String.java
+++ b/javalib-intf/src/main/java/scala/scalanative/javalibintf/String.java
@@ -1,0 +1,23 @@
+package scala.scalanative.javalibintf;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+/**
+ * Utilities to build {@link java.lang.String}s from lower level
+ * primitives.
+ */
+public final class String {
+  private String() {}
+
+  /**
+   * Builds a string from a {@link java.nio.ByteBuffer}.
+   *
+   * @param data the ByteBuffer with the data
+   * @param encoding the charset to use to decode the data
+   * @return String built from the decoded @param data
+   */
+  public static final java.lang.String fromByteBuffer(ByteBuffer data, Charset encoding){
+    throw new AssertionError("stub");
+  }
+}

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -172,6 +172,15 @@ final class _String()
     sb.getChars(0, count, value, 0)
   }
 
+  // Extended API
+  def this(data: ByteBuffer, encoding: Charset) = {
+    this()
+    offset = 0
+    val charBuffer = encoding.decode(data)
+    value = charBuffer.array()
+    count = charBuffer.length()
+  }
+
   def charAt(index: Int): Char = {
     if (0 <= index && index < count) {
       value(offset + index)

--- a/javalib/src/main/scala/niocharset/UTF_8.scala
+++ b/javalib/src/main/scala/niocharset/UTF_8.scala
@@ -69,10 +69,9 @@ private[niocharset] object UTF_8
 
   private class Decoder extends CharsetDecoder(UTF_8, 1.0f, 1.0f) {
     def decodeLoop(in: ByteBuffer, out: CharBuffer): CoderResult = {
-      val inArray = if (in.hasArray()) in.array() else null
-      val inOffset = if (in.hasArray()) in.arrayOffset() else 0
-      val inStart = in.position() + inOffset
-      val inEnd = in.limit() + inOffset
+      val inPtr = if (in.hasPointer()) in.pointer() else null
+      val inStart = in.position()
+      val inEnd = in.limit()
 
       val outArray = if (out.hasArray()) out.array() else null
       val outOffset = if (out.hasArray()) out.arrayOffset() else 0
@@ -84,7 +83,7 @@ private[niocharset] object UTF_8
       def loop(inPos: Int, outPos: Int): CoderResult = {
         @inline
         def finalize(result: CoderResult): CoderResult = {
-          in.position(inPos - inOffset)
+          in.position(inPos)
           out.position(outPos - outOffset)
           result
         }
@@ -93,7 +92,7 @@ private[niocharset] object UTF_8
           finalize(CoderResult.UNDERFLOW)
         } else {
           val leading =
-            if (inArray != null) inArray(inPos).toInt
+            if (inPtr != null) inPtr(inPos).toInt
             else in.get(inPos).toInt
           if (leading >= 0) {
             // US-ASCII repertoire
@@ -118,7 +117,7 @@ private[niocharset] object UTF_8
                   DecodedMultiByte(CoderResult.UNDERFLOW)
                 } else {
                   val b2 =
-                    if (inArray != null) inArray(inPos + 1)
+                    if (inPtr != null) inPtr(inPos + 1)
                     else in.get(inPos + 1)
                   if (isInvalidNextByte(b2)) {
                     DecodedMultiByte(CoderResult.malformedForLength(1))
@@ -128,7 +127,7 @@ private[niocharset] object UTF_8
                     DecodedMultiByte(CoderResult.UNDERFLOW)
                   } else {
                     val b3 =
-                      if (inArray != null) inArray(inPos + 2)
+                      if (inPtr != null) inPtr(inPos + 2)
                       else in.get(inPos + 2)
                     if (isInvalidNextByte(b3)) {
                       DecodedMultiByte(CoderResult.malformedForLength(2))
@@ -138,7 +137,7 @@ private[niocharset] object UTF_8
                       DecodedMultiByte(CoderResult.UNDERFLOW)
                     } else {
                       val b4 =
-                        if (inArray != null) inArray(inPos + 3)
+                        if (inPtr != null) inPtr(inPos + 3)
                         else in.get(inPos + 3)
                       if (isInvalidNextByte(b4))
                         DecodedMultiByte(CoderResult.malformedForLength(3))

--- a/javalib/src/main/scala/scala/scalanative/javalibintf/String.scala
+++ b/javalib/src/main/scala/scala/scalanative/javalibintf/String.scala
@@ -1,0 +1,11 @@
+package scala.scalanative.javalibintf
+
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+
+object String {
+
+  def fromByteBuffer(data: ByteBuffer, encoding: Charset): java.lang._String =
+    new java.lang._String(data, encoding)
+
+}

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -6,6 +6,7 @@ import scalanative.runtime.{Platform, fromRawPtr, intrinsic, ffi}
 import scalanative.runtime.Intrinsics._
 import scalanative.unsigned._
 import scala.scalanative.meta.LinktimeInfo
+import scala.scalanative.memory.PointerBuffer
 
 package object unsafe extends unsafe.UnsafePackageCompat {
 
@@ -161,11 +162,11 @@ package object unsafe extends unsafe.UnsafePackageCompat {
       val len = ffi.strlen(cstr)
       val intLen = len.toInt
       if (intLen > 0) {
-        val bytes = new Array[Byte](intLen)
-
-        ffi.memcpy(bytes.at(0), cstr, len)
-
-        new String(bytes, charset)
+        val inputBuffer = PointerBuffer.wrap(cstr, intLen)
+        javalibintf.String.fromByteBuffer(
+          inputBuffer,
+          charset
+        )
       } else ""
     }
   }


### PR DESCRIPTION
Part of https://github.com/scala-native/scala-native/issues/4280

As mentioned by Wojciech:
> We can however create a special shim in javalib-intf - this project defines only Java sources providing us with interface (bytecode only), can can be implemented inside javalib (NIR only). That's also how PointerByteBuffer are usable inside nativelib.
We can use the new interface to introduce a factory method that would have access to new javalib-private String constructor.

I'm not entirely sure if this is how I was supposed to do it, but I'm open to feedback.

I also had to change the decoders yet again to make them faster when handling pointers. `HeapByteBuffer` seems to always define a pointer, so the special array handling became redundant.
I didn't change the UTF-16 decoding, as that didn't have any array optimizations, so it should be as slow as it always was.

Benchmarks:

```scala
def time[T](task: String)(f: => T): T = {
  println(s"Starting $task")
  val start = System.currentTimeMillis()
  val res = f
  println(s"Done in ${System.currentTimeMillis() - start}ms")
  res
]

  val ascii = Charset.forName("US-ASCII")
  val utf8 = Charset.forName("UTF-8")
  Zone {
    val cString = toCString("Foo Foo Foo / Bar Bar Bar / Baz Baz Baz")
    val resAscii = time("Convert Strings (ASCII)"){
      (0 until 1_000_000).map(_ => fromCString(cString, ascii).length).sum
    }
    val resUtf8 = time("Convert Strings (UTF-8)"){
      (0 until 1_000_000).map(_ => fromCString(cString, utf8).length).sum
    }
    println(fromCString(cString, ascii) + " - " + resAscii)
    println(fromCString(cString, utf8) + " - " + resUtf8)
  }
```

On 0.5.7:

```
Starting Convert Strings (ASCII)
Done in 101ms
Starting Convert Strings (UTF-8)
Done in 123ms
Foo Foo Foo / Bar Bar Bar / Baz Baz Baz - 39000000
Foo Foo Foo / Bar Bar Bar / Baz Baz Baz - 39000000
```

With this PR:

```
Starting Convert Strings (ASCII)
Done in 80ms
Starting Convert Strings (UTF-8)
Done in 93ms
Foo Foo Foo / Bar Bar Bar / Baz Baz Baz - 39000000
Foo Foo Foo / Bar Bar Bar / Baz Baz Baz - 39000000
```