### PR TITLE
Use more efficient algorithms in javalib String#indexOf(String, begin, end)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1892,3 +1892,8 @@ Sections of the work carry alternate permissive licenses:
        The terms of that license requires this notice that the code
        from that paper has been altered by being translated to Scala.
 ```
+
+# License notice for Android Open Source Project  memmem() implementation.
+
+As required by the license, the full text of the license is included
+in the file `scalanative_memmem.c`.

--- a/javalib/src/main/scala/java/lang/MemmemImpl.scala
+++ b/javalib/src/main/scala/java/lang/MemmemImpl.scala
@@ -1,0 +1,46 @@
+package java.lang
+
+import scalanative.meta.LinktimeInfo._
+import scalanative.unsafe._
+
+private[java] object MemmemImpl {
+  /* The central idea is to use a memmem() provided by the operating system
+   * where possible or else fall back to a less efficient local implementation.
+   *
+   * Unix-like systems, listed below, are known to have implemented memmem()
+   * in libc for at least a few decades. The POSIX version may be less than 8
+   * 
+   * ScalaNativeMemmem.memmem() will use posix.string.memmem on unspecified
+   * systems which implement Open Group Issue 8 or above. Otherwise,
+   * such as on Windows, it will use the local implementation.
+   */
+
+  /** CX - The Open Group Base Specifications Issue 8 */
+  def memmem(
+      haystack: CVoidPtr,
+      haystacklen: CInt,
+      needle: CVoidPtr,
+      needlelen: CInt
+  ): CVoidPtr = {
+    val impl =
+      if (isLinux || isMac || isFreeBSD || isOpenBSD || isNetBSD)
+        scalanative.posix.string.memmem(_, _, _, _)
+      else
+        ScalaNativeMemmem.memmem(_, _, _, _)
+
+    impl(haystack, haystacklen, needle, needlelen)
+  }
+}
+
+@define("__SCALANATIVE_JAVALIB_MEMMEM")
+@extern
+private[java] object ScalaNativeMemmem {
+
+  @name("scalanative_memmem")
+  def memmem(
+      haystack: CVoidPtr,
+      haystacklen: CInt,
+      needle: CVoidPtr,
+      needlelen: CInt
+  ): CVoidPtr = extern
+}

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -424,12 +424,16 @@ final class _String()
     fromIndex
   }
 
-  /* By convention, caller has validated arguments.
-   * See also notes above indexOfImpl(str, fromIndex, toIndex).
-   *
-   * This is a good candidate for someday using memmem() or memchr().
+  /* Preconditions:
+   *   By convention, caller has validated arguments, but strangely.
+   *   beginIndex is usually guaranteed to be within 'this' but there is no
+   *   such guarantee here.
+   * 
+   *   For details, see note above indexOfImpl(str, fromIndex, toIndex).
    */
   private def indexOfImpl(ch: Int, beginIndex: Int, endIndex: Int): Int = {
+    // This is a good candidate for someday using memchr().
+
     var start = beginIndex
 
     if (ch >= 0 && ch <= Character.MAX_VALUE) {
@@ -470,18 +474,30 @@ final class _String()
     indexOfImpl(ch, beginIndex, endIndex)
   }
 
-  /* By convention, caller has validated index arguments so that slice
-   * (endIndex - beginIndex) <= this.count.
+  /* Preconditions:
+   *   By convention, caller has validated index arguments so that:
+   *     - beginIndex >= 0
+   *     - beginIndex <= endIndex
+   *     - endIndex <= this.count
+   *
+   *   Beware & handle an empty 'this' or an empty slice range!
+   *   beginIndex is usually guaranteed to be a valid index for this.value
+   *   but there is no such guarantee here.
+   * 
+   *   Especially note that when (this.count == 0) indexOf(str, 0, 0)
+   *   fulfills the preconditions but 'this(beginIndex)' will throw.
    */
   private def indexOfImpl(str: _String, beginIndex: Int, endIndex: Int): Int = {
     val needleLen = str.count
 
     if (needleLen == 0) {
       beginIndex
-    } else if ((beginIndex + needleLen) > endIndex) {
+    } else if (needleLen > (endIndex - beginIndex)) {
       /* needleLen is now known to be >= 1.
        * If needle is longer than haystack slice, it will never match.
-       * Also filter 'this' slice being a zero length empty _String, a.k.a ""
+       * Given prior precondition checking, this also filters out either
+       * or both of 'this' or the slice being a zero length empty _String,
+       * a.k.a "".
        */
       -1
     } else {

--- a/posixlib/src/main/resources/scala-native/memmem.c
+++ b/posixlib/src/main/resources/scala-native/memmem.c
@@ -1,0 +1,103 @@
+#if 1 // FIXME - 2025-07-06 07:39 -0400
+// #if true || defined(SCALANATIVE_COMPILE_ALWAYS) ||
+// defined(__SCALANATIVE_POSIX_STDIO)
+#include <string.h>
+
+#include <stdio.h> // FIXME
+
+// To force known presence of memcmp(), define on compilation command.
+#if !(defined(__SCALANATIVE_HAVE_OS_MEMMEM))
+#if defined(__unix__) || defined(__unix) || defined(unix)
+#define __SCALANATIVE_HAVE_OS_MEMMEM 1 // Should allow FreeBSD & NetBSD
+#elif (defined(__APPLE__) && defined(__MACH__))
+#// define __SCALANATIVE_HAVE_OS_MEMMEM 1 // FIXME
+#define __SCALANATIVE_HAVE_OS_MEMMEM 1 // FIXME
+#endif
+#endif // !(defined(__SCALANATIVE_HAVE_OS_MEMMEM)
+
+#if (defined(__SCALANATIVE_HAVE_OS_MEMMEM))
+void *scalanative_memmem(const void *haystack, size_t n, const void *needle, si\
+ze_t m) {
+  /* // Use output here carefully; it breaks ProcessInheritTest.
+    printf("\n\n"); // FIXME
+    printf("\n\n>>> Using libc memmem\n\n"); // FIXME
+    printf("\n\n"); // FIXME
+  */
+    return memmem(haystack, n, needle, m);
+}
+
+#else  // Windows & unknown/unproven operating systems.
+
+/* URL: https://android.googlesource.com/
+ *        platform/bionic/+/ics-mr0/libc/string/memmem.c
+ *
+ * Modified slightly for Scala Native. Can not rely upon compiler having
+ * __builtin_expect() in the application build environment.
+ */
+
+/*
+ * Copyright (C) 2008 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/*
+ * This uses the "Not So Naive" algorithm, a very simple but
+ * usually effective algorithm, see:
+ * http://www-igm.univ-mlv.fr/~lecroq/string/
+ */
+
+void *scalanative_memmem(const void *haystack, size_t n, const void *needle,
+                         size_t m) {
+  //    printf("\n\n>>> Using Android memmem\n\n"); // FIXME
+
+    if (m > n || !m || !n)
+        return NULL;
+    if (m > 1) {
+        const unsigned char *y = (const unsigned char *)haystack;
+        const unsigned char *x = (const unsigned char *)needle;
+        size_t j = 0;
+        size_t k = 1, l = 2;
+        if (x[0] == x[1]) {
+            k = 2;
+            l = 1;
+        }
+        while (j <= n - m) {
+            if (x[1] != y[j + 1]) {
+                j += k;
+            } else {
+                if (!memcmp(x + 2, y + j + 2, m - 2) && x[0] == y[j])
+                    return (void *)&y[j];
+                j += l;
+            }
+        }
+    } else {
+        /* degenerate case */
+        return memchr(haystack, ((unsigned char *)needle)[0], n);
+    }
+    return NULL;
+}
+#endif // !defined(__SCALANATIVE_HAVE_OS_MEMMEM)
+
+#endif

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -50,9 +50,9 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-pc-linux-gnu"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1092, members = 7012)
-      else if (isScala2_13) SymbolsCount(types = 1052, members = 7094)
-      else SymbolsCount(types = 1034, members = 7240)
+      if (isScala3) SymbolsCount(types = 1094, members = 7032)
+      else if (isScala2_13) SymbolsCount(types = 1053, members = 7110)
+      else SymbolsCount(types = 1035, members = 7256)
     )
 
   @Test def multithreading(): Unit =

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -50,9 +50,9 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-pc-linux-gnu"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1089, members = 7004)
-      else if (isScala2_13) SymbolsCount(types = 1049, members = 7087)
-      else SymbolsCount(types = 1031, members = 7232)
+      if (isScala3) SymbolsCount(types = 1092, members = 7012)
+      else if (isScala2_13) SymbolsCount(types = 1052, members = 7094)
+      else SymbolsCount(types = 1034, members = 7240)
     )
 
   @Test def multithreading(): Unit =

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/lang/StringTestOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/lang/StringTestOnJDK21.scala
@@ -51,7 +51,7 @@ class StringTestOnJDK21 {
   @Test def IndexOf_String_BeginIndexEndIndex_CheckArgs(): Unit = {
     val needle = "needle"
 
-    // No Exception in this special case of zero range, strarting at index 0
+    // No Exception in this special case of zero range, starting at index 0
     assertEquals("length 0, start & end 0", 0, "".indexOf("", 0, 0))
 
     assertThrows(
@@ -79,6 +79,10 @@ class StringTestOnJDK21 {
     assertEquals("a1_3", 4, haystack_1.indexOf(needle_1, 0, 10))
     assertEquals("a1_4", -1, haystack_1.indexOf(needle_1, 5, 10))
     assertEquals("a1_5", 20, haystack_1.indexOf(needle_1, 5, 26))
+
+    // Do not find byte 'n' == 0x63 on an odd byte boundary
+    val haystack_1a = "straw-\u6E00eedle-more_hay-needle-straw"
+    assertEquals("a1a_1", 22, haystack_1a.indexOf(needle_1, 4, 29))
 
     // Use non-ANSI character, change length to exercise different indices.
     val needle_2 = "ne€dle"


### PR DESCRIPTION
javalib `String#indexOf(String, begin, end)` now uses more efficient algorithms.

On unix-like systems, the system libc `memmem()` is used where available.
On Windows and other systems, a 'not-so-naive` algorithm is used.
Previously a naive algorithm had been used in all cases.

This change should also benefit `String#contains()`.
