### PR TITLE
GenericProcessWatcher: move most to nested object

### DIFF
--- a/javalib/src/main/scala/java/lang/process/GenericProcessWatcher.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcessWatcher.scala
@@ -11,76 +11,87 @@ private[process] object GenericProcessWatcher {
 
   import ju.concurrent._
 
-  private val processes = new ConcurrentHashMap[jl.Long, GenericProcessHandle]
+  @alwaysinline def watchForTermination(handle: GenericProcessHandle): Unit =
+    Processes.add(handle)
 
-  /* Custom "mutex" to make sure we don't try to reap until there are processes
-   * to wait for.
-   * - release() is called anytime a process is added, and will mark this open
-   * - acquire() is called ONLY if processes was empty:
-   *   - if it's closed, blocks until it's marked open (a process is added)
-   *   - if it's open, close it and check if processes is empty again
-   * Between processes.isEmpty and processesMutex.acquire, several scenarios
-   * could play out:
-   * - processes isn't empty: we proceed to reaping
-   *   - the state of processesMutex is irrelevant here, although it
-   *     is likely open since it's opened anytime a process is added,
-   *     and not closed until processes is empty;
-   * - processes is empty but processesMutex is open:
-   *   - the check is repeated after processesMutex is closed
-   * - processes is empty and processesMutex is closed:
-   *   - acquire() blocks until released
-   *   - it could be released even before acquire() is called, if a
-   *     process is added during the gap between these two calls
-   *   - or it could be released after acquire() is called
-   */
-  private val processesMutex = new locks.AbstractQueuedSynchronizer {
-    // initial state is 0, for "closed"
-    // we don't need the "Shared" versions as we'll have only one waiter
-    override protected final def tryRelease(releases: Int): Boolean =
-      compareAndSetState(0, 1) // if was closed, open it, unblock waiters
-    override protected final def tryAcquire(releases: Int): Boolean =
-      // called only if processes is empty
-      // see more detailed explanation below, where acquire() is called
-      compareAndSetState(1, 0) // if was open, close it, else block
-  }
+  private object Processes {
+    private val processes = new ConcurrentHashMap[jl.Long, GenericProcessHandle]
 
-  def watchForTermination(handle: GenericProcessHandle): Unit = {
-    processes.put(handle.pid(), handle)
-    assert(
-      watcherThread.isAlive(),
-      "GenericProcessWatcher watch thread is terminated"
-    )
-    processesMutex.release(1)
-  }
+    /* Custom "mutex" to make sure we don't try to reap until there are processes
+     * to wait for.
+     * - release() is called anytime a process is added, and will mark this open
+     * - acquire() is called ONLY if processes was empty:
+     *   - if it's closed, blocks until it's marked open (a process is added)
+     *   - if it's open, close it and check if processes is empty again
+     * Between processes.isEmpty and processesMutex.acquire, several scenarios
+     * could play out:
+     * - processes isn't empty: we proceed to reaping
+     *   - the state of processesMutex is irrelevant here, although it
+     *     is likely open since it's opened anytime a process is added,
+     *     and not closed until processes is empty;
+     * - processes is empty but processesMutex is open:
+     *   - the check is repeated after processesMutex is closed
+     * - processes is empty and processesMutex is closed:
+     *   - acquire() blocks until released
+     *   - it could be released even before acquire() is called, if a
+     *     process is added during the gap between these two calls
+     *   - or it could be released after acquire() is called
+     */
+    private val processesMutex = new locks.AbstractQueuedSynchronizer {
+      // initial state is 0, for "closed"
+      // we don't need the "Shared" versions as we'll have only one waiter
+      override protected final def tryRelease(releases: Int): Boolean =
+        compareAndSetState(0, 1) // if was closed, open it, unblock waiters
+      override protected final def tryAcquire(releases: Int): Boolean =
+        // called only if processes is empty; see detailed explanation above
+        compareAndSetState(1, 0) // if was open, close it, else block
+    }
 
-  private lazy val watcherThread: Thread = Thread
-    .ofPlatform()
-    .daemon(true)
-    .group(ThreadGroup.System)
-    .name("ScalaNative-GenericProcessWatcher")
-    .startInternal { () =>
-      while (true) Try {
-        removeProcessesIf(_.hasExited)
-        while (processes.isEmpty()) processesMutex.acquire(1)
-        if (!reapSomeProcesses()) Thread.sleep(100) // ms
+    def add(handle: GenericProcessHandle): Unit = {
+      processes.put(handle.pid(), handle)
+      assert(
+        watcherThread.isAlive(),
+        "GenericProcessWatcher watch thread is terminated"
+      )
+      processesMutex.release(1)
+    }
+
+    @alwaysinline
+    def remove(pid: Long): GenericProcessHandle = processes.remove(pid)
+
+    private final val watcherThread: Thread = Thread
+      .ofPlatform()
+      .daemon(true)
+      .group(ThreadGroup.System)
+      .name("ScalaNative-GenericProcessWatcher")
+      .startInternal(Task)
+
+    private object Task extends Runnable {
+      override def run(): Unit = {
+        while (true) Try {
+          removeProcessesIf(_.hasExited)
+          while (processes.isEmpty()) processesMutex.acquire(1)
+          if (!reapSomeProcesses()) Thread.sleep(100) // ms
+        }
       }
     }
 
-  // return true if something has been reaped
-  private val reapSomeProcesses: () => Boolean =
-    if (LinktimeInfo.isWindows) claimAllCompleted
-    else if (UnixProcess.useGen2) claimAllCompleted
-    else UnixProcessGen1.waitpidAny
+    // return true if something has been reaped
+    private val reapSomeProcesses: () => Boolean =
+      if (LinktimeInfo.isWindows) claimAllCompleted
+      else if (UnixProcess.useGen2) claimAllCompleted
+      else UnixProcessGen1.waitpidAny
 
-  @alwaysinline
-  def claimAllCompleted(): Boolean = removeProcessesIf(_.checkIfExited())
+    @alwaysinline
+    def claimAllCompleted(): Boolean = removeProcessesIf(_.checkIfExited())
 
-  @alwaysinline
-  def removeProcessesIf(f: GenericProcessHandle => Boolean): Boolean =
-    removeIf(processes.values())(f)
+    @alwaysinline
+    def removeProcessesIf(f: GenericProcessHandle => Boolean): Boolean =
+      removeIf(processes.values())(f)
+  }
 
   def completeWith(pid: Long)(ec: => Int): Boolean = {
-    val ref = processes.remove(pid)
+    val ref = Processes.remove(pid)
     (ref ne null) && ref.setCachedExitCode(ec)
   }
 


### PR DESCRIPTION
Move processes field, watcher thread and some methods to a nested object so that we both encapsulate this functionality and also delay thread initialization without using `lazy`.

This will allow us to add another "lazy" field to the Processes object later on.