### PR TITLE
scalafmt: fix the scalalib exclusion pattern

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -41,7 +41,7 @@ newlines {
 project {
   git = true
   excludePaths = [
-    "glob:**/scala-native/scalalib/**"
+    "glob:**/scalalib/overrides-*/**"
     # Files to big to disable formating using directive // format: off
     "glob:**/nativelib/**/unsafe/Tag.scala"
   ]


### PR DESCRIPTION
It was an incorrect assumption that this repository would necessarily be checked out in the `scala-native` directory, as it could have been named anything else (including `scala-native-2`).

Instead, look for the subdirectories following the real `scalalib` project, to distinguish from test packages containing `scalalib`.

Supersedes #4605.