### PR TITLE
Fix #4442: Port Java JSR-166 concurrent.atomic.DoubleAdder

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/DoubleAdder.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/DoubleAdder.scala
@@ -1,0 +1,182 @@
+/* Ported from JSR 166 revision 1.23, dated: 2020-11-27
+ *   https://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166/src/main/
+ *     java/util/concurrent/atomic/DoubleAdder.java?revision=1.23&view=markup
+ *
+ * Serialization has not been implemted on Scala Native.
+ *
+ * The code style is neither idiomatic nor demo quality Scala.
+ * Rather the code is written to hew closely, but not exactly, to the
+ * JSR-166 Java original, Java idioms, a.k.a Scala warts, and all.
+ */
+
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent.atomic;
+
+import java.{lang => jl}
+
+/** One or more variables that together maintain an initially zero
+ *  {@code double} sum. When updates (method {@link #add}) are contended across
+ *  threads, the set of variables may grow dynamically to reduce contention.
+ *  Method {@link #sum} (or, equivalently {@link #doubleValue}) returns the
+ *  current total combined across the variables maintaining the sum. The order
+ *  of accumulation within or across threads is not guaranteed. Thus, this class
+ *  may not be applicable if numerical stability is required, especially when
+ *  combining values of substantially different orders of magnitude.
+ *
+ *  <p>This class is usually preferable to alternatives when multiple threads
+ *  update a common value that is used for purposes such as summary statistics
+ *  that are frequently updated but less frequently read.
+ *
+ *  <p>This class extends {@link Number}, but does <em>not</em> define methods
+ *  such as {@code equals}, {@code hashCode} and {@code compareTo} because
+ *  instances are expected to be mutated, and so are not useful as collection
+ *  keys.
+ *
+ *  @since 1.8
+ *  @author
+ *    Doug Lea
+ */
+
+class DoubleAdder() extends Striped64 {
+  import Striped64.{Cell, getProbe}
+
+  /*
+   * Note that we must use "long" for underlying representations,
+   * because there is no compareAndSet for double, due to the fact
+   * that the bitwise equals used in any CAS implementation is not
+   * the same as double-precision equals.  However, we use CAS only
+   * to detect and alleviate contention, for which bitwise equals
+   * works best anyway. In principle, the long/double conversions
+   * used here should be essentially free on most platforms since
+   * they just re-interpret bits.
+   */
+
+  /** Adds the given value.
+   *
+   *  @param x
+   *    the value to add
+   */
+  def add(x: Double): Unit = {
+    var cs: Array[Cell] = null
+    var b: Long = 0
+    var v: Long = 0
+    var m: Int = 0
+    var c: Cell = null
+
+    if ({ cs = cells; cs != null } || !casBase(
+          { b = base; b },
+          jl.Double.doubleToRawLongBits(jl.Double.longBitsToDouble(b) + x)
+        )) {
+
+      val index = getProbe()
+      var uncontended = true
+      if ((cs == null) ||
+          { m = cells.length - 1; m < 0 } ||
+          { c = cells(index & m); c == null } ||
+          {
+            uncontended = c.cas(
+              { v = c.value; v },
+              jl.Double.doubleToRawLongBits(jl.Double.longBitsToDouble(v) + x)
+            )
+            !uncontended
+          }) {
+        doubleAccumulate(x, null, uncontended, index)
+      }
+    }
+  }
+
+  /** Returns the current sum. The returned value is <em>NOT</em> an atomic
+   *  snapshot; invocation in the absence of concurrent updates returns an
+   *  accurate result, but concurrent updates that occur while the sum is being
+   *  calculated might not be incorporated. Also, because floating-point
+   *  arithmetic is not strictly associative, the returned result need not be
+   *  identical to the value that would be obtained in a sequential series of
+   *  updates to a single variable.
+   *
+   *  @return
+   *    the sum
+   */
+  def sum: Double = {
+    val cs = cells
+    var sum = jl.Double.longBitsToDouble(base)
+
+    if (cs != null) for (c <- cs) {
+      if (c != null)
+        sum += jl.Double.longBitsToDouble(c.value)
+    }
+    sum
+  }
+
+  /** Resets variables maintaining the sum to zero. This method may be a useful
+   *  alternative to creating a new adder, but is only effective if there are no
+   *  concurrent updates. Because this method is intrinsically racy, it should
+   *  only be used when it is known that no threads are concurrently updating.
+   */
+  def reset(): Unit = {
+    val cs = cells
+
+    base = 0L; // relies on fact that double 0 must have same rep as long
+    if (cs != null) for (c <- cs) {
+      if (c != null) c.reset()
+    }
+  }
+
+  /** Equivalent in effect to {@link #sum} followed by {@link #reset}. This
+   *  method may apply for example during quiescent points between multithreaded
+   *  computations. If there are updates concurrent with this method, the
+   *  returned value is <em>not</em> guaranteed to be the final value occurring
+   *  before the reset.
+   *
+   *  @return
+   *    the sum
+   */
+
+  def sumThenReset: Double = {
+    val cs = cells
+    var sum = jl.Double.longBitsToDouble(getAndSetBase(0L));
+
+    if (cs != null) for (c <- cs) {
+      if (c != null)
+        sum += jl.Double.longBitsToDouble(c.getAndSet(0L));
+    }
+    sum
+  }
+
+  /** Returns the String representation of the {@link #sum}.
+   *  @return
+   *    the String representation of the {@link #sum}
+   */
+
+  override def toString: String = sum.toString()
+
+  /** Equivalent to {@link #sum}.
+   *
+   *  @return
+   *    the sum
+   */
+
+  override def doubleValue(): Double = sum.toDouble
+
+  /** Returns the {@link #sum} as a {@code long} after a narrowing primitive
+   *  conversion.
+   */
+
+  def longValue(): Long = sum.toLong
+
+  /** Returns the {@link #sum} as an {@code int} after a narrowing primitive
+   *  conversion.
+   */
+
+  override def intValue(): Int = sum.toInt
+
+  /** Returns the {@link #sum} as a {@code float} after a narrowing primitive
+   *  conversion.
+   */
+
+  def floatValue(): Float = sum.toFloat
+}

--- a/javalib/src/main/scala/java/util/concurrent/atomic/DoubleAdder.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/DoubleAdder.scala
@@ -20,9 +20,9 @@ package java.util.concurrent.atomic;
 import java.{lang => jl}
 
 /** One or more variables that together maintain an initially zero
- *  {@code double} sum. When updates (method {@link #add}) are contended across
+ *  {@code double} sum. When updates (method {@code add}) are contended across
  *  threads, the set of variables may grow dynamically to reduce contention.
- *  Method {@link #sum} (or, equivalently {@link #doubleValue}) returns the
+ *  Method {@code sum} (or, equivalently {@code doubleValue}) returns the
  *  current total combined across the variables maintaining the sum. The order
  *  of accumulation within or across threads is not guaranteed. Thus, this class
  *  may not be applicable if numerical stability is required, especially when
@@ -32,7 +32,7 @@ import java.{lang => jl}
  *  update a common value that is used for purposes such as summary statistics
  *  that are frequently updated but less frequently read.
  *
- *  <p>This class extends {@link Number}, but does <em>not</em> define methods
+ *  <p>This class extends {@code Number}, but does <em>not</em> define methods
  *  such as {@code equals}, {@code hashCode} and {@code compareTo} because
  *  instances are expected to be mutated, and so are not useful as collection
  *  keys.
@@ -126,11 +126,13 @@ class DoubleAdder() extends Striped64 {
     }
   }
 
-  /** Equivalent in effect to {@link #sum} followed by {@link #reset}. This
-   *  method may apply for example during quiescent points between multithreaded
-   *  computations. If there are updates concurrent with this method, the
-   *  returned value is <em>not</em> guaranteed to be the final value occurring
-   *  before the reset.
+  /** Equivalent in effect to {@code sum} followed by {@code reset}. This method
+   *  may apply for example during quiescent points between multithreaded
+   *  computations.
+   *
+   *  If there are updates concurrent with this method, the computations. If
+   *  there are updates concurrent with this method, the returned value is
+   *  <em>not</em> guaranteed to be the final value occurring before the reset.
    *
    *  @return
    *    the sum
@@ -147,14 +149,14 @@ class DoubleAdder() extends Striped64 {
     sum
   }
 
-  /** Returns the String representation of the {@link #sum}.
+  /** Returns the String representation of the {@code sum}.
    *  @return
-   *    the String representation of the {@link #sum}
+   *    the String representation of the {@code sum}
    */
 
   override def toString: String = sum.toString()
 
-  /** Equivalent to {@link #sum}.
+  /** Equivalent to {@code sum}.
    *
    *  @return
    *    the sum
@@ -162,19 +164,19 @@ class DoubleAdder() extends Striped64 {
 
   override def doubleValue(): Double = sum.toDouble
 
-  /** Returns the {@link #sum} as a {@code long} after a narrowing primitive
+  /** Returns the {@code sum} as a {@code long} after a narrowing primitive
    *  conversion.
    */
 
   def longValue(): Long = sum.toLong
 
-  /** Returns the {@link #sum} as an {@code int} after a narrowing primitive
+  /** Returns the {@code sum} as an {@code int} after a narrowing primitive
    *  conversion.
    */
 
   override def intValue(): Int = sum.toInt
 
-  /** Returns the {@link #sum} as a {@code float} after a narrowing primitive
+  /** Returns the {@code sum} as a {@code float} after a narrowing primitive
    *  conversion.
    */
 

--- a/javalib/src/main/scala/java/util/concurrent/atomic/DoubleAdder.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/DoubleAdder.scala
@@ -15,7 +15,7 @@
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
 
-package java.util.concurrent.atomic;
+package java.util.concurrent.atomic
 
 import java.{lang => jl}
 
@@ -120,7 +120,7 @@ class DoubleAdder() extends Striped64 {
   def reset(): Unit = {
     val cs = cells
 
-    base = 0L; // relies on fact that double 0 must have same rep as long
+    base = 0L // relies on fact that double 0 must have same rep as long
     if (cs != null) for (c <- cs) {
       if (c != null) c.reset()
     }
@@ -140,11 +140,11 @@ class DoubleAdder() extends Striped64 {
 
   def sumThenReset: Double = {
     val cs = cells
-    var sum = jl.Double.longBitsToDouble(getAndSetBase(0L));
+    var sum = jl.Double.longBitsToDouble(getAndSetBase(0L))
 
     if (cs != null) for (c <- cs) {
       if (c != null)
-        sum += jl.Double.longBitsToDouble(c.getAndSet(0L));
+        sum += jl.Double.longBitsToDouble(c.getAndSet(0L))
     }
     sum
   }

--- a/javalib/src/main/scala/java/util/concurrent/atomic/Striped64.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/Striped64.scala
@@ -204,75 +204,76 @@ private[atomic] abstract class Striped64 private[atomic] () extends Number {
   ): Unit = {
     var index = _index
     var wasUncontended = _wasUncontended
+
     if (index == 0) {
-      ThreadLocalRandom.current()
-      index = Striped64.getProbe()
+      ThreadLocalRandom.current() // force initialization
+      index = getProbe()
       wasUncontended = true
     }
-    var continue1 = true
-    var continue2 = true
     var collide = false
-    while (continue1) {
-      var cs: Array[Striped64.Cell] = null
-      var c: Striped64.Cell = null
-      var n = 0
-      var v = 0L
-      if ({ cs = cells; n = cs.length; cs != null && n > 0 }) {
-        if ({ c = cs((n - 1) & index); c == null }) {
+
+    while (true) {
+      var cs: Array[Cell] = null
+      var c: Cell = null
+      var n: Int = 0
+      var v: Long = 0
+
+      if (cells != null && { n = cells.length; n > 0 }) {
+        c = cells((n - 1) & index)
+        if (c == null) {
+          var continue = false
           if (cellsBusy == 0) {
-            val r = new Striped64.Cell(doubleToRawLongBits(x))
+            val r = new Cell(doubleToRawLongBits(x))
             if (cellsBusy == 0 && casCellsBusy()) {
               try {
-                var rs: Array[Striped64.Cell] = null
-                var m = 0
-                var j = 0
-                if ({
-                  rs = cells; m = rs.length; j = (m - 1) & index;
-                  rs != null && m > 0 && rs(j) == null
-                }) {
+                var rs: Array[Cell] = null
+                var m: Int = 0
+                var j: Int = 0
+                rs = cells
+                if (rs != null && { m = rs.length; m > 0 } &&
+                    rs({ j = (m - 1) & index; j }) == null) {
                   rs(j) = r
-                  continue1 = false
-                  continue2 = false
+                  return
                 }
-              } finally cellsBusy = 0
-              continue2 = false
+              } finally {
+                cellsBusy = 0
+              }
+              continue = true
             }
           }
-          if (continue2 == true)
-            collide = false
-        } else if (!wasUncontended) wasUncontended = true
-        else if (c.cas({ v = c.value; v }, Striped64._apply(fn, v, x))) {
-          continue1 = false
-          continue2 = false
-        } else if (n >= Striped64.NCPU || (cells != cs)) collide = false
+          if (!continue) collide = false
+        } else if (!wasUncontended) { // CAS already known to fail
+          wasUncontended = true // Continue after rehash
+        } else if (c.cas({ v = c.value; v }, Striped64._apply(fn, v, x)))
+          return
+        else if (n >= NCPU || cells != cs)
+          collide = false // At max size or stale
         else if (!collide) collide = true
         else if (cellsBusy == 0 && casCellsBusy()) {
           try {
-            if (cells == cs)
+            if (cells == cs) { // Expand table unless stale
               cells = Arrays.copyOf(cs, n << 1)
+            }
           } finally {
             cellsBusy = 0
           }
           collide = false
-          continue2 = false
+          return
         }
-        if (continue2 == true)
-          index = Striped64.advanceProbe(index)
-      } else if (cellsBusy == 0 && cells == cs && casCellsBusy())
-        try {
+        index = advanceProbe(index)
+      } else if (cellsBusy == 0 && cells == cs && casCellsBusy()) {
+        try { // Initialize table
           if (cells == cs) {
-            val rs = new Array[Striped64.Cell](2)
-            rs(index & 1) = new Striped64.Cell(doubleToRawLongBits(x))
+            val rs = new Array[Cell](2)
+            rs(index & 1) = new Cell(doubleToLongBits(x))
             cells = rs
-            continue1 = false
+            return
           }
-        } finally {
-          cellsBusy = 0
-        }
-      else if (casBase({ v = base; v }, Striped64._apply(fn, v, x))) {
-        continue1 = false
-        continue2 = false
-      }
+        } finally cellsBusy = 0
+      } else if (casBase( // Fall back on using base
+            { v = base; v },
+            Striped64._apply(fn, v, x)
+          )) return
     }
   }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/DoubleAdderTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/DoubleAdderTest.scala
@@ -1,0 +1,164 @@
+/* Ported from JSR 166 revision 1.8, dated: 2017-08-04
+ *   https://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166
+ *     /src/test/tck/DoubleAdderTest.java?revision=1.8&pathrev=MAIN&view=markup
+ */
+
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent.atomic
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.javalib.util.concurrent.JSR166Test
+
+import JSR166Test._
+
+import java.{lang => jl}
+
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.DoubleAdder
+
+class DoubleAdderTest extends JSR166Test {
+  import JSR166Test._
+
+  /** default constructed initializes to zero
+   */
+  @Test def testConstructor(): Unit = {
+    val ai = new DoubleAdder
+    assertEquals(0.0, ai.sum, 0.0)
+  }
+
+  /** add adds given value to current, and sum returns current value
+   */
+  @Test def testAddAndSum() = {
+    val ai = new DoubleAdder()
+    ai.add(2.0)
+    assertEquals(2.0, ai.sum(), 0.0)
+    ai.add(-4.0)
+    assertEquals(-2.0, ai.sum(), 0.0)
+  }
+
+  /** reset() causes subsequent sum() to return zero
+   */
+  @Test def testReset() = {
+    val ai = new DoubleAdder()
+    ai.add(2.0)
+    assertEquals(2.0, ai.sum(), 0.0)
+    ai.reset()
+    assertEquals(0.0, ai.sum(), 0.0)
+  }
+
+  /** sumThenReset() returns sum; subsequent sum() returns zero
+   */
+  @Test def testSumThenReset() = {
+    val ai = new DoubleAdder()
+    ai.add(2.0)
+    assertEquals(2.0, ai.sum(), 0.0)
+    assertEquals(2.0, ai.sumThenReset(), 0.0)
+    assertEquals(0.0, ai.sum(), 0.0)
+  }
+
+  // Serialization is not implemented on Scala Native
+  //
+  // /**
+  //  * a deserialized/reserialized adder holds same value
+  //  */
+  // public void testSerialization() throws Exception
+
+  /** toString returns current value.
+   */
+  @Test def testToString() = {
+    val ai = new DoubleAdder()
+    assertEquals(jl.Double.toString(0.0), ai.toString())
+    ai.add(1.0)
+    assertEquals(jl.Double.toString(1.0), ai.toString())
+  }
+
+  /** intValue returns current value.
+   */
+  @Test def testIntValue() = {
+    val ai = new DoubleAdder()
+    assertEquals(0, ai.intValue())
+    ai.add(1.0)
+    assertEquals(1, ai.intValue())
+  }
+
+  /** longValue returns current value.
+   */
+  @Test def testLongValue() = {
+    val ai = new DoubleAdder()
+    assertEquals(0L, ai.longValue())
+    ai.add(1.0)
+    assertEquals(1L, ai.longValue())
+  }
+
+  /** floatValue returns current value.
+   */
+  @Test def testFloatValue() = {
+    val ai = new DoubleAdder()
+    assertEquals(0.0f, ai.floatValue(), 0.0f)
+    ai.add(1.0)
+    assertEquals(1.0f, ai.floatValue(), 0.0f)
+  }
+
+  /** doubleValue returns current value.
+   */
+  @Test def testDoubleValue() = {
+    val ai = new DoubleAdder()
+    assertEquals(0.0, ai.doubleValue(), 0.0)
+    ai.add(1.0)
+    assertEquals(1.0, ai.doubleValue(), 0.0)
+  }
+
+  @throws[Throwable]
+  @Test def testAddAndSumMT: Unit = {
+
+    val incs = 1000000
+    val nthreads = 4
+
+    val pool = Executors.newCachedThreadPool()
+    usingPoolCleaner(pool) { _ =>
+      val a = new DoubleAdder
+      val barrier = new CyclicBarrier(nthreads + 1)
+      for (i <- 0 until nthreads) {
+        pool.execute(new AdderTask(a, barrier, incs))
+      }
+      barrier.await
+      barrier.await
+      val total = nthreads * incs
+      val sum = a.sum
+      assertEquals(total.toDouble, sum, 0.0)
+    }
+    pool.shutdown()
+  }
+
+  final class AdderTask(
+      val adder: DoubleAdder,
+      val barrier: CyclicBarrier,
+      val incs: Int
+  ) extends Runnable {
+    var result = 0.0 // Appears unnecessary; _may_ be here to trick optimizer.
+
+    override def run(): Unit = {
+      try {
+        barrier.await
+        val a = adder
+        for (i <- 0 until incs) {
+          a.add(1L)
+        }
+        result = a.sum
+        barrier.await
+      } catch {
+        case t: Throwable =>
+          throw new Error(t)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix #4442

Implement javalib `java.util.concurrent.atomic` `DoubleAdder` by porting & adapting the
Doug Lea et al. public domain Oswego code for the class & associated unit-test.

`DoubleAdderTest` mostly exercises simple cases.  It does have a case which explicitly
exercises slightly` contended additions and summations.

A future improvement would be to implement industrial strength contended cases for both `DoubleAdder`
and `LongAdder`.
