### PR TITLE
[toolchain] When checking NIR accept `Op.Field` on Null 

### DIFF
--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -479,6 +479,7 @@ private[scalanative] final class Check(implicit
   ): Unit = {
 
     obj.ty match {
+      case nir.Type.Null => ok
       case ScopeRef(scope) =>
         scope.implementors.foreach { cls =>
           val field = cls.fields.collectFirst {

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -811,6 +811,29 @@ class IssuesTest {
     }
     new R().run()
   }
+
+  @Test def issue4387(): Unit = {
+    class XString {
+      private var count: Int = 0
+      def startsWith(prefix: XString, start: Int): scala.Boolean =
+        regionMatches(start, prefix, 0, prefix.count)
+
+      def startsWith(prefix: XString): scala.Boolean =
+        startsWith(prefix, 0)
+
+      @noinline def regionMatches(
+          start: Int,
+          prefix: XString,
+          offset: Int,
+          count: Int
+      ) = true
+    }
+    // Ensure links in release mode
+    assertThrows(
+      classOf[NullPointerException],
+      () => new XString().startsWith(null)
+    )
+  }
 }
 
 package issue1090 {


### PR DESCRIPTION
Fixes errors when checking NIR in #4387 when inlined method call tries to use Op.Field operation on instance of null object.  

Now it follows the same behaviour as we had for Op.Method - we accept null since it's handled later in `Lower` - it could have been optimized to just throwig exception, but Interflow currently assumes that are inlinable executation paths are non exceptional