### PR TITLE
unsafe: remove extra memory copy in toCXxxString

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -53,6 +53,7 @@ object BinaryIncompatibilities {
     exclude[ReversedMissingMethodProblem]("scala.scalanative.runtime.NativeThread#Companion.defaultOSStackSize"),
     exclude[Problem]("scala.scalanative.runtime._Class.*"),
     exclude[Problem]("scala.scalanative.runtime.unwind.*"),
+    exclude[DirectMissingMethodProblem]("scala.scalanative.unsafe.package.toCWideStringImpl"),
   )
   final val CLib: Filters = Nil
 

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -21,16 +21,16 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   def isScala2_12 = ScalaNativeBuildInfo.scalaVersion.startsWith("2.12")
 
   @Test def default(): Unit = checkMinimalRequiredSymbols()(expected =
-    if (isScala3) SymbolsCount(types = 622, members = 3056)
-    else if (isScala2_13) SymbolsCount(types = 597, members = 3064)
-    else SymbolsCount(types = 694, members = 4212)
+    if (isScala3) SymbolsCount(types = 622, members = 3058)
+    else if (isScala2_13) SymbolsCount(types = 597, members = 3066)
+    else SymbolsCount(types = 694, members = 4214)
   )
 
   @Test def debugMetadata(): Unit =
     checkMinimalRequiredSymbols(withDebugMetadata = true)(expected =
-      if (isScala3) SymbolsCount(types = 622, members = 3056)
-      else if (isScala2_13) SymbolsCount(types = 597, members = 3064)
-      else SymbolsCount(types = 694, members = 4212)
+      if (isScala3) SymbolsCount(types = 622, members = 3058)
+      else if (isScala2_13) SymbolsCount(types = 597, members = 3066)
+      else SymbolsCount(types = 694, members = 4214)
     )
 
   // Only MacOS and Linux DWARF metadata currently
@@ -50,16 +50,16 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-pc-linux-gnu"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1095, members = 7032)
-      else if (isScala2_13) SymbolsCount(types = 1054, members = 7105)
-      else SymbolsCount(types = 1044, members = 7354)
+      if (isScala3) SymbolsCount(types = 1095, members = 7042)
+      else if (isScala2_13) SymbolsCount(types = 1054, members = 7111)
+      else SymbolsCount(types = 1044, members = 7362)
     )
 
   @Test def multithreading(): Unit =
     checkMinimalRequiredSymbols(withMultithreading = true)(expected =
       if (isScala3) SymbolsCount(types = 1073, members = 6674)
-      else if (isScala2_13) SymbolsCount(types = 1041, members = 6755)
-      else SymbolsCount(types = 995, members = 6826)
+      else if (isScala2_13) SymbolsCount(types = 1041, members = 6757)
+      else SymbolsCount(types = 995, members = 6828)
     )
 
   private def checkMinimalRequiredSymbols(

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
@@ -111,7 +111,7 @@ class CStringTest {
   }
 
   @Test def toCStringNullReturnsNullIssue1796(): Unit = {
-    Zone.acquire { implicit z => assertNull(toCString(null)) }
+    Zone.acquire { implicit z => assertNull(toCString(null: String)) }
   }
 
   @Test def testToCString(): Unit = {


### PR DESCRIPTION
Our implementation of String.getBytes involves calling Charset.encode and then copying the resulting ByteBuffer into a byte array.

Instead, let's encode ourselves and `memcpy` the resulting ByteBuffer.