### PR TITLE
Add sbt to dev-shell in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,10 @@
                   stdenv = pkgs.llvmPackages.stdenv;
 
                   languages = {
-                    scala.enable = true;
+                    scala = {
+                      enable = true;
+                      sbt.enable = true;
+                    };
                     c.enable = true;
                     java.enable = true;
                   };


### PR DESCRIPTION
I set up the development environment using `flake.nix` on NixOS, and everything works smoothly. However, `sbt` was missing - this PR fixes it.