### PR TITLE
Fix #4398: deprecate 2 runtime.compare which produce incorrect results

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -117,6 +117,9 @@ object Array {
     }
   }
 
+  @deprecated(
+     "Incorrect results, will be removed. Use `java.util.Arrays` instead",
+     "0.5.9")
   def compare(left: AnyRef,
               leftPos: Int,
               right: AnyRef,
@@ -137,6 +140,9 @@ object Array {
     }
   }
 
+  @deprecated(
+     "Incorrect results, will be removed. Use `java.util.Arrays` instead",
+     "0.5.9")
   def compare(left: Array[_],
               leftPos: Int,
               right: Array[_],
@@ -145,7 +151,7 @@ object Array {
     if (left == null || right == null) {
       throw new NullPointerException()
     } else if (left.getClass != right.getClass) {
-      throw new ArrayStoreException("Invalid array copy.")
+      throw new ArrayStoreException("Invalid array comparison.")
     } else if (len < 0) {
       throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (leftPos < 0 || leftPos + len > left.length) {


### PR DESCRIPTION
Mark two `runtime.compare` methods as:
```
 @deprecated(
     "Incorrect results, will be removed. Use `java.util.Arrays` instead",
     "0.5.9")
```

These methods are not used by Scala Native itself but may, since they are `public`,
have users in the wild. Hence, deprecation rather than the simpler and more robust
straight removal.