### PR TITLE
Fix #4368: javalib Math#multiplyHigh and #unsignedMultiplyHigh now use 128 bit operations if available

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1892,3 +1892,28 @@ Sections of the work carry alternate permissive licenses:
        The terms of that license requires this notice that the code
        from that paper has been altered by being translated to Scala.
 ```
+# License notice  plokhotnyuk/jsoniter-scala 
+As required by https://github.com/plokhotnyuk/jsoniter-scala/LICENSE:
+```
+MIT License
+
+Copyright (c) 2017 Andriy Plokhotnyuk, and respective contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/javalib/src/main/resources/scala-native/lang/math_impl.c
+++ b/javalib/src/main/resources/scala-native/lang/math_impl.c
@@ -1,0 +1,92 @@
+/* Derived, with thanks & appreciation, from
+ * "plokhotnyuk/jsoniter-scala multiply_high.c",
+ * URL: https://github.com/plokhotnyuk/jsoniter-scala
+ *
+ * commit: d69ebc6 dated: 2025-06-10
+ *
+ * Used under the original's permissive MIT license as reproduced in
+ * this projects LICENSE.md.
+ */
+
+#if defined(SCALANATIVE_COMPILE_ALWAYS) ||                                     \
+    defined(__SCALANATIVE_JAVALIB_LANG_MATHIMPL_H)
+
+#include <stdint.h>
+
+#if defined(_WIN64)
+
+#include <intrin.h>
+
+scalanative_javalib_multiplyhigh
+
+    int64_t
+    scalanative_javalib_multiply_high(int64_t x, int64_t y) {
+    return __mulh(x, y);
+}
+
+uint64_t scalanative_javalib_unsigned_multiply_high(uint64_t x, uint64_t y) {
+    return __umulh(x, y);
+}
+
+#elif defined(__SIZEOF_INT128__)
+
+int64_t scalanative_javalib_multiply_high(int64_t x, int64_t y) {
+    return (x * (__int128)y) >> 64;
+}
+
+uint64_t scalanative_javalib_unsigned_multiply_high(uint64_t x, uint64_t y) {
+    return (x * (unsigned __int128)y) >> 64;
+}
+
+#else
+#if !defined(__clang__) && !defined(__GNUC__)
+
+/* The C standard specifies the right shift operator as implementation
+ * defined.
+ *
+ * clang and gcc both specify an arithmetic shift (sign bit)
+ * is used to fill vacated bits if the the possibly promoted left hand
+ * operand is signed. If the left operand is unsigned, a logical shift
+ * will be used and vacated bits are filled with zeros.
+ *
+ * Scala Native specifies that it is built using Clang.
+ * If a compiler is used which is not known to
+ * use the clang right shift definition, use the gentlest
+ * available method to bring attention to the possibly incorrect
+ * runtime behavior.
+ *
+ * In the general case, use the #warning directive. Not all compilers
+ * have that directive. Those which do not will get
+ * a compilation error here, which serves to direct attention to this issue.
+ */
+
+#warning "C '>>' is implementation defined and not known to be correct here."
+
+#endif // __clang__
+
+// Based on `int mulhs(int u, int v)` function from
+// Hacker’s Delight 2nd Ed. by Henry S. Warren, Jr.
+int64_t scalanative_javalib_multiply_high(int64_t x, int64_t y) {
+    int64_t x0 = x & 0xFFFFFFFFL;
+    int64_t x1 = x >> 32;
+    int64_t y0 = y & 0xFFFFFFFFL;
+    int64_t y1 = y >> 32;
+    int64_t t = x1 * y0 + ((uint64_t)(x0 * y0) >> 32);
+    return x1 * y1 + (t >> 32) + (((t & 0xFFFFFFFFL) + x0 * y1) >> 32);
+}
+
+// Based on `unsigned mulhu(unsigned u, unsigned v)` function from
+// Hacker’s Delight 2nd Ed. by Henry S. Warren, Jr.
+uint64_t scalanative_javalib_unsigned_multiply_high(uint64_t x, uint64_t y) {
+    uint64_t x0 = x & 0xFFFFFFFFL;
+    uint64_t x1 = x >> 32;
+    uint64_t y0 = y & 0xFFFFFFFFL;
+    uint64_t y1 = y >> 32;
+    uint64_t t = x1 * y0 + ((x0 * y0) >> 32);
+    return x1 * y1 + (t >> 32) + (((t & 0xFFFFFFFFL) + x0 * y1) >> 32);
+}
+
+#endif
+
+#endif // defined(SCALANATIVE_COMPILE_ALWAYS) ||
+       // defined(__SCALANATIVE_JAVALIB_LANG_MATHIMPL_H)

--- a/javalib/src/main/resources/scala-native/lang/math_impl.c
+++ b/javalib/src/main/resources/scala-native/lang/math_impl.c
@@ -17,10 +17,7 @@
 
 #include <intrin.h>
 
-scalanative_javalib_multiplyhigh
-
-    int64_t
-    scalanative_javalib_multiply_high(int64_t x, int64_t y) {
+int64_t scalanative_javalib_multiply_high(int64_t x, int64_t y) {
     return __mulh(x, y);
 }
 

--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -313,53 +313,14 @@ object Math {
     else overflow.value
   }
 
-  /* If benchmarking shows that  multiplyHigh() and/or unsignedMultiply()
-   * is a hotspot, one could explore using C23, _BitInt. That or its
-   * experimental predecessor is available in LLVM 18 or later.
-   * It would be a bakeoff to see whose optimizer is better. My money
-   * would be on LLVM, but data tells.
-   */
+  @alwaysinline def multiplyHigh(x: scala.Long, y: scala.Long): scala.Long =
+    MathImpl.multiplyHighImpl(x, y)
 
-  @alwaysinline def multiplyHigh(x: scala.Long, y: scala.Long): scala.Long = {
-    /* Ported from Scala.js commit: 7569c24 dated: 2025-05-20
-     * Prior, believed correct, code replaced so that multiplyHigh() and
-     * unsignedMultiplyHigh() comments & implementation correspond.
-     */
-
-    /* Hacker's Delight, Section 8-2, Figure 8-2,
-     * where we have "inlined" all the variables used only once to help our
-     * optimizer perform simplifications.
-     */
-
-    val x0 = x & 0xffffffffL
-    val x1 = x >> 32
-    val y0 = y & 0xffffffffL
-    val y1 = y >> 32
-
-    val t = x1 * y0 + ((x0 * y0) >>> 32)
-    x1 * y1 + (t >> 32) + (((t & 0xffffffffL) + x0 * y1) >> 32)
-  }
-
-  /** Since: Java 18 */
   @alwaysinline def unsignedMultiplyHigh(
       x: scala.Long,
       y: scala.Long
-  ): scala.Long = {
-    // Ported from Scala.js commit: 7569c24 dated: 2025-05-20
-    /* Hacker's Delight, Section 8-2:
-     * > For an unsigned version, simply change all the int declarations to
-     * > unsigned.
-     * In Scala, that means changing all the >> into >>>.
-     */
-
-    val x0 = x & 0xffffffffL
-    val x1 = x >>> 32
-    val y0 = y & 0xffffffffL
-    val y1 = y >>> 32
-
-    val t = x1 * y0 + ((x0 * y0) >>> 32)
-    x1 * y1 + (t >>> 32) + (((t & 0xffffffffL) + x0 * y1) >>> 32)
-  }
+  ): scala.Long =
+    MathImpl.unsignedMultiplyHighImpl(x, y)
 
   @alwaysinline def multiplyExact(a: scala.Long, b: scala.Int): scala.Long =
     multiplyExact(a, b.toLong)

--- a/javalib/src/main/scala/java/lang/MathImpl.scala
+++ b/javalib/src/main/scala/java/lang/MathImpl.scala
@@ -1,0 +1,29 @@
+/* Derived, with thanks & appreciation, from
+ * "plokhotnyuk/jsoniter-scala multiply_high.c",
+ * URL: https://github.com/plokhotnyuk/jsoniter-scala
+ *
+ * commit: 71fef04 dated: 2025-06-07
+ *
+ * Used under the original's permissive MIT license as reproduced in
+ * this projects LICENSE.md.
+ */
+
+package java.lang
+
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.unsafe._
+
+@define("__SCALANATIVE_JAVALIB_LANG_MATHIMPL_H")
+@extern
+object MathImpl {
+
+  @alwaysinline
+  @name("scalanative_javalib_multiply_high")
+  def multiplyHighImpl(x: scala.Long, y: scala.Long): scala.Long = extern
+
+  @alwaysinline
+  @name("scalanative_javalib_unsigned_multiply_high")
+  def unsignedMultiplyHighImpl(x: scala.Long, y: scala.Long): scala.Long =
+    extern
+
+}


### PR DESCRIPTION
Fix #4368 

Port the `NativeMath` code from [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala) so that
 javalib `Math#multiplyHigh` and `#unsignedMultiplyHigh` now use 128 bit operations, if available.

This PR has been an ensemble effort. Mentioning people involved is meant to thank and give credit,
 as it is well due, and not to imply that they endorse or have even seen this PR.
 I apologize if I have left anybody out.

- 'plokhotnyuk' created & iterated the essential `jsoniter-scala` 128 bit code, announced it on Discord
  and suggested that it be ported to Scala Native.

- 'JD557' created SN Issue #4368 
  and advocated for the port.

- 'Aly', on Discord,  provided background about retaining at least 0.5.8 performance
  on possible non-128 bit systems and encouraged the port.

- `LeeTibbert` acted only as clerk of record and provided the bugs.

The minimum product requirement goal was to provide no worse than SN 0.5.8 performance
 in all cases, or at least detect and announce the regressing cases. 

Any improvement in performance is likely to be highly dependent upon Operating System
and architecture and the direction of the wind.  

Notes:

- The WINDOWS64 code passes CI tests for correctness but its performance has not 
  been characterized on SN. It derived from code exercised in `jsoniter-scala`, whose goal 
  is performance. This PR can be modified to disable that branch if possibility of regression
  on Windows is a concern.
  
- The C code used when 128 bit math is not available has been shown in private tests
  to perform no worse than the equivalent Scala code used in SN 0.5.8. As an aside,
  that indicates that the scala.js SJRD code and SN code generation and optimization did a pretty 
  good job.

- The `*multiplyHigh` performance on macOS AArch64 was compared in private design studies
  using, in succession, the C code equivalent to SN 0.5.8 and the 128 bit code. Very preliminary
  evidence over multiple runs  shows a slight speedup and no regression. 
