### PR TITLE
scalafmt: cosmetic, re-order settings

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,40 +4,59 @@
 # the Scala language evolves and styles change.
 # Test upgrades: $ scripts/scalafmt --test 2> diff.txt
 version = 3.9.10
-docstrings.style = AsteriskSpace
-project.git = true
-project.excludePaths = [
-  "glob:**/scalalib/**",
-  # Files to big to disable formating using directive // format: off
-  "glob:**/nativelib/**/unsafe/Tag.scala"
-  # Scalafmt does not support capture checking syntax yet.
-  "glob:**/src/**/scala-next/**"
-]
-# Default runner.dialect is deprecated now, needs to be explicitly set
-runner.dialect = scala3
-# Added for CI error via --test option
-runner.fatalWarnings = true
-# This creates less of a diff but is not default
-# but is more aligned with Scala.js syntax.
-newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
 
-# Keep control sites more streamlined
-indent.ctrlSite = 4
-danglingParentheses.ctrlSite = false
-
-# Default is not recommended
-indentOperator.exemptScope = aloneEnclosed
-
-# default value is 10,000
-# Message about NirGenExpr.scala goes away between 18k and 20k
-runner.optimizer.maxVisitsPerToken = 20000
-rewriteTokens = {
-  "⇒": "=>"
-  "→": "->"
-  "←": "<-"
+danglingParentheses {
+  ctrlSite = false
 }
+
+docstrings {
+  style = AsteriskSpace
+}
+
 fileOverride {
   "glob:**/src/**/scala-2*/**" {
      runner.dialect = scala213
   }
+}
+
+indent {
+  # Keep control sites more streamlined
+  ctrlSite = 4
+  # Default is not recommended
+  infix.exemptScope = aloneEnclosed
+}
+
+newlines {
+  # This creates less of a diff but is not default
+  # but is more aligned with Scala.js syntax.
+  beforeCurlyLambdaParams = multilineWithCaseOnly
+}
+
+project {
+  git = true
+  excludePaths = [
+    "glob:**/scalalib/**"
+    # Files to big to disable formating using directive // format: off
+    "glob:**/nativelib/**/unsafe/Tag.scala"
+    # Scalafmt does not support capture checking syntax yet.
+    "glob:**/src/**/scala-next/**"
+  ]
+}
+
+rewrite {
+  tokens = {
+    "⇒": "=>"
+    "→": "->"
+    "←": "<-"
+  }
+}
+
+runner {
+  # Default runner.dialect is deprecated now, needs to be explicitly set
+  dialect = scala3
+  # Added for CI error via --test option
+  fatalWarnings = true
+  # default value is 10,000
+  # Message about NirGenExpr.scala goes away between 18k and 20k
+  optimizer.maxVisitsPerToken = 20000
 }


### PR DESCRIPTION
Step 1, extracted from #4507. No change in formatting, just a config file beautification.