### PR TITLE
Fix #4296: Create a script to run scalafmt native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ _build/
 .idea
 scripts/.coursier
 scripts/.scalafmt*
+scripts/.scala-cli*
 sbt-crossproject/
 local.sbt
 .ammonite/

--- a/scripts/scalafmt-native
+++ b/scripts/scalafmt-native
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 
+# No Windows support - a script could be created using the dedicated launcher scala-cli.bat
+
 set -e
 
 HERE="`dirname $0`"
 VERSION=$(sed -nre "s#[[:space:]]*version[^0-9]+([0-9.]+)#\1#p" $HERE/../.scalafmt.conf)
-SCALACLI="$HERE/.scala-cli"
+SCALACLI="$HERE/.scala-cli-$VERSION"
 SCALAFMT="$SCALACLI fmt --scalafmt-version $VERSION"
 CHECK_MODIFIED_ONLY=${CHECK_MODIFIED_ONLY:-false}
 
-# ver for windows works for dos
+# Location of scalafmt binary
+# macOS $HOME/Library/Caches/Coursier/v1
+# Linux $HOME/.cache/coursier/v1
+# Plus the following path: /https/github.com/VirtusLab/scalafmt-native-image
+# A scalafmt version change forces a new scala-cli download which should in turn update scalafmt
 if [ ! -f $SCALACLI ]; then
   curl https://raw.githubusercontent.com/VirtusLab/scala-cli/refs/heads/main/scala-cli.sh > $SCALACLI
   chmod +x $SCALACLI

--- a/scripts/scalafmt-native
+++ b/scripts/scalafmt-native
@@ -13,8 +13,6 @@ if [ ! -f $SCALACLI ]; then
   curl https://raw.githubusercontent.com/VirtusLab/scala-cli/refs/heads/main/scala-cli.sh > $SCALACLI
   chmod +x $SCALACLI
 fi
-echo $HERE
-echo $SCALAFMT
 
 if [[ "$CHECK_MODIFIED_ONLY" == "1" ]]; then
   git diff --name-only main | \

--- a/scripts/scalafmt-native
+++ b/scripts/scalafmt-native
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+HERE="`dirname $0`"
+VERSION=$(sed -nre "s#[[:space:]]*version[^0-9]+([0-9.]+)#\1#p" $HERE/../.scalafmt.conf)
+SCALACLI="$HERE/.scala-cli"
+SCALAFMT="$SCALACLI fmt --scalafmt-version $VERSION"
+CHECK_MODIFIED_ONLY=${CHECK_MODIFIED_ONLY:-false}
+
+# ver for windows works for dos
+if [ ! -f $SCALACLI ]; then
+  curl https://raw.githubusercontent.com/VirtusLab/scala-cli/refs/heads/main/scala-cli.sh > $SCALACLI
+  chmod +x $SCALACLI
+fi
+echo $HERE
+echo $SCALAFMT
+
+if [[ "$CHECK_MODIFIED_ONLY" == "1" ]]; then
+  git diff --name-only main | \
+    grep -E '.*\.scala$' |
+    xargs "$SCALAFMT"
+else 
+  $SCALAFMT "$@"
+fi


### PR DESCRIPTION
At first blush it seems to be faster

```sh
eric@Erics-MBP-M1 scala-native % time scripts/scalafmt                             
Reformatting... [##########]
  out 100.0% 1919, fmt 100.0% 1919, in 100.0% 1919
scripts/scalafmt  134.25s user 4.26s system 777% cpu 17.806 total

eric@Erics-MBP-M1 scala-native % time scripts/scalafmt-native
scripts
scripts/.scala-cli fmt --scalafmt-version 3.9.4
Reformatting... [##########]
  out 100.0% 1919, fmt 100.0% 1919, in 100.0% 1919
scripts/scalafmt-native  39.02s user 19.32s system 340% cpu 17.127 total
```