### PR TITLE
UnixProcessGen2: don't copy stderr on redirect

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -27,7 +27,9 @@ private[process] object UnixProcess {
   ): GenericProcess = new GenericProcess(handle) {
     override protected def fdIn = new FileDescriptor(!(infds + 1))
     override protected def fdOut = new FileDescriptor(!outfds, readOnly = true)
-    override protected def fdErr = new FileDescriptor(!errfds, readOnly = true)
+    override protected def fdErr =
+      if (null == errfds) new FileDescriptor()
+      else new FileDescriptor(!errfds, readOnly = true)
   }
 
   def apply(pb: ProcessBuilder): GenericProcess = {


### PR DESCRIPTION
When stderr is redirected to stdout, we need ensure stderr is the same file descriptor as stdout (that was done correctly), and after that the exposed error stream is empty (as everything is available from stdout). However, this last part wasn't done, so let's rectify that.

Helps with #4544.
⚠️ Please review only the last commit, for earlier ones, review #4542.
⚠️  Must be merged ONLY after #4542.
