### PR TITLE
doc: Disable unhelpful code badges on SN landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Scala Native
 
+<!-- Disable unhelpful red badges until after Issue #4489 is resolved
 ![Posix Status](https://github.com/scala-native/scala-native/actions/workflows/run-tests-linux.yml/badge.svg)
 ![MacOS Status](https://github.com/scala-native/scala-native/actions/workflows/run-tests-macos.yml/badge.svg)
 ![Windows Status](https://github.com/scala-native/scala-native/actions/workflows/run-tests-windows.yml/badge.svg)
 [![Maven Central](https://img.shields.io/maven-central/v/org.scala-native/tools_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/org.scala-native/tools_2.12)
+-->
 
 Scala Native is an optimizing ahead-of-time compiler and lightweight managed runtime designed specifically for Scala.
 


### PR DESCRIPTION
Disable unhelpful red badges on Scala Native landing page until after Issue #4489 is resolved.

Scala Native is Continuous Integration (CI) but not Continuous Release (CR). 
Because of complexities the Scala Native artifact release process, the published artifacts
could be correct and current CI runs could be passing but the code badges would show failure; 
be RED and ORANGE.  Seeing those warning badges, readers of the page could be lead
to believe that the Scala Native build state was not fit for usage.
 