### PR TITLE
[nscplugin] Depend only on sources of `testingCompilerInterface` 

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -129,7 +129,9 @@ object Build {
       case "2.12" => _.settings(disabledDocsSettings)
       case _      => identity
     }
-    .mapBinaryVersions(_ => _.dependsOn(testingCompilerInterface % "test"))
+    .settings(
+      Test / unmanagedSourceDirectories ++= (testingCompilerInterface / Compile / unmanagedSourceDirectories).value
+    )
     .dependsOnSource(nirJVM)
     .dependsOnSource(utilJVM)
     .zippedSettings(Seq("testingCompiler", "nativelib")) {


### PR DESCRIPTION
Instead of introducing a hard dependency use only sources from other module. Fixes issues when publishing to sonatype fails during validation - nscplugin was having a dependency to snapshot version of testingCompilerInterface