### PR TITLE
Fix #4432: javalib Files#list Exceptions now match JVM

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -827,7 +827,7 @@ object Files {
       private val posixDir: Ptr[DIR] = Zone.acquire { implicit z =>
         val ptr = opendir(toCString(dirString))
         if (ptr == null)
-          throw new UncheckedIOException(PosixException(dirString, errno))
+          throw PosixException(dirString, errno)
 
         posixDirClosed = false
         ptr
@@ -862,9 +862,7 @@ object Files {
 
               if (entry == null) {
                 if (errno != 0) {
-                  throw new UncheckedIOException(
-                    PosixException(dirString, errno)
-                  )
+                  throw PosixException(dirString, errno)
                 } else { // End of OS directory stream
                   closeImpl()
                   false
@@ -905,7 +903,7 @@ object Files {
         if (!posixDirClosed) {
           val err = closedir(posixDir)
           if (err != 0)
-            throw new UncheckedIOException(PosixException(dirString, errno))
+            throw PosixException(dirString, errno)
 
           posixDirClosed = true
         }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -1016,6 +1016,26 @@ class FilesTest {
     }
   }
 
+  // Issue #4432
+  @Test def filesListMatchJvmExceptions(): Unit = {
+    withTemporaryDirectory { dirFile =>
+      val dir = dirFile.toPath()
+      val file = dir.resolve("fileNotDir")
+      Files.createFile(file)
+
+      assertTrue("a1", Files.exists(file) && Files.isRegularFile(file))
+
+      try {
+        assertThrows(
+          classOf[NotDirectoryException],
+          Files.list(file) // it's a file, not a directory
+        )
+      } finally {
+        Files.delete(file)
+      }
+    }
+  }
+
   @Test def filesReadSymbolicLinkCanReadValidSymbolicLink(): Unit = {
     assumeShouldTestSymlinks()
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -1025,14 +1025,21 @@ class FilesTest {
 
       assertTrue("a1", Files.exists(file) && Files.isRegularFile(file))
 
-      try {
-        assertThrows(
-          classOf[NotDirectoryException],
-          Files.list(file) // it's a file, not a directory
-        )
-      } finally {
-        Files.delete(file)
-      }
+      val expectedException =
+        if (isWindows)
+
+          try {
+            val expectedException =
+              if (isWindows) classOf[IOException]
+              else classOf[NotDirectoryException]
+
+            assertThrows(
+              expectedException,
+              Files.list(file) // it's a file, not a directory
+            )
+          } finally {
+            Files.delete(file)
+          }
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/scala-native/scala-native/issues/4432

The Exceptions thrown by the private method `posixList` in javalib `Files#list` now matches those of JVM
`Files#list`.

The unit-test is based, with permission and appreciation, on the reproducer in the referenced Issue.
Thank you user iRevive.
