### PR TITLE
Implement JDK11 Collection#toArray(generator: IntFunction) method

### DIFF
--- a/javalib/src/main/scala/java/util/Collection.scala
+++ b/javalib/src/main/scala/java/util/Collection.scala
@@ -1,9 +1,12 @@
-// Ported from Scala.js commit: f122aa5 dated: 2019-07-03
-// Additional Spliterator code implemented for Scala Native
-// Additional Stream code implemented for Scala Native
+/* Ported from Scala.js commit: f122aa5 dated: 2019-07-03
+ * Additional Spliterator code implemented for Scala Native
+ * Additional Stream code implemented for Scala Native
+ * JDK 11 toArray(IntFunction) default method implemented for Scala Native
+ */
+
 package java.util
 
-import java.util.function.Predicate
+import java.util.function.{IntFunction, Predicate}
 import java.util.stream.{Stream, StreamSupport}
 
 trait Collection[E] extends java.lang.Iterable[E] {
@@ -12,6 +15,10 @@ trait Collection[E] extends java.lang.Iterable[E] {
   def contains(o: Any): Boolean
   def iterator(): Iterator[E]
   def toArray(): Array[AnyRef]
+
+  def toArray[T <: AnyRef](generator: IntFunction[Array[T]]): Array[T] =
+    toArray(generator(0))
+
   def toArray[T <: AnyRef](a: Array[T]): Array[T]
   def add(e: E): Boolean
   def remove(o: Any): Boolean

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/util/CollectionTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/util/CollectionTestOnJDK11.scala
@@ -1,0 +1,33 @@
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.util.ArrayList
+
+class CollectionTestOnJDK11 {
+  /* Test the documented Collections#toArray(IntFunction),
+   * ensuring that any possible overrides in java.* concrete classes
+   * are not inadvertently reached and used.
+   */
+
+  @Test def toArray_IntFunction(): Unit = {
+    type T = Array[String]
+
+    val nElements = 3
+    val expected = new T(nElements)
+    expected(0) = "Selene"
+    expected(1) = "Helios"
+    expected(2) = "Eos"
+
+    val collection = TrivialImmutableCollection(expected: _*)
+
+    val result = collection.toArray((n) => new T(n))
+
+    assertTrue("type", result.isInstanceOf[T])
+    assertEquals("size", nElements, result.length)
+
+    for (j <- 0 until nElements)
+      assertEquals(s"element(${j})", expected(j), result(j))
+  }
+}


### PR DESCRIPTION
Implement the JDK11 `Collection#toArray(generator: IntFunction)` default method and associated Test.

This method brings to `Collection` the similar JDK 8 method from `java.util.stream.Stream` & variants,
allowing one to use the same idiom in either or both domains. 

One can use lambdas for the IntFunction. For example, to get an convert a list[T] to an Array[T] rather than
 an Array[Object]:  `lst.toArray(n => new Array[String])`. Knowing that the result Array is an Array[T] often
 allows one to avoid casting and makes it easier to use the result Array.

The Javadoc describes the implementation as always passing a zero to the IntFunction.  The design
goal for Scala Native javalib is to follow Javadoc descriptions as closely as feasible.

Applications which sub-class Collection and extensively use this form of `toArray()` may want to override this
method to pass the usually known size of the `this` collection.  This saves allocating a zero sized
array just to use its type to allocate an array matching the collection size. The cost of unnecessary allocations
can add up in production use. 
