### PR TITLE
Re-factor several methods in javalib String.scala to reduce allocations & shorten code paths

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -662,7 +662,7 @@ final class _String()
 
         nextOrigin = cursor
 
-        _String.valueOf(src, origin, nChars)
+        new _String(src, origin, nChars)
       }
     }
   }
@@ -1323,25 +1323,11 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     }
   }
 
-  def contentEquals(sb: StringBuffer): scala.Boolean = {
-    val size = sb.length()
-    if (count != size) {
-      false
-    } else {
-      regionMatches(0, new _String(0, size, sb.getValue()), 0, size)
-    }
-  }
+  def contentEquals(sb: StringBuffer): scala.Boolean =
+    this.equals(sb.toString())
 
-  def contentEquals(cs: CharSequence): scala.Boolean = {
-    val len = cs.length()
-    if (len != count) {
-      false
-    } else if (len == 0 && count == 0) {
-      true
-    } else {
-      regionMatches(0, _String.valueOf(cs.toString), 0, len)
-    }
-  }
+  def contentEquals(cs: CharSequence): scala.Boolean =
+    this.equals(cs.toString())
 
   def matches(expr: _String): scala.Boolean =
     Pattern.matches(expr, this)
@@ -1434,7 +1420,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     }
 
   def contains(cs: CharSequence): scala.Boolean =
-    indexOf(_String.valueOf(cs.toString)) >= 0
+    indexOf(cs.toString) >= 0
 
   def offsetByCodePoints(index: Int, codePointOffset: Int): Int = {
     val s = index + offset


### PR DESCRIPTION
Re-factor the two javalib `String#contentEquals` methods and `String#contains` to remove
unnecessary, redundant String allocations and to shorten some code paths.

Aside from a slight but welcome decrease in resource consumption, end users should
see no change.

Add some Tests to exercise the changed code.

 
