### PR TITLE
Use scalaformat which has Scala Native backend

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - uses: coursier/cache-action@v6
+      - uses: VirtusLab/scala-cli-setup@v1.7.1
       - run: ./scripts/check-lint.sh
         env:
           CLANG_FORMAT_PATH: "/usr/bin/clang-format-14"

--- a/scripts/check-lint.sh
+++ b/scripts/check-lint.sh
@@ -4,4 +4,4 @@ set -e
 
 scripts/clangfmt --test
 
-scripts/scalafmt --test
+scala-cli format --check


### PR DESCRIPTION
`scala-cli format`, after it's version 1.7.0, will use the variant of `scalafmt` built using 
Scala Native itself.   

This PR is the logical complement to Ekrich`s now merged PR #4302 

There is no circularity to the build, since `scalafmt` used does not
use the Scala Native version being built. Even if it did, it  would attempt to
do so before the SN being built had created artifacts.

This PR is `Draft` 
1. to see if it works in all the SN build configurations
2. to provide a basis for discussion

The script uses a known, fixed version of `scala-cli`  for strict version control.
The Repository will be formatted according to the scalafmt version in its
`<projectRoot>.scalafmt.conf`.  When the latter is updated in the Repository
the `scalafmt`, but not the `scala-cli` version, will change at a known time.

This is similar to how a wide range of `sbt` version can be used to build
Scala Native privately, but the `sbt` version used in that build is 
the one in `project/build.properties`.

If this PR first works and then is accepted by the community, the next step
is to figure out how to get `Dependabot` to report changes to `scala-cli`
versions. Then a person gets to make the decision to allow the update or not
and at a chosen time & date.
