### PR TITLE
Add short write handling to javalib FileChannel#transferFrom and #transferTo

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -387,9 +387,6 @@ private[java] final class FileChannelImpl(
    * They differ just enough in how they must handle the position of
    * the 'this' FileChannel that such a common implementation exceeds the
    * day is left for the reader.
-   *
-   * Useful example:
-   *   URL: https://www.happycoders.eu/java/filechannel-memory-mapped-io-locks/
    */
 
   override def transferFrom(
@@ -432,15 +429,15 @@ private[java] final class FileChannelImpl(
           // Bounding the limit is key to not reading/writing too many bytes.
           val nRemaining = count - totalWritten
           if ((nRemaining) < bufSize)
-            buf.limit(nRemaining.toInt) // Enable next partial buffer short read
+            buf.limit(nRemaining.toInt) // Enable next partial buf short read
 
-          val nRead = src.read(buf)
-          if (nRead == -1) {
+          if (src.read(buf) == -1) {
             done = true
           } else {
             buf.flip()
-            totalWritten += this.write(buf)
-            buf.compact()
+            while (buf.hasRemaining())
+              totalWritten += this.write(buf)
+            buf.flip()
           }
         }
       } finally {
@@ -494,16 +491,15 @@ private[java] final class FileChannelImpl(
           // Bounding the limit is key to not reading/writing too many bytes.
           val nRemaining = count - totalWritten
           if (nRemaining < bufSize)
-            buf.limit(nRemaining.toInt) // Enable next partial buffer short read
+            buf.limit(nRemaining.toInt) // Enable next partial buf short read
 
-          val nRead = this.read(buf)
-
-          if (nRead == -1) {
+          if (this.read(buf) == -1) {
             done = true
           } else {
             buf.flip()
-            totalWritten += totalWritten + target.write(buf)
-            buf.compact()
+            while (buf.hasRemaining())
+              totalWritten += totalWritten + target.write(buf)
+            buf.flip()
           }
         }
       } finally {

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -429,7 +429,7 @@ private[java] final class FileChannelImpl(
         } else {
           buf.flip()
 
-          /* Using absolute write at position takes math but avoids
+          /* Using absolute write-at-position takes math but avoids
            * set, save, and then restore of position. That overload
            * does all that work already.
            */
@@ -494,10 +494,6 @@ private[java] final class FileChannelImpl(
         } else {
           buf.flip()
 
-          /* Using write with position costs math but avoids
-           * set, save, and then restore of position. That overload
-           * does all that work already.
-           */
           val nWritten = target.write(buf)
           buf.compact()
 


### PR DESCRIPTION
Javalib `FileChannel#transferFrom` and `#transferTo` methods now handle 
cases where write() returned a count less than requested; a.k.a a "short write".

They also handle cases where bytes may have been left in the intermediate
buffer after the last successful read because of prior short writes.

Short writes are hard to provoke when you want them but abound
when one does not. There are no changes to the existing unit-tests 
for these methods.   