### PR TITLE
Scala Native fails unit-tests building itself using Windows_2025

### DIFF
--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
   tests-windows-jdk-compliance:
     name: Test Windows JDK compliance
-    runs-on: windows-2022
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -14,7 +14,7 @@ jobs:
   test-runtime:
     name: Test runtime
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')
-    runs-on: windows-2022
+    runs-on: windows-2025
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true
     strategy:
@@ -73,7 +73,7 @@ jobs:
   run-scripted-tests:
     name: Scripted tests
     if: github.event_name == 'pull_request' || ((github.event_name == 'schedule' || github.event_name == 'workflow_call') && github.repository == 'scala-native/scala-native')
-    runs-on: windows-2022
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:
@@ -94,7 +94,7 @@ jobs:
   test-runtime-ext:
     name: Test runtime extension
     if: ((github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native') || (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') && contains(github.event.pull_request.body, '[test-extended]'))
-    runs-on: windows-2022
+    runs-on: windows-2025
     env:
       ENABLE_EXPERIMENTAL_COMPILER: true
     needs: [test-runtime]
@@ -149,7 +149,7 @@ jobs:
         shell: cmd
 
   test-llvm-versions:
-    runs-on: windows-2022
+    runs-on: windows-2025
     if: ((github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native') || (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') && contains(github.event.pull_request.body, '[test-extended]'))
     strategy:
       fail-fast: false


### PR DESCRIPTION
As originally discovered and isolated by kitbellew in Draft PR #4484, Scala Native itself
does not build and pass its unit-test when using Windows_2025.  This Draft PR is a simplification of #4484.

`scalafmt` builds using Windows_2025, so this Issue prevents scalafmt from shipping with
a putative 0.5.9. It also prevents testing recent SN bug fixes as they originally presented in
scalafmt.  

To size the concern, I have a question in the SN Discourse trying to ascertain if SN 0.5.8, and
 presumably 0.5.9Mumble _applications_ work with Windows_2025 and/or Windows 11. 
