### PR TITLE
Align posixlib string.scala with Open Group Issue 8, 2024

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/string.scala
@@ -7,7 +7,7 @@ import scala.scalanative.posix.sys.types
 /** POSIX string.h for Scala
  *
  *  The Open Group Base Specifications
- *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
+ *  [[https://pubs.opengroup.org/onlinepubs/9799919799 Issue 8, 2024]] edition.
  *
  *  A method with a CX comment indicates it is a POSIX extension to the ISO/IEEE
  *  C standard.
@@ -15,6 +15,7 @@ import scala.scalanative.posix.sys.types
  *  A method with an XSI comment indicates it is defined in extended POSIX
  *  X/Open System Interfaces, not base POSIX.
  */
+
 @extern object string extends string
 
 @extern trait string extends libc.string {
@@ -31,16 +32,22 @@ import scala.scalanative.posix.sys.types
   def memccpy(dest: CVoidPtr, src: CVoidPtr, c: CInt, n: size_t): CVoidPtr =
     extern
 
+  /** CX - The Open Group Base Specifications Issue 8 */
+  def memmem(
+      haystack: CVoidPtr,
+      haystacklen: CInt,
+      needle: CVoidPtr,
+      needlelen: CInt
+  ): CVoidPtr = extern
+
   /** CX */
   def stpcpy(dest: CString, src: CString): CVoidPtr = extern
 
   /** CX */
   def stpncpy(dest: CString, src: CString, n: size_t): CVoidPtr = extern
 
-  def stroll(s1: CString, s2: CString): CInt = extern
-
   /** CX */
-  def stroll_l(s1: CString, s2: CString, locale: locale_t): CInt = extern
+  def strcoll_l(s1: CString, s2: CString, locale: locale_t): CInt = extern
 
   /** CX */
   def strdup(s: CString): CString = extern
@@ -51,7 +58,11 @@ import scala.scalanative.posix.sys.types
   /** CX */
   def strerror_r(errnum: CInt, buf: CString, buflen: size_t): CInt = extern
 
-  def strcpy(dest: CString, src: CString, n: size_t): CString = extern
+  /** CX - The Open Group Base Specifications Issue 8 */
+  def strlcat(dst: CString, src: CString, dstsize: size_t): CInt = extern
+
+  /** CX - The Open Group Base Specifications Issue 8 */
+  def strlcpy(dst: CString, src: CString, dstsize: size_t): CInt = extern
 
   /** CX */
   def strndup(s: CString, n: size_t): CString = extern

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -53,7 +53,13 @@ object BinaryIncompatibilities {
     exclude[Problem]("scala.scalanative.runtime.unwind.*"),
   )
   final val CLib: Filters = Nil
-  final val PosixLib: Filters = Seq.empty
+
+  final val PosixLib: Filters = Seq(
+    exclude[Problem]("scala.scalanative.posix.string.stroll"), // remove typo 
+    exclude[Problem]("scala.scalanative.posix.string.stroll_l"), // remove typo
+    exclude[Problem]("scala.scalanative.posix.string.strcpy") // libc not CX
+  )
+
   final val WindowsLib: Filters = Nil
 
   final val TestRunner: Filters = Nil


### PR DESCRIPTION
Align posixlib `string.scala` with [Open Group Issue 8](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/string.h.html).

```
Issue 8

    Austin Group Defect 986 is applied, adding strlcat() and strlcpy().

    Austin Group Defect 1061 is applied, adding memmem().

```

###### Binary incompatibility

The Mima binary compatibility checker validly reported a binary compatibility mismatch during
the  first CI run for this PR.  Those mismatches have been now been excluded.

The incompatibility is the result of removing three symbols: `stroll`, `stroll_l`, and `strcpy`.
I believe this removal and resultant incompatibility is unlikely to affect existing users.

The putative `stroll` and `stroll_l` appear to be typographical error for `strcoll` and `strcoll_l`.
Those typos have been corrected, so the correct Open Group defined entry points are now available.
Any prior use of the typos would have lead to 'missing symbol' failures at link time.

The `strpcy` is not a C extension (not CX in the Open Group standard 8 and before) so it
should be inherited from `libc.string` and not defined in `posixlib.string`.   Compiling and
linking with the SN 0.5.8 `posixlib.string#strcpy` would have been resolved by the linker
to the same `libc strcpy` entry point in the external `libc`.  So previously compiled and
linked applications should continue to execute.



