### PR TITLE
UnixProcessGen2: use atomic to close pidfd

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixFileDescriptorAtomic.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixFileDescriptorAtomic.scala
@@ -1,0 +1,27 @@
+package java.lang.process
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.posix.unistd
+
+class UnixFileDescriptorAtomic(val value: AtomicInteger) extends AnyVal {
+
+  @alwaysinline def get(): Int = value.get()
+
+  @alwaysinline def release(): Int = value.getAndSet(-1)
+
+  @alwaysinline def close(): Unit = {
+    val prev = release()
+    if (prev != -1) unistd.close(prev)
+  }
+
+}
+
+object UnixFileDescriptorAtomic {
+
+  @alwaysinline
+  def apply(value: Int): UnixFileDescriptorAtomic =
+    new UnixFileDescriptorAtomic(new AtomicInteger(value))
+
+}


### PR DESCRIPTION
We must not close pidfd twice since by the time we try it again, that file descriptor may have already been re-used and assigned to another, unrelated reource.