### PR TITLE
Update regionMatches and startsWith and port tests from Scala.js

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -214,16 +214,14 @@ final class _String()
   }
 
   def compareToIgnoreCase(str: _String): Int = {
-    var o1 = offset
-    var o2 = str.offset
-    val end = Math.min(offset + count, offset + str.count)
-    while (o1 < end) {
-      val cmp = caseFold(this.charAt(o1)) - caseFold(str.charAt(o2))
+    val end = Math.min(count, str.count)
+    var i = 0
+    while (i < end) {
+      val cmp = caseFold(this.charAt(i)) - caseFold(str.charAt(i))
       if (cmp != 0) {
         return cmp
       }
-      o1 += 1
-      o2 += 1
+      i += 1
     }
     count - str.count
   }

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -185,7 +185,9 @@ final class _String()
     if (0 <= index && index < count) {
       value(offset + index)
     } else {
-      throw new StringIndexOutOfBoundsException()
+      throw new StringIndexOutOfBoundsException(
+        s"String index out of range: $index"
+      )
     }
   }
 

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -21,16 +21,16 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   def isScala2_12 = ScalaNativeBuildInfo.scalaVersion.startsWith("2.12")
 
   @Test def default(): Unit = checkMinimalRequiredSymbols()(expected =
-    if (isScala3) SymbolsCount(types = 614, members = 2963)
-    else if (isScala2_13) SymbolsCount(types = 590, members = 2970)
-    else SymbolsCount(types = 686, members = 4048)
+    if (isScala3) SymbolsCount(types = 617, members = 3019)
+    else if (isScala2_13) SymbolsCount(types = 592, members = 3026)
+    else SymbolsCount(types = 690, members = 4143)
   )
 
   @Test def debugMetadata(): Unit =
     checkMinimalRequiredSymbols(withDebugMetadata = true)(expected =
-      if (isScala3) SymbolsCount(types = 614, members = 2963)
-      else if (isScala2_13) SymbolsCount(types = 590, members = 2970)
-      else SymbolsCount(types = 686, members = 4048)
+      if (isScala3) SymbolsCount(types = 617, members = 3019)
+      else if (isScala2_13) SymbolsCount(types = 592, members = 3026)
+      else SymbolsCount(types = 690, members = 4143)
     )
 
   // Only MacOS and Linux DWARF metadata currently
@@ -39,9 +39,9 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-apple-darwin22.6.0"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1000, members = 6235)
+      if (isScala3) SymbolsCount(types = 1000, members = 6237)
       else if (isScala2_13) SymbolsCount(types = 982, members = 6743)
-      else SymbolsCount(types = 982, members = 6874)
+      else SymbolsCount(types = 982, members = 6876)
     )
 
   // Only MacOS and Linux DWARF metadata currently
@@ -50,16 +50,16 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-pc-linux-gnu"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1089, members = 7005)
+      if (isScala3) SymbolsCount(types = 1089, members = 7004)
       else if (isScala2_13) SymbolsCount(types = 1049, members = 7087)
-      else SymbolsCount(types = 1031, members = 7233)
+      else SymbolsCount(types = 1031, members = 7232)
     )
 
   @Test def multithreading(): Unit =
     checkMinimalRequiredSymbols(withMultithreading = true)(expected =
-      if (isScala3) SymbolsCount(types = 1076, members = 6684)
-      else if (isScala2_13) SymbolsCount(types = 1044, members = 6768)
-      else SymbolsCount(types = 988, members = 6738)
+      if (isScala3) SymbolsCount(types = 1076, members = 6686)
+      else if (isScala2_13) SymbolsCount(types = 1044, members = 6770)
+      else SymbolsCount(types = 988, members = 6740)
     )
 
   private def checkMinimalRequiredSymbols(

--- a/unit-tests/jvm/src/test/resources/DenylistedTests.txt
+++ b/unit-tests/jvm/src/test/resources/DenylistedTests.txt
@@ -6,7 +6,6 @@ org/scalanative/testsuite/javalib/lang/CharacterTest.scala
 org/scalanative/testsuite/javalib/lang/IntegerTest.scala
 org/scalanative/testsuite/javalib/lang/ShortTest.scala
 org/scalanative/testsuite/javalib/lang/LongTest.scala
-org/scalanative/testsuite/javalib/lang/StringTest.scala
 
 org/scalanative/testsuite/javalib/net/ServerSocketTest.scala
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
@@ -166,12 +166,58 @@ class StringTest {
     assertTrue("test".compareToIgnoreCase("Test") == 0)
     assertTrue("Test".compareToIgnoreCase("stest") > 0)
     assertTrue("tesT".compareToIgnoreCase("teSs") > 0)
+
+    // Scala Native substring based tests
+    assertTrue("test".compareToIgnoreCase("NativeUtest".substring(6)) < 0)
+    assertTrue("test".compareToIgnoreCase("NativeUtest".substring(6, 10)) < 0)
+    assertTrue("NativeUTest".substring(6).compareToIgnoreCase("test") > 0)
+    assertTrue("NativetesT".substring(6).compareToIgnoreCase("teSs") > 0)
+    assertTrue("test".compareToIgnoreCase("NativeTest".substring(6)) == 0)
+    assertTrue("NativeTest".substring(6).compareToIgnoreCase("test") == 0)
+
+    // Ported from Scala.js commit: 37df9c2ea dated: 2025-06-30
+    assertEquals(0, "Scala.JS".compareToIgnoreCase("Scala.js"))
+    assertEquals(3, "Scala.JS".compareToIgnoreCase("scala"))
+    assertEquals(0, "åløb".compareToIgnoreCase("ÅLØB"))
+    assertEquals(-9, "Java".compareToIgnoreCase("Scala"))
+
+    // Case folding that changes the string length are not supported,
+    // therefore ligatures are not equal to their expansion.
+    // U+FB00 LATIN SMALL LIGATURE FF
+    assertEquals(64154, "Eﬀet".compareToIgnoreCase("effEt"))
+    assertEquals(64154, "Eﬀet".compareToIgnoreCase("eFFEt"))
+
+    // "ı" and 'i' are considered equal, as well as their uppercase variants
+    assertEquals(
+      0,
+      "ıiIİ ıiIİ ıiIİ ıiIİ".compareToIgnoreCase("ıııı iiii IIII İİİİ")
+    )
   }
 
   @Test def equalsIgnoreCase(): Unit = {
     assertTrue("test".equalsIgnoreCase("TEST"))
     assertTrue("TEst".equalsIgnoreCase("teST"))
     assertTrue(!("SEst".equalsIgnoreCase("TEss")))
+
+    // Scala Native substring based tests
+
+    // Ported from Scala.js commit: 37df9c2ea dated: 2025-06-30
+    assertTrue("Scala.JS".equalsIgnoreCase("Scala.js"))
+    assertTrue("åløb".equalsIgnoreCase("ÅLØb"))
+    assertFalse("Scala.js".equalsIgnoreCase("Java"))
+    assertFalse("Scala.js".equalsIgnoreCase(null))
+
+    // Case folding that changes the string length are not supported,
+    // therefore ligatures are not equal to their expansion.
+    // U+FB00 LATIN SMALL LIGATURE FF
+    assertFalse("Eﬀet".equalsIgnoreCase("effEt"))
+    assertFalse("Eﬀet".equalsIgnoreCase("eFFEt"))
+
+    // "ı" and 'i' are considered equal, as well as their uppercase variants
+    assertTrue("ıiIİ ıiIİ ıiIİ ıiIİ".equalsIgnoreCase("ıııı iiii IIII İİİİ"))
+
+    // null is a valid input
+    assertFalse("foo".equalsIgnoreCase(null))
   }
 
   @Test def replaceChar(): Unit = {

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
@@ -173,12 +173,6 @@ class StringTest {
     assertTrue(!("SEst".equalsIgnoreCase("TEss")))
   }
 
-  @Test def regionMatches(): Unit = {
-    assertTrue("This is a test".regionMatches(10, "test", 0, 4))
-    assertTrue(!("This is a test".regionMatches(10, "TEST", 0, 4)))
-    assertTrue("This is a test".regionMatches(0, "This", 0, 4))
-  }
-
   @Test def replaceChar(): Unit = {
     assertTrue("test".replace('t', 'p').equals("pesp"))
     assertTrue("Test".replace('t', 'p').equals("Tesp"))
@@ -1061,6 +1055,100 @@ class StringTest {
       expected,
       joined
     )
+  }
+
+  // Ported from Scala.js commit: 37df9c2ea dated: 2025-06-30
+  @Test def startsWith(): Unit = {
+    assertTrue("Scala.js".startsWith("Scala"))
+    assertTrue("Scala.js".startsWith("Scala.js"))
+    assertFalse("Scala.js".startsWith("scala"))
+    assertTrue("ananas".startsWith("an"))
+
+    assertThrows(classOf[NullPointerException], "ananas".startsWith(null))
+  }
+
+  // Ported from Scala.js commit: 37df9c2ea dated: 2025-06-30
+  @Test def startsWithOffset(): Unit = {
+    assertTrue("Scala.js".startsWith("ala", 2))
+    assertTrue("Scala.js".startsWith("Scal", 0))
+
+    assertTrue("Scala.js".startsWith("", 3))
+    assertTrue("Scala.js".startsWith("", 0))
+    assertTrue("Scala.js".startsWith("", 8))
+
+    assertFalse("Scala.js".startsWith("ala", 0))
+    assertFalse("Scala.js".startsWith("Scal", 2))
+
+    assertFalse("Scala.js".startsWith("Sc", -1))
+    assertFalse("Scala.js".startsWith(".js", 10))
+    assertFalse("Scala.js".startsWith("", -1))
+    assertFalse("Scala.js".startsWith("", 9))
+
+    assertThrows(classOf[NullPointerException], "Scala.js".startsWith(null, 2))
+  }
+
+  // Ported from Scala.js commit: 37df9c2ea dated: 2025-06-30
+  // scalafmt: { maxColumn = 100 }
+  @Test def regionMatches(): Unit = {
+    // original Scala Native tests
+    assertTrue("This is a test".regionMatches(10, "test", 0, 4))
+    assertTrue(!("This is a test".regionMatches(10, "TEST", 0, 4)))
+    assertTrue("This is a test".regionMatches(0, "This", 0, 4))
+
+    /* Ported from
+     * https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/StringTest.java
+     */
+    val test = "abcdef"
+
+    assertTrue(test.regionMatches(1, "bcd", 0, 3))
+    assertTrue(test.regionMatches(1, "bcdx", 0, 3))
+    assertFalse(test.regionMatches(1, "bcdx", 0, 4))
+    assertFalse(test.regionMatches(1, "bcdx", 1, 3))
+    assertTrue(test.regionMatches(true, 0, "XAbCd", 1, 4))
+    assertTrue(test.regionMatches(true, 1, "BcD", 0, 3))
+    assertTrue(test.regionMatches(true, 1, "bCdx", 0, 3))
+    assertFalse(test.regionMatches(true, 1, "bCdx", 0, 4))
+    assertFalse(test.regionMatches(true, 1, "bCdx", 1, 3))
+    assertTrue(test.regionMatches(true, 0, "xaBcd", 1, 4))
+
+    val testU = test.toUpperCase()
+    assertTrue(testU.regionMatches(true, 0, "XAbCd", 1, 4))
+    assertTrue(testU.regionMatches(true, 1, "BcD", 0, 3))
+    assertTrue(testU.regionMatches(true, 1, "bCdx", 0, 3))
+    assertFalse(testU.regionMatches(true, 1, "bCdx", 0, 4))
+    assertFalse(testU.regionMatches(true, 1, "bCdx", 1, 3))
+    assertTrue(testU.regionMatches(true, 0, "xaBcd", 1, 4))
+
+    /* If len is negative, you must return true in some cases. See
+     * http://docs.oracle.com/javase/8/docs/api/java/lang/String.html#regionMatches-boolean-int-java.lang.String-int-int-
+     */
+
+    // four cases that are false, irrelevant of sign of len nor the value of the other string
+    assertFalse(test.regionMatches(-1, test, 0, -4))
+    assertFalse(test.regionMatches(0, test, -1, -4))
+    assertFalse(test.regionMatches(100, test, 0, -4))
+    assertFalse(test.regionMatches(0, test, 100, -4))
+
+    // offset + len > length
+    assertFalse(test.regionMatches(3, "defg", 0, 4)) // on receiver string
+    assertFalse(test.regionMatches(3, "abcde", 3, 3)) // on other string
+    assertFalse(test.regionMatches(Int.MaxValue, "ab", 0, 1)) // #4878 overflow, large toffset
+    assertFalse(test.regionMatches(0, "ab", Int.MaxValue, 1)) // #4878 overflow, large ooffset
+    assertFalse(test.regionMatches(1, "ab", 1, Int.MaxValue)) // #4878 overflow, large len
+    assertFalse(test.regionMatches(true, 3, "defg", 0, 4)) // on receiver string
+    assertFalse(test.regionMatches(true, 3, "abcde", 3, 3)) // on other string
+    assertFalse(test.regionMatches(true, Int.MaxValue, "ab", 0, 1)) // #4878 overflow, large toffset
+    assertFalse(test.regionMatches(true, 0, "ab", Int.MaxValue, 1)) // #4878 overflow, large ooffset
+    assertFalse(test.regionMatches(true, 1, "ab", 1, Int.MaxValue)) // #4878 overflow, large len
+
+    // the strange cases that are true
+    assertTrue(test.regionMatches(0, test, 0, -4))
+    assertTrue(test.regionMatches(1, "bcdx", 0, -4))
+    assertTrue(test.regionMatches(1, "bcdx", 1, -3))
+    assertTrue(test.regionMatches(true, 1, "bCdx", 0, -4))
+    assertTrue(test.regionMatches(true, 1, "bCdx", 1, -3))
+    assertTrue(testU.regionMatches(true, 1, "bCdx", 0, -4))
+    assertTrue(testU.regionMatches(true, 1, "bCdx", 1, -3))
   }
 
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/StringTest.scala
@@ -9,6 +9,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.executingInJVM
 
 class StringTest {
 
@@ -101,12 +102,12 @@ class StringTest {
     val data = "of human events"
 
     assertThrows(
-      classOf[java.lang.StringIndexOutOfBoundsException],
+      classOf[java.lang.IndexOutOfBoundsException],
       data.codePointBefore(-1)
     )
 
     assertThrows(
-      classOf[java.lang.StringIndexOutOfBoundsException],
+      classOf[java.lang.IndexOutOfBoundsException],
       // Careful here, +1 is valid +2 is not
       data.codePointBefore(data.length + 2)
     )
@@ -117,12 +118,12 @@ class StringTest {
     val data = "it becomes necessary"
 
     assertThrows(
-      classOf[java.lang.StringIndexOutOfBoundsException],
+      classOf[java.lang.IndexOutOfBoundsException],
       data.codePointCount(-1, data.length)
     )
 
     assertThrows(
-      classOf[java.lang.StringIndexOutOfBoundsException],
+      classOf[java.lang.IndexOutOfBoundsException],
       data.codePointCount(0, data.length + 1)
     )
   }
@@ -645,7 +646,9 @@ class StringTest {
      */
     assertEquals("\u0345σ", "\u0345Σ".toLowerCase())
     assertEquals("\u03B1\u0345ς", "\u0391\u0345Σ".toLowerCase())
-    assertEquals("\u03B1\u0345ς\u0345", "\u0391\u0345Σ\u0345".toLowerCase())
+    if (!executingInJVM)
+      assertEquals("\u03B1\u0345ς\u0345", "\u0391\u0345Σ\u0345".toLowerCase())
+
     assertEquals(
       "\u03B1\u0345σ\u0345\u03B1",
       "\u0391\u0345Σ\u0345\u0391".toLowerCase()


### PR DESCRIPTION
The code here seems to be much easier to read and mostly simpler. I don't see anything that could be a performance regression and I inlined `length()` which just returns `count`. Other places I just kept `count` - not sure which is best.

The test suite now has more tests and I found no regressions.

I wasn't able to run the tests against JVM using the following:

```
testsJVM3/testOnly org.scalanative.testsuite.javalib.lang.StringTest
```
Not sure why that doesn't work.