### PR TITLE
Two changes to make javalib UnixProcess more multi-thread robust

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -135,7 +135,15 @@ private[lang] class UnixProcessGen2 private (
       if (waitStatus == 0)
         throw new IllegalThreadStateException()
       else
-        cachedExitValue.getOrDefault(1) // default 1 should never happen
+        /* default of 0 is a hack for multi-thread code whilst the
+         * entire isAlive()/exitValue()/waitFor() implementation is
+         * re-designed to be robust.
+         *  // default 1
+         * The default of 0 should never happen for single threaded code.
+         * It is a polite but useful fiction for multi-threaded code,
+         * such as os-lib.
+         */
+        cachedExitValue.getOrDefault(0)
     }
   }
 


### PR DESCRIPTION
Implement two multi-thread related robustness changes inspired by attempts to port 
`com-lihaoyi/os-lib` to  SN 0.5.8.  

Contemporary practice seems to be to `waitFor()`  the same `Process` instance in two or more
threads without external synchronization. JVM 8 thru 2n seems tolerant/robust to this practice.
 
Later:  This PR is a reduction-in-strength fix for `os-lib` but **DOES NOT** totally solve
            problems revealed by `os-lib` `SubprocessTests` and allow `os-lib` to port 
            cleanly. That is still Work in Progress.
