### PR TITLE
Improvement [Build]: Update sbt to 1.11.2

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -55,12 +55,10 @@ object ScalaVersions {
   //   1.9.0 is required in order to use Java >= 21
   //   1.9.4 fixes (Common Vulnerabilities and Exposures) CVE-2022-46751
   //   1.9.7 fixes sbt IO.unzip vulnerability described in sbt release notes.
-  //   1.10.0 Latest sbt version.
-  //   1.10.1 Latest sbt version.
   //   1.10.7 Latest sbt version, 1.10.2 had bug, see comment in SN Issue #4126
-  //   1.10.11 Latest sbt version
+  //   1.11.2 Latest sbt version
 
-  val sbt10Version: String = "1.10.11"
+  val sbt10Version: String = "1.11.2"
   val sbt10ScalaVersion: String = scala212
 
   val libCrossScalaVersions: Seq[String] =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.11.1
+sbt.version = 1.11.2


### PR DESCRIPTION
Update sbt version used in Scala Native Build to 1.11.2.

The SBT GitHub [announcement](https://github.com/sbt/sbt/releases/tag/v1.11.2).

This PR also updates the SBT version in both project/build.properties & project/ScalaVersions.scala.

This change has been heavily exercised for 10+ days on MacOS ARM.