### PR TITLE
[CI] Use Java 17 by default

### DIFF
--- a/.github/actions/linux-setup-env/action.yml
+++ b/.github/actions/linux-setup-env/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   java-version:
     description: "Java version to use in tests"
-    default: "8"
+    default: "17"
   llvm-version:
     description: "LLVM toolchain version"
 runs:

--- a/.github/actions/macos-setup-env/action.yml
+++ b/.github/actions/macos-setup-env/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   java-version:
     description: "Java version to use in tests"
-    default: "8"
+    default: "17"
   llvm-version:
     description: "Custom version of LLVM to use"
   gc: 

--- a/.github/actions/windows-setup-env/action.yml
+++ b/.github/actions/windows-setup-env/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   java-version:
     description: "Java version to use in tests"
-    default: "8"
+    default: "17"
   llvm-version:
     description: "LLVM version to use"
     default: "20.1.4"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,6 @@ jobs:
       - uses: ./.github/actions/linux-setup-env
         with:
           scala-version: "2.13" #Unused, any version can be placed here
-          java-version: 8
 
       - name: Compile everything
         run: sbt "-v" "-J-Xmx7G" "++3.1.3; Test/compile; ++2.13.14; Test/compile; ++2.12.19; Test/compile"
@@ -70,7 +69,6 @@ jobs:
       - uses: ./.github/actions/linux-setup-env
         with:
           scala-version: ${{ matrix.scala }} #Unused, any version can be placed here
-          java-version: 8
 
       - name: Setup PGP Key
         run: |

--- a/.github/workflows/publishForScalaRelease.yml
+++ b/.github/workflows/publishForScalaRelease.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: ./.github/actions/linux-setup-env
         with:
           scala-version: ${{ inputs.scala-version }}
-          java-version: 8
 
       - name: Setup PGP Key
         run: |

--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   # Compile and run tests against given version of the JDK to check compliance
-  # We test against Java 8 as default in other CI jobs
+  # We test against Java 17 as default in other CI jobs
   tests-unix-jdk-compliance:
     name: Test Unix JDK compliance
     runs-on: ${{matrix.os}}

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: ./.github/actions/linux-setup-env
         with:
           scala-version: ${{matrix.scala}}
-          java-version: 8
 
       - name: Test tools
         run: sbt "test-tools ${{ matrix.scala }}; toolsBenchmarks${{env.project-version}}/Jmh/compile"
@@ -43,7 +42,6 @@ jobs:
       - uses: ./.github/actions/linux-setup-env
         with:
           scala-version: 3
-          java-version: 8
 
       - name: Compile everything
         # Publish 2.13.latest artifacts locally first, these are required by scalalib3
@@ -64,7 +62,6 @@ jobs:
       - uses: ./.github/actions/linux-setup-env
         with:
           scala-version: ${{matrix.scala}}
-          java-version: 8
 
       - name: Test cross compilation of compiler plugins
         run: sbt "+nscplugin${{ env.project-version }}/test; +junitPlugin${{ env.project-version }}/compile; +scalalib${{ env.project-version }}/compile"
@@ -218,7 +215,6 @@ jobs:
         with:
           scala-version: ${{matrix.scala}}
           llvm-version: ${{ matrix.llvm }}
-          java-version: 8
 
       - name: Run tests
         timeout-minutes: 45
@@ -241,7 +237,6 @@ jobs:
       - uses: ./.github/actions/linux-setup-env
         with:
           scala-version: ${{matrix.scala}}
-          java-version: 11
 
         # Make sure that Scala partest denylisted tests contain only valid test names
       - name: Setup Scala-cli
@@ -258,7 +253,6 @@ jobs:
       - uses: ./.github/actions/linux-setup-env
         with:
           scala-version: ${{matrix.scala}}
-          java-version: 11
 
         # Running all partests would take ~2h for each Scala version, run only single test of each kind
         # to make sure that infrastructure works correctly.

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -158,7 +158,6 @@ jobs:
         with:
           scala-version: ${{matrix.scala}}
           llvm-version: ${{ matrix.llvm }}
-          java-version: 8
 
       - name: Run tests
         timeout-minutes: 45

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -165,7 +165,6 @@ jobs:
         with:
           scala-version: ${{matrix.scala}}
           llvm-version: ${{ matrix.llvm }}
-          java-version: 8
 
       - name: Run tests
         shell: cmd


### PR DESCRIPTION
We'd need Java 17 for Scala 3.8 - extracts upgrade to Java 17 from #4485 
Artifacts are still published using `-target:8` / `-release:8` flags 