### PR TITLE
[scalalib] Add scalalib patches for 2.13.18

### DIFF
--- a/scalalib/overrides-2.13.18/scala/Array.scala.patch
+++ b/scalalib/overrides-2.13.18/scala/Array.scala.patch
@@ -1,0 +1,41 @@
+--- 2.13.17-bin-98a15e6/scala/Array.scala
++++ overrides-2.13.17/scala/Array.scala
+@@ -32,7 +32,7 @@
+  *  where the array objects `a`, `b` and `c` have respectively the values
+  *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
+  */
+-object Array {
++private object EmptyArrays {
+   val emptyBooleanArray = new Array[Boolean](0)
+   val emptyByteArray    = new Array[Byte](0)
+   val emptyCharArray    = new Array[Char](0)
+@@ -42,7 +42,19 @@
+   val emptyLongArray    = new Array[Long](0)
+   val emptyShortArray   = new Array[Short](0)
+   val emptyObjectArray  = new Array[Object](0)
++}
+ 
++object Array {
++  @inline def emptyBooleanArray = EmptyArrays.emptyBooleanArray
++  @inline def emptyByteArray    = EmptyArrays.emptyByteArray
++  @inline def emptyCharArray    = EmptyArrays.emptyCharArray
++  @inline def emptyDoubleArray  = EmptyArrays.emptyDoubleArray
++  @inline def emptyFloatArray   = EmptyArrays.emptyFloatArray
++  @inline def emptyIntArray     = EmptyArrays.emptyIntArray
++  @inline def emptyLongArray    = EmptyArrays.emptyLongArray
++  @inline def emptyShortArray   = EmptyArrays.emptyShortArray
++  @inline def emptyObjectArray  = EmptyArrays.emptyObjectArray
++
+   /** Provides an implicit conversion from the Array object to a collection Factory */
+   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
+   @SerialVersionUID(3L)
+@@ -124,7 +136,8 @@
+     * @see `java.util.Arrays#copyOf`
+     */
+   def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
+-    case original: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
++//  We cannot distinguish Array[BoxedUnit] from Array[Object] in Scala Native
++//	case original: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
+     case original: Array[AnyRef]     => java.util.Arrays.copyOf(original, newLength)
+     case original: Array[Int]        => java.util.Arrays.copyOf(original, newLength)
+     case original: Array[Double]     => java.util.Arrays.copyOf(original, newLength)


### PR DESCRIPTION
Adds patch for Scala 2.13.18 (same as 2.13.17) 
Versions 2.13.12..16 now use existing patch from scalalib-2.13 (based on 2.13.12)