### PR TITLE
{Generic,Windows}ProcessHandle: move to own files

### DIFF
--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -1,9 +1,8 @@
 package java.lang.process
 
 import java.io.{FileDescriptor, InputStream, OutputStream}
-import java.util.concurrent.{CompletableFuture, TimeUnit, TimeoutException}
+import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util.stream.Stream
-import java.util.{Optional, function}
 
 import scala.scalanative.meta.LinktimeInfo
 
@@ -74,121 +73,11 @@ private[process] abstract class GenericProcess(val handle: GenericProcessHandle)
 
 }
 
-// Represents ProcessHandle for process started by Scala Native runtime
-// Cannot be used with processes started by other programs
-private[process] abstract class GenericProcessHandle extends ProcessHandle {
-  protected def getExitCodeImpl: Option[Int]
-  protected def destroyImpl(force: Boolean): Boolean
-  protected def waitForImpl(): Boolean
-  protected def waitForImpl(timeout: scala.Long, unit: TimeUnit): Boolean
-
-  /** Closes any resources associated with a running process.
-   *
-   *  After this call completes, no attempts should be made to call [[close]]
-   *  itself, or any of the `Impl` methods above.
-   *
-   *  Currently, [[close]] is called only by [[setCachedExitCode]] upon
-   *  successful reaping of the terminated child.
-   */
-  protected def close(): Unit
-
-  val builder: ProcessBuilder
-
-  private val processInfo: GenericProcessInfo = GenericProcessInfo(builder)
-  protected val completion = new CompletableFuture[java.lang.Integer]()
-
-  override final def isAlive(): Boolean = !hasExited
-
-  final def checkIfExited(): Boolean =
-    hasExited || checkAndSetExitCode() || hasExited
-
-  final def hasExited: Boolean = completion.isDone()
-
-  final def getCachedExitCode: Option[Int] = {
-    if (!completion.isDone()) None
-    else if (completion.isCompletedExceptionally()) Some(-1)
-    else {
-      val res = completion.getNow(null)
-      Some(if (res == null) -1 else res.intValue())
-    }
-  }
-
-  final def setCachedExitCode(value: Int): Boolean = {
-    val ok = completion.complete(value)
-    if (ok) close()
-    ok
-  }
-
-  protected final def checkAndSetExitCode(): Boolean =
-    getExitCodeImpl.exists(setCachedExitCode)
-
-  def onExitApply[A <: AnyRef](
-      fn: function.Function[java.lang.Integer, A]
-  ): CompletableFuture[A] =
-    completion.thenApplyAsync(fn)
-
-  def onExitHandle[A <: AnyRef](
-      fn: function.BiFunction[java.lang.Integer, Throwable, A]
-  ): CompletableFuture[A] =
-    completion.handleAsync(fn)
-
-  override def parent(): Optional[ProcessHandle] = Optional.empty()
-
-  // We don't track transitive children
-  override def children(): Stream[ProcessHandle] = Stream.empty()
-  override def descendants(): Stream[ProcessHandle] = Stream.empty()
-
-  override final def destroy(): Boolean = destroy(force = false)
-  override final def destroyForcibly(): Boolean = destroy(force = true)
-  @inline private def destroy(force: Boolean) =
-    hasExited || destroyImpl(force = force)
-
-  private def waitForWith(check: => Boolean) = hasExited || check && hasExited
-  def waitFor(): Boolean = waitForWith(waitForImpl())
-  def waitFor(timeout: scala.Long, unit: TimeUnit): Boolean =
-    waitForWith(timeout > 0L && waitForImpl(timeout, unit))
-
-  override def onExit(): CompletableFuture[ProcessHandle] =
-    onExitApply(_ => this: ProcessHandle)
-
-  override def info(): ProcessHandle.Info = processInfo
-
-  override def compareTo(other: ProcessHandle): Int = other match {
-    case other: GenericProcessHandle =>
-      val res = pid().compareTo(other.pid())
-      if (res != 0) res
-      else processInfo.createdAt.compareTo(other.processInfo.createdAt)
-    case _ => -1
-  }
-  override def equals(that: Any): Boolean = that match {
-    case other: ProcessHandle => this.compareTo(other) == 0
-    case _                    => false
-  }
-  override def hashCode(): Int =
-    ((31 * this.pid().##) * 31) + processInfo.createdAt.##
-  override def toString: String =
-    s"Process[pid=${pid()}, exitValue=${getCachedExitCode.getOrElse("\"not exited\"")}"
-
-  protected object ProcessExitCheckerCompletion extends ProcessExitChecker {
-    override def close(): Unit = {}
-    override def waitAndReapSome(
-        timeout: Long,
-        unitOpt: Option[TimeUnit]
-    ): Boolean =
-      unitOpt.fold { completion.get(); true } { unit =>
-        timeout > 0L && {
-          try { completion.get(timeout, unit); true }
-          catch { case _: TimeoutException => false }
-        }
-      }
-  }
-
-}
-
 private[lang] object GenericProcess {
 
   def apply(pb: ProcessBuilder): GenericProcess = {
-    if (LinktimeInfo.isWindows) WindowsProcess(pb) else UnixProcessFactory(pb)
+    if (LinktimeInfo.isWindows) WindowsProcessFactory(pb)
+    else UnixProcessFactory(pb)
   }
 
 }

--- a/javalib/src/main/scala/java/lang/process/GenericProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcessHandle.scala
@@ -1,0 +1,116 @@
+package java.lang.process
+
+import java.util.concurrent.{CompletableFuture, TimeUnit, TimeoutException}
+import java.util.stream.Stream
+import java.util.{Optional, function}
+
+// Represents ProcessHandle for process started by Scala Native runtime
+// Cannot be used with processes started by other programs
+private[process] abstract class GenericProcessHandle extends ProcessHandle {
+  protected def getExitCodeImpl: Option[Int]
+  protected def destroyImpl(force: Boolean): Boolean
+  protected def waitForImpl(): Boolean
+  protected def waitForImpl(timeout: scala.Long, unit: TimeUnit): Boolean
+
+  /** Closes any resources associated with a running process.
+   *
+   *  After this call completes, no attempts should be made to call [[close]]
+   *  itself, or any of the `Impl` methods above.
+   *
+   *  Currently, [[close]] is called only by [[setCachedExitCode]] upon
+   *  successful reaping of the terminated child.
+   */
+  protected def close(): Unit
+
+  val builder: ProcessBuilder
+
+  private val processInfo: GenericProcessInfo = GenericProcessInfo(builder)
+  protected val completion = new CompletableFuture[java.lang.Integer]()
+
+  override final def isAlive(): Boolean = !hasExited
+
+  final def checkIfExited(): Boolean =
+    hasExited || checkAndSetExitCode() || hasExited
+
+  final def hasExited: Boolean = completion.isDone()
+
+  final def getCachedExitCode: Option[Int] = {
+    if (!completion.isDone()) None
+    else if (completion.isCompletedExceptionally()) Some(-1)
+    else {
+      val res = completion.getNow(null)
+      Some(if (res == null) -1 else res.intValue())
+    }
+  }
+
+  final def setCachedExitCode(value: Int): Boolean = {
+    val ok = completion.complete(value)
+    if (ok) close()
+    ok
+  }
+
+  protected final def checkAndSetExitCode(): Boolean =
+    getExitCodeImpl.exists(setCachedExitCode)
+
+  def onExitApply[A <: AnyRef](
+      fn: function.Function[java.lang.Integer, A]
+  ): CompletableFuture[A] =
+    completion.thenApplyAsync(fn)
+
+  def onExitHandle[A <: AnyRef](
+      fn: function.BiFunction[java.lang.Integer, Throwable, A]
+  ): CompletableFuture[A] =
+    completion.handleAsync(fn)
+
+  override def parent(): Optional[ProcessHandle] = Optional.empty()
+
+  // We don't track transitive children
+  override def children(): Stream[ProcessHandle] = Stream.empty()
+  override def descendants(): Stream[ProcessHandle] = Stream.empty()
+
+  override final def destroy(): Boolean = destroy(force = false)
+  override final def destroyForcibly(): Boolean = destroy(force = true)
+  @inline private def destroy(force: Boolean) =
+    hasExited || destroyImpl(force = force)
+
+  private def waitForWith(check: => Boolean) = hasExited || check && hasExited
+  def waitFor(): Boolean = waitForWith(waitForImpl())
+  def waitFor(timeout: scala.Long, unit: TimeUnit): Boolean =
+    waitForWith(timeout > 0L && waitForImpl(timeout, unit))
+
+  override def onExit(): CompletableFuture[ProcessHandle] =
+    onExitApply(_ => this: ProcessHandle)
+
+  override def info(): ProcessHandle.Info = processInfo
+
+  override def compareTo(other: ProcessHandle): Int = other match {
+    case other: GenericProcessHandle =>
+      val res = pid().compareTo(other.pid())
+      if (res != 0) res
+      else processInfo.createdAt.compareTo(other.processInfo.createdAt)
+    case _ => -1
+  }
+  override def equals(that: Any): Boolean = that match {
+    case other: ProcessHandle => this.compareTo(other) == 0
+    case _                    => false
+  }
+  override def hashCode(): Int =
+    ((31 * this.pid().##) * 31) + processInfo.createdAt.##
+  override def toString: String =
+    s"Process[pid=${pid()}, exitValue=${getCachedExitCode.getOrElse("\"not exited\"")}"
+
+  protected object ProcessExitCheckerCompletion extends ProcessExitChecker {
+    override def close(): Unit = {}
+    override def waitAndReapSome(
+        timeout: Long,
+        unitOpt: Option[TimeUnit]
+    ): Boolean =
+      unitOpt.fold { completion.get(); true } { unit =>
+        timeout > 0L && {
+          try { completion.get(timeout, unit); true }
+          catch { case _: TimeoutException => false }
+        }
+      }
+  }
+
+}

--- a/javalib/src/main/scala/java/lang/process/WindowsProcessFactory.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcessFactory.scala
@@ -4,7 +4,6 @@ import java.io.FileDescriptor
 import java.lang.ProcessBuilder._
 import java.nio.file.WindowsException
 import java.util.ScalaOps._
-import java.util.concurrent.TimeUnit
 
 // Required only for cross-compilation with Scala 2
 import scala.language.existentials
@@ -25,47 +24,7 @@ import ProcessThreadsApiOps._
 import WinBaseApi._
 import WinBaseApiOps._
 
-private[process] class WindowsProcessHandle(
-    _pid: DWord,
-    handle: Handle,
-    override val builder: ProcessBuilder
-) extends GenericProcessHandle {
-  override final def pid(): Long = _pid.toLong
-
-  override def supportsNormalTermination(): Boolean = false
-
-  override protected def destroyImpl(force: Boolean): Boolean =
-    ProcessThreadsApi.TerminateProcess(handle, 1.toUInt)
-
-  override protected def close(): Unit = CloseHandle(handle)
-
-  override protected def waitForImpl(): Boolean =
-    osWaitForImpl(Constants.Infinite)
-
-  override protected def waitForImpl(timeout: Long, unit: TimeUnit): Boolean =
-    osWaitForImpl(unit.toMillis(timeout).toUInt)
-
-  private def osWaitForImpl(timeoutMillis: DWord): Boolean =
-    SynchApi.WaitForSingleObject(handle, timeoutMillis) match {
-      case SynchApiExt.WAIT_TIMEOUT => false
-      case SynchApiExt.WAIT_FAILED  =>
-        if (!hasExited)
-          throw WindowsException("Failed to wait on process handle")
-        true // someone may have closed the handle
-      case _ => checkAndSetExitCode(); true
-    }
-
-  override protected def getExitCodeImpl: Option[Int] = {
-    val exitCode: Ptr[DWord] = stackalloc[DWord]()
-    if (ProcessThreadsApi.GetExitCodeProcess(handle, exitCode)) {
-      val code = !exitCode
-      if (code != ProcessThreadsApiExt.STILL_ACTIVE) Some(code.toInt) else None
-    } else None
-  }
-
-}
-
-private[process] object WindowsProcess {
+private[process] object WindowsProcessFactory {
   type PipeHandles = CArray[Handle, Nat._2]
   private final val readEnd = 0
   private final val writeEnd = 1

--- a/javalib/src/main/scala/java/lang/process/WindowsProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcessHandle.scala
@@ -1,0 +1,53 @@
+package java.lang.process
+
+import java.nio.file.WindowsException
+import java.util.concurrent.TimeUnit
+
+// Required only for cross-compilation with Scala 2
+import scala.language.existentials
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+import scala.scalanative.windows._
+
+import HandleApi._
+
+private[process] class WindowsProcessHandle(
+    _pid: DWord,
+    handle: Handle,
+    override val builder: ProcessBuilder
+) extends GenericProcessHandle {
+  override final def pid(): Long = _pid.toLong
+
+  override def supportsNormalTermination(): Boolean = false
+
+  override protected def destroyImpl(force: Boolean): Boolean =
+    ProcessThreadsApi.TerminateProcess(handle, 1.toUInt)
+
+  override protected def close(): Unit = CloseHandle(handle)
+
+  override protected def waitForImpl(): Boolean =
+    osWaitForImpl(Constants.Infinite)
+
+  override protected def waitForImpl(timeout: Long, unit: TimeUnit): Boolean =
+    osWaitForImpl(unit.toMillis(timeout).toUInt)
+
+  private def osWaitForImpl(timeoutMillis: DWord): Boolean =
+    SynchApi.WaitForSingleObject(handle, timeoutMillis) match {
+      case SynchApiExt.WAIT_TIMEOUT => false
+      case SynchApiExt.WAIT_FAILED  =>
+        if (!hasExited)
+          throw WindowsException("Failed to wait on process handle")
+        true // someone may have closed the handle
+      case _ => checkAndSetExitCode(); true
+    }
+
+  override protected def getExitCodeImpl: Option[Int] = {
+    val exitCode: Ptr[DWord] = stackalloc[DWord]()
+    if (ProcessThreadsApi.GetExitCodeProcess(handle, exitCode)) {
+      val code = !exitCode
+      if (code != ProcessThreadsApiExt.STILL_ACTIVE) Some(code.toInt) else None
+    } else None
+  }
+
+}


### PR DESCRIPTION
Refactor GenericProcess and WindowsProcess extracting definitions of GenericProcessHandle and WindowsProcessHandle, respectively, into their own separate source files, without any other change. Purely cosmetic.