### PR TITLE
module-init-exception: nest Boom module in Test

### DIFF
--- a/scripted-tests/run/module-init-exception/src/main/scala/Test.scala
+++ b/scripted-tests/run/module-init-exception/src/main/scala/Test.scala
@@ -1,14 +1,14 @@
 import java.util.concurrent.CountDownLatch
 
-class Boom extends RuntimeException("BOOM")
-object Boom {
-  val t: String = {
-    println(s"throw in ${Thread.currentThread()}")
-    throw new Boom()
-  }
-}
-
 object Test {
+  class Boom extends RuntimeException("BOOM")
+  object Boom {
+    val t: String = {
+      println(s"throw in ${Thread.currentThread()}")
+      throw new Boom()
+    }
+  }
+
   private final def doWork(cdl: CountDownLatch): Unit = {
     cdl.await()
     Boom.t.##


### PR DESCRIPTION
There's a chance that this approach would delay module initialization until first access and not during scala-native link time.