### PR TITLE
Fix #4426: Port Scala.js java.lang.{Integer, Long}{expand, compress}

### DIFF
--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -607,4 +607,88 @@ object Integer {
       new String(buffer)
     }
   }
+
+  /** @since JDK 19 */
+  // Ported from Scala.js, revision: f335260, dated 2025-06-21.
+
+  def compress(i: scala.Int, mask: scala.Int): scala.Int = {
+    // Hacker's Delight, Section 7-4, Figure 7-10
+
+    val LogBitSize = 5 // log_2(32)
+
+    // !!! Verbatim copy-paste of Long.compress
+
+    var m = mask
+    var x = i & mask // clear irrelevant bits
+    var mk = ~m << 1 // we will count 0's to right
+
+    var j = 0 // i in Hacker's Delight, but we already have an i
+    while (j < LogBitSize) {
+      val mp = parallelSuffix(mk)
+      val mv = mp & m // bits to move
+      m = (m ^ mv) | (mv >>> (1 << j)) // compress m
+      val t = x & mv
+      x = (x ^ t) | (t >>> (1 << j)) // compress x
+      mk = mk & ~mp
+      j += 1
+    }
+
+    x
+  }
+
+  /** @since JDK 19 */
+  // Ported from Scala.js, revision: f335260, dated 2025-06-21.
+
+  def expand(i: scala.Int, mask: scala.Int): scala.Int = {
+    // Hacker's Delight, Section 7-5, Figure 7-12
+
+    val LogBitSize = 5 // log_2(32)
+
+    val array = new Array[scala.Int](LogBitSize)
+
+    // !!! Verbatim copy-paste of Long.expand
+
+    var m = mask
+    var x = i
+    var mk = ~m << 1 // we will count 0's to right
+
+    var j = 0 // i in Hacker's Delight, but we already have an i
+    while (j < LogBitSize) {
+      val mp = parallelSuffix(mk)
+      val mv = mp & m // bits to move
+      array(j) = mv
+      m = (m ^ mv) | (mv >>> (1 << j)) // compress m
+      mk = mk & ~mp
+      j += 1
+    }
+
+    j = LogBitSize - 1
+    while (j >= 0) {
+      val mv = array(j)
+      val t = x << (1 << j)
+
+      /* See the last line of the section text, but there is a mistake in the
+       * book: y should be t. There is no y in this algorithm, so it doesn't
+       * make sense. Plugging t instead matches the formula (c) of "Exchanging
+       * Corresponding Fields of Registers" in Section 2-20.
+       */
+      x = ((x ^ t) & mv) ^ x
+
+      j -= 1
+    }
+
+    x & mask // clear out extraneous bits
+  }
+
+  // Ported from Scala.js, revision: f335260, dated 2025-06-21.
+  @inline
+  private def parallelSuffix(x: Int): Int = {
+    // Hacker's Delight, Section 5-2
+    var y = x ^ (x << 1)
+    y = y ^ (y << 2)
+    y = y ^ (y << 4)
+    y = y ^ (y << 8)
+    y ^ (y << 16)
+  }
+
 }

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -581,6 +581,91 @@ object Long {
       new String(buffer)
     }
   }
+
+  /** @since JDK 19 */
+  // Ported from Scala.js, revision: f335260, dated 2025-06-21.
+
+  def compress(i: scala.Long, mask: scala.Long): scala.Long = {
+    // Hacker's Delight, Section 7-4, Figure 7-10
+
+    val LogBitSize = 6 // log_2(64)
+
+    // !!! Verbatim copy-paste of Integer.compress
+
+    var m = mask
+    var x = i & mask // clear irrelevant bits
+    var mk = ~m << 1 // we will count 0's to right
+
+    var j = 0 // i in Hacker's Delight, but we already have an i
+    while (j < LogBitSize) {
+      val mp = parallelSuffix(mk)
+      val mv = mp & m // bits to move
+      m = (m ^ mv) | (mv >>> (1 << j)) // compress m
+      val t = x & mv
+      x = (x ^ t) | (t >>> (1 << j)) // compress x
+      mk = mk & ~mp
+      j += 1
+    }
+
+    x
+  }
+
+  /** @since JDK 19 */
+  // Ported from Scala.js, revision: f335260, dated 2025-06-21.
+
+  def expand(i: scala.Long, mask: scala.Long): scala.Long = {
+    // Hacker's Delight, Section 7-5, Figure 7-12
+
+    val LogBitSize = 6 // log_2(64)
+
+    val array = new Array[scala.Long](LogBitSize)
+
+    // !!! Verbatim copy-paste of Integer.expand
+
+    var m = mask
+    var x = i
+    var mk = ~m << 1 // we will count 0's to right
+
+    var j = 0 // i in Hacker's Delight, but we already have an i
+    while (j < LogBitSize) {
+      val mp = parallelSuffix(mk)
+      val mv = mp & m // bits to move
+      array(j) = mv
+      m = (m ^ mv) | (mv >>> (1 << j)) // compress m
+      mk = mk & ~mp
+      j += 1
+    }
+
+    j = LogBitSize - 1
+    while (j >= 0) {
+      val mv = array(j)
+      val t = x << (1 << j)
+
+      /* See the last line of the section text, but there is a mistake in the
+       * book: y should be t. There is no y in this algorithm, so it doesn't
+       * make sense. Plugging t instead matches the formula (c) of "Exchanging
+       * Corresponding Fields of Registers" in Section 2-20.
+       */
+      x = ((x ^ t) & mv) ^ x
+
+      j -= 1
+    }
+
+    x & mask // clear out extraneous bits
+  }
+
+  // Ported from Scala.js, revision: f335260, dated 2025-06-21.
+  @inline
+  private def parallelSuffix(x: scala.Long): scala.Long = {
+    // Hacker's Delight, Section 5-2
+    var y = x ^ (x << 1)
+    y = y ^ (y << 2)
+    y = y ^ (y << 4)
+    y = y ^ (y << 8)
+    y = y ^ (y << 16)
+    y ^ (y << 32)
+  }
+
 }
 
 private[lang] object LongCache {

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/IntegerTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/IntegerTestOnJDK19.scala
@@ -1,0 +1,126 @@
+/* Ported from Scala.js IntegerTestOnJDK21, revision: f335260,
+ * dated 2025-06-21.
+ */
+
+package org.scalanative.testsuite.javalib.lang
+
+import org.junit.Test
+import org.junit.Assert._
+
+class IntegerTestOnJDK19 {
+
+  @Test def compress(): Unit = {
+    // Example from the doc
+    assertEquals(0x000cabab, Integer.compress(0xcafebabe, 0xff00fff0))
+
+    // Random test cases
+    assertEquals(0x00000106, Integer.compress(0x89709d4b, 0x7a865060))
+    assertEquals(0x000000ab, Integer.compress(0x99933665, 0x0b505400))
+    assertEquals(0x00000014, Integer.compress(0x01d4851c, 0x101c1040))
+    assertEquals(0x0000020a, Integer.compress(0xd09d94a0, 0x1742a082))
+    assertEquals(0x00000032, Integer.compress(0x45ca9572, 0x1ac04203))
+    assertEquals(0x00000136, Integer.compress(0xf53bb659, 0x20ee0402))
+    assertEquals(0x0000003e, Integer.compress(0x3aca6e68, 0x00304e44))
+    assertEquals(0x00000007, Integer.compress(0x80e5df8f, 0x00028500))
+    assertEquals(0x0000000e, Integer.compress(0x6ec079f2, 0x10002091))
+    assertEquals(0x000007b7, Integer.compress(0xfc8242fc, 0x5e828288))
+    assertEquals(0x00000101, Integer.compress(0xccc51aaa, 0xa2184460))
+    assertEquals(0x0000001b, Integer.compress(0x8f673f64, 0x04520200))
+    assertEquals(0x0000001b, Integer.compress(0xbf6fd8b3, 0x480420a0))
+    assertEquals(0x000000ee, Integer.compress(0x3be5a94a, 0x8580e980))
+    assertEquals(0x0000001e, Integer.compress(0xb03e6c68, 0x41282810))
+    assertEquals(0x00000043, Integer.compress(0x2020edaf, 0x20c30180))
+    assertEquals(0x00000001, Integer.compress(0xb385d407, 0x00000001))
+    assertEquals(0x00000017, Integer.compress(0x416158fa, 0x12504060))
+    assertEquals(0x00000006, Integer.compress(0x857ee772, 0x48806800))
+    assertEquals(0x00000057, Integer.compress(0xb7803dee, 0xe001000e))
+    assertEquals(0x00000030, Integer.compress(0xb815b083, 0x002c8c44))
+    assertEquals(0x00000001, Integer.compress(0x3587593b, 0x00000008))
+    assertEquals(0x00000144, Integer.compress(0xb5a433fa, 0xd8004905))
+    assertEquals(0x00000007, Integer.compress(0x8b7e53b5, 0x00000031))
+    assertEquals(0x0000006a, Integer.compress(0x2f8a5041, 0x12023148))
+    assertEquals(0x0000004b, Integer.compress(0x34d1dd9f, 0x620400c9))
+    assertEquals(0x00000001, Integer.compress(0x9d6feff4, 0x00800100))
+    assertEquals(0x00000000, Integer.compress(0x943fb671, 0x00000000))
+    assertEquals(0x00000176, Integer.compress(0x978edc70, 0x044c4232))
+    assertEquals(0x00000000, Integer.compress(0x20162f69, 0x00000002))
+    assertEquals(0x000000c8, Integer.compress(0x4be28cf0, 0x0040c24e))
+    assertEquals(0x00000009, Integer.compress(0xfa162c33, 0x00005a50))
+    assertEquals(0x000000f7, Integer.compress(0xc7f24ff6, 0x80905c80))
+    assertEquals(0x00000006, Integer.compress(0x2c0da46a, 0x11108003))
+    assertEquals(0x00000004, Integer.compress(0x01e9c326, 0x00002681))
+    assertEquals(0x00000017, Integer.compress(0xa5978785, 0x00209601))
+    assertEquals(0x0000002a, Integer.compress(0xfd14e766, 0x80089003))
+    assertEquals(0x00000009, Integer.compress(0xbd1ea1b2, 0x0000c820))
+    assertEquals(0x00000002, Integer.compress(0xa07002e3, 0x00002928))
+    assertEquals(0x0000000a, Integer.compress(0x81eb15c0, 0x06200841))
+    assertEquals(0x0000001e, Integer.compress(0x79d37ad6, 0x02406808))
+    assertEquals(0x000001e2, Integer.compress(0xf555014c, 0x110590d0))
+    assertEquals(0x0000009a, Integer.compress(0xf7e3e446, 0x02186085))
+    assertEquals(0x000000ef, Integer.compress(0xbe25b6b9, 0x94081488))
+    assertEquals(0x00000033, Integer.compress(0xc9c80a95, 0x40810490))
+    assertEquals(0x0000004c, Integer.compress(0xf8fbd5c8, 0x13208204))
+    assertEquals(0x000000b7, Integer.compress(0xba67e36f, 0x08a04528))
+    assertEquals(0x0000005d, Integer.compress(0xbd49dddb, 0x00403505))
+    assertEquals(0x00000008, Integer.compress(0x40c7f608, 0x00001821))
+    assertEquals(0x00000004, Integer.compress(0xc663e6f4, 0x28008102))
+  }
+
+  @Test def expand(): Unit = {
+    // Example from the doc
+    assertEquals(0xca00bab0, Integer.expand(0x000cabab, 0xff00fff0))
+
+    // Random test cases
+    assertEquals(0x68804060, Integer.expand(0x89709d4b, 0x7a865060))
+    assertEquals(0x03004400, Integer.expand(0x99933665, 0x0b505400))
+    assertEquals(0x001c0000, Integer.expand(0x01d4851c, 0x101c1040))
+    assertEquals(0x02400000, Integer.expand(0xd09d94a0, 0x1742a082))
+    assertEquals(0x12c00002, Integer.expand(0x45ca9572, 0x1ac04203))
+    assertEquals(0x004c0002, Integer.expand(0xf53bb659, 0x20ee0402))
+    assertEquals(0x00104400, Integer.expand(0x3aca6e68, 0x00304e44))
+    assertEquals(0x00028500, Integer.expand(0x80e5df8f, 0x00028500))
+    assertEquals(0x10000010, Integer.expand(0x6ec079f2, 0x10002091))
+    assertEquals(0x16828200, Integer.expand(0xfc8242fc, 0x5e828288))
+    assertEquals(0x20104040, Integer.expand(0xccc51aaa, 0xa2184460))
+    assertEquals(0x00100000, Integer.expand(0x8f673f64, 0x04520200))
+    assertEquals(0x480000a0, Integer.expand(0xbf6fd8b3, 0x480420a0))
+    assertEquals(0x04802100, Integer.expand(0x3be5a94a, 0x8580e980))
+    assertEquals(0x41080000, Integer.expand(0xb03e6c68, 0x41282810))
+    assertEquals(0x00830180, Integer.expand(0x2020edaf, 0x20c30180))
+    assertEquals(0x00000001, Integer.expand(0xb385d407, 0x00000001))
+    assertEquals(0x12500040, Integer.expand(0x416158fa, 0x12504060))
+    assertEquals(0x48002000, Integer.expand(0x857ee772, 0x48806800))
+    assertEquals(0xc001000c, Integer.expand(0xb7803dee, 0xe001000e))
+    assertEquals(0x00200044, Integer.expand(0xb815b083, 0x002c8c44))
+    assertEquals(0x00000008, Integer.expand(0x3587593b, 0x00000008))
+    assertEquals(0xd8004804, Integer.expand(0xb5a433fa, 0xd8004905))
+    assertEquals(0x00000021, Integer.expand(0x8b7e53b5, 0x00000031))
+    assertEquals(0x02000008, Integer.expand(0x2f8a5041, 0x12023148))
+    assertEquals(0x400400c9, Integer.expand(0x34d1dd9f, 0x620400c9))
+    assertEquals(0x00000000, Integer.expand(0x9d6feff4, 0x00800100))
+    assertEquals(0x00000000, Integer.expand(0x943fb671, 0x00000000))
+    assertEquals(0x000c4000, Integer.expand(0x978edc70, 0x044c4232))
+    assertEquals(0x00000002, Integer.expand(0x20162f69, 0x00000002))
+    assertEquals(0x0040c200, Integer.expand(0x4be28cf0, 0x0040c24e))
+    assertEquals(0x00005050, Integer.expand(0xfa162c33, 0x00005a50))
+    assertEquals(0x80904c00, Integer.expand(0xc7f24ff6, 0x80905c80))
+    assertEquals(0x10100002, Integer.expand(0x2c0da46a, 0x11108003))
+    assertEquals(0x00000280, Integer.expand(0x01e9c326, 0x00002681))
+    assertEquals(0x00000401, Integer.expand(0xa5978785, 0x00209601))
+    assertEquals(0x80001002, Integer.expand(0xfd14e766, 0x80089003))
+    assertEquals(0x00000800, Integer.expand(0xbd1ea1b2, 0x0000c820))
+    assertEquals(0x00000028, Integer.expand(0xa07002e3, 0x00002928))
+    assertEquals(0x00000000, Integer.expand(0x81eb15c0, 0x06200841))
+    assertEquals(0x00402800, Integer.expand(0x79d37ad6, 0x02406808))
+    assertEquals(0x10041080, Integer.expand(0xf555014c, 0x110590d0))
+    assertEquals(0x00100084, Integer.expand(0xf7e3e446, 0x02186085))
+    assertEquals(0x84081008, Integer.expand(0xbe25b6b9, 0x94081488))
+    assertEquals(0x00800410, Integer.expand(0xc9c80a95, 0x40810490))
+    assertEquals(0x10200000, Integer.expand(0xf8fbd5c8, 0x13208204))
+    assertEquals(0x00a00528, Integer.expand(0xba67e36f, 0x08a04528))
+    assertEquals(0x00401405, Integer.expand(0xbd49dddb, 0x00403505))
+    assertEquals(0x00001000, Integer.expand(0x40c7f608, 0x00001821))
+    assertEquals(0x20008000, Integer.expand(0xc663e6f4, 0x28008102))
+  }
+
+}

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/LongTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/LongTestOnJDK19.scala
@@ -1,0 +1,434 @@
+/* Ported from Scala.js LongTestOnJDK21, revision: f335260,
+ * dated 2025-06-21.
+ */
+
+package org.scalanative.testsuite.javalib.lang
+
+import java.lang.{Long => JLong}
+
+import org.junit.Test
+import org.junit.Assert._
+
+class LongTestOnJDK19 {
+
+  @Test def compress(): Unit = {
+    // Example from the doc
+    assertEquals(
+      0x00000000000cababL,
+      JLong.compress(0x00000000cafebabeL, 0x00000000ff00fff0L)
+    )
+
+    // Random test cases
+    assertEquals(
+      0x0000000000000000L,
+      JLong.compress(0x8ba5e11cb2dbe50bL, 0x0000000000000000L)
+    )
+    assertEquals(
+      0x0000000000000c41L,
+      JLong.compress(0xe40e22f388afccf8L, 0x026c1c0224502020L)
+    )
+    assertEquals(
+      0x00000000000013b4L,
+      JLong.compress(0xeeae0b35b17b8194L, 0x02110024291400e0L)
+    )
+    assertEquals(
+      0x0000000000007a15L,
+      JLong.compress(0x345ae610c64f3d4eL, 0x834a336481020012L)
+    )
+    assertEquals(
+      0x0000000000000b1aL,
+      JLong.compress(0x7641d455e2ed281bL, 0x008902403e041880L)
+    )
+    assertEquals(
+      0x000000000000004eL,
+      JLong.compress(0xac861cf1b05b0398L, 0x0000000000101a8cL)
+    )
+    assertEquals(
+      0x0000000000002a9aL,
+      JLong.compress(0xc06624be2e92bf17L, 0x0000950905c41138L)
+    )
+    assertEquals(
+      0x000000000001c3b5L,
+      JLong.compress(0xdbb3627dc7fbd3aeL, 0x103418a80026ba00L)
+    )
+    assertEquals(
+      0x00000000000cdd88L,
+      JLong.compress(0xa882378c6c18041bL, 0x2d82919c00803704L)
+    )
+    assertEquals(
+      0x0000000000000000L,
+      JLong.compress(0x6f38dc8510006c48L, 0x0000000000000000L)
+    )
+    assertEquals(
+      0x000000000000066bL,
+      JLong.compress(0x06b883c2e379e9efL, 0x00000008c8b23003L)
+    )
+    assertEquals(
+      0x00000000000007c3L,
+      JLong.compress(0x91f7e88ba084ce40L, 0x4114d00001128200L)
+    )
+    assertEquals(
+      0x0000000000002226L,
+      JLong.compress(0x02c045d59624182dL, 0x006304006045008eL)
+    )
+    assertEquals(
+      0x0000000000000001L,
+      JLong.compress(0xbf4d46a3bafce253L, 0x0000000000000010L)
+    )
+    assertEquals(
+      0x000000000000001bL,
+      JLong.compress(0x33237efb1e633f63L, 0x000000000000884bL)
+    )
+    assertEquals(
+      0x0000000000000001L,
+      JLong.compress(0x93107f2bacf81b2fL, 0x0000000000000008L)
+    )
+    assertEquals(
+      0x0000000000003363L,
+      JLong.compress(0xc2bb29b362f8e219L, 0x08520262c02400b8L)
+    )
+    assertEquals(
+      0x000000000000b877L,
+      JLong.compress(0xc78b262b39eb2cddL, 0xa68050843800880cL)
+    )
+    assertEquals(
+      0x00000000000028ceL,
+      JLong.compress(0x7d930cac7d303e64L, 0x00398010c4053810L)
+    )
+    assertEquals(
+      0x0000000000000057L,
+      JLong.compress(0x08ee90c1822e6c4aL, 0x000004108a1c0008L)
+    )
+    assertEquals(
+      0x000000000006885cL,
+      JLong.compress(0xde0c2c816052fc18L, 0x062582003636040eL)
+    )
+    assertEquals(
+      0x0000000000031203L,
+      JLong.compress(0xaa1ba08c10d8c985L, 0x0810450901a1226dL)
+    )
+    assertEquals(
+      0x00000000000001c0L,
+      JLong.compress(0x440b3f6882e34c60L, 0x0a9a040041000107L)
+    )
+    assertEquals(
+      0x000000000000003bL,
+      JLong.compress(0x68a311b59b1ab404L, 0x000000040800e004L)
+    )
+    assertEquals(
+      0x00000000000357caL,
+      JLong.compress(0xfa906cbb8fd930deL, 0x20d138200a445403L)
+    )
+    assertEquals(
+      0x000000000000026cL,
+      JLong.compress(0x38d1ba9226fa0ba6L, 0x2610d00030000040L)
+    )
+    assertEquals(
+      0x00000000000000fbL,
+      JLong.compress(0xf36f2165fba941c7L, 0x1102000020800016L)
+    )
+    assertEquals(
+      0x0000000000001a0aL,
+      JLong.compress(0x00c5ef0a8c060754L, 0x0604201802509192L)
+    )
+    assertEquals(
+      0x0000000000003a32L,
+      JLong.compress(0x830c388d7aa0f394L, 0x00011801a00a074dL)
+    )
+    assertEquals(
+      0x000000000000000fL,
+      JLong.compress(0x70fbac9a03d7ba53L, 0x00000000000e0210L)
+    )
+    assertEquals(
+      0x000000000003f9ebL,
+      JLong.compress(0x0eb1be8df6d84d3aL, 0x6c91912806005170L)
+    )
+    assertEquals(
+      0x0000000000000009L,
+      JLong.compress(0x0f352e179f551dc5L, 0x0000000000018024L)
+    )
+    assertEquals(
+      0x0000000000005072L,
+      JLong.compress(0x5552eede68f76decL, 0x7a2c800c02008006L)
+    )
+    assertEquals(
+      0x000000000000bb68L,
+      JLong.compress(0x042fbb7df8e7a486L, 0x5018420f0a034541L)
+    )
+    assertEquals(
+      0x0000000000000e61L,
+      JLong.compress(0x063102eb1ee90360L, 0x0000002a6884e020L)
+    )
+    assertEquals(
+      0x00000000000010fcL,
+      JLong.compress(0x48e2a60f7acfb970L, 0x1a14420e12200004L)
+    )
+    assertEquals(
+      0x000000000000000aL,
+      JLong.compress(0x34c3b8688f7469aaL, 0x0000000000005840L)
+    )
+    assertEquals(
+      0x00000000000552caL,
+      JLong.compress(0x22f86b59622f04b9L, 0x0021452aa043a584L)
+    )
+    assertEquals(
+      0x0000000000000000L,
+      JLong.compress(0xa83647a4aa67df00L, 0x0000000000000065L)
+    )
+    assertEquals(
+      0x0000000000000137L,
+      JLong.compress(0x744857857573feb5L, 0x000001008c262800L)
+    )
+    assertEquals(
+      0x0000000000000005L,
+      JLong.compress(0xf42e4dbd7d7143ccL, 0x0000000000018004L)
+    )
+    assertEquals(
+      0x0000000000000a8eL,
+      JLong.compress(0x4b2fb8215e743fb8L, 0x0542020040889421L)
+    )
+    assertEquals(
+      0x0000000000060a4cL,
+      JLong.compress(0xa71c17c938f8a501L, 0xa0c18a100d23a090L)
+    )
+    assertEquals(
+      0x0000000000000000L,
+      JLong.compress(0x7a405827c85af885L, 0x0000000000810010L)
+    )
+    assertEquals(
+      0x000000000009af25L,
+      JLong.compress(0xaea0f896b0fa389bL, 0x2003c2a6ac100235L)
+    )
+    assertEquals(
+      0x0000000000000004L,
+      JLong.compress(0x55b341855d14f960L, 0x000000000000002cL)
+    )
+    assertEquals(
+      0x00000000000001b3L,
+      JLong.compress(0x6cfd8fa32717da97L, 0x000000042230a111L)
+    )
+    assertEquals(
+      0x000000000005616aL,
+      JLong.compress(0x0ea774c43535bee0L, 0x480a940b81a45188L)
+    )
+    assertEquals(
+      0x0000000000000315L,
+      JLong.compress(0x73d1d6786823626bL, 0x040209064a4a12c0L)
+    )
+    assertEquals(
+      0x00000000000000fdL,
+      JLong.compress(0xd918a1dda6d9f1e4L, 0x0000000006185300L)
+    )
+  }
+
+  @Test def expand(): Unit = {
+    // Example from the doc
+    assertEquals(
+      0x00000000ca00bab0L,
+      JLong.expand(0x00000000000cababL, 0x00000000ff00fff0L)
+    )
+
+    // Random test cases
+    assertEquals(
+      0x0000000000000000L,
+      JLong.expand(0x8ba5e11cb2dbe50bL, 0x0000000000000000L)
+    )
+    assertEquals(
+      0x020c040224400000L,
+      JLong.expand(0xe40e22f388afccf8L, 0x026c1c0224502020L)
+    )
+    assertEquals(
+      0x0000000420100080L,
+      JLong.expand(0xeeae0b35b17b8194L, 0x02110024291400e0L)
+    )
+    assertEquals(
+      0x820a312001020010L,
+      JLong.expand(0x345ae610c64f3d4eL, 0x834a336481020012L)
+    )
+    assertEquals(
+      0x0081000002040880L,
+      JLong.expand(0x7641d455e2ed281bL, 0x008902403e041880L)
+    )
+    assertEquals(
+      0x0000000000000a00L,
+      JLong.expand(0xac861cf1b05b0398L, 0x0000000000101a8cL)
+    )
+    assertEquals(
+      0x0000850905001038L,
+      JLong.expand(0xc06624be2e92bf17L, 0x0000950905c41138L)
+    )
+    assertEquals(
+      0x1030102800223800L,
+      JLong.expand(0xdbb3627dc7fbd3aeL, 0x103418a80026ba00L)
+    )
+    assertEquals(
+      0x2000008000001504L,
+      JLong.expand(0xa882378c6c18041bL, 0x2d82919c00803704L)
+    )
+    assertEquals(
+      0x0000000000000000L,
+      JLong.expand(0x6f38dc8510006c48L, 0x0000000000000000L)
+    )
+    assertEquals(
+      0x0000000808b03003L,
+      JLong.expand(0x06b883c2e379e9efL, 0x00000008c8b23003L)
+    )
+    assertEquals(
+      0x4110400000000000L,
+      JLong.expand(0x91f7e88ba084ce40L, 0x4114d00001128200L)
+    )
+    assertEquals(
+      0x002200000004008aL,
+      JLong.expand(0x02c045d59624182dL, 0x006304006045008eL)
+    )
+    assertEquals(
+      0x0000000000000010L,
+      JLong.expand(0xbf4d46a3bafce253L, 0x0000000000000010L)
+    )
+    assertEquals(
+      0x0000000000008003L,
+      JLong.expand(0x33237efb1e633f63L, 0x000000000000884bL)
+    )
+    assertEquals(
+      0x0000000000000008L,
+      JLong.expand(0x93107f2bacf81b2fL, 0x0000000000000008L)
+    )
+    assertEquals(
+      0x0850002000040088L,
+      JLong.expand(0xc2bb29b362f8e219L, 0x08520262c02400b8L)
+    )
+    assertEquals(
+      0x0480400428008804L,
+      JLong.expand(0xc78b262b39eb2cddL, 0xa68050843800880cL)
+    )
+    assertEquals(
+      0x0019801004041000L,
+      JLong.expand(0x7d930cac7d303e64L, 0x00398010c4053810L)
+    )
+    assertEquals(
+      0x0000000080140000L,
+      JLong.expand(0x08ee90c1822e6c4aL, 0x000004108a1c0008L)
+    )
+    assertEquals(
+      0x0205820030020400L,
+      JLong.expand(0xde0c2c816052fc18L, 0x062582003636040eL)
+    )
+    assertEquals(
+      0x0000440100210009L,
+      JLong.expand(0xaa1ba08c10d8c985L, 0x0810450901a1226dL)
+    )
+    assertEquals(
+      0x0280040040000000L,
+      JLong.expand(0x440b3f6882e34c60L, 0x0a9a040041000107L)
+    )
+    assertEquals(
+      0x0000000000004000L,
+      JLong.expand(0x68a311b59b1ab404L, 0x000000040800e004L)
+    )
+    assertEquals(
+      0x0081200002405402L,
+      JLong.expand(0xfa906cbb8fd930deL, 0x20d138200a445403L)
+    )
+    assertEquals(
+      0x2600800030000000L,
+      JLong.expand(0x38d1ba9226fa0ba6L, 0x2610d00030000040L)
+    )
+    assertEquals(
+      0x1100000000000016L,
+      JLong.expand(0xf36f2165fba941c7L, 0x1102000020800016L)
+    )
+    assertEquals(
+      0x0000001802101080L,
+      JLong.expand(0x00c5ef0a8c060754L, 0x0604201802509192L)
+    )
+    assertEquals(
+      0x00011800200a0108L,
+      JLong.expand(0x830c388d7aa0f394L, 0x00011801a00a074dL)
+    )
+    assertEquals(
+      0x0000000000080210L,
+      JLong.expand(0x70fbac9a03d7ba53L, 0x00000000000e0210L)
+    )
+    assertEquals(
+      0x4010110800005120L,
+      JLong.expand(0x0eb1be8df6d84d3aL, 0x6c91912806005170L)
+    )
+    assertEquals(
+      0x0000000000008004L,
+      JLong.expand(0x0f352e179f551dc5L, 0x0000000000018024L)
+    )
+    assertEquals(
+      0x6a0c800802008000L,
+      JLong.expand(0x5552eede68f76decL, 0x7a2c800c02008006L)
+    )
+    assertEquals(
+      0x5018020202000140L,
+      JLong.expand(0x042fbb7df8e7a486L, 0x5018420f0a034541L)
+    )
+    assertEquals(
+      0x0000000248800000L,
+      JLong.expand(0x063102eb1ee90360L, 0x0000002a6884e020L)
+    )
+    assertEquals(
+      0x1a00400e00000000L,
+      JLong.expand(0x48e2a60f7acfb970L, 0x1a14420e12200004L)
+    )
+    assertEquals(
+      0x0000000000004800L,
+      JLong.expand(0x34c3b8688f7469aaL, 0x0000000000005840L)
+    )
+    assertEquals(
+      0x002140008002a404L,
+      JLong.expand(0x22f86b59622f04b9L, 0x0021452aa043a584L)
+    )
+    assertEquals(
+      0x0000000000000000L,
+      JLong.expand(0xa83647a4aa67df00L, 0x0000000000000065L)
+    )
+    assertEquals(
+      0x0000000084220800L,
+      JLong.expand(0x744857857573feb5L, 0x000001008c262800L)
+    )
+    assertEquals(
+      0x0000000000010000L,
+      JLong.expand(0xf42e4dbd7d7143ccL, 0x0000000000018004L)
+    )
+    assertEquals(
+      0x0542020040089000L,
+      JLong.expand(0x4b2fb8215e743fb8L, 0x0542020040889421L)
+    )
+    assertEquals(
+      0x0040801004000010L,
+      JLong.expand(0xa71c17c938f8a501L, 0xa0c18a100d23a090L)
+    )
+    assertEquals(
+      0x0000000000800010L,
+      JLong.expand(0x7a405827c85af885L, 0x0000000000810010L)
+    )
+    assertEquals(
+      0x200100a408000225L,
+      JLong.expand(0xaea0f896b0fa389bL, 0x2003c2a6ac100235L)
+    )
+    assertEquals(
+      0x0000000000000000L,
+      JLong.expand(0x55b341855d14f960L, 0x000000000000002cL)
+    )
+    assertEquals(
+      0x0000000402008111L,
+      JLong.expand(0x6cfd8fa32717da97L, 0x000000042230a111L)
+    )
+    assertEquals(
+      0x0802840b80a40000L,
+      JLong.expand(0x0ea774c43535bee0L, 0x480a940b81a45188L)
+    )
+    assertEquals(
+      0x00020800404810c0L,
+      JLong.expand(0x73d1d6786823626bL, 0x040209064a4a12c0L)
+    )
+    assertEquals(
+      0x0000000006101000L,
+      JLong.expand(0xd918a1dda6d9f1e4L, 0x0000000006185300L)
+    )
+  }
+
+}


### PR DESCRIPTION
Ported `java.lang.{Integer, Long}` `expand` and `compress` methods and associated
unit-tests from Scala.js.

The unit-tests on Scala.js had a `OnJDK21` suffix.  For Scala Native, the suffix `OnJDK19`
is used because these methods were introduced in JDK 19. 
