### PR TITLE
ProcessTestOnJDK9: increase `destroy()` timeout

### DIFF
--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
@@ -121,7 +121,7 @@ class ProcessTestOnJDK9 {
     // Throws on timeout
     assertFalse(
       "process should have been terminated",
-      handle.onExit().get(500, TimeUnit.MILLISECONDS).isAlive()
+      handle.onExit().get(2, TimeUnit.SECONDS).isAlive()
     )
     assertEquals(
       "exitValue",
@@ -140,7 +140,7 @@ class ProcessTestOnJDK9 {
     // Throws on timeout
     assertFalse(
       "process should have been terminated",
-      handle.onExit().get(500, TimeUnit.MILLISECONDS).isAlive()
+      handle.onExit().get(2, TimeUnit.SECONDS).isAlive()
     )
     assertEquals(
       "exitValue",


### PR DESCRIPTION
This test has been very flaky on Windows, timing out after close to a second, so let's increase it as the result is the same.