### PR TITLE
Correct defects & wordsmith

### DIFF
--- a/docs/user/release-types.md
+++ b/docs/user/release-types.md
@@ -13,15 +13,19 @@
    A 'Latest' release is intended for developers who want to 
    exercise the committed Scala Native code at the time of publication. 
 
-   The version has the format major.minor.patch-<date>-<gitref>-SNAPSHOT.
-   <date> gives UTC year, month, and day of publication.
-   <gitref>, formerly informally known as SHA1,
-   gives the Git reference for the youngest commit at the time of publication.
+   The version format is: "major.minor.patch-\<date\>-\<gitref\>-SNAPSHOT".
 
-   These releases generally happen early in the (UTC) day where at least one
-   commit happened the
-   day before. They are short lived and currently are kept available for only
-   a few weeks. For complex reasons, there is no easy way to list prior
-   SNAPSHOT releases.
+   "\<date\>" gives UTC year, month, and day of the youngest commit 
+   contained. The version date is usually not the posted date of the 
+   rest of the landing page or the invisible date of posting the SNAPSHOT.
+
+   "\<gitref\>", formerly informally known as SHA1, gives the leading, 
+   currently 7,  digits of the Git reference to that youngest commit. 
+   
+   'Latest' releases generally happen early in the (UTC) day where at least
+   one commit happened the day before. 
+   They are short lived and are kept available for only a limited time;
+   currently, but not guaranteed to stay, 3 months. For complex reasons,
+   there is no easy way to list prior SNAPSHOT releases.
 
 Continue to [lib](../lib/communitylib.md)


### PR DESCRIPTION

Improve the description of the date contained in the SNAPSHOT and correct some
ReStructuredText errors.

Change some wording so that the detail oriented will not be looking for an invisible
date of actual SNAPSHOT publication and will not be freaked when the "page updated"
date of the rest of the landing page is months earlier.

These cross checks passing or at least understandable  builds confidence in the project, especially 
on a landing page.