### PR TITLE
WeakReference: fix JDK compliance w/ clear/enqueue

### DIFF
--- a/javalib/src/main/scala/java/lang/ref/WeakReference.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReference.scala
@@ -31,19 +31,19 @@ class WeakReference[T](
 
   override def get(): T = _gc_modified_referent
 
-  override def enqueue(): Boolean =
+  override def enqueue(): Boolean = {
+    clear()
     if (!enqueued && queue != null) {
       queue.enqueue(this)
       enqueued = true
       true
     } else false
+  }
 
   override def isEnqueued(): Boolean = enqueued
 
-  override def clear(): Unit = {
+  override def clear(): Unit =
     _gc_modified_referent = null.asInstanceOf[T]
-    enqueue()
-  }
 
   override private[ref] def dequeue(): Reference[T] = {
     enqueued = false

--- a/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/MinimalRequiredSymbolsTest.scala
@@ -21,16 +21,16 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
   def isScala2_12 = ScalaNativeBuildInfo.scalaVersion.startsWith("2.12")
 
   @Test def default(): Unit = checkMinimalRequiredSymbols()(expected =
-    if (isScala3) SymbolsCount(types = 622, members = 3058)
-    else if (isScala2_13) SymbolsCount(types = 597, members = 3066)
-    else SymbolsCount(types = 694, members = 4214)
+    if (isScala3) SymbolsCount(types = 635, members = 3134)
+    else if (isScala2_13) SymbolsCount(types = 609, members = 3140)
+    else SymbolsCount(types = 707, members = 4291)
   )
 
   @Test def debugMetadata(): Unit =
     checkMinimalRequiredSymbols(withDebugMetadata = true)(expected =
-      if (isScala3) SymbolsCount(types = 622, members = 3058)
-      else if (isScala2_13) SymbolsCount(types = 597, members = 3066)
-      else SymbolsCount(types = 694, members = 4214)
+      if (isScala3) SymbolsCount(types = 635, members = 3134)
+      else if (isScala2_13) SymbolsCount(types = 609, members = 3140)
+      else SymbolsCount(types = 707, members = 4291)
     )
 
   // Only MacOS and Linux DWARF metadata currently
@@ -50,16 +50,16 @@ class MinimalRequiredSymbolsTest extends LinkerSpec {
       withDebugMetadata = true,
       withTargetTriple = "x86_64-pc-linux-gnu"
     )(expected =
-      if (isScala3) SymbolsCount(types = 1095, members = 7042)
-      else if (isScala2_13) SymbolsCount(types = 1054, members = 7111)
-      else SymbolsCount(types = 1044, members = 7362)
+      if (isScala3) SymbolsCount(types = 1103, members = 7076)
+      else if (isScala2_13) SymbolsCount(types = 1061, members = 7147)
+      else SymbolsCount(types = 1052, members = 7399)
     )
 
   @Test def multithreading(): Unit =
     checkMinimalRequiredSymbols(withMultithreading = true)(expected =
-      if (isScala3) SymbolsCount(types = 1073, members = 6674)
-      else if (isScala2_13) SymbolsCount(types = 1041, members = 6757)
-      else SymbolsCount(types = 995, members = 6828)
+      if (isScala3) SymbolsCount(types = 1084, members = 6732)
+      else if (isScala2_13) SymbolsCount(types = 1052, members = 6816)
+      else SymbolsCount(types = 1007, members = 6890)
     )
 
   private def checkMinimalRequiredSymbols(

--- a/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -57,4 +57,5 @@ object Platform {
   final val hasArm64SignalQuirk = false
 
   final val isMultithreadingEnabled = true
+  final val isWeakReferenceSupported = true
 }

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/utils/Platform.scala
@@ -61,4 +61,6 @@ object Platform {
   final val isMultithreadingEnabled =
     scala.scalanative.meta.LinktimeInfo.isMultithreadingEnabled
 
+  final val isWeakReferenceSupported =
+    scala.scalanative.meta.LinktimeInfo.isWeakReferenceSupported
 }


### PR DESCRIPTION
The usual, JDK behaviour of `clear()` and `enqueue()` methods is a bit different than what was implemented in scala-native. Let's fix that and make sure to test for consistency between JDK and SN.

For that, move WeakReferenceTest to shared, but also require JDK9. JDK9 contains Cleaner and thus will allow us to test advanced logic.