### PR TITLE
Fix #4431: javalib Files.list() iterator hasNext now matches JVM

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -990,6 +990,32 @@ class FilesTest {
     }
   }
 
+  // Issue #4431
+  @Test def filesListHasNextOnExhaustedIterator(): Unit = {
+    withTemporaryDirectory { dirFile =>
+      val dir = dirFile.toPath()
+
+      for (j <- 1 to 3) {
+        val f = dir.resolve(s"file${j}")
+        Files.createFile(f)
+        assertTrue(s"a${j}", Files.exists(f) && Files.isRegularFile(f))
+      }
+
+      val fileStream = Files.list(dir)
+
+      try {
+        val files = new java.util.HashSet[Path]()
+        val iter = fileStream.iterator()
+
+        while (iter.hasNext())
+          files.add(iter.next())
+
+        assertFalse("hasNext on exhausted iterater", iter.hasNext())
+
+      } finally fileStream.close()
+    }
+  }
+
   @Test def filesReadSymbolicLinkCanReadValidSymbolicLink(): Unit = {
     assumeShouldTestSymlinks()
 


### PR DESCRIPTION
Fix #4431

The behavior of `hasNext()` on an an Iterator on javalib `Files#list` stream where all elements of the 
stream have been previously retrieved now matches that of the JVM.

The unit-test is based, with permission and appreciation, on the reproducer in the referenced Issue.
Thank you user iRevive.