### PR TITLE
Remove spurious dependencies of `test-runner`.

### DIFF
--- a/.github/actions/windows-setup-env/action.yml
+++ b/.github/actions/windows-setup-env/action.yml
@@ -22,7 +22,7 @@ runs:
         distribution: "zulu"
         java-version: ${{inputs.java-version}}
     # We need to set proper Pagefile limits in advance.
-    # Github actions default page file size is quite small,
+    # GitHub actions default page file size is quite small,
     # it's not enough to run all tests, especially when using None GC.
     # We've observed that on Unix memory management is less strict,
     # you can reserve more memory than it's physically possible.

--- a/auxlib/src/main/scala/scala/runtime/BoxesRunTime.scala
+++ b/auxlib/src/main/scala/scala/runtime/BoxesRunTime.scala
@@ -112,7 +112,7 @@ object BoxesRunTime {
   @inline def unboxToDouble(o: java.lang.Object): scala.Double =
     if (o == null) 0 else o.asInstanceOf[java.lang.Double].doubleValue
 
-  // Comparsion
+  // Comparison
   @inline def equals(x: java.lang.Object, y: java.lang.Object): Boolean = {
     if (x eq y) true
     else equals2(x, y)

--- a/docs/blog/interflow.md
+++ b/docs/blog/interflow.md
@@ -2,7 +2,7 @@
 
 June 16, 2018.
 
-This post provides a sneak peak at Interflow, an upcoming optimizer for Scala Native. For more details, see [our publication preprint](https://github.com/densh/talks/blob/master/2018-06-16-interflow-preprint-v1.pdf).
+This post provides a sneak peek at Interflow, an upcoming optimizer for Scala Native. For more details, see [our publication preprint](https://github.com/densh/talks/blob/master/2018-06-16-interflow-preprint-v1.pdf).
 
 ## The Interflow Optimizer
 
@@ -44,7 +44,7 @@ Additionally, we also compare our performance results with Graal Native Image (1
 
 ![](throughput-native-image.png)
 
-Both Scala Native 0.3.7 (geomean 0.49x) and Native Image 1.0-RC1 (geomean 0.47x) without PGO fail to achieve performance comparable to the a warmed-up JIT compiler. Native Image's implementation of PGO obtains impressive speedups, but it is still behind JDK8 (geomean 0.73x).
+Both Scala Native 0.3.7 (geomean 0.49x) and Native Image 1.0-RC1 (geomean 0.47x) without PGO fail to achieve performance comparable to a warmed-up JIT compiler. Native Image's implementation of PGO obtains impressive speedups, but it is still behind JDK8 (geomean 0.73x).
 
 On the other hand, Interflow (geomean 0.89x) outperforms Graal Native Image statically. With the addition of PGO, Interflow gets quite close to the throughput of a fully warmed JIT compiler (geomean 0.96x).
 
@@ -52,4 +52,4 @@ Interestingly enough, with Interflow, profile-guided optimizations are not stric
 
 ## Conclusion
 
-This post provides a sneak peak at Interflow, an upcoming optimizer for Scala Native. Additionally, we're also going to provide support for profile-guided optimization as an opt-in feature for users who want to obtain absolute best peak performance for Scala Native compiled code. Interflow and PGO are currently in development. Stay tuned for updates on general availability on [twitter.com/scala_native](https://twitter.com/scala_native).
+This post provides a sneak peek at Interflow, an upcoming optimizer for Scala Native. Additionally, we're also going to provide support for profile-guided optimization as an opt-in feature for users who want to obtain absolute best peak performance for Scala Native compiled code. Interflow and PGO are currently in development. Stay tuned for updates on general availability on [twitter.com/scala_native](https://twitter.com/scala_native).

--- a/docs/changelog/0.4.x/0.4.0.md
+++ b/docs/changelog/0.4.x/0.4.0.md
@@ -211,7 +211,7 @@ Commix GC was written in C and uses `pthread` to work. In case your application 
 * `toCString` & `fromCString` now correctly return null,
 * Fixed errors with not cleared `errno` when using POSIX `readdir`
 * Array operation now throw JVM-compliant `ArrayIndexOutOfBoundsException`,
-* Fix bug with `BufferedInputStream.read()` for values bigger then 0x7f,
+* Fix bug with `BufferedInputStream.read()` for values bigger than 0x7f,
 * `Files.walk` accepts non-directory files,
 * Improved IEEE754 specification compliance when parsing strings,
 * Fixed infinite loop in `java.io.RandomAccesFile.readLine`,
@@ -268,7 +268,7 @@ $ git shortlog -sn --no-merges v0.4.0-M2..v0.4.0
 - Fix #2084 Allow identifiers containing double-quote characters
   [\#2085](https://github.com/scala-native/scala-native/pull/2085)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Fix #2035: Guard virtual lookup of non virtual methods
+- Fix #2035: Guard virtual lookup of non-virtual methods
   [\#2051](https://github.com/scala-native/scala-native/pull/2051)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Fix #415: Report usage positions of missing definitions when linking
@@ -385,7 +385,7 @@ $ git shortlog -sn --no-merges v0.4.0-M2..v0.4.0
 - Support boehm installed from macports
   [\#2071](https://github.com/scala-native/scala-native/pull/2071)
   ([catap](https://github.com/catap))
-- Never use default path that doesn't exists
+- Never use default path that doesn't exist
   [\#2091](https://github.com/scala-native/scala-native/pull/2091)
   ([catap](https://github.com/catap))
 - Fix crash when HOME env variable is not set

--- a/docs/changelog/0.4.x/0.4.1.md
+++ b/docs/changelog/0.4.x/0.4.1.md
@@ -38,7 +38,7 @@ We're happy to announce the release of Scala Native v0.4.1!
 ## Most impacting changes
 ### Windows support
 This release of Scala Native brings native support for compilation and running 
-Scala Native applications on Windows. For instructions how to setup your environment 
+Scala Native applications on Windows. For instructions how to set up your environment 
 check out our [documentation](https://scala-native.readthedocs.io/en/latest/user/setup.html)
 
 ### Linktime resolved expressions
@@ -66,12 +66,12 @@ at the time of performing linking of NIR files, whole condition expression
 would be replaced with constant boolean value equal to `true` or `false`.
 At this point we can dead-code eliminate never taken branch. 
 This feature is crucial for cross compilation on different platforms - if we eliminate
-branch containing call to OS specific function it would be never used, and though we would 
+branch containing call to OS specific function it would never be used, and though we would 
 not need its definition when building.
 
 In the snippet below you can see an example of linktime conditional branching. Depending on
 Native Config settings only one of the if condition branch would be taken, the second one
-would be always discarded. 
+would always be discarded. 
 
 ```scala
 import scala.scalanative.meta.LinktimeInfo.isWindows

--- a/docs/changelog/0.4.x/0.4.10.md
+++ b/docs/changelog/0.4.x/0.4.10.md
@@ -148,7 +148,7 @@ $ git shortlog -sn --no-merges v0.4.9..v0.4.10
 - Handle whitespaces in the files passed to the clang when linking
   [\#3062](https://github.com/scala-native/scala-native/pull/3062)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- Fix #3078, allow methods to have more then 10k instructions
+- Fix #3078, allow methods to have more than 10k instructions
   [\#3095](https://github.com/scala-native/scala-native/pull/3095)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - Introduce `scalanative.build.Mode.ReleaseSize`

--- a/docs/changelog/0.4.x/0.4.13.md
+++ b/docs/changelog/0.4.x/0.4.13.md
@@ -103,7 +103,7 @@ $ git shortlog -sn --no-merges v0.4.12..
   ([armanbilge](https://github.com/armanbilge))
 
 ### Java Standard Library
-- Fix handling of Path.relativze on Windows
+- Fix handling of Path.relativize on Windows
   [/#3299](https://github.com/scala-native/scala-native/pull/3299)
   ([jpsacha](https://github.com/jpsacha))
 -  Provide an evolution of Scala Native support for the Java Stream API

--- a/docs/changelog/0.4.x/0.4.3-RC1.md
+++ b/docs/changelog/0.4.x/0.4.3-RC1.md
@@ -142,6 +142,6 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3-RC1
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### Linker
-- Make reachability phase more user friendly
+- Make reachability phase more user-friendly
   [\#2469](https://github.com/scala-native/scala-native/pull/2469)
   ([WojciechMazur](https://github.com/WojciechMazur))

--- a/docs/changelog/0.4.x/0.4.3-RC2.md
+++ b/docs/changelog/0.4.x/0.4.3-RC2.md
@@ -33,7 +33,7 @@ More information can be found in [#2480](https://github.com/scala-native/scala-n
 ## Known issues
 ### Cannot create documentation using scaladoc in Scala Native sbt project
 When trying to generate documentation using Scaladoc for projects using Scala Native compilation would fail with an exception. 
-This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1-RC2 compiler. As a workaround in Scala 3.1.0 we would recommend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`. Workaround can be find in [this discussion](https://github.com/scala-native/scala-native/issues/2503#issuecomment-1005290906)
+This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1-RC2 compiler. As a workaround in Scala 3.1.0 we would recommend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`. Workaround can be found in [this discussion](https://github.com/scala-native/scala-native/issues/2503#issuecomment-1005290906)
 
 
 <table>

--- a/docs/changelog/0.4.x/0.4.3.md
+++ b/docs/changelog/0.4.x/0.4.3.md
@@ -10,7 +10,7 @@ from Java standard library.
 
 ## Breaking changes in release 0.4.3
 The minimal version of Scala 3 supported by Scala Native is 3.1.0, due to fatal blockers in Scala 3.0.x. 
-In the future, when improved backward compatibility support in Scala 3.2 would implemented, Scala Native 
+In the future, when improved backward compatibility support in Scala 3.2 would be implemented, Scala Native 
 might be backported to the older version of the compiler.
 
 ### Changes to the main method resolving
@@ -32,7 +32,7 @@ More information can be found in [#2480](https://github.com/scala-native/scala-n
 ## Known issues
 ### Cannot create documentation using scaladoc in Scala Native sbt project
 When trying to generate documentation using Scaladoc for projects using Scala Native compilation would fail with an exception. 
-This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1 compiler. As a workaround in Scala 3.1.0 we would recommend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`. Workaround can be find in [this discussion](https://github.com/scala-native/scala-native/issues/2503#issuecomment-1005290906)
+This issue is common for most of the compiler plugins and was already fixed in Scala 3.1.1 compiler. As a workaround in Scala 3.1.0 we would recommend adjusting sbt build, by filtering out all `-Xplugin` settings from `Compile / doc / scalacOptions`. Workaround can be found in [this discussion](https://github.com/scala-native/scala-native/issues/2503#issuecomment-1005290906)
 
 <table>
 <tbody>
@@ -179,7 +179,7 @@ $ git shortlog -sn --no-merges v0.4.2..v0.4.3
   ([WojciechMazur](https://github.com/WojciechMazur))
 
 ### Linker
-- Make reachability phase more user friendly
+- Make reachability phase more user-friendly
   [\#2469](https://github.com/scala-native/scala-native/pull/2469)
   ([WojciechMazur](https://github.com/WojciechMazur))
 

--- a/docs/changelog/0.4.x/0.4.8.md
+++ b/docs/changelog/0.4.x/0.4.8.md
@@ -66,7 +66,7 @@ $ git shortlog -sn --no-merges v0.4.7..v0.4.8
 ## New features
 
 ### Producing native libraries using Scala Native
-Scala Native can now produce both dynamic and static libraries. This features allows to use Scala Native code in foreign runtimes, eg. in C, Rust or on the JVM.
+Scala Native can now produce both dynamic and static libraries. This features allows to use Scala Native code in foreign runtimes, e.g. in C, Rust or on the JVM.
 To enable this feature switch the build target of your project and annotate entry points for library using `@exported` annotation.
 ```scala
 import scala.scalanative.build.BuildTarget

--- a/docs/changelog/0.5.x/0.5.0-RC1.md
+++ b/docs/changelog/0.5.x/0.5.0-RC1.md
@@ -68,16 +68,16 @@ Be aware that both Scala Native optimizer and LLVM optimizers can remove some of
 See our [debugging guide](../../user/testing.md#source-level-debugging) for more information.
 
 ### SIP-51 support: Drop forward binary compatibility of the Scala 2.13 standard library
-We're changing how the Scala standard library artifacts are published. Previously each Scala Native version shipped with 1 artifact for Scala standard library based on latest version of Scala. However this approach was insufficient to fully cover changes in Scala 3 standard library and it's 2 lines of releases: Scala LTS and Scala Next.
-To mitigate this issue and to prepare for unfreezing Scala 2 standard library we're changing how artifacts are published. Now each release of Scala Native would contain N variants of Scala standard library with custom versioning in format `<ScalaVersion>+<ScalaNativeVersion>`, eg. `3.3.2+0.5.0`.
+We're changing how the Scala standard library artifacts are published. Previously each Scala Native version shipped with 1 artifact for Scala standard library based on latest version of Scala. However, this approach was insufficient to fully cover changes in Scala 3 standard library and its 2 lines of releases: Scala LTS and Scala Next.
+To mitigate this issue and to prepare for unfreezing Scala 2 standard library we're changing how artifacts are published. Now each release of Scala Native would contain N variants of Scala standard library with custom versioning in format `<ScalaVersion>+<ScalaNativeVersion>`, e.g. `3.3.2+0.5.0`.
 
 ### Improved missing symbols reports
 The new release introduces a refactored mechanism for tracking and reporting missing symbols in the linked code.
-Now when referring to not implemented Java standard library method, or a type from not cross-compiled library you would receive a detailed information about missing symbols containing its signature approximation and detailed stack trace of method calls leading to usage of missing symbol.
+Now when referring to not implemented Java standard library method, or a type from not cross-compiled library you would receive detailed information about missing symbols containing its signature approximation and detailed stack trace of method calls leading to usage of missing symbol.
 
 ### JVM service providers supports
 We're introducing a user configured support for Java Service Providers.
-Similarly to it's JVM variant these would allow you to introduce implementations of Service Provider Interfaces however due to Ahead-of-time compilation constraint and to limit amount of introduced dependencies only explicitly enabled implementations would be linked in the final binary.
+Similarly to its JVM variant these would allow you to introduce implementations of Service Provider Interfaces however due to Ahead-of-time compilation constraint and to limit amount of introduced dependencies only explicitly enabled implementations would be linked in the final binary.
 For more details refer to {ref}`our guide <service_providers>`.
 
 ### User build settings
@@ -570,7 +570,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Implement java.net DatagramSocket and DatagramPacket
   [\#3614](https://github.com/scala-native/scala-native/pull/3614)
   ([RustedBones](https://github.com/RustedBones))
-- Fix #3657: Remove a number of java.net defects
+- Fix #3657: Remove number of java.net defects
   [\#3666](https://github.com/scala-native/scala-native/pull/3666)
   ([LeeTibbert](https://github.com/LeeTibbert))
 - fix: Fix accessing mapped byte buffers if offset is not page size aligned
@@ -725,7 +725,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - improvement: Detect user config change and prune generated/native sources on change
   [\#3724](https://github.com/scala-native/scala-native/pull/3724)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- refactor: Pipeline generation of LLVM IR and it's compilation
+- refactor: Pipeline generation of LLVM IR and its compilation
   [\#3622](https://github.com/scala-native/scala-native/pull/3622)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - fix [toolchain]:Prevent usage of outdated compilation outputs in incremental compilation

--- a/docs/changelog/0.5.x/0.5.0.md
+++ b/docs/changelog/0.5.x/0.5.0.md
@@ -68,12 +68,12 @@ Be aware that both Scala Native optimizer and LLVM optimizers can remove some of
 See our [debugging guide](../../user/testing.md#source-level-debugging) for more information.
 
 ### SIP-51 support: Drop forward binary compatibility of the Scala 2.13 standard library
-We're changing how the Scala standard library artifacts are published. Previously each Scala Native version shipped with 1 artifact for Scala standard library based on latest version of Scala. However this approach was insufficient to fully cover changes in Scala 3 standard library and it's 2 lines of releases: Scala LTS and Scala Next.
-To mitigate this issue and to prepare for unfreezing Scala 2 standard library we're changing how artifacts are published. Now each release of Scala Native would contain N variants of Scala standard library with custom versioning in format `<ScalaVersion>+<ScalaNativeVersion>`, eg. `3.3.2+0.5.0`.
+We're changing how the Scala standard library artifacts are published. Previously each Scala Native version shipped with 1 artifact for Scala standard library based on latest version of Scala. However, this approach was insufficient to fully cover changes in Scala 3 standard library and its 2 lines of releases: Scala LTS and Scala Next.
+To mitigate this issue and to prepare for unfreezing Scala 2 standard library we're changing how artifacts are published. Now each release of Scala Native would contain N variants of Scala standard library with custom versioning in format `<ScalaVersion>+<ScalaNativeVersion>`, e.g. `3.3.2+0.5.0`.
 
 ### Improved missing symbols reports
 The new release introduces a refactored mechanism for tracking and reporting missing symbols in the linked code.
-Now when referring to not implemented Java standard library method, or a type from not cross-compiled library you would receive a detailed information about missing symbols containing its signature approximation and detailed stack trace of method calls leading to usage of missing symbol.
+Now when referring to not implemented Java standard library method, or a type from not cross-compiled library you would receive detailed information about missing symbols containing its signature approximation and detailed stack trace of method calls leading to usage of missing symbol.
 
 ### JVM service providers supports
 We're introducing a user configured support for Java Service Providers.
@@ -597,7 +597,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - Implement java.net DatagramSocket and DatagramPacket
   [\#3614](https://github.com/scala-native/scala-native/pull/3614)
   ([RustedBones](https://github.com/RustedBones))
-- Fix #3657: Remove a number of java.net defects
+- Fix #3657: Remove number of java.net defects
   [\#3666](https://github.com/scala-native/scala-native/pull/3666)
   ([LeeTibbert](https://github.com/LeeTibbert))
 - fix: Fix accessing mapped byte buffers if offset is not page size aligned
@@ -773,7 +773,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 - improvement: Detect user config change and prune generated/native sources on change
   [\#3724](https://github.com/scala-native/scala-native/pull/3724)
   ([WojciechMazur](https://github.com/WojciechMazur))
-- refactor: Pipeline generation of LLVM IR and it's compilation
+- refactor: Pipeline generation of LLVM IR and its compilation
   [\#3622](https://github.com/scala-native/scala-native/pull/3622)
   ([WojciechMazur](https://github.com/WojciechMazur))
 - fix [toolchain]: Prevent usage of outdated compilation outputs in incremental compilation

--- a/docs/changelog/0.5.x/0.5.7.md
+++ b/docs/changelog/0.5.x/0.5.7.md
@@ -12,7 +12,7 @@ We're happy to announce the release of Scala Native 0.5.7.
 - Scala Native runtime no longer requires C++ standard library (on Unix systems) by default. 
   `@scala.scalanative.unsafe.linkCppRuntime` annotation can be used on extern methods bindings to require linking with C++ standard library if these are used. 
   Scala Native would still use C++ runtime on Windows or if the LTO is enabled, due to not yet resolved issues. 
-  Adding `-fno-cxx-exceptions` or `-fcxx-exceptions` settings to `NativeConfig.compileOptions` allows to explicitly control if Scala Native should use it's own exception handling implementation or to continue using C++ exception wrappers.
+  Adding `-fno-cxx-exceptions` or `-fcxx-exceptions` settings to `NativeConfig.compileOptions` allows to explicitly control if Scala Native should use its own exception handling implementation or to continue using C++ exception wrappers.
 - StackOverflowError can now be detected and handled instead of terminating program
 - `SCALANATIVE_THREAD_STACK_SIZE` environment variable can now be used to control default platform Thread size at runtime (-Xss on the JVM)
 - Optimized layout of Class virtual tables to reduce size of binaries
@@ -89,7 +89,7 @@ $ git shortlog -sn --no-merges v0.5.6..0.5.7
 - Try to fix exceptions during main thread initialization [#4188](https://github.com/scala-native/scala-native/pull/4188) ([WojciechMazur](https://github.com/WojciechMazur))
 - Implement minimal C++-like runtime to support exceptions without linking libc++ [#4122](https://github.com/scala-native/scala-native/pull/4122) ([lolgab](https://github.com/lolgab))
 - Fallback to C++ exceptions when using LTO or explicitly enabled [#4201](https://github.com/scala-native/scala-native/pull/4201) ([WojciechMazur](https://github.com/WojciechMazur))
-- Try optimize collection of stacktraces [#4115](https://github.com/scala-native/scala-native/pull/4115) ([WojciechMazur](https://github.com/WojciechMazur))
+- Try to optimize collection of stacktraces [#4115](https://github.com/scala-native/scala-native/pull/4115) ([WojciechMazur](https://github.com/WojciechMazur))
 - Detect and handle StackOverflowErrors [#4153](https://github.com/scala-native/scala-native/pull/4153) ([WojciechMazur](https://github.com/WojciechMazur))
 - Improve Class.toString for primitives. [#4187](https://github.com/scala-native/scala-native/pull/4187) ([WojciechMazur](https://github.com/WojciechMazur))
 

--- a/docs/contrib/build.md
+++ b/docs/contrib/build.md
@@ -162,7 +162,7 @@ Native sides of test interface.
 
 Scalalib project does not introduce any new classes but provides
 overrides for the existing Scala standard library. Some of these
-overrides exist to improve the performance of Scala Native, eg. by
+overrides exist to improve the performance of Scala Native, e.g. by
 explicit inlining of some methods. When running
 `scalalib/compile` it will automatically use existing
 `*.scala` files defined in `overrides`
@@ -190,7 +190,7 @@ e.g. `scala-cli scripts/scalalib-patch-tool.sc -- recreate 2.13.10`
 
 Each of these commands is applied to all files defined in the overrides
 directory. By default override directory is selected based on the used
-scala version, if it\'s not the present script will try to use directory
+scala version, if it's not the present script will try to use directory
 with corresponding Scala binary version, or it would try to use Scala
 epoch version or `overrides` directory. If none of these
 directories exists it will fail. It is also possible to define

--- a/docs/contrib/contributing.md
+++ b/docs/contrib/contributing.md
@@ -38,7 +38,7 @@ Formatting C and C++ code uses `clang-format` which requires
 LLVM library dependencies. For `clang-format` we use any
 version greater than `10` as most developers use a newer
 version of LLVM and `clang`. In order to make this easier we
-have a environment variable, `CLANG_FORMAT_PATH` which can
+have an environment variable, `CLANG_FORMAT_PATH` which can
 be set to a compatible version. Another option is to make sure the
 correct version of `clang-format` is available in your path.
 Refer to [setup](../user/setup.md) for the minimum version
@@ -171,7 +171,7 @@ be merged into the distribution, and need not even be reviewed.
 ## Documentation
 
 All code contributed to the user-facing standard library (the
-`nativelib/` directory) should come accompanied with
+`nativelib/` directory) should come accompanied by
 documentation. Pull requests containing undocumented code will not be
 accepted.
 

--- a/docs/contrib/ides.md
+++ b/docs/contrib/ides.md
@@ -25,13 +25,13 @@ sbt plugins or Scala 2 specific sources.
         link against). Not excluding it makes IDEA think that the Scala
         library comes from it, which results into highlighting errors.
     -   `nscplugin`: We need to add what SBT calls
-        `unmanagedSourceDirectories` as dependencies. Go go Project
+        `unmanagedSourceDirectories` as dependencies. Go to Project
         Structure -> Modules -> `nscplugin` -> Dependencies and click
         the + icon. Select "JARs or Directories" and navigate to the
         `nir` directory at the root of the Scala Native project. Repeat
         for the `util` directory.
     -   `native-build`: We need to add the `sbt-scala-native` module as
-        a dependency. Go go Project Structure -> Modules ->
+        a dependency. Go to Project Structure -> Modules ->
         `native-build` -> Dependencies and click the + icon. Select
         "Module Dependency" and select the `sbt-scala-native` module.
 

--- a/docs/contrib/nir.md
+++ b/docs/contrib/nir.md
@@ -7,7 +7,7 @@ efficiently compile modern languages like Scala.
 
 ## Introduction
 
-Lets have a look at the textual form of NIR generated for a simple Scala
+Let's have a look at the textual form of NIR generated for a simple Scala
 module:
 
 ``` scala

--- a/docs/contrib/quickstart.md
+++ b/docs/contrib/quickstart.md
@@ -118,7 +118,7 @@ enablePlugins(ScalaNativePlugin)
 
 ## Locally build docs
 
-1.  First time building the docs. This command will setup & build the
+1.  First time building the docs. This command will set up & build the
     docs.
 
 ``` text
@@ -157,4 +157,4 @@ To configure the native build in this project, you can edit
 -   [compiler](./compiler.md)
 -   [nir](./nir.md)
 -   [name mangling](./mangling.md)
--   How to setup IDEs [ides](./ides.md)
+-   How to set up IDEs [ides](./ides.md)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,7 @@ Community
   Ask it on `Stack Overflow with tag scala-native <https://stackoverflow.com/questions/tagged/scala-native>`_.
 
 * Found a bug or want to propose a new feature?
-  Open `an issue on Github <https://github.com/scala-native/scala-native/issues>`_.
+  Open `an issue on GitHub <https://github.com/scala-native/scala-native/issues>`_.
 
 Documentation
 -------------

--- a/docs/lib/javalib.md
+++ b/docs/lib/javalib.md
@@ -140,7 +140,7 @@ resulting binary file.
 
 Also, you can specify which resources would be embedded in an executable
 using include or exclude glob pattern. By default, scala-native will
-include all the files in the classpath, and exclude none (there're some
+include all the files in the classpath, and exclude none (there are some
 exceptions for files such as `.class`, see below). By specifying the
 include patterns, only the files matching the include patterns will be
 included. This can be useful for reducing the size of your executables.

--- a/docs/user/interop.md
+++ b/docs/user/interop.md
@@ -135,7 +135,7 @@ object mystdio {
 }
 ```
 
-The limitation of `...` interop requires that it's
+The limitation of `...` interop requires that its
 arguments needs to passed directly to variadic arguments function or
 arguments need to be inlined. This is required to obtain enough
 information on how arguments show be passed in regards to C ABI. Passing
@@ -177,7 +177,7 @@ name of field.
 `int ScalaNativeInit(void);` function is special exported
 function that needs to be called before invoking any code defined in
 Scala Native. It returns `0` on successful initialization
-and non-zero value in the otherwise.
+and non-zero value otherwise.
 
 For dynamic libraries a constructor
 would be generated to invoke `ScalaNativeInit` function
@@ -457,8 +457,8 @@ stdio.printf(msg)
 ```
 
 It does not allow any octal values or escape characters not supported by
-Scala compiler, like `\a` or `\?`, but also unicode escapes. It is
-possible to use C-style hex values up to value 0xFF, eg.
+Scala compiler, like `\a` or `\?`, but also Unicode escapes. It is
+possible to use C-style hex values up to value 0xFF, e.g.
 `c"Hello \x61\x62\x63"`
 
 Additionally, we also expose two helper functions `unsafe.fromCString`

--- a/docs/user/native.md
+++ b/docs/user/native.md
@@ -128,9 +128,9 @@ published library can avoid the error described above. Use the following
 procedure to implement this feature.
 
 1. Add the following content to your new `scala-native.properties` file
-desdribed above. For the purposes of this example assume the library is
-`z`. Note that if your library has more that one library you can add a
-comma delimited list of libraries. If desired, the comments are not
+described above. For the purposes of this example assume the library is
+`z`. Note that if your library has more than one library you can add a
+comma-delimited list of libraries. If desired, the comments are not
 needed.
 
 ``` properties

--- a/docs/user/profiling.md
+++ b/docs/user/profiling.md
@@ -67,7 +67,7 @@ its UI. Samply has support for de-mangling Scala Native symbols.
 [hotspot](https://github.com/KDAB/hotspot) is a GUI for `perf` which provides a flamegraph view. As of this
 writing, hotspot does not de-mangle Scala Native symbols.
 
-### Using using `perf` and `FlameGraph`
+### Using `perf` and `FlameGraph`
 
 Follow these steps:
 

--- a/docs/user/sbt.md
+++ b/docs/user/sbt.md
@@ -160,8 +160,8 @@ Scala Native supports three distinct linking modes:
 5.  **release-full.** (introduced in 0.4.0)
 
     Optimized for best runtime performance, even if hurts compilation
-    time and code size. This modes includes a number of more aggresive
-    optimizations such type-driven method duplication and more aggresive
+    time and code size. This mode includes a number of more aggressive
+    optimizations such type-driven method duplication and more aggressive
     inliner. Similar to clang's `-O3` with addition of link-time
     optimization over the whole application code.
 
@@ -182,7 +182,7 @@ Scala Native supports three distinct linking modes:
 3.  **boehm.** (default through 0.3.7)
 
     Conservative generational garbage collector. More information is
-    available at the [Github project "ivmai/bdgc" page](https://github.com/ivmai/bdwgc).
+    available at the [GitHub project "ivmai/bdgc" page](https://github.com/ivmai/bdwgc).
 
 4.  **none.** (experimental, introduced in 0.2)
 

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -119,7 +119,7 @@ installation of FreeBSD.
 pkg install boehm-gc # optional
 ```
 
-*Note 3:* Using the boehm GC with multi-threaded binaries doesn\'t work
+*Note 3:* Using the boehm GC with multi-threaded binaries doesn't work
 out-of-the-box yet.
 
 **OpenBSD 7.5 and later**
@@ -151,7 +151,7 @@ nix-shell scala-native.nix -A clangEnv
 **Windows**
 
 Corporate environments and Windows policies can affect the method used
-to setup your environment. The following procedure involves downloading
+to set up your environment. The following procedure involves downloading
 installers and running the installers using Powershell (Administrative)
 to avoid some of these issues. If you have full access to your machine
 then you can install using your favorite method.

--- a/docs/user/testing.md
+++ b/docs/user/testing.md
@@ -41,10 +41,10 @@ testOnly MyTest.superComplicatedTest
 
 ## Source level debugging
 
-Scala Native provides initial support for generating source level debug informations, which can be used to map code executed in the debugger to the original sources or to represent local variables.
+Scala Native provides initial support for generating source level debug information, which can be used to map code executed in the debugger to the original sources or to represent local variables.
 When executing on MacOS it also allows to obtain approximated source code lines in the exception stack traces.
 Be aware that both Scala Native optimizer and
-LLVM optimizers can remove some of the optimized out debug informations.
+LLVM optimizers can remove some of the optimized out debug information.
 For best experience run with disabled optimizations:
 
 ```scala
@@ -57,7 +57,7 @@ nativeConfig ~= { c =>
 }
 ```
 
-When using LLDB based debugger you can use our [custom formatter](https://github.com/scala-native/scala-native/blob/main/ScalaNativeLLDBFormatter.py) which would provide more user friendly information about Scala types, e.g. representation of Arrays and Strings.
+When using LLDB based debugger you can use our [custom formatter](https://github.com/scala-native/scala-native/blob/main/ScalaNativeLLDBFormatter.py) which would provide more user-friendly information about Scala types, e.g. representation of Arrays and Strings.
 
 ### Testing with debug metadata
 Debug builds with enabled debug metadata allows to produce stack traces containing source positions, however, to obtain them runtime needs to parse the produced debug metadata. This operation is performed when generating stack traces for the first time and can take more than 1 second. This behavior can influence tests expecting to finish within some fixed amount of time.

--- a/javalib/src/main/scala/java/lang/CharSequence.scala
+++ b/javalib/src/main/scala/java/lang/CharSequence.scala
@@ -6,7 +6,7 @@ import java.util.function.IntConsumer
 
 trait CharSequence {
 
-  /* sub classes, particularly those with fast access to an internal array,
+  /* subclasses, particularly those with fast access to an internal array,
    * should override the default implementations of chars() and
    * codePoints() to avoid the cost of the frequent charAt(index) calls
    * below.

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -887,7 +887,7 @@ object Character {
   // charType: contains the type of the carater in the range ends
   // note that charTypeIndices.length + 1 = charType.length and that the
   // range 0 to 255 is not included because it is contained in charTypesFirst256
-  // They where generated with the following script:
+  // They were generated with the following script:
   //
   //  val indicesAndTypes = (256 to Character.MAX_CODE_POINT)
   //    .map(i => (i, Character.getType(i)))
@@ -1557,7 +1557,7 @@ object Character {
   }
 
   /* Indices defining ranges of case-ignorable characters defined in Unicode reference chapter 3.13.
-   * They are only used in String special casing method, eg. String.toLowerCase
+   * They are only used in String special casing method, e.g. String.toLowerCase
    *
    * Definition of case-ignorable character form Unicode [reference document](https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G33992):
    * A character C is defined to be case-ignorable if C has the value MidLetter (ML),
@@ -1645,7 +1645,7 @@ object Character {
   }
 
   /* Indices defining ranges of case-ignorable characters defined in Unicode reference chapter 3.13.
-   * They are only used in String special casing method, eg. String.toLowerCase.
+   * They are only used in String special casing method, e.g. String.toLowerCase.
    * Indices were generated based on [DerivedCodeProperties.txt](https://www.unicode.org/Public/13.0.0/ucd/DerivedCoreProperties.txt)
    *
    * Definition of cased character from Unicode [reference document](https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G33992):

--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -98,7 +98,7 @@ private[java] object IEEE754Helpers {
       val bytesLen = nChars
       val nSeen = !end - cStr
 
-      // If we used less bytes than in our input, there is a risk that the input contains invalid characters.
+      // If we used fewer bytes than in our input, there is a risk that the input contains invalid characters.
       // We should thus verify if the input contains only valid characters.
       // See: https://github.com/scala-native/scala-native/issues/2903
       if (nSeen != bytesLen) {

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -60,7 +60,7 @@ class Runtime private () {
     // JDK specifies that hooks might run in any order.
     // However, for Scala Native it might be beneficial to support partial ordering
     // E.g. Zone/MemoryPool shutdownHook cleaning pools should be run after DeleteOnExit using `toCString`
-    // Group the hooks by priority starting with the ones with highest priority
+    // Group the hooks by priority starting with the ones with the highest priority
     val limit = hooks.size
     var idx = 0
     while (idx < limit) {

--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -88,7 +88,7 @@ import scala.scalanative.windows.NamedPipeApi.PeekNamedPipe
  *     series of steps it calls "draining" to accomplish this. When
  *     the parent becomes aware that the child process has exited, the
  *     parent copies all bytes remaining at its input end of the os pipe
- *     to a local buffer and and closes its os fd. That releases the resource
+ *     to a local buffer and closes its os fd. That releases the resource
  *     and keeps it from becoming unavailable until the parent process
  *     exits.
  *
@@ -100,7 +100,7 @@ import scala.scalanative.windows.NamedPipeApi.PeekNamedPipe
  *     synchronized methods.
  *
  *     - UnixProcess* and WindowProcess check if the child process has exited
- *       at different places in the code. This can have a major affect on
+ *       at different places in the code. This can have a major effect on
  *       the timing of events, including the number of bytes available at
  *       an I/O event.
  *

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -349,7 +349,7 @@ private[lang] class UnixProcessGen2 private (
           1000L * 1000
         case _ if (unit == TimeUnit.NANOSECONDS) =>
           1000L * 1000 * 1000
-        case _ => 1L // For all i: Int, (i % 1) == 0, which propagates thru.
+        case _ => 1L // For all i: Int, (i % 1) == 0, which propagates through.
       }
 
       unit.toNanos(timeout % modulus).toSize
@@ -436,7 +436,7 @@ private[lang] class UnixProcessGen2 private (
       )
     }
 
-    /* Some Scala non-idiomatic slight of hand is going on here to
+    /* Some Scala non-idiomatic sleight of hand is going on here to
      * ease implementation. Scala 3 has union types, but other versions
      * do not.  "struct kevent" and "struct kevent64_s" overlay exactly in
      * the fields of interest here. In C and Scala 3 they could be a union.
@@ -503,7 +503,7 @@ object UnixProcessGen2 {
      * POXIX 2023 should allow changing the working directory.
      *
      * Checking for ".", which callers tend to specify, is an optimization
-     * to elide changing directory to the what is already the working
+     * to elide changing directory to what is already the working
      * directory.
      */
 

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -943,7 +943,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
   }
 
   def divide(divisor: BigDecimal, mc: MathContext): BigDecimal = {
-    // Calculating how many zeros must be append to 'dividend'
+    // Calculating how many zeros must be appended to 'dividend'
     // to obtain a  quotient with at least 'mc.precision()' digits
 
     // In special cases it reduces the problem to call the dual method
@@ -1061,7 +1061,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     val diffScale = this._scale.toLong - divisor._scale
     val quotPrecision = diffPrecision - diffScale + 1
 
-    // In special cases it call the dual method
+    // In special cases it calls the dual method
     if (mcPrecision == 0 || this.isZero || divisor.isZero)
       return this.divideToIntegralValue(divisor)
 

--- a/javalib/src/main/scala/java/math/BitLevel.scala
+++ b/javalib/src/main/scala/java/math/BitLevel.scala
@@ -372,7 +372,7 @@ private[math] object BitLevel {
    *  @param count
    *    the number of bits to be shifted
    *  @return
-   *    dropped bit's are all zero (i.e. remaider is zero)
+   *    dropped bits are all zero (i.e. remainder is zero)
    */
   def shiftRight(
       result: Array[Int],
@@ -407,8 +407,7 @@ private[math] object BitLevel {
 
   /** Performs a fast bit testing for positive numbers.
    *
-   *  The bit to to be tested must be in the range {@code [0,
-   *  val.bitLength()-1]}
+   *  The bit to be tested must be in the range {@code [0, val.bitLength()-1]}
    */
   def testBit(bi: BigInteger, n: Int): Boolean =
     (bi.digits(n >> 5) & (1 << (n & 31))) != 0

--- a/javalib/src/main/scala/java/math/Conversion.scala
+++ b/javalib/src/main/scala/java/math/Conversion.scala
@@ -24,7 +24,7 @@
  *      the literature is left an exercise for the Gentle Reader.
  *
  *      The Scala.js algorithm from the Scala.js code likes to insert
- *      characters at the beginning of strings. The idiom is wide spread.
+ *      characters at the beginning of strings. The idiom is widespread.
  *
  *      In order to do an insert(), StringBuilder internals must move all
  *      existing characters to the right, which is much more expensive than
@@ -35,7 +35,7 @@
  *
  *      A characteristic usage pessimistic case is where the digits of
  *      the resultant String are converted. The Scala.CSS, and current
- *      Scala Native, algorithm starts started with the low order digits.
+ *      Scala Native, algorithm starts with the low order digits.
  *      Higher order digits are inserted _before_ the digits converted to
  *      date.
  *
@@ -225,7 +225,7 @@ private[math] object Conversion {
     if (sign == 0) {
       "0"
     } else {
-      // one 32-bit unsigned value may contains 10 decimal digits
+      // one 32-bit unsigned value may contain 10 decimal digits
       // Explanation why +1+7:
       // +1 - one char for sign if needed.
       // +7 - For "special case 2" (see below) we have 7 free chars for inserting necessary scaled digits.
@@ -342,7 +342,7 @@ private[math] object Conversion {
           result.toString()
       }
     } else {
-      // one 32-bit unsigned value may contains 10 decimal digits
+      // one 32-bit unsigned value may contain 10 decimal digits
       // Explanation why 10+1+7:
       // +1 - one char for sign if needed.
       // +7 - For "special case 2" (see below) we have 7 free chars for inserting necessary scaled digits.
@@ -401,7 +401,7 @@ private[math] object Conversion {
     } else {
       /*
        * Make the dividend positive shifting it right by 1 bit then get
-       * the quotient an remainder and correct them properly
+       * the quotient and remainder and correct them properly
        */
       val aPos: Long = a >>> 1
       val bPos: Long = 1000000000L >>> 1

--- a/javalib/src/main/scala/java/math/Division.scala
+++ b/javalib/src/main/scala/java/math/Division.scala
@@ -277,7 +277,7 @@ private[math] object Division {
       } else {
         /*
          * make the dividend positive shifting it right by 1 bit then get the
-         * quotient an remainder and correct them properly
+         * quotient and remainder and correct them properly
          */
         val aPos: Long = temp >>> 1
         val bPos: Long = divisor >>> 1
@@ -328,7 +328,7 @@ private[math] object Division {
     } else {
       /*
        * Make the dividend positive shifting it right by 1 bit then get the
-       * quotient an remainder and correct them properly
+       * quotient and remainder and correct them properly
        */
       val aPos: Long = a >>> 1
       val bPos: Long = b >>> 1
@@ -865,7 +865,7 @@ private[math] object Division {
     val baseMod2toN = base.copy()
     /*
      * If 'base' is odd then it's coprime with 2^j and phi(2^j) = 2^(j-1); so we
-     * can reduce reduce the exponent (mod 2^(j-1)).
+     * can reduce the exponent (mod 2^(j-1)).
      */
     if (base.testBit(0))
       inplaceModPow2(e, j - 1)

--- a/javalib/src/main/scala/java/math/Elementary.scala
+++ b/javalib/src/main/scala/java/math/Elementary.scala
@@ -259,7 +259,7 @@ private[math] object Elementary {
 
   /** Performs: {@code op1 += addend}.
    *
-   *  The number must to have place to hold a possible carry.
+   *  The number must have place to hold a possible carry.
    */
   def inplaceAdd(op1: BigInteger, addend: Int): Unit = {
     val carry = inplaceAdd(op1.digits, op1.numberLength, addend)

--- a/javalib/src/main/scala/java/math/Logical.scala
+++ b/javalib/src/main/scala/java/math/Logical.scala
@@ -282,7 +282,7 @@ private[math] object Logical {
       val resLength = Math.min(positive.numberLength, negative.numberLength)
       val resDigits = new Array[Int](resLength)
 
-      // Always start from first non zero of positive
+      // Always start from first non-zero of positive
       var i = iPos
       while (i < iNeg) {
         resDigits(i) = positive.digits(i)
@@ -547,7 +547,7 @@ private[math] object Logical {
       val resDigits = new Array[Int](resLength)
       var i = 0
       if (iNeg < iPos) {
-        // We know for sure that this will be the first non zero digit in the result
+        // We know for sure that this will be the first non-zero digit in the result
         i = iNeg
         while (i < iPos) {
           resDigits(i) = negative.digits(i)

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -59,7 +59,7 @@ class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
        * Scala Native has historically used a looser sense of
        * comparing only address bytes and letting hostname differ.
        *
-       * This is analogous to the difference between a case sensitive and
+       * This is analogous to the difference between a case-sensitive and
        * insensitive test of strings. Each has its use case.
        *
        * Currently the looser comparison of InetAddress instances must be done
@@ -698,7 +698,7 @@ object InetAddress {
      * if the host resolves as numeric.  If the host resolves to non-numeric
      * then the InetAddress is created using that String.
      *
-     * There is not good way to test after a single omnibus lookup to tell
+     * There is no good way to test after a single omnibus lookup to tell
      * if the host resolved as numeric or non-numeric.  inet_pton() for
      * IPv4 addresses requires full dotted decimal: ddd.ddd.ddd.ddd.
      * ScalaJVM parses and passes some more obscure but valid IPv4 addresses.
@@ -739,7 +739,7 @@ object InetAddress {
          *   has been found by searching the 4 combinations of the 2x2 matrix:
          *   IPv4/IPv6 by TCP/UDP.
          *
-         *   Java 8 does not throw in this situation, it appears to fallback
+         *   Java 8 does not throw in this situation, it appears to fall back
          *   to creating an InetAddress using the hostname and the IPv4
          *   loopback address 127.0.0.1.  Be robust and do the same here.
          */

--- a/javalib/src/main/scala/java/net/NetworkInterface.scala
+++ b/javalib/src/main/scala/java/net/NetworkInterface.scala
@@ -34,7 +34,7 @@ import macOsIfDl._
  *   2) The Unix implementation often splits into a Linux path and a
  *      macOS/BSD path.  The former uses ioctl() calls and lets the
  *      operating system search for the named interface.  Such a kernel
- *      search should be marginally faster and less error prone than
+ *      search should be marginally faster and less error-prone than
  *      the user land search of getifaddrs() results done on the
  *      macOS/BSD path.
  *
@@ -978,9 +978,9 @@ private object macOsIf {
    *
    * struct if_data {
    *   // generic interface information
-   *   u_char          ifi_type;       // ethernet, tokenring, etc
+   *   u_char          ifi_type;       // ethernet, tokenring, etc.
    *   u_char          ifi_typelen;    // Length of frame type id
-   *   u_char          ifi_physical;   // e.g., AUI, Thinnet, 10base-T, etc
+   *   u_char          ifi_physical;   // e.g., AUI, Thinnet, 10base-T, etc.
    *   u_char          ifi_addrlen;    // media address length
    *   u_char          ifi_hdrlen;     // media header length
    *   u_char          ifi_recvquota;  // polling quota for receive intrs

--- a/javalib/src/main/scala/java/net/ServerSocket.scala
+++ b/javalib/src/main/scala/java/net/ServerSocket.scala
@@ -101,7 +101,7 @@ class ServerSocket(
      * InetAddress as IPv4 (0.0.0.0).
      *   "LocalSocketAddress: |0.0.0.0/0.0.0.0:8090|"
      *
-     * This section, and SocketHelpers.getWildcardAddressForBind()
+     * This section and SocketHelpers.getWildcardAddressForBind()
      * will need to be revisited for robust FreeBSD support.
      * See also notes in getWildcardAddressForBind().
      */

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -198,7 +198,7 @@ object SocketHelpers {
 
       val dst = sa6.sin6_addr.toPtr.s6_addr
 
-      // By contract, the leading bytes are already zero already.
+      // By contract, the leading bytes are already zero.
       val FF = 255.toUByte
       dst(10) = FF // set the IPv4mappedIPv6 indicator bytes
       dst(11) = FF

--- a/javalib/src/main/scala/java/net/WindowsPlainDatagramSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/WindowsPlainDatagramSocketImpl.scala
@@ -18,7 +18,7 @@ private[net] class WindowsPlainDatagramSocketImpl
     val socket = WSASocketW(
       addressFamily = unixSocket.AF_INET,
       socketType = unixSocket.SOCK_DGRAM,
-      protocol = 0, // choosed by provider
+      protocol = 0, // chosen by provider
       protocolInfo = null,
       group = 0.toUInt,
       flags = WSA_FLAG_OVERLAPPED

--- a/javalib/src/main/scala/java/net/WindowsPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/WindowsPlainSocketImpl.scala
@@ -17,7 +17,7 @@ private[net] class WindowsPlainSocketImpl extends AbstractPlainSocketImpl {
     val socket = WSASocketW(
       addressFamily = unixSocket.AF_INET,
       socketType = unixSocket.SOCK_STREAM,
-      protocol = 0, // choosed by provider
+      protocol = 0, // chosen by provider
       protocolInfo = null,
       group = 0.toUInt,
       flags = WSA_FLAG_OVERLAPPED

--- a/javalib/src/main/scala/java/nio/Buffers.scala
+++ b/javalib/src/main/scala/java/nio/Buffers.scala
@@ -237,7 +237,7 @@ abstract class ByteBuffer private[nio] (
   final def alignmentOffset(index: Int, unitSize: Int): Int = {
     require(index >= 0, "Index less then zero: " + index)
     require(unitSize >= 1 && (unitSize & (unitSize - 1)) == 0, "Unit size not a power of two: " + unitSize)
-    if(unitSize > 8 && !isDirect()) throw new UnsupportedOperationException("Unit size unsupported for non-direct dufferes: " + unitSize)
+    if(unitSize > 8 && !isDirect()) throw new UnsupportedOperationException("Unit size unsupported for non-direct buffers: " + unitSize)
     ((this.address.toLong + index) & (unitSize -1)).toInt
   }
 

--- a/javalib/src/main/scala/java/nio/Buffers.scala.gyb
+++ b/javalib/src/main/scala/java/nio/Buffers.scala.gyb
@@ -278,7 +278,7 @@ abstract class ${T}Buffer private[nio] (
   final def alignmentOffset(index: Int, unitSize: Int): Int = {
     require(index >= 0, "Index less then zero: " + index)
     require(unitSize >= 1 && (unitSize & (unitSize - 1)) == 0, "Unit size not a power of two: " + unitSize)
-    if(unitSize > 8 && !isDirect()) throw new UnsupportedOperationException("Unit size unsupported for non-direct dufferes: " + unitSize)
+    if(unitSize > 8 && !isDirect()) throw new UnsupportedOperationException("Unit size unsupported for non-direct buffers: " + unitSize)
     ((this.address.toLong + index) & (unitSize -1)).toInt
   }
 %else:

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -178,7 +178,7 @@ private[java] final class FileChannelImpl(
 
     /* JVM requires the "size" argument to be a long, but throws
      * an exception if that long is greater than Integer.MAX_VALUE.
-     * toInt() would cause such a large value to rollover to a negative value.
+     * toInt() would cause such a large value to roll over to a negative value.
      *
      * Call to MappedByteBufferImpl() below truncates its third argument
      * to an Int, knowing this guard is in place.
@@ -641,7 +641,7 @@ private[java] final class FileChannelImpl(
     nWritten
   }
 
-  // since all of java package can call this, be stricter with argument checks.
+  // since all of Java packages can call this, be stricter with argument checks.
   private[java] def write(
       buffer: Array[Byte],
       offset: Int,
@@ -717,7 +717,7 @@ private[java] final class FileChannelImpl(
    * "Current position" when file has been opened for APPEND is
    * a logical place, End of File (EOF), not an absolute number.
    * When APPEND mode changes the position it reports as "current" to the
-   * new EOF rather than stashed position, according to JVM is is not
+   * new EOF rather than stashed position, according to JVM it is not
    * really changing the "current position".
    */
   override def write(src: ByteBuffer, pos: Long): Int = {
@@ -744,9 +744,9 @@ private[java] final class FileChannelImpl(
   /* The Scala Native implementation of FileInputStream#available delegates
    * to this method. This method now implements "available()" as described in
    * the Java description of FileInputStream#available. So the delegator
-   * now matches the its JDK description and behavior (Issue 3333).
+   * now matches its JDK description and behavior (Issue 3333).
    *
-   * There are a couple of fine points to this implemention which might
+   * There are a couple of fine points to this implementation which might
    * be helpful to know:
    *    1) There is no requirement that this method itself not block.
    *       Indeed, depending upon what, if anything, is in the underlying

--- a/javalib/src/main/scala/java/nio/file/FileTreeWalker.scala
+++ b/javalib/src/main/scala/java/nio/file/FileTreeWalker.scala
@@ -67,7 +67,7 @@ private class WalkFileAttrRetriever(
     visitor: FileVisitor[_ >: Path]
 ) {
 
-  /* This class concentrates mind bending intricacy. The goal is to
+  /* This class concentrates mind-bending intricacy. The goal is to
    * not do a double fetch of attributes for 'start', given that JVM
    * looks up its attributes _before_ first use.
    *

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -173,7 +173,7 @@ object Files {
          *   - This method follows the practice from early Scala Native
          *     development days of modifying files in-place.  This
          *     leaves a pretty wide window for misadventure, particularly
-         *     if more that one thread or process is accessing the file.
+         *     if more than one thread or process is accessing the file.
          * 
          *     Many contemporary applications create a temporary intermediate
          *     file, copy the source contents to the temporary,
@@ -244,7 +244,7 @@ object Files {
           if (createFd != -1) {
             createFd
           } else if (replaceExisting && (errno == EACCES)) {
-            /* Handle what should be an vanishingly rare but possible
+            /* Handle what should be a vanishingly rare but possible
              * corner case where cTarget exists but is not user writable;
              * r-xr-xr-x, --xr-xr-x, and kin. O_TRUNC will fail in those cases.
              * 
@@ -319,7 +319,7 @@ object Files {
         errno = 0
 
         /* Hold the 'source' read-lock the shortest amount of time.
-         * Do the potentially time consuming open of 'target' first.
+         * Do the potentially time-consuming open of 'target' first.
          *
          * Other Java I/O options probably do not make sense for uxix I/O.
          * Time & experience will tell.
@@ -1253,7 +1253,7 @@ object Files {
   def readString(path: Path, cs: Charset): String = {
     val reader = newBufferedReader(path, cs)
     try {
-      // Guess an cost-effective amortized size.
+      // Guess a cost-effective amortized size.
       val writer = new StringWriter(2 * 1024)
       reader.transferTo(writer)
       writer.toString()

--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -68,7 +68,7 @@ abstract class AbstractList[E] protected ()
   def listIterator(index: Int): ListIterator[E] = {
     checkIndexOnBounds(index)
     // By default we use RandomAccessListIterator because we only have access to
-    // the get(index) operation in the API. Subclasses override this if needs
+    // the get(index) operation in the API. Subclasses override this if needed
     // using their knowledge of the structure instead.
     new RandomAccessListIterator(self, index, 0, size())
   }
@@ -103,7 +103,7 @@ abstract class AbstractList[E] protected ()
         new AbstractListView(self, fromIndex, toIndex) { selfView =>
           override def listIterator(index: Int): ListIterator[E] = {
             checkIndexOnBounds(index)
-            // Iterator that accesses the original list using it's iterator
+            // Iterator that accesses the original list using its iterator
             new BackedUpListIterator(
               list.listIterator(fromIndex + index),
               fromIndex,

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -691,7 +691,7 @@ class ArrayDeque[E](
 
   /** Returns an iterator over the elements in this deque. The elements will be
    *  ordered from first (head) to last (tail). This is the same order that
-   *  elements would be dequeued (via successive calls to remove or popped (via
+   *  elements would be dequeued (via successive calls to remove) or popped (via
    *  successive calls to {@link #pop}).
    *
    *  @return

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -175,7 +175,7 @@ class ArrayList[E] private (
   }
 
   override def clear(): Unit = {
-    // fill the content of inner by null so that the elements can be garbage collected
+    // fill the content of inner with null so that the elements can be garbage collected
     for (i <- (0 until _size)) {
       inner(i) = null
     }

--- a/javalib/src/main/scala/java/util/LinkedHashSet.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashSet.scala
@@ -35,7 +35,7 @@ class LinkedHashSet[E]
    *   relocated if necessary so that it is first in encounter order."
    *
    * The reason for the minimal is that the current SN implementation
-   * relies on scala.collection.mutable. There has been a long standing
+   * relies on scala.collection.mutable. There has been a long-standing
    * effort in javalib to remove possibly circular scala collection
    * dependencies.
    *

--- a/javalib/src/main/scala/java/util/Spliterators.scala
+++ b/javalib/src/main/scala/java/util/Spliterators.scala
@@ -10,9 +10,9 @@ import Spliterator._
  *
  *  It is most empathically __NOT__ intended for production use.
  *
- *  The limitations of the this implementation may not be as strong as they
- *  appear at first blush. Many/most classes which extend Spliterator (no s)
- *  supply more competent and efficient implementations.
+ *  The limitations of this implementation may not be as strong as they appear
+ *  at first blush. Many/most classes which extend Spliterator (no s) supply
+ *  more competent and efficient implementations.
  *
  *  The implementation of methods on Spliterators are, to current knowledge,
  *  robust. Many of these methods return spliterators. Those spliterators have
@@ -44,7 +44,7 @@ import Spliterator._
  *      need to be reduced.
  *
  *      For example, an individual development-only Test
- *      in SpliteratorsTrySplitTest showed an an un-optimized Scala Native
+ *      in SpliteratorsTrySplitTest showed an un-optimized Scala Native
  *      executable having results matching the same Test on JVM but taking
  *      approximately 50% longer (a minute or so), possibly due to swapping
  *      caused by higher memory usage.

--- a/javalib/src/main/scala/java/util/SplittableRandom.scala
+++ b/javalib/src/main/scala/java/util/SplittableRandom.scala
@@ -105,7 +105,7 @@ final class SplittableRandom private (private var seed: Long, gamma: Long)
 
   /* The JVM 17 & 23 documentation clearly indicate that this method is
    * inherited from RandomGenerator and not overridden.
-   * Without the override, long standing pre-JDK17 Tests fail.
+   * Without the override, long-standing pre-JDK17 Tests fail.
    * Override to maintain traditional behavior.
    *
    * Scala.js PR 5142 discovered this glitch also. See discussion in that

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -51,7 +51,7 @@ object ConcurrentHashMap {
    * placeholders while establishing values in computeIfAbsent and
    * related methods.  The types TreeBin, ForwardingNode, and
    * ReservationNode do not hold normal user keys, values, or
-   * hashes, and are readily distinguishable during search etc
+   * hashes, and are readily distinguishable during search etc.
    * because they have negative hash fields and null key and value
    * fields. (These special nodes are either uncommon or transient,
    * so the impact of carrying around some unused fields is
@@ -126,9 +126,9 @@ object ConcurrentHashMap {
    * O(log N).  Each search step in a TreeBin is at least twice as
    * slow as in a regular list, but given that N cannot exceed
    * (1<<64) (before running out of addresses) this bounds search
-   * steps, lock hold times, etc, to reasonable constants (roughly
+   * steps, lock hold times, etc., to reasonable constants (roughly
    * 100 nodes inspected per operation worst case) so long as keys
-   * are Comparable (which is very common -- String, Long, etc).
+   * are Comparable (which is very common -- String, Long, etc.).
    * TreeBin nodes (TreeNodes) also maintain the same "next"
    * traversal pointers as regular nodes, so can be traversed in
    * iterators in the same way.

--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -911,7 +911,7 @@ class ForkJoinPool private (
     val rs = runState
     if (rs >= 0) { // set SHUTDOWN and/or STOP
       if ((config & ISCOMMON) != 0)
-        return false // cannot shutdown
+        return false // cannot shut down
       if (!now) {
         if ((rs & SHUTDOWN) == 0) {
           if (!enable)

--- a/javalib/src/main/scala/java/util/concurrent/LinkedTransferQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/LinkedTransferQueue.scala
@@ -70,7 +70,7 @@ import scala.scalanative.runtime.{fromRawPtr, Intrinsics}
    * status. While there are other possible variants, we implement
    * this here as: for a data-mode node, matching entails CASing an
    * "item" field from a non-null data value to null upon match, and
-   * vice-versa for request nodes, CASing from null to a data
+   * vice versa for request nodes, CASing from null to a data
    * value. (Note that the linearization properties of this style of
    * queue are easy to verify -- elements are made available by
    * linking, and unavailable by matching.) Compared to plain M&S

--- a/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadPoolExecutor.scala
@@ -63,7 +63,7 @@ object ThreadPoolExecutor {
 
 class ThreadPoolExecutor(
     /** Core pool size is the minimum number of workers to keep alive (and not
-     *  allow to time out etc) unless allowCoreThreadTimeOut is set, in which
+     *  allow to time out etc.) unless allowCoreThreadTimeOut is set, in which
      *  case the minimum is zero.
      *
      *  Since the worker count is actually stored in COUNT_BITS bits, the

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.scala
@@ -9,7 +9,7 @@ import java.util.function.BinaryOperator
 import java.util.function.UnaryOperator
 
 object AtomicIntegerFieldUpdater {
-  // Imposible to define currently in Scala Native, requires reflection
+  // Impossible to define currently in Scala Native, requires reflection
   // Don't define it, allow to fail at linktime instead of runtime
   // def newUpdater[U <: AnyRef](
   //     tclass: Class[U],

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongFieldUpdater.scala
@@ -9,7 +9,7 @@ import java.util.function.BinaryOperator
 import java.util.function.UnaryOperator
 
 object AtomicLongFieldUpdater {
-  // Imposible to define currently in Scala Native, requires reflection
+  // Impossible to define currently in Scala Native, requires reflection
   // Don't define it, allow to fail at linktime instead of runtime
   // def newUpdater[U <: AnyRef](
   //     tclass: Class[U],

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.scala
@@ -9,7 +9,7 @@ import java.util.function.BinaryOperator
 import java.util.function.UnaryOperator
 
 object AtomicReferenceFieldUpdater {
-  // Imposible to define currently in Scala Native, requires reflection
+  // Impossible to define currently in Scala Native, requires reflection
   // Don't define it, allow to fail at linktime instead of runtime
   // def newUpdater[U <: AnyRef, W <: AnyRef](
   //     tclass: Class[U],

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -66,7 +66,7 @@ object Pattern {
     // left when execution reaches this point.
     //
     // The constants for these three definitely differ between j.u.regex
-    // and snRegex and must be be translated.
+    // and snRegex and must be translated.
 
     val optionTranslations = Array[(Int, Int)](
       (CASE_INSENSITIVE, snRegex.Pattern.CASE_INSENSITIVE),

--- a/javalib/src/main/scala/java/util/stream/DoubleStream.scala
+++ b/javalib/src/main/scala/java/util/stream/DoubleStream.scala
@@ -13,7 +13,7 @@ import java.util.function._
  *
  * In this file "Double" types should be qualified to ease tracing the code
  * and prevent confusion & defects.
- *   * jl.Double indicates an Java Object qua Scala AnyRef is desired.
+ *   * jl.Double indicates a Java Object qua Scala AnyRef is desired.
  *   * scala.Double indicates a Java "double" primitive is desired.
  *     Someday, the generated code should be examined to ensure that
  *     unboxed primitives are actually being used.

--- a/javalib/src/main/scala/java/util/zip/ZipByteConversions.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipByteConversions.scala
@@ -57,7 +57,7 @@ private[zip] object ZipByteConversions {
    *      may be available.
    *
    *      Scala Native currently (2024-03) uses Unicode version 13.0.
-   *      Unicode 15.1 was released in September, 2023.
+   *      Unicode 15.1 was released on September, 2023.
    *
    *      In theory, attempting to convert codepoints defined after
    *      Unicode 13.0 should throw an Exception. How strict is the

--- a/javalib/src/main/scala/java/util/zip/ZipFile.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipFile.scala
@@ -68,9 +68,9 @@ class ZipFile(file: File, mode: Int, charset: Charset) extends Closeable {
 
   /* The magic number 64 is a guess.
    * With the defaults of 16 entries and a 0.75 load factor, the map will
-   * resize at 12 entires.  Seems like most zip archives will have more than
+   * resize at 12 entries.  Seems like most zip archives will have more than
    * that number. With specified 64 entries and the default load factor,
-   * the map will resize at 48 entries & the "growth" will be be larger to
+   * the map will resize at 48 entries & the "growth" will be larger to
    * boot. The number could probably be more like 128 or so.
    */
 

--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -110,7 +110,7 @@ object Assert {
   def assertNotEquals(unexpected: Float, actual: Float, delta: Float): Unit =
     assertNotEquals(null, unexpected, actual, delta)
 
-  // This deprecation should not be removed, it mapping the deprecation in the JUnit library to match bevaiour on the JVM
+  // This deprecation should not be removed, it maps the deprecation in the JUnit library to match bevaiour on the JVM
   @deprecated(
     "Use assertEquals(double expected, double actual, double " +
       "epsilon) instead",
@@ -124,7 +124,7 @@ object Assert {
     )
   }
 
-  // This deprecation should not be removed, it mapping the deprecation in the JUnit library to match bevaiour on the JVM
+  // This deprecation should not be removed, it maps the deprecation in the JUnit library to match bevaiour on the JVM
   @deprecated(
     "Use assertEquals(String message, double expected, double " +
       "actual, double epsilon) instead",

--- a/junit-runtime/src/main/scala/org/junit/runners/BlockJUnit4ClassRunner.scala
+++ b/junit-runtime/src/main/scala/org/junit/runners/BlockJUnit4ClassRunner.scala
@@ -4,7 +4,7 @@ import org.junit.runners.model.FrameworkMethod
 
 /* In the Scala Native JUnit framework (com.novocode.junit.JUnitFramework) there
  * is a custom runner that executes the tests. Therefore the implementation of
- * the original runner is not used. But we still want to be able the compile a
+ * the original runner is not used. But we still want to be able to compile a
  * class that explicitly specifies the default runner using @RunWith(JUnit4).
  * For this we need only a dummy implementation because we just need to
  * identify the runner using classOf[...].

--- a/nativelib/src/main/java/scala/scalanative/runtime/UnsupportedFeature.java
+++ b/nativelib/src/main/java/scala/scalanative/runtime/UnsupportedFeature.java
@@ -2,7 +2,7 @@ package scala.scalanative.runtime;
 
 /**
  * Mock methods used to detect at linktime usage of unsupported features. Use
- * with caution and always use guarded with linktime-reasolved conditions. Eg.
+ * with caution and always use guarded with linktime-reasolved conditions. E.g.
  * 
  * <pre>
  * {@code

--- a/nativelib/src/main/resources/scala-native/module_load.c
+++ b/nativelib/src/main/resources/scala-native/module_load.c
@@ -71,7 +71,7 @@ inline static ModuleRef waitForInitialization(ModuleSlot slot,
     assert(module != NULL);
     if (*module != classInfo) {
         InitializationContext *ctx = (InitializationContext *)module;
-        // Usage of module in it's constructor, return unitializied instance
+        // Usage of module in its constructor, return unitializied instance
         if (isThreadEqual(ctx->initThreadId, getThreadId())) {
             return ctx->instance;
         }

--- a/nativelib/src/main/scala/scala/scalanative/annotation/memoryModel.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/memoryModel.scala
@@ -7,11 +7,11 @@ import scala.annotation.meta.field
  *  initializing and reading final fields.
  *
  *  The compiler would ensure that final field would be reachable in fully
- *  innitialized state by other reads, by introducing synchronization primitives
- *  on each it's access. Applies only to type immutable field mebers (`val`s)
+ *  initialized state by other reads, by introducing synchronization primitives
+ *  on each access. Applies only to type immutable field members (`val`s)
  *
- *  Can be used either on single field or whole type if all of it's fields
- *  should be safetly published.
+ *  Can be used either on single field or whole type if all of its fields should
+ *  be safely published.
  */
 @field
 final class safePublish extends scala.annotation.StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/concurrent/NativeExecutionContext.scala
+++ b/nativelib/src/main/scala/scala/scalanative/concurrent/NativeExecutionContext.scala
@@ -53,8 +53,8 @@ object NativeExecutionContext {
   private[scalanative] trait WorkStealing { self: QueueExecutionContext =>
 
     /** Apply work-stealing mechanism to help with completion of any tasks
-     *  available for execution.Returns after work-stealing maximal number or
-     *  tasks or there is no more tasks available for execution
+     *  available for execution.Returns after work-stealing maximal number of
+     *  tasks or there are no more tasks available for execution
      *  @param maxSteals
      *    maximal ammount of tasks that can be executed, if <= 0 then no tasks
      *    would be completed

--- a/nativelib/src/main/scala/scala/scalanative/regex/CharClass.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/CharClass.scala
@@ -27,9 +27,9 @@ class CharClass(
   // prefix of |r| that is defined.  Even.
   private var len: Int = r.length
 
-  // Size the initial allocaton to reduce the number of doublings & copies
-  // yet still be provident with memory.
-  // 16 bytes is a best guess. See commit mesage for details on its derivation.
+  // Size the initial allocation to reduce the number of doublings & copies
+  // yet still be provided with memory.
+  // 16 bytes is the best guess. See commit message for details on its derivation.
 
   // Constructs an empty CharClass.
   def this() = {

--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -1169,7 +1169,7 @@ class Parser(wholeRegexp: String, _flags: Int) {
   }
 
   // parseUnicodeClass() parses a leading Unicode character class like \p{Han}
-  // from the beginning of t.  If one is present, it appends the characters to
+  // from the beginning of t.  If one is present, it appends the characters
   // to |cc|, advances |t| and returns true.
   //
   // Returns false if such a pattern is not present or UNICODE_GROUPS

--- a/nativelib/src/main/scala/scala/scalanative/regex/RE2.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/RE2.scala
@@ -214,7 +214,7 @@ class RE2 private {
     replaceAllFunc(src, 1) { orig => repl }
 
   // Returns a copy of {@code src} in which at most {@code maxReplaces} matches
-  // for this regexp have been replaced by the return value of of function
+  // for this regexp have been replaced by the return value of function
   // {@code repl} (whose first argument is the matched string). No support is
   // provided for expressions (e.g. {@code \1} or {@code $1}) in the
   // replacement string.
@@ -358,7 +358,7 @@ class RE2 private {
   // otherwise it is a UTF-16 encoded java.lang.String return values
   // are adjusted as appropriate.
   //
-  // If 'Submatch' is present, the return value is an list identifying
+  // If 'Submatch' is present, the return value is a list identifying
   // the successive submatches of the expression.  Submatches are
   // matches of parenthesized subexpressions within the regular
   // expression, numbered from left to right in order of opening
@@ -462,7 +462,7 @@ class RE2 private {
 
   // Returns an array holding the index pairs identifying the leftmost
   // match of this regular expression in {@code b} and the matches, if
-  // any, of its subexpressions, as defined by the the <a
+  // any, of its subexpressions, as defined by the <a
   // href='#submatch'>Submatch</a> and <a href='#index'>Index</a>
   // descriptions above.
   //

--- a/nativelib/src/main/scala/scala/scalanative/regex/Utils.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Utils.scala
@@ -163,7 +163,7 @@ object Utils {
     return -1
   }
 
-  // isWordRune reports whether r is consider a ``word character''
+  // isWordRune reports whether r is considered a ``word character''
   // during the evaluation of the \b and \B zero-width assertions.
   // These assertions are ASCII-only: the word characters are [A-Za-z0-9_].
   def isWordRune(r: Int): Boolean =

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -53,7 +53,7 @@ object GC {
   /*  Multithreading awareness for GC Every implementation of GC supported in
    *  ScalaNative needs to register a given thread The main thread is
    *  automatically registered. Every additional thread needs to explicitly
-   *  notify GC about it's creation and termination. For that purpose we follow
+   *  notify GC about its creation and termination. For that purpose we follow
    *  the Boehm GC convention for overloading the pthread_create/CreateThread
    *  functions respectively for POSIX and Windows.
    */
@@ -132,7 +132,7 @@ object GC {
 
   /** Notify the Garbage Collector about the range of memory which should be
    *  scanned when marking the objects. The range should contain only memory NOT
-   *  allocated using the GC, eg. using malloc. Otherwise it might lead to the
+   *  allocated using the GC, e.g. using malloc. Otherwise it might lead to the
    *  undefined behaviour at runtime.
    *
    *  @param addressLow
@@ -150,7 +150,7 @@ object GC {
    *  registered range of addressed using [[addRoots]] which is fully contained
    *  withen the range of addressLow and addressHigh would be exluded from the
    *  subsequent scanning during the GC. It is safe to pass a range of addressed
-   *  which doen't match any of the previously registered memory regions.
+   *  which doesn't match any of the previously registered memory regions.
    *
    *  @param addressLow
    *    Start of the range including the first address that should be scanned

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -150,7 +150,7 @@ object Intrinsics {
   /** Intrinsified cast that reinterprets raw pointer as an int. */
   def castRawPtrToInt(rawptr: RawPtr): Int = intrinsic
 
-  /** Intrinsified cast that reinterprets raw pointer as an long. */
+  /** Intrinsified cast that reinterprets raw pointer as a long. */
   def castRawPtrToLong(rawptr: RawPtr): Long = intrinsic
 
   /** Intrinsified cast that reinterprets int as a raw pointer. */

--- a/nativelib/src/main/scala/scala/scalanative/runtime/MemoryLayout.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/MemoryLayout.scala
@@ -7,7 +7,7 @@ import scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 private[runtime] object MemoryLayout {
 
   /*  Even though it might seem non-idiomatic to use `def` instead of `final val`
-   *  for the constants it actual can be faster at runtime. Vals would require
+   *  for the constants it actually can be faster at runtime. Vals would require
    *  a fieldload operation and loading the module instance. Def would be
    *  evaluated and inlined in the optimizer - it would result with replacing
    *  method call with a constant value.

--- a/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
@@ -129,7 +129,7 @@ private[runtime] object StackTrace {
         offset
       )
       // Make sure the name is definitely 0-terminated.
-      // Unmangler is going to use strlen on this name and it's
+      // Unmangler is going to use strlen on this name and its
       // behavior is not defined for non-zero-terminated strings.
       symbol(SymbolMaxLength - 1) = 0.toByte
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/SymbolFormatter.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/SymbolFormatter.scala
@@ -24,7 +24,7 @@ object SymbolFormatter {
     methodNameOut(0) = 0.toByte
 
     def readSymbol(): Boolean = {
-      // On Windows symbol names are different then on Unix platforms.
+      // On Windows symbol names are different than on Unix platforms.
       // Due to differences in implementation between WinDbg and libUnwind used
       // on each platform, symbols on Windows do not contain '_' prefix.
       // When debug metadata is generated and there is no symbols (LTO) then

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/BasicMonitor.scala
@@ -81,7 +81,7 @@ private[runtime] final class BasicMonitor(val lockWordRef: RawPtr)
         castIntToRawPtr(0),
         memory_order_release
       )
-    else if (current.isUnlocked) () // can happend only in main thread
+    else if (current.isUnlocked) () // can happen only on the main thread
     else if (current.isInflated) current.getObjectMonitor.exit(thread)
     else storeRawPtr(lockWordRef, current.withDecresedRecursion)
   }
@@ -124,7 +124,7 @@ private[runtime] final class BasicMonitor(val lockWordRef: RawPtr)
     )
   }
 
-  // Monitor is currently locked by other thread. Wait until getting over owership
+  // Monitor is currently locked by other thread. Wait until getting over ownership
   // of this object and transform LockWord to use HeavyWeight monitor
   @inline private def lockAndInflate(
       thread: Thread,
@@ -162,7 +162,7 @@ private[runtime] final class BasicMonitor(val lockWordRef: RawPtr)
     // Increment recursion by basic lock recursion count if present
     objectMonitor.recursion += lockWord.recursionCount
 
-    // Since pointers are always alligned we can safely override N=sizeof(Word) right most bits
+    // Since pointers are always aligned we can safely override N=sizeof(Word) right-most bits
     val monitorAddress = castObjectToRawPtr(objectMonitor)
     val inflated =
       if (is32bit) {

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/ObjectMonitor.scala
@@ -10,7 +10,7 @@ import scala.scalanative.runtime.ffi.stdatomic.memory_order._
 import scala.scalanative.unsafe.{stackalloc => _, sizeOf => _, _}
 import java.util.concurrent.locks.LockSupport
 
-/** Heavy weight monitor created only upon detection of access from multiple
+/** Heavy-weight monitor created only upon detection of access from multiple
  *  threads is inflated in ObjectMonitor
  */
 private[monitor] class ObjectMonitor() {
@@ -44,7 +44,7 @@ private[monitor] class ObjectMonitor() {
 
   /** Ring list of waiting threads. Access limited by the modification lock.
    *  Upon InEnterQueue the wait zone threads would enqueue to the queue, and
-   *  would remove themself upon exiting the zone. Threads would be notified
+   *  would remove themselves upon exiting the zone. Threads would be notified
    *  sequentially based on their order in the queue. Nodes from waitQueue can
    *  be detached and moved to the enterQueue
    */
@@ -94,7 +94,7 @@ private[monitor] class ObjectMonitor() {
 
   // enter slow-path
   private def enterMonitor(currentThread: Thread): Unit = {
-    // Enqueue the node the node to the arriveQueue using CAS
+    // Enqueue the node to the arriveQueue using CAS
     val node = new WaiterNode(currentThread, WaiterNode.InArriveQueue)
     while ({
       val next = arriveQueue

--- a/nativelib/src/main/scala/scala/scalanative/runtime/monitor/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/monitor/package.scala
@@ -56,7 +56,7 @@ package object monitor {
       @alwaysinline def Inflated = 1
     }
 
-    // Potentially can decreased 60bits if we would need to encode additioanl flags
+    // Potentially can decrease 60bits if we would need to encode additional flags
     @alwaysinline def ObjectMonitorOffset = 1
     @alwaysinline def ObjectMonitorBits = 63
     @alwaysinline def ObjectMonitorMask = -2L

--- a/nir/src/main/scala/scala/scalanative/nir/SourcePosition.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/SourcePosition.scala
@@ -66,7 +66,7 @@ sealed trait SourceFile {
 }
 object SourceFile {
 
-  /** An abstract file without location, eg. in-memory source or generated */
+  /** An abstract file without location, e.g. in-memory source or generated */
   case object Virtual extends SourceFile
 
   /** Relative path to source file based on the workspace path. Used for

--- a/nir/src/main/scala/scala/scalanative/nir/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/package.scala
@@ -7,9 +7,9 @@ package object nir {
 
   /** A map from SSA identifier to its name in program sources.
    *
-   *  Local variables get lowered to an static assignment that is assigned to a
+   *  Local variables get lowered to a static assignment that is assigned to a
    *  unique identifier in the context of its definition. Instances of this type
-   *  are used to maintain the correspondance between an SSA ID and its
+   *  are used to maintain the correspondence between an SSA ID and its
    *  corresponding name in program sources.
    */
   type LocalNames = Map[Local, LocalName]

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -205,7 +205,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           if (localNames.contains(id) || isMutable) ()
           else localNames.update(id, name)
           vd.rhs match {
-            // When rhs is a block patch the scopeId of it's result to match the current scopeId
+            // When rhs is a block patch the scopeId of its result to match the current scopeId
             // This allows us to reflect that ValDef is accessible in this scope
             case _: Block | Typed(_: Block, _) | Try(_: Block, _, _) |
                 Try(Typed(_: Block, _), _, _) =>
@@ -339,7 +339,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       def genIfsChain(): nir.Val = {
         /* Default label needs to be generated before any others and then added to
          * current MethodEnv. It's label might be referenced in any of them in
-         * case of match with guards, eg.:
+         * case of match with guards, e.g.:
          *
          * "Hello, World!" match {
          *  case "Hello" if cond1 => "foo"

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -173,8 +173,8 @@ trait NirGenName[G <: Global with Singleton] {
         scalanative.util.unreachable
       }
       /*
-       * Double quoted identifiers are not allowed in CLang.
-       * We're replacing them with unicode to allow distinction between x / `x` and `"x"`.
+       * Double-quoted identifiers are not allowed in CLang.
+       * We're replacing them with Unicode to allow distinction between x / `x` and `"x"`.
        * It follows Scala JVM naming convention.
        */
       id.replace("\"", "$u0022")

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -114,12 +114,12 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
         val regularDefns = statBuffer.toSeq.toList
 
         /* #4148 Add generated static forwarder classes, except those that
-         * would collide with regular classes on case insensitive file
+         * would collide with regular classes on case-insensitive file
          * systems.
          */
 
         /* I could not find any reference anywhere about what locale is used
-         * by case insensitive file systems to compare case-insensitively.
+         * by case-insensitive file systems to compare case-insensitively.
          * In doubt, force the English locale, which is probably going to do
          * the right thing in virtually all cases (especially if users stick
          * to ASCII class names), and it has the merit of being deterministic,

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -56,7 +56,7 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
     /** Nicer syntax for `allEnclosingOwners is kind`. */
     private def anyEnclosingOwner: OwnerKind = allEnclosingOwners
 
-    /** Nicer syntax for `allEnclosingOwners isnt kind`. */
+    /** Nicer syntax for `allEnclosingOwners isn't kind`. */
     private object noEnclosingOwner {
       @inline def is(kind: OwnerKind): Boolean =
         allEnclosingOwners isnt kind

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -32,7 +32,7 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
     bitmapFieldNames.clear()
   }
 
-  // Collect informations about offset fields
+  // Collect information about offset fields
   def prepareForTypeDef(td: TypeDef)(using Context): Unit = {
     val sym = td.symbol
     val hasLazyFields = sym.denot.info.fields

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -111,11 +111,11 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
     if (generatedMirrorClasses.nonEmpty) {
       // Ported from Scala.js
       /* #4148 Add generated static forwarder classes, except those that
-       * would collide with regular classes on case insensitive file systems.
+       * would collide with regular classes on case-insensitive file systems.
        */
 
       /* I could not find any reference anywhere about what locale is used
-       * by case insensitive file systems to compare case-insensitively.
+       * by case-insensitive file systems to compare case-insensitively.
        * In doubt, force the English locale, which is probably going to do
        * the right thing in virtually all cases (especially if users stick
        * to ASCII class names), and it has the merit of being deterministic,

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -662,7 +662,7 @@ trait NirGenExpr(using Context) {
       def genIfsChain(): nir.Val = {
         /* Default label needs to be generated before any others and then added to
          * current MethodEnv. It's label might be referenced in any of them in
-         * case of match with guards, eg.:
+         * case of match with guards, e.g.:
          *
          * "Hello, World!" match {
          *  case "Hello" if cond1 => "foo"
@@ -1031,7 +1031,7 @@ trait NirGenExpr(using Context) {
           if !(localNames.contains(id) || isMutable)
           then localNames.update(id, name)
           vd.rhs match {
-            // When rhs is a block patch the scopeId of it's result to match the current scopeId
+            // When rhs is a block patch the scopeId of its result to match the current scopeId
             // This allows us to reflect that ValDef is accessible in this scope
             case _: Block | Typed(_: Block, _) | Try(_: Block, _, _) |
                 Try(Typed(_: Block, _), _, _) =>
@@ -2533,7 +2533,7 @@ trait NirGenExpr(using Context) {
     }
 
     private lazy val optimizedFunctions = {
-      // Included functions should be pure, and should not not narrow the result type
+      // Included functions should be pure, and should not narrow the result type
       Set[Symbol](
         defnNir.Intrinsics_castIntToRawSize,
         defnNir.Intrinsics_castIntToRawSizeUnsigned,
@@ -2937,7 +2937,7 @@ trait NirGenExpr(using Context) {
     )(using nir.SourcePosition): nir.Defn = {
       val attrs = nir.Attrs.None.withIsExtern(true)
 
-      // In case if passed function is adapted closure it's param types
+      // In case if passed function is adapted closure its param types
       // would be erased, in such case we would recover original types
       // using evidence types (materialized unsafe.Tags)
       val isAdapted = funSym.name.mangledString.contains("$adapted$")
@@ -2977,7 +2977,7 @@ trait NirGenExpr(using Context) {
         val boxedParams = origTypes.zip(params).map(buf.fromExtern(_, _))
         val argsp = boxedParams.map(ValTree(funTree)(_))
 
-        // Check number of arguments that would be be used in a call to the function,
+        // Check number of arguments that would be used in a call to the function,
         // it should be equal to the quantity of implicit evidences (without return type evidence)
         // and arguments passed via closure env.
         if (argsp.size != evidences.length - 1 + funTree.env.size) {
@@ -3121,7 +3121,7 @@ trait NirGenExpr(using Context) {
         unwind
       )
       // Proxies operate only on boxed types, however formal param types and name of the method
-      // might contain primitive types. With current imlementation of proxies we workaround it
+      // might contain primitive types. With current implementation of proxies we work around it
       // by always using boxed types in function calls
       val boxedFormalParamTypeRefs = formalParamTypeRefs.map {
         case ty: nir.Type.PrimitiveKind =>

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -155,8 +155,8 @@ trait NirGenName(using Context) {
           else scalanative.util.unreachable
 
         /*
-         * Double quoted identifiers are not allowed in CLang.
-         * We're replacing them with unicode to allow distinction between x / `x` and `"x"`.
+         * Double-quoted identifiers are not allowed in CLang.
+         * We're replacing them with Unicode to allow distinction between x / `x` and `"x"`.
          * It follows Scala JVM naming convention.
          */
         id.replace("\"", "$u0022")

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -756,8 +756,8 @@ trait NirGenStat(using Context) {
    *        to true, or
    *      - the symbol was originally at the package level
    *
-   *  Other than the the fact that we also consider interfaces, this performs
-   *  the same tests as the JVM back-end.
+   *  Other than the fact that we also consider interfaces, this performs the
+   *  same tests as the JVM back-end.
    */
   private def isCandidateForForwarders(sym: Symbol): Boolean = {
     !ctx.settings.XnoForwarders.value && sym.isStatic && {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -242,11 +242,11 @@ trait NirGenType(using Context) {
   private def genStruct(st: SimpleType): nir.Type = {
     val symInfo = st.sym.info
     // In Scala 2 we used fields to create struct type, but this seems to be broken in Scala 3 -
-    // when compiling original file (eg. in nativelib) we do get correct list of fields,
-    // however in the place of usage in other project (eg. javalib) symbol info does contain only accessors,
+    // when compiling original file (e.g. in nativelib) we do get correct list of fields,
+    // however in the place of usage in other project (e.g. javalib) symbol info does contain only accessors,
     // but no information about fields.
-    // .class fiele do contain information about fields, so probablly TASTy (which is used)
-    // in compilation in dependent projects does not contains this information
+    // .class field do contain information about fields, so probably TASTy (which is used)
+    // in compilation in dependent projects does not contain this information
     // Since structs in the current form are a legacy feature, and are used only to
     // receive output from native function returning Struct by value (only in LLVMIntriniscs)
     // we can leave it as it is in the current, simplified form using constructor arguments

--- a/nscplugin/src/test/scala/scala/scalanative/compiler/LocalNamesTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/compiler/LocalNamesTest.scala
@@ -365,7 +365,7 @@ class LocalNamesTest {
   //     findDefinition(defns)
   //       .foreach { defn =>
   //         val lets = namedLets(defn).values
-  //         // Ensure each of vals n and x has it's own let
+  //         // Ensure each of vals n and x has its own let
   //         val expectedLets = Seq("n", "x")
   //         assertContainsAll("lets defined", expectedLets, lets)
   //         val expectedVals = expectedLets

--- a/posixlib/src/main/resources/scala-native/pwd.c
+++ b/posixlib/src/main/resources/scala-native/pwd.c
@@ -6,7 +6,7 @@
 #include "types.h"
 
 // We don't use the "standard" types such as `dev_t` for instance
-// because these have different sizes on eg. Linux and OSX. We use the
+// because these have different sizes on e.g. Linux and OSX. We use the
 // smallest type that can hold all the possible values for the different
 // systems.
 

--- a/posixlib/src/main/resources/scala-native/sys/stat.c
+++ b/posixlib/src/main/resources/scala-native/sys/stat.c
@@ -5,7 +5,7 @@
 #include <sys/stat.h>
 
 // We don't use the "standard" types such as `dev_t` for instance
-// because these have different sizes on eg. Linux and OSX. We use the
+// because these have different sizes on e.g. Linux and OSX. We use the
 // smallest type that can hold all the possible values for the different
 // systems.
 struct scalanative_stat {

--- a/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
@@ -28,7 +28,7 @@ object inet {
    * because Scala Native supports only passing structures by reference,
    * not value.
    *
-   * It is hard to obtain a in_addr structure without a pointer being
+   * It is hard to obtain an in_addr structure without a pointer being
    * involved.  If a Ptr[in_addr] is not immediately available, a
    * Ptr[sockaddr_in] or Ptr[sockaddr_in6] may be.  In that case, try
    * ptr.at3, for sockaddr_in or ptr.at1 for sockaddr_in6 (

--- a/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
@@ -8,7 +8,7 @@ import scala.scalanative.unsafe._, Nat._
 private[scalanative] object DirentTypes {
   type _256 = Digit3[_2, _5, _6] // see comment above 'type dirent' below.
 
-  type DIR = CStruct0 // An opaque structure from os. Deconstruct a your peril.
+  type DIR = CStruct0 // An opaque structure from os. Deconstruct at your peril.
 
   /* Use "glue" is here because Direct call through to the operating
    * system is beyond the scope of time available. Linux, FreeBSD and,
@@ -24,7 +24,7 @@ private[scalanative] object DirentTypes {
    *
    * Guarantees of the allocated size of that CString are stated but
    * unreliable.  Some operating systems do not specify NAME_MAX.
-   * Some specify it as 255 but can return a string longer that that.
+   * Some specify it as 255 but can return a string longer than that.
    * macOS specifies 255 UTF-8 characters. Since each UTF-8 character
    * can be up to, currently, 5 bytes long, the total size can
    * exceed the _256 here.

--- a/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
@@ -215,7 +215,7 @@ import scala.scalanative.unsafe._
   def SIGSTKSZ: CInt = extern
 
   // A machine-specific representation of the saved context
-  // mac OS type mcontext_t = Ptr[__darwin_mcontext64]
+  // macOS type mcontext_t = Ptr[__darwin_mcontext64]
   // __darwin_mcontext64 -> _STRUCT_MCONTEXT64 -> typedef _STRUCT_MCONTEXT64	*mcontext_t;
   type mcontext_t = CVoidPtr
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdio.scala
@@ -24,7 +24,7 @@ import scalanative.posix.sys.types, types.{off_t, size_t}
   /* Open Group POSIX defines this as a C macro.
    * To provide the value in a portable manner, it is implemented here as
    * an external method.  A slight but necessary deviation from the
-   * specification. The same idiom is used in an number of other posixlib
+   * specification. The same idiom is used in a number of other posixlib
    * files.
    */
   @name("scalanative_l_ctermid")

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -170,9 +170,9 @@ object unistd {
    *  Kernighan & Ritchie C developers will recognize the direct equivalence to
    *  "int *", where staying within bounds is up to the user.
    *
-   *  Here first argument of both pipe() and pipe2() is declared as as
-   *  Ptr[CInt], not CArray[CInt_2]. This is to be consistent with other uses of
-   *  C arrays where the size is not known, cf. "var environ: Ptr[CString]".
+   *  Here first argument of both pipe() and pipe2() is declared as Ptr[CInt],
+   *  not CArray[CInt_2]. This is to be consistent with other uses of C arrays
+   *  where the size is not known, cf. "var environ: Ptr[CString]".
    *
    *  See Scala Native Pull Request #4019 for discussion.
    */

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -58,11 +58,11 @@ object Build {
     testMultiScalaProjects.flatMap(_.componentProjects) ::: testNoCrossProject
   lazy val allProjects = publishedProjects ::: testProjects
 
-  private def setDepenency[T](key: TaskKey[T], projects: Seq[Project]) = {
+  private def setDependency[T](key: TaskKey[T], projects: Seq[Project]) = {
     key := key.dependsOn(projects.map(_ / key): _*).value
   }
 
-  private def setDepenencyForCurrentBinVersion[T](
+  private def setDependencyForCurrentBinVersion[T](
       key: TaskKey[T],
       projects: Seq[MultiScalaProject],
       includeNoCrossProjects: Boolean = true
@@ -94,13 +94,13 @@ object Build {
         commonSettings,
         noPublishSettings,
         disabledTestsSettings,
-        setDepenency(clean, allProjects),
+        setDependency(clean, allProjects),
         mavenPublishSettings,
         Seq(Compile / compile, Test / compile).map(
-          setDepenencyForCurrentBinVersion(_, allMultiScalaProjects)
+          setDependencyForCurrentBinVersion(_, allMultiScalaProjects)
         ),
         Seq(publish, publishSigned, publishLocal, Compile / doc).map(
-          setDepenencyForCurrentBinVersion(_, publishedMultiScalaProjects)
+          setDependencyForCurrentBinVersion(_, publishedMultiScalaProjects)
         )
       )
 
@@ -381,7 +381,7 @@ object Build {
         scriptedDependencies := {
           import java.nio.file.{Files, StandardCopyOption}
           // Synchronize SocketHelpers used in java-net-socket test
-          // Each scripted test creates it's own environment in tmp directory
+          // Each scripted test creates its own environment in tmp directory
           // which does not allow us to define external sources in script build
           Files.copy(
             ((javalib.v2_12 / Compile / scalaSource).value / "java/net/SocketHelpers.scala").toPath,
@@ -438,7 +438,7 @@ object Build {
 
               publishLocalVersion(ver)
                 .dependsOn(
-                  // Scala 3 needs 2.13 deps for it's cross version compat tests
+                  // Scala 3 needs 2.13 deps for its cross version compat tests
                   if (ver.startsWith("3")) publishLocalVersion("2.13")
                   else Def.task(())
                 )

--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -178,7 +178,7 @@ object Commands {
     projectFullVersionCommand("publish-local-dev") {
       case (version, state) =>
         List(
-          // Sbt plugin and it's dependencies
+          // Sbt plugin and its dependencies
           s"++${ScalaVersions.scala212} publishLocal",
           // Artifact for current version
           s"++${version} publishLocal"

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -31,7 +31,7 @@ object Deps {
     case (3, _) => "org.scala-lang" % "scala-partest" % ScalaVersions.scala213 :: Nil
 
   }
-  lazy val TestRunner = List(SbtTestInterface, JUnitInterface, JUnit)
+  lazy val TestRunner = List(SbtTestInterface, JUnitInterface % "test", JUnit % "test")
   lazy val JUnitJvm   = List(JUnitInterface % "test", JUnit % "test")
   private def scalaVersionsDependendent(
       scalaVersion: String

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -9,7 +9,7 @@ package build
  *
  *   This means that Continuous Integration (CI) is run using
  *   the highest patch version. Scala Native may or may not build from
- *   from scratch when using lower patch versions.
+ *   scratch when using lower patch versions.
  *
  *   This information can save time and frustration when preparing
  *   contributions for submission: Build privately using highest,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -461,7 +461,7 @@ object Settings {
         scalaVersionDirectories(sharedTestsDir, "scala", scalaVersion.value)
           .++(extraSharedDirectories)
           .flatMap(allScalaFromDir(_))
-      // Denylist contains relative paths from inside of scala version directory (scala, scala-2, etc)
+      // Denylist contains relative paths from inside of scala version directory (scala, scala-2, etc.)
       // List content of all scala directories when checking denylist coherency
       val allScalaSources = sharedTestsDir
         .listFiles()

--- a/scripts/scalalib-patch-tool.sc
+++ b/scripts/scalalib-patch-tool.sc
@@ -64,7 +64,7 @@ def main(
   assert(os.exists(overridesDirPath), "Overrides dir does not exists")
 
   cmd match {
-    // Create patches based on fetched Scala sources and it's overrideds
+    // Create patches based on fetched Scala sources and its overrideds
     case CreatePatches =>
       sourcesExistsOrFetch(scalaVersion, sourcesDir)
 

--- a/test-interface-common/src/main/scala/scala/scalanative/testinterface/common/RunMuxRPC.scala
+++ b/test-interface-common/src/main/scala/scala/scalanative/testinterface/common/RunMuxRPC.scala
@@ -22,8 +22,8 @@ private[testinterface] final class RunMuxRPC(rpc: RPCCore) {
 
   /** Multiplexer map.
    *
-   *  Access to the outer map needs to synchronized. Access to the inner map
-   *  only needs to be synchronize for writing.
+   *  Access to the outer map needs to be synchronized. Access to the inner map
+   *  only needs to be synchronized for writing.
    */
   private val mux =
     mutable.Map.empty[RPCCore.OpCode, java.util.HashMap[RunID, _]]

--- a/test-interface-sbt-defs/src/main/scala-2/sbt/testing/Status.scala
+++ b/test-interface-sbt-defs/src/main/scala-2/sbt/testing/Status.scala
@@ -2,12 +2,12 @@ package sbt.testing
 
 /** Represents the status of running a test.
  *
- *  Test frameworks can decided which of these to use and what they mean, but in
+ *  Test frameworks can decide which of these to use and what they mean, but in
  *  general, the intended meanings are:
  *
  *    - Success - a test succeeded
  *    - Error - an "error" occurred during a test
- *    - Failure - an "failure" during a test
+ *    - Failure - a "failure" during a test
  *    - Skipped - a test was skipped for any reason
  *    - Ignored - a test was ignored, <em>i.e.</em>, temporarily disabled with
  *      the intention of fixing it later

--- a/test-interface-sbt-defs/src/main/scala-3/sbt/testing/Status.scala
+++ b/test-interface-sbt-defs/src/main/scala-3/sbt/testing/Status.scala
@@ -2,12 +2,12 @@ package sbt.testing
 
 /** Represents the status of running a test.
  *
- *  Test frameworks can decided which of these to use and what they mean, but in
+ *  Test frameworks can decide which of these to use and what they mean, but in
  *  general, the intended meanings are:
  *
  *    - Success - a test succeeded
  *    - Error - an "error" occurred during a test
- *    - Failure - an "failure" during a test
+ *    - Failure - a "failure" during a test
  *    - Skipped - a test was skipped for any reason
  *    - Ignored - a test was ignored, <em>i.e.</em>, temporarily disabled with
  *      the intention of fixing it later

--- a/test-interface-sbt-defs/src/main/scala/sbt/testing/Logger.scala
+++ b/test-interface-sbt-defs/src/main/scala/sbt/testing/Logger.scala
@@ -21,7 +21,7 @@ trait Logger {
    */
   def error(msg: String): Unit
 
-  /** Provide an warning message.
+  /** Provide a warning message.
    *
    *  @param msg
    *    the warning message

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ProcessRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ProcessRunner.scala
@@ -13,7 +13,7 @@ private[testinterface] class ProcessRunner(
 ) extends AutoCloseable {
 
   private val process = {
-    // Optional emualator config used internally for testing non amd64 architectures
+    // Optional emulator config used internally for testing non amd64 architectures
     val emulatorOpts: List[String] = sys.env
       .get("CROSSCOMPILING_EMULATOR")
       .map(_.split(" ").toList)

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/adapter/RunnerAdapter.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/adapter/RunnerAdapter.scala
@@ -50,7 +50,7 @@ private final class RunnerAdapter private (
       workers
         .map(_.mux.call(NativeEndpoints.done, runID)(()))
         .foreach(_.await())
-      // RPC connection was closed, probaly due to native runner crash, skip sending fruitless command
+      // RPC connection was closed, probably due to native runner crash, skip sending fruitless command
       if (controller.com.isClosed) ""
       else controller.mux.call(NativeEndpoints.done, runID)(()).await()
     } finally {

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -327,7 +327,7 @@ object Build {
   private def await[T](
       task: ExecutionContext => Future[T]
   )(logTrace: Throwable => Unit): T = {
-    // Fatal errors, eg. StackOverflowErrors are not propagated by Futures
+    // Fatal errors, e.g. StackOverflowErrors are not propagated by Futures
     // Use a helper promise to get notified about the underlying problem
     val promise = Promise[T]()
     val executor = Executors.newFixedThreadPool(
@@ -348,7 +348,7 @@ object Build {
     implicit val ec: ExecutionContext =
       ExecutionContext.fromExecutor(executor, logTrace(_))
 
-    // Schedue the task and record completion
+    // Schedule the task and record completion
     task(ec).onComplete(promise.complete)
     try Await.result(promise.future, Duration.Inf)
     finally executor.shutdown()

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -197,8 +197,8 @@ private[scalanative] object LLVM {
   /** This function allows a project to have multiple `main` files by copying
    *  the one selected to the same parent directory as the `workDir` which is by
    *  default named `native`. Since the directory is named `native`, having a
-   *  project named `native` will by default produce a executable named `native`
-   *  which will throw an exception since the copy command uses
+   *  project named `native` will by default produce an executable named
+   *  `native` which will throw an exception since the copy command uses
    *  REPLACE_EXISTING.
    *
    *  Having a project or `baseName` named `native` conflicts with the build.
@@ -271,7 +271,7 @@ private[scalanative] object LLVM {
         // https://github.com/scala-native/scala-native/issues/2372
         // When using LTO make sure to use lld linker instead of default one
         // LLD might find some duplicated symbols defined in both C and C++,
-        // runtime libraries (libUCRT, libCPMT), we ignore this warnings.
+        // runtime libraries (libUCRT, libCPMT), we ignore these warnings.
         val ltoSupport = config.compilerConfig.lto match {
           case LTO.None => Nil
           case _        => Seq("-fuse-ld=lld", "-Wl,/force:multiple")
@@ -394,7 +394,7 @@ private[scalanative] object LLVM {
   }
 
   /** Checks the input timestamp to see if the file needs compiling. The call to
-   *  lastModified will return 0 for a non existent output file but that makes
+   *  lastModified will return 0 for a non-existent output file but that makes
    *  the timestamp always less forcing a recompile.
    *
    *  @param in
@@ -421,7 +421,7 @@ private[scalanative] object LLVM {
    *  @param out
    *    the executable
    *  @return
-   *    true if it need linking
+   *    true if it needs linking
    */
   @inline private def needsLinking(in: Seq[Path], out: Path): Boolean = {
     val inmax = in.map(_.toFile().lastModified()).max

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -238,7 +238,7 @@ sealed trait NativeConfig {
   /** Create a new [[NativeConfig]] with updated resource exclude patterns. */
   def withResourceExcludePatterns(value: Seq[String]): NativeConfig
 
-  /** Create a new [[NativeConfig]] with a updated list of service providers
+  /** Create a new [[NativeConfig]] with an updated list of service providers
    *  allowed in the final binary
    */
   def withServiceProviders(
@@ -251,7 +251,7 @@ sealed trait NativeConfig {
    */
   def withBaseName(value: String): NativeConfig
 
-  /** Create a optimization configuration */
+  /** Create an optimization configuration */
   final def withOptimizerConfig(value: OptimizerConfig): NativeConfig =
     withOptimizerConfig(_ => value)
 

--- a/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/SemanticsConfig.scala
@@ -4,14 +4,14 @@ package scala.scalanative.build
 sealed trait SemanticsConfig {
 //format: off
   /** Controls behaviour of final fields and their complaince with the Java Memory Model. 
-   *  The outputs of the program would depend of compliance level:
+   *  The outputs of the program would depend on compliance level:
    *  - [[JVMMemoryModelCompliance.Strict]] all final fields are synchronized - ensures safe publication,but it might lead to runtime performance overhead.
    *  - [[JVMMemoryModelCompliance.None]] final fields are never synchronized - no runtime overhead when accessing final fields, but it might lead to unexpected state in highly concurrent programs.
    *  - [[JVMMemoryModelCompliance.Relaxed]] (default) only fields marked with scala.scalanative.annotation.safePublish are synchronized.
    */
   def finalFields: JVMMemoryModelCompliance
   /** Sets the behaviour of final fields and their complaince with the Java Memory Model
-   *   The outputs of the program would depend of compliance level:
+   *   The outputs of the program would depend on compliance level:
    *  - [[JVMMemoryModelCompliance.Strict]] all final fields are synchronized - ensures safe publication,but it might lead to runtime performance overhead.
    *  - [[JVMMemoryModelCompliance.None]] final fields are never synchronized - no runtime overhead when accessing final fields, but it might lead to unexpected state in highly concurrent programs.
    *  - [[JVMMemoryModelCompliance.Relaxed]] (default) only fields marked with scala.scalanative.annotation.safePublish are synchronized.
@@ -22,14 +22,14 @@ sealed trait SemanticsConfig {
     * Controls behaviour of calls to extern methods when executing in multithreading mode.
     * When executing extern functions Garbage Collector needs to be notified about the internal state of thread, it's required to correctly track reachable objects and skip waiting for threads executing unmanged code.
     * When disabled (default) only calls to methods annotated with `scala.scalanative.unsafe.blocking` would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
-    * When enabled every invocation of foreign function would notify the GC about the thread state which guarantess no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
+    * When enabled every invocation of foreign function would notify the GC about the thread state which guarantees no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
     */
   def strictExternCallSemantics: Boolean
   /**
     * Sets behaviour of calls to extern methods when executing in multithreading mode.
     * When executing extern functions Garbage Collector needs to be notified about the internal state of thread, it's required to correctly track reachable objects and skip waiting for threads executing unmanged code.
     * When disabled only calls to methods annotated with `scala.scalanative.unsafe.blocking` would notify the GC - it allows to reduce overhead of extern method calls, but might lead to deadlocks or longer GC pauses when waiting for unannotated blocking function call.
-    * When enabled every invocation of foreign function would notify the GC about the thread state which guarantess no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
+    * When enabled every invocation of foreign function would notify the GC about the thread state which guarantees no deadlocks introduced by waiting for threads executing foreign code, but might reduce overall performance.
     */
   def withStrictExternCallSemantics(value: Boolean): SemanticsConfig
 // format: on

--- a/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CommonMemoryLayouts.scala
@@ -37,7 +37,7 @@ private[codegen] class CommonMemoryLayouts(implicit meta: Metadata) {
     final val ClassNameIdx = InterfacesIdx + 1
   }
 
-  // RTTI specific for classess, see class RuntimeTypeInformation
+  // RTTI specific for classes, see class RuntimeTypeInformation
   object ClassRtti extends Layout() {
     val usesDynMap = meta.analysis.dynsigs.nonEmpty
     private val dynMapType = if (usesDynMap) Some(DynamicHashMap.ty) else None

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -263,7 +263,7 @@ private[scalanative] object Lower {
 
         case inst @ nir.Inst.Jump(next) =>
           implicit val pos: nir.SourcePosition = inst.pos
-          // Generate GC yield points before backward jumps, eg. in loops
+          // Generate GC yield points before backward jumps, e.g. in loops
           next match {
             case nir.Next.Label(target, _) if labelPositions(target) <= currentBlockPosition =>
               genGCYieldpoint(buf)

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -1005,7 +1005,7 @@ private[codegen] abstract class AbstractCodeGen(
 
     val nir.Op.Call(ty, pointee, args) = call
     pointee match {
-      // Lower emits a alloc function with exact result type of the class instead of a raw pointer
+      // Lower emits an alloc function with exact result type of the class instead of a raw pointer
       // It's probablatic to emit when not using opaque pointers. Retry with simplified signature
       case Lower.alloc | Lower.largeAlloc
           if !useOpaquePointers && ty != Lower.allocSig =>

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/CodeGen.scala
@@ -85,7 +85,7 @@ object CodeGen {
           .getOrElse(EmptyPath)
 
       // Partition into multiple LLVM IR files proportional to number
-      // of available processesors. This prevents LLVM from optimizing
+      // of available processors. This prevents LLVM from optimizing
       // across IR module boundary unless LTO is turned on.
       def separate(): IRGenerators =
         partitionBy(assembly, procs)(outputFileId).toSeq.map {

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -630,7 +630,7 @@ private[codegen] object MetadataCodeGen {
           id
         case _ =>
           // We add an extra `_` to match the procedure names
-          // generated without debug informations.
+          // generated without debug information.
           // This makes demangling work regardless of the debug setting
           "__S" + defn.name.mangle
       }

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -35,7 +35,7 @@ private[interflow] trait Eval { self: Interflow =>
 
     pc += 1
 
-    // Implicit scopeId required for materialization of insts other then Inst.Let
+    // Implicit scopeId required for materialization of insts other than Inst.Let
     implicit var lastScopeId = scopeMapping(nir.ScopeId.TopLevel)
     while (true) {
       val inst = insts(pc)
@@ -297,9 +297,9 @@ private[interflow] trait Eval { self: Interflow =>
       case nir.Op.Method(rawObj, sig) =>
         val obj = eval(rawObj)
         val objty = {
-          /* If method is not virtual (eg. constructor) we need to ensure that
+          /* If method is not virtual (e.g. constructor) we need to ensure that
            * we would fetch for expected type targets (rawObj) instead of real (evaluated) type
-           * It might result in calling wrong method and lead to infinite loops, eg. issue #1909
+           * It might result in calling wrong method and lead to infinite loops, e.g. issue #1909
            */
           val realType = obj match {
             case InstanceRef(ty) => ty

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -44,7 +44,7 @@ private[scalanative] class Interflow(val config: build.Config)(implicit
     new ScopedVar[mutable.UnrolledBuffer[DebugInfo.LexicalScope]]
   )
 
-  // Not thread-safe, each thread shall contain it's own stack
+  // Not thread-safe, each thread shall contain its own stack
   protected class SymbolsStack {
     private var state: List[nir.Global.Member] = Nil
     private var cachedSize = 0

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -526,8 +526,8 @@ private[interflow] object MergeProcessor {
 
   /* To mitigate risk of duplicated ids each merge block uses a dedicated
    *  namespace. Translation to the new namespace is performed by multiplicating
-   *  id by value of MergeBlockOffset. This adds a restiction for maximal number
-   *  of instructions within a function to no larger then value of MergeBlockOffset.
+   *  id by value of MergeBlockOffset. This adds a restriction for maximal number
+   *  of instructions within a function to no larger than value of MergeBlockOffset.
    */
   private val MergeBlockOffset = 1000000L
 

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -115,9 +115,9 @@ private[interflow] final class State(val blockId: nir.Local)(
     import instance.{srcPosition, scopeId}
 
     val value = emit(op, idempotent)
-    // there might cases when virtualName for given addres might be assigned to two different instances
-    // It can happend when we deal with partially-evaluated instances, eg. arrayalloc + arraystore
-    // Don't emit local names for ops returing unit value
+    // there might be cases when virtualName for given address might be assigned to two different instances
+    // It can happen when we deal with partially-evaluated instances, e.g. arrayalloc + arraystore
+    // Don't emit local names for ops returning unit value
     if (preserveDebugInfo && op.resty != nir.Type.Unit) {
       virtualNames.get(addr).foreach { name =>
         this.localNames += value.id -> name

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
@@ -295,7 +295,7 @@ private[linker] trait LinktimeIntrinsicCallsResolver { self: Reach =>
       unwind = let.unwind
     )
 
-    // Create instance of ServiceLoader and call it's constructor
+    // Create instance of ServiceLoader and call its constructor
     val alloc = let.copy(op = Op.Classalloc(ServiceLoader, None))
     buf += alloc
     buf.call(

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -207,7 +207,7 @@ private[linker] trait LinktimeValueResolver { self: Reach =>
 
             comparsionFn(resolved.value, condition.value)
 
-          // In case if we cannot get common Ordering that can be used, eg.: comparison with Null
+          // In case if we cannot get common Ordering that can be used, e.g.: comparison with Null
           case (ComparableVal(condition, _), ComparableVal(resolved, _)) =>
             comparison match {
               case nir.Comp.Ieq | nir.Comp.Feq => resolved == condition

--- a/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/LocalNamesTest.scala
@@ -324,7 +324,7 @@ class LocalNamesTest extends OptimizerSpec {
     |  }
     |}""".stripMargin)
   ) {
-    // TODO: How to effectively distinguish inlined `temp2` in `result` and `result2`? Maybe concatation of owner strings, eg. `result.temp2`
+    // TODO: How to effectively distinguish inlined `temp2` in `result` and `result2`? Maybe concatenation of owner strings, e.g. `result.temp2`
     // %3000007 <result> = imul[int] %17000001 <temp2> : int, %7000001 <argInt> : int
     // %3000008 <result2> = imul[int] %24000001 <temp2> : int, %7000001 <argInt> : int
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LocaleTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/LocaleTest.scala
@@ -132,7 +132,7 @@ class LocaleTest {
         fromCString(currentLconv.thousands_sep)
       )
 
-      /* Skip grouping testing on FreeBSD. There is some long standing
+      /* Skip grouping testing on FreeBSD. There is some long-standing
        * discussion that FreeBSD does not use POSIX compliant values.
        * Do not test for an exact value that is known to be buggy.
        * The is to reduce them maintenance headache & cost if that

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/MonetaryTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/MonetaryTest.scala
@@ -8,7 +8,7 @@ import org.junit.BeforeClass
 import scala.scalanative.meta.LinktimeInfo._
 
 /* Using both LinktimeInfo & runtime.Platform looks strange.
- * It is a workaround to let this test run whilst I a suspected bug
+ * It is a workaround to let this test run whilst a suspected bug
  * in LinktimeInfo is tracked down.
  */
 import scalanative.runtime.Platform

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/StdlibTest.scala
@@ -29,7 +29,7 @@ class StdlibTest {
    * declarations. That is, the ones which keep me awake at night, wondering
    * if they will blow up on the first person who goes to use them.
    *
-   * Also gives end users a working example of how to setup and use these
+   * Also gives end users a working example of how to set up and use these
    * methods.
    */
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/TimeTest.scala
@@ -86,7 +86,7 @@ class TimeTest {
       val haveCI =
         java.lang.Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"))
 
-      // Test has proven to fragile to run outside known environments.
+      // Test has proven too fragile to run outside known environments.
       assumeTrue(
         "Tested only by GitHub continuous integration or developer bypass.",
         haveCI
@@ -95,7 +95,7 @@ class TimeTest {
       /* unix epoch is defined as 0 seconds UTC (Universal Time).
        * 'timezone' is defined in Posix as seconds WEST of UTC. Yes WEST.
        * At 'epoch + timezone seconds' it will be 0 seconds local time.
-       * That local time should display as the expected "Thu Jan etc".
+       * That local time should display as the expected "Thu Jan etc.".
        *
        * The logic here is the inverse of what one would expect. This
        * is to avoid having to deal with daylight saving issues. We
@@ -295,7 +295,7 @@ class TimeTest {
     if (!isWindows) {
       Zone.acquire { implicit z =>
         // The purpose of this test is to check that time.scala method
-        // declaration had an "@name" annotation, so that structure
+        // declaration had a "@name" annotation, so that structure
         // copy-in/copy-out happened? Failure case is if 36 byte
         // Scala Native tm got passed as-is to C strptime on a BSD/glibc
         // or macOS system; see the tm_gmtoff & tm_zone handling below.
@@ -499,7 +499,7 @@ class TimeTest {
      * Normally, the two times would be withing microseconds of each other,
      * well less than a second. Leap seconds, double leap seconds can add
      * a second or more, slow machines, etc.
-     * 5 is a generous guess. Lets see if time proves it a good trade off.
+     * 5 is a generous guess. Let's see if time proves it a good trade off.
      * The basic idea is to detect wildly wrong results from the unit under
      * test, not to stress either race conditions or developers.
      */
@@ -530,7 +530,7 @@ class TimeTest {
       /* Full sleep should have happened.
        * Hard to test/verify. Nanosecond delays,
        * even rounded up to clock granularity, are exceedingly small
-       * compared to background of OS & hardware, especialy VM, noise.
+       * compared to background of OS & hardware, especially VM, noise.
        */
     } else if (result == EINTR) {
       // EINTR means sleep was interrupted, clock_nanosleep() executed.

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/MsgIoSocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/MsgIoSocketTest.scala
@@ -186,7 +186,7 @@ class MsgIoSocketTest {
           inMsgHdr.msg_namelen
         )
 
-        // Did packet came from where we expected, and not from Mars?
+        // Did packet come from where we expected, and not from Mars?
         assertEquals(
           "unexpected remote address",
           dstAddr.asInstanceOf[Ptr[sockaddr_in]].sin_addr.s_addr,

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/TimesTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/TimesTest.scala
@@ -60,7 +60,7 @@ class TimesTest {
        *
        * Continuous Integration (CI) experience has shown that in
        * unknown situations either or both tms_utime & tms_stime can be zero,
-       * even in the middle of what appears to be a long running process.
+       * even in the middle of what appears to be a long-running process.
        * This appears to be something the operating systems, plural, are
        * doing, rather than a misunderstanding of times(), a broken SN
        * implementation, or a blatantly bad test here. Subtly bad
@@ -77,7 +77,7 @@ class TimesTest {
        * As experience is gained or the cause of the zeros is better
        * understood, this test should be updated.
        *
-       * In the mean time, do not inject intermittent failures into
+       * In the meantime, do not inject intermittent failures into
        * the CI builds. They annoy the residents.
        */
 

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/posixlib/sys/Udp6SocketTest.scala
@@ -161,7 +161,7 @@ class Udp6SocketTest {
       checkIoResult(nBytesRecvd, "recvfrom_2")
       assertEquals("recvfrom_2 length", nBytesSent, nBytesRecvd)
 
-      // Did packet came from where we expected, and not from Mars?
+      // Did packet come from where we expected, and not from Mars?
 
       val expectedAddr = out6Addr.asInstanceOf[Ptr[sockaddr_in6]]
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/annotation/AlignTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/annotation/AlignTest.scala
@@ -96,7 +96,7 @@ class AlignTest {
       expected.toList,
       fieldPointers
         .map(_.toLong - basePointer.toLong)
-        .ensuring(_.forall(_ >= 0), "negative calucated offset")
+        .ensuring(_.forall(_ >= 0), "negative calculated offset")
         .toList
     )
   }

--- a/unit-tests/native/src/test/scala/scala/scalanative/libc/FenvTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/libc/FenvTest.scala
@@ -22,7 +22,7 @@ class FEnvTest {
 
   @Test def raiseCheckClearException(): Unit = {
     if (LinktimeInfo.isWindows) {
-      // Avoid link time error --`fe_raiseexcept` does not exists-- because it is not supported on Windows.
+      // Avoid link time error --`fe_raiseexcept` does not exist -- because it is not supported on Windows.
     } else {
 
       def assertContainsFlags(expected: CInt, actual: CInt): Unit = {

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/ApiTestUtils.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/ApiTestUtils.scala
@@ -89,7 +89,7 @@ object ApiTestUtils {
     )
   }
 
-  /** This takes a regex and it's compile time flags, a string that is expected
+  /** This takes a regex and its compile time flags, a string that is expected
    *  to match the regex and a string that is not expected to match the regex.
    *
    *  We don't check for JDK compatibility here, since the flags are not in a
@@ -189,7 +189,7 @@ object ApiTestUtils {
       count == m.groupCount()
     )
 
-    // JDK -- SN j.u.regex calls into scalanative.regex, so somethin
+    // JDK -- SN j.u.regex calls into scalanative.regex, so something
     // rotten on false.
     val pj = java.util.regex.Pattern.compile(pattern)
     val mj = pj.matcher("x")

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/PatternTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/PatternTest.scala
@@ -302,7 +302,7 @@ class PatternTest {
     pass("(?>a|aa)aabb", "aaabb")
     pass("(?>aa|a)aabb", "aaabb")
 
-    // quantifiers over look ahead
+    // quantifiers over look-ahead
     passAndFail(".*(?<=abc)*\\.log$", "cde.log", "cde.log")
   }
 
@@ -407,7 +407,7 @@ class PatternTest {
     }
 
     /// Ordered alphabetical by description (second arg).
-    /// Helps ensuring that each scalanative/regex Parser description
+    /// Helps ensure that each scalanative/regex Parser description
     /// matches its JVM equivalent.
     ///
     /// These are _not_ all the JVM parser PatternSyntaxExceptions available.

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/Utils.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/Utils.scala
@@ -164,7 +164,7 @@ object Utils {
     return -1
   }
 
-  // isWordRune reports whether r is consider a ``word character''
+  // isWordRune reports whether r is considered a ``word character''
   // during the evaluation of the \b and \B zero-width assertions.
   // These assertions are ASCII-only: the word characters are [A-Za-z0-9_].
   def isWordRune(r: Int): Boolean =

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
@@ -31,7 +31,7 @@ private object IntrinsicsTest {
       override def toString(): String = s"{$a}"
     }
 
-    // Make sure each type and it's fields are reachable to prevent elimination of unused fields
+    // Make sure each type and its fields are reachable to prevent elimination of unused fields
     def init() =
       Seq(new A(), new B(), new C(), new C2(), new D(), new E(), E, new F())
         .map(_.toString())

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/gc/CustomGCRootsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/gc/CustomGCRootsTest.scala
@@ -18,7 +18,7 @@ class CustomGCRootsTest {
       : Unit = {
     case class Node(var v: Int, var next: Node)
     val sizeOfNode = sizeof[Node]
-    // It should be take at least 12 bytes on 32bit, or 20 bytes on 64bit arch
+    // It should be at least 12 bytes on 32bit, or 20 bytes on 64bit arch
     assert(sizeOfNode.toInt > 8)
     val zone = new CustomGCRootsTest.Zone(10.toUSize * sizeOfNode)
 
@@ -41,8 +41,8 @@ class CustomGCRootsTest {
           val local2 = new Node(43, next = local)
           val local3 = new Node(44, next = local2)
           /* Bug workaround:
-           * Objects not allocted using the `new` operator, and though not executing their constructor might be assumed to never use their accessors
-           * Becouse of that if accessors are never used the underlying field might be treated as unreachable. This would further lead to not including it in the final
+           * Objects not allocated using the `new` operator, and though not executing their constructor might be assumed to never use their accessors
+           * Because of that if accessors are never used the underlying field might be treated as unreachable. This would further lead to not including it in the final
            * memory layout of the class.
            * Make sure to use at least accessors of all the fields at least once for memory allocated on the heap using `new` operator
            */
@@ -60,7 +60,7 @@ class CustomGCRootsTest {
 
       // Allocate additional objects to move cursor away from the last object pointing to memory on the heap
       Seq.fill(8)(allocNode())
-      // Sanity check - make sure the zone cannot allocate more memory then the amount passed in it's ctor
+      // Sanity check - make sure the zone cannot allocate more memory than the amount passed in its ctor
       org.junit.Assert.assertThrows(
         classOf[OutOfMemoryError],
         () => allocNode()
@@ -69,7 +69,7 @@ class CustomGCRootsTest {
       x
     }
 
-    // head is the object allocated in the zone, its childs can point to memory allocated using GC on the heap
+    // head is the object allocated in the zone, its children can point to memory allocated using GC on the heap
     try {
       val head = allocNodes()
       assertNotSame(head, head.next)

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuDoubleTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuDoubleTest.scala
@@ -31,7 +31,7 @@
 //
 // This is a semantic rather than textual port of the RYU GitHub
 // file DoubleToString.java. The java and scalanative testing environments
-// differ too much for a cost effective textual port.
+// differ too much for a cost-effective textual port.
 //
 // There is always the issue of lumpers & splitters. DoubleSuite.scala
 // already exists and covers methods in addition to Double.toString.
@@ -126,7 +126,7 @@ class RyuDoubleTest {
 
     /// Comment from original RYU source.
     // This number naively requires 65 bit for the intermediate results if we
-    // reduce the lookup table by half. This checks that we don't loose any
+    // reduce the lookup table by half. This checks that we don't lose any
     // information in that case.
     assertD2sEquals("1.8531501765868567E21", 1.8531501765868567e21)
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloatTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloatTest.scala
@@ -31,7 +31,7 @@
 //
 // This is a semantic rather than textual port of the RYU GitHub
 // file FloatToString.java. The java and scalanative testing environments
-// differ too much for a cost effective textual port.
+// differ too much for a cost-effective textual port.
 //
 // There is always the issue of lumpers & splitters. FloatSuite.scala
 // already exists and covers methods in addition to Float.toString.

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CArrayOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CArrayOpsTest.scala
@@ -57,7 +57,7 @@ class CArrayOpsTest {
     type Array4Byte = CArray[Byte, _4]
     type Array2D = CArray[Array4Byte, _4]
 
-    // In the folloing we just want to check in NullPointerException is not being thrown
+    // In the following we just want to check in NullPointerException is not being thrown
     val simpleArray = stackalloc[Array4Byte]()
     assertNotNull("Can assign null to Ptr[CArray]", !simpleArray = null)
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CFuncPtrOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CFuncPtrOpsTest.scala
@@ -24,7 +24,7 @@ class CFuncPtrOpsTest {
     type CFuncUnit = CFuncPtr0[Unit]
     type FuncStruct = CStruct2[CFuncUnit, Ptr[CFuncUnit]]
 
-    // In the folloing we just want to check in NullPointerException is not being thrown
+    // In the following we just want to check in NullPointerException is not being thrown
     val funcPtr = stackalloc[CFuncUnit]()
     assertNotNull("Can assign null to Ptr[CFuncPtr]", !funcPtr = null)
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStructOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStructOpsTest.scala
@@ -56,7 +56,7 @@ class CStructOpsTest {
     type IntStruct = CStruct1[Int]
     type BigStruct = CStruct2[Ptr[IntStruct], IntStruct]
 
-    // In the folloing we just want to check in NullPointerException is not being thrown
+    // In the following we just want to check in NullPointerException is not being thrown
     val simpleStruct = stackalloc[IntStruct]()
     assertNotNull("Can assign null to Ptr[CStruct]", !simpleStruct = null)
 

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/FilesTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/nio/file/FilesTestOnJDK11.scala
@@ -22,7 +22,7 @@ class FilesTestOnJDK11 {
 
   /* Design Notes:
    *
-   * 1) This set of Tests is designed to clean up after itself. That is
+   * 1) This set of Tests is designed to clean up after itself. That is,
    *    delete all directories and files created.  For debugging one
    *    can comment-out the Files.delete() in the afterClass() static method.
    *
@@ -258,7 +258,7 @@ class FilesTestOnJDK11 {
    * of leaving a large otherwise useless file lying around.
    *
    * The SN standard is to use "/* */" for multiline comments, as is done here.
-   * If someone if offended by the @Ignore, they could convert the contents
+   * If someone is offended by the @Ignore, they could convert the contents
    * below to "//" line comments then enclose the region in a "/* */" pair.
    */
   @Ignore
@@ -420,7 +420,7 @@ object FilesTestOnJDK11 {
     try {
       // Delete Files; start with deepest & work upwards to beginning of walk.
       stream.forEach(stack.addFirst(_)) // push() Path
-      stack.forEach(Files.delete(_)) // pop() a Path then delete it's File.
+      stack.forEach(Files.delete(_)) // pop() a Path then delete its File.
     } finally {
       stream.close()
     }

--- a/unit-tests/shared/src/test/require-jdk12/org/scalanative/testsuite/javalib/nio/file/FilesTestOnJDK12.scala
+++ b/unit-tests/shared/src/test/require-jdk12/org/scalanative/testsuite/javalib/nio/file/FilesTestOnJDK12.scala
@@ -129,7 +129,7 @@ object FilesTestOnJDK12 {
     try {
       // Delete Files; start with deepest & work upwards to beginning of walk.
       stream.forEach(stack.addFirst(_)) // push() Path
-      stack.forEach(Files.delete(_)) // pop() a Path then delete it's File.
+      stack.forEach(Files.delete(_)) // pop() a Path then delete its File.
     } finally {
       stream.close()
     }

--- a/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_L32X64MixRandomTestOnJDK17.scala
+++ b/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_L32X64MixRandomTestOnJDK17.scala
@@ -55,7 +55,7 @@ class JEP356_L32X64MixRandomTestOnJDK17 {
 
   @Test def create_Constructor_ZeroArg(): Unit = {
     /* Does the constructor link, execute without Exception, and
-     * return a useable method?
+     * return a usable method?
      */
 
     val rng = factory.create()
@@ -928,7 +928,7 @@ class JEP356_L32X64MixRandomTestOnJDK17 {
 
   @Test def splits(): Unit = {
     /* The Stream returned by splits() is supposed to be infinite.
-     * Since it might take awhile to examine the entire stream, only
+     * Since it might take a while to examine the entire stream, only
      * the first few elements are tested here.
      */
 

--- a/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_L64X128MixRandomTestOnJDK17.scala
+++ b/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_L64X128MixRandomTestOnJDK17.scala
@@ -44,7 +44,7 @@ class JEP356_L64X128MixRandomTestOnJDK17 {
 
   @Test def create_Constructor_ZeroArg(): Unit = {
     /* Does the constructor link, execute without Exception, and
-     * return a useable method?
+     * return a usable method?
      */
 
     val rng = factory.create()
@@ -917,7 +917,7 @@ class JEP356_L64X128MixRandomTestOnJDK17 {
 
   @Test def splits(): Unit = {
     /* The Stream returned by splits() is supposed to be infinite.
-     * Since it might take awhile to examine the entire stream, only
+     * Since it might take a while to examine the entire stream, only
      * the first few elements are tested here.
      */
 

--- a/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_RandomTestOnJDK17.scala
+++ b/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_RandomTestOnJDK17.scala
@@ -34,7 +34,7 @@ class JEP356_RandomTestOnJDK17 {
 
   @Test def create_Constructor_ZeroArg(): Unit = {
     /* Does the constructor link, execute without Exception, and
-     * return a useable method?
+     * return a usable method?
      */
 
     val rng = factory.create()
@@ -63,7 +63,7 @@ class JEP356_RandomTestOnJDK17 {
         factory.create(byteSeed)
       )
     } else {
-      /* JDK 17 thru 22, inclusive, explicitly specify silently fall back to
+      /* JDK 17 through 22, inclusive, explicitly specify silently fall back to
        * using the zero arg constructor.
        */
       val rng = factory.create()

--- a/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_SplittableRandomTestOnJDK17.scala
+++ b/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_SplittableRandomTestOnJDK17.scala
@@ -31,7 +31,7 @@ class JEP356_SplittableRandomTestOnJDK17 {
 
   @Test def create_Constructor_ZeroArg(): Unit = {
     /* Does the constructor link, execute without Exception, and
-     * return a useable method?
+     * return a usable method?
      */
 
     val rng = factory.create()
@@ -59,7 +59,7 @@ class JEP356_SplittableRandomTestOnJDK17 {
         factory.create(byteSeed)
       )
     } else {
-      /* JDK 17 thru 22, inclusive, explicitly specify silently fall back to
+      /* JDK 17 through 22, inclusive, explicitly specify silently fall back to
        * using the zero arg constructor.
        */
       val rng = factory.create()
@@ -940,7 +940,7 @@ class JEP356_SplittableRandomTestOnJDK17 {
 
   @Test def splits(): Unit = {
     /* The Stream returned by splits() is supposed to be infinite.
-     * Since it might take awhile to examine the entire stream, only
+     * Since it might take a while to examine the entire stream, only
      * the first few elements are tested here.
      */
 

--- a/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_ThreadLocalRandomTestOnJDK17.scala
+++ b/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_ThreadLocalRandomTestOnJDK17.scala
@@ -39,7 +39,7 @@ class JEP356_ThreadLocalRandomTestOnJDK17 {
 
   @Test def create_Constructor_ZeroArg(): Unit = {
     /* Does the constructor link, execute without Exception, and
-     * return a useable method?
+     * return a usable method?
      */
 
     val rng = ThreadLocalRandom.current()

--- a/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_Xoroshiro128PlusPlusRandomTestOnJDK17.scala
+++ b/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_Xoroshiro128PlusPlusRandomTestOnJDK17.scala
@@ -39,7 +39,7 @@ class JEP356_Xoroshiro128PlusPlusRandomTestOnJDK17 {
 
   @Test def create_Constructor_ZeroArg(): Unit = {
     /* Does the constructor link, execute without Exception, and
-     * return a useable method?
+     * return a usable method?
      */
 
     val rng = factory.create()

--- a/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_Xoshiro256PlusPlusRandomTestOnJDK17.scala
+++ b/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_Xoshiro256PlusPlusRandomTestOnJDK17.scala
@@ -40,7 +40,7 @@ class JEP356_Xoshiro256PlusPlusRandomTestOnJDK17 {
 
   @Test def create_Constructor_ZeroArg(): Unit = {
     /* Does the constructor link, execute without Exception, and
-     * return a useable method?
+     * return a usable method?
      */
 
     val rng = factory.create()

--- a/unit-tests/shared/src/test/require-jdk18/org/scalanative/testsuite/javalib/io/PrintStreamTestOnJDK18.scala
+++ b/unit-tests/shared/src/test/require-jdk18/org/scalanative/testsuite/javalib/io/PrintStreamTestOnJDK18.scala
@@ -12,7 +12,7 @@ class PrintStreamTestOnJDK18 {
 
   @Test def charset(): Unit = {
     val outStream = OutputStream.nullOutputStream()
-    val expectedCharset = StandardCharsets.UTF_16LE // pick an usual one.
+    val expectedCharset = StandardCharsets.UTF_16LE // pick a usual one.
     val ps = new PrintStream(outStream, false, expectedCharset)
 
     assertEquals(

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/JEP431_ReverseOrderOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/JEP431_ReverseOrderOnJDK21.scala
@@ -1959,7 +1959,7 @@ trait JEP431_ReverseOrderNavigableSetTestTraitOnJDK21
     )
 
     /* reversedSubSet.pollFirst() & reversedSubSet.pollLast() may be
-     * untested at this point, do no rely upon them; be explicit & declarative.
+     * untested at this point, do not rely upon them; be explicit & declarative.
      */
 
     val subSetFirst = revFromElement
@@ -2464,7 +2464,7 @@ trait JEP431_ReverseOrderSortedSetTestTraitOnJDK21
     )
   }
 
-  /* SortedSet has a different sense of "first & ""last", than SequencedSet
+  /* SortedSet has a different sense of "first" & "last" than SequencedSet
    * so Tests inherited from the latter must be overridden.
    */
   @Test override def removeFirst(): Unit = {

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/ListStaticMethodsTestOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/ListStaticMethodsTestOnJDK21.scala
@@ -210,7 +210,7 @@ class ListStaticMethodsTestOnJDK21 {
 
   @Test def of_VarArgs_SmallN(): Unit = {
     /* Does a varargs with less than 10 elements conflict with the overloads
-     * which specify one thru 10 args explicitly?  Can I break things before
+     * which specify one through 10 args explicitly?  Can I break things before
      * users do?
      */
 
@@ -231,7 +231,7 @@ class ListStaticMethodsTestOnJDK21 {
   @Test def of_VarArgs_LargeN(): Unit = {
 
     /* Does a varargs with more than 10 elements conflict with the overloads
-     * which specify one thru 10 args explicitly?  Can I break things before
+     * which specify one through 10 args explicitly?  Can I break things before
      * users do?
      */
 

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/SetStaticMethodsTestOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/SetStaticMethodsTestOnJDK21.scala
@@ -173,7 +173,7 @@ class SetStaticMethodsTestOnJDK21 {
 
   @Test def of_VarArgs_SmallN(): Unit = {
     /* Does a varargs with less than 10 elements conflict with the overloads
-     * which specify one thru 10 args explicitly?  Can I break things before
+     * which specify one through 10 args explicitly?  Can I break things before
      * users do?
      */
 
@@ -199,7 +199,7 @@ class SetStaticMethodsTestOnJDK21 {
   @Test def of_VarArgs_LargeN(): Unit = {
 
     /* Does a varargs with more than 10 elements conflict with the overloads
-     * which specify one thru 10 args explicitly?  Can I break things before
+     * which specify one through 10 args explicitly?  Can I break things before
      * users do?
      */
 

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/ArraysOfAnyValTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/ArraysOfAnyValTestOnJDK9.scala
@@ -4711,7 +4711,7 @@ class ArraysOfCharCornerCasesTestOnJDK9 {
 
   @Test def exerciseGreekCharacters: Unit = {
     /* Reviewer JD557 recommended exercising Non-Latin-1 characters
-     * to strengthen coverage. A suggeston well worth implementing.
+     * to strengthen coverage. A suggestion well worth implementing.
      *
      * People familiar with other Non-Latin-1 character sets are
      * encouraged to add additional Tests for that set.

--- a/windowslib/src/main/scala/scala/scalanative/windows/ErrorCodes.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ErrorCodes.scala
@@ -577,8 +577,8 @@ object ErrorCodes {
   final val ERROR_FILE_TOO_LARGE = 0xdf.toUInt
 
   /** Access Denied. Before opening files in this location, you must first add
-   *  the web site to your trusted sites list, browse to the web site, and
-   *  select the option to login automatically.
+   *  the website to your trusted sites list, browse to the website, andselect
+   *  the option to login automatically.
    */
   final val ERROR_FORMS_AUTH_REQUIRED = 0xe0.toUInt
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/package.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/package.scala
@@ -10,7 +10,7 @@ package object windows {
   /* Actually large integers are union types with size of 64-bits
    * When the compiler does not support large integer types it allows to store
    * low and high parts of number in its structure fields. In all other cases
-   * its recommended to use its QuadPart field directly.
+   * it is recommended to use its QuadPart field directly.
    */
   type LargeInteger = Long
   type ULargeInteger = ULong


### PR DESCRIPTION
Marked a couple of test dependencies as such in `project/Deps.scala`.

The rest of this pull request fixes some typos; the only change to the actual code is in `project/Build.scala`, where the spelling of the names of two private methods - `setDepenency` and `setDepenencyForCurrentBinVersion` - was corrected.