### PR TITLE
Implement 7 javalib jl.Math JDK25 methods

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -95,7 +95,7 @@ object Math {
       min: scala.Float,
       max: scala.Float
   ): scala.Float = {
-    // JVM checks arguments before checking value.isNaN()
+    // JVM checks arguments before checking value.isNaN().
 
     if (min.isNaN())
       throw new IllegalArgumentException("min is NaN")

--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -307,26 +307,20 @@ object Math {
     else overflow.value
   }
 
-  @inline def multiplyExact(a: scala.Long, b: scala.Long): scala.Long = {
+  @alwaysinline def multiplyExact(a: scala.Long, b: scala.Int): scala.Long =
+    multiplyExact(a, b.toLong)
+
+  @alwaysinline def multiplyExact(a: scala.Long, b: scala.Long): scala.Long = {
     val overflow = `llvm.smul.with.overflow.i64`(a, b)
     if (overflow.flag) throw new ArithmeticException("Long overflow")
     else overflow.value
   }
 
-  @alwaysinline def multiplyHigh(x: scala.Long, y: scala.Long): scala.Long =
-    scalanative.runtime.Intrinsics.multiplyHigh(x, y)
-
-  /** Since: Java 18 */
-  @alwaysinline def unsignedMultiplyHigh(
-      x: scala.Long,
-      y: scala.Long
-  ): scala.Long = scalanative.runtime.Intrinsics.unsignedMultiplyHigh(x, y)
-
-  @alwaysinline def multiplyExact(a: scala.Long, b: scala.Int): scala.Long =
-    multiplyExact(a, b.toLong)
-
   @alwaysinline def multiplyFull(a: scala.Int, b: scala.Int): scala.Long =
     a.toLong * b.toLong
+
+  @alwaysinline def multiplyHigh(x: scala.Long, y: scala.Long): scala.Long =
+    scalanative.runtime.Intrinsics.multiplyHigh(x, y)
 
   @alwaysinline def negateExact(a: scala.Int): scala.Int =
     subtractExact(0, a)
@@ -388,6 +382,71 @@ object Math {
 
   @alwaysinline def pow(a: scala.Double, b: scala.Double): scala.Double =
     `llvm.pow.f64`(a, b)
+
+  /* powExact Family Algorithm Note:
+   *
+   *   The algorithm used in powExact() and unsignedPowExact() variants
+   *   is the "Exponentiation_by_squaring" basic iterative algorithm
+   *   as described at URL:
+   *     https://en.wikipedia.org/wiki/Exponentiation_by_squaring
+   *
+   *   One web reference mentions the algorithm as extensively discussed in
+   *   Donald Knuth's "The Art of Computer Programming".
+   *
+   *   The algorithm is O(log n), where n is the exponent. It is better
+   *   than the O(n) naive algorithm but probably leaves room for improvement
+   *   by future math keen developers.
+   */
+
+  /** Since: Java 25 */
+  def powExact(a: scala.Int, b: scala.Int): scala.Int = {
+    if (b < 0)
+      throw new ArithmeticException("negative exponent")
+
+    if (b == 0) 1
+    else {
+      // See "powExact Family Algorithm Note" above powExact(int, int) method.
+      var x = a
+      var y = 1
+      var n = b
+
+      while (n > 1) {
+        if ((n & 1) == 1) {
+          y = Math.multiplyExact(x, y)
+          n -= 1
+        }
+        x = Math.multiplyExact(x, x)
+        n >>>= 1
+      }
+
+      x * y
+    }
+  }
+
+  /** Since: Java 25 */
+  def powExact(a: scala.Long, b: Int): scala.Long = {
+    if (b < 0)
+      throw new ArithmeticException("negative exponent")
+
+    if (b == 0) 1
+    else {
+      // See "powExact Family Algorithm Note" above powExact(int, int) method.
+      var x = a
+      var y = 1L
+      var n = b
+
+      while (n > 1) {
+        if ((n & 1) == 1) {
+          y = Math.multiplyExact(x, y)
+          n -= 1
+        }
+        x = Math.multiplyExact(x, x)
+        n >>>= 1
+      }
+
+      x * y
+    }
+  }
 
   @alwaysinline def random(): scala.Double =
     MathRand.rand.nextDouble()
@@ -502,6 +561,86 @@ object Math {
     } else {
       val d = abs(a)
       cmath.nextafter(d, scala.Double.MaxValue) - d
+    }
+  }
+
+  /** Since: Java 25 */
+  @inline def unsignedMultiplyExact(a: scala.Int, b: scala.Int): scala.Int = {
+    val overflow = `llvm.umul.with.overflow.i32`(a, b)
+    if (overflow.flag) throw new ArithmeticException("Integer overflow")
+    else overflow.value
+  }
+
+  /** Since: Java 25 */
+  @alwaysinline def unsignedMultiplyExact(
+      a: scala.Long,
+      b: scala.Int
+  ): scala.Long =
+    unsignedMultiplyExact(a, b & 0xffffffffL) // b as Long, no sign extension
+
+  /** Since: Java 25 */
+  @alwaysinline def unsignedMultiplyExact(
+      a: scala.Long,
+      b: scala.Long
+  ): scala.Long = {
+    val overflow = `llvm.umul.with.overflow.i64`(a, b)
+    if (overflow.flag) throw new ArithmeticException("Long overflow")
+    else overflow.value
+  }
+
+  /** Since: Java 18 */
+  @alwaysinline def unsignedMultiplyHigh(
+      x: scala.Long,
+      y: scala.Long
+  ): scala.Long = scalanative.runtime.Intrinsics.unsignedMultiplyHigh(x, y)
+
+  /** Since: Java 25 */
+  def unsignedPowExact(a: scala.Int, b: scala.Int): scala.Int = {
+    if (b < 0)
+      throw new ArithmeticException("negative exponent")
+
+    if (b == 0) 1
+    else {
+      // See "powExact Family Algorithm Note" above powExact(int, int) method.
+      var x = a
+      var y = 1
+      var n = b
+
+      while (n > 1) {
+        if ((n & 1) == 1) {
+          y = Math.unsignedMultiplyExact(x, y)
+          n -= 1
+        }
+        x = Math.unsignedMultiplyExact(x, x)
+        n >>>= 1
+      }
+
+      x * y
+    }
+  }
+
+  /** Since: Java 25 */
+  def unsignedPowExact(a: scala.Long, b: Int): scala.Long = {
+    if (b < 0)
+      throw new ArithmeticException("negative exponent")
+
+    if (b == 0) 1
+    else {
+      // See "powExact Family Algorithm Note" above powExact(int, int) method.
+      var x = a
+      var y = 1L
+      var n = b
+
+      while (n > 1) {
+        if ((n & 1) == 1) {
+          y = Math.unsignedMultiplyExact(x, y)
+          n -= 1
+        }
+        x = Math.unsignedMultiplyExact(x, x)
+        n >>>= 1
+      }
+
+      x * y
     }
   }
 }

--- a/unit-tests/shared/src/test/require-jdk25/org/scalanative/testsuite/javalib/lang/MathTestOnJDK25.scala
+++ b/unit-tests/shared/src/test/require-jdk25/org/scalanative/testsuite/javalib/lang/MathTestOnJDK25.scala
@@ -1,0 +1,292 @@
+package org.scalanative.testsuite.javalib.lang
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+import java.lang._
+
+class MathTestOnJDK25 {
+
+  @Test def powExact_IntInt_ArithmeticExceptions(): Unit = {
+    assertThrows(
+      "n is negative",
+      classOf[ArithmeticException],
+      Math.powExact(Integer.MAX_VALUE, -1)
+    )
+
+    assertThrows(
+      "overflows Int",
+      classOf[ArithmeticException],
+      Math.powExact(
+        Math.ceil(Math.sqrt(Integer.MAX_VALUE)).toInt,
+        2
+      )
+    )
+  }
+
+  @Test def powExact_IntInt(): Unit = {
+    case class powExactCase(x: Int, y: Int, expected: Int)
+
+    val testCases = java.util.List.of(
+      powExactCase(-1, 0, 1),
+      powExactCase(-1, 1, -1),
+      powExactCase(-1, 2, 1),
+      powExactCase(1, 2, 1),
+      powExactCase(2, 2, 4),
+      powExactCase(2, 3, 8),
+      powExactCase(2, 9, 512),
+      powExactCase(2, 10, 1024),
+      powExactCase(2, 19, 524288),
+      powExactCase(3, 3, 27),
+      powExactCase(3, 5, 243),
+      powExactCase(
+        Math.floor(Math.sqrt(Integer.MAX_VALUE)).toInt,
+        2,
+        2147395600
+      )
+    )
+
+    testCases.forEach { tc =>
+      try {
+        assertEquals(tc.expected, Math.powExact(tc.x, tc.y))
+      } catch {
+        case e: ArithmeticException =>
+          fail(s"ArithmeticException powExact(${tc.x}, ${tc.y})")
+      }
+    }
+  }
+
+  @Test def powExact_LongInt_ArithmeticExceptions(): Unit = {
+    assertThrows(
+      "n is negative",
+      classOf[ArithmeticException],
+      Math.powExact(Long.MAX_VALUE, -2)
+    )
+
+    assertThrows(
+      "overflows Int",
+      classOf[ArithmeticException],
+      Math.powExact(
+        Math.ceil(Math.cbrt(Long.MAX_VALUE)).toInt,
+        3
+      )
+    )
+  }
+
+  @Test def powExact_LongInt(): Unit = {
+    case class powExactCase(x: Long, y: Int, expected: Long)
+
+    val testCases = java.util.List.of(
+      powExactCase(-1L, 0, 1L),
+      powExactCase(-1L, 1, -1L),
+      powExactCase(-1L, 2, 1L),
+      powExactCase(1L, 2, 1L),
+      powExactCase(2L, 2, 4L),
+      powExactCase(2L, 3, 8L),
+      powExactCase(2L, 9, 512L),
+      powExactCase(2L, 10, 1024L),
+      powExactCase(2L, 19, 524288L),
+      powExactCase(3L, 3, 27L),
+      powExactCase(3L, 5, 243L),
+      powExactCase(
+        Math.floor(Math.sqrt(Long.MAX_VALUE)).toLong,
+        2,
+        9223372030926249001L
+      )
+    )
+
+    testCases.forEach { tc =>
+      try {
+        assertEquals(tc.expected, Math.powExact(tc.x, tc.y))
+      } catch {
+        case e: ArithmeticException =>
+          fail(s"ArithmeticException powExact(${tc.x}, ${tc.y})")
+      }
+    }
+
+  }
+
+  @Test def unsignedMultiplyExact_IntInt_ArithmeticException(): Unit = {
+    val x = Integer.MIN_VALUE
+    assertThrows(
+      "overflows unsigned Int",
+      classOf[ArithmeticException],
+      Math.unsignedMultiplyExact(x, 2)
+    )
+  }
+
+  @Test def unsignedMultiplyExact_IntInt(): Unit = {
+    case class unsignedMultiplyExactCase(x: Int, y: Int, expected: Int)
+
+    val m1 = Math.ceil(Math.sqrt(Integer.MAX_VALUE)).toInt
+
+    val testCases = java.util.List.of(
+      unsignedMultiplyExactCase(m1, m1, -2147479015),
+      unsignedMultiplyExactCase(Integer.MAX_VALUE, 2, -2),
+      unsignedMultiplyExactCase(Integer.MAX_VALUE >> 1, 3, -1073741827)
+    )
+
+    testCases.forEach { tc =>
+      try {
+        assertEquals(tc.expected, Math.unsignedMultiplyExact(tc.x, tc.y))
+      } catch {
+        case e: ArithmeticException =>
+          fail(s"ArithmeticException unsignedMultiplyExact(${tc.x}, ${tc.y})")
+      }
+    }
+  }
+
+  @Test def unsignedMultiplyExact_LongInt_ArithmeticException(): Unit = {
+    val x = Long.MIN_VALUE
+    assertThrows(
+      "overflows unsigned Long",
+      classOf[ArithmeticException],
+      Math.unsignedMultiplyExact(x, 3)
+    )
+  }
+
+  @Test def unsignedMultiplyExact_LongInt(): Unit = {
+    case class unsignedMultiplyExactCase(x: Long, y: Int, expected: Long)
+
+    val m1 = Math.ceil(Math.sqrt(Long.MAX_VALUE)).toLong
+
+    val testCases = java.util.List.of(
+      unsignedMultiplyExactCase(m1, m1.toInt, -9223372036709301616L),
+      unsignedMultiplyExactCase(Long.MAX_VALUE, 2, -2L)
+    )
+
+    testCases.forEach { tc =>
+      try {
+        assertEquals(tc.expected, Math.unsignedMultiplyExact(tc.x, tc.y))
+      } catch {
+        case e: ArithmeticException =>
+          fail(s"ArithmeticException unsignedMultiplyExact(${tc.x}, ${tc.y})")
+      }
+    }
+  }
+
+  @Test def unsignedMultiplyExact_LongLong_ArithmeticException(): Unit = {
+    val x = Long.MIN_VALUE
+    assertThrows(
+      "overflows unsigned Long",
+      classOf[ArithmeticException],
+      Math.unsignedMultiplyExact(x, x)
+    )
+  }
+
+  @Test def unsignedMultiplyExact_LongLong(): Unit = {
+    case class unsignedMultiplyExactCase(x: Long, y: Long, expected: Long)
+
+    val m1 = Math.ceil(Math.sqrt(Long.MAX_VALUE)).toLong
+
+    val testCases = java.util.List.of(
+      unsignedMultiplyExactCase(m1, m1, -9223372036709301616L),
+      unsignedMultiplyExactCase(Long.MAX_VALUE, 2L, -2L)
+    )
+
+    testCases.forEach { tc =>
+      try {
+        assertEquals(tc.expected, Math.unsignedMultiplyExact(tc.x, tc.y))
+      } catch {
+        case e: ArithmeticException =>
+          fail(s"ArithmeticException unsignedMultiplyExact(${tc.x}, ${tc.y})")
+      }
+    }
+  }
+
+  @Test def unsignedPowExact_IntInt_ArithmeticExceptions(): Unit = {
+    assertThrows(
+      "n is negative",
+      classOf[ArithmeticException],
+      Math.unsignedPowExact(Integer.MAX_VALUE, -1)
+    )
+
+    assertThrows(
+      "overflows Int",
+      classOf[ArithmeticException],
+      Math.unsignedPowExact(-1, 3)
+    )
+  }
+
+  @Test def unsignedPowExact_IntInt(): Unit = {
+    case class unsignedPowExactCase(x: Int, y: Int, expected: Int)
+
+    /* Note: Any negative x to a power higher than 1 will cause
+     * ArithmeticException because the correct math result overflows.
+     */
+
+    val testCases = java.util.List.of(
+      unsignedPowExactCase(-1, 0, 1),
+      unsignedPowExactCase(-1, 1, -1),
+      unsignedPowExactCase(1, 2, 1),
+      unsignedPowExactCase(2, 2, 4),
+      unsignedPowExactCase(2, 3, 8),
+      unsignedPowExactCase(2, 9, 512),
+      unsignedPowExactCase(2, 10, 1024),
+      unsignedPowExactCase(2, 19, 524288),
+      unsignedPowExactCase(3, 3, 27),
+      unsignedPowExactCase(3, 5, 243),
+      unsignedPowExactCase(
+        Math.floor(Math.sqrt(Integer.MAX_VALUE)).toInt,
+        2,
+        2147395600
+      ),
+      unsignedPowExactCase(
+        Math.ceil(Math.sqrt(Integer.MAX_VALUE)).toInt,
+        2,
+        -2147479015 // observe the move into unsigned space
+      )
+    )
+
+    testCases.forEach { tc =>
+      try {
+        assertEquals(tc.expected, Math.unsignedPowExact(tc.x, tc.y))
+      } catch {
+        case e: ArithmeticException =>
+          fail(s"ArithmeticException unsignedPowExact(${tc.x}, ${tc.y})")
+      }
+    }
+  }
+
+  @Test def unsignedPowExact_LongInt(): Unit = {
+    case class unsignedPowExactCase(x: Long, y: Int, expected: Long)
+
+    /* Note: Any negative x to a power higher than 1 will cause
+     * ArithmeticException because the correct math result overflows.
+     */
+
+    val testCases = java.util.List.of(
+      unsignedPowExactCase(-1L, 0, 1L),
+      unsignedPowExactCase(-1L, 1, -1L),
+      unsignedPowExactCase(1L, 2, 1L),
+      unsignedPowExactCase(2L, 2, 4L),
+      unsignedPowExactCase(2L, 3, 8L),
+      unsignedPowExactCase(2L, 9, 512L),
+      unsignedPowExactCase(2L, 10, 1024L),
+      unsignedPowExactCase(2L, 19, 524288L),
+      unsignedPowExactCase(3L, 3, 27L),
+      unsignedPowExactCase(3L, 5, 243L),
+      unsignedPowExactCase(
+        Math.floor(Math.sqrt(Long.MAX_VALUE)).toLong,
+        2,
+        9223372030926249001L
+      ),
+      unsignedPowExactCase(
+        Math.ceil(Math.sqrt(Long.MAX_VALUE)).toLong,
+        2,
+        -9223372036709301616L // observe the move into unsigned space
+      )
+    )
+
+    testCases.forEach { tc =>
+      try {
+        assertEquals(tc.expected, Math.unsignedPowExact(tc.x, tc.y))
+      } catch {
+        case e: ArithmeticException =>
+          fail(s"ArithmeticException unsignedPowExact(${tc.x}, ${tc.y})")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement 7 javalib `java.lang.Math` methods introduced in JDK25 and associated unit-tests.

The methods are:
```
powExact(int, int)                                                              
powExact(long, int)                                                             
unsignedMultiplyExact(int, int)                                                 
unsignedMultiplyExact(long, int)                                                
unsignedMultiplyExact(long, long)                                               
unsignedPowExact(int, int)                                                      
unsignedPowExact(long, int)     
```

This PR includes some housekeeping in `Math.scala` to keep the methods in alphabetical order.
This makes it easier to compare with the JDK "Method Summary" section tell what is and is not implemented.

<hr>
This PR is "Draft" until after PR #4474 is merged.  The `MathTestOnJDK25` test will not run until then
but breakage on Java 8 paths can be detected and the code can be reviewed by the community.
