### PR TITLE
Add fromCStringSlice

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -171,6 +171,29 @@ package object unsafe extends unsafe.UnsafePackageCompat {
     }
   }
 
+  /** Convert a CString to a String using given charset and length. If the value
+   *  of length is larger than the underlying data, this method has undefined
+   *  behavior.
+   */
+  def fromCStringSlice(
+      cstr: CString,
+      length: CSize,
+      charset: Charset = Charset.defaultCharset()
+  ): String = {
+    if (cstr == null) {
+      null
+    } else {
+      val intLen = length.toInt
+      if (intLen > 0) {
+        val inputBuffer = PointerBuffer.wrap(cstr, intLen)
+        javalibintf.String.fromByteBuffer(
+          inputBuffer,
+          charset
+        )
+      } else ""
+    }
+  }
+
   /** Convert a java.lang.String to a CString using default charset and given
    *  allocator.
    */

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
@@ -85,6 +85,28 @@ class CStringTest {
     assertTrue(szTo.charAt(3) == '4')
   }
 
+  @Test def fromCStringSliceNullReturnsNull(): Unit = {
+    assertNull(fromCStringSlice(null, 0.toUSize))
+  }
+
+  @Test def testFromCStringSlice(): Unit = {
+    val cstrFrom = c"1234"
+    val sameSize = fromCStringSlice(cstrFrom, 4.toUSize)
+
+    assertTrue(sameSize.size == 4)
+    assertTrue(sameSize.charAt(0) == '1')
+    assertTrue(sameSize.charAt(1) == '2')
+    assertTrue(sameSize.charAt(2) == '3')
+    assertTrue(sameSize.charAt(3) == '4')
+
+    val smaller = fromCStringSlice(cstrFrom, 3.toUSize)
+
+    assertTrue(smaller.size == 3)
+    assertTrue(smaller.charAt(0) == '1')
+    assertTrue(smaller.charAt(1) == '2')
+    assertTrue(smaller.charAt(2) == '3')
+  }
+
   @Test def toCStringNullReturnsNullIssue1796(): Unit = {
     Zone.acquire { implicit z => assertNull(toCString(null)) }
   }


### PR DESCRIPTION
Adds a `fromCStringSlice` method, similar to `fromCString`, but that takes an explicit length.

This is helpful to interop with some libraries (e.g. YYJSON and NGINX UNIT) that explicitly return a length when refering to a string.

This is not only faster (as the `strlen` might be skipped) but can also be more correct, as the string slice can be part of a larger buffer being reused for something else.

The performance benefits are not huge, but here are some benchmarks anyway:

```scala
  val utf8 = Charset.forName("UTF-8")
  Zone {
    val cString = toCString("Foo Foo Foo / Bar Bar Bar / Baz Baz Baz")
    val size = "Foo Foo Foo / Bar Bar Bar / Baz Baz Baz".size.toUSize
    val resString = time("Convert Strings (fromCString)"){
      (0 until 10_000_000).map(_ => fromCString(cString, utf8).length).sum
    }
    val resSlice = time("Convert Strings (fromCStringSlice)"){
      (0 until 10_000_000).map(_ => fromCStringSlice(cString, size, utf8).length).sum
    }
    println(fromCString(cString, utf8) + " - " + resString)
    println(fromCStringSlice(cString, size, utf8) + " - " + resSlice)
  }
```

```
Starting Convert Strings (fromCString)
Done in 1028ms
Starting Convert Strings (fromCStringSlice)
Done in 943ms
Foo Foo Foo / Bar Bar Bar / Baz Baz Baz - 390000000
Foo Foo Foo / Bar Bar Bar / Baz Baz Baz - 390000000
```