### PR TITLE
Fix #3237: Configure default GC settings at compile time

### DIFF
--- a/docs/user/runtime.md
+++ b/docs/user/runtime.md
@@ -1,4 +1,4 @@
-# Runtime Settings
+# Runtime / Garbage Collector Settings
 
 Scala Native comes with some ability to change the runtime
 characteristics.
@@ -13,17 +13,59 @@ supported are listed below for each GC.
 
 ## All Garbage Collectors
 
-The following environment variables will be used for all GCs. They can
-go from 1 MB to the system memory maximum or up to about 512 GB. The
-size is in bytes, kilobytes(k or K), megabytes(m or M), or gigabytes(g
-or G). Examples: 1024k, 1M, or 1G etc.
+The following **environment** variables will be used for all GCs. They can go from 1 MB to the system memory maximum or up to about 512 GB or less than 4 GB for 32 bit systems. The size can be specified in bytes, kilobytes(k or K), megabytes(m or M), or gigabytes(g or G).
+
+*Examples: 1048576, 1024k, 1M, or 1G etc.*
 
 - GC_INITIAL_HEAP_SIZE changes the minimum heap size.
 - GC_MAXIMUM_HEAP_SIZE changes the maximum heap size.
 
-The `GC_INITIAL_HEAP_SIZE` and `GC_MAXIMUM_HEAP_SIZE` are ignored by None GC when multithreading is enabled. When using this pseudo-GC implementation `GC_THREAD_HEAP_BLOCK_SIZE` env variable can be set to control the granuality of allocted heap memory blocks for each of the threads (defaults to 64MB). This env variable is ignored in sigle-threaded execution.
+The GC_INITIAL_HEAP_SIZE and GC_MAXIMUM_HEAP_SIZE are ignored by None GC when multi-threading is enabled and GC_THREAD_HEAP_BLOCK_SIZE is used instead. See the None GC section below for details.
 
-The plan is to add more GC settings in the future using the Boehm
+## Compile Time Memory Settings
+
+The GC_INITIAL_HEAP_SIZE, GC_MAXIMUM_HEAP_SIZE and for None GC the GC_THREAD_HEAP_BLOCK_SIZE can be set at **compile time** by using **defines** in the build. Refer to the None GC section below for details about GC_THREAD_HEAP_BLOCK_SIZE.
+
+The following examples shows how to set compile time memory values which is useful for the developer to provide a good user experience. A key feature is that the values can be overridden with environment variables by the user if supported on the platform. We also support the define DEBUG_PRINT to see the values passed to the GC as shown below in the first example build setup.
+
+*Note: Currently, Boehm only supports values in bytes for **defines** as shown in the third example.*
+
+``` scala
+import scala.scalanative.build._
+
+// Compile time GC defines (default Immix GC)
+nativeConfig ~= { c =>
+  c.withCompileOptions(
+    _ ++ Seq(
+      "-DGC_INITIAL_HEAP_SIZE=5m",
+      "-DGC_MAXIMUM_HEAP_SIZE=5m",
+      "-DDEBUG_PRINT"
+    )
+  )
+}
+
+// None GC with Multi-threading
+nativeConfig ~= { c =>
+  c.withCompileOptions(
+    _ ++ Seq(
+      "-DGC_THREAD_HEAP_BLOCK_SIZE=32m"
+    )
+  ).withGC(GC.none)
+    .withMultithreading(true)
+}
+
+// Boehm GC (use number of bytes) - 5m shown
+nativeConfig ~= { c =>
+  c.withCompileOptions(
+    _ ++ Seq(
+      "-DGC_INITIAL_HEAP_SIZE=5242880",
+      "-DGC_MAXIMUM_HEAP_SIZE=5242880"
+    )
+  ).withGC(GC.boehm)
+}
+```
+
+More GC settings may be added in the future using the Boehm
 setting names where applicable.
 
 ## Boehm GC
@@ -38,7 +80,11 @@ The following document shows all the variables available for Boehm:
 
 ## None GC
 
-The None GC uses the two variables shown above.
+The None GC uses the two variables shown above **or** the following one when multi-threading is selected.
+
+-   GC_THREAD_HEAP_BLOCK_SIZE (defaults to 64 MB)
+
+ When using this pseudo-GC implementation, GC_THREAD_HEAP_BLOCK_SIZE env variable can be set to control the granuality of allocated heap memory blocks for each of the threads. This env variable is ignored in single-threaded execution.
 
 ## Immix GC
 
@@ -65,20 +111,28 @@ defines -DGC_ENABLE_STATS for Commix.
 
 ## Examples
 
-If you are developing in the Scala Native sandbox, the following are
-examples showing some error conditions using Immix, the default GC.
-Adjust the path to your executable as needed:
+If you are developing in the Scala Native *sandbox*, the following are
+examples showing some error conditions using Immix, the default GC. These errors will also occur if using **defines** as described above or mixing **defines** with environment variables. Adjust the path to your executable as needed (Scala 2.13 shown).
 
+*Example 1:*
 ``` shell
-export GC_INITIAL_HEAP_SIZE=64k; export GC_MAXIMUM_HEAP_SIZE=512k; sandbox/.2.13/target/scala-2.13/sandbox
+export GC_INITIAL_HEAP_SIZE=64k
+export GC_MAXIMUM_HEAP_SIZE=512k
+./sandbox/.2.13/target/scala-2.13/sandbox
 ```
+*Note: Error shown.*
 ```
 GC_MAXIMUM_HEAP_SIZE too small to initialize heap.
 Minimum required: 1m
 ```
+
+*Example 2:*
 ```shell
-export GC_INITIAL_HEAP_SIZE=2m; export GC_MAXIMUM_HEAP_SIZE=1m; sandbox/.2.13/target/scala-2.13/sandbox
+export GC_INITIAL_HEAP_SIZE=2m
+export GC_MAXIMUM_HEAP_SIZE=1m;
+./sandbox/.2.13/target/scala-2.13/sandbox
 ```
+*Note: Error shown.*
 ```
 GC_MAXIMUM_HEAP_SIZE should be at least GC_INITIAL_HEAP_SIZE
 ```

--- a/docs/user/runtime.md
+++ b/docs/user/runtime.md
@@ -1,15 +1,10 @@
 # Runtime / Garbage Collector Settings
 
-Scala Native comes with some ability to change the runtime
-characteristics.
+Scala Native comes with some ability to change the runtime characteristics.
 
 ## Garbage Collector (GC) Settings
 
-Scala Native supports the [Boehm-Demers-Weiser Garbage
-Collector](https://www.hboehm.info/gc/). The environment variables
-defined in Boehm are planned to be shared by all the Garbage Collectors
-supported in Scala Native so they are consistent. The variables
-supported are listed below for each GC.
+Scala Native supports the [Boehm-Demers-Weiser Garbage Collector](https://www.hboehm.info/gc/). The environment variables defined in Boehm are shared as much as possible by all the Garbage Collectors supported in Scala Native so they are consistent and easier to use. Refer to the Boehm section below for the list. The variables supported are listed below for each GC.
 
 ## All Garbage Collectors
 
@@ -76,7 +71,7 @@ available for Boehm and Commix.
 -   GC_NPROCS
 
 The following document shows all the variables available for Boehm:
-[README](https://github.com/ivmai/bdwgc/blob/master/docs/README.environment).
+[environment.md](https://github.com/ivmai/bdwgc/blob/master/docs/environment.md).
 
 ## None GC
 

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -3,7 +3,7 @@
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
 int getifaddrs(void *dummy) { return -1; };
-void freeifaddrs(void *dummy) {};
+void freeifaddrs(void *dummy){};
 #else
 #include <ifaddrs.h>
 #include <stddef.h>

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -3,7 +3,7 @@
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
 int getifaddrs(void *dummy) { return -1; };
-void freeifaddrs(void *dummy){};
+void freeifaddrs(void *dummy) {};
 #else
 #include <ifaddrs.h>
 #include <stddef.h>

--- a/javalib/src/main/resources/scala-native/ifaddrs.c
+++ b/javalib/src/main/resources/scala-native/ifaddrs.c
@@ -3,7 +3,7 @@
 #if defined(_WIN32)
 // No Windows support. These are dummies for linking.
 int getifaddrs(void *dummy) { return -1; };
-void freeifaddrs(void *dummy){};
+void freeifaddrs(void *dummy) {}
 #else
 #include <ifaddrs.h>
 #include <stddef.h>

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -7,7 +7,7 @@ int scalanative_iff_multicast() { return 0; }
 int scalanative_iff_pointopoint() { return 0; }
 int scalanative_iff_up() { return 0; }
 void *if_nameindex(void) { return (void *)0; }
-void if_freenameindex(void *dummy) {};
+void if_freenameindex(void *dummy){};
 #else
 #include <sys/ioctl.h>
 #include <net/if.h>

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -7,7 +7,7 @@ int scalanative_iff_multicast() { return 0; }
 int scalanative_iff_pointopoint() { return 0; }
 int scalanative_iff_up() { return 0; }
 void *if_nameindex(void) { return (void *)0; }
-void if_freenameindex(void *dummy){};
+void if_freenameindex(void *dummy) {};
 #else
 #include <sys/ioctl.h>
 #include <net/if.h>

--- a/javalib/src/main/resources/scala-native/netinet/unixIf.c
+++ b/javalib/src/main/resources/scala-native/netinet/unixIf.c
@@ -7,7 +7,7 @@ int scalanative_iff_multicast() { return 0; }
 int scalanative_iff_pointopoint() { return 0; }
 int scalanative_iff_up() { return 0; }
 void *if_nameindex(void) { return (void *)0; }
-void if_freenameindex(void *dummy) {};
+void if_freenameindex(void *dummy) {}
 #else
 #include <sys/ioctl.h>
 #include <net/if.h>

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -108,9 +108,9 @@ int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
 #endif // SCALANATIVE_MULTITHREADING_ENABLED
 
 // ScalaNativeGC interface stubs. Boehm GC relies on STW using signal handlers
-void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused) {};
+void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused){};
 
-void scalanative_GC_yield() {};
+void scalanative_GC_yield(){};
 
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {
     GC_add_roots(addr_low, addr_high);

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -108,9 +108,9 @@ int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
 #endif // SCALANATIVE_MULTITHREADING_ENABLED
 
 // ScalaNativeGC interface stubs. Boehm GC relies on STW using signal handlers
-void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused){};
+void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused) {}
 
-void scalanative_GC_yield(){};
+void scalanative_GC_yield() {}
 
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {
     GC_add_roots(addr_low, addr_high);

--- a/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/boehm/gc.c
@@ -108,9 +108,9 @@ int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
 #endif // SCALANATIVE_MULTITHREADING_ENABLED
 
 // ScalaNativeGC interface stubs. Boehm GC relies on STW using signal handlers
-void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused){};
+void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused) {};
 
-void scalanative_GC_yield(){};
+void scalanative_GC_yield() {};
 
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {
     GC_add_roots(addr_low, addr_high);

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -158,7 +158,7 @@ void *scalanative_GC_alloc_array(Rtti *info, size_t length, size_t stride) {
     return alloc;
 }
 
-void scalanative_GC_collect() {}
+void scalanative_GC_collect(){}
 
 void scalanative_GC_set_weak_references_collected_callback(
     WeakReferencesCollectedCallback callback) {}
@@ -180,8 +180,8 @@ int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
 #endif
 
 // ScalaNativeGC interface stubs. None GC does not need STW
-void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused) {};
-void scalanative_GC_yield() {};
-void scalanative_GC_add_roots(void *addr_low, void *addr_high) {}
-void scalanative_GC_remove_roots(void *addr_low, void *addr_high) {}
+void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused){}
+void scalanative_GC_yield(){}
+void scalanative_GC_add_roots(void *addr_low, void *addr_high){}
+void scalanative_GC_remove_roots(void *addr_low, void *addr_high){}
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -158,7 +158,7 @@ void *scalanative_GC_alloc_array(Rtti *info, size_t length, size_t stride) {
     return alloc;
 }
 
-void scalanative_GC_collect(){}
+void scalanative_GC_collect() {}
 
 void scalanative_GC_set_weak_references_collected_callback(
     WeakReferencesCollectedCallback callback) {}
@@ -180,8 +180,8 @@ int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
 #endif
 
 // ScalaNativeGC interface stubs. None GC does not need STW
-void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused){}
-void scalanative_GC_yield(){}
-void scalanative_GC_add_roots(void *addr_low, void *addr_high){}
-void scalanative_GC_remove_roots(void *addr_low, void *addr_high){}
+void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused) {}
+void scalanative_GC_yield() {}
+void scalanative_GC_add_roots(void *addr_low, void *addr_high) {}
+void scalanative_GC_remove_roots(void *addr_low, void *addr_high) {}
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -180,8 +180,8 @@ int scalanative_GC_pthread_create(pthread_t *thread, pthread_attr_t *attr,
 #endif
 
 // ScalaNativeGC interface stubs. None GC does not need STW
-void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused){};
-void scalanative_GC_yield(){};
+void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState unused) {};
+void scalanative_GC_yield() {};
 void scalanative_GC_add_roots(void *addr_low, void *addr_high) {}
 void scalanative_GC_remove_roots(void *addr_low, void *addr_high) {}
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
@@ -55,6 +55,9 @@ size_t Parse_Size_Or_Default(const char *str, size_t defaultSizeInBytes) {
 }
 
 const char *get_defined_or_env(const char *envName) {
+    if (envName == NULL)
+        return NULL;
+
     const char *defined = NULL;
     if (strcmp(envName, "GC_INITIAL_HEAP_SIZE") == 0) {
 #if defined(GC_INITIAL_HEAP_SIZE)
@@ -84,18 +87,21 @@ const char *get_defined_or_env(const char *envName) {
 }
 
 size_t Parse_Env_Or_Default(const char *envName, size_t defaultSizeInBytes) {
-    return Parse_Size_Or_Default(get_defined_or_env(envName),
-                                 defaultSizeInBytes);
+    const char *res = get_defined_or_env(envName);
+#ifdef DEBUG_PRINT
+    printf("%s=%s\n", envName, res);
+    fflush(stdout);
+#endif
+    return Parse_Size_Or_Default(res, defaultSizeInBytes);
 }
 
 size_t Parse_Env_Or_Default_String(const char *envName,
                                    const char *defaultSizeString) {
+    size_t defaultSizeInBytes = Parse_Size_Or_Default(defaultSizeString, 0L);
     if (envName == NULL)
-        return Parse_Size_Or_Default(defaultSizeString, 0L);
+        return defaultSizeInBytes;
     else
-        return Parse_Size_Or_Default(
-            get_defined_or_env(envName),
-            Parse_Size_Or_Default(defaultSizeString, 0L));
+        return Parse_Env_Or_Default(envName, defaultSizeInBytes);
 }
 
 size_t Choose_IF(size_t left, qualifier qualifier, size_t right) {

--- a/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
@@ -60,27 +60,29 @@ const char *get_defined_or_env(const char *envName) {
 
     const char *env = getenv(envName);
     if (env != NULL)
-        return env; // override
+        return env; // override with env var
 
-#if defined(GC_INITIAL_HEAP_SIZE)       
+    // check for compile time values
+
+#if defined(GC_INITIAL_HEAP_SIZE)
     if (strcmp(envName, "GC_INITIAL_HEAP_SIZE") == 0) {
-       return VAL_STR(GC_INITIAL_HEAP_SIZE);
-     }
-#endif
-
-#if defined(GC_MAXIMUM_HEAP_SIZE)
-     if (strcmp(envName, "GC_MAXIMUM_HEAP_SIZE") == 0) {
-        return VAL_STR(GC_MAXIMUM_HEAP_SIZE);
-     }
-#endif
-    
-#if defined(GC_THREAD_HEAP_BLOCK_SIZE)
-    if (strcmp(envName, "GC_THREAD_HEAP_BLOCK_SIZE") == 0) {
-       return VAL_STR(GC_THREAD_HEAP_BLOCK_SIZE);
+        return VAL_STR(GC_INITIAL_HEAP_SIZE);
     }
 #endif
 
-    return NULL; // no either compiltime or runtime value
+#if defined(GC_MAXIMUM_HEAP_SIZE)
+    if (strcmp(envName, "GC_MAXIMUM_HEAP_SIZE") == 0) {
+        return VAL_STR(GC_MAXIMUM_HEAP_SIZE);
+    }
+#endif
+
+#if defined(GC_THREAD_HEAP_BLOCK_SIZE)
+    if (strcmp(envName, "GC_THREAD_HEAP_BLOCK_SIZE") == 0) {
+        return VAL_STR(GC_THREAD_HEAP_BLOCK_SIZE);
+    }
+#endif
+
+    return NULL; // no compile time or runtime value
 }
 
 size_t Parse_Env_Or_Default(const char *envName, size_t defaultSizeInBytes) {

--- a/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
@@ -7,7 +7,7 @@
 #include <windows.h>
 #endif
 
-// Helpers for compile time memory
+// Idiomatic 'stringify' macros for compile time memory
 #define VAL_STR(x) STR(x)
 #define STR(x) #x
 
@@ -60,9 +60,9 @@ const char *get_defined_or_env(const char *envName) {
 
     const char *env = getenv(envName);
     if (env != NULL)
-        return env; // override with env var
+        return env; // environment overrides compile time
 
-// check for defined, compile time values
+// check for compile time defined values
 #if defined(GC_INITIAL_HEAP_SIZE)
     if (strcmp(envName, "GC_INITIAL_HEAP_SIZE") == 0) {
         return VAL_STR(GC_INITIAL_HEAP_SIZE);

--- a/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
@@ -59,12 +59,10 @@ const char *get_defined_or_env(const char *envName) {
         return NULL;
 
     const char *env = getenv(envName);
-    // override with env var
     if (env != NULL)
-        return env;
+        return env; // override with env var
 
-    // check for defined, compile time values
-
+// check for defined, compile time values
 #if defined(GC_INITIAL_HEAP_SIZE)
     if (strcmp(envName, "GC_INITIAL_HEAP_SIZE") == 0) {
         return VAL_STR(GC_INITIAL_HEAP_SIZE);

--- a/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
@@ -59,10 +59,11 @@ const char *get_defined_or_env(const char *envName) {
         return NULL;
 
     const char *env = getenv(envName);
+    // override with env var
     if (env != NULL)
-        return env; // override with env var
+        return env;
 
-    // check for compile time values
+    // check for defined, compile time values
 
 #if defined(GC_INITIAL_HEAP_SIZE)
     if (strcmp(envName, "GC_INITIAL_HEAP_SIZE") == 0) {

--- a/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Parsing.c
@@ -58,32 +58,29 @@ const char *get_defined_or_env(const char *envName) {
     if (envName == NULL)
         return NULL;
 
-    const char *defined = NULL;
-    if (strcmp(envName, "GC_INITIAL_HEAP_SIZE") == 0) {
-#if defined(GC_INITIAL_HEAP_SIZE)
-        defined = VAL_STR(GC_INITIAL_HEAP_SIZE);
-#else
-        defined = NULL;
-#endif
-    } else if (strcmp(envName, "GC_MAXIMUM_HEAP_SIZE") == 0) {
-#if defined(GC_MAXIMUM_HEAP_SIZE)
-        defined = VAL_STR(GC_MAXIMUM_HEAP_SIZE);
-#else
-        defined = NULL;
-#endif
-    } else if (strcmp(envName, "GC_THREAD_HEAP_BLOCK_SIZE") == 0) {
-#if defined(GC_THREAD_HEAP_BLOCK_SIZE)
-        defined = VAL_STR(GC_THREAD_HEAP_BLOCK_SIZE);
-#else
-        defined = NULL;
-#endif
-    }
-
     const char *env = getenv(envName);
     if (env != NULL)
         return env; // override
-    else
-        return defined;
+
+#if defined(GC_INITIAL_HEAP_SIZE)       
+    if (strcmp(envName, "GC_INITIAL_HEAP_SIZE") == 0) {
+       return VAL_STR(GC_INITIAL_HEAP_SIZE);
+     }
+#endif
+
+#if defined(GC_MAXIMUM_HEAP_SIZE)
+     if (strcmp(envName, "GC_MAXIMUM_HEAP_SIZE") == 0) {
+        return VAL_STR(GC_MAXIMUM_HEAP_SIZE);
+     }
+#endif
+    
+#if defined(GC_THREAD_HEAP_BLOCK_SIZE)
+    if (strcmp(envName, "GC_THREAD_HEAP_BLOCK_SIZE") == 0) {
+       return VAL_STR(GC_THREAD_HEAP_BLOCK_SIZE);
+    }
+#endif
+
+    return NULL; // no either compiltime or runtime value
 }
 
 size_t Parse_Env_Or_Default(const char *envName, size_t defaultSizeInBytes) {


### PR DESCRIPTION
The only thing really to note is that for Boehm you need to define with memory in bytes. I couldn't really verify that the setting worked as it doesn't seem to really allocate the initial heap right away but looking at the code it seems to be ok. Plus, if I try to set `3m` or something, the build fails because the `#define` passed on the command line needs to be an `int`. Our memory parser also just passes back the bytes if passed to it so you can set the other GCs with bytes.

- [X] Docs

Note: in the `clang-format` it seems if you have a defined function with an empty body either `fun{};` or `fun {}` are ok. you don't really need a semi-colon on the first one so the second one makes more sense.