### PR TITLE
scalafmt: adjust dialects (scala212 as default)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -14,6 +14,9 @@ docstrings {
 }
 
 fileOverride {
+  # default is 2.12, see under runner
+  "glob:**/scripts/*" = scala3
+  "glob:**/src/**/require-scala3*/**" = scala3
   "lang:scala-next" = scala3future
 }
 
@@ -51,7 +54,7 @@ rewrite {
 
 runner {
   # Default runner.dialect is deprecated now, needs to be explicitly set
-  dialect = scala3
+  dialect = scala212
   # Added for CI error via --test option
   fatalWarnings = true
   # default value is 10,000

--- a/javalib/src/main/scala/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala/java/lang/ProcessBuilder.scala
@@ -151,9 +151,7 @@ object ProcessBuilder {
       override def file(): File = redirectFile
 
       override def toString =
-        s"Redirect.$tpe${
-            if (redirectFile != null) s": ${redirectFile}" else ""
-          }"
+        s"Redirect.$tpe${if (redirectFile != null) s": ${redirectFile}" else ""}"
     }
 
     val INHERIT: Redirect = new RedirectImpl(Type.INHERIT, null)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -125,7 +125,7 @@ object Intrinsics {
   def elemRawPtr(rawptr: RawPtr, offset: RawSize): RawPtr =
     intrinsic
 
-    /** Intrinsified computation of derived raw pointer. */
+  /** Intrinsified computation of derived raw pointer. */
   def elemRawPtr(rawptr: RawPtr, offset: Int): RawPtr =
     intrinsic
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
@@ -19,7 +19,7 @@ trait Zone {
   def alloc(size: Int): Ptr[Byte] =
     alloc(unsignedOf(castIntToRawSizeUnsigned(size)))
 
-    /** Allocates memory of given size. */
+  /** Allocates memory of given size. */
   def alloc(size: UInt): Ptr[Byte] =
     alloc(size.toUSize)
 

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -117,25 +117,25 @@ object MyScalaNativePlugin extends AutoPlugin {
         None
       }
 
-      val module = moduleName.value
-      val out =
-        (crossTarget.value / s"$module-profile.${outputType.extension}").toString
-      profilerOpt match {
-        case Some(profiler) =>
-          Def.task {
-            logger.info(
-              s"[async-profiler] starting profiler with commands: start,$commands"
-            )
-            profiler.execute(s"start,$commands")
-            nativeLink.value
-          } andFinally {
-            logger.info(s"[async-profiler] stop profiler, output to ${out}")
-            profiler.execute("stop")
-            profiler.execute(s"${outputType.name},file=${out}")
-          }
-        case None =>
-          nativeLink
-      }
+    val module = moduleName.value
+    val out =
+      (crossTarget.value / s"$module-profile.${outputType.extension}").toString
+    profilerOpt match {
+      case Some(profiler) =>
+        Def.task {
+          logger.info(
+            s"[async-profiler] starting profiler with commands: start,$commands"
+          )
+          profiler.execute(s"start,$commands")
+          nativeLink.value
+        } andFinally {
+          logger.info(s"[async-profiler] stop profiler, output to ${out}")
+          profiler.execute("stop")
+          profiler.execute(s"${outputType.name},file=${out}")
+        }
+      case None =>
+        nativeLink
+    }
   }
 
   override def projectSettings: Seq[Setting[_]] = Def.settings(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -866,9 +866,9 @@ object Settings {
         def listFilesInOrder(patterns: Glob*) =
           patterns.flatMap(fileTree.list(_))
 
-          /* Exclude files coming from Scala's `library-aux` directory, as they are not
-           * meant to be compiled. They are part of the source jar since Scala 2.13.14.
-           */
+        /* Exclude files coming from Scala's `library-aux` directory, as they are not
+         * meant to be compiled. They are part of the source jar since Scala 2.13.14.
+         */
         val ignoredSourceFiles = Set(
           "Any.scala",
           "AnyRef.scala",

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -51,45 +51,45 @@ object ScalaNativePluginInternal {
   val nativeWarnOldJVM =
     taskKey[Unit]("Warn if JVM 7 or older is used.")
 
-    lazy val scalaNativeDependencySettings: Seq[Setting[_]] = {
-      val nativeStandardLibraries =
-        Seq("nativelib", "clib", "posixlib", "windowslib", "javalib", "auxlib")
+  lazy val scalaNativeDependencySettings: Seq[Setting[_]] = {
+    val nativeStandardLibraries =
+      Seq("nativelib", "clib", "posixlib", "windowslib", "javalib", "auxlib")
 
-      Seq(
-        libraryDependencies ++= {
-          val org = nativeOrgName
-          val ver = nativeVersion
-          val scalalib = CrossVersion.partialVersion(scalaVersion.value) match {
-            case Some((2, _)) => "scalalib"
-            case Some((3, _)) => "scala3lib"
-            case _ => throw new RuntimeException("Unsupported Scala Version")
-          }
-          Seq(
-            org %%% "test-interface" % ver % Test,
-            org %%% scalalib % scalalibVersion(scalaVersion.value, ver),
-            compilerPlugin(org % "nscplugin" % ver cross CrossVersion.full)
-          ) ++ nativeStandardLibraries.map(org %%% _ % ver)
-        },
-        excludeDependencies ++= {
-          // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
-          // When using Scala 3 exclude Scala 2.13 standard native libraries,
-          // when using Scala 2.13 exclude Scala 3 standard native libraries
-          // Use full name, Maven style published artifacts cannot use artifact/cross version for exclusion rules
-          (CrossVersion.partialVersion(scalaVersion.value) match {
-            case Some((2, 13)) => Some("_3")
-            case Some((3, _))  => Some("_2.13")
-            case _             => None
-          }).fold(Seq.empty[ExclusionRule]) { scalaBinSuffix =>
-            val suffix = "_" +
-              ScalaNativeCrossVersion.scalaNativePrefix + scalaBinSuffix
-            val exclRule = ExclusionRule(nativeOrgName)
-            nativeStandardLibraries.map { lib =>
-              exclRule.withName(lib + suffix)
-            }
+    Seq(
+      libraryDependencies ++= {
+        val org = nativeOrgName
+        val ver = nativeVersion
+        val scalalib = CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, _)) => "scalalib"
+          case Some((3, _)) => "scala3lib"
+          case _ => throw new RuntimeException("Unsupported Scala Version")
+        }
+        Seq(
+          org %%% "test-interface" % ver % Test,
+          org %%% scalalib % scalalibVersion(scalaVersion.value, ver),
+          compilerPlugin(org % "nscplugin" % ver cross CrossVersion.full)
+        ) ++ nativeStandardLibraries.map(org %%% _ % ver)
+      },
+      excludeDependencies ++= {
+        // Exclude cross published version dependencies leading to conflicts in Scala 3 vs 2.13
+        // When using Scala 3 exclude Scala 2.13 standard native libraries,
+        // when using Scala 2.13 exclude Scala 3 standard native libraries
+        // Use full name, Maven style published artifacts cannot use artifact/cross version for exclusion rules
+        (CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, 13)) => Some("_3")
+          case Some((3, _))  => Some("_2.13")
+          case _             => None
+        }).fold(Seq.empty[ExclusionRule]) { scalaBinSuffix =>
+          val suffix = "_" +
+            ScalaNativeCrossVersion.scalaNativePrefix + scalaBinSuffix
+          val exclRule = ExclusionRule(nativeOrgName)
+          nativeStandardLibraries.map { lib =>
+            exclRule.withName(lib + suffix)
           }
         }
-      )
-    }
+      }
+    )
+  }
 
   lazy val scalaNativeBaseSettings: Seq[Setting[_]] = Seq(
     crossVersion := ScalaNativeCrossVersion.binary,

--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -50,7 +50,7 @@ private[scalanative] object ResourceEmbedder {
 
     val includePatterns =
       config.compilerConfig.resourceIncludePatterns.map(toGlob)
-      // explicitly enabled pattern overwrites exclude pattern
+    // explicitly enabled pattern overwrites exclude pattern
     val excludePatterns = {
       (config.compilerConfig.resourceExcludePatterns).map(toGlob) ++
         internalExclusionPatterns

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -33,7 +33,7 @@ object ClassPath {
   private[scalanative] def apply(directory: VirtualDirectory): ClassPath =
     new Impl(directory, Logger.nullLogger)
 
-    /** Create classpath based on the virtual directory. */
+  /** Create classpath based on the virtual directory. */
   private[scalanative] def apply(
       directory: VirtualDirectory,
       log: Logger

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
@@ -942,8 +942,8 @@ class DoubleStreamTest {
     // JVM 8 expects 0x11 (decimal 17), JVM >= 17 expects 0x4051 (Dec 16465)
     val expectedSAllLimitedCharacteristics =
       Spliterator.ORDERED | Spliterator.DISTINCT // 0x11
-      // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
-      // SORTED was not there to drop.
+    // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
+    // SORTED was not there to drop.
 
     assertEquals(
       "Unexpected characteristics for all characteristics stream",

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/IntStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/IntStreamTest.scala
@@ -1044,8 +1044,8 @@ class IntStreamTest {
     // JVM 8 expects 0x11 (decimal 17), JVM >= 17 expects 0x4051 (Dec 16465)
     val expectedSAllLimitedCharacteristics =
       Spliterator.ORDERED | Spliterator.DISTINCT // 0x11
-      // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
-      // SORTED was not there to drop.
+    // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
+    // SORTED was not there to drop.
 
     assertEquals(
       "Unexpected characteristics for all characteristics stream",

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/LongStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/LongStreamTest.scala
@@ -1016,8 +1016,8 @@ class LongStreamTest {
     // JVM 8 expects 0x11 (decimal 17), JVM >= 17 expects 0x4051 (Dec 16465)
     val expectedSAllLimitedCharacteristics =
       Spliterator.ORDERED | Spliterator.DISTINCT // 0x11
-      // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
-      // SORTED was not there to drop.
+    // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
+    // SORTED was not there to drop.
 
     assertEquals(
       "Unexpected characteristics for all characteristics stream",

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -929,8 +929,8 @@ class StreamTest {
     // JVM 8 expects 0x11 (decimal 17), JVM >= 17 expects 0x4051 (Dec 16465)
     val expectedSAllLimitedCharacteristics =
       Spliterator.ORDERED | Spliterator.DISTINCT // 0x11
-      // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
-      // SORTED was not there to drop.
+    // Drop SIZED, SUBSIZED, CONCURRENT, IMMUTABLE, & NONNULL.
+    // SORTED was not there to drop.
 
     assertEquals(
       "Unexpected characteristics for all characteristics stream",


### PR DESCRIPTION
Also, remove excluded paths and re-order `.scalafmt.conf`.