### PR TITLE
Make `nativeConfig` a setting key again and restore`nativeLink/artifactParh`

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -34,7 +34,7 @@ object ScalaNativePlugin extends AutoPlugin {
     }
 
     val nativeConfig =
-      taskKey[build.NativeConfig](
+      settingKey[build.NativeConfig](
         "User configuration for the native build, NativeConfig"
       )
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -243,6 +243,13 @@ object ScalaNativePluginInternal {
       }
       .tag(NativeTags.Link)
       .value,
+    nativeLink / artifactPath := build.Config.empty
+      .withBaseDir(crossTarget.value.toPath())
+      .withModuleName(moduleName.value)
+      .withCompilerConfig(nativeConfig.value)
+      .withTestConfig(testConfig)
+      .artifactPath
+      .toFile,
     nativeLink := Def
       .task {
         val sbtLogger = streams.value.log

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -54,53 +54,53 @@ object ScalaNativePluginInternal {
   val baseBuildConfig =
     settingKey[build.Config]("Base configuration for nativeLink commands")
 
-    lazy val scalaNativeDependencySettings: Seq[Setting[_]] = {
-      val organization = "org.scala-native"
-      val nativeStandardLibraries =
-        Seq("nativelib", "clib", "posixlib", "windowslib", "javalib", "auxlib")
+  lazy val scalaNativeDependencySettings: Seq[Setting[_]] = {
+    val organization = "org.scala-native"
+    val nativeStandardLibraries =
+      Seq("nativelib", "clib", "posixlib", "windowslib", "javalib", "auxlib")
 
-      Seq(
-        libraryDependencies ++= Seq(
-          organization %%% "test-interface" % nativeVersion % Test
-        ),
-        libraryDependencies += CrossVersion
-          .partialVersion(scalaVersion.value)
-          .fold(throw new RuntimeException("Unsupported Scala Version")) {
-            case (2, _) =>
-              organization %%% "scalalib" % scalalibVersion(
-                scalaVersion.value,
-                nativeVersion
-              )
-            case (3, _) =>
-              organization %%% "scala3lib" % scalalibVersion(
-                scalaVersion.value,
-                nativeVersion
-              )
-          },
-        libraryDependencies ++= nativeStandardLibraries.map(
-          organization %%% _ % nativeVersion
-        ),
-        excludeDependencies ++= {
-          // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
-          // When using Scala 3 exclude Scala 2.13 standard native libraries,
-          // when using Scala 2.13 exclude Scala 3 standard native libraries
-          // Use full name, Maven style published artifacts cannot use artifact/cross version for exclusion rules
-          nativeStandardLibraries.map { lib =>
-            val scalaBinVersion =
-              if (scalaVersion.value.startsWith("3.")) "2.13"
-              else "3"
-            ExclusionRule()
-              .withOrganization(organization)
-              .withName(
-                s"${lib}_native${ScalaNativeCrossVersion.currentBinaryVersion}_${scalaBinVersion}"
-              )
-          }
+    Seq(
+      libraryDependencies ++= Seq(
+        organization %%% "test-interface" % nativeVersion % Test
+      ),
+      libraryDependencies += CrossVersion
+        .partialVersion(scalaVersion.value)
+        .fold(throw new RuntimeException("Unsupported Scala Version")) {
+          case (2, _) =>
+            organization %%% "scalalib" % scalalibVersion(
+              scalaVersion.value,
+              nativeVersion
+            )
+          case (3, _) =>
+            organization %%% "scala3lib" % scalalibVersion(
+              scalaVersion.value,
+              nativeVersion
+            )
         },
-        addCompilerPlugin(
-          organization % "nscplugin" % nativeVersion cross CrossVersion.full
-        )
+      libraryDependencies ++= nativeStandardLibraries.map(
+        organization %%% _ % nativeVersion
+      ),
+      excludeDependencies ++= {
+        // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
+        // When using Scala 3 exclude Scala 2.13 standard native libraries,
+        // when using Scala 2.13 exclude Scala 3 standard native libraries
+        // Use full name, Maven style published artifacts cannot use artifact/cross version for exclusion rules
+        nativeStandardLibraries.map { lib =>
+          val scalaBinVersion =
+            if (scalaVersion.value.startsWith("3.")) "2.13"
+            else "3"
+          ExclusionRule()
+            .withOrganization(organization)
+            .withName(
+              s"${lib}_native${ScalaNativeCrossVersion.currentBinaryVersion}_${scalaBinVersion}"
+            )
+        }
+      },
+      addCompilerPlugin(
+        organization % "nscplugin" % nativeVersion cross CrossVersion.full
       )
-    }
+    )
+  }
 
   lazy val scalaNativeBaseSettings: Seq[Setting[_]] = Seq(
     crossVersion := ScalaNativeCrossVersion.binary,

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -51,8 +51,9 @@ object ScalaNativePluginInternal {
   val nativeWarnOldJVM =
     taskKey[Unit]("Warn if JVM 7 or older is used.")
 
-  val baseBuildConfig =
-    settingKey[build.Config]("Base configuration for nativeLink commands")
+  val baseBuildConfig = settingKey[build.Config](
+    "Base configuration for nativeLink commands calcullated base on setting keys. Internal, not visible to users"
+  )
 
   lazy val scalaNativeDependencySettings: Seq[Setting[_]] = {
     val organization = "org.scala-native"


### PR DESCRIPTION
Fixes #4146 

AFAIR `nativeConfig` was changed to `taskKey` only to workaround the issue with duplicate definitions in the 0.4.x where we needed a way to populate `nativeMode`,`nativeGC`, etc. into `nativeConfig` and intitialize the former using the later. 

 This cyclic dependency does no longer exist so we can switch to using settingKey again. It allows us to restore `nativeLink/artifactPath`. 
 We do the same for `nativeLinkRelease{Full,Fast}` commands and simply the `nativeLinkImpl` so that in only takes varying inputs. 