### PR TITLE
scalafmt: un-exclude scala-next, use scala3future

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -14,6 +14,7 @@ docstrings {
 }
 
 fileOverride {
+  "lang:scala-next" = scala3future
 }
 
 indent {
@@ -35,8 +36,6 @@ project {
     "glob:**/scalalib/**"
     # Files to big to disable formating using directive // format: off
     "glob:**/nativelib/**/unsafe/Tag.scala"
-    # Scalafmt does not support capture checking syntax yet.
-    "glob:**/src/**/scala-next/**"
   ]
   layout = StandardConvention
 }

--- a/nativelib/src/main/scala-next/scala/scalanative/memory/SafeZone.scala
+++ b/nativelib/src/main/scala-next/scala/scalanative/memory/SafeZone.scala
@@ -5,7 +5,12 @@ import scalanative.unsigned._
 import scala.annotation.implicitNotFound
 import scala.scalanative.unsafe.CSize
 import scala.scalanative.unsigned.USize
-import scala.scalanative.runtime.{RawPtr, RawSize, SafeZoneAllocator, Intrinsics}
+import scala.scalanative.runtime.{
+  RawPtr,
+  RawSize,
+  SafeZoneAllocator,
+  Intrinsics
+}
 import scala.scalanative.runtime.SafeZoneAllocator.allocate
 
 @implicitNotFound("Given method requires an implicit zone.")
@@ -23,8 +28,11 @@ trait SafeZone {
       throw new IllegalStateException(s"Zone ${this} is already closed.")
   }
 
-  /** Allocates an object in this zone. The expression of obj must be an instance creation expression. */
-  infix inline def alloc[T <: AnyRef](inline obj: T): T^{this} = allocate(this, obj)
+  /** Allocates an object in this zone. The expression of obj must be an
+   *  instance creation expression.
+   */
+  infix inline def alloc[T <: AnyRef](inline obj: T): T^{this} =
+    allocate(this, obj)
 
   /** Frees allocations. This zone is not reusable once closed. */
   private[scalanative] def close(): Unit
@@ -32,7 +40,9 @@ trait SafeZone {
   /** Return the handle of this zone. */
   private[scalanative] def handle: RawPtr
 
-  /** The low-level implementation of allocation. This function shouldn't be inlined because it's directly called in the lowering phase. */
+  /** The low-level implementation of allocation. This function shouldn't be
+   *  inlined because it's directly called in the lowering phase.
+   */
   @noinline
   private[scalanative] def allocImpl(cls: RawPtr, size: RawSize): RawPtr = {
     checkOpen()
@@ -41,6 +51,7 @@ trait SafeZone {
 }
 
 object SafeZone {
+
   /** Run given function with a fresh zone and destroy it afterwards. */
   final def apply[T](f: (SafeZone^) ?=> T): T = {
     val sz: SafeZone^ = new MemorySafeZone(SafeZoneAllocator.Impl.open())
@@ -49,12 +60,14 @@ object SafeZone {
   }
 
   /* Allocates an object in the implicit zone. The expression of obj must be an instance creation expression. */
-  inline def alloc[T <: AnyRef](inline obj: T)(using sz: SafeZone^): T^{sz} = allocate(sz, obj)
+  inline def alloc[T <: AnyRef](inline obj: T)(using sz: SafeZone^): T^{sz} =
+    allocate(sz, obj)
 
   /** Summon the implicit zone. */
   transparent inline def zone(using sz: SafeZone^): SafeZone^{sz} = sz
 
-  private class MemorySafeZone (private[scalanative] val handle: RawPtr) extends SafeZone {
+  private class MemorySafeZone(private[scalanative] val handle: RawPtr)
+      extends SafeZone {
     private var flagIsOpen = true
     override def isOpen: Boolean = flagIsOpen
     override def close(): Unit = {

--- a/nativelib/src/main/scala-next/scala/scalanative/runtime/SafeZoneAllocator.scala
+++ b/nativelib/src/main/scala-next/scala/scalanative/runtime/SafeZoneAllocator.scala
@@ -1,19 +1,18 @@
-package scala.scalanative.runtime 
+package scala.scalanative.runtime
 
 import language.experimental.captureChecking
 import scala.scalanative.memory.SafeZone
 import scala.scalanative.unsafe._
 
-/**
-  * We can move SafeZoneAllocator to package `memory` and make it 
-  * `private[scalanative]` after dotty supports using `new {sz} T(...)` 
-  * to create new instance allocated in sz. Currently, we need it not 
-  * private to package scalanative for unit tests.
-*/
+/** We can move SafeZoneAllocator to package `memory` and make it
+ *  `private[scalanative]` after dotty supports using `new {sz} T(...)` to
+ *  create new instance allocated in sz. Currently, we need it not private to
+ *  package scalanative for unit tests.
+ */
 object SafeZoneAllocator {
   def allocate[T](sz: SafeZone^, obj: T): T^{sz} = intrinsic
 
-  @extern @define("__SCALANATIVE_MEMORY_SAFEZONE") object Impl{
+  @extern @define("__SCALANATIVE_MEMORY_SAFEZONE") object Impl {
     @name("scalanative_zone_open")
     def open(): RawPtr = extern
 

--- a/nscplugin/src/test/scala-next/scala/scalanative/memory/SafeZoneTest.scala
+++ b/nscplugin/src/test/scala-next/scala/scalanative/memory/SafeZoneTest.scala
@@ -17,7 +17,7 @@ class SafeZoneTest {
     }
   }
 
-  @Test def referenceNonEscapedObject(): Unit =  nativeCompilation(
+  @Test def referenceNonEscapedObject(): Unit = nativeCompilation(
     """
       |import scala.language.experimental.captureChecking
       |import scala.scalanative.memory.SafeZone
@@ -37,8 +37,9 @@ class SafeZoneTest {
   )
 
   @Test def referenceEscapedObject(): Unit = {
-    val err = assertThrows(classOf[CompilationFailedException], () => 
-      NIRCompiler(_.compile("""
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () => NIRCompiler(_.compile("""
         |import scala.language.experimental.captureChecking
         |import scala.scalanative.memory.SafeZone
         |import scala.scalanative.runtime.SafeZoneAllocator.allocate
@@ -56,8 +57,10 @@ class SafeZoneTest {
     )
     assertTrue(
       "Got:" + err.getMessage,
-     err.getMessage.contains("local reference sz1 leaks into outer capture set of type parameter T of method apply")
-     )
+      err.getMessage.contains(
+        "local reference sz1 leaks into outer capture set of type parameter T of method apply"
+      )
+    )
   }
 
   @Test def typeCheckCapturedZone(): Unit = nativeCompilation(
@@ -86,8 +89,9 @@ class SafeZoneTest {
   )
 
   @Test def typeCheckNotCaptured(): Unit = {
-    val err = assertThrows(classOf[CompilationFailedException], () => 
-      NIRCompiler(_.compile("""
+    val err = assertThrows(
+      classOf[CompilationFailedException],
+      () => NIRCompiler(_.compile("""
         |import scala.language.experimental.captureChecking
         |import scala.scalanative.memory.SafeZone
         |import scala.scalanative.runtime.SafeZoneAllocator.allocate
@@ -107,6 +111,8 @@ class SafeZoneTest {
         |
         |""".stripMargin))
     )
-    assertTrue(err.getMessage().contains("Found:    B{val a: A^{aInHeap}}^{aInHeap, sz}"))
+    assertTrue(
+      err.getMessage().contains("Found:    B{val a: A^{aInHeap}}^{aInHeap, sz}")
+    )
   }
 }

--- a/unit-tests/native/src/test/scala-next/scala/SafeZoneTest.scala
+++ b/unit-tests/native/src/test/scala-next/scala/SafeZoneTest.scala
@@ -8,11 +8,11 @@ import scala.language.experimental.captureChecking
 import scala.scalanative.runtime.SafeZoneAllocator.allocate
 import scala.scalanative.memory.SafeZone
 import scala.scalanative.memory.SafeZone._
-import scala.util.{Try,Success,Failure}
+import scala.util.{Try, Success, Failure}
 
 class SafeZoneTest {
   @Test def `correctly open and close a safe zone`(): Unit = {
-    SafeZone { sz ?=> 
+    SafeZone { sz ?=>
       assertTrue(sz.isOpen)
       assertFalse(sz.isClosed)
     }
@@ -37,11 +37,12 @@ class SafeZoneTest {
     }
   }
 
-  @Test def `allocate instances with members in different memory areas`(): Unit = {
+  @Test def `allocate instances with members in different memory areas`()
+      : Unit = {
     case class A()
     case class B(a: A^)
     SafeZone { sz0 ?=>
-      SafeZone { sz1 ?=> 
+      SafeZone { sz1 ?=>
         val aInSz0 = allocate(sz0, new A())
         val aInHeap = new A()
         val b0: B^{sz1, sz0} = allocate(sz1, new B(aInSz0))
@@ -55,11 +56,11 @@ class SafeZoneTest {
   @Test def `arrays with elements in different memory areas`(): Unit = {
     case class A()
     SafeZone { sz0 ?=>
-      SafeZone { sz1 ?=> 
+      SafeZone { sz1 ?=>
         val aInSz0 = allocate(sz0, new A())
         val aInHeap = new A()
         val arr0: Array[A^{sz0}]^{sz1} = allocate(sz1, new Array[A^{sz0}](1))
-        arr0(0)  = aInSz0
+        arr0(0) = aInSz0
         val arr1: Array[A]^{sz1} = allocate(sz1, new Array[A](1))
         arr1(0) = aInHeap
       }
@@ -69,13 +70,11 @@ class SafeZoneTest {
   @Test def `objects allocated in safe zone is accessible`(): Unit = {
     def assertAccessible(n: Int): Unit = {
       case class A(v: Int)
-      SafeZone { sz ?=> 
+      SafeZone { sz ?=>
         val ary = new Array[A^{sz}](n)
-        for i <- 0 until n do
-          ary(i) = allocate(sz, new A(i))
+        for i <- 0 until n do ary(i) = allocate(sz, new A(i))
         var sum = 0
-        for i <- n - 1 to 0 by -1 do
-          sum += ary(i).v
+        for i <- n - 1 to 0 by -1 do sum += ary(i).v
         assertTrue(sum == (0 until n).sum)
       }
     }
@@ -96,12 +95,13 @@ class SafeZoneTest {
     }
   }
 
-  @Test def `can use alloc API instead of instance creation expression`(): Unit = {
+  @Test def `can use alloc API instead of instance creation expression`()
+      : Unit = {
     case class A(v: Int)
     SafeZone { sz ?=>
       // Using explicit zone.
-      val a0: A^{sz} = sz alloc(new A(0))
-      val a1: A^{sz}= sz alloc new A(1)
+      val a0: A^{sz} = sz alloc (new A(0))
+      val a1: A^{sz} = sz alloc new A(1)
       // Using implicit zone.
       val a2: A^{sz} = alloc(new A(2))
       assertTrue(a0.v + a1.v + a2.v == 3)
@@ -111,7 +111,7 @@ class SafeZoneTest {
       val a2 = alloc(new A(2))
       // Summon the zone to make it explicit.
       val sz = summon[SafeZone]
-      val a0: A^{sz} = sz alloc(new A(0))
+      val a0: A^{sz} = sz alloc (new A(0))
       val a1: A^{sz} = sz alloc new A(1)
       assertTrue(a0.v + a1.v + a2.v == 3)
     }
@@ -119,8 +119,8 @@ class SafeZoneTest {
 
   @Test def `can use the zone API to summon implicit zone`(): Unit = {
     case class A(v: Int)
-    SafeZone { 
-      val a0: A^{zone} = zone alloc(new A(0))
+    SafeZone {
+      val a0: A^{zone} = zone alloc (new A(0))
       val a1: A^{zone} = zone alloc new A(1)
       assertTrue(a0.v + a1.v == 1)
     }

--- a/unit-tests/native/src/test/scala-next/scala/scalanative/SafeZoneTest.scala
+++ b/unit-tests/native/src/test/scala-next/scala/scalanative/SafeZoneTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 
-import scala.util.{Try,Success,Failure}
+import scala.util.{Try, Success, Failure}
 import scala.language.experimental.captureChecking
 import scala.scalanative.runtime.SafeZoneAllocator.allocate
 import scala.scalanative.memory.SafeZone
@@ -19,15 +19,18 @@ class SafeZoneTest {
     }
   }
 
-  @Test def `report error when trying to allocate an instances in a closed safe zone`(): Unit = {
+  @Test def `report error when trying to allocate an instances in a closed safe zone`()
+      : Unit = {
     case class A()
-    assertThrows(classOf[IllegalStateException], 
-      SafeZone { sz ?=> 
+    assertThrows(
+      classOf[IllegalStateException],
+      SafeZone { sz ?=>
         sz.close()
         Try[A^{sz}].apply(allocate(sz, new A())) match {
-          case Success(_) => fail("Should not allocate instances in a closed safe zone.")
+          case Success(_) =>
+            fail("Should not allocate instances in a closed safe zone.")
           case Failure(e: IllegalStateException) => ()
-          case Failure(_) => fail("Unexpected error.")
+          case Failure(_)                        => fail("Unexpected error.")
         }
       }
     )


### PR DESCRIPTION
Step 2, extracted from #4507.