### PR TITLE
Implement javalib JDK 11 *Buffer#mismatch methods

### DIFF
--- a/javalib/src/main/scala/java/nio/Buffers.scala
+++ b/javalib/src/main/scala/java/nio/Buffers.scala
@@ -2,11 +2,14 @@
 package java.nio
 
 // Ported from Scala.js
+// Also has JDK 11 & 16 Additions for Scala Native
 import scala.scalanative.unsafe
 import scala.scalanative.unsafe.UnsafeRichArray
 import scala.scalanative.runtime.{fromRawPtr, toRawPtr}
 import scala.scalanative.runtime.Intrinsics
 import scala.scalanative.annotation.alwaysinline
+
+import java.{util => ju}
 
 object ByteBuffer {
   private final val HashSeed = -547316498 // "java.nio.ByteBuffer".##
@@ -39,8 +42,51 @@ abstract class ByteBuffer private[nio] (
 
   private[nio] var _isBigEndian: Boolean = true
 
-  // TODO: JDK11
-  // def mismatch(that: ByteBuffer): Int  = ???
+  /** @since JDK 11 */
+  def mismatch(that: ByteBuffer): Int  = {
+    /* Circa SN 0.5.8 and well before, all Scala Native nio.Buffers,
+     * both direct and non-direct, have backing arrays.
+     * When a buffer is ReadOnly, that array is not accessible so one must
+     * compare the long, slow way.
+     */
+
+    if (this.hasArray() && that.hasArray()) {
+      ju.Arrays.mismatch(
+        this.array(),
+        this.position(),
+        this.limit(),
+        that.array(),
+        that.position(),
+        that.limit()
+      )
+    } else {
+      val thisStart = this.position()
+      val thisRemaining = this.remaining()
+
+      val thatStart = that.position()
+      val thatRemaining = that.remaining()
+
+      val shortestLength = Math.min(thisRemaining, thatRemaining)
+
+      var mismatchedAt = -1
+
+      try {
+        var j = 0
+        while((j < shortestLength) && (mismatchedAt < 0)) {
+          if (this.get() != that.get())
+            mismatchedAt = j
+          j += 1
+        }
+      } finally {
+        this.position(thisStart)
+        that.position(thatStart)
+      }
+
+      if (mismatchedAt > -1) mismatchedAt
+      else if (thisRemaining == thatRemaining) -1
+      else shortestLength
+    }
+  }
 
   private def genBuffer = GenBuffer[ByteBuffer](this)
 
@@ -72,7 +118,7 @@ abstract class ByteBuffer private[nio] (
     store(validateIndex(index), elem)
     this
   }
-  
+
   // Since: JDK 13
   def get(index: Int, dst: Array[Byte], offset: Int, length: Int): ByteBuffer = GenBuffer[ByteBuffer](this).generic_get(index, dst, offset, length)
   def get(index: Int, dst: Array[Byte]): ByteBuffer = get(index, dst, 0, dst.length)
@@ -93,7 +139,7 @@ abstract class ByteBuffer private[nio] (
     genBuffer.generic_put(src)
     // Since: JDK16
   def put(index: Int, src: ByteBuffer, offset: Int, length: Int) = GenBuffer[ByteBuffer](this).generic_put(index, src, offset, length)
-    
+
   @noinline
   def put(src: Array[Byte], offset: Int, length: Int): ByteBuffer =
     genBuffer.generic_put(src, offset, length)
@@ -387,8 +433,51 @@ abstract class CharBuffer private[nio] (
   private[nio] type BufferType = CharBuffer
 
 
-  // TODO: JDK11
-  // def mismatch(that: CharBuffer): Int  = ???
+  /** @since JDK 11 */
+  def mismatch(that: CharBuffer): Int  = {
+    /* Circa SN 0.5.8 and well before, all Scala Native nio.Buffers,
+     * both direct and non-direct, have backing arrays.
+     * When a buffer is ReadOnly, that array is not accessible so one must
+     * compare the long, slow way.
+     */
+
+    if (this.hasArray() && that.hasArray()) {
+      ju.Arrays.mismatch(
+        this.array(),
+        this.position(),
+        this.limit(),
+        that.array(),
+        that.position(),
+        that.limit()
+      )
+    } else {
+      val thisStart = this.position()
+      val thisRemaining = this.remaining()
+
+      val thatStart = that.position()
+      val thatRemaining = that.remaining()
+
+      val shortestLength = Math.min(thisRemaining, thatRemaining)
+
+      var mismatchedAt = -1
+
+      try {
+        var j = 0
+        while((j < shortestLength) && (mismatchedAt < 0)) {
+          if (this.get() != that.get())
+            mismatchedAt = j
+          j += 1
+        }
+      } finally {
+        this.position(thisStart)
+        that.position(thatStart)
+      }
+
+      if (mismatchedAt > -1) mismatchedAt
+      else if (thisRemaining == thatRemaining) -1
+      else shortestLength
+    }
+  }
 
   private def genBuffer = GenBuffer[CharBuffer](this)
 
@@ -420,7 +509,7 @@ abstract class CharBuffer private[nio] (
     store(validateIndex(index), elem)
     this
   }
-  
+
   // Since: JDK 13
   def get(index: Int, dst: Array[Char], offset: Int, length: Int): CharBuffer = GenBuffer[CharBuffer](this).generic_get(index, dst, offset, length)
   def get(index: Int, dst: Array[Char]): CharBuffer = get(index, dst, 0, dst.length)
@@ -441,7 +530,7 @@ abstract class CharBuffer private[nio] (
     genBuffer.generic_put(src)
     // Since: JDK16
   def put(index: Int, src: CharBuffer, offset: Int, length: Int) = GenBuffer[CharBuffer](this).generic_put(index, src, offset, length)
-    
+
   @noinline
   def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
     genBuffer.generic_put(src, offset, length)
@@ -621,8 +710,51 @@ abstract class ShortBuffer private[nio] (
   private[nio] type BufferType = ShortBuffer
 
 
-  // TODO: JDK11
-  // def mismatch(that: ShortBuffer): Int  = ???
+  /** @since JDK 11 */
+  def mismatch(that: ShortBuffer): Int  = {
+    /* Circa SN 0.5.8 and well before, all Scala Native nio.Buffers,
+     * both direct and non-direct, have backing arrays.
+     * When a buffer is ReadOnly, that array is not accessible so one must
+     * compare the long, slow way.
+     */
+
+    if (this.hasArray() && that.hasArray()) {
+      ju.Arrays.mismatch(
+        this.array(),
+        this.position(),
+        this.limit(),
+        that.array(),
+        that.position(),
+        that.limit()
+      )
+    } else {
+      val thisStart = this.position()
+      val thisRemaining = this.remaining()
+
+      val thatStart = that.position()
+      val thatRemaining = that.remaining()
+
+      val shortestLength = Math.min(thisRemaining, thatRemaining)
+
+      var mismatchedAt = -1
+
+      try {
+        var j = 0
+        while((j < shortestLength) && (mismatchedAt < 0)) {
+          if (this.get() != that.get())
+            mismatchedAt = j
+          j += 1
+        }
+      } finally {
+        this.position(thisStart)
+        that.position(thatStart)
+      }
+
+      if (mismatchedAt > -1) mismatchedAt
+      else if (thisRemaining == thatRemaining) -1
+      else shortestLength
+    }
+  }
 
   private def genBuffer = GenBuffer[ShortBuffer](this)
 
@@ -654,7 +786,7 @@ abstract class ShortBuffer private[nio] (
     store(validateIndex(index), elem)
     this
   }
-  
+
   // Since: JDK 13
   def get(index: Int, dst: Array[Short], offset: Int, length: Int): ShortBuffer = GenBuffer[ShortBuffer](this).generic_get(index, dst, offset, length)
   def get(index: Int, dst: Array[Short]): ShortBuffer = get(index, dst, 0, dst.length)
@@ -675,7 +807,7 @@ abstract class ShortBuffer private[nio] (
     genBuffer.generic_put(src)
     // Since: JDK16
   def put(index: Int, src: ShortBuffer, offset: Int, length: Int) = GenBuffer[ShortBuffer](this).generic_put(index, src, offset, length)
-    
+
   @noinline
   def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
     genBuffer.generic_put(src, offset, length)
@@ -805,8 +937,51 @@ abstract class IntBuffer private[nio] (
   private[nio] type BufferType = IntBuffer
 
 
-  // TODO: JDK11
-  // def mismatch(that: IntBuffer): Int  = ???
+  /** @since JDK 11 */
+  def mismatch(that: IntBuffer): Int  = {
+    /* Circa SN 0.5.8 and well before, all Scala Native nio.Buffers,
+     * both direct and non-direct, have backing arrays.
+     * When a buffer is ReadOnly, that array is not accessible so one must
+     * compare the long, slow way.
+     */
+
+    if (this.hasArray() && that.hasArray()) {
+      ju.Arrays.mismatch(
+        this.array(),
+        this.position(),
+        this.limit(),
+        that.array(),
+        that.position(),
+        that.limit()
+      )
+    } else {
+      val thisStart = this.position()
+      val thisRemaining = this.remaining()
+
+      val thatStart = that.position()
+      val thatRemaining = that.remaining()
+
+      val shortestLength = Math.min(thisRemaining, thatRemaining)
+
+      var mismatchedAt = -1
+
+      try {
+        var j = 0
+        while((j < shortestLength) && (mismatchedAt < 0)) {
+          if (this.get() != that.get())
+            mismatchedAt = j
+          j += 1
+        }
+      } finally {
+        this.position(thisStart)
+        that.position(thatStart)
+      }
+
+      if (mismatchedAt > -1) mismatchedAt
+      else if (thisRemaining == thatRemaining) -1
+      else shortestLength
+    }
+  }
 
   private def genBuffer = GenBuffer[IntBuffer](this)
 
@@ -838,7 +1013,7 @@ abstract class IntBuffer private[nio] (
     store(validateIndex(index), elem)
     this
   }
-  
+
   // Since: JDK 13
   def get(index: Int, dst: Array[Int], offset: Int, length: Int): IntBuffer = GenBuffer[IntBuffer](this).generic_get(index, dst, offset, length)
   def get(index: Int, dst: Array[Int]): IntBuffer = get(index, dst, 0, dst.length)
@@ -859,7 +1034,7 @@ abstract class IntBuffer private[nio] (
     genBuffer.generic_put(src)
     // Since: JDK16
   def put(index: Int, src: IntBuffer, offset: Int, length: Int) = GenBuffer[IntBuffer](this).generic_put(index, src, offset, length)
-    
+
   @noinline
   def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
     genBuffer.generic_put(src, offset, length)
@@ -989,8 +1164,51 @@ abstract class LongBuffer private[nio] (
   private[nio] type BufferType = LongBuffer
 
 
-  // TODO: JDK11
-  // def mismatch(that: LongBuffer): Int  = ???
+  /** @since JDK 11 */
+  def mismatch(that: LongBuffer): Int  = {
+    /* Circa SN 0.5.8 and well before, all Scala Native nio.Buffers,
+     * both direct and non-direct, have backing arrays.
+     * When a buffer is ReadOnly, that array is not accessible so one must
+     * compare the long, slow way.
+     */
+
+    if (this.hasArray() && that.hasArray()) {
+      ju.Arrays.mismatch(
+        this.array(),
+        this.position(),
+        this.limit(),
+        that.array(),
+        that.position(),
+        that.limit()
+      )
+    } else {
+      val thisStart = this.position()
+      val thisRemaining = this.remaining()
+
+      val thatStart = that.position()
+      val thatRemaining = that.remaining()
+
+      val shortestLength = Math.min(thisRemaining, thatRemaining)
+
+      var mismatchedAt = -1
+
+      try {
+        var j = 0
+        while((j < shortestLength) && (mismatchedAt < 0)) {
+          if (this.get() != that.get())
+            mismatchedAt = j
+          j += 1
+        }
+      } finally {
+        this.position(thisStart)
+        that.position(thatStart)
+      }
+
+      if (mismatchedAt > -1) mismatchedAt
+      else if (thisRemaining == thatRemaining) -1
+      else shortestLength
+    }
+  }
 
   private def genBuffer = GenBuffer[LongBuffer](this)
 
@@ -1022,7 +1240,7 @@ abstract class LongBuffer private[nio] (
     store(validateIndex(index), elem)
     this
   }
-  
+
   // Since: JDK 13
   def get(index: Int, dst: Array[Long], offset: Int, length: Int): LongBuffer = GenBuffer[LongBuffer](this).generic_get(index, dst, offset, length)
   def get(index: Int, dst: Array[Long]): LongBuffer = get(index, dst, 0, dst.length)
@@ -1043,7 +1261,7 @@ abstract class LongBuffer private[nio] (
     genBuffer.generic_put(src)
     // Since: JDK16
   def put(index: Int, src: LongBuffer, offset: Int, length: Int) = GenBuffer[LongBuffer](this).generic_put(index, src, offset, length)
-    
+
   @noinline
   def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
     genBuffer.generic_put(src, offset, length)
@@ -1173,8 +1391,51 @@ abstract class FloatBuffer private[nio] (
   private[nio] type BufferType = FloatBuffer
 
 
-  // TODO: JDK11
-  // def mismatch(that: FloatBuffer): Int  = ???
+  /** @since JDK 11 */
+  def mismatch(that: FloatBuffer): Int  = {
+    /* Circa SN 0.5.8 and well before, all Scala Native nio.Buffers,
+     * both direct and non-direct, have backing arrays.
+     * When a buffer is ReadOnly, that array is not accessible so one must
+     * compare the long, slow way.
+     */
+
+    if (this.hasArray() && that.hasArray()) {
+      ju.Arrays.mismatch(
+        this.array(),
+        this.position(),
+        this.limit(),
+        that.array(),
+        that.position(),
+        that.limit()
+      )
+    } else {
+      val thisStart = this.position()
+      val thisRemaining = this.remaining()
+
+      val thatStart = that.position()
+      val thatRemaining = that.remaining()
+
+      val shortestLength = Math.min(thisRemaining, thatRemaining)
+
+      var mismatchedAt = -1
+
+      try {
+        var j = 0
+        while((j < shortestLength) && (mismatchedAt < 0)) {
+          if (this.get() != that.get())
+            mismatchedAt = j
+          j += 1
+        }
+      } finally {
+        this.position(thisStart)
+        that.position(thatStart)
+      }
+
+      if (mismatchedAt > -1) mismatchedAt
+      else if (thisRemaining == thatRemaining) -1
+      else shortestLength
+    }
+  }
 
   private def genBuffer = GenBuffer[FloatBuffer](this)
 
@@ -1206,7 +1467,7 @@ abstract class FloatBuffer private[nio] (
     store(validateIndex(index), elem)
     this
   }
-  
+
   // Since: JDK 13
   def get(index: Int, dst: Array[Float], offset: Int, length: Int): FloatBuffer = GenBuffer[FloatBuffer](this).generic_get(index, dst, offset, length)
   def get(index: Int, dst: Array[Float]): FloatBuffer = get(index, dst, 0, dst.length)
@@ -1227,7 +1488,7 @@ abstract class FloatBuffer private[nio] (
     genBuffer.generic_put(src)
     // Since: JDK16
   def put(index: Int, src: FloatBuffer, offset: Int, length: Int) = GenBuffer[FloatBuffer](this).generic_put(index, src, offset, length)
-    
+
   @noinline
   def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
     genBuffer.generic_put(src, offset, length)
@@ -1357,8 +1618,51 @@ abstract class DoubleBuffer private[nio] (
   private[nio] type BufferType = DoubleBuffer
 
 
-  // TODO: JDK11
-  // def mismatch(that: DoubleBuffer): Int  = ???
+  /** @since JDK 11 */
+  def mismatch(that: DoubleBuffer): Int  = {
+    /* Circa SN 0.5.8 and well before, all Scala Native nio.Buffers,
+     * both direct and non-direct, have backing arrays.
+     * When a buffer is ReadOnly, that array is not accessible so one must
+     * compare the long, slow way.
+     */
+
+    if (this.hasArray() && that.hasArray()) {
+      ju.Arrays.mismatch(
+        this.array(),
+        this.position(),
+        this.limit(),
+        that.array(),
+        that.position(),
+        that.limit()
+      )
+    } else {
+      val thisStart = this.position()
+      val thisRemaining = this.remaining()
+
+      val thatStart = that.position()
+      val thatRemaining = that.remaining()
+
+      val shortestLength = Math.min(thisRemaining, thatRemaining)
+
+      var mismatchedAt = -1
+
+      try {
+        var j = 0
+        while((j < shortestLength) && (mismatchedAt < 0)) {
+          if (this.get() != that.get())
+            mismatchedAt = j
+          j += 1
+        }
+      } finally {
+        this.position(thisStart)
+        that.position(thatStart)
+      }
+
+      if (mismatchedAt > -1) mismatchedAt
+      else if (thisRemaining == thatRemaining) -1
+      else shortestLength
+    }
+  }
 
   private def genBuffer = GenBuffer[DoubleBuffer](this)
 
@@ -1390,7 +1694,7 @@ abstract class DoubleBuffer private[nio] (
     store(validateIndex(index), elem)
     this
   }
-  
+
   // Since: JDK 13
   def get(index: Int, dst: Array[Double], offset: Int, length: Int): DoubleBuffer = GenBuffer[DoubleBuffer](this).generic_get(index, dst, offset, length)
   def get(index: Int, dst: Array[Double]): DoubleBuffer = get(index, dst, 0, dst.length)
@@ -1411,7 +1715,7 @@ abstract class DoubleBuffer private[nio] (
     genBuffer.generic_put(src)
     // Since: JDK16
   def put(index: Int, src: DoubleBuffer, offset: Int, length: Int) = GenBuffer[DoubleBuffer](this).generic_put(index, src, offset, length)
-    
+
   @noinline
   def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
     genBuffer.generic_put(src, offset, length)

--- a/javalib/src/main/scala/java/nio/Buffers.scala.gyb
+++ b/javalib/src/main/scala/java/nio/Buffers.scala.gyb
@@ -2,11 +2,14 @@
 package java.nio
 
 // Ported from Scala.js
+// Also has JDK 11 & 16 Additions for Scala Native
 import scala.scalanative.unsafe
 import scala.scalanative.unsafe.UnsafeRichArray
 import scala.scalanative.runtime.{fromRawPtr, toRawPtr}
 import scala.scalanative.runtime.Intrinsics
 import scala.scalanative.annotation.alwaysinline
+
+import java.{util => ju}
 
 %{
    variants = [
@@ -25,7 +28,7 @@ object ${T}Buffer {
 
   def allocate(capacity: Int): ${T}Buffer = wrap(new Array[${T}](capacity))
 
-% if T == 'Byte': 
+% if T == 'Byte':
   def allocateDirect(capacity: Int): ${T}Buffer = allocate(capacity)
 % end
 
@@ -54,7 +57,7 @@ abstract class ${T}Buffer private[nio] (
     private[nio] val _offset: Int,
     _address: unsafe.CVoidPtr,
 ) extends Buffer(_capacity, _address)
-    with Comparable[${T}Buffer] 
+    with Comparable[${T}Buffer]
 % if T == 'Char':
     with CharSequence
     with Appendable
@@ -68,8 +71,51 @@ abstract class ${T}Buffer private[nio] (
   private[nio] var _isBigEndian: Boolean = true
 % end
 
-  // TODO: JDK11
-  // def mismatch(that: ${T}Buffer): Int  = ???
+  /** @since JDK 11 */
+  def mismatch(that: ${T}Buffer): Int  = {
+    /* Circa SN 0.5.8 and well before, all Scala Native nio.Buffers,
+     * both direct and non-direct, have backing arrays.
+     * When a buffer is ReadOnly, that array is not accessible so one must
+     * compare the long, slow way.
+     */
+
+    if (this.hasArray() && that.hasArray()) {
+      ju.Arrays.mismatch(
+        this.array(),
+        this.position(),
+        this.limit(),
+        that.array(),
+        that.position(),
+        that.limit()
+      )
+    } else {
+      val thisStart = this.position()
+      val thisRemaining = this.remaining()
+
+      val thatStart = that.position()
+      val thatRemaining = that.remaining()
+
+      val shortestLength = Math.min(thisRemaining, thatRemaining)
+
+      var mismatchedAt = -1
+
+      try {
+        var j = 0
+        while((j < shortestLength) && (mismatchedAt < 0)) {
+          if (this.get() != that.get())
+            mismatchedAt = j
+          j += 1
+        }
+      } finally {
+        this.position(thisStart)
+        that.position(thatStart)
+      }
+
+      if (mismatchedAt > -1) mismatchedAt
+      else if (thisRemaining == thatRemaining) -1
+      else shortestLength
+    }
+  }
 
   private def genBuffer = GenBuffer[${T}Buffer](this)
 
@@ -101,14 +147,14 @@ abstract class ${T}Buffer private[nio] (
     store(validateIndex(index), elem)
     this
   }
-  
+
   // Since: JDK 13
   def get(index: Int, dst: Array[${T}], offset: Int, length: Int): ${T}Buffer = GenBuffer[${T}Buffer](this).generic_get(index, dst, offset, length)
-  def get(index: Int, dst: Array[${T}]): ${T}Buffer = get(index, dst, 0, dst.length) 
+  def get(index: Int, dst: Array[${T}]): ${T}Buffer = get(index, dst, 0, dst.length)
 
   // Since: JDK13
   def put(index: Int, src: Array[${T}], offset: Int, length: Int): ${T}Buffer = GenBuffer[${T}Buffer](this).generic_put(index, src, offset, length)
-  def put(index: Int, src: Array[${T}]): ${T}Buffer = put(index, src, 0, src.length)  
+  def put(index: Int, src: Array[${T}]): ${T}Buffer = put(index, src, 0, src.length)
 
   @noinline
   def get(dst: Array[${T}], offset: Int, length: Int): ${T}Buffer =
@@ -122,7 +168,7 @@ abstract class ${T}Buffer private[nio] (
     genBuffer.generic_put(src)
     // Since: JDK16
   def put(index: Int, src: ${T}Buffer, offset: Int, length: Int) = GenBuffer[${T}Buffer](this).generic_put(index, src, offset, length)
-    
+
   @noinline
   def put(src: Array[${T}], offset: Int, length: Int): ${T}Buffer =
     genBuffer.generic_put(src, offset, length)
@@ -136,7 +182,7 @@ abstract class ${T}Buffer private[nio] (
 
   final def put(src: String): CharBuffer =
     put(src, 0, src.length)
-% end 
+% end
 
   @inline final def hasArray(): Boolean =
     genBuffer.generic_hasArray()
@@ -237,7 +283,7 @@ abstract class ${T}Buffer private[nio] (
   }
 %else:
   def order(): ByteOrder
-%end 
+%end
 
 %if T == 'Byte':
 %for (E, unused, Size, JavaType) in variants:
@@ -252,7 +298,7 @@ abstract class ${T}Buffer private[nio] (
   def put${E}(index: Int, value: ${E}): ByteBuffer = {
     ensureNotReadOnly()
     store${E}(validateIndex(index, ${Size}), value)
-  }  
+  }
   @alwaysinline private def load${E}(index: Int): ${E} = {
 %if E == 'Float':
     val value = Intrinsics.loadInt(Intrinsics.elemRawPtr(_rawAddress, index))

--- a/scripts/gyb_all.sh
+++ b/scripts/gyb_all.sh
@@ -8,12 +8,13 @@ scalaNext=scala-next
 unsafe=scala/scalanative/unsafe
 unsigned=scala/scalanative/unsigned
 runtime=scala/scalanative/runtime
-javaNIO=javalib/src/main/scala/java/nio/
+javaNIO=javalib/src/main/scala/java/nio
 javaUtil=javalib/src/main/scala/java/util
 
 sharedTest=unit-tests/shared/src/test
 
 javalibTestJDK9=${sharedTest}/require-jdk9/org/scalanative/testsuite/javalib
+javalibTestJDK11=${sharedTest}/require-jdk11/org/scalanative/testsuite/javalib
 
 function gyb() {
   file=$1
@@ -56,3 +57,4 @@ gyb unit-tests/native/src/test/scala/org/scalanative/testsuite/niobuffer/ByteBuf
 gyb unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/BufferAdapter.scala.template.gyb
 
 gyb ${javalibTestJDK9}/util/ArraysOfAnyValTestOnJDK9.scala.gyb
+gyb ${javalibTestJDK11}/nio/BuffersMismatchTestOnJDK11.scala.gyb

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/BuffersMismatchTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/BuffersMismatchTestOnJDK11.scala
@@ -1,0 +1,546 @@
+package org.scalanative.testsuite.javalib.nio.file
+
+/* This code is generated from BuffersMismatchTestOnJDK11.scala.gyb.
+ * Any edits here and not in the .gyb will be lost when this file is next
+ * generated.
+ */
+
+
+// format: off
+
+import java.nio.ByteOrder
+
+import java.nio.ByteBuffer
+import java.nio.CharBuffer
+import java.nio.DoubleBuffer
+import java.nio.FloatBuffer
+import java.nio.IntBuffer
+import java.nio.LongBuffer
+import java.nio.ShortBuffer
+
+import java.{util => ju}
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Ignore
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class BuffersMismatchTestOnJDK11 {
+
+  private val fullData =
+    ju.List.of('-', '|', 'a', 'b', 'c', 'd', 'e', '|', '-', '$')
+
+  private val matchData =
+    ju.List.of('a', 'b', 'c', 'd', 'e')
+
+  @Test def byteBuffersMismatchBE(): Unit = {
+
+    val byteBufA = ByteBuffer.allocate(matchData.size())
+    matchData.forEach(e => byteBufA.put(e.toByte))
+    byteBufA.flip()
+
+    /* Try to trip things up and expose bugs.
+     * Skew byteBufferB so that its position is not zero and it has both
+     *	a matching range and some characters in the buffer after that range.
+     */
+    val byteBufB = ByteBuffer.allocate(fullData.size())
+    fullData.forEach(e => byteBufB.put(e.toByte))
+
+    val startPositionByteBufB = 2
+    val endLimitByteBufB = byteBufB.limit() - 3
+    byteBufB
+      .flip()
+      .position(startPositionByteBufB)
+      .limit(endLimitByteBufB)
+
+    val byteBufC = ByteBuffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => byteBufC.put(e.toByte))
+    byteBufC.put('M'.toByte)
+    byteBufC.flip()
+
+    assertEquals("bufA should match bufB", -1, byteBufA.mismatch(byteBufB))
+
+    assertEquals("byteBufA position should not move", 0, byteBufA.position())
+    assertEquals(
+      "byteBufB position should not move",
+      startPositionByteBufB,
+      byteBufB.position()
+    )
+
+    val changeAt = 3
+    byteBufB.put(startPositionByteBufB + changeAt, 'z'.toByte)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      byteBufA.mismatch(byteBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      byteBufA.mismatch(byteBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      byteBufC.mismatch(byteBufA)
+    )
+  }
+
+  @Test def byteBuffersMismatchLE(): Unit = {
+
+    val byteBufA = ByteBuffer
+      .allocate(matchData.size())
+      .order(ByteOrder.LITTLE_ENDIAN)
+    matchData.forEach(e => byteBufA.put(e.toByte))
+    byteBufA.flip()
+
+    /* Try to trip things up and expose bugs.
+     * Skew byteBufferB so that its position is not zero and it has both
+     *	a matching range and some characters in the buffer after that range.
+     */
+    val byteBufB = ByteBuffer
+      .allocate(fullData.size())
+      .order(ByteOrder.LITTLE_ENDIAN)
+    fullData.forEach(e => byteBufB.put(e.toByte))
+
+    val startPositionByteBufB = 2
+    val endLimitByteBufB = byteBufB.limit() - 3
+    byteBufB
+      .flip()
+      .position(startPositionByteBufB)
+      .limit(endLimitByteBufB)
+
+    val byteBufC = ByteBuffer
+      .allocate(matchData.size() + 1)
+      .order(ByteOrder.LITTLE_ENDIAN)
+    matchData.forEach(e => byteBufC.put(e.toByte))
+    byteBufC.put('M'.toByte)
+    byteBufC.flip()
+
+    assertEquals("bufA should match bufB", -1, byteBufA.mismatch(byteBufB))
+
+    assertEquals("byteBufA position should not move", 0, byteBufA.position())
+    assertEquals(
+      "byteBufB position should not move",
+      startPositionByteBufB,
+      byteBufB.position()
+    )
+
+    val changeAt = 3
+    byteBufB.put(startPositionByteBufB + changeAt, 'z'.toByte)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      byteBufA.mismatch(byteBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      byteBufA.mismatch(byteBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      byteBufC.mismatch(byteBufA)
+    )
+  }
+
+  @Test def byteBuffersMismatchReadOnly(): Unit = {
+
+    val byteBufA = {
+      val bb = ByteBuffer.allocate(matchData.size())
+      matchData.forEach(e => bb.put(e.toByte))
+      bb.asReadOnlyBuffer()
+    }
+
+    byteBufA.flip()
+
+    val byteBufB = {
+      val bb = ByteBuffer.allocate(matchData.size())
+      matchData.forEach(e => bb.put(e.toByte))
+      bb.asReadOnlyBuffer()
+    }
+
+    byteBufB.flip()
+
+    val mismatchAt = 3
+
+    val byteBufC = {
+      val bb = ByteBuffer.allocate(matchData.size())
+      matchData.forEach(e => bb.put(e.toByte))
+      bb.put(mismatchAt, 'z'.toByte).asReadOnlyBuffer()
+    }
+
+    byteBufC.flip()
+
+    val byteBufD = {
+      val bb = ByteBuffer.allocate(matchData.size() + 1)
+      matchData.forEach(e => bb.put(e.toByte))
+      bb.put('M'.toByte).asReadOnlyBuffer()
+    }
+
+    byteBufD.flip()
+
+    assertEquals("bufA should match bufB", -1, byteBufA.mismatch(byteBufB))
+
+    assertEquals("byteBufA position should not move", 0, byteBufA.position())
+    assertEquals("byteBufB position should not move", 0, byteBufB.position())
+
+    assertEquals(
+      "bufA should mismatch bufC",
+      mismatchAt,
+      byteBufA.mismatch(byteBufC)
+    )
+
+    assertEquals(
+      "bufA < bufD",
+      matchData.size(),
+      byteBufA.mismatch(byteBufD)
+    )
+
+    assertEquals(
+      "bufD < bufA",
+      matchData.size(),
+      byteBufD.mismatch(byteBufA)
+    )
+  }
+
+
+  @Test def CharBuffersMismatchNativeOrder(): Unit = {
+
+    val charBufA = CharBuffer.allocate(matchData.size())
+    matchData.forEach(e => charBufA.put(e.toChar))
+    charBufA.flip()
+
+    val charBufB = CharBuffer.allocate(matchData.size())
+    matchData.forEach(e => charBufB.put(e.toChar))
+    charBufB.flip()
+
+    val charBufC = CharBuffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => charBufC.put(e.toChar))
+    charBufC.put('M'.toChar)
+    charBufC.flip()
+
+    assertEquals("bufA should match bufB",
+                 -1,
+                 charBufA.mismatch(charBufB))
+
+    assertEquals("charBufA position should not move",
+                 0,
+                 charBufA.position())
+    assertEquals("charBufB position should not move",
+                 0,
+                 charBufB.position())
+
+    val changeAt = 4
+    charBufB.put(changeAt, 'z'.toChar)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      charBufA.mismatch(charBufB)
+    )
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      charBufA.mismatch(charBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      charBufA.mismatch(charBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      charBufC.mismatch(charBufA)
+    )
+  }
+
+
+  @Test def DoubleBuffersMismatchNativeOrder(): Unit = {
+
+    val doubleBufA = DoubleBuffer.allocate(matchData.size())
+    matchData.forEach(e => doubleBufA.put(e.toDouble))
+    doubleBufA.flip()
+
+    val doubleBufB = DoubleBuffer.allocate(matchData.size())
+    matchData.forEach(e => doubleBufB.put(e.toDouble))
+    doubleBufB.flip()
+
+    val doubleBufC = DoubleBuffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => doubleBufC.put(e.toDouble))
+    doubleBufC.put('M'.toDouble)
+    doubleBufC.flip()
+
+    assertEquals("bufA should match bufB",
+                 -1,
+                 doubleBufA.mismatch(doubleBufB))
+
+    assertEquals("doubleBufA position should not move",
+                 0,
+                 doubleBufA.position())
+    assertEquals("doubleBufB position should not move",
+                 0,
+                 doubleBufB.position())
+
+    val changeAt = 4
+    doubleBufB.put(changeAt, 'z'.toDouble)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      doubleBufA.mismatch(doubleBufB)
+    )
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      doubleBufA.mismatch(doubleBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      doubleBufA.mismatch(doubleBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      doubleBufC.mismatch(doubleBufA)
+    )
+  }
+
+
+  @Test def FloatBuffersMismatchNativeOrder(): Unit = {
+
+    val floatBufA = FloatBuffer.allocate(matchData.size())
+    matchData.forEach(e => floatBufA.put(e.toFloat))
+    floatBufA.flip()
+
+    val floatBufB = FloatBuffer.allocate(matchData.size())
+    matchData.forEach(e => floatBufB.put(e.toFloat))
+    floatBufB.flip()
+
+    val floatBufC = FloatBuffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => floatBufC.put(e.toFloat))
+    floatBufC.put('M'.toFloat)
+    floatBufC.flip()
+
+    assertEquals("bufA should match bufB",
+                 -1,
+                 floatBufA.mismatch(floatBufB))
+
+    assertEquals("floatBufA position should not move",
+                 0,
+                 floatBufA.position())
+    assertEquals("floatBufB position should not move",
+                 0,
+                 floatBufB.position())
+
+    val changeAt = 4
+    floatBufB.put(changeAt, 'z'.toFloat)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      floatBufA.mismatch(floatBufB)
+    )
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      floatBufA.mismatch(floatBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      floatBufA.mismatch(floatBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      floatBufC.mismatch(floatBufA)
+    )
+  }
+
+
+  @Test def IntBuffersMismatchNativeOrder(): Unit = {
+
+    val integerBufA = IntBuffer.allocate(matchData.size())
+    matchData.forEach(e => integerBufA.put(e.toInt))
+    integerBufA.flip()
+
+    val integerBufB = IntBuffer.allocate(matchData.size())
+    matchData.forEach(e => integerBufB.put(e.toInt))
+    integerBufB.flip()
+
+    val integerBufC = IntBuffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => integerBufC.put(e.toInt))
+    integerBufC.put('M'.toInt)
+    integerBufC.flip()
+
+    assertEquals("bufA should match bufB",
+                 -1,
+                 integerBufA.mismatch(integerBufB))
+
+    assertEquals("integerBufA position should not move",
+                 0,
+                 integerBufA.position())
+    assertEquals("integerBufB position should not move",
+                 0,
+                 integerBufB.position())
+
+    val changeAt = 4
+    integerBufB.put(changeAt, 'z'.toInt)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      integerBufA.mismatch(integerBufB)
+    )
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      integerBufA.mismatch(integerBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      integerBufA.mismatch(integerBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      integerBufC.mismatch(integerBufA)
+    )
+  }
+
+
+  @Test def LongBuffersMismatchNativeOrder(): Unit = {
+
+    val longBufA = LongBuffer.allocate(matchData.size())
+    matchData.forEach(e => longBufA.put(e.toLong))
+    longBufA.flip()
+
+    val longBufB = LongBuffer.allocate(matchData.size())
+    matchData.forEach(e => longBufB.put(e.toLong))
+    longBufB.flip()
+
+    val longBufC = LongBuffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => longBufC.put(e.toLong))
+    longBufC.put('M'.toLong)
+    longBufC.flip()
+
+    assertEquals("bufA should match bufB",
+                 -1,
+                 longBufA.mismatch(longBufB))
+
+    assertEquals("longBufA position should not move",
+                 0,
+                 longBufA.position())
+    assertEquals("longBufB position should not move",
+                 0,
+                 longBufB.position())
+
+    val changeAt = 4
+    longBufB.put(changeAt, 'z'.toLong)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      longBufA.mismatch(longBufB)
+    )
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      longBufA.mismatch(longBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      longBufA.mismatch(longBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      longBufC.mismatch(longBufA)
+    )
+  }
+
+
+  @Test def ShortBuffersMismatchNativeOrder(): Unit = {
+
+    val shortBufA = ShortBuffer.allocate(matchData.size())
+    matchData.forEach(e => shortBufA.put(e.toShort))
+    shortBufA.flip()
+
+    val shortBufB = ShortBuffer.allocate(matchData.size())
+    matchData.forEach(e => shortBufB.put(e.toShort))
+    shortBufB.flip()
+
+    val shortBufC = ShortBuffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => shortBufC.put(e.toShort))
+    shortBufC.put('M'.toShort)
+    shortBufC.flip()
+
+    assertEquals("bufA should match bufB",
+                 -1,
+                 shortBufA.mismatch(shortBufB))
+
+    assertEquals("shortBufA position should not move",
+                 0,
+                 shortBufA.position())
+    assertEquals("shortBufB position should not move",
+                 0,
+                 shortBufB.position())
+
+    val changeAt = 4
+    shortBufB.put(changeAt, 'z'.toShort)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      shortBufA.mismatch(shortBufB)
+    )
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      shortBufA.mismatch(shortBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      shortBufA.mismatch(shortBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      shortBufC.mismatch(shortBufA)
+    )
+  }
+
+
+}

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/BuffersMismatchTestOnJDK11.scala.gyb
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/BuffersMismatchTestOnJDK11.scala.gyb
@@ -1,0 +1,293 @@
+package org.scalanative.testsuite.javalib.nio.file
+
+%{
+## BuffersMismatchTestOnJDK11.scala.gyb
+##
+##
+## To generate this file's output manually, execute the python script
+## 'scripts/gyb.py' under the project root. For example, from the project root:
+##
+##   scripts/gyb.py \
+##     ${thisDirectory}/BuffersMismatchTestOnJDK11.scala.gyb \
+##     --line-directive '' \
+##     -o ${thisDirectory}/BuffersMismatchTestOnJDK11.scala
+}%
+/* This code is generated from BuffersMismatchTestOnJDK11.scala.gyb.
+ * Any edits here and not in the .gyb will be lost when this file is next
+ * generated.
+ */
+
+%{
+   variants = [
+     # scala.T,	 lowercase.T
+     ('Char',	 'char'),
+     ('Double',	 'double'),
+     ('Float',	 'float'),
+     ('Int',	 'integer'),
+     ('Long',	 'long'),
+     ('Short',	 'short')
+   ]
+}%
+
+// format: off
+
+import java.nio.ByteOrder
+
+import java.nio.ByteBuffer
+% for (T, lowercaseT) in variants:
+import java.nio.${T}Buffer
+% end ## for variants
+
+import java.{util => ju}
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Ignore
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class BuffersMismatchTestOnJDK11 {
+
+  private val fullData =
+    ju.List.of('-', '|', 'a', 'b', 'c', 'd', 'e', '|', '-', '$')
+
+  private val matchData =
+    ju.List.of('a', 'b', 'c', 'd', 'e')
+
+  @Test def byteBuffersMismatchBE(): Unit = {
+
+    val byteBufA = ByteBuffer.allocate(matchData.size())
+    matchData.forEach(e => byteBufA.put(e.toByte))
+    byteBufA.flip()
+
+    /* Try to trip things up and expose bugs.
+     * Skew byteBufferB so that its position is not zero and it has both
+     *	a matching range and some characters in the buffer after that range.
+     */
+    val byteBufB = ByteBuffer.allocate(fullData.size())
+    fullData.forEach(e => byteBufB.put(e.toByte))
+
+    val startPositionByteBufB = 2
+    val endLimitByteBufB = byteBufB.limit() - 3
+    byteBufB
+      .flip()
+      .position(startPositionByteBufB)
+      .limit(endLimitByteBufB)
+
+    val byteBufC = ByteBuffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => byteBufC.put(e.toByte))
+    byteBufC.put('M'.toByte)
+    byteBufC.flip()
+
+    assertEquals("bufA should match bufB", -1, byteBufA.mismatch(byteBufB))
+
+    assertEquals("byteBufA position should not move", 0, byteBufA.position())
+    assertEquals(
+      "byteBufB position should not move",
+      startPositionByteBufB,
+      byteBufB.position()
+    )
+
+    val changeAt = 3
+    byteBufB.put(startPositionByteBufB + changeAt, 'z'.toByte)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      byteBufA.mismatch(byteBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      byteBufA.mismatch(byteBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      byteBufC.mismatch(byteBufA)
+    )
+  }
+
+  @Test def byteBuffersMismatchLE(): Unit = {
+
+    val byteBufA = ByteBuffer
+      .allocate(matchData.size())
+      .order(ByteOrder.LITTLE_ENDIAN)
+    matchData.forEach(e => byteBufA.put(e.toByte))
+    byteBufA.flip()
+
+    /* Try to trip things up and expose bugs.
+     * Skew byteBufferB so that its position is not zero and it has both
+     *	a matching range and some characters in the buffer after that range.
+     */
+    val byteBufB = ByteBuffer
+      .allocate(fullData.size())
+      .order(ByteOrder.LITTLE_ENDIAN)
+    fullData.forEach(e => byteBufB.put(e.toByte))
+
+    val startPositionByteBufB = 2
+    val endLimitByteBufB = byteBufB.limit() - 3
+    byteBufB
+      .flip()
+      .position(startPositionByteBufB)
+      .limit(endLimitByteBufB)
+
+    val byteBufC = ByteBuffer
+      .allocate(matchData.size() + 1)
+      .order(ByteOrder.LITTLE_ENDIAN)
+    matchData.forEach(e => byteBufC.put(e.toByte))
+    byteBufC.put('M'.toByte)
+    byteBufC.flip()
+
+    assertEquals("bufA should match bufB", -1, byteBufA.mismatch(byteBufB))
+
+    assertEquals("byteBufA position should not move", 0, byteBufA.position())
+    assertEquals(
+      "byteBufB position should not move",
+      startPositionByteBufB,
+      byteBufB.position()
+    )
+
+    val changeAt = 3
+    byteBufB.put(startPositionByteBufB + changeAt, 'z'.toByte)
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      byteBufA.mismatch(byteBufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      byteBufA.mismatch(byteBufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      byteBufC.mismatch(byteBufA)
+    )
+  }
+
+  @Test def byteBuffersMismatchReadOnly(): Unit = {
+
+    val byteBufA = {
+      val bb = ByteBuffer.allocate(matchData.size())
+      matchData.forEach(e => bb.put(e.toByte))
+      bb.asReadOnlyBuffer()
+    }
+
+    byteBufA.flip()
+
+    val byteBufB = {
+      val bb = ByteBuffer.allocate(matchData.size())
+      matchData.forEach(e => bb.put(e.toByte))
+      bb.asReadOnlyBuffer()
+    }
+
+    byteBufB.flip()
+
+    val mismatchAt = 3
+
+    val byteBufC = {
+      val bb = ByteBuffer.allocate(matchData.size())
+      matchData.forEach(e => bb.put(e.toByte))
+      bb.put(mismatchAt, 'z'.toByte).asReadOnlyBuffer()
+    }
+
+    byteBufC.flip()
+
+    val byteBufD = {
+      val bb = ByteBuffer.allocate(matchData.size() + 1)
+      matchData.forEach(e => bb.put(e.toByte))
+      bb.put('M'.toByte).asReadOnlyBuffer()
+    }
+
+    byteBufD.flip()
+
+    assertEquals("bufA should match bufB", -1, byteBufA.mismatch(byteBufB))
+
+    assertEquals("byteBufA position should not move", 0, byteBufA.position())
+    assertEquals("byteBufB position should not move", 0, byteBufB.position())
+
+    assertEquals(
+      "bufA should mismatch bufC",
+      mismatchAt,
+      byteBufA.mismatch(byteBufC)
+    )
+
+    assertEquals(
+      "bufA < bufD",
+      matchData.size(),
+      byteBufA.mismatch(byteBufD)
+    )
+
+    assertEquals(
+      "bufD < bufA",
+      matchData.size(),
+      byteBufD.mismatch(byteBufA)
+    )
+  }
+
+% for (T, lowercaseT) in variants:
+
+  @Test def ${T}BuffersMismatchNativeOrder(): Unit = {
+
+    val ${lowercaseT}BufA = ${T}Buffer.allocate(matchData.size())
+    matchData.forEach(e => ${lowercaseT}BufA.put(e.to${T}))
+    ${lowercaseT}BufA.flip()
+
+    val ${lowercaseT}BufB = ${T}Buffer.allocate(matchData.size())
+    matchData.forEach(e => ${lowercaseT}BufB.put(e.to${T}))
+    ${lowercaseT}BufB.flip()
+
+    val ${lowercaseT}BufC = ${T}Buffer.allocate(matchData.size() + 1)
+    matchData.forEach(e => ${lowercaseT}BufC.put(e.to${T}))
+    ${lowercaseT}BufC.put('M'.to${T})
+    ${lowercaseT}BufC.flip()
+
+    assertEquals("bufA should match bufB",
+                 -1,
+                 ${lowercaseT}BufA.mismatch(${lowercaseT}BufB))
+
+    assertEquals("${lowercaseT}BufA position should not move",
+                 0,
+                 ${lowercaseT}BufA.position())
+    assertEquals("${lowercaseT}BufB position should not move",
+                 0,
+                 ${lowercaseT}BufB.position())
+
+    val changeAt = 4
+    ${lowercaseT}BufB.put(changeAt, 'z'.to${T})
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      ${lowercaseT}BufA.mismatch(${lowercaseT}BufB)
+    )
+
+    assertEquals(
+      "bufA should mismatch bufB",
+      changeAt,
+      ${lowercaseT}BufA.mismatch(${lowercaseT}BufB)
+    )
+
+    assertEquals(
+      "bufA < bufC",
+      matchData.size(),
+      ${lowercaseT}BufA.mismatch(${lowercaseT}BufC)
+    )
+
+    assertEquals(
+      "bufC < bufB",
+      matchData.size(),
+      ${lowercaseT}BufC.mismatch(${lowercaseT}BufA)
+    )
+  }
+
+% end ## for variants
+
+}


### PR DESCRIPTION

javalib now implements the `*Buffer#mismatch` methods introduced in JDK 11.