### PR TITLE
Fix building scalalib with 3.3.7-RC1

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -30,12 +30,12 @@ object ScalaVersions {
     crossScalaVersions("3.4", 0 to 3),
     crossScalaVersions("3.5", 0 to 2),
     crossScalaVersions("3.6", 2 to 4), // 3.6.0 is broken, 3.6.1 is hotfix
-    crossScalaVersions("3.7", 0 to 1)
+    crossScalaVersions("3.7", 0 to 2)
   ).flatten.distinct
 
   // Tested in scheduled nightly CI to check compiler plugins
   // List maintains only upcoming releases, removed from the list after reaching stable status
-  lazy val scala3RCVersions = List("3.7.3-RC2")
+  lazy val scala3RCVersions = List("3.3.7-RC1", "3.7.3-RC2")
 
   // Scala versions used for publishing libraries
   val scala212: String = crossScala212.last

--- a/scalalib/overrides-3.3.5/scala/runtime/LazyVals.scala.patch
+++ b/scalalib/overrides-3.3.5/scala/runtime/LazyVals.scala.patch
@@ -1,4 +1,4 @@
---- 3.3.7-RC1/scala/runtime/LazyVals.scala
+--- 3.3.5-RC3/scala/runtime/LazyVals.scala
 +++ overrides-3.3/scala/runtime/LazyVals.scala
 @@ -4,44 +4,14 @@
  
@@ -71,14 +71,14 @@
 -      println(s"CAS($t, $offset, $e, $v, $ord)")
 -    val mask = ~(LAZY_VAL_MASK << ord * BITS_PER_LAZY_VAL)
 -    val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
--    unsafe.compareAndSwapLong(t, offset, e, n): @nowarn("cat=deprecation")
+-    unsafe.compareAndSwapLong(t, offset, e, n)
 +    unexpectedUsage()
    }
  
    def objCAS(t: Object, offset: Long, exp: Object, n: Object): Boolean = {
 -    if (debug)
 -      println(s"objCAS($t, $exp, $n)")
--    unsafe.compareAndSwapObject(t, offset, exp, n): @nowarn("cat=deprecation")
+-    unsafe.compareAndSwapObject(t, offset, exp, n)
 +    unexpectedUsage()
    }
  
@@ -126,7 +126,7 @@
    def get(t: Object, off: Long): Long = {
 -    if (debug)
 -      println(s"get($t, $off)")
--    unsafe.getLongVolatile(t, off): @nowarn("cat=deprecation")
+-    unsafe.getLongVolatile(t, off)
 +    unexpectedUsage()
    }
  

--- a/scalalib/overrides-3.3.6/scala/runtime/LazyVals.scala.patch
+++ b/scalalib/overrides-3.3.6/scala/runtime/LazyVals.scala.patch
@@ -1,4 +1,4 @@
---- 3.3.7-RC1/scala/runtime/LazyVals.scala
+--- 3.3.5-RC3/scala/runtime/LazyVals.scala
 +++ overrides-3.3/scala/runtime/LazyVals.scala
 @@ -4,44 +4,14 @@
  
@@ -71,14 +71,14 @@
 -      println(s"CAS($t, $offset, $e, $v, $ord)")
 -    val mask = ~(LAZY_VAL_MASK << ord * BITS_PER_LAZY_VAL)
 -    val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
--    unsafe.compareAndSwapLong(t, offset, e, n): @nowarn("cat=deprecation")
+-    unsafe.compareAndSwapLong(t, offset, e, n)
 +    unexpectedUsage()
    }
  
    def objCAS(t: Object, offset: Long, exp: Object, n: Object): Boolean = {
 -    if (debug)
 -      println(s"objCAS($t, $exp, $n)")
--    unsafe.compareAndSwapObject(t, offset, exp, n): @nowarn("cat=deprecation")
+-    unsafe.compareAndSwapObject(t, offset, exp, n)
 +    unexpectedUsage()
    }
  
@@ -126,7 +126,7 @@
    def get(t: Object, off: Long): Long = {
 -    if (debug)
 -      println(s"get($t, $off)")
--    unsafe.getLongVolatile(t, off): @nowarn("cat=deprecation")
+-    unsafe.getLongVolatile(t, off)
 +    unexpectedUsage()
    }
  


### PR DESCRIPTION
Adds patches acknowledging changes in scala.runtime.LazyVals