### PR TITLE
Update posixlib spawn.scala to Open Group Issue 8, 2024

### DIFF
--- a/posixlib/src/main/resources/scala-native/spawn.c
+++ b/posixlib/src/main/resources/scala-native/spawn.c
@@ -47,6 +47,17 @@ int scalanative_posix_spawn_setscheduler() {
 #endif // !__APPLE__
 }
 
+int scalanative_posix_spawn_setsid() {
+#if defined(POSIX_SPAWN_SETSID)
+    return POSIX_SPAWN_SETSID;
+#elif defined(__linux__)
+    return 0x80; // HACK, __USE_GNU value
+#else
+#warning "POSIX_SPAWN_SETSID is not defined on this platform, using 0"
+    return 0x0;
+#endif
+}
+
 int scalanative_posix_spawn_setsigdef() { return POSIX_SPAWN_SETSIGDEF; }
 
 int scalanative_posix_spawn_setsigmask() { return POSIX_SPAWN_SETSIGMASK; }

--- a/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
@@ -7,7 +7,7 @@ import scalanative.unsafe._
 /** POSIX spawn.h for Scala
  *
  *  The Open Group Base Specifications
- *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
+ *  [[https://pubs.opengroup.org/onlinepubs/9799919799 Issue 8, 2024]] edition.
  *
  *  A method with a PS comment indicates it is defined in POSIX extension
  *  "Process Scheduling", not base POSIX.
@@ -52,6 +52,11 @@ object spawn {
       envp: Ptr[CString]
   ): CInt = extern
 
+  def posix_spawn_file_actions_addchdir(
+      file_actions: Ptr[posix_spawn_file_actions_t],
+      path: Ptr[CString]
+  ): CInt = extern
+
   def posix_spawn_file_actions_addclose(
       file_actions: Ptr[posix_spawn_file_actions_t],
       filedes: CInt
@@ -61,6 +66,11 @@ object spawn {
       file_actions: Ptr[posix_spawn_file_actions_t],
       filedes: CInt,
       newfiledes: CInt
+  ): CInt = extern
+
+  def posix_spawn_file_actions_addfchdir(
+      file_actions: Ptr[posix_spawn_file_actions_t],
+      filedes: CInt
   ): CInt = extern
 
   def posix_spawn_file_actions_addopen(
@@ -175,6 +185,9 @@ object spawn {
   /** PS - Unsupported (zero) on Apple */
   @name("scalanative_posix_spawn_setscheduler")
   def POSIX_SPAWN_SETSCHEDULER: CInt = extern
+
+  @name("scalanative_posix_spawn_setsid")
+  def POSIX_SPAWN_SETSID: CInt = extern
 
   @name("scalanative_posix_spawn_setsigdef")
   def POSIX_SPAWN_SETSIGDEF: CInt = extern


### PR DESCRIPTION

The Open Group Issue 8, 2024 specifications added three definitions to `spawn.h`.
This PR implements those definitions for Scala Native.

* posix_spawn_file_actions_addchdir()

*  posix_spawn_file_actions_addfchdir()

* POSIX_SPAWN_SETSID  -  see file spawn.c for complexity

This builds on kitbellew's correction in merged PR #4554.