### PR TITLE
[CI] Remove redundant cache actions, already covered by `coursier/cache-action`

### DIFF
--- a/.github/actions/linux-setup-env/action.yml
+++ b/.github/actions/linux-setup-env/action.yml
@@ -48,12 +48,3 @@ runs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         (yes "" || true) | sudo ./llvm.sh ${{ inputs.llvm-version }}
-        
-    # Loads cache with dependencies created in test-tools job
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/coursier
-          ~/.sbt/boot
-        key: ${{ runner.os }}-deps-${{ inputs.scala-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}

--- a/.github/actions/macos-setup-env/action.yml
+++ b/.github/actions/macos-setup-env/action.yml
@@ -47,12 +47,3 @@ runs:
         else 
           brew install llvm@${{ inputs.llvm-version }}
         fi
-
-    # Loads cache with dependencies created in test-tools job
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/coursier
-          ~/.sbt/boot
-        key: ${{ runner.os }}-deps-${{ inputs.scala-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}

--- a/.github/actions/windows-setup-env/action.yml
+++ b/.github/actions/windows-setup-env/action.yml
@@ -63,9 +63,7 @@ runs:
       with:
         path: |
           ${{steps.resolve-env.outputs.ProgramFiles}}\LLVM\
-          ${{steps.resolve-env.outputs.LocalAppData}}\Coursier\Cache\v1\
-          ${{steps.resolve-env.outputs.UserProfile}}\.ivy2\cache
-        key: ${{ runner.os }}-${{ inputs.scala-version }}-deps
+        key: llvm-${{ inputs.llvm-version }}
 
     # Install LLVM in case if cache is missing
     - name: Install LLVM


### PR DESCRIPTION
Fixes CI issues, I'm not sure why exactly following input is invalid on MacOs
```yaml
key: ${{ runner.os }}-deps-${{ inputs.scala-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
```

However it's already handled by `coursier/cache-action`, see https://github.com/coursier/cache-action/blob/02f666a4dac9add5772f3597ab33b6384393a55c/action.yml#L40C1-L50C16