### PR TITLE
ProcessExitChecker: split Factory, change Single

### DIFF
--- a/javalib/src/main/scala/java/lang/process/GenericProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcessHandle.scala
@@ -4,9 +4,13 @@ import java.util.concurrent.{CompletableFuture, TimeUnit, TimeoutException}
 import java.util.stream.Stream
 import java.util.{Optional, function}
 
+import scala.scalanative.javalib.io.ObjectHandle
+
 // Represents ProcessHandle for process started by Scala Native runtime
 // Cannot be used with processes started by other programs
-private[process] abstract class GenericProcessHandle extends ProcessHandle {
+private[process] abstract class GenericProcessHandle(
+    protected val processId: ObjectHandle
+) extends ProcessHandle {
   protected def getExitCodeImpl: Option[Int]
   protected def destroyImpl(force: Boolean): Boolean
   protected def waitForImpl(): Boolean

--- a/javalib/src/main/scala/java/lang/process/ProcessExitChecker.scala
+++ b/javalib/src/main/scala/java/lang/process/ProcessExitChecker.scala
@@ -2,6 +2,7 @@ package java.lang.process
 
 import java.util.concurrent.TimeUnit
 
+import scala.scalanative.javalib.io.ObjectHandle
 import scala.scalanative.meta.LinktimeInfo
 
 /** Provides ability to query a process or processes for their exit. Doesn't
@@ -28,12 +29,15 @@ private[process] object ProcessExitChecker {
   }
 
   trait Factory {
-    def createMulti(implicit pr: ProcessRegistry): Multi
 
     /** @return None if process has exited */
-    def createSingle(pid: Int)(implicit
+    def createSingle(procesId: ObjectHandle)(implicit
         pr: ProcessRegistry
     ): ProcessExitChecker
+  }
+
+  trait MultiFactory extends Factory {
+    def createMulti(implicit pr: ProcessRegistry): Multi
   }
 
   val unixFactoryOpt: Option[Factory] =

--- a/javalib/src/main/scala/java/lang/process/ProcessExitCheckerFreeBSD.scala
+++ b/javalib/src/main/scala/java/lang/process/ProcessExitCheckerFreeBSD.scala
@@ -6,6 +6,7 @@ import scala.annotation.tailrec
 
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.bsd
+import scala.scalanative.javalib.io.ObjectHandle
 import scala.scalanative.posix._
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
@@ -13,16 +14,16 @@ import scala.scalanative.unsigned._
 import ju.concurrent.TimeUnit
 
 private[process] object ProcessExitCheckerFreeBSD
-    extends ProcessExitChecker.Factory {
+    extends ProcessExitChecker.MultiFactory {
 
   import bsd.kevent._
 
   private val keventSize = scalanative_kevent_size()
 
-  override def createSingle(pid: CInt)(implicit
+  override def createSingle(procesId: ObjectHandle)(implicit
       pr: ProcessRegistry
   ): ProcessExitChecker =
-    new Single(pid)
+    new Single(procesId.asInt)
 
   // XXX: this watcher is NOT thread-safe, must be used from single thread
   override def createMulti(implicit

--- a/javalib/src/main/scala/java/lang/process/ProcessExitCheckerWaitpid.scala
+++ b/javalib/src/main/scala/java/lang/process/ProcessExitCheckerWaitpid.scala
@@ -2,17 +2,19 @@ package java.lang.process
 
 import java.util.concurrent.TimeUnit
 
+import scala.scalanative.javalib.io.ObjectHandle
+
 private[process] object ProcessExitCheckerWaitpid
-    extends ProcessExitChecker.Factory {
+    extends ProcessExitChecker.MultiFactory {
 
   override def createMulti(implicit
       pr: ProcessRegistry
   ): ProcessExitChecker.Multi = new Multi
 
-  override def createSingle(pid: Int)(implicit
+  override def createSingle(procesId: ObjectHandle)(implicit
       pr: ProcessRegistry
   ): ProcessExitChecker =
-    new Single(pid)
+    new Single(procesId.asInt)
 
   private class Single(pid: Int)(implicit pr: ProcessRegistry)
       extends ProcessExitChecker {

--- a/javalib/src/main/scala/java/lang/process/UnixProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessHandle.scala
@@ -2,13 +2,14 @@ package java.lang.process
 
 import java.util.concurrent.TimeUnit
 
+import scala.scalanative.javalib.io.ObjectHandle
 import scala.scalanative.libc.{signal => csig}
 import scala.scalanative.posix.{signal => psig}
 import scala.scalanative.unsafe.CInt
 
 private[process] class UnixProcessHandle(_pid: CInt)(
     override val builder: ProcessBuilder
-) extends GenericProcessHandle {
+) extends GenericProcessHandle(ObjectHandle(_pid)) {
   /* Make sure we have exactly one entity calling waitpid on a process.
    * Reasons are having fewer kernel interactions, plus an unlikely but
    * theoretically possible scenario whereby by the time a second waiter
@@ -22,7 +23,7 @@ private[process] class UnixProcessHandle(_pid: CInt)(
           override def completeWith(pid: Long)(ec: Int): Unit =
             setCachedExitCode(ec)
         }
-        factory.createSingle(_pid)
+        factory.createSingle(processId)
       }
   }.getOrElse(ProcessExitCheckerCompletion)
 

--- a/javalib/src/main/scala/java/lang/process/WindowsProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcessHandle.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 // Required only for cross-compilation with Scala 2
 import scala.language.existentials
 
+import scala.scalanative.javalib.io.ObjectHandle
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.windows._
@@ -16,7 +17,7 @@ private[process] class WindowsProcessHandle(
     _pid: DWord,
     handle: Handle,
     override val builder: ProcessBuilder
-) extends GenericProcessHandle {
+) extends GenericProcessHandle(ObjectHandle(handle)) {
   override final def pid(): Long = _pid.toLong
 
   override def supportsNormalTermination(): Boolean = false


### PR DESCRIPTION
Single factory will now use GenericProcessHandle as its parameter.