### PR TITLE
Re-work recent dottiness in java.io.RandomAccessTest

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/RandomAccessFileTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/RandomAccessFileTest.scala
@@ -142,7 +142,6 @@ class RandomAccessFileTest {
     assertTrue(raf.readUTF() == value)
   }
 
-  /*
   @Test def canNotOpenReadOnlyFileForWrite(): Unit = {
     val roFile = File.createTempFile("tmp", "")
 
@@ -156,21 +155,5 @@ class RandomAccessFileTest {
     } finally {
       assertTrue("Could not delete read-only temporary file", roFile.delete())
     }
-  }
-   */
-
-  @Test def canNotOpenReadOnlyFileForWrite(): Unit = {
-    val tmpFile = File.createTempFile("tmp", "")
-
-    assertTrue("Could not set file read-only", tmpFile.setReadOnly())
-    assumeNotRoot()
-
-    assertThrows(
-      classOf[FileNotFoundException],
-      new RandomAccessFile(tmpFile, "rw")
-    )
-
-    assertTrue("Could not set file read-write", tmpFile.setWritable(true))
-    assertTrue("Could not delete writable temporary file", tmpFile.delete())
   }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/RandomAccessFileTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/io/RandomAccessFileTest.scala
@@ -153,6 +153,10 @@ class RandomAccessFileTest {
         new RandomAccessFile(roFile, "rw")
       )
     } finally {
+      assertTrue(
+        "Could not set file read-write before delete()",
+        roFile.setWritable(true) // Windows requires writable
+      )
       assertTrue("Could not delete read-only temporary file", roFile.delete())
     }
   }


### PR DESCRIPTION
kitbellew kindly noticed that changes to `java.io.RandomAccessTest` Test `canNotOpenReadOnlyFileForWrite`
did not make sense. Those changes were introduced in PR #4474.

Re-work that dottiness to:
1. make it clear that the change is required for Windows.  
    Linux & macOS do not require the change in file protection.
    Making the protection change explicit makes the logic easier 
    to follow without knowing specific os pecularities. 

3. restore the prior and correct try/finally block structure.

My thanks to kitbellew for the discovery & report.