### PR TITLE
[toolchain]: Ensure debug positions are in LLVM limits

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
@@ -277,10 +277,13 @@ private[codegen] object Metadata {
     def const: Const = Const(v.toString())
   }
   implicit class IntDIOps(v: Int) {
+    private final val PositionLimit = 65535
     def toDISize: DISize = new DISize(v)
-    def toDILine: DILine = new DILine(v + Constants.SourceToDILineOffset)
+    def toDILine: DILine = new DILine(
+      PositionLimit.min(v + Constants.SourceToDILineOffset)
+    )
     def toDIColumn: DIColumn = new DIColumn(
-      v + Constants.SourceToDIColumnOffset
+      PositionLimit.min(v + Constants.SourceToDIColumnOffset)
     )
     def const: Const = Const(v.toString())
 


### PR DESCRIPTION
Some long sources, eg. some ZIO emdedings in kyo would have column size > 65535 leading to complation error