### PR TITLE
Use scalafmt built to use Scala Native

### DIFF
--- a/scripts/check-lint.sh
+++ b/scripts/check-lint.sh
@@ -4,4 +4,12 @@ set -e
 
 scripts/clangfmt --test
 
-scripts/scalafmt --test
+## Provisioning and version control
+##
+## Script down loads the scalafmt version built using Scala Native specified
+## in <projectRoot>.scalafmt.conf.
+##
+## --check will quit after first format failure.
+
+scripts/scalafmt-native --check
+


### PR DESCRIPTION
Fix #4295

 Use `scripts/scalafmt-native` script to download an scalafmt executable which itself
was built to use Scala Native.

Version of scalafmt used is given in `<projectRoot>.scalafmt.conf`, as has been the
long standing practice. Change the version there and the script should download
and use the newly specified version.

