### PR TITLE
Refactor javalib String#regionMatches to avoid unnecessary substring instantiation

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -246,7 +246,7 @@ final class _String()
   }
 
   def endsWith(suffix: _String): scala.Boolean =
-    regionMatches(count - suffix.count, suffix, 0, suffix.count)
+    regionMatches(false, count - suffix.count, suffix, 0, suffix.count)
 
   override def equals(obj: Any): scala.Boolean = obj match {
     case s: _String =>
@@ -698,8 +698,12 @@ final class _String()
     jus.StreamSupport.stream(spliter, parallel = false)
   }
 
-  /* Both regionMatches ported from
-   * https://github.com/gwtproject/gwt/blob/master/user/super/com/google/gwt/emul/java/lang/String.java
+  /* Both regionMatches ported from:
+   *   https://github.com/gwtproject/gwt/blob/master/
+   *     user/super/com/google/gwt/emul/java/lang/String.java
+   *
+   * regionMatches(ignoreCase) modified to take advantage of Scala Native
+   * capabilities.
    */
   def regionMatches(
       ignoreCase: scala.Boolean,
@@ -715,10 +719,26 @@ final class _String()
       false
     } else if (len <= 0) {
       true
-    } else {
+    } else if (ignoreCase) {
       val left = this.substring(toffset, toffset + len)
       val right = other.substring(ooffset, ooffset + len)
-      if (ignoreCase) left.equalsIgnoreCase(right) else left == right
+      left.equalsIgnoreCase(right)
+    } else {
+      /* Avoid actually instantiating substrings.
+       *
+       * This is logically a six argument ju.Arrays.equals(). Open code here
+       * to skip the latter checking arguments that have already been checked.
+       */
+
+      val data1 = this.value
+        .at(this.offset + toffset)
+        .asInstanceOf[Ptr[scala.Byte]]
+
+      val data2 = other.value
+        .at(other.offset + ooffset)
+        .asInstanceOf[Ptr[scala.Byte]]
+
+      memcmp(data1, data2, (len * 2).toUInt) == 0
     }
   }
 
@@ -821,10 +841,10 @@ final class _String()
   }
 
   def startsWith(prefix: _String, start: Int): scala.Boolean =
-    regionMatches(start, prefix, 0, prefix.count)
+    regionMatches(false, start, prefix, 0, prefix.count)
 
   def startsWith(prefix: _String): scala.Boolean =
-    startsWith(prefix, 0)
+    regionMatches(false, 0, prefix, 0, prefix.count)
 
   def substring(start: Int): _String =
     if (start == 0) {


### PR DESCRIPTION

Refactor javalib `String#regionMatches`  & callers to improve performance in certain cases.

1) On the probably dominant case sensitive path, avoid actually instantiating two substrings. 
    Additionally, use the long standing practice from `String#equals` to provide an execution
    path which should be faster for all but the tiniest of regions, where tiny probably means
    lengths of less than 4 or so. 

    The benefit on small to HUGE string should be noticeable, leading to a better amortized cost for most
    work loads. such as Scala Native unit-test  and Continuous Integration runs

2) Partially repay any regression on tiny by modifying a few callers of `regionMatchers` which
    know they require case-sensitive comparisons to skip over the four argument overload, 
    even though it is currently `@inline`, and call the 5 argument overload.
  
   Yes we are counting only a few CPU cycles here, but every CPU cycle of execution or
   build time is useful.