### PR TITLE
Make javalib linux_sched.c robust to _GNU_SOURCE already being defined

### DIFF
--- a/javalib/src/main/resources/scala-native/sys/linux_sched.c
+++ b/javalib/src/main/resources/scala-native/sys/linux_sched.c
@@ -4,11 +4,14 @@
 
 /* Define _GNU_SOURCE to make the CPU_* macros available.
  * This file is already GNU Linux specific, so adding more GNU does not
- * add impurity. What is a bit of GNU amoung friends?
+ * add impurity. What is a bit of GNU among friends?
  *
  * Those macros greatly ease this implementation.
  */
-#define _GNU_SOURCE
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE 1
+#endif
+
 #include <sched.h>
 
 int scalanative_sched_cpuset_cardinality() {


### PR DESCRIPTION
Sometimes people define _GNU_SOURCE on the clang/gcc command line, especially
in larger projects.  'linux_sched.c' should be robust to that and be smart enough to
not complain.

From a conversation on Discourse, re: some Cats Effects code broken by the 0.5.9
change to "-std=c11":
```
$ scala-cli  --native-compile "-D_GNU_SOURCE" broken_ce.scala
[info] Linking (multithreadingEnabled=true, disable if not used) (5900 ms)
[info] Discovered 2666 classes and 17685 methods after classloading
[info] Checking intermediate code (quick) (288 ms)
[info] Discovered 2638 classes and 13835 methods after optimization
[info] Optimizing (debug mode) (7811 ms)
[error] /mnt/AthaBHdd1/lee49/DevoHdd1/scala_native/WorkSpace_1/2025/.scala-build/2025_b3557dfd11-dc7b6f9c58/native/native/dependencies/javalib_native0.5_3-0.5.9-0/scala-native/sys/linux_sched.c:11:9: warning: '_GNU_SOURCE' macro redefined [-Wmacro-redefined]
[error]    11 | #define _GNU_SOURCE
[error]       |         ^
[error] <command line>:1:9: note: previous definition is here
[error]     1 | #define _GNU_SOURCE 1
[error]       |         ^
[error] 1 warning generated.
[info] Produced 5 LLVM IR files
[info] Generating intermediate code (11084 ms)
[info] Compiling to native code (7308 ms)
```

