### PR TITLE
Make javalib InputStream#transferTo short write behavior evident

### DIFF
--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -293,7 +293,7 @@ abstract class InputStream extends Closeable {
       val nRead = readNBytes(buffer, 0, limit)
       if (nRead == 0) done = true // EOF
       else {
-        out.write(buffer, 0, nRead)
+        out.write(buffer, 0, nRead) // short write safe; write will throw
         nTransferred += nRead
       }
     }


### PR DESCRIPTION
A person reading the prior javalib `InputStream#transferTo` code might notice the lack of the
usual idiom for handling potential short writes.  This PR adds a short comment to make
it evident that the section of code which does the write does indeed handle short writes.
In this case, by throwing an Exception.   

The prior code is correct. If one is exceedingly familiar with javalib `java.io, understanding that
is trivial and the comment unnecessary.  If one is switching between different I/O models in
javalib, some which throw and some which return short counts, the comment saves 
time tracing and increases confidence.    This is the kind of code which gets traced & re-traced.

This improvement is related to PR #4379. The code in question in both was written about the same time
and by the same author (nobody here but us chickens).  