### PR TITLE
MyScalaNativePlugin: move to scala.scalanative pkg

### DIFF
--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -4,7 +4,7 @@ import sbt._
 import Keys._
 import Def.SettingsDefinition
 import scala.language.implicitConversions
-import MyScalaNativePlugin.{ideScalaVersion, enableExperimentalCompiler}
+import scala.scalanative.build.MyScalaNativePlugin
 
 final case class MultiScalaProject private (
     val name: String,
@@ -30,7 +30,7 @@ final case class MultiScalaProject private (
     )
 
   override def componentProjects: Seq[Project] = Seq(v2_12, v2_13, v3) ++ {
-    if (enableExperimentalCompiler) Some(v3Next) else None
+    if (MyScalaNativePlugin.enableExperimentalCompiler) Some(v3Next) else None
   }
 
   def mapBinaryVersions(
@@ -195,7 +195,8 @@ object MultiScalaProject {
     val projects = for {
       (major, minors) <- scalaCrossVersions
     } yield {
-      val ideScalaVersions = additionalIDEScalaVersions :+ ideScalaVersion
+      val ideScalaVersions =
+        additionalIDEScalaVersions :+ MyScalaNativePlugin.ideScalaVersion
       val noIDEExportSettings =
         if (ideScalaVersions.contains(major)) Nil
         else NoIDEExport.noIDEExportSettings

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -1,10 +1,10 @@
+package scala.scalanative
 package build
 
 import sbt._
 import sbt.Keys._
 
 import scala.scalanative.sbtplugin.Utilities._
-import scala.scalanative.sbtplugin.ScalaNativePlugin
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 import scala.sys.env
 import complete.DefaultParsers._
@@ -12,9 +12,10 @@ import complete.DefaultParsers._
 import one.profiler.AsyncProfilerLoader
 import one.profiler.AsyncProfiler
 import build.OutputType._
+import _root_.build.ScalaVersions
 
 object MyScalaNativePlugin extends AutoPlugin {
-  override def requires: Plugins = ScalaNativePlugin
+  override def requires: Plugins = sbtplugin.ScalaNativePlugin
 
   lazy val nativeLinkProfiling =
     inputKey[File]("Running nativeLink with AsyncProfiler.")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -14,7 +14,7 @@ import ScriptedPlugin.autoImport._
 import com.jsuereth.sbtpgp.PgpKeys
 
 import scala.collection.mutable
-import MyScalaNativePlugin.isGeneratingForIDE
+import scala.scalanative.build.MyScalaNativePlugin.isGeneratingForIDE
 
 import java.io.File
 import java.util.Locale


### PR DESCRIPTION
That way, we'll be able to use package-private code in it. Helps with #4488.