### PR TITLE
unix javalib jl.Process waitFor changes for os-lib

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -44,7 +44,7 @@ import scalanative.posix.unistd
  * about the class being thread-safe. That means that one must treat
  * it as concurrent access requiring external synchronization.
  *
- * So much for "de jure". "De facto" applications such as Li Hayoi's os-lib
+ * So much for "de jure". "De facto" applications such as Li Haoyi's os-lib
  * test cases, seem to work better, meaning succeed where they also succeed on
  * JVM, when these methods are synchronized.
  *
@@ -53,10 +53,20 @@ import scalanative.posix.unistd
  * external synchronization or if it a set of bugs in this implementation.
  * In either case, try to match JVM success, albeit at the price of
  * 'synchronized'
+ *
+ * Best current guess/hypothesis is that applications are using an
+ * unsynchronized 'isAlive()', to poll or watch "watch" if another process
+ * in a 'waitFor()' has completed.
  * 
  * When the problem is better understood and shown to be a problem here,
  * it may mean that the current 'synchronized' needs to be replaced
  * by something more runtime efficient, such as AtomicInteger.
+ *
+ * Another, possibly better,  alternative might be to give up caching
+ * _exitValue all together. That may have a lower amortized runtime cost even
+ * though it makes the 'isAlive()' case where the exit value has already been
+ * determined more expensive.
+ * Are there other reasons other methods are synchronized?  Tread lightly here.
  */
 
 private[lang] class UnixProcessGen2 private (

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -194,7 +194,7 @@ private[lang] class UnixProcessGen2 private (
         throw new InterruptedException()
       } else if (errno == ECHILD) {
         /* See extensive discussion in SN Issue #4208 and identical
-         * closely related #4348.
+         * closely related #4208.
          */
         // If not empty someone else already reaped the process; be idempotent.
         if (_exitValue.isEmpty)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -310,7 +310,7 @@ class ProcessTest {
        */
 
       assertTrue(
-        s"Second waitFor after procees exit should be robust.)",
+        s"Second waitFor after process exit should be robust.)",
         proc.waitFor(timeout, TimeUnit.SECONDS)
       )
 


### PR DESCRIPTION
This is a "reduction in strength" change to partially address SN Issue #4348.  
The hope is to catch the 0.5.8 bus when, in the fullness of time, it leaves.

I would not call it a "fix" and would like to leave that SN Issue open whilst it is
being investigated. That could take months or longer since my available time over
the next few months is asymptotically zero.  

It is not clear at all if the "feature" is in os-lib or SN.

The os-lib tests which are problematic for UnixGen2 pass on Windows & JVM. So the idea
of this PR is to follow the SN WindowsProcess practice of not throwing when presented
with an invalid pid, but returning an error (?) code. 

<hr>
There is room for the suggestion that UnixProcessGen2 should be silent only if the
`_exitValue` has been previously set (be idempotent there) and continue to throw
if `_exitValue` is clear, meaning presented pid is indeed bogus, not just previously reaped.

This PR uses the 'Big Hammer' approach in an attempt to get os-lib building.  That hammer
should not affect other projects.  The more gentle approach can be considered when/if
it is determined how os-lib manages to exercise the previously problematic path. 
Any good problem deserves several evolutions.

<hr>
Later: 2025-05-28

SN Issue #4348 appears closely related, if not identical, to #4208.

I have still not figured how one gets a race condition in code that is supposed to
require "external synchronization", but the situation appears to have appeared in
the wild at least twice now and does not appear with the JVM.
 
The changes of this PR may or may not fix or reduce the likelihood of the
defect reported in those PRs, but they should do not harm in everyday usage.