### PR TITLE
doc: re-work documentation & chat section on SN landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Scala Native is an optimizing ahead-of-time compiler and lightweight managed run
 
 ## Documentation and Chat
 
-Getting Started and full documentation can be found at [https://www.scala-native.org/](https://www.scala-native.org/)
+Getting Started and full documentation can be found at [https://www.scala-native.org/](https://www.scala-native.org/).
 
-Chat on the Scala Discord channel 
+Chat on the Scala Discord channel.
 [![Discord](https://img.shields.io/discord/632150470000902164.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/scala)
 
 ## Online Scaladoc


### PR DESCRIPTION
Re-work the Scala Native landing page so that:

* Documentation is presented first, presenting the clue that a new user should start there
  rather than asking questions.

  Yes, an anachronistic approach in the age of ChatGPT and other LLMs but directs
  new users to better information more quickly. Better in the sense of starting from introductory
  and moving on to increasing levels of complexity, bounds, & restrictions.

* The Discord icon now has an introductory text label.  This should help people who
   may not be familiar with the otherwise inscrutable icon.  The icon is preserved.
   The chat information should now be accessible those with either alphabetic or iconic learning styles.