### PR TITLE
Fix `isPositionIndependentBinary`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Backtrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Backtrace.scala
@@ -211,7 +211,7 @@ private[runtime] object Backtrace {
         subprograms = dwarf._1,
         strings = dwarf._2,
         offset = offset,
-        isPositionIndependentBinary = true
+        isPositionIndependentBinary = dwarf._3,
       )
     }
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Backtrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Backtrace.scala
@@ -211,7 +211,7 @@ private[runtime] object Backtrace {
         subprograms = dwarf._1,
         strings = dwarf._2,
         offset = offset,
-        isPositionIndependentBinary = dwarf._3,
+        isPositionIndependentBinary = dwarf._3
       )
     }
   }


### PR DESCRIPTION
As far as I can tell, the `isPositionIndependentBinary` information is parsed from the ELF header, but then it's just hardcoded to `true`. This PR fixes that.

This seems to fix the incorrect exception stacktraces I've encountered locally (as I've mentioned in typelevel/cats-effect/pull/4362).