### PR TITLE
posix/epoll: remove epoll_event, it's invalid

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stdint.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdint.scala
@@ -7,6 +7,16 @@ import scala.scalanative.unsafe._
 // A very partial implementation. May it grow to completeness with time.
 
 @extern private[scalanative] trait stdint {
+
+  type int16_t = CShort
+  type uint16_t = CUnsignedShort
+
+  type int32_t = CInt
+  type uint32_t = CUnsignedInt
+
+  type int64_t = CLongLong
+  type uint64_t = CUnsignedLongLong
+
   // intmax_t and uintmax_t are not always equivalent to `long long`,
   // but they are usually `long long` in common data models.
   type intmax_t = CLongLong

--- a/posixlib/src/main/resources/scala-native/linux/epoll.c
+++ b/posixlib/src/main/resources/scala-native/linux/epoll.c
@@ -2,6 +2,7 @@
 
 #ifdef __linux__
 
+#include <stddef.h>
 #include <sys/epoll.h>
 
 int scalanative_epoll_cloexec() { return EPOLL_CLOEXEC; }
@@ -24,6 +25,24 @@ int scalanative_epolloneshot() { return EPOLLONESHOT; }
 // int scalanative_epollwakeup() { return EPOLLWAKEUP; }
 // linux 4.5
 // int scalanative_epollexclusive() { return EPOLLEXCLUSIVE; }
+
+size_t scalanative_epoll_event_size() { return sizeof(struct epoll_event); }
+
+void scalanative_epoll_event_set(struct epoll_event *ev, int idx,
+                                 uint32_t events, uint64_t data64) {
+    struct epoll_event *evidx = ev + idx;
+    evidx->events = events;
+    evidx->data.u64 = data64;
+}
+
+void scalanative_epoll_event_get(struct epoll_event *ev, int idx,
+                                 uint32_t *events, uint64_t *data64) {
+    struct epoll_event *evidx = ev + idx;
+    if (NULL != events)
+        *events = evidx->events;
+    if (NULL != data64)
+        *data64 = evidx->data.u64;
+}
 
 #endif // __linux__
 

--- a/posixlib/src/main/scala/scala/scalanative/linux/epoll.scala
+++ b/posixlib/src/main/scala/scala/scalanative/linux/epoll.scala
@@ -6,12 +6,14 @@ package linux
  * https://man7.org/linux/man-pages/man2/epoll_create1.2.html
  */
 
+import posix._
 import unsafe._
-import unsigned._
 
 @extern
 @define("__SCALANATIVE_POSIX_EPOLL")
 object epoll {
+
+  import stdint._
 
   @name("scalanative_epoll_cloexec")
   def EPOLL_CLOEXEC: CInt = extern
@@ -41,9 +43,6 @@ object epoll {
   @name("scalanative_epolloneshot")
   def EPOLLONESHOT: CInt = extern
 
-  type epoll_data_t = CStruct1[CLongLong] // 64-bit
-  type epoll_event = CStruct2[UInt, epoll_data_t]
-
   def epoll_create(size: CInt): CInt = extern
   def epoll_create1(flags: CInt): CInt = extern
 
@@ -51,39 +50,31 @@ object epoll {
       epfd: CInt,
       op: CInt,
       fd: CInt,
-      event: Ptr[epoll_event]
+      event: CVoidPtr
   ): CInt = extern
 
   @blocking
   def epoll_wait(
       epfd: CInt,
-      events: Ptr[epoll_event],
+      events: CVoidPtr,
       maxevents: CInt,
       timeoutMillis: CInt
   ): CInt = extern
 
-  // scalafmt: { align.preset = more }
+  def scalanative_epoll_event_size(): CSize = extern
 
-  implicit class dataOps(val ref: epoll_data_t) extends AnyVal {
-    def ptr = ref._1.toPtr[Byte]
-    def fd  = ref._1.toInt
-    def u32 = ref._1.toUInt
-    def u64 = ref._1.toULong
+  def scalanative_epoll_event_set(
+      ev: CVoidPtr,
+      idx: CInt,
+      events: uint32_t,
+      data: uint64_t
+  ): Unit = extern
 
-    def ptr_=(v: CVoidPtr): Unit = ref._1 = v.toLong
-    def fd_=(v: CInt): Unit      = ref._1 = v.toLong
-    def u32_=(v: UInt): Unit     = ref._1 = v.toLong
-    def u64_=(v: ULong): Unit    = ref._1 = v.toLong
-  }
-
-  implicit class eventOps(val ptr: Ptr[epoll_event]) extends AnyVal {
-    def events = ptr._1
-    def data   = ptr._2
-
-    def events_=(v: UInt): Unit       = ptr._1 = v
-    def data_=(v: epoll_data_t): Unit = ptr._2 = v
-  }
-
-  // scalafmt: { align.preset = none }
+  def scalanative_epoll_event_get(
+      ev: CVoidPtr,
+      idx: CInt,
+      events: Ptr[uint32_t],
+      data: Ptr[uint64_t]
+  ): Unit = extern
 
 }


### PR DESCRIPTION
In reality, on some systems, the structure, along with the union-type second field, might be packed whereas on others it would be aligned.

Therefore, add C-lang methods to manipulate it and do not rely on any scala CStruct constructs.

Unfortunately, we had to learn this the hard way.