### PR TITLE
Introduce Int128 to the toolchain and intrinsic `Math.multipleHigh` functions

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -313,53 +313,14 @@ object Math {
     else overflow.value
   }
 
-  /* If benchmarking shows that  multiplyHigh() and/or unsignedMultiply()
-   * is a hotspot, one could explore using C23, _BitInt. That or its
-   * experimental predecessor is available in LLVM 18 or later.
-   * It would be a bakeoff to see whose optimizer is better. My money
-   * would be on LLVM, but data tells.
-   */
-
-  @alwaysinline def multiplyHigh(x: scala.Long, y: scala.Long): scala.Long = {
-    /* Ported from Scala.js commit: 7569c24 dated: 2025-05-20
-     * Prior, believed correct, code replaced so that multiplyHigh() and
-     * unsignedMultiplyHigh() comments & implementation correspond.
-     */
-
-    /* Hacker's Delight, Section 8-2, Figure 8-2,
-     * where we have "inlined" all the variables used only once to help our
-     * optimizer perform simplifications.
-     */
-
-    val x0 = x & 0xffffffffL
-    val x1 = x >> 32
-    val y0 = y & 0xffffffffL
-    val y1 = y >> 32
-
-    val t = x1 * y0 + ((x0 * y0) >>> 32)
-    x1 * y1 + (t >> 32) + (((t & 0xffffffffL) + x0 * y1) >> 32)
-  }
+  @alwaysinline def multiplyHigh(x: scala.Long, y: scala.Long): scala.Long =
+    scalanative.runtime.Intrinsics.multiplyHigh(x, y)
 
   /** Since: Java 18 */
   @alwaysinline def unsignedMultiplyHigh(
       x: scala.Long,
       y: scala.Long
-  ): scala.Long = {
-    // Ported from Scala.js commit: 7569c24 dated: 2025-05-20
-    /* Hacker's Delight, Section 8-2:
-     * > For an unsigned version, simply change all the int declarations to
-     * > unsigned.
-     * In Scala, that means changing all the >> into >>>.
-     */
-
-    val x0 = x & 0xffffffffL
-    val x1 = x >>> 32
-    val y0 = y & 0xffffffffL
-    val y1 = y >>> 32
-
-    val t = x1 * y0 + ((x0 * y0) >>> 32)
-    x1 * y1 + (t >>> 32) + (((t & 0xffffffffL) + x0 * y1) >>> 32)
-  }
+  ): scala.Long = scalanative.runtime.Intrinsics.unsignedMultiplyHigh(x, y)
 
   @alwaysinline def multiplyExact(a: scala.Long, b: scala.Int): scala.Long =
     multiplyExact(a, b.toLong)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Class.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Class.scala
@@ -231,12 +231,6 @@ private[runtime] object _Class {
 }
 
 private object LinkedClassesRepository {
-  /* Reachable only from `forName` method
-   * Needs to be non-optmized to not allowing optimizer to change it's result signature type to Nothing
-   * which is correct (it can only throw), but it's not going to be Nothing after Lowering phase
-   * Also prevent inlining so that we don't loose this method before Lowering
-   */
-  @nooptimize @noinline
   private def loadAll(): scala.Array[_Class[_]] = intrinsic
   val byName: Map[String, _Class[_]] = loadAll().map { cls =>
     cls.name -> cls

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -194,4 +194,7 @@ object Intrinsics {
   def unsignedOf(value: Int): UInt = intrinsic
   def unsignedOf(value: Long): ULong = intrinsic
   def unsignedOf(value: RawSize): USize = intrinsic
+
+  def multiplyHigh(x: scala.Long, y: scala.Long): scala.Long = intrinsic
+  def unsignedMultiplyHigh(x: scala.Long, y: scala.Long): scala.Long = intrinsic
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -517,6 +517,9 @@ object Show {
       case Val.Long(value) =>
         str("long ")
         str(value)
+      case value: Val.Int128 =>
+        str("int128 ")
+        str(value.bigIntValue)
       case Val.Float(value) =>
         str("float ")
         str(value)
@@ -650,6 +653,7 @@ object Show {
       case Type.Byte   => str("byte")
       case Type.Short  => str("short")
       case Type.Int    => str("int")
+      case Type.Int128 => str("int128")
       case Type.Long   => str("long")
       case Type.Float  => str("float")
       case Type.Double => str("double")

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -98,6 +98,9 @@ object Type {
   /** The type of a 64-bit signed integer. */
   case object Long extends FixedSizeI(64, signed = true)
 
+  /** The type of a 128-bit signed integer. */
+  case object Int128 extends FixedSizeI(128, signed = true)
+
   /** The type of a 32-bit IEEE 754 single-precision float. */
   case object Float extends F(32)
 

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -27,6 +27,8 @@ sealed abstract class Val {
       Type.Int
     case Val.Long(_) =>
       Type.Long
+    case Val.Int128(_, _) =>
+      Type.Int128
     case Val.Float(_) =>
       Type.Float
     case Val.Double(_) =>
@@ -267,6 +269,17 @@ object Val {
 
   /** A 64-bit signed two’s complement integer. */
   final case class Long(value: scala.Long) extends Val
+
+  /** A 128-bit signed two’s complement integer, encoded as two 64‑bit words.
+   *  Not emmited by compiler!
+   */
+  final case class Int128(hi: scala.Long, lo: scala.Long) extends Val {
+    def bigIntValue: math.BigInt = {
+      val hiPart = math.BigInt(hi) << 64
+      val loPart = math.BigInt(lo & 0xFFFFffffFFFFffffL)
+      hiPart | loPart
+    }
+  }
 
   /** A 32-bit IEEE 754 single-precision float. */
   final case class Float(value: scala.Float) extends Val {

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -276,7 +276,7 @@ object Val {
   final case class Int128(hi: scala.Long, lo: scala.Long) extends Val {
     def bigIntValue: math.BigInt = {
       val hiPart = math.BigInt(hi) << 64
-      val loPart = math.BigInt(lo & 0xFFFFffffFFFFffffL)
+      val loPart = math.BigInt(lo & 0xffffffffffffffffL)
       hiPart | loPart
     }
   }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -428,6 +428,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, nirSource: NIRSource) {
       case T.ArrayType   => Type.Array(getType(), getBool())
       case T.RefType     => Type.Ref(getGlobal().narrow[nir.Global.Top], getBool(), getBool())
       case T.SizeType    => Type.Size
+      case T.Int128Type  => Type.Int128
     }
   }
 
@@ -457,6 +458,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, nirSource: NIRSource) {
       case T.VirtualVal => Val.Virtual(getLebUnsignedLong())
       case T.ClassOfVal => Val.ClassOf(getGlobal().narrow[Global.Top])
       case T.SizeVal    => Val.Size(getLebUnsignedLong())
+      case T.Int128Val  => Val.Int128(getLebSignedLong(), getLebUnsignedLong())
     }
   }
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -30,6 +30,10 @@ final class BinarySerializer(channel: WritableByteChannel) {
   private val sections = Seq(Header, Offsets, Strings, Positions, Globals, Types, Defns, Vals, Insts)
   private var hasEntryPoints: Boolean = false
 
+  private def nonSerializable(kind: String) = throw new IllegalStateException(
+    s"$kind should not be serialized in .nir files. It only exists in the backend"
+  )
+
   private object Header extends NIRSectionWriter(Prelude.length) {
     def put(): Unit = {
       putInt(Versions.magic)
@@ -135,7 +139,12 @@ final class BinarySerializer(channel: WritableByteChannel) {
       case Type.StructValue(tys)        => putTag(T.StructValueType); putTypes(tys)
       case Type.Vararg                  => putTag(T.VarargType)
       case Type.Var(ty)                 => putTag(T.VarType); putType(ty)
-      case Type.Virtual                 => putTag(T.VirtualType)
+      case Type.Virtual =>
+        nonSerializable("Type.Virtual")
+      // putTag(T.VirtualType)
+      case Type.Int128 =>
+        nonSerializable("Type.Int128")
+      // putTag(T.Int128Type)
     }
   }
 
@@ -169,7 +178,12 @@ final class BinarySerializer(channel: WritableByteChannel) {
       case Val.Zero(ty)           => putTag(T.ZeroVal); putType(ty)
       case Val.ArrayValue(ty, vs) => putTag(T.ArrayValueVal); putType(ty); putVals(vs)
       case Val.StructValue(vs)    => putTag(T.StructValueVal); putVals(vs)
-      case Val.Virtual(v)         => putTag(T.VirtualVal); putLebUnsignedLong(v)
+      case Val.Virtual(v) =>
+        nonSerializable("Val.Virtual")
+      // putTag(T.VirtualVal); putLebUnsignedLong(v)
+      case Val.Int128(hi, lo) =>
+        nonSerializable("Val.Int128")
+      // putTag(T.Int128Val); putLebSignedLong(hi); putLebUnsignedLong(lo);
     }
   }
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -216,7 +216,6 @@ object Tags {
   final val SizeVal = 1 + LinktimeConditionVal
   final val Int128Val = 1 + SizeVal
 
-
   // Synchronization info
   final val Unordered = 1
   final val MonotonicOrder = 1 + Unordered

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -188,6 +188,7 @@ object Tags {
   final val ArrayType = 1 + UnitType
   final val RefType = 1 + ArrayType
   final val SizeType = 1 + RefType
+  final val Int128Type = 1 + SizeType
 
   // Values
   final val TrueVal = 1
@@ -213,6 +214,8 @@ object Tags {
   final val ClassOfVal = 1 + VirtualVal
   final val LinktimeConditionVal = 1 + ClassOfVal
   final val SizeVal = 1 + LinktimeConditionVal
+  final val Int128Val = 1 + SizeVal
+
 
   // Synchronization info
   final val Unordered = 1

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -139,6 +139,7 @@ trait NirDefinitions {
     lazy val RuntimeModule = getRequiredModule(
       "scala.scalanative.runtime.package"
     )
+    lazy val IntrinsicMarker = getMember(RuntimePackage, TermName("intrinsic"))
     lazy val IntrinsicsModule = getRequiredModule(
       "scala.scalanative.runtime.Intrinsics"
     )

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -102,6 +102,7 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val RuntimeSafeZoneAllocator_allocate = optional(RuntimeSafeZoneAllocatorModule.requiredMethod("allocate"))
 
   // Runtime intriniscs
+  @tu lazy val IntrinsicMarker = RuntimePackageClass.requiredMethod("intrinsic")
   @tu lazy val IntrinsicsModule = requiredModule("scala.scalanative.runtime.Intrinsics")
   @tu lazy val IntrinsicsInternalModule = requiredModule("scala.scalanative.runtime.Intrinsics.internal")
   @tu lazy val Intrinsics_divUInt = IntrinsicsModule.requiredMethod("divUInt")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -276,8 +276,9 @@ trait NirGenStat(using Context) {
       val owner = curClassSym.get
 
       val isExtern = sym.isExtern
+      val isIntrinsic = dd.rhs.symbol == defnNir.IntrinsicMarker
 
-      val attrs = genMethodAttrs(sym, isExtern)
+      val attrs = genMethodAttrs(sym, isExtern, isIntrinsic)
       val name = genMethodName(sym)
       val sig = genMethodSig(sym)
 
@@ -327,7 +328,8 @@ trait NirGenStat(using Context) {
 
   private def genMethodAttrs(
       sym: Symbol,
-      isExtern: Boolean
+      isExtern: Boolean,
+      isIntrinsic: Boolean
   ): nir.Attrs = {
     val attrs = Seq.newBuilder[nir.Attr]
 
@@ -363,6 +365,11 @@ trait NirGenStat(using Context) {
             .foreach(attrs += nir.Attr.Define(_))
         case _ => ()
       }
+    }
+    if isIntrinsic then {
+      // Overrides previouslly set
+      attrs += nir.Attr.NoOpt
+      attrs += nir.Attr.NoInline
     }
     nir.Attrs.fromSeq(attrs.result())
   }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -16,16 +16,13 @@ object BinaryIncompatibilities {
     )
   )
   final val Nir: Filters = Seq(
-    exclude[DirectMissingMethodProblem]("scala.scalanative.nir.Rt.*")
-  )
-
-  final val NscPlugin = Seq(
     exclude[DirectMissingMethodProblem]("scala.scalanative.nir.Rt.*"),
-    exclude[IncompatibleMethTypeProblem](
-      "scala.scalanative.nscplugin.NirCompat*"
-    )
+    // Conversion case-class -> class
+    exclude[DirectMissingMethodProblem]("scala.scalanative.nir.Attrs._*"),
+    exclude[DirectMissingMethodProblem]("scala.scalanative.nir.Attrs.fromProduct"),
+    exclude[IncompatibleResultTypeProblem]("scala.scalanative.nir.Attrs.unapply"),
+    exclude[MissingTypesProblem]("scala.scalanative.nir.Attrs$"),
   )
-  final val JUnitPlugin: Filters = Nil
 
   final val Tools: Filters = Seq(
     exclude[Problem]("scala.scalanative.codegen.*"),
@@ -52,6 +49,8 @@ object BinaryIncompatibilities {
     exclude[ReversedMissingMethodProblem]("scala.scalanative.runtime.NativeThread.companion"),
     exclude[ReversedMissingMethodProblem]("scala.scalanative.runtime.NativeThread.stackSize"),
     exclude[ReversedMissingMethodProblem]("scala.scalanative.runtime.NativeThread#Companion.defaultOSStackSize"),
+    exclude[Problem]("scala.scalanative.runtime._Class.*"),
+    exclude[Problem]("scala.scalanative.runtime.unwind.*"),
   )
   final val CLib: Filters = Nil
   final val PosixLib: Filters = Seq.empty
@@ -65,7 +64,6 @@ object BinaryIncompatibilities {
   val moduleFilters = Map(
     "util" -> Util,
     "nir" -> Nir,
-    "nscplugin" -> NscPlugin,
     "tools" -> Tools,
     "clib" -> CLib,
     "posixlib" -> PosixLib,
@@ -74,7 +72,6 @@ object BinaryIncompatibilities {
     "test-runner" -> TestRunner,
     "test-interface" -> TestInterface,
     "test-interface-sbt-defs" -> TestInterfaceSbtDefs,
-    "junit-plugin" -> JUnitPlugin,
     "junit-runtime" -> JUnitRuntime
   )
 }

--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -86,7 +86,7 @@ object Commands {
         .map(_.forBinaryVersion(version).id)
         .map(id => s"$id/test")
       tests :::
-        List("test-mima") :::
+        List(s"test-mima $version") :::
         state
   }
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -213,6 +213,9 @@ object Settings {
         }
     }
   )
+  lazy val disableMimaSettings = Seq(
+    mimaPreviousArtifacts := Set.empty
+  )
 
   // Publishing
   lazy val basePublishSettings: Seq[Setting[_]] = Seq(
@@ -604,7 +607,8 @@ object Settings {
     mavenPublishSettings,
     exportJars := true,
     scalacOptions --= Seq("-deprecation", "-Xfatal-warnings"),
-    scalacOptions ++= ignoredScalaDeprecations(scalaVersion.value)
+    scalacOptions ++= ignoredScalaDeprecations(scalaVersion.value),
+    disableMimaSettings,
   )
 
   lazy val sbtPluginSettings = Def.settings(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -608,7 +608,7 @@ object Settings {
     exportJars := true,
     scalacOptions --= Seq("-deprecation", "-Xfatal-warnings"),
     scalacOptions ++= ignoredScalaDeprecations(scalaVersion.value),
-    disableMimaSettings,
+    disableMimaSettings
   )
 
   lazy val sbtPluginSettings = Def.settings(

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -516,8 +516,7 @@ private[codegen] abstract class AbstractCodeGen(
         str(" (")
         rep(args, sep = ", ")(genType)
         str(")")
-      case ty =>
-        unsupported(ty)
+      case nir.Type.Virtual | nir.Type.Var(_) => unsupported(ty)
     }
   }
 
@@ -567,6 +566,7 @@ private[codegen] abstract class AbstractCodeGen(
       case nir.Val.Short(v)  => str(v)
       case nir.Val.Int(v)    => str(v)
       case nir.Val.Long(v)   => str(v)
+      case v: nir.Val.Int128 => str(v.bigIntValue)
       case nir.Val.Float(v)  => genFloatHex(v)
       case nir.Val.Double(v) => genDoubleHex(v)
       case nir.Val.StructValue(vs) =>
@@ -594,7 +594,7 @@ private[codegen] abstract class AbstractCodeGen(
           genGlobal(n)
           str(" to i8*)")
         }
-      case _ =>
+      case _: nir.Val.Global | _: nir.Val.Const | _: nir.Val.String | _: nir.Val.Virtual | _: nir.Val.ClassOf => 
         unsupported(v)
     }
   }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -594,7 +594,8 @@ private[codegen] abstract class AbstractCodeGen(
           genGlobal(n)
           str(" to i8*)")
         }
-      case _: nir.Val.Global | _: nir.Val.Const | _: nir.Val.String | _: nir.Val.Virtual | _: nir.Val.ClassOf => 
+      case _: nir.Val.Global | _: nir.Val.Const | _: nir.Val.String |
+          _: nir.Val.Virtual | _: nir.Val.ClassOf =>
         unsupported(v)
     }
   }


### PR DESCRIPTION
Introduces `Int128` type internally to the toolchain - these types/values are not emitted by the compiler in the .nir files and are only used in the toolchain for intrinsic implementaiton of `Math.multipleHigh` methods.  These might be extended for public usage in the future, but would require to introduce an introducation to nativelib API and proper handling in compiler plugin / optimizer. 

We don't increment the NIR version since the Type.Int128 and Val.Int128 are prohibited from being serialised into the files thus would never lead to breaking binary compatibility.  

Also fixes mima issues (especially testing on Scala 2.13/3)  found when testing 

The `Intrinsic.multipleHigh` implemntation is based on LLVM `__mulh` implementation https://reviews.llvm.org/D106721