### PR TITLE
Fix #4395: Support for configurable C++ standard (e.g. C++17) when compiling C++ sources

### DIFF
--- a/docs/user/native.md
+++ b/docs/user/native.md
@@ -197,9 +197,10 @@ and C++ exception handling settings. Each compilation unit (sub-project) or
 library is compiled using settings provided by the end user and also provided
 in the deployment descriptor included in the project. For example, if you
 include C++ code that uses exceptions and provide that setting, you should
-handle all internal exceptions within the boundaries of that code. A user
-could decide to compile their Scala Native project without using C++ exceptions
-and the program could crash.
+handle all internal exceptions within the boundaries of that code. The default
+for the Scala Native build is compiling without using C++ exceptions so
+the program could crash if the module is expecting the user to handle C++
+exceptions.
 
 *Clang command-line options tend to allow the last one specified takes effect,
 overriding any previous conflicting options.*

--- a/docs/user/native.md
+++ b/docs/user/native.md
@@ -81,9 +81,9 @@ so it is transparent to the library user.
 Using a library that contains native code can be used in combination
 with the feature above that allows native code in your application.
 
-## EXPERIMENTAL: Deployment Descriptor for passing settings to the compiler
+## Deployment Descriptor for passing settings to the compiler
 
-These are **experimental** features that were added because they are
+These are features that were added because they are
 used internally by Scala Native to simplify the build and organize the
 native code with their respective projects. These features allow a
 library developer that has native code included with their project to
@@ -189,6 +189,29 @@ needed on the Windows platform.
 # path to vendored libunwind a base gc path
 compile.include.paths = platform/posix/libunwind, gc
 ```
+
+## Add C and C++ compiler specific settings
+
+You may add specific platform independent settings such as compiler standards
+and C++ exception handling settings. Each compilation unit (sub-project) or
+library is compiled using settings provided by the end user and also provided
+in the deployment descriptor included in the project. For example, if you
+include C++ code that uses exceptions and provide that setting, you should
+handle all internal exceptions within the boundaries of that code. A user
+could decide to compile their Scala Native project without using C++ exceptions
+and the program could crash.
+
+*Clang command-line options tend to allow the last one specified takes effect,
+overriding any previous conflicting options.*
+
+``` properties
+# C options
+compile.c.options = -std=c17
+compile.cpp.options = -std=c++17, -fcxx-exceptions
+```
+
+
+
 
 ## Add unique identity to your library for debugging
 

--- a/docs/user/sbt.md
+++ b/docs/user/sbt.md
@@ -121,6 +121,7 @@ Set C and C++ only options using the folowing in `sbt`:
 ```scala
 // Example setting standard flags
 // Other C or C++ flags can be added to the `Seq`
+// To enable C++ exceptions, add `"-fcxx-exceptions"` to `cppOptions`
 nativeConfig ~= {
   _.withCOptions(Seq("-std=c17"))
   .withCppOptions(Seq("-std=c++17"))

--- a/docs/user/sbt.md
+++ b/docs/user/sbt.md
@@ -112,6 +112,23 @@ nativeConfig ~= { c =>
  */
 ```
 
+Certain settings such as standard settings and exception settings only apply to
+C files and C++ files respectively. Refer to the
+[Clang Command Guide](https://clang.llvm.org/docs/CommandGuide/clang.html).
+
+Set C and C++ only options using the folowing in `sbt`:
+
+```scala
+// Example setting standard flags
+// Other C or C++ flags can be added to the `Seq`
+nativeConfig ~= {
+  _.withCOptions(Seq("-std=c17"))
+  .withCppOptions(Seq("-std=c++17"))
+}
+```
+Note: These apply to all library units where the library has not specified
+settings. See [Native Code in your Application or Library](native.md)
+
 | Since  | Name                    | Type            | Description                                                                   |
 |--------|-------------------------|-----------------|-------------------------------------------------------------------------------|
 | 0.1    | `compile`               | `Analysis`      | Compile Scala code to NIR                                                     |

--- a/javalib/src/main/resources/scala-native/scala-native.properties
+++ b/javalib/src/main/resources/scala-native/scala-native.properties
@@ -2,6 +2,6 @@
 project.organization = org.scala-native
 project.name = javalib
 
-# C standard
-compile.std.c = gnu11
+# C options
+compile.c.options = -std=gnu11
 

--- a/javalib/src/main/resources/scala-native/scala-native.properties
+++ b/javalib/src/main/resources/scala-native/scala-native.properties
@@ -2,3 +2,6 @@
 project.organization = org.scala-native
 project.name = javalib
 
+# C standard
+compile.std.c = gnu11
+

--- a/nativelib/src/main/resources/scala-native/scala-native.properties
+++ b/nativelib/src/main/resources/scala-native/scala-native.properties
@@ -8,5 +8,8 @@ project.gcProject = true
 # CG define
 preprocessor.defines = NDEBUG
 
+# C standard
+compile.std.c = gnu11
+
 # path to vendored libunwind and GC
 compile.include.paths = platform/posix/libunwind, gc, .

--- a/nativelib/src/main/resources/scala-native/scala-native.properties
+++ b/nativelib/src/main/resources/scala-native/scala-native.properties
@@ -8,8 +8,8 @@ project.gcProject = true
 # CG define
 preprocessor.defines = NDEBUG
 
-# C standard
-compile.std.c = gnu11
+# C options
+compile.c.options = -std=gnu11
 
 # path to vendored libunwind and GC
 compile.include.paths = platform/posix/libunwind, gc, .

--- a/posixlib/src/main/resources/scala-native/scala-native.properties
+++ b/posixlib/src/main/resources/scala-native/scala-native.properties
@@ -1,0 +1,6 @@
+# output for debugging
+project.organization = org.scala-native
+project.name = posixlib
+
+# C options
+compile.c.options = -std=gnu11

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -199,8 +199,8 @@ sealed trait Config {
 
   private[scalanative] lazy val usingCppExceptions: Boolean =
     targetsWindows || {
-      val disabled = compileOptions.contains("-fno-cxx-exceptions")
-      val enabled = compileOptions.contains("-fcxx-exceptions")
+      val disabled = compilerConfig.cppOptions.contains("-fno-cxx-exceptions")
+      val enabled = compilerConfig.cppOptions.contains("-fcxx-exceptions")
       // New EH does not work good with LTO https://github.com/scala-native/scala-native/issues/4190
       val enabledLTO = compilerConfig.lto != build.LTO.none
       !disabled && (enabled || enabledLTO)

--- a/tools/src/main/scala/scala/scalanative/build/Descriptor.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Descriptor.scala
@@ -12,11 +12,11 @@ private[build] final case class Descriptor(
     organization: Option[String],
     name: Option[String],
     gcProject: Boolean,
-    links: List[String],
-    defines: List[String],
-    includes: List[String],
-    stdC: Option[String],
-    stdCpp: Option[String]
+    links: Seq[String],
+    defines: Seq[String],
+    includes: Seq[String],
+    cOptions: Seq[String],
+    cppOptions: Seq[String]
 )
 
 private[build] object Descriptor {
@@ -34,8 +34,8 @@ private[build] object Descriptor {
         parseStrings("nir.link.names", props),
         parseStrings("preprocessor.defines", props),
         parseStrings("compile.include.paths", props),
-        Option(props.getProperty("compile.std.c")),
-        Option(props.getProperty("compile.std.cpp"))
+        parseStrings("compile.c.options", props),
+        parseStrings("compile.cpp.options", props)
       )
     } finally {
       if (reader != null) {
@@ -48,10 +48,10 @@ private[build] object Descriptor {
     }
   }
 
-  private def parseStrings(prop: String, props: Properties): List[String] =
+  private def parseStrings(prop: String, props: Properties): Seq[String] =
     Option(props.getProperty(prop)) match {
-      case Some(value) => value.split(',').map(_.trim()).toList
-      case None        => List.empty
+      case Some(value) => value.split(',').map(_.trim()).toSeq
+      case None        => Seq.empty
     }
 
 }

--- a/tools/src/main/scala/scala/scalanative/build/Descriptor.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Descriptor.scala
@@ -14,7 +14,9 @@ private[build] final case class Descriptor(
     gcProject: Boolean,
     links: List[String],
     defines: List[String],
-    includes: List[String]
+    includes: List[String],
+    stdC: Option[String],
+    stdCpp: Option[String]
 )
 
 private[build] object Descriptor {
@@ -31,7 +33,9 @@ private[build] object Descriptor {
         props.getProperty("project.gcProject", "false").toBoolean,
         parseStrings("nir.link.names", props),
         parseStrings("preprocessor.defines", props),
-        parseStrings("compile.include.paths", props)
+        parseStrings("compile.include.paths", props),
+        Option(props.getProperty("compile.std.c")),
+        Option(props.getProperty("compile.std.cpp"))
       )
     } finally {
       if (reader != null) {

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -20,7 +20,7 @@ private[scalanative] object LLVM {
   // shipped with Windows 10 / Server 2016+ (we do not plan supporting older versions)
   val defaultWinCpp = "c++14"
   val defaultCpp = "c++11"
-  val defaultC = "gnu11" // "c11"
+  val defaultC = "c11"
 
   /** Object file extension: ".o" */
   val oExt = ".o"

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -20,7 +20,7 @@ private[scalanative] object LLVM {
   // shipped with Windows 10 / Server 2016+ (we do not plan supporting older versions)
   val defaultWinCpp = "c++14"
   val defaultCpp = "c++11"
-  val defaultC = "c11" // "gnu11"
+  val defaultC = "gnu11" // "c11"
 
   /** Object file extension: ".o" */
   val oExt = ".o"

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -20,7 +20,7 @@ private[scalanative] object LLVM {
   // shipped with Windows 10 / Server 2016+ (we do not plan supporting older versions)
   val defaultWinCpp = "c++14"
   val defaultCpp = "c++11"
-  val defaultC = "gnu11"
+  val defaultC = "c11" //"gnu11"
 
   /** Object file extension: ".o" */
   val oExt = ".o"

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -20,7 +20,7 @@ private[scalanative] object LLVM {
   // shipped with Windows 10 / Server 2016+ (we do not plan supporting older versions)
   val defaultWinCpp = "c++14"
   val defaultCpp = "c++11"
-  val defaultC = "c11" //"gnu11"
+  val defaultC = "c11" // "gnu11"
 
   /** Object file extension: ".o" */
   val oExt = ".o"

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -19,10 +19,14 @@ sealed trait NativeConfig {
   /** The compilation options passed to LLVM. */
   def compileOptions: Seq[String]
 
-  /** C only options including -std=XXX */
+  /** The compilation options used when compiling .c files combined with
+   *  'compileOptions' used on all sources.
+   */
   def cOptions: Seq[String]
 
-  /** C++ only options including -std=XXX */
+  /** The compilation options used when compiling .cpp files combined with
+   *  'compileOptions' used on all sources.
+   */
   def cppOptions: Seq[String]
 
   /** Optional target triple that defines current OS, ABI and CPU architecture.
@@ -503,8 +507,8 @@ object NativeConfig {
         | - clangPP:                 $clangPP
         | - linkingOptions:          ${showSeq(linkingOptions)}
         | - compileOptions:          ${showSeq(compileOptions)}
-        | - cOptions:                $cOptions
-        | - cppOptions:              $cppOptions
+        | - cOptions:                ${showSeq(cOptions)}
+        | - cppOptions:              ${showSeq(cppOptions)}
         | - targetTriple:            $targetTriple
         | - GC:                      $gc
         | - LTO:                     $lto

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -19,11 +19,11 @@ sealed trait NativeConfig {
   /** The compilation options passed to LLVM. */
   def compileOptions: Seq[String]
 
-  /** The compiler C version -std=XXX */
-  def compileStdC: Option[String]
+  /** C only options including -std=XXX */
+  def cOptions: Seq[String]
 
-  /** The compiler C++ version -std=XXX */
-  def compileStdCpp: Option[String]
+  /** C++ only options including -std=XXX */
+  def cppOptions: Seq[String]
 
   /** Optional target triple that defines current OS, ABI and CPU architecture.
    */
@@ -165,11 +165,19 @@ sealed trait NativeConfig {
   /** Create a new config with updated compilation options. */
   def withCompileOptions(update: Mapping[Seq[String]]): NativeConfig
 
-  /** Create a new config with custom C std. */
-  def withCompileStdC(value: String): NativeConfig
+  /** Create a new config with given C only options */
+  final def withCOptions(value: Seq[String]): NativeConfig =
+    withCOptions(_ => value)
 
-  /** Create a new config with custom C++ std. */
-  def withCompileStdCpp(value: String): NativeConfig
+  /** Create a new config with updated C only options */
+  def withCOptions(update: Mapping[Seq[String]]): NativeConfig
+
+  /** Create a new config with given C++ only options */
+  final def withCppOptions(value: Seq[String]): NativeConfig =
+    withCppOptions(_ => value)
+
+  /** Create a new config with updated C++ only options */
+  def withCppOptions(update: Mapping[Seq[String]]): NativeConfig
 
   /** Create a new config given a target triple. */
   def withTargetTriple(value: Option[String]): NativeConfig
@@ -291,8 +299,8 @@ object NativeConfig {
       clangPP = Paths.get(""),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
-      compileStdC = None,
-      compileStdCpp = None,
+      cOptions = Seq.empty,
+      cppOptions = Seq.empty,
       targetTriple = None,
       gc = GC.default,
       lto = LTO.default,
@@ -323,8 +331,8 @@ object NativeConfig {
       clangPP: Path,
       linkingOptions: Seq[String],
       compileOptions: Seq[String],
-      compileStdC: Option[String],
-      compileStdCpp: Option[String],
+      cOptions: Seq[String],
+      cppOptions: Seq[String],
       targetTriple: Option[String],
       gc: GC,
       lto: LTO,
@@ -362,11 +370,11 @@ object NativeConfig {
     def withCompileOptions(update: Mapping[Seq[String]]): NativeConfig =
       copy(compileOptions = update(compileOptions).map(_.trim()))
 
-    def withCompileStdC(value: String): NativeConfig =
-      copy(compileStdC = Some(value))
+    def withCOptions(update: Mapping[Seq[String]]): NativeConfig =
+      copy(cOptions = update(cOptions).map(_.trim()))
 
-    def withCompileStdCpp(value: String): NativeConfig =
-      copy(compileStdCpp = Some(value))
+    def withCppOptions(update: Mapping[Seq[String]]): NativeConfig =
+      copy(cppOptions = update(cppOptions).map(_.trim()))
 
     def withTargetTriple(value: Option[String]): NativeConfig = {
       val propertyName = "target.triple"
@@ -495,8 +503,8 @@ object NativeConfig {
         | - clangPP:                 $clangPP
         | - linkingOptions:          ${showSeq(linkingOptions)}
         | - compileOptions:          ${showSeq(compileOptions)}
-        | - compileStdC:             $compileStdC
-        | - compileStdCpp:           $compileStdCpp
+        | - cOptions:                $cOptions
+        | - cppOptions:              $cppOptions
         | - targetTriple:            $targetTriple
         | - GC:                      $gc
         | - LTO:                     $lto

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -19,6 +19,12 @@ sealed trait NativeConfig {
   /** The compilation options passed to LLVM. */
   def compileOptions: Seq[String]
 
+  /** The compiler C version -std=XXX */
+  def compileStdC: Option[String]
+
+  /** The compiler C++ version -std=XXX */
+  def compileStdCpp: Option[String]
+
   /** Optional target triple that defines current OS, ABI and CPU architecture.
    */
   def targetTriple: Option[String]
@@ -159,6 +165,12 @@ sealed trait NativeConfig {
   /** Create a new config with updated compilation options. */
   def withCompileOptions(update: Mapping[Seq[String]]): NativeConfig
 
+  /** Create a new config with custom C std. */
+  def withCompileStdC(value: String): NativeConfig
+
+  /** Create a new config with custom C++ std. */
+  def withCompileStdCpp(value: String): NativeConfig
+
   /** Create a new config given a target triple. */
   def withTargetTriple(value: Option[String]): NativeConfig
 
@@ -279,6 +291,8 @@ object NativeConfig {
       clangPP = Paths.get(""),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
+      compileStdC = None,
+      compileStdCpp = None,
       targetTriple = None,
       gc = GC.default,
       lto = LTO.default,
@@ -309,6 +323,8 @@ object NativeConfig {
       clangPP: Path,
       linkingOptions: Seq[String],
       compileOptions: Seq[String],
+      compileStdC: Option[String],
+      compileStdCpp: Option[String],
       targetTriple: Option[String],
       gc: GC,
       lto: LTO,
@@ -345,6 +361,12 @@ object NativeConfig {
 
     def withCompileOptions(update: Mapping[Seq[String]]): NativeConfig =
       copy(compileOptions = update(compileOptions).map(_.trim()))
+
+    def withCompileStdC(value: String): NativeConfig =
+      copy(compileStdC = Some(value))
+
+    def withCompileStdCpp(value: String): NativeConfig =
+      copy(compileStdCpp = Some(value))
 
     def withTargetTriple(value: Option[String]): NativeConfig = {
       val propertyName = "target.triple"
@@ -473,6 +495,8 @@ object NativeConfig {
         | - clangPP:                 $clangPP
         | - linkingOptions:          ${showSeq(linkingOptions)}
         | - compileOptions:          ${showSeq(compileOptions)}
+        | - compileStdC:             $compileStdC
+        | - compileStdCpp:           $compileStdCpp
         | - targetTriple:            $targetTriple
         | - GC:                      $gc
         | - LTO:                     $lto

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -76,7 +76,7 @@ private[scalanative] object NativeLib {
       config.withCompilerConfig(_.withCompileOptions(_ ++ preprocessorFlags))
     }
 
-    // Apply dependency specific configuratin based on descriptor if found
+    // Apply dependency specific configuration based on descriptor if found
     def withProjectDescriptor(config: Config): Config = {
       findDescriptor(nativeCodePath).fold(config) { filepath =>
         val descriptor = Descriptor.load(filepath) match {
@@ -95,7 +95,23 @@ private[scalanative] object NativeLib {
           analysis = analysis,
           nativeCodePath = nativeCodePath
         )
-        config.withCompilerConfig(_.withCompileOptions(_ ++ projectSettings))
+
+        def withStdCOpt(nativeConfig: NativeConfig): NativeConfig =
+          descriptor.stdC match {
+            case None        => nativeConfig
+            case Some(value) => nativeConfig.withCompileStdC(value)
+          }
+
+        def withStdCppOpt(nativeConfig: NativeConfig): NativeConfig =
+          descriptor.stdCpp match {
+            case None        => nativeConfig
+            case Some(value) => nativeConfig.withCompileStdCpp(value)
+          }
+
+        config
+          .withCompilerConfig(_.withCompileOptions(_ ++ projectSettings))
+          .withCompilerConfig(withStdCOpt _)
+          .withCompilerConfig(withStdCppOpt _)
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -96,22 +96,40 @@ private[scalanative] object NativeLib {
           nativeCodePath = nativeCodePath
         )
 
-        def withStdCOpt(nativeConfig: NativeConfig): NativeConfig =
-          descriptor.stdC match {
-            case None        => nativeConfig
-            case Some(value) => nativeConfig.withCompileStdC(value)
+        def withCOptions(nativeConfig: NativeConfig): NativeConfig =
+          descriptor.cOptions match {
+            case Seq()    => nativeConfig
+            case descOpts =>
+              descOpts.exists(s => s.startsWith(LLVM.stdPrefix)) match {
+                case false => nativeConfig.withCOptions(c => c ++ descOpts)
+                case true  => {
+                  val filtOpts = nativeConfig.cOptions.filterNot(e =>
+                    e.startsWith(LLVM.stdPrefix)
+                  )
+                  nativeConfig.withCOptions(filtOpts ++ descOpts)
+                }
+              }
           }
 
-        def withStdCppOpt(nativeConfig: NativeConfig): NativeConfig =
-          descriptor.stdCpp match {
-            case None        => nativeConfig
-            case Some(value) => nativeConfig.withCompileStdCpp(value)
+        def withCppOptions(nativeConfig: NativeConfig): NativeConfig =
+          descriptor.cppOptions match {
+            case Seq()    => nativeConfig
+            case descOpts =>
+              descOpts.exists(s => s.startsWith(LLVM.stdPrefix)) match {
+                case false => nativeConfig.withCppOptions(c => c ++ descOpts)
+                case true  => {
+                  val filtOpts = nativeConfig.cppOptions.filterNot(e =>
+                    e.startsWith(LLVM.stdPrefix)
+                  )
+                  nativeConfig.withCppOptions(filtOpts ++ descOpts)
+                }
+              }
           }
 
         config
           .withCompilerConfig(_.withCompileOptions(_ ++ projectSettings))
-          .withCompilerConfig(withStdCOpt _)
-          .withCompilerConfig(withStdCppOpt _)
+          .withCompilerConfig(withCOptions _)
+          .withCompilerConfig(withCppOptions _)
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -96,40 +96,10 @@ private[scalanative] object NativeLib {
           nativeCodePath = nativeCodePath
         )
 
-        def withCOptions(nativeConfig: NativeConfig): NativeConfig =
-          descriptor.cOptions match {
-            case Seq()    => nativeConfig
-            case descOpts =>
-              descOpts.exists(s => s.startsWith(LLVM.stdPrefix)) match {
-                case false => nativeConfig.withCOptions(c => c ++ descOpts)
-                case true  => {
-                  val filtOpts = nativeConfig.cOptions.filterNot(e =>
-                    e.startsWith(LLVM.stdPrefix)
-                  )
-                  nativeConfig.withCOptions(filtOpts ++ descOpts)
-                }
-              }
-          }
-
-        def withCppOptions(nativeConfig: NativeConfig): NativeConfig =
-          descriptor.cppOptions match {
-            case Seq()    => nativeConfig
-            case descOpts =>
-              descOpts.exists(s => s.startsWith(LLVM.stdPrefix)) match {
-                case false => nativeConfig.withCppOptions(c => c ++ descOpts)
-                case true  => {
-                  val filtOpts = nativeConfig.cppOptions.filterNot(e =>
-                    e.startsWith(LLVM.stdPrefix)
-                  )
-                  nativeConfig.withCppOptions(filtOpts ++ descOpts)
-                }
-              }
-          }
-
         config
           .withCompilerConfig(_.withCompileOptions(_ ++ projectSettings))
-          .withCompilerConfig(withCOptions _)
-          .withCompilerConfig(withCppOptions _)
+          .withCompilerConfig(_.withCOptions(_ ++ descriptor.cOptions))
+          .withCompilerConfig(_.withCppOptions(_ ++ descriptor.cppOptions))
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
@@ -3,14 +3,14 @@ package scala.scalanative.build
 /** An object describing configuration of the Scala Native semantics. */
 sealed trait SemanticsConfig {
 //format: off
-  /** Controls behaviour of final fields and their complaince with the Java Memory Model. 
+  /** Controls behaviour of final fields and their compliance with the Java Memory Model.
    *  The outputs of the program would depend on compliance level:
    *  - [[JVMMemoryModelCompliance.Strict]] all final fields are synchronized - ensures safe publication,but it might lead to runtime performance overhead.
    *  - [[JVMMemoryModelCompliance.None]] final fields are never synchronized - no runtime overhead when accessing final fields, but it might lead to unexpected state in highly concurrent programs.
    *  - [[JVMMemoryModelCompliance.Relaxed]] (default) only fields marked with scala.scalanative.annotation.safePublish are synchronized.
    */
   def finalFields: JVMMemoryModelCompliance
-  /** Sets the behaviour of final fields and their complaince with the Java Memory Model
+  /** Sets the behaviour of final fields and their compliance with the Java Memory Model
    *   The outputs of the program would depend on compliance level:
    *  - [[JVMMemoryModelCompliance.Strict]] all final fields are synchronized - ensures safe publication,but it might lead to runtime performance overhead.
    *  - [[JVMMemoryModelCompliance.None]] final fields are never synchronized - no runtime overhead when accessing final fields, but it might lead to unexpected state in highly concurrent programs.


### PR DESCRIPTION
The intent here is to allow a default, and project specific settings.

This means that if someones project needs C++17 and there compiler is not new enough, things will fail. If it is the end users project wanting a newer version if should still work. We will test that out.