### PR TITLE
Nightly publish job: run only if there are changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,48 @@ on:
     - 'v0.5.*'
   workflow_dispatch:
   schedule:
-  # Snapshot release every second work day
-  - cron: '0 0 * * 1,3,5'
+  # Snapshot release every day at midnight
+  - cron: '0 0 * * *'
+
+env:
+  LAST_PUBLISHED_TAG: last-published
 
 jobs:
+  load_tag:
+    name: Check last nightly tag
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    runs-on: ubuntu-22.04
+    if: github.repository == 'scala-native/scala-native'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check if there are changes since last run
+        id: check
+        run: |
+          PREV_SHA=none
+          if \
+            [[ "${{ github.event_name }}" != "push" || "${{ github.ref_type }}" != "tag"  ]] \
+            && git fetch origin tag ${LAST_PUBLISHED_TAG} 2> /dev/null
+          then # if this is not a tag push (so, not a release) and the tag exists
+            PREV_SHA=$(git rev-parse --verify --quiet refs/tags/${LAST_PUBLISHED_TAG} || true)
+          fi
+
+          echo "Previous SHA: $PREV_SHA"
+          echo "Current  SHA: $GITHUB_SHA"
+
+          if [ "$PREV_SHA" = "$GITHUB_SHA" ]; then
+            echo "No changes since last run."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
   check-compiles:
     name: Test compilation of all modules
     runs-on: ubuntu-22.04
-    if: github.repository == 'scala-native/scala-native'
+    needs: [load_tag]
+    if: needs.load_tag.outputs.skip == 'false' # repository check is done in load_tag
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/linux-setup-env
@@ -27,7 +61,6 @@ jobs:
     name: Publish for each Scala binary version
     runs-on: ubuntu-22.04
     needs: [check-compiles]
-    if: github.repository == 'scala-native/scala-native'
     strategy:
       fail-fast: false
       matrix:
@@ -52,11 +85,27 @@ jobs:
           PGP_PASSPHRASE: "${{ secrets.PGP_PASSWORD }}"
         run: sbt "-v" "-J-Xmx7G" "-J-XX:+UseG1GC" "publish-release-for-version ${{ matrix.scala }}"
 
+  save_tag:
+    name: Save SHA as last published tag
+    runs-on: ubuntu-22.04
+    needs: [publish]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Tag commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f ${LAST_PUBLISHED_TAG} $GITHUB_SHA
+          git push origin -f ${LAST_PUBLISHED_TAG}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   dispatch:
     name: Dispatch trigger builds for dependant projects
     runs-on: ubuntu-latest
     needs: [publish]
-    if: github.event_name == 'schedule' && github.repository == 'scala-native/scala-native'
+    if: github.event_name == 'schedule'
     strategy:
       matrix:
         repo: ['scala-native/scala-native-cli']


### PR DESCRIPTION
Use a fixed tag to save the most recent successfully released SHA and avoid releasing if the previous SHA and the current one are the same.
