### PR TITLE
[refactor] Remove `SimpleType` abstraction in compiler plugin

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -274,16 +274,24 @@ trait NirDefinitions {
     )
     lazy val ResolvedMethod = getMember(NativeModule, TermName("resolved"))
 
-    lazy val RuntimePrimitive: Map[Char, Symbol] = Map(
-      'B' -> getRequiredClass("scala.scalanative.runtime.PrimitiveBoolean"),
-      'C' -> getRequiredClass("scala.scalanative.runtime.PrimitiveChar"),
-      'Z' -> getRequiredClass("scala.scalanative.runtime.PrimitiveByte"),
-      'S' -> getRequiredClass("scala.scalanative.runtime.PrimitiveShort"),
-      'I' -> getRequiredClass("scala.scalanative.runtime.PrimitiveInt"),
-      'L' -> getRequiredClass("scala.scalanative.runtime.PrimitiveLong"),
-      'F' -> getRequiredClass("scala.scalanative.runtime.PrimitiveFloat"),
-      'D' -> getRequiredClass("scala.scalanative.runtime.PrimitiveDouble"),
-      'U' -> getRequiredClass("scala.scalanative.runtime.PrimitiveUnit")
+    lazy val RuntimePrimitive: Map[Symbol, Symbol] = Map(
+      BooleanClass -> getRequiredClass(
+        "scala.scalanative.runtime.PrimitiveBoolean"
+      ),
+      CharClass -> getRequiredClass("scala.scalanative.runtime.PrimitiveChar"),
+      ByteClass -> getRequiredClass("scala.scalanative.runtime.PrimitiveByte"),
+      ShortClass -> getRequiredClass(
+        "scala.scalanative.runtime.PrimitiveShort"
+      ),
+      IntClass -> getRequiredClass("scala.scalanative.runtime.PrimitiveInt"),
+      LongClass -> getRequiredClass("scala.scalanative.runtime.PrimitiveLong"),
+      FloatClass -> getRequiredClass(
+        "scala.scalanative.runtime.PrimitiveFloat"
+      ),
+      DoubleClass -> getRequiredClass(
+        "scala.scalanative.runtime.PrimitiveDouble"
+      ),
+      UnitClass -> getRequiredClass("scala.scalanative.runtime.PrimitiveUnit")
     )
     lazy val RuntimePrimitiveTypes: Set[Symbol] =
       RuntimePrimitive.values.toSet ++ Set(
@@ -291,38 +299,29 @@ trait NirDefinitions {
         RawSizeClass
       )
 
-    lazy val RuntimeArrayClass: Map[Char, Symbol] = Map(
-      'B' -> getRequiredClass("scala.scalanative.runtime.BooleanArray"),
-      'C' -> getRequiredClass("scala.scalanative.runtime.CharArray"),
-      'Z' -> getRequiredClass("scala.scalanative.runtime.ByteArray"),
-      'S' -> getRequiredClass("scala.scalanative.runtime.ShortArray"),
-      'I' -> getRequiredClass("scala.scalanative.runtime.IntArray"),
-      'L' -> getRequiredClass("scala.scalanative.runtime.LongArray"),
-      'F' -> getRequiredClass("scala.scalanative.runtime.FloatArray"),
-      'D' -> getRequiredClass("scala.scalanative.runtime.DoubleArray"),
-      'O' -> getRequiredClass("scala.scalanative.runtime.ObjectArray")
-    )
+    // Used only by Scala 2.12
+    def RuntimeArrayClass(nirTpe: nir.Type): Symbol = nirTpe match {
+      case nir.Type.Bool =>
+        getRequiredClass("scala.scalanative.runtime.BooleanArray")
+      case nir.Type.Char =>
+        getRequiredClass("scala.scalanative.runtime.CharArray")
+      case nir.Type.Byte =>
+        getRequiredClass("scala.scalanative.runtime.ByteArray")
+      case nir.Type.Short =>
+        getRequiredClass("scala.scalanative.runtime.ShortArray")
+      case nir.Type.Int =>
+        getRequiredClass("scala.scalanative.runtime.IntArray")
+      case nir.Type.Long =>
+        getRequiredClass("scala.scalanative.runtime.LongArray")
+      case nir.Type.Float =>
+        getRequiredClass("scala.scalanative.runtime.FloatArray")
+      case nir.Type.Double =>
+        getRequiredClass("scala.scalanative.runtime.DoubleArray")
+      case _ => getRequiredClass("scala.scalanative.runtime.ObjectArray")
+    }
 
-    private def mapValue[K, V1, V2](fn: V1 => V2)(in: (K, V1)): (K, V2) =
-      (in._1, fn(in._2))
-
-    lazy val RuntimeArrayModule: Map[Char, Symbol] =
-      RuntimeArrayClass.map(mapValue(_.companion))
-
-    lazy val RuntimeArrayAllocMethod: Map[Char, Symbol] =
-      RuntimeArrayModule.map(mapValue(getMember(_, TermName("alloc"))))
-
-    lazy val RuntimeArrayApplyMethod: Map[Char, Symbol] =
-      RuntimeArrayClass.map(mapValue(getMember(_, TermName("apply"))))
-
-    lazy val RuntimeArrayUpdateMethod: Map[Char, Symbol] =
-      RuntimeArrayClass.map(mapValue(getMember(_, TermName("update"))))
-
-    lazy val RuntimeArrayLengthMethod: Map[Char, Symbol] =
-      RuntimeArrayClass.map(mapValue(getMember(_, TermName("length"))))
-
-    lazy val RuntimeArrayCloneMethod: Map[Char, Symbol] =
-      RuntimeArrayClass.map(mapValue(getMember(_, TermName("clone"))))
+    def RuntimeArrayCloneMethod(elemType: nir.Type): Symbol =
+      getMember(RuntimeArrayClass(elemType), TermName("clone"))
 
     lazy val RuntimeBoxesModule = getRequiredModule(
       "scala.scalanative.runtime.Boxes"

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExports.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExports.scala
@@ -10,7 +10,6 @@ trait NirGenExports[G <: nsc.Global with Singleton] {
   import definitions._
   import nirAddons._
   import nirDefinitions._
-  import SimpleType._
 
   case class ExportedSymbol(symbol: Symbol, defn: nir.Defn.Define)
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -9,7 +9,6 @@ trait NirGenName[G <: Global with Singleton] {
 
   import global.{Name => _, _}, definitions._
   import nirAddons.nirDefinitions._
-  import SimpleType.{fromSymbol, fromType}
 
   def genAnonName(owner: Symbol, anon: Symbol) =
     genName(owner).member(nir.Sig.Extern(anon.fullName.toString))
@@ -141,7 +140,7 @@ trait NirGenName[G <: Global with Singleton] {
 
     val tpe = sym.tpe.widen
     val paramTypes = tpe.params.toSeq.map(p => genType(p.info))
-    val retType = genType(fromType(sym.info.resultType))
+    val retType = genType(sym.info.resultType)
 
     val name = sym.name
     val sig = nir.Sig.Method(id, paramTypes :+ retType, scope)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -15,7 +15,6 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
   import definitions._
   import nirAddons._
   import nirDefinitions._
-  import SimpleType.{fromType, fromSymbol}
 
   val reflectiveInstantiationInfo =
     mutable.UnrolledBuffer.empty[ReflectiveInstantiationBuffer]

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -176,46 +176,21 @@ final class NirDefinitions()(using ctx: Context) {
       .ensuring(_.size == 5)
 
   // Runtime types
-  @tu lazy val RuntimePrimitive: Map[Char, Symbol] = Map(
-    'B' -> requiredClass("scala.scalanative.runtime.PrimitiveBoolean"),
-    'C' -> requiredClass("scala.scalanative.runtime.PrimitiveChar"),
-    'Z' -> requiredClass("scala.scalanative.runtime.PrimitiveByte"),
-    'S' -> requiredClass("scala.scalanative.runtime.PrimitiveShort"),
-    'I' -> requiredClass("scala.scalanative.runtime.PrimitiveInt"),
-    'L' -> requiredClass("scala.scalanative.runtime.PrimitiveLong"),
-    'F' -> requiredClass("scala.scalanative.runtime.PrimitiveFloat"),
-    'D' -> requiredClass("scala.scalanative.runtime.PrimitiveDouble"),
-    'U' -> requiredClass("scala.scalanative.runtime.PrimitiveUnit")
+  @tu lazy val RuntimePrimitive: Map[Symbol, Symbol] = Map(
+    defn.BooleanClass -> requiredClass("scala.scalanative.runtime.PrimitiveBoolean"),
+    defn.CharClass -> requiredClass("scala.scalanative.runtime.PrimitiveChar"),
+    defn.ByteClass -> requiredClass("scala.scalanative.runtime.PrimitiveByte"),
+    defn.ShortClass -> requiredClass("scala.scalanative.runtime.PrimitiveShort"),
+    defn.IntClass -> requiredClass("scala.scalanative.runtime.PrimitiveInt"),
+    defn.LongClass -> requiredClass("scala.scalanative.runtime.PrimitiveLong"),
+    defn.FloatClass -> requiredClass("scala.scalanative.runtime.PrimitiveFloat"),
+    defn.DoubleClass -> requiredClass("scala.scalanative.runtime.PrimitiveDouble"),
+    defn.UnitClass -> requiredClass("scala.scalanative.runtime.PrimitiveUnit")
   )
   @tu lazy val RuntimePrimitiveTypes: Set[Symbol] = RuntimePrimitive.values.toSet ++ Set(
     RawPtrClass,
     RawSizeClass
   )
-
-  @tu lazy val RuntimeArrayClass: Map[Char, Symbol] = Map(
-    'B' -> requiredClass("scala.scalanative.runtime.BooleanArray"),
-    'C' -> requiredClass("scala.scalanative.runtime.CharArray"),
-    'Z' -> requiredClass("scala.scalanative.runtime.ByteArray"),
-    'S' -> requiredClass("scala.scalanative.runtime.ShortArray"),
-    'I' -> requiredClass("scala.scalanative.runtime.IntArray"),
-    'L' -> requiredClass("scala.scalanative.runtime.LongArray"),
-    'F' -> requiredClass("scala.scalanative.runtime.FloatArray"),
-    'D' -> requiredClass("scala.scalanative.runtime.DoubleArray"),
-    'O' -> requiredClass("scala.scalanative.runtime.ObjectArray")
-  )
-
-  private def mapValues[K, V1, V2](in: Map[K, V1])(fn: V1 => V2): Map[K, V2] =
-    in.map { (key, value) =>
-      (key, fn(value))
-    }
-
-  // Runtime array
-  @tu lazy val RuntimeArrayModule = mapValues(RuntimeArrayClass)(_.companionModule)
-  @tu lazy val RuntimeArray_alloc = mapValues(RuntimeArrayModule)(_.requiredMethod("alloc"))
-  @tu lazy val RuntimeArray_apply = mapValues(RuntimeArrayClass)(_.requiredMethod("apply"))
-  @tu lazy val RuntimeArray_update = mapValues(RuntimeArrayClass)(_.requiredMethod("update"))
-  @tu lazy val RuntimeArray_length = mapValues(RuntimeArrayClass)(_.requiredMethod("length"))
-  @tu lazy val RuntimeArray_clone = mapValues(RuntimeArrayClass)(_.requiredMethod("clone"))
 
   // Scala Native runtime boxes
   @tu lazy val RuntimeBoxesModule = requiredModule("scala.scalanative.runtime.Boxes")
@@ -232,29 +207,6 @@ final class NirDefinitions()(using ctx: Context) {
     UIntClass -> RuntimeBoxesModule.requiredMethod("unboxToUInt"),
     ULongClass -> RuntimeBoxesModule.requiredMethod("unboxToULong"),
     USizeClass -> RuntimeBoxesModule.requiredMethod("unboxToUSize")
-  )
-
-  // Scala boxes
-  @tu lazy val BoxMethod = Map[Char, Symbol](
-    'B' -> defn.BoxesRunTimeModule.requiredMethod("boxToBoolean"),
-    'C' -> defn.BoxesRunTimeModule.requiredMethod("boxToCharacter"),
-    'Z' -> defn.BoxesRunTimeModule.requiredMethod("boxToByte"),
-    'S' -> defn.BoxesRunTimeModule.requiredMethod("boxToShort"),
-    'I' -> defn.BoxesRunTimeModule.requiredMethod("boxToInteger"),
-    'L' -> defn.BoxesRunTimeModule.requiredMethod("boxToLong"),
-    'F' -> defn.BoxesRunTimeModule.requiredMethod("boxToFloat"),
-    'D' -> defn.BoxesRunTimeModule.requiredMethod("boxToDouble")
-  )
-
-  @tu lazy val UnboxMethod = Map[Char, Symbol](
-    'B' -> defn.BoxesRunTimeModule.requiredMethod("unboxToBoolean"),
-    'C' -> defn.BoxesRunTimeModule.requiredMethod("unboxToChar"),
-    'Z' -> defn.BoxesRunTimeModule.requiredMethod("unboxToByte"),
-    'S' -> defn.BoxesRunTimeModule.requiredMethod("unboxToShort"),
-    'I' -> defn.BoxesRunTimeModule.requiredMethod("unboxToInt"),
-    'L' -> defn.BoxesRunTimeModule.requiredMethod("unboxToLong"),
-    'F' -> defn.BoxesRunTimeModule.requiredMethod("unboxToFloat"),
-    'D' -> defn.BoxesRunTimeModule.requiredMethod("unboxToDouble")
   )
 
   // Scala Native reflect

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -77,7 +77,6 @@ trait NirGenName(using Context) {
       else nir.Sig.Scope.Public
 
     def paramTypes = sym.info.paramInfoss.flatten
-      .map(fromType)
       .map(genType(_))
 
     if (sym == defn.`String_+`) genMethodName(defnNir.String_concat)
@@ -87,7 +86,7 @@ trait NirGenName(using Context) {
     else if (sym.name == nme.TRAIT_CONSTRUCTOR)
       owner.member(nir.Sig.Method(id, Seq(nir.Type.Unit), scope))
     else
-      val retType = genType(fromType(sym.info.resultType))
+      val retType = genType(sym.info.resultType)
       owner.member(nir.Sig.Method(id, paramTypes :+ retType, scope))
   }
 
@@ -128,9 +127,8 @@ trait NirGenName(using Context) {
       else nir.Sig.Scope.PublicStatic
 
     val paramTypes = sym.info.paramInfoss.flatten
-      .map(fromType)
       .map(genType(_))
-    val retType = genType(fromType(sym.info.resultType))
+    val retType = genType(sym.info.resultType)
 
     val sig = nir.Sig.Method(id, paramTypes :+ retType, scope)
     owner.member(sig)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -401,8 +401,11 @@ trait NirGenStat(using Context) {
     }
     val thisParam = Option.unless(isStatic) {
       nir.Val.Local(
-        fresh.namedId("this"),
-        genType(curClassSym.get)
+        fresh.namedId("this"), {
+          val clsSymbol = curClassSym.get
+          if clsSymbol.isStruct then genType(clsSymbol.info)
+          else genRefType(clsSymbol.info)
+        }
       )
     }
     val params = thisParam.toList ::: argParams


### PR DESCRIPTION
Removes `SimpleType` types used in the compiler plugin - instead we're now using directly Type / Symbol from compiler. 
This change would allow us to have better control on the processes types and would be also needed to correctly implement nested arrays, e.g. `Array[Array[Int]]` 