### PR TITLE
posix/kevent: remove scala kevent type, use C-lang

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stdint.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdint.scala
@@ -7,6 +7,16 @@ import scala.scalanative.unsafe._
 // A very partial implementation. May it grow to completeness with time.
 
 @extern private[scalanative] trait stdint {
+
+  type int16_t = CShort
+  type uint16_t = CUnsignedShort
+
+  type int32_t = CInt
+  type uint32_t = CUnsignedInt
+
+  type int64_t = CLongLong
+  type uint64_t = CUnsignedLongLong
+
   // intmax_t and uintmax_t are not always equivalent to `long long`,
   // but they are usually `long long` in common data models.
   type intmax_t = CLongLong

--- a/posixlib/src/main/resources/scala-native/bsd/kevent.c
+++ b/posixlib/src/main/resources/scala-native/bsd/kevent.c
@@ -16,6 +16,7 @@
  *   https://wiki.netbsd.org/tutorials/kqueue_tutorial/
  */
 
+#include <stddef.h>
 #include <sys/event.h>
 
 int scalanative_kevent_evfilt_read() { return EVFILT_READ; }
@@ -43,6 +44,38 @@ int scalanative_kevent_ev_error() { return EV_ERROR; }
 
 int scalanative_kevent_note_exit() { return NOTE_EXIT; }
 int scalanative_kevent_note_exitstatus() { return NOTE_EXITSTATUS; }
+
+size_t scalanative_kevent_size() { return sizeof(struct kevent); }
+
+void scalanative_kevent_set(struct kevent *ev, int idx, uintptr_t ident,
+                            int16_t filter, uint16_t flags, uint32_t fflags,
+                            intptr_t data, void *udata) {
+    struct kevent *evidx = ev + idx;
+    evidx->ident = ident;
+    evidx->filter = filter;
+    evidx->flags = flags;
+    evidx->fflags = fflags;
+    evidx->data = data;
+    evidx->udata = udata;
+}
+
+void scalanative_kevent_get(struct kevent *ev, int idx, uintptr_t *ident,
+                            int16_t *filter, uint16_t *flags, uint32_t *fflags,
+                            intptr_t *data, void **udata) {
+    struct kevent *evidx = ev + idx;
+    if (NULL != ident)
+        *ident = evidx->ident;
+    if (NULL != filter)
+        *filter = evidx->filter;
+    if (NULL != flags)
+        *flags = evidx->flags;
+    if (NULL != fflags)
+        *fflags = evidx->fflags;
+    if (NULL != data)
+        *data = evidx->data;
+    if (NULL != udata)
+        *udata = evidx->udata;
+}
 
 #endif // HAVE_KQUEUE
 

--- a/posixlib/src/main/scala/scala/scalanative/bsd/kevent.scala
+++ b/posixlib/src/main/scala/scala/scalanative/bsd/kevent.scala
@@ -3,27 +3,12 @@ package bsd
 
 import posix._
 import unsafe._
-import unsigned._
 
 @extern
 @define("__SCALANATIVE_POSIX_KEVENT")
 object kevent {
 
-  type intptr_t = stdint.intptr_t
-  type uintptr_t = stdint.uintptr_t
-
-  // scalafmt: { align.preset = more }
-
-  type kevent = CStruct6[
-    uintptr_t,      // ident       /* identifier for this event: uintptr_t */
-    CShort,         // filter      /* filter for event */
-    CUnsignedShort, // flags       /* action flags for kqueue */
-    CUnsignedInt,   // fflags      /* filter flag value */
-    intptr_t,       // data        /* filter data value: intptr_t */
-    CVoidPtr        // void *udata /* opaque user data identifier */
-  ]
-
-  // scalafmt: { align.preset = none }
+  import stdint._
 
   @name("scalanative_kevent_evfilt_read")
   def EVFILT_READ: CInt = extern
@@ -65,42 +50,35 @@ object kevent {
   @blocking
   def kevent(
       kq: CInt,
-      changelist: Ptr[kevent],
+      changelist: CVoidPtr,
       nchanges: CInt,
-      eventlist: Ptr[kevent],
+      eventlist: CVoidPtr,
       nevents: CInt,
       timeout: Ptr[time.timespec]
   ): CInt = extern
 
-  // scalafmt: { align.preset = more }
+  def scalanative_kevent_size(): CSize = extern
 
-  implicit class keventOps(val ptr: Ptr[kevent]) extends AnyVal {
-    def ident  = ptr._1
-    def filter = ptr._2
-    def flags  = ptr._3
-    def fflags = ptr._4
-    def data   = ptr._5
-    def udata  = ptr._6
+  def scalanative_kevent_set(
+      ev: CVoidPtr,
+      idx: CInt,
+      ident: uintptr_t,
+      filter: int16_t,
+      flags: uint16_t,
+      fflags: uint32_t,
+      data: intptr_t,
+      udata: CVoidPtr
+  ): Unit = extern
 
-    def ident_=(v: uintptr_t): Unit      = ptr._1 = v
-    def filter_=(v: CShort): Unit        = ptr._2 = v
-    def flags_=(v: CUnsignedShort): Unit = ptr._3 = v
-    def fflags_=(v: CUnsignedInt): Unit  = ptr._4 = v
-    def data_=(v: intptr_t): Unit        = ptr._5 = v
-    def udata_=(v: CVoidPtr): Unit       = ptr._6 = v
-
-    /* Convenience methods for common conversions hide and rely upon
-     * some abstraction layer jumping illicit knowledge that CSSize is
-     * a typedef for CSize.
-     */
-
-    def ident_=(v: CInt): Unit         = ptr._1 = v.toCSize
-    def ident_=(v: CUnsignedInt): Unit = ptr._1 = v.toInt.toCSize
-
-    def data_=(v: CInt): Unit         = ptr._1 = v.toCSize
-    def data_=(v: CUnsignedInt): Unit = ptr._1 = v.toInt.toCSize
-  }
-
-  // scalafmt: { align.preset = none }
+  def scalanative_kevent_get(
+      ev: CVoidPtr,
+      idx: CInt,
+      ident: Ptr[uintptr_t],
+      filter: Ptr[int16_t],
+      flags: Ptr[uint16_t],
+      fflags: Ptr[uint32_t],
+      data: Ptr[intptr_t],
+      udata: Ptr[CVoidPtr]
+  ): Unit = extern
 
 }


### PR DESCRIPTION
Similar to epoll_event, it's possible that kevent might have different memory alignment within kernel, thus scala representation might not be correct.