### PR TITLE
javalib: Ensure ArrayList#clone creates independent state

### DIFF
--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -81,7 +81,7 @@ class ArrayList[E] private (
   override def lastIndexOf(o: Any): Int = inner.lastIndexOf(o)
 
   // shallow-copy
-  override def clone(): AnyRef = new ArrayList(inner, _size)
+  override def clone(): AnyRef = new ArrayList(inner.clone(), _size)
 
   override def toArray(): Array[AnyRef] =
     inner.slice(0, _size).map(_.asInstanceOf[AnyRef])

--- a/unit-tests/native/src/test/scala/java/util/ArrayListTest.scala
+++ b/unit-tests/native/src/test/scala/java/util/ArrayListTest.scala
@@ -158,6 +158,14 @@ class ArrayListTest {
     assertTrue(al1 == al2)
   }
 
+  @Test def cloneNoSharedState(): Unit = {
+    val al1 = new ArrayList[Int](1)
+    val al2 = al1.clone().asInstanceOf[ArrayList[Int]]
+    al1.add(0)
+    al2.add(1)
+    assertTrue(al1.get(0) == 0)
+  }
+
   @Test def toArray(): Unit = {
     val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     assertTrue(


### PR DESCRIPTION
The previous implementation of `java.util.ArrayList.clone()` created a shallow copy (of itself) where the cloned list shared the same internal array (`inner`) with the original list. This caused modifications to one list to incorrectly affect the other list due to the shared state.

```scala
val al1 = new java.util.ArrayList[Int](1)
val al2 = al1.clone().asInstanceOf[java.util.ArrayList[Int]]
// al1 - inner: [], _size: 0
// al2 - inner: [], _size: 0
al1.add(0)
// al1 - inner: [0], _size: 1
// al2 - inner: [0], _size: 0
al2.add(1) // updates 0th element to 1 because al2._size is 0
// al1 - inner: [1], _size: 1
// al2 - inner: [1], _size: 1
println(al1) // [1] // but it should be 0
```

This commit fixes the `clone()` method by explicitly shallow copying the internal `inner` array using `inner.clone()`. This ensures that the original and the cloned `ArrayList` instances has independent states.

---

In fact in JVM,

```scala
object Test {
  def main(args: Array[String]): Unit = {
    val al1 = new java.util.ArrayList[Int](1)
    val al2 = al1.clone().asInstanceOf[java.util.ArrayList[Int]]
    al1.add(0)
    al2.add(1)
    println(al1) // [0]
    println(al2) // [1]
  }
}
```