### PR TITLE
JUnit: populate `sbt.testing.Event.throwable` and `duration`.

### DIFF
--- a/.github/actions/linux-setup-env/action.yml
+++ b/.github/actions/linux-setup-env/action.yml
@@ -1,5 +1,5 @@
 name: "Unix tests env setup"
-description: "Used to setup Unix tests environemt"
+description: "Used to setup Unix tests environment"
 inputs:
   scala-version:
     description: "Scala version used in the tests"

--- a/.github/actions/macos-setup-env/action.yml
+++ b/.github/actions/macos-setup-env/action.yml
@@ -1,5 +1,5 @@
 name: "MacOs tests env setup"
-description: "Used to setup MacOS tests environemt"
+description: "Used to setup MacOS tests environment"
 inputs:
   scala-version:
     description: "Scala version used in the tests"

--- a/.github/actions/windows-setup-env/action.yml
+++ b/.github/actions/windows-setup-env/action.yml
@@ -1,5 +1,5 @@
 name: "Windows test env setup"
-description: "Used to setup Windows tests environemt"
+description: "Used to setup Windows tests environment"
 inputs:
   scala-version:
     description: "Scala version used in the tests"

--- a/docs/changelog/0.4.x/0.4.0.md
+++ b/docs/changelog/0.4.x/0.4.0.md
@@ -210,7 +210,7 @@ Commix GC was written in C and uses `pthread` to work. In case your application 
 * `malloc` will now throw `OutOfMemoryError` when it cannot allocate memory,
 * `toCString` & `fromCString` now correctly return null,
 * Fixed errors with not cleared `errno` when using POSIX `readdir`
-* Array operation now throw JVM-compilant `ArrayIndexOutOfBoundsException`,
+* Array operation now throw JVM-compliant `ArrayIndexOutOfBoundsException`,
 * Fix bug with `BufferedInputStream.read()` for values bigger then 0x7f,
 * `Files.walk` accepts non-directory files,
 * Improved IEEE754 specification compliance when parsing strings,

--- a/docs/changelog/0.4.x/0.4.1.md
+++ b/docs/changelog/0.4.x/0.4.1.md
@@ -61,7 +61,7 @@ object LinktimeInfo {
 }
 ```
 
-In case of usage of `if` condition containg linktime resolved value,
+In case of usage of `if` condition containing linktime resolved value,
 at the time of performing linking of NIR files, whole condition expression 
 would be replaced with constant boolean value equal to `true` or `false`.
 At this point we can dead-code eliminate never taken branch. 
@@ -220,7 +220,7 @@ $ git shortlog -sn --no-merges v0.4.0..v0.4.1
 - Performs better checks in commix semaphore operations
   [\#2229](https://github.com/scala-native/scala-native/pull/2229)
   ([ncordon](https://github.com/ncordon))
-- Removes magic constants from the commix sempahore length code
+- Removes magic constants from the commix semaphore length code
   [\#2232](https://github.com/scala-native/scala-native/pull/2232)
   ([ncordon](https://github.com/ncordon))
 - Support GC shared code and add experimental GC setup

--- a/docs/changelog/0.4.x/0.4.11.md
+++ b/docs/changelog/0.4.x/0.4.11.md
@@ -151,7 +151,7 @@ $ git shortlog -sn --no-merges v0.4.10..v0.4.11
 - Use opaque pointers in generated LLVM IR when possible
   [\#3190](https://github.com/scala-native/scala-native/pull/3190)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Don't emit debug logs when skipping embeding source files
+- Don't emit debug logs when skipping embedded source files
   [\#3191](https://github.com/scala-native/scala-native/pull/3191)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Emit `Val.Unit`/`Type.Unit` as `void` in LLVM IR instead of ref to `BoxedUnit`
@@ -168,7 +168,7 @@ $ git shortlog -sn --no-merges v0.4.10..v0.4.11
 - Update LLVM libunwind to 15.0.7 (was 12.0.1)
   [\#3184](https://github.com/scala-native/scala-native/pull/3184)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Commix GC - fix deadlocks due to missaligned pointers when marking range
+- Commix GC - fix deadlocks due to misaligned pointers when marking range
   [\#3185](https://github.com/scala-native/scala-native/pull/3185)
   ([WojciechMazur](https://github.com/WojciechMazur))
 

--- a/docs/changelog/0.4.x/0.4.15.md
+++ b/docs/changelog/0.4.x/0.4.15.md
@@ -154,7 +154,7 @@ $ git shortlog -sn --no-merges v0.4.14..v0.4.15
 - Fix #3439: Implement javalib sequential setAll methods
   [\#3441](https://github.com/scala-native/scala-native/pull/3441)
   ([LeeTibbert](https://github.com/LeeTibbert))
-- Fix #3440: Provide a restricted implementation of  javalib Array parallel methods
+- Fix #3440: Provide a restricted implementation of javalib Array parallel methods
   [\#3445](https://github.com/scala-native/scala-native/pull/3445)
   ([LeeTibbert](https://github.com/LeeTibbert))
 

--- a/docs/changelog/0.4.x/0.4.17.md
+++ b/docs/changelog/0.4.x/0.4.17.md
@@ -1,7 +1,7 @@
 
 # 0.4.17 (2024-01-19)
 
-We're happy to announce the release of Scala Native 0.4.17, which is the next maintance release.
+We're happy to announce the release of Scala Native 0.4.17, which is the next maintenance release.
 The new version introduces support for the Scala 3.4.0 and fixes some of found bugs.
 
 ## Compatibility notes
@@ -68,7 +68,7 @@ $ git shortlog -sn --no-merges v0.4.16..v0.4.17
 
 **Merged pull requests:**
 ## Java Standard Library
-- Simplifiy `java.io.FileDescriptor.valid()` test, invalidate file descriptor on close.
+- Simplify `java.io.FileDescriptor.valid()` test, invalidate file descriptor on close.
   [\#3578](https://github.com/scala-native/scala-native/pull/3578)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Respect `java.lang.Clonable` trait and throw exception on clone when it's missing
@@ -121,7 +121,7 @@ $ git shortlog -sn --no-merges v0.4.16..v0.4.17
 
 
 ## JUnit runtime
-- Exlcude internal part of stacktraces from JUnit error reports
+- Exclude internal part of stacktraces from JUnit error reports
   [\#3617](https://github.com/scala-native/scala-native/pull/3617)
   ([WojciechMazur](https://github.com/WojciechMazur))
 

--- a/docs/changelog/0.4.x/0.4.3-RC1.md
+++ b/docs/changelog/0.4.x/0.4.3-RC1.md
@@ -19,7 +19,7 @@ build tools needed to always add `$` suffix to actual main class to make sure th
 With the 0.4.3 release, Scala Native does generate static method forwarders in the same way as it is done in JVM and Scala.js.
 Build tools should make sure to no longer add `$` to the discovered main class name.
 
-### Source compatibity of `stackalloc[T]` and `alloc[T]` methods
+### Source compatibility of `stackalloc[T]` and `alloc[T]` methods
 No-param methods `scalanative.unsafe.stackalloc[T]` and `scalanative.unsafe.alloc[T]` were removed from Scala 3 `unsafe` package. 
 In Scala 2 these methods have been deprecated and it is recommended to use empty-param variants of these methods instead, eg. `scalanative.unsafe.stackalloc[T]()`.
 This change was introduced due to changes of how does Scala 3 interpret source code as it could lead to dangerous, hard to debug, runtime errors. 
@@ -31,7 +31,7 @@ More information can be found in [\#2480](https://github.com/scala-native/scala-
 ## Known issues
 ### Cannot create documentation using scaladoc in Scala Native sbt project
 When trying to generate documentation using Scaladoc for projects using Scala Native compilation would fail with an exception. 
-This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1-RC2 compiler. As a workaround in Scala 3.1.0 we would recomend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`.
+This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1-RC2 compiler. As a workaround in Scala 3.1.0 we would recommend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`.
 
 <table>
 <tbody>
@@ -84,7 +84,7 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3-RC1
 - Make `java.nio.MappedByteBuffer` JDK9+ compliant
   [\#2453](https://github.com/scala-native/scala-native/pull/2453)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Remove redundant coversion of `CharSequence` into `Array` in `Character.codePoint{at, before}` methods
+- Remove redundant conversion of `CharSequence` into `Array` in `Character.codePoint{at, before}` methods
   [\#2495](https://github.com/scala-native/scala-native/pull/2495)
   ([WojciechMazur](https://github.com/WojciechMazur))
 
@@ -98,7 +98,7 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3-RC1
 - Touch up NIO for Java 9+
   [\#2455](https://github.com/scala-native/scala-native/pull/2455)
   ([ekrich](https://github.com/ekrich))
-- Allow to define top-level extern definitons in Scala 3
+- Allow to define top-level extern definitions in Scala 3
   [\#2496](https://github.com/scala-native/scala-native/pull/2496)
   ([WojciechMazur](https://github.com/WojciechMazur))
 
@@ -142,6 +142,6 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3-RC1
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### Linker
-- Make reachablity phase more user friendly
+- Make reachability phase more user friendly
   [\#2469](https://github.com/scala-native/scala-native/pull/2469)
   ([WojciechMazur](https://github.com/WojciechMazur))

--- a/docs/changelog/0.4.x/0.4.3-RC2.md
+++ b/docs/changelog/0.4.x/0.4.3-RC2.md
@@ -21,7 +21,7 @@ build tools needed to always add `$` suffix to actual main class to make sure th
 With the 0.4.3 release, Scala Native does generate static method forwarders in the same way as it is done in JVM and Scala.js.
 Build tools should make sure to no longer add `$` to the discovered main class name.
 
-### Source compatibity of `stackalloc[T]` and `alloc[T]` methods
+### Source compatibility of `stackalloc[T]` and `alloc[T]` methods
 No-param methods `scalanative.unsafe.stackalloc[T]` and `scalanative.unsafe.alloc[T]` were removed from Scala 3 `unsafe` package. 
 In Scala 2 these methods have been deprecated and it is recommended to use empty-param variants of these methods instead, eg. `scalanative.unsafe.stackalloc[T]()`.
 This change was introduced due to changes of how does Scala 3 interpret source code as it could lead to dangerous, hard to debug, runtime errors. 
@@ -33,7 +33,7 @@ More information can be found in [#2480](https://github.com/scala-native/scala-n
 ## Known issues
 ### Cannot create documentation using scaladoc in Scala Native sbt project
 When trying to generate documentation using Scaladoc for projects using Scala Native compilation would fail with an exception. 
-This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1-RC2 compiler. As a workaround in Scala 3.1.0 we would recomend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`. Workaround can be find in [this discussion](https://github.com/scala-native/scala-native/issues/2503#issuecomment-1005290906)
+This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1-RC2 compiler. As a workaround in Scala 3.1.0 we would recommend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`. Workaround can be find in [this discussion](https://github.com/scala-native/scala-native/issues/2503#issuecomment-1005290906)
 
 
 <table>
@@ -85,7 +85,7 @@ $ git shortlog -sn --no-merges v0.4.3-RC1..v0.4.3-RC2
 - Better error messages for `CFuncPtr.fromScalaFunction`
   [\#2512](https://github.com/scala-native/scala-native/pull/2512)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- When enabling reflective instantiation check base classess instead of parents
+- When enabling reflective instantiation check base classes instead of parents
   [\#2521](https://github.com/scala-native/scala-native/pull/2521)
   ([WojciechMazur](https://github.com/WojciechMazur))
 
@@ -93,10 +93,10 @@ $ git shortlog -sn --no-merges v0.4.3-RC1..v0.4.3-RC2
 - Port URLDecoder from Scala.js
   [\#2506](https://github.com/scala-native/scala-native/pull/2506)
   ([kpodsiad](https://github.com/kpodsiad))
-- Allign implemenation of UTF-8 and UTF-16 charsets with Scala.js
+- Align implementation of UTF-8 and UTF-16 charsets with Scala.js
   [\#2515](https://github.com/scala-native/scala-native/pull/2515)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- ProcessMonitor should not busy wait if there are no active processess
+- ProcessMonitor should not busy wait if there are no active processes
   [\#2518](https://github.com/scala-native/scala-native/pull/2518)
   ([WojciechMazur](https://github.com/WojciechMazur))
 

--- a/docs/changelog/0.4.x/0.4.3-RC2.md
+++ b/docs/changelog/0.4.x/0.4.3-RC2.md
@@ -101,7 +101,7 @@ $ git shortlog -sn --no-merges v0.4.3-RC1..v0.4.3-RC2
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### sbt plugin
-- Store config cached fingerprints seperetly for each version of Scala
+- Store config cached fingerprints separately for each version of Scala
   [\#2516](https://github.com/scala-native/scala-native/pull/2516)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Add `-test` suffix to artifact path of test executables

--- a/docs/changelog/0.4.x/0.4.3.md
+++ b/docs/changelog/0.4.x/0.4.3.md
@@ -171,7 +171,7 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### sbt plugin
-- Store config cached fingerprints seperetly for each version of Scala
+- Store config cached fingerprints separately for each version of Scala
   [\#2516](https://github.com/scala-native/scala-native/pull/2516)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Add `-test` suffix to artifact path of test executables

--- a/docs/changelog/0.4.x/0.4.3.md
+++ b/docs/changelog/0.4.x/0.4.3.md
@@ -20,7 +20,7 @@ build tools needed to always add `$` suffix to actual main class to make sure th
 With the 0.4.3 release, Scala Native does generate static method forwarders in the same way as it is done in JVM and Scala.js.
 Build tools should make sure to no longer add `$` to the discovered main class name.
 
-### Source compatibity of `stackalloc[T]` and `alloc[T]` methods
+### Source compatibility of `stackalloc[T]` and `alloc[T]` methods
 No-param methods `scalanative.unsafe.stackalloc[T]` and `scalanative.unsafe.alloc[T]` were removed from Scala 3 `unsafe` package. 
 In Scala 2 these methods have been deprecated and it is recommended to use empty-param variants of these methods instead, eg. `scalanative.unsafe.stackalloc[T]()`.
 This change was introduced due to changes of how does Scala 3 interpret source code as it could lead to dangerous, hard to debug, runtime errors. 
@@ -32,7 +32,7 @@ More information can be found in [#2480](https://github.com/scala-native/scala-n
 ## Known issues
 ### Cannot create documentation using scaladoc in Scala Native sbt project
 When trying to generate documentation using Scaladoc for projects using Scala Native compilation would fail with an exception. 
-This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1 compiler. As a workaround in Scala 3.1.0 we would recomend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`. Workaround can be find in [this discussion](https://github.com/scala-native/scala-native/issues/2503#issuecomment-1005290906)
+This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1 compiler. As a workaround in Scala 3.1.0 we would recommend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`. Workaround can be find in [this discussion](https://github.com/scala-native/scala-native/issues/2503#issuecomment-1005290906)
 
 <table>
 <tbody>
@@ -87,7 +87,7 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3
 - Make `java.nio.MappedByteBuffer` JDK9+ compliant
   [\#2453](https://github.com/scala-native/scala-native/pull/2453)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Remove redundant coversion of `CharSequence` into `Array` in `Character.codePoint{at, before}` methods
+- Remove redundant conversion of `CharSequence` into `Array` in `Character.codePoint{at, before}` methods
   [\#2495](https://github.com/scala-native/scala-native/pull/2495)
   ([WojciechMazur](https://github.com/WojciechMazur))
 
@@ -103,10 +103,10 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3
 - Port URLDecoder from Scala.js
   [\#2506](https://github.com/scala-native/scala-native/pull/2506)
   ([kpodsiad](https://github.com/kpodsiad))
-- Allign implemenation of UTF-8 and UTF-16 charsets with Scala.js
+- Align implementation of UTF-8 and UTF-16 charsets with Scala.js
   [\#2515](https://github.com/scala-native/scala-native/pull/2515)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- ProcessMonitor should not busy wait if there are no active processess
+- ProcessMonitor should not busy wait if there are no active processes
   [\#2518](https://github.com/scala-native/scala-native/pull/2518)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - System.properties define `os.arch`
@@ -166,7 +166,7 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3
 - Better error messages for `CFuncPtr.fromScalaFunction`
   [\#2512](https://github.com/scala-native/scala-native/pull/2512)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- When enabling reflective instantiation check base classess instead of parents
+- When enabling reflective instantiation check base classes instead of parents
   [\#2521](https://github.com/scala-native/scala-native/pull/2521)
   ([WojciechMazur](https://github.com/WojciechMazur))
 
@@ -179,12 +179,12 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### Linker
-- Make reachablity phase more user friendly
+- Make reachability phase more user friendly
   [\#2469](https://github.com/scala-native/scala-native/pull/2469)
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### Misc
-- Allow to define top-level extern definitons in Scala 3
+- Allow to define top-level extern definitions in Scala 3
   [\#2496](https://github.com/scala-native/scala-native/pull/2496)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Add missing `Show` implementation for `Inst.LinktimeIf`

--- a/docs/changelog/0.4.x/0.4.4.md
+++ b/docs/changelog/0.4.x/0.4.4.md
@@ -1,7 +1,7 @@
 
 # 0.4.4 (2022-03-02)
 
-We're happy to announce the new patch release of Scala Native v0.4.4, which brings improved support for Arm64, introduces experimental embeding of resources and adds dedicated ScalaNativeJUnitPlugin for easier setup of tests. Also in this release we'have fixed all the issues found in the recent support for Scala 3, including Selectables, cross version with Scala 2.13 dependencies and many more.
+We're happy to announce the new patch release of Scala Native v0.4.4, which brings improved support for Arm64, introduces experimental embedding of resources and adds dedicated ScalaNativeJUnitPlugin for easier setup of tests. Also in this release we have fixed all the issues found in the recent support for Scala 3, including Selectables, cross version with Scala 2.13 dependencies and many more.
 
 <table>
 <tbody>
@@ -116,7 +116,7 @@ $ git shortlog -sn --no-merges v0.4.3..v0.4.4
 - Fix negation of floating point numbers
   [\#2577](https://github.com/scala-native/scala-native/pull/2577)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Add missing contructors for throwables and improve JVM compliance
+- Add missing constructors for throwables and improve JVM compliance
   [\#2578](https://github.com/scala-native/scala-native/pull/2578)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Fix runtime problems on MacOS using M1 chips

--- a/docs/changelog/0.4.x/0.4.5.md
+++ b/docs/changelog/0.4.x/0.4.5.md
@@ -97,7 +97,7 @@ $ git shortlog -sn --no-merges v0.4.4..v0.4.5
 - Port new implementation of TreeSet and PriorityQueue from Scala.js
   [\#2677](https://github.com/scala-native/scala-native/pull/2677)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Port stubs for java.util.concurrent data stractures from Scala.js
+- Port stubs for java.util.concurrent data structures from Scala.js
   [\#2682](https://github.com/scala-native/scala-native/pull/2682)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Port `ConcurrentSkipListSet`

--- a/docs/changelog/0.4.x/0.4.8.md
+++ b/docs/changelog/0.4.x/0.4.8.md
@@ -130,7 +130,7 @@ Now you can use the dedicated extension method instead to make this easier.
 
 **Merged pull requests:**
 ### Scala Native Compiler Plugin
-- Don't unapply unecessary unboxing in lambdas
+- Don't unapply unnecessary unboxing in lambdas
   [\#2938](https://github.com/scala-native/scala-native/pull/2938)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Fix encoding of `scala.Nothing` and `scala.Null` in type signatures

--- a/docs/changelog/0.4.x/0.4.9.md
+++ b/docs/changelog/0.4.x/0.4.9.md
@@ -3,7 +3,7 @@
 
 We're happy to announce the release of Scala Native 0.4.9.
 
-It's a patch release fixing linkage errors when building Scala 2.13 libraries using Scala 3 dependenices.
+It's a patch release fixing linkage errors when building Scala 2.13 libraries using Scala 3 dependencies.
 
 It does also reverse version policy changes leading to problems in sbt-crossproject. Improved version policy would be restored in Scala Native 0.5.x.
 

--- a/docs/changelog/0.5.x/0.5.0-RC1.md
+++ b/docs/changelog/0.5.x/0.5.0-RC1.md
@@ -43,12 +43,12 @@ Check out the documentation at
 ## New features
 ### Multithreading support
 Scala Native now allows to use system threads based on `java.lang.Thread` implementation, along with all the necessary primitives to work with concurrency:
- * `synchronized` blocks are now using object monitors following partially JVM semantics - these might be less performant when compared to JVM, but are going to achive improvements in the followup patch releases.
+ * `synchronized` blocks are now using object monitors following partially JVM semantics - these might be less performant when compared to JVM, but are going to achieve improvements in the followup patch releases.
  * JVM compliant support for `@volatile` annotations
  * Configurable mostly JVM-compliant support for final fields semantics, see [multithreading guide](../../user/lang.md/#multithreading)
  * Thread safe implementation of most `java.util.concurrent` types and methods, including atomics, thread pools, etc. See list of currently implemented primitives in our [meta-issue on GitHub](https://github.com/scala-native/scala-native/issues/3165). Be aware that our Java Standard Library implementation might still contain thread-unsafe implementations of types not listed in the tracker.
  * Support for most of `scala.concurrent` and `scala.collection.concurrent` types.
- * Multithreading-aware implemenation of all garbage collections.
+ * Multithreading-aware implementation of all garbage collections.
 
 ### Support for 32-bit architectures
 We've introduced preliminary, experimental support for targeting 32bit architectures, like ARMv7.
@@ -56,28 +56,28 @@ To allow for representing variable-length integers in C bindings, we've introduc
 Multiple C standard library and POSIX bindings were adapted to use these new types.
 
 ### Initial support for source level debugging
-We've introduced initial support for generating source level debug informations, allowing to map code executed in the debugger to the original sources or to represent local variables. When executing on MacOS it also allows to obtain approximated source code lines in the exception stack traces.
-Be aware that both Scala Native optimizer and LLVM optimizers can remove some of the optimized out debug informations. For best experience run with disabled optimizations:
+We've introduced initial support for generating source level debug information, allowing to map code executed in the debugger to the original sources or to represent local variables. When executing on MacOS it also allows to obtain approximated source code lines in the exception stack traces.
+Be aware that both Scala Native optimizer and LLVM optimizers can remove some of the optimized out debug information. For best experience run with disabled optimizations:
 ```scala
   nativeConfig ~= {
-        .withSourceLevelDebuggingConfig(_.enableAll) // enable generation of debug informations
+        .withSourceLevelDebuggingConfig(_.enableAll) // enable generation of debug information
         .withOptimize(false)  // disable Scala Native optimizer
         .withMode(scalanative.build.Mode.debug) // compile using LLVM without optimizations
    }
 ```
-See our [debugging guide](../../user/testing.md#source-level-debugging) for more informations.
+See our [debugging guide](../../user/testing.md#source-level-debugging) for more information.
 
 ### SIP-51 support: Drop forward binary compatibility of the Scala 2.13 standard library
-We're chaning how the Scala standard library artifacts are published. Previously each Scala Native version shipped with 1 artifact for Scala standard library based on latest version of Scala. However this approach was insufficient to fully cover changes in Scala 3 standard library and it's 2 lines of releases: Scala LTS and Scala Next.
-To mittigate this issue and to prepare for unfreezing Scala 2 standard library we're changing how artifacts are published. Now each release of Scala Native would contain N variants of Scala standard library with custom versioning in format `<ScalaVersion>+<ScalaNativeVersion>`, eg. `3.3.2+0.5.0`.
+We're changing how the Scala standard library artifacts are published. Previously each Scala Native version shipped with 1 artifact for Scala standard library based on latest version of Scala. However this approach was insufficient to fully cover changes in Scala 3 standard library and it's 2 lines of releases: Scala LTS and Scala Next.
+To mitigate this issue and to prepare for unfreezing Scala 2 standard library we're changing how artifacts are published. Now each release of Scala Native would contain N variants of Scala standard library with custom versioning in format `<ScalaVersion>+<ScalaNativeVersion>`, eg. `3.3.2+0.5.0`.
 
 ### Improved missing symbols reports
-The new release introuduces a refactored machanism for tracking and reporting missing symbols in the linked code.
-Now when referring to not implemented Java standard library method, or a type from not cross-compiled library you would receive a detailed information about missing symbols containg its signature approximation and detailed stack trace of method calls leading to usage of missing symbol.
+The new release introduces a refactored mechanism for tracking and reporting missing symbols in the linked code.
+Now when referring to not implemented Java standard library method, or a type from not cross-compiled library you would receive a detailed information about missing symbols containing its signature approximation and detailed stack trace of method calls leading to usage of missing symbol.
 
 ### JVM service providers supports
 We're introducing a user configured support for Java Service Providers.
-Similarry to it's JVM variant these would allow you to introduce implementations of Service Provider Interfaces however due to Ahead-of-time compilation constraint and to limit ammount of introduced dependencies only explicitly enabled implementations would be linked in the final binary.
+Similarly to it's JVM variant these would allow you to introduce implementations of Service Provider Interfaces however due to Ahead-of-time compilation constraint and to limit amount of introduced dependencies only explicitly enabled implementations would be linked in the final binary.
 For more details refer to {ref}`our guide <service_providers>`.
 
 ### User build settings
@@ -100,12 +100,12 @@ Scala Native 0.5.0 breaks backward binary compatibility with previous releases o
 Libraries published using version 0.4.x or older must be republished for Scala Native 0.5.x.
 
 ### Scala Native Runtime
-* `scala.scalanative.unsafe.Zone.apply` by default uses a context function argument. For Scala 2 cross-compilation see [Memory managment section](../../user/interop.md#memory-management)
+* `scala.scalanative.unsafe.Zone.apply` by default uses a context function argument. For Scala 2 cross-compilation see [Memory management section](../../user/interop.md#memory-management)
 * The idiomatic alternative for C `void*` is now `Ptr[?]`(Scala 3) / `Ptr[_]` (Scala 2). Use `unsafe.CVoidPtr` for alias when defining bindings.
 
 ### Java Standard Library
-* Removed harmfull stub types defined in multiple packages, for 0.4.x implementation see [scala-native-java-stubs](https://github.com/scala-native/scala-native-java-stubs):
-  * Removed `java.security` stubs - these were harmfull, by providing a false sense of security, especially in `java.security.MessageDiggest`.
+* Removed harmful stub types defined in multiple packages, for 0.4.x implementation see [scala-native-java-stubs](https://github.com/scala-native/scala-native-java-stubs):
+  * Removed `java.security` stubs - these were harmful, by providing a false sense of security, especially in `java.security.MessageDiggest`.
   * Removed `java.net.URL` stubs - these had no working implementation for majority of features.
   * Removed `java.reflect` stubs - cannot be implemented to provide real reflective access.
 
@@ -298,8 +298,8 @@ Big thanks to everybody who contributed to this release or reported an issue!
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 
-### Scala Native Compiler PLugin
-- Don't unapply unecessary unboxing in lambdas
+### Scala Native Compiler Plugin
+- Don't unapply unnecessary unboxing in lambdas
   [\#2938](https://github.com/scala-native/scala-native/pull/2938)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Fix encoding of `scala.Nothing` and `scala.Null` in type signatures
@@ -329,7 +329,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - refactor: Remove `mapSourceURI`, always use local copy of sources when debugging
   [\#3635](https://github.com/scala-native/scala-native/pull/3635)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- improvement: Use` java.lang.StringBuilder` for optimized concatation of Strings in NIR CodeGen
+- improvement: Use` java.lang.StringBuilder` for optimized concatenation of Strings in NIR CodeGen
   [\#3640](https://github.com/scala-native/scala-native/pull/3640)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - improvement: Better source positions relativization
@@ -349,7 +349,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### Scala Native runtime
-- Add mulithreading support - part 1
+- Add multithreading support - part 1
   [\#3114](https://github.com/scala-native/scala-native/pull/3114)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Support JavaMemoryModel behaviour for shared variables
@@ -573,7 +573,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Fix #3657: Remove a number of java.net defects
   [\#3666](https://github.com/scala-native/scala-native/pull/3666)
   ([LeeTibbert](https://github.com/LeeTibbert))
-- fix: Fix accessing mapped byte buffers if offset is not page size alligned
+- fix: Fix accessing mapped byte buffers if offset is not page size aligned
   [\#3679](https://github.com/scala-native/scala-native/pull/3679)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - improvement: Add most of missing JDK9+ methods for `java.nio` buffers
@@ -588,7 +588,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Fix #3705: java.net ServerSockets can now listen on both IPv6 & IPv4
   [\#3710](https://github.com/scala-native/scala-native/pull/3710)
   ([LeeTibbert](https://github.com/LeeTibbert))
-- Fix #3708: javalib Inet6Address ipv6Address argumentsare now resistant to outside change.
+- Fix #3708: javalib Inet6Address ipv6Address arguments are now resistant to outside change.
   [\#3715](https://github.com/scala-native/scala-native/pull/3715)
   ([LeeTibbert](https://github.com/LeeTibbert))
 - Fix #3706: java.net.ServerSocket now reports local address of accepted socket correctly
@@ -674,7 +674,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Preserve local variables names in NIR
   [\#3386](https://github.com/scala-native/scala-native/pull/3386)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Add information about lexical scopes to NIR debug informations
+- Add information about lexical scopes to NIR debug information
   [\#3438](https://github.com/scala-native/scala-native/pull/3438)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Enforce narrower types in NIR and toolchain
@@ -707,7 +707,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - improvement: Better resolution of sources classpath
   [\#3646](https://github.com/scala-native/scala-native/pull/3646)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- feature: Autmatically disable unused multithreading to improve performance
+- feature: Automatically disable unused multithreading to improve performance
   [\#3670](https://github.com/scala-native/scala-native/pull/3670)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Allow cross-compiling from Mac to Linux and vice versa
@@ -716,7 +716,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - improvement: Use debug metadata to create stacktraces on Windows when LTO enabled
   [\#3659](https://github.com/scala-native/scala-native/pull/3659)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- feautre: Relaxed memory model for final fields, strict semantics with `@safePublish` annotation
+- feature: Relaxed memory model for final fields, strict semantics with `@safePublish` annotation
   [\#3719](https://github.com/scala-native/scala-native/pull/3719)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - fix: Optimize inlining decisions and set reasonable values to optimizer config
@@ -728,7 +728,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - refactor: Pipeline generation of LLVM IR and it's compilation
   [\#3622](https://github.com/scala-native/scala-native/pull/3622)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- fix [toolchain]:Prevent usage of outdated compilation outputs in incremenal compilatiation
+- fix [toolchain]:Prevent usage of outdated compilation outputs in incremental compilation
   [\#3728](https://github.com/scala-native/scala-native/pull/3728)
   ([WojciechMazur](https://github.com/WojciechMazur))
 
@@ -801,7 +801,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Simplify & shorten additional posixlib socket code paths
   [\#2742](https://github.com/scala-native/scala-native/pull/2742)
   ([LeeTibbert](https://github.com/LeeTibbert))
-- Fix #2738: Shorten posixlib uio codepaths & add UioTest
+- Fix #2738: Shorten posixlib uio code paths & add UioTest
   [\#2741](https://github.com/scala-native/scala-native/pull/2741)
   ([LeeTibbert](https://github.com/LeeTibbert))
 - Simplify & shorten posixlib netdb code paths

--- a/docs/changelog/0.5.x/0.5.0-RC2.md
+++ b/docs/changelog/0.5.x/0.5.0-RC2.md
@@ -102,7 +102,7 @@ $ git shortlog -sn --no-merges v0.5.0-RC1..
 - feature: Allow to enable strict semantic of extern function calls.
   [\#3829](https://github.com/scala-native/scala-native/pull/3829)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- improvment: Warn when using LTO.thin on MacOS
+- improvement: Warn when using LTO.thin on MacOS
   [\#3833](https://github.com/scala-native/scala-native/pull/3833)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - fix: Try to mitigate Windows AccessDeniedException when using `IO.deleteRecursive`

--- a/docs/changelog/0.5.x/0.5.0.md
+++ b/docs/changelog/0.5.x/0.5.0.md
@@ -43,12 +43,12 @@ Check out the documentation at
 ## New features
 ### Multithreading support
 Scala Native now allows to use system threads based on `java.lang.Thread` implementation, along with all the necessary primitives to work with concurrency:
- * `synchronized` blocks are now using object monitors following partially JVM semantics - these might be less performant when compared to JVM, but are going to achive improvements in the followup patch releases.
+ * `synchronized` blocks are now using object monitors following partially JVM semantics - these might be less performant when compared to JVM, but are going to achieve improvements in the followup patch releases.
  * JVM compliant support for `@volatile` annotations
  * Configurable mostly JVM-compliant support for final fields semantics, see {ref}`multithreading guide <multithreading>`
  * Thread safe implementation of most `java.util.concurrent` types and methods, including atomics, thread pools, etc. See list of currently implemented primitives in our [meta-issue on GitHub](https://github.com/scala-native/scala-native/issues/3165). Be aware that our Java Standard Library implementation might still contain thread-unsafe implementations of types not listed in the tracker.
  * Support for most of `scala.concurrent` and `scala.collection.concurrent` types.
- * Multithreading-aware implemenation of all garbage collections.
+ * Multithreading-aware implementation of all garbage collections.
 
 ### Support for 32-bit architectures
 We've introduced preliminary, experimental support for targeting 32bit architectures, like ARMv7.
@@ -56,28 +56,28 @@ To allow for representing variable-length integers in C bindings, we've introduc
 Multiple C standard library and POSIX bindings were adapted to use these new types.
 
 ### Initial support for source level debugging
-We've introduced initial support for generating source level debug informations, allowing to map code executed in the debugger to the original sources or to represent local variables. When executing on MacOS it also allows to obtain approximated source code lines in the exception stack traces (best effort, might not point to exact line, but rather to function definitions).
-Be aware that both Scala Native optimizer and LLVM optimizers can remove some of the optimized out debug informations. For best experience run with disabled optimizations:
+We've introduced initial support for generating source level debug information, allowing to map code executed in the debugger to the original sources or to represent local variables. When executing on MacOS it also allows to obtain approximated source code lines in the exception stack traces (best effort, might not point to exact line, but rather to function definitions).
+Be aware that both Scala Native optimizer and LLVM optimizers can remove some of the optimized out debug information. For best experience run with disabled optimizations:
 ```scala
   nativeConfig ~= {
-        .withSourceLevelDebuggingConfig(_.enableAll) // enable generation of debug informations
+        .withSourceLevelDebuggingConfig(_.enableAll) // enable generation of debug information
         .withOptimize(false)  // disable Scala Native optimizer
         .withMode(scalanative.build.Mode.debug) // compile using LLVM without optimizations
    }
 ```
-See our [debugging guide](../../user/testing.md#source-level-debugging) for more informations.
+See our [debugging guide](../../user/testing.md#source-level-debugging) for more information.
 
 ### SIP-51 support: Drop forward binary compatibility of the Scala 2.13 standard library
-We're chaning how the Scala standard library artifacts are published. Previously each Scala Native version shipped with 1 artifact for Scala standard library based on latest version of Scala. However this approach was insufficient to fully cover changes in Scala 3 standard library and it's 2 lines of releases: Scala LTS and Scala Next.
-To mittigate this issue and to prepare for unfreezing Scala 2 standard library we're changing how artifacts are published. Now each release of Scala Native would contain N variants of Scala standard library with custom versioning in format `<ScalaVersion>+<ScalaNativeVersion>`, eg. `3.3.2+0.5.0`.
+We're changing how the Scala standard library artifacts are published. Previously each Scala Native version shipped with 1 artifact for Scala standard library based on latest version of Scala. However this approach was insufficient to fully cover changes in Scala 3 standard library and it's 2 lines of releases: Scala LTS and Scala Next.
+To mitigate this issue and to prepare for unfreezing Scala 2 standard library we're changing how artifacts are published. Now each release of Scala Native would contain N variants of Scala standard library with custom versioning in format `<ScalaVersion>+<ScalaNativeVersion>`, eg. `3.3.2+0.5.0`.
 
 ### Improved missing symbols reports
-The new release introuduces a refactored machanism for tracking and reporting missing symbols in the linked code.
-Now when referring to not implemented Java standard library method, or a type from not cross-compiled library you would receive a detailed information about missing symbols containg its signature approximation and detailed stack trace of method calls leading to usage of missing symbol.
+The new release introduces a refactored mechanism for tracking and reporting missing symbols in the linked code.
+Now when referring to not implemented Java standard library method, or a type from not cross-compiled library you would receive a detailed information about missing symbols containing its signature approximation and detailed stack trace of method calls leading to usage of missing symbol.
 
 ### JVM service providers supports
 We're introducing a user configured support for Java Service Providers.
-Similarry to it's JVM variant these would allow you to introduce implementations of Service Provider Interfaces however due to Ahead-of-time compilation constraint and to limit ammount of introduced dependencies only explicitly enabled implementations would be linked in the final binary.
+Similarly to its JVM variant, these would allow you to introduce implementations of Service Provider Interfaces however due to Ahead-of-time compilation constraint and to limit amount of introduced dependencies only explicitly enabled implementations would be linked in the final binary.
 For more details refer to {ref}`our guide <service_providers>`.
 
 ### User build settings
@@ -100,12 +100,12 @@ Scala Native 0.5.0 breaks backward binary compatibility with previous releases o
 Libraries published using version 0.4.x or older must be republished for Scala Native 0.5.x.
 
 ### Scala Native Runtime
-* `scala.scalanative.unsafe.Zone.apply` by default uses a context function argument. For Scala 2 cross-compilation see [Memory managment section](../../user/interop.md#memory-management)
+* `scala.scalanative.unsafe.Zone.apply` by default uses a context function argument. For Scala 2 cross-compilation see [Memory management section](../../user/interop.md#memory-management)
 * The idiomatic alternative for C `void*` is now `Ptr[?]`(Scala 3) / `Ptr[_]` (Scala 2). Use `unsafe.CVoidPtr` for alias when defining bindings.
 
 ### Java Standard Library
-* Removed harmfull stub types defined in multiple packages, for 0.4.x implementation see [scala-native-java-stubs](https://github.com/scala-native/scala-native-java-stubs):
-  * Removed `java.security` stubs - these were harmfull, by providing a false sense of security, especially in `java.security.MessageDiggest`.
+* Removed harmful stub types defined in multiple packages, for 0.4.x implementation see [scala-native-java-stubs](https://github.com/scala-native/scala-native-java-stubs):
+  * Removed `java.security` stubs - these were harmful, by providing a false sense of security, especially in `java.security.MessageDiggest`.
   * Removed `java.net.URL` stubs - these had no working implementation for majority of features.
   * Removed `java.reflect` stubs - cannot be implemented to provide real reflective access.
 
@@ -301,8 +301,8 @@ Big thanks to everybody who contributed to this release or reported an issue!
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 
-### Scala Native Compiler PLugin
-- Don't unapply unecessary unboxing in lambdas
+### Scala Native Compiler Plugin
+- Don't unapply unnecessary unboxing in lambdas
   [\#2938](https://github.com/scala-native/scala-native/pull/2938)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Fix encoding of `scala.Nothing` and `scala.Null` in type signatures
@@ -332,7 +332,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - refactor: Remove `mapSourceURI`, always use local copy of sources when debugging
   [\#3635](https://github.com/scala-native/scala-native/pull/3635)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- improvement: Use` java.lang.StringBuilder` for optimized concatation of Strings in NIR CodeGen
+- improvement: Use` java.lang.StringBuilder` for optimized concatenation of Strings in NIR CodeGen
   [\#3640](https://github.com/scala-native/scala-native/pull/3640)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - improvement: Better source positions relativization
@@ -352,7 +352,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### Scala Native runtime
-- Add mulithreading support - part 1
+- Add multithreading support - part 1
   [\#3114](https://github.com/scala-native/scala-native/pull/3114)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Support JavaMemoryModel behaviour for shared variables
@@ -600,7 +600,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Fix #3657: Remove a number of java.net defects
   [\#3666](https://github.com/scala-native/scala-native/pull/3666)
   ([LeeTibbert](https://github.com/LeeTibbert))
-- fix: Fix accessing mapped byte buffers if offset is not page size alligned
+- fix: Fix accessing mapped byte buffers if offset is not page size aligned
   [\#3679](https://github.com/scala-native/scala-native/pull/3679)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - improvement: Add most of missing JDK9+ methods for `java.nio` buffers
@@ -615,7 +615,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Fix #3705: java.net ServerSockets can now listen on both IPv6 & IPv4
   [\#3710](https://github.com/scala-native/scala-native/pull/3710)
   ([LeeTibbert](https://github.com/LeeTibbert))
-- Fix #3708: javalib Inet6Address ipv6Address argumentsare now resistant to outside change.
+- Fix #3708: javalib Inet6Address ipv6Address arguments are now resistant to outside change.
   [\#3715](https://github.com/scala-native/scala-native/pull/3715)
   ([LeeTibbert](https://github.com/LeeTibbert))
 - Fix #3706: java.net.ServerSocket now reports local address of accepted socket correctly
@@ -722,7 +722,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Preserve local variables names in NIR
   [\#3386](https://github.com/scala-native/scala-native/pull/3386)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Add information about lexical scopes to NIR debug informations
+- Add information about lexical scopes to NIR debug information
   [\#3438](https://github.com/scala-native/scala-native/pull/3438)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Enforce narrower types in NIR and toolchain
@@ -755,7 +755,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - improvement: Better resolution of sources classpath
   [\#3646](https://github.com/scala-native/scala-native/pull/3646)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- feature: Autmatically disable unused multithreading to improve performance
+- feature: Automatically disable unused multithreading to improve performance
   [\#3670](https://github.com/scala-native/scala-native/pull/3670)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Allow cross-compiling from Mac to Linux and vice versa
@@ -764,7 +764,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - improvement: Use debug metadata to create stacktraces on Windows when LTO enabled
   [\#3659](https://github.com/scala-native/scala-native/pull/3659)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- feautre: Relaxed memory model for final fields, strict semantics with `@safePublish` annotation
+- feature: Relaxed memory model for final fields, strict semantics with `@safePublish` annotation
   [\#3719](https://github.com/scala-native/scala-native/pull/3719)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - fix: Optimize inlining decisions and set reasonable values to optimizer config
@@ -776,7 +776,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - refactor: Pipeline generation of LLVM IR and it's compilation
   [\#3622](https://github.com/scala-native/scala-native/pull/3622)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- fix [toolchain]:Prevent usage of outdated compilation outputs in incremenal compilatiation
+- fix [toolchain]: Prevent usage of outdated compilation outputs in incremental compilation
   [\#3728](https://github.com/scala-native/scala-native/pull/3728)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - refactor: Restrict access to tools and nir types
@@ -785,7 +785,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - feature: Allow to enable strict semantic of extern function calls.
   [\#3829](https://github.com/scala-native/scala-native/pull/3829)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- improvment: Warn when using LTO.thin on MacOS
+- improvement: Warn when using LTO.thin on MacOS
   [\#3833](https://github.com/scala-native/scala-native/pull/3833)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - fix: Try to mitigate Windows AccessDeniedException when using `IO.deleteRecursive`
@@ -864,7 +864,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Simplify & shorten additional posixlib socket code paths
   [\#2742](https://github.com/scala-native/scala-native/pull/2742)
   ([LeeTibbert](https://github.com/LeeTibbert))
-- Fix #2738: Shorten posixlib uio codepaths & add UioTest
+- Fix #2738: Shorten posixlib uio code paths & add UioTest
   [\#2741](https://github.com/scala-native/scala-native/pull/2741)
   ([LeeTibbert](https://github.com/LeeTibbert))
 - Simplify & shorten posixlib netdb code paths

--- a/docs/changelog/0.5.x/0.5.1.md
+++ b/docs/changelog/0.5.x/0.5.1.md
@@ -3,7 +3,7 @@
 
 We're happy to announce the release of Scala Native v0.5.1. 
 
-This patch release is focued on elimination of compiler plugin crashes and bugfixes to Java concurrent collections.
+This patch release is focused on elimination of compiler plugin crashes and bugfixes to Java concurrent collections.
 It does also fix some of the issues when using MinGW compiler.
 
 ## Supported Scala versions

--- a/docs/changelog/0.5.x/0.5.2.md
+++ b/docs/changelog/0.5.x/0.5.2.md
@@ -2,7 +2,7 @@
 # 0.5.2 (2024-05-28)
 
 We're happy to announce the release of Scala Native 0.5.2. 
-It's a second patch release, providing fixes to Java Standard Library reimplementaiton and adding support for new Scala versions 3.4.2 and 3.5.0-RC1
+It's a second patch release, providing fixes to Java Standard Library reimplementation and adding support for new Scala versions 3.4.2 and 3.5.0-RC1
 
 ## Supported Scala versions
 

--- a/docs/changelog/0.5.x/0.5.3.md
+++ b/docs/changelog/0.5.x/0.5.3.md
@@ -4,7 +4,7 @@
 We're happy to announce the release of Scala Native 0.5.3.
 
 This release introduces bugfixes the runtime and toolchains. 
-Notably it fixes spurious segmentation faults coused by lack of null guards before calling methods, but also brings multiple fixes to IO operations on files.
+Notably it fixes spurious segmentation faults caused by lack of null guards before calling methods, but also brings multiple fixes to IO operations on files.
 
 ## Supported Scala versions
 
@@ -63,7 +63,7 @@ $ git shortlog -sn --no-merges v0.5.2..v0.5.3
 - fix [javalib] Fix access to redirected output of the file directly after finishing the subprocess execution
   [\#3941](https://github.com/scala-native/scala-native/pull/3941)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- fix[javalib] Acknownledge `kevent` and `ppol` as blocking extern functions
+- fix[javalib] Acknowledge `kevent` and `ppol` as blocking extern functions
   [\#3945](https://github.com/scala-native/scala-native/pull/3945)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - improve [javalib]: handling of EINTR errno when waiting process termination

--- a/docs/changelog/0.5.x/0.5.4.md
+++ b/docs/changelog/0.5.x/0.5.4.md
@@ -4,7 +4,7 @@
 We're happy to announce the path release of Scala Native 0.5.4.
 
 This release introduces bugfixes the runtime and toolchains. 
-Notably it fixes spurious segmentation faults coused by lack of null guards before calling methods, but also brings multiple fixes to IO operations on files.
+Notably it fixes spurious segmentation faults caused by lack of null guards before calling methods, but also brings multiple fixes to IO operations on files.
 
 ## Supported Scala versions
 

--- a/docs/changelog/0.5.x/0.5.6.md
+++ b/docs/changelog/0.5.x/0.5.6.md
@@ -109,7 +109,7 @@ $ git shortlog -sn --no-merges v0.5.5..v0.5.6
 
 ## Scala Native Compiler Plugin
 
-- fix[compiler-plugin] Intrinisic ClassFieldRawPtr should always mangle symbol names when comparing symbols [#4045](https://github.com/scala-native/scala-native/pull/4045) ([WojciechMazur](https://github.com/WojciechMazur))
+- fix[compiler-plugin] Intrinsic ClassFieldRawPtr should always mangle symbol names when comparing symbols [#4045](https://github.com/scala-native/scala-native/pull/4045) ([WojciechMazur](https://github.com/WojciechMazur))
 - Don't allow to define CFuncPtr lambda closing over `this` [#4079](https://github.com/scala-native/scala-native/pull/4079) ([WojciechMazur](https://github.com/WojciechMazur))
 
 ## Scala Native sbt plugin

--- a/docs/changelog/0.5.x/0.5.7.md
+++ b/docs/changelog/0.5.x/0.5.7.md
@@ -12,7 +12,7 @@ We're happy to announce the release of Scala Native 0.5.7.
 - Scala Native runtime no longer requires C++ standard library (on Unix systems) by default. 
   `@scala.scalanative.unsafe.linkCppRuntime` annotation can be used on extern methods bindings to require linking with C++ standard library if these are used. 
   Scala Native would still use C++ runtime on Windows or if the LTO is enabled, due to not yet resolved issues. 
-  Adding `-fno-cxx-exceptions` or `-fcxx-exceptions` settings to `NativeConfig.compileOptions` allows to explicitlly control if Scala Native should use it's own exception handling implementation or to continue using C++ exception wrappers.
+  Adding `-fno-cxx-exceptions` or `-fcxx-exceptions` settings to `NativeConfig.compileOptions` allows to explicitly control if Scala Native should use it's own exception handling implementation or to continue using C++ exception wrappers.
 - StackOverflowError can now be detected and handled instead of terminating program
 - `SCALANATIVE_THREAD_STACK_SIZE` environment variable can now be used to control default platform Thread size at runtime (-Xss on the JVM)
 - Optimized layout of Class virtual tables to reduce size of binaries
@@ -85,7 +85,7 @@ $ git shortlog -sn --no-merges v0.5.6..0.5.7
 ## Scala Native runtime
 
 - Replace single TraitDispatchTable with class specific itables to reduce size of binaries [#4085](https://github.com/scala-native/scala-native/pull/4085) ([WojciechMazur](https://github.com/WojciechMazur))
-- Fix not inititalizied Posix thread state of Main thread [#4112](https://github.com/scala-native/scala-native/pull/4112) ([WojciechMazur](https://github.com/WojciechMazur))
+- Fix not initialized Posix thread state of Main thread [#4112](https://github.com/scala-native/scala-native/pull/4112) ([WojciechMazur](https://github.com/WojciechMazur))
 - Try to fix exceptions during main thread initialization [#4188](https://github.com/scala-native/scala-native/pull/4188) ([WojciechMazur](https://github.com/WojciechMazur))
 - Implement minimal C++-like runtime to support exceptions without linking libc++ [#4122](https://github.com/scala-native/scala-native/pull/4122) ([lolgab](https://github.com/lolgab))
 - Fallback to C++ exceptions when using LTO or explicitly enabled [#4201](https://github.com/scala-native/scala-native/pull/4201) ([WojciechMazur](https://github.com/WojciechMazur))
@@ -115,7 +115,7 @@ $ git shortlog -sn --no-merges v0.5.6..0.5.7
 - Add missing dbg metadata to generated `scalanative_catch` calls [#4179](https://github.com/scala-native/scala-native/pull/4179) ([WojciechMazur](https://github.com/WojciechMazur))
 - Optimize throwing exception to local handler as jump [#4194](https://github.com/scala-native/scala-native/pull/4194) ([WojciechMazur](https://github.com/WojciechMazur))
 - Fix handling of intrinsic methods in lowering in non-optimized builds [#4186](https://github.com/scala-native/scala-native/pull/4186) ([WojciechMazur](https://github.com/WojciechMazur))
-- Don't warn on unresolved intrisnic method call that is defined inside handled intrinsic method [#4202](https://github.com/scala-native/scala-native/pull/4202) ([WojciechMazur](https://github.com/WojciechMazur))
+- Don't warn on unresolved intrinsic method call that is defined inside handled intrinsic method [#4202](https://github.com/scala-native/scala-native/pull/4202) ([WojciechMazur](https://github.com/WojciechMazur))
 - Improve detection when system threads are used. [#4204](https://github.com/scala-native/scala-native/pull/4204) ([WojciechMazur](https://github.com/WojciechMazur))
 - Refine when to check for StackOverflowError [#4203](https://github.com/scala-native/scala-native/pull/4203) ([WojciechMazur](https://github.com/WojciechMazur))
 

--- a/docs/lib/javalib.md
+++ b/docs/lib/javalib.md
@@ -174,7 +174,7 @@ Reasoning for the lack of `getResource()` and `getResources()`:
 
 In Scala Native, the outputted file that can be run is a binary, unlike
 JVM's classfiles and jars. For that reason, if `getResources()` URI
-methods would be implemented, a new URI format using a seperate
+methods would be implemented, a new URI format using a separate
 FileSystem would have to be added (e.g. instead of obtaining
 `jar:file:path.ext` you would obtain `embedded:path.ext`). As this still
 would provide a meaningful inconsistency between JVM's javalib API and

--- a/javalib/src/main/scala/java/lang/ref/WeakReference.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReference.scala
@@ -10,7 +10,7 @@ class WeakReference[T](
     queue: ReferenceQueue[T]
 ) extends Reference[T](null.asInstanceOf[T]) {
   // Since compiler generates _gc_modified_referent and referent
-  // (of the Reference class) as two seperate fields and GC only
+  // (of the Reference class) as two separate fields and GC only
   // controls _gc_modified_ referent field, we pass null to the
   // superclass to avoid adding additional control to the GC.
   // This should not be a problem as all Reference class methods were

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
@@ -44,11 +44,11 @@ class WindowsPath private[windows] (
       case (PathType.DriveRelative, Some(root)) => root
       case _                                    => ""
     }
-    drivePrefix + segments.mkString(seperator)
+    drivePrefix + segments.mkString(separator)
   }
 
   @alwaysinline
-  final private def seperator: String = fs.getSeparator()
+  final private def separator: String = fs.getSeparator()
 
   override def getFileSystem(): FileSystem = fs
 
@@ -146,7 +146,7 @@ class WindowsPath private[windows] (
         case winPath: WindowsPath =>
           new WindowsPath(pathType, root, segments ++ winPath.segments)
         case _ =>
-          WindowsPathParser(path.toString + seperator + other.toString)
+          WindowsPathParser(path.toString + separator + other.toString)
       }
   }
 
@@ -292,8 +292,8 @@ private[windows] object WindowsPath {
       }
       .reverse
 
-    path.root.fold(components.mkString(path.seperator)) {
-      components.mkString(_, path.seperator, "")
+    path.root.fold(components.mkString(path.separator)) {
+      components.mkString(_, path.separator, "")
     }
   }
 

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
@@ -41,7 +41,7 @@ final class TestMetadata(
     val annotation: org.junit.Test
 )
 
-/** Scala Native interal JUnit test class metadata
+/** Scala Native internal JUnit test class metadata
  *
  *  This class is public due to implementation details. Only the junit compiler
  *  plugin may create instances of it.

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertEquals2Test started
 ldTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertEquals2Test started
 ldTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEquals2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEquals2TestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEquals2Test started
 liTest scala.scalanative.junit.AssertEquals2Test.test started
 leTest scala.scalanative.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEquals2Test.test
+e2scala.scalanative.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEquals2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_.txt
@@ -1,21 +1,21 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_a.txt
@@ -1,21 +1,21 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_n.txt
@@ -1,21 +1,21 @@
 ldTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ldTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_na.txt
@@ -1,21 +1,21 @@
 ldTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ldTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nv.txt
@@ -1,21 +1,21 @@
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nva.txt
@@ -1,21 +1,21 @@
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvc.txt
@@ -1,21 +1,21 @@
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_nvca.txt
@@ -1,21 +1,21 @@
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_v.txt
@@ -1,21 +1,21 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_va.txt
@@ -1,21 +1,21 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vc.txt
@@ -1,21 +1,21 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=0.txt
@@ -1,21 +1,21 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=1.txt
@@ -1,21 +1,21 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=2.txt
@@ -1,21 +1,21 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_verbosity=3.txt
@@ -1,21 +1,21 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vs.txt
@@ -1,21 +1,21 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest scala.scalanative.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsDoubleTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsDoubleTestAssertions_vsn.txt
@@ -1,21 +1,21 @@
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest started
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDouble::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage
+e0scala.scalanative.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort
+e0scala.scalanative.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run scala.scalanative.junit.AssertEqualsDoubleTest finished: 0 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertEqualsTest started
 ldTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertEqualsTest started
 ldTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertEqualsTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertEqualsTest started
 liTest scala.scalanative.junit.AssertEqualsTest.test started
 leTest scala.scalanative.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
-e2scala.scalanative.junit.AssertEqualsTest.test
+e2scala.scalanative.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest scala.scalanative.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertFalse2Test started
 ldTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertFalse2Test started
 ldTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalse2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalse2TestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalse2Test started
 liTest scala.scalanative.junit.AssertFalse2Test.test started
 leTest scala.scalanative.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
-e2scala.scalanative.junit.AssertFalse2Test.test
+e2scala.scalanative.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest scala.scalanative.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalse2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertFalseTest started
 ldTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertFalseTest started
 ldTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertFalseTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertFalseTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertFalseTest started
 liTest scala.scalanative.junit.AssertFalseTest.test started
 leTest scala.scalanative.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertFalseTest.test
+e2scala.scalanative.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertFalseTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertFalseTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertStringEqualsTest started
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssertStringEqualsTest started
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertStringEqualsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertStringEqualsTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssertStringEqualsTest started
 liTest scala.scalanative.junit.AssertStringEqualsTest.test started
 leTest scala.scalanative.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2scala.scalanative.junit.AssertStringEqualsTest.test
+e2scala.scalanative.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest scala.scalanative.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertStringEqualsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_a.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_n.txt
@@ -2,7 +2,7 @@ ldTest run scala.scalanative.junit.AssertThrows2Test started
 ldTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_na.txt
@@ -2,7 +2,7 @@ ldTest run scala.scalanative.junit.AssertThrows2Test started
 ldTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nv.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nva.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvc.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvca.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_v.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_va.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vc.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=0.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=1.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=2.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_verbosity=3.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vs.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m star
 liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrows2Test[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vsn.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrows2Test started
 liTest scala.scalanative.junit.AssertThrows2Test.test started
 leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
 leCaused by: java.lang.IllegalAccessException: Exception message
-e2scala.scalanative.junit.AssertThrows2Test.test
+e2scala.scalanative.junit.AssertThrows2Test.test::java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>::true
 ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrows2Test finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_a.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_n.txt
@@ -2,7 +2,7 @@ ldTest run scala.scalanative.junit.AssertThrowsTest started
 ldTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_na.txt
@@ -2,7 +2,7 @@ ldTest run scala.scalanative.junit.AssertThrowsTest started
 ldTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nv.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nva.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvc.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvca.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_v.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_va.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vc.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=0.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=1.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=2.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_verbosity=3.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vs.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m start
 liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mAssertThrowsTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vsn.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssertThrowsTest started
 liTest scala.scalanative.junit.AssertThrowsTest.test started
 leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException: Exception message
-e2scala.scalanative.junit.AssertThrowsTest.test
+e2scala.scalanative.junit.AssertThrowsTest.test::java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.AssertThrowsTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_.txt
@@ -1,10 +1,10 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_a.txt
@@ -1,10 +1,10 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_n.txt
@@ -1,10 +1,10 @@
 ldTest run scala.scalanative.junit.AssertTrueTest started
 ldTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 ldTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 ldTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_na.txt
@@ -1,10 +1,10 @@
 ldTest run scala.scalanative.junit.AssertTrueTest started
 ldTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 ldTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 ldTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nv.txt
@@ -1,10 +1,10 @@
 liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nva.txt
@@ -1,10 +1,10 @@
 liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nvc.txt
@@ -1,10 +1,10 @@
 liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_nvca.txt
@@ -1,10 +1,10 @@
 liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_v.txt
@@ -1,10 +1,10 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_va.txt
@@ -1,10 +1,10 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vc.txt
@@ -1,10 +1,10 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=0.txt
@@ -1,10 +1,10 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=1.txt
@@ -1,10 +1,10 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=2.txt
@@ -1,10 +1,10 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_verbosity=3.txt
@@ -1,10 +1,10 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vs.txt
@@ -1,10 +1,10 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest scala.scalanative.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest scala.scalanative.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssertTrueTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertTrueTestAssertions_vsn.txt
@@ -1,10 +1,10 @@
 liTest run scala.scalanative.junit.AssertTrueTest started
 liTest scala.scalanative.junit.AssertTrueTest.failTest started
 leTest scala.scalanative.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
-e2scala.scalanative.junit.AssertTrueTest.failTest
+e2scala.scalanative.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest scala.scalanative.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest scala.scalanative.junit.AssertTrueTest.successTest started
 ldTest scala.scalanative.junit.AssertTrueTest.successTest finished, took <TIME>
-e0scala.scalanative.junit.AssertTrueTest.successTest
+e0scala.scalanative.junit.AssertTrueTest.successTest::::true
 liTest run scala.scalanative.junit.AssertTrueTest finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_a.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_n.txt
@@ -2,7 +2,7 @@ ldTest run scala.scalanative.junit.AssumeAfterAssume started
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_na.txt
@@ -2,7 +2,7 @@ ldTest run scala.scalanative.junit.AssumeAfterAssume started
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nv.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nva.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvc.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvca.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_v.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_va.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vc.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=0.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=1.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=2.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_verbosity=3.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vs.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterAssume[0m[34m star
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vsn.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.AssumeAfterAssume started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
+e2scala.scalanative.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_a.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_n.txt
@@ -1,8 +1,8 @@
 ldTest run scala.scalanative.junit.AssumeAfterClassTest started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_na.txt
@@ -1,8 +1,8 @@
 ldTest run scala.scalanative.junit.AssumeAfterClassTest started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nv.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nva.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvc.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvca.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_v.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_va.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vc.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=0.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=1.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=2.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_verbosity=3.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vs.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vsn.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeAfterClassTest started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeAfterClassTest.test
+e0scala.scalanative.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeAfterClassTest
+e3scala.scalanative.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.AssumeAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssumeAfterException started
 ldTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.AssumeAfterException started
 ldTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeAfterException[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.AssumeAfterException started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2scala.scalanative.junit.AssumeAfterException.test
+e2scala.scalanative.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_a.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_n.txt
@@ -1,8 +1,8 @@
 ldTest run scala.scalanative.junit.AssumeInAfter started
 ldTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 ldTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_na.txt
@@ -1,8 +1,8 @@
 ldTest run scala.scalanative.junit.AssumeInAfter started
 ldTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 ldTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nv.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nva.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nvc.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nvca.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_v.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_va.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vc.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=0.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=1.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=2.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_verbosity=3.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vs.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeInAfter[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vsn.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeInAfter started
 liTest scala.scalanative.junit.AssumeInAfter.test started
 lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeInAfter.test
+e3scala.scalanative.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
-e0scala.scalanative.junit.AssumeInAfter.test
+e0scala.scalanative.junit.AssumeInAfter.test::::true
 liTest run scala.scalanative.junit.AssumeInAfter finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_a.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_n.txt
@@ -1,8 +1,8 @@
 ldTest run scala.scalanative.junit.AssumeTest started
 ldTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 ldTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_na.txt
@@ -1,8 +1,8 @@
 ldTest run scala.scalanative.junit.AssumeTest started
 ldTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 ldTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nv.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nva.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nvc.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nvca.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_v.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_va.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vc.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=0.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=1.txt
@@ -1,8 +1,8 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=2.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_verbosity=3.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vs.txt
@@ -1,8 +1,8 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAssumeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vsn.txt
@@ -1,8 +1,8 @@
 liTest run scala.scalanative.junit.AssumeTest started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
 lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.AssumeTest.assumeFail
+e3scala.scalanative.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
-e0scala.scalanative.junit.AssumeTest.assumeFail
+e0scala.scalanative.junit.AssumeTest.assumeFail::::true
 liTest run scala.scalanative.junit.AssumeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_.txt
@@ -1,13 +1,13 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_a.txt
@@ -1,13 +1,13 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_n.txt
@@ -1,13 +1,13 @@
 ldTest run scala.scalanative.junit.AsyncTest started
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure finished, took <TIME>
 ldTest scala.scalanative.junit.AsyncTest.expectedException started
 ldTest scala.scalanative.junit.AsyncTest.expectedException finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 ldTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 ldTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_na.txt
@@ -1,13 +1,13 @@
 ldTest run scala.scalanative.junit.AsyncTest started
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure finished, took <TIME>
 ldTest scala.scalanative.junit.AsyncTest.expectedException started
 ldTest scala.scalanative.junit.AsyncTest.expectedException finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 ldTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 ldTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nv.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest scala.scalanative.junit.AsyncTest.expectedException started
 ldTest scala.scalanative.junit.AsyncTest.expectedException finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nva.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest scala.scalanative.junit.AsyncTest.expectedException started
 ldTest scala.scalanative.junit.AsyncTest.expectedException finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nvc.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest scala.scalanative.junit.AsyncTest.expectedException started
 ldTest scala.scalanative.junit.AsyncTest.expectedException finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_nvca.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest scala.scalanative.junit.AsyncTest.expectedException started
 ldTest scala.scalanative.junit.AsyncTest.expectedException finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_v.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_va.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vc.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=0.txt
@@ -1,13 +1,13 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=1.txt
@@ -1,13 +1,13 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=2.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_verbosity=3.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vs.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest scala.scalanative.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest scala.scalanative.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 li[34mTest run [0mscala.scalanative.junit.[33mAsyncTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AsyncTestAssertions_vsn.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.AsyncTest started
 liTest scala.scalanative.junit.AsyncTest.asyncFailure started
 leTest scala.scalanative.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2scala.scalanative.junit.AsyncTest.asyncFailure
+e2scala.scalanative.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest scala.scalanative.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest scala.scalanative.junit.AsyncTest.expectedException started
 ldTest scala.scalanative.junit.AsyncTest.expectedException finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.expectedException
+e0scala.scalanative.junit.AsyncTest.expectedException::::true
 liTest scala.scalanative.junit.AsyncTest.success started
 ldTest scala.scalanative.junit.AsyncTest.success finished, took <TIME>
-e0scala.scalanative.junit.AsyncTest.success
+e0scala.scalanative.junit.AsyncTest.success::::true
 liTest run scala.scalanative.junit.AsyncTest finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 ldTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 ldTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=0.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=1.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=2.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_verbosity=3.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterClassTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterClassTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest started
 liTest scala.scalanative.junit.BeforeAndAfterClassTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterClassTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterClassTest.test
+e0scala.scalanative.junit.BeforeAndAfterClassTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterClassTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.BeforeAndAfterTest started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 ldTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.BeforeAndAfterTest started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 ldTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=0.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=1.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=2.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_verbosity=3.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAndAfterTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAndAfterTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.BeforeAndAfterTest started
 liTest scala.scalanative.junit.BeforeAndAfterTest.test started
 ldTest scala.scalanative.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0scala.scalanative.junit.BeforeAndAfterTest.test
+e0scala.scalanative.junit.BeforeAndAfterTest.test::::true
 liTest run scala.scalanative.junit.BeforeAndAfterTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=0.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=1.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=2.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_verbosity=3.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.BeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.BeforeAssumeFailTest
+e3scala.scalanative.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.BeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_a.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_n.txt
@@ -2,7 +2,7 @@ ldTest run scala.scalanative.junit.ExceptionAfterAssume started
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_na.txt
@@ -2,7 +2,7 @@ ldTest run scala.scalanative.junit.ExceptionAfterAssume started
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nv.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nva.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvc.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvca.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_v.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_va.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vc.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=0.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=1.txt
@@ -2,7 +2,7 @@ ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=2.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_verbosity=3.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vs.txt
@@ -2,7 +2,7 @@ li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m s
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterAssume[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vsn.txt
@@ -2,7 +2,7 @@ liTest run scala.scalanative.junit.ExceptionAfterAssume started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
+e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionAfterAssume finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_.txt
@@ -1,11 +1,11 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_a.txt
@@ -1,11 +1,11 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_n.txt
@@ -1,11 +1,11 @@
 ldTest run scala.scalanative.junit.ExceptionAfterClass started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ldTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_na.txt
@@ -1,11 +1,11 @@
 ldTest run scala.scalanative.junit.ExceptionAfterClass started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ldTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nv.txt
@@ -1,11 +1,11 @@
 liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.ExceptionAfterClass.test2 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nva.txt
@@ -1,11 +1,11 @@
 liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.ExceptionAfterClass.test2 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nvc.txt
@@ -1,11 +1,11 @@
 liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.ExceptionAfterClass.test2 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.ExceptionAfterClass failed: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_nvca.txt
@@ -1,11 +1,11 @@
 liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.ExceptionAfterClass.test2 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.ExceptionAfterClass failed: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_v.txt
@@ -1,11 +1,11 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_va.txt
@@ -1,11 +1,11 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vc.txt
@@ -1,11 +1,11 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=0.txt
@@ -1,11 +1,11 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=1.txt
@@ -1,11 +1,11 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=2.txt
@@ -1,11 +1,11 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_verbosity=3.txt
@@ -1,11 +1,11 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vs.txt
@@ -1,11 +1,11 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest scala.scalanative.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionAfterClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterClassAssertions_vsn.txt
@@ -1,11 +1,11 @@
 liTest run scala.scalanative.junit.ExceptionAfterClass started
 liTest scala.scalanative.junit.ExceptionAfterClass.test1 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test1
+e0scala.scalanative.junit.ExceptionAfterClass.test1::::true
 liTest scala.scalanative.junit.ExceptionAfterClass.test2 started
 ldTest scala.scalanative.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0scala.scalanative.junit.ExceptionAfterClass.test2
+e0scala.scalanative.junit.ExceptionAfterClass.test2::::true
 leTest scala.scalanative.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionAfterClass
+e2scala.scalanative.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionAfterClass finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: after, took <TIME>
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: after, took <TIME>
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: after, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=0.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=1.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=2.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_verbosity=3.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeAndAfterClass[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeAndAfterClassAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass started
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeAndAfterClass
+e2scala.scalanative.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest scala.scalanative.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 liTest run scala.scalanative.junit.ExceptionBeforeAndAfterClass finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ldTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ldTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=0.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=1.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=2.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_verbosity=3.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionBeforeClass[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionBeforeClassAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.ExceptionBeforeClass started
 leTest scala.scalanative.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2scala.scalanative.junit.ExceptionBeforeClass
+e2scala.scalanative.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run scala.scalanative.junit.ExceptionBeforeClass finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
 liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
 liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.ExceptionEverywhere failed: after class, took <TIME>
 liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.ExceptionEverywhere failed: after class, took <TIME>
 liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=0.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=1.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=2.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_verbosity=3.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m started[0m
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionEverywhere[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionEverywhereAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.ExceptionEverywhere started
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
-e2scala.scalanative.junit.ExceptionEverywhere
+e2scala.scalanative.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest scala.scalanative.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
 liTest run scala.scalanative.junit.ExceptionEverywhere finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.ExceptionInAfterTest started
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.ExceptionInAfterTest started
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInAfterTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInAfterTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInAfterTest started
 liTest scala.scalanative.junit.ExceptionInAfterTest.test started
 leTest scala.scalanative.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2scala.scalanative.junit.ExceptionInAfterTest.test
+e2scala.scalanative.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest scala.scalanative.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInAfterTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.ExceptionInBeforeTest started
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.ExceptionInBeforeTest started
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInBeforeTest[0m[34m finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInBeforeTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInBeforeTest started
 liTest scala.scalanative.junit.ExceptionInBeforeTest.test started
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2scala.scalanative.junit.ExceptionInBeforeTest.test
+e2scala.scalanative.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest scala.scalanative.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInBeforeTest finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.ExceptionInConstructorTest started
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.ExceptionInConstructorTest started
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionInConstructorTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionInConstructorTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionInConstructorTest started
 liTest scala.scalanative.junit.ExceptionInConstructorTest.test started
 leTest scala.scalanative.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2scala.scalanative.junit.ExceptionInConstructorTest.test
+e2scala.scalanative.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest scala.scalanative.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionInConstructorTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.ExceptionTest started
 ldTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run scala.scalanative.junit.ExceptionTest started
 ldTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
 ldTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=0.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=1.txt
@@ -1,7 +1,7 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=2.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_verbosity=3.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExceptionTest[0m[34m finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run scala.scalanative.junit.ExceptionTest started
 liTest scala.scalanative.junit.ExceptionTest.test started
 leTest scala.scalanative.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2scala.scalanative.junit.ExceptionTest.test
+e2scala.scalanative.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest scala.scalanative.junit.ExceptionTest.test finished, took <TIME>
 liTest run scala.scalanative.junit.ExceptionTest finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_.txt
@@ -1,22 +1,22 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_a.txt
@@ -1,22 +1,22 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_n.txt
@@ -1,22 +1,22 @@
 ldTest run scala.scalanative.junit.ExpectTest started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 ldTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert started
 leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
 leTest scala.scalanative.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 ldTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_na.txt
@@ -1,22 +1,22 @@
 ldTest run scala.scalanative.junit.ExpectTest started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 ldTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert started
 leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
 leTest scala.scalanative.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 ldTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nv.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.ExpectTest.failExpectAssert started
 leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
 leTest scala.scalanative.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nva.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.ExpectTest.failExpectAssert started
 leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
 leTest scala.scalanative.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nvc.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.ExpectTest.failExpectAssert started
 leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
 leTest scala.scalanative.junit.ExpectTest.failExpectDifferent failed: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_nvca.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.ExpectTest.failExpectAssert started
 leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
 leTest scala.scalanative.junit.ExpectTest.failExpectDifferent failed: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_v.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_va.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vc.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=0.txt
@@ -1,22 +1,22 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=1.txt
@@ -1,22 +1,22 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=2.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_verbosity=3.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vs.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest scala.scalanative.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run [0mscala.scalanative.junit.[33mExpectTest[0m[34m finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExpectTestAssertions_vsn.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.ExpectTest started
 liTest scala.scalanative.junit.ExpectTest.expectAssert started
 ldTest scala.scalanative.junit.ExpectTest.expectAssert finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectAssert
+e0scala.scalanative.junit.ExpectTest.expectAssert::::true
 liTest scala.scalanative.junit.ExpectTest.expectNormal started
 ldTest scala.scalanative.junit.ExpectTest.expectNormal finished, took <TIME>
-e0scala.scalanative.junit.ExpectTest.expectNormal
+e0scala.scalanative.junit.ExpectTest.expectNormal::::true
 liTest scala.scalanative.junit.ExpectTest.failExpectAssert started
 leTest scala.scalanative.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectAssert
+e2scala.scalanative.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectDifferent started
 leTest scala.scalanative.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2scala.scalanative.junit.ExpectTest.failExpectDifferent
+e2scala.scalanative.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest scala.scalanative.junit.ExpectTest.failExpectNoThrow started
 leTest scala.scalanative.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
-e2scala.scalanative.junit.ExpectTest.failExpectNoThrow
+e2scala.scalanative.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest scala.scalanative.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run scala.scalanative.junit.ExpectTest finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 ldTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 ldTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=0.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=1.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=2.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_verbosity=3.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTest started
 liTest scala.scalanative.junit.IgnoreAllTest ignored
-e4scala.scalanative.junit.IgnoreAllTest
+e4scala.scalanative.junit.IgnoreAllTest::::true
 liTest run scala.scalanative.junit.IgnoreAllTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 ldTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 ldTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=0.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=1.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=2.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_verbosity=3.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreAllTestWithReason[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason started
 liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
-e4scala.scalanative.junit.IgnoreAllTestWithReason
+e4scala.scalanative.junit.IgnoreAllTestWithReason::::true
 liTest run scala.scalanative.junit.IgnoreAllTestWithReason finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 ldTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 ldTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=0.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=1.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=2.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_verbosity=3.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 li[34mTest run [0mscala.scalanative.junit.[33mIgnoreTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.IgnoreTest started
 liTest scala.scalanative.junit.IgnoreTest.onlyTest ignored
-e4scala.scalanative.junit.IgnoreTest.onlyTest
+e4scala.scalanative.junit.IgnoreTest.onlyTest::::true
 liTest run scala.scalanative.junit.IgnoreTest finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.MethodNameDecodeTest started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ldTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run scala.scalanative.junit.MethodNameDecodeTest started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ldTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=0.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=1.txt
@@ -1,6 +1,6 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=2.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_verbosity=3.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd ∆ƒ 😀 * #&$[0m started
 ldTest scala.scalanative.junit.[33mMethodNameDecodeTest[0m.[36mabcd ∆ƒ 😀 * #&$[0m finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMethodNameDecodeTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MethodNameDecodeTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run scala.scalanative.junit.MethodNameDecodeTest started
 liTest scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$ started
 ldTest scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$ finished, took <TIME>
-e0scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$
+e0scala.scalanative.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$::::true
 liTest run scala.scalanative.junit.MethodNameDecodeTest finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_.txt
@@ -1,9 +1,9 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_a.txt
@@ -1,9 +1,9 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_n.txt
@@ -1,9 +1,9 @@
 ldTest run scala.scalanative.junit.Multi1Test started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 ldTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_na.txt
@@ -1,9 +1,9 @@
 ldTest run scala.scalanative.junit.Multi1Test started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 ldTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nv.txt
@@ -1,9 +1,9 @@
 liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nva.txt
@@ -1,9 +1,9 @@
 liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nvc.txt
@@ -1,9 +1,9 @@
 liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_nvca.txt
@@ -1,9 +1,9 @@
 liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_v.txt
@@ -1,9 +1,9 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_va.txt
@@ -1,9 +1,9 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vc.txt
@@ -1,9 +1,9 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=0.txt
@@ -1,9 +1,9 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=1.txt
@@ -1,9 +1,9 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=2.txt
@@ -1,9 +1,9 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_verbosity=3.txt
@@ -1,9 +1,9 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vs.txt
@@ -1,9 +1,9 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi1TestAssertions_vsn.txt
@@ -1,9 +1,9 @@
 liTest run scala.scalanative.junit.Multi1Test started
 liTest scala.scalanative.junit.Multi1Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest1
+e0scala.scalanative.junit.Multi1Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi1Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi1Test.multiTest2
+e0scala.scalanative.junit.Multi1Test.multiTest2::::true
 liTest run scala.scalanative.junit.Multi1Test finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_.txt
@@ -1,18 +1,18 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_a.txt
@@ -1,18 +1,18 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_n.txt
@@ -1,18 +1,18 @@
 ldTest run scala.scalanative.junit.Multi2Test started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 ldTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_na.txt
@@ -1,18 +1,18 @@
 ldTest run scala.scalanative.junit.Multi2Test started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 ldTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nv.txt
@@ -1,18 +1,18 @@
 liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest3 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest4 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nva.txt
@@ -1,18 +1,18 @@
 liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest3 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest4 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nvc.txt
@@ -1,18 +1,18 @@
 liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest3 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest4 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_nvca.txt
@@ -1,18 +1,18 @@
 liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest3 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest4 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_v.txt
@@ -1,18 +1,18 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_va.txt
@@ -1,18 +1,18 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vc.txt
@@ -1,18 +1,18 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=0.txt
@@ -1,18 +1,18 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=1.txt
@@ -1,18 +1,18 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=2.txt
@@ -1,18 +1,18 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_verbosity=3.txt
@@ -1,18 +1,18 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vs.txt
@@ -1,18 +1,18 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMulti2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/Multi2TestAssertions_vsn.txt
@@ -1,18 +1,18 @@
 liTest run scala.scalanative.junit.Multi2Test started
 liTest scala.scalanative.junit.Multi2Test.multiTest1 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest1
+e0scala.scalanative.junit.Multi2Test.multiTest1::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest2 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest2
+e0scala.scalanative.junit.Multi2Test.multiTest2::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest3 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest3
+e0scala.scalanative.junit.Multi2Test.multiTest3::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest4 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest4
+e0scala.scalanative.junit.Multi2Test.multiTest4::::true
 liTest scala.scalanative.junit.Multi2Test.multiTest5 started
 ldTest scala.scalanative.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.Multi2Test.multiTest5
+e0scala.scalanative.junit.Multi2Test.multiTest5::::true
 liTest run scala.scalanative.junit.Multi2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_.txt
@@ -1,20 +1,20 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_a.txt
@@ -1,20 +1,20 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_n.txt
@@ -1,20 +1,20 @@
 ldTest run scala.scalanative.junit.MultiAssumeFail1Test started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_na.txt
@@ -1,20 +1,20 @@
 ldTest run scala.scalanative.junit.MultiAssumeFail1Test started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nv.txt
@@ -1,20 +1,20 @@
 liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nva.txt
@@ -1,20 +1,20 @@
 liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nvc.txt
@@ -1,20 +1,20 @@
 liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nvca.txt
@@ -1,20 +1,20 @@
 liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_v.txt
@@ -1,20 +1,20 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_va.txt
@@ -1,20 +1,20 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vc.txt
@@ -1,20 +1,20 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=0.txt
@@ -1,20 +1,20 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=1.txt
@@ -1,20 +1,20 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=2.txt
@@ -1,20 +1,20 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_verbosity=3.txt
@@ -1,20 +1,20 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vs.txt
@@ -1,20 +1,20 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vsn.txt
@@ -1,20 +1,20 @@
 liTest run scala.scalanative.junit.MultiAssumeFail1Test started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail1Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_.txt
@@ -1,22 +1,22 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_a.txt
@@ -1,22 +1,22 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_n.txt
@@ -1,22 +1,22 @@
 ldTest run scala.scalanative.junit.MultiAssumeFail2Test started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_na.txt
@@ -1,22 +1,22 @@
 ldTest run scala.scalanative.junit.MultiAssumeFail2Test started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nv.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nva.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nvc.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nvca.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_v.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_va.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vc.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=0.txt
@@ -1,22 +1,22 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=1.txt
@@ -1,22 +1,22 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=2.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_verbosity=3.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vs.txt
@@ -1,22 +1,22 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiAssumeFail2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vsn.txt
@@ -1,22 +1,22 @@
 liTest run scala.scalanative.junit.MultiAssumeFail2Test started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5
+e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiAssumeFail2Test finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=0.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=1.txt
@@ -1,5 +1,5 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=2.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_verbosity=3.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m started[0m
 lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest started
 lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3scala.scalanative.junit.MultiBeforeAssumeFailTest
+e3scala.scalanative.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run scala.scalanative.junit.MultiBeforeAssumeFailTest finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_.txt
@@ -1,17 +1,17 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_a.txt
@@ -1,17 +1,17 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_n.txt
@@ -1,17 +1,17 @@
 ldTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_na.txt
@@ -1,17 +1,17 @@
 ldTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nv.txt
@@ -1,17 +1,17 @@
 liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nva.txt
@@ -1,17 +1,17 @@
 liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nvc.txt
@@ -1,17 +1,17 @@
 liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_nvca.txt
@@ -1,17 +1,17 @@
 liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_v.txt
@@ -1,17 +1,17 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_va.txt
@@ -1,17 +1,17 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vc.txt
@@ -1,17 +1,17 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=0.txt
@@ -1,17 +1,17 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=1.txt
@@ -1,17 +1,17 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=2.txt
@@ -1,17 +1,17 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_verbosity=3.txt
@@ -1,17 +1,17 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vs.txt
@@ -1,17 +1,17 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore1Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore1TestAssertions_vsn.txt
@@ -1,17 +1,17 @@
 liTest run scala.scalanative.junit.MultiIgnore1Test started
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore1Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore1Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest4
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore1Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore1Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore1Test finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_.txt
@@ -1,16 +1,16 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_a.txt
@@ -1,16 +1,16 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_n.txt
@@ -1,16 +1,16 @@
 ldTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_na.txt
@@ -1,16 +1,16 @@
 ldTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nv.txt
@@ -1,16 +1,16 @@
 liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nva.txt
@@ -1,16 +1,16 @@
 liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nvc.txt
@@ -1,16 +1,16 @@
 liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_nvca.txt
@@ -1,16 +1,16 @@
 liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_v.txt
@@ -1,16 +1,16 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_va.txt
@@ -1,16 +1,16 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vc.txt
@@ -1,16 +1,16 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=0.txt
@@ -1,16 +1,16 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=1.txt
@@ -1,16 +1,16 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=2.txt
@@ -1,16 +1,16 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_verbosity=3.txt
@@ -1,16 +1,16 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vs.txt
@@ -1,16 +1,16 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest scala.scalanative.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnore2Test[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnore2TestAssertions_vsn.txt
@@ -1,16 +1,16 @@
 liTest run scala.scalanative.junit.MultiIgnore2Test started
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest1
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest2
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest3
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnore2Test.multiTest4
+e4scala.scalanative.junit.MultiIgnore2Test.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 started
 ldTest scala.scalanative.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0scala.scalanative.junit.MultiIgnore2Test.multiTest5
+e0scala.scalanative.junit.MultiIgnore2Test.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnore2Test finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_.txt
@@ -1,13 +1,13 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_a.txt
@@ -1,13 +1,13 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_n.txt
@@ -1,13 +1,13 @@
 ldTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_na.txt
@@ -1,13 +1,13 @@
 ldTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 ldTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nv.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nva.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nvc.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_nvca.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_v.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_va.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vc.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=0.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=0.txt
@@ -1,13 +1,13 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=1.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=1.txt
@@ -1,13 +1,13 @@
 ld[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=2.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=2.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=3.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_verbosity=3.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vs.txt
@@ -1,13 +1,13 @@
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m started[0m
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run [0mscala.scalanative.junit.[33mMultiIgnoreAllTest[0m[34m finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiIgnoreAllTestAssertions_vsn.txt
@@ -1,13 +1,13 @@
 liTest run scala.scalanative.junit.MultiIgnoreAllTest started
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest1 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest2 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest3 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest4 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest scala.scalanative.junit.MultiIgnoreAllTest.multiTest5 ignored
-e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5
+e4scala.scalanative.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run scala.scalanative.junit.MultiIgnoreAllTest finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/nativelib/src/main/scala/scala/scalanative/annotation/align.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/align.scala
@@ -17,12 +17,12 @@ final class align(size: Int, group: String)
 
   // JVM  Contended compat
 
-  /** Dynamic, platform specific alignment. Can be used as replecement JVM
+  /** Dynamic, platform specific alignment. Can be used as replacement JVM
    *  \@Contended
    */
   def this(group: String) = this(contendedPaddingWidth, group)
 
-  /** Dynamic, platform specific alignment. Can be used as replecement JVM
+  /** Dynamic, platform specific alignment. Can be used as replacement JVM
    *  \@Contended
    */
   def this() = this(contendedPaddingWidth, "")

--- a/nativelib/src/main/scala/scala/scalanative/runtime/SymbolFormatter.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/SymbolFormatter.scala
@@ -115,27 +115,27 @@ object SymbolFormatter {
           true
         } else false
       } else {
-        val lineSeperator = strrchr(location, ':')
+        val lineSeparator = strrchr(location, ':')
         val fileName = strrchr(location, '\\')
         val fileOffset = 2 // ':('
-        if (lineSeperator != null) {
+        if (lineSeparator != null) {
           // skip ':(', take until line number ':num)'
           if (fileName != null) {
             strncpy(
               fileNameOut,
               fileName + 1,
-              toRawSize(strlen(fileName) - strlen(lineSeperator) - 1.toUSize)
+              toRawSize(strlen(fileName) - strlen(lineSeparator) - 1.toUSize)
             )
           } else {
             strncpy(
               fileNameOut,
               location + fileOffset,
               toRawSize(
-                strlen(location) - strlen(lineSeperator) - fileOffset.toUSize
+                strlen(location) - strlen(lineSeparator) - fileOffset.toUSize
               )
             )
           }
-          pos = (lineSeperator - sym).toInt + 1
+          pos = (lineSeparator - sym).toInt + 1
           !lineOut = readNumber()
         } else if (fileName != null) strcpy(fileNameOut, fileName + 1)
         else strcpy(fileNameOut, location + fileOffset)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -87,7 +87,7 @@ class ScalaNativePlugin(val global: Global) extends Plugin {
       |     Change the source file positions in generated outputs based on list of provided paths.
       |     It would strip the prefix of the source file if it matches given path.
       |     Non-absolute paths would be ignored.
-      |     Multiple paths should be seperated by a single semicolon ';' character.
+      |     Multiple paths should be separated by a single semicolon ';' character.
       |     If none of the patches matches path would be relative to -sourcepath if defined or -sourceroot otherwise.
       """.stripMargin)
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -27,7 +27,7 @@ class ScalaNativePlugin extends StandardPlugin:
       |     Change the source file positions in generated outputs based on list of provided paths.
       |     It would strip the prefix of the source file if it matches given path.
       |     Non-absolute paths would be ignored.
-      |     Multiple paths should be seperated by a single semicolon ';' character. 
+      |     Multiple paths should be separated by a single semicolon ';' character.
       |     If none of the patches matches path would be relative to -sourcepath if defined or -sourceroot otherwise.
       """.stripMargin)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -75,12 +75,12 @@ object Build {
       val optNoCrossProjects = noCrossProjects.filter(_ =>
         includeNoCrossProjects && binVersion == "2.12"
       )
-      val dependenices =
+      val dependencies =
         optNoCrossProjects ++ projects.map(_.forBinaryVersion(binVersion))
       val prev = key.value
       Def
         .task { prev }
-        .dependsOn(dependenices.map(_ / key): _*)
+        .dependsOn(dependencies.map(_ / key): _*)
     }.value
   }
 
@@ -124,7 +124,7 @@ object Build {
     )
     .mapBinaryVersions {
       // Scaladoc for Scala 2.12 does not handle literal constants correctly
-      // It does not allow integer contstant < 255 to be passed as arugment of function taking byte
+      // It does not allow integer constant < 255 to be passed as arugment of function taking byte
       case "2.12" => _.settings(disabledDocsSettings)
       case _      => identity
     }
@@ -447,7 +447,7 @@ object Build {
       )
       .dependsOn(toolsJVM.v2_12, testRunner.v2_12)
 
-// Native moduels ------------------------------------------------
+// Native modules ------------------------------------------------
   lazy val nativelib =
     MultiScalaProject("nativelib")
       .enablePlugins(MyScalaNativePlugin)

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -115,7 +115,7 @@ object Build {
       linkNIRForEntries
         .flatMap { linkerResult =>
           val (updatedConfig, needsToReload) =
-            postRechabilityAnalysisConfigUpdate(config, linkerResult)
+            postReachabilityAnalysisConfigUpdate(config, linkerResult)
           config = updatedConfig
           if (needsToReload) linkNIRForEntries
           else Future.successful(linkerResult)
@@ -175,7 +175,7 @@ object Build {
   /** Based on reachability analysis check if config can be tuned for better
    *  performance
    */
-  private def postRechabilityAnalysisConfigUpdate(
+  private def postReachabilityAnalysisConfigUpdate(
       config: Config,
       analysis: ReachabilityAnalysis.Result
   ): (Config, Boolean) = {

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -97,7 +97,7 @@ object CodeGen {
         }
 
       // Incremental compilation code generation
-      def seperateIncrementally(): IRGenerators = {
+      def separateIncrementally(): IRGenerators = {
         val ctx = new IncrementalCodeGenContext(config)
         ctx.collectFromPreviousState()
 
@@ -154,7 +154,7 @@ object CodeGen {
 
       val llvmIRGenerators =
         if (config.compilerConfig.useIncrementalCompilation)
-          seperateIncrementally()
+          separateIncrementally()
         else separate()
       llvmIRGenerators ++ maybeBuildInfoGenerator
     }

--- a/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LexicalScopesTest.scala
@@ -209,7 +209,7 @@ class LexicalScopesTest extends OptimizerSpec {
           Seq("a", "myTmp"),
           namedLets(defn).values
         )
-        // a and b can move moved to seperate scopes in transofrmation, but shall still have common parent
+        // a and b can move moved to separate scopes in transformation, but shall still have common parent
         val a = scopeOf("a")
         assertEquals("a-parent", a.id, nir.ScopeId.TopLevel)
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/PropertiesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/PropertiesTest.scala
@@ -197,8 +197,8 @@ class PropertiesTest {
       props.list(ps)
       ps.close()
       assertEquals(
-        withUnixLineSeperators(out.toString.trim),
-        withUnixLineSeperators(result.trim)
+        withUnixLineSeparators(out.toString.trim),
+        withUnixLineSeparators(result.trim)
       )
     }
 
@@ -365,14 +365,14 @@ class PropertiesTest {
     assertAll(expected = prop1, actual = prop2)
     // Avoid variable Date output which is last line in comment
     // Matches JVM output
-    val commentsWithoutDate = withUnixLineSeperators("""|#A Header
+    val commentsWithoutDate = withUnixLineSeparators("""|#A Header
          |#Line2
          |#Line3
          |#Line4
          |!AfterExclaim
          |#AfterPound
          |#Wow!""".stripMargin)
-    val out = withUnixLineSeperators(out1.toString())
+    val out = withUnixLineSeparators(out1.toString())
     assertTrue(s"starts with, got: '$out'", out.startsWith(commentsWithoutDate))
   }
 
@@ -509,7 +509,7 @@ class PropertiesTest {
     """.stripMargin
   }
 
-  def withUnixLineSeperators(str: String): String = {
+  def withUnixLineSeparators(str: String): String = {
     if (str != null && isWindows) {
       str.replaceAll(System.lineSeparator(), "\n")
     } else str


### PR DESCRIPTION
If a Throwable associated with the test event is available, bubble it up through the SBT's test interface using the slot dedicated to just such information: `sbt.testing.Event.throwable`.

If duration associated with the test event is available, bubble it up through the SBT's test interface using the slot dedicated to just such information: sbt.testing.Event.duration; if duration is not available, populate the slot with `0`.

It seems a shame to throw away information that is literally in our hands; also, this change:
- simplifies integration with runners that assume that test failure is always accompanied by a `Throwable` (e.g., Gradle) and
- avoids weird-looking negative duration values in test reports.

FYI: this issue was ported to Scala Native from Scala.js, as it was to MUnit; it has been fixed in both: https://github.com/scala-js/scala-js/pull/5132, https://github.com/scala-js/scala-js/pull/5134, https://github.com/scalameta/munit/pull/918.