### PR TITLE
Matcher: fix bugs in appendReplacement

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Matcher.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Matcher.scala
@@ -473,7 +473,7 @@ final class Matcher private (private var _pattern: Pattern) {
           var break = false
           while (!break && i < m) {
             c = replacement.charAt(i)
-            if (c < '0' || c > '9' || n * 10 + c - '0' > _groupCount) {
+            if (c < '0' || c > '9') {
               break = true
             } else {
               n = n * 10 + c - '0'
@@ -493,24 +493,22 @@ final class Matcher private (private var _pattern: Pattern) {
           if (last < i) {
             sb.append(replacement, last, i)
           }
-          i += 1 // '{'
-          var j = i + 1
-          while (j < replacement.length && replacement.charAt(
-                j
-              ) != '}' && replacement
-                .charAt(j) != ' ') {
-            j += 1
+          i += 2 // after '${'
+          val off = i
+          while (i < replacement.length &&
+              replacement.charAt(i) != '}' &&
+              replacement.charAt(i) != ' ') {
+            i += 1
           }
-          if (j == replacement.length || replacement.charAt(j) == ' ') {
+          if (i == replacement.length || replacement.charAt(i) == ' ') {
             throw new IllegalStateException("No match available")
           }
-          val groupName = replacement.substring(i + 1, j)
+          val groupName = replacement.substring(off, i)
           // JVM uses slightly different Exception message for non-extant
           // named group in replacement string.
           val gid = getNamedGroupOrThrow(groupName, "No match available")
           sb.append(this.group(gid))
-          i += 1 // '}'
-          last = j + 1
+          last = i + 1 // after '}'
         }
       }
       i += 1

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/MatcherTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/MatcherTest.scala
@@ -247,8 +247,9 @@ class MatcherTest {
       re2jAppendReplacement(m, "what$2ever${bag}")
     )
 
-    assertEquals(
-      "whatbbarrrrr1ever",
+    assertThrows(
+      "`$21` exceeds number of groups (5)",
+      classOf[IndexOutOfBoundsException],
       re2jAppendReplacement(m, "what$21ever")
     )
 
@@ -302,8 +303,9 @@ class MatcherTest {
       re2jAppendReplacement(m, "what$2ever${bag}")
     )
 
-    assertEquals(
-      "whatbbarrrrr1ever",
+    assertThrows(
+      "`$21` exceeds number of groups (5)",
+      classOf[IndexOutOfBoundsException],
       re2jAppendReplacement(m, "what$21ever")
     )
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/RE2MatcherTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/RE2MatcherTest.scala
@@ -36,7 +36,7 @@ class RE2MatcherTest {
     ApiTestUtils.testReplaceAll(
       "abcdefghijklmnopqrstuvwxyz123",
       "(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)",
-      "$10$20",
+      "$10$2\\0",
       "jb0wo0123"
     )
     ApiTestUtils.testReplaceAll(
@@ -80,7 +80,7 @@ class RE2MatcherTest {
     ApiTestUtils.testReplaceFirst(
       "abcdefghijklmnopqrstuvwxyz123",
       "(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)",
-      "$10$20",
+      "$10$2\\0",
       "jb0nopqrstuvwxyz123"
     )
     ApiTestUtils.testReplaceFirst(


### PR DESCRIPTION
- bug: read group number greedily and complain
  - previously, parser would stop if the group number WOULD overflow thus never really triggering the over-group-limit exception
- inefficiency: when parsing group name, move read index to after it
  - previously, we'd substitute the group value but keep the read index after the opening `{` rather than the closing `}`
  - while not a bug, this led to retracing steps since that part of the sequence didn't contain any special characters and `last` (the part of input not yet appended) by then was pointing past the sequence
