### PR TITLE
GenericProcess: no synchronized, ignore reaped

### DIFF
--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -114,14 +114,14 @@ private[process] abstract class GenericProcessHandle extends ProcessHandle {
     }
   }
 
-  protected final def setCachedExitCode(value: Int): Boolean = {
+  final def setCachedExitCode(value: Int): Boolean = {
     val ok = completion.complete(value)
     if (ok) close()
     ok
   }
 
   protected final def checkAndSetExitCode(): Boolean =
-    synchronized(getExitCodeImpl.exists(setCachedExitCode))
+    getExitCodeImpl.exists(setCachedExitCode)
 
   def onExitApply[A <: AnyRef](
       fn: function.Function[java.lang.Integer, A]
@@ -150,9 +150,9 @@ private[process] abstract class GenericProcessHandle extends ProcessHandle {
     hasExited || destroyImpl(force = force)
 
   private def waitForWith(check: => Boolean) = hasExited || check && hasExited
-  def waitFor(): Boolean = waitForWith(synchronized(waitForImpl()))
+  def waitFor(): Boolean = waitForWith(waitForImpl())
   def waitFor(timeout: scala.Long, unit: TimeUnit): Boolean =
-    waitForWith(timeout > 0L && synchronized(waitForImpl(timeout, unit)))
+    waitForWith(timeout > 0L && waitForImpl(timeout, unit))
 
   override def onExit(): CompletableFuture[ProcessHandle] =
     onExitApply(_ => this: ProcessHandle)

--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -79,7 +79,7 @@ private[process] object UnixProcess {
       case -1 =>
         import posix.errno._
         if (errno == EINTR) throw new InterruptedException()
-        else if (errno == ECHILD) Some(1) // see SN issues #4208 and #4348
+        else if (errno == ECHILD) None // see SN issues #4208 and #4348
         else throw new IOException(s"waitpid failed: ${LibcExt.strError()}")
       case _ => Some(getExitCodeFromWaitStatus(!wstatus))
     }

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen1.scala
@@ -46,7 +46,9 @@ private[process] class UnixProcessHandleGen1(
       if (res == 0) {
         setCachedExitCode(!exitCode)
         return true
-      } else if (res == posix.errno.ETIMEDOUT) return false
+      }
+      if (hasExited) return true
+      if (res == posix.errno.ETIMEDOUT) return false
     }
     false
   }

--- a/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessGen2.scala
@@ -108,7 +108,7 @@ private[process] class UnixProcessHandleGen2(pidFd: CInt)(
     val ok = UnixProcessHandleGen2.osWaitForImpl(this, timeout)
     if (ok) {
       val ec = UnixProcess.waitpidNoECHILD(_pid, options = 0)
-      setCachedExitCode(ec.getOrElse(1))
+      ec.foreach(setCachedExitCode)
     }
     ok
   } catch {


### PR DESCRIPTION
One of the reasons we used to synchronize waitFor and setExitCode was the race condition between learning the child exited, then reading its exit status and, finally, setting it in the completion object.

So, make the following changes:
- tolerate inability to reap a child which was presumably signaled, as it may have been reaped by another;
- do not "invent" an exit code if a child cannot be reaped; this way, only the thread which succeeded in reading the exit code will set it.