### PR TITLE
Fix #4359: Posixlib waitid status param needs to be ptr siginfo_t infop

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
@@ -102,17 +102,17 @@ object wait {
   /** See declaration & usage note in class description.
    */
   @blocking
-  def wait(status: Ptr[CInt]): pid_t = extern
+  def wait(stat_loc: Ptr[CInt]): pid_t = extern
 
   @blocking
   def waitid(
       idtype: idtype_t,
       id: id_t,
-      status: Ptr[siginfo_t],
+      infop: Ptr[siginfo_t],
       options: CInt
   ): CInt = extern
 
   @blocking
-  def waitpid(pid: pid_t, status: Ptr[CInt], options: CInt): pid_t = extern
+  def waitpid(pid: pid_t, stat_loc: Ptr[CInt], options: CInt): pid_t = extern
 
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
@@ -108,7 +108,7 @@ object wait {
   def waitid(
       idtype: idtype_t,
       id: id_t,
-      status: Ptr[CInt],
+      status: Ptr[siginfo_t],
       options: CInt
   ): CInt = extern
 


### PR DESCRIPTION
As pointed out by Rahul_123 on Discord.

We should be as posix compliant as possible given limitations. If you look at the applicable specs https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_wait.h.html and https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html versus the posixlib source it is definitely not correct and/or incomplete. 

Not sure if this has an easy way to test.