### PR TITLE
Gentle some ProcessTests ScalaProcess tests

### DIFF
--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTest.scala
@@ -612,7 +612,17 @@ class ProcessTest {
     assertEquals("foo", Files.readAllLines(out).toArray().mkString)
   }
 
+  /* Problems using j.l.Process via Scala are under active investigation.
+   * Reduce the sensitivity of some '*usingScala*' Tests so to
+   * reduce the number of failures for other PRs in mainline CI for
+   * a cause known to be highly unrelated to the changes of those PRs.
+   *
+   * Use the time saved from tracing failure logs to chase the root cause.
+   */
+
+  private val gitTestIterationsSmall = 1
   private val gitTestIterations = 20
+
   private val githubWorkspace =
     Paths.get(sys.env.get("GITHUB_WORKSPACE").getOrElse("."))
 
@@ -760,7 +770,6 @@ class ProcessTest {
       assertTrue(s"$prefix`git log` exited", !proc.isAlive)
       assertEquals(s"$prefix`git log` exit code", 128, proc.exitValue())
     }
-
   }
 
   @Test def testGitLsFilesUsingScalaProcessRun(
@@ -783,7 +792,7 @@ class ProcessTest {
   }
 
   @Test def testGitInitUsingScalaProcessRun(
-  ): Unit = (0 until gitTestIterations).foreach { iter =>
+  ): Unit = (0 until gitTestIterationsSmall).foreach { iter =>
 
     val prefix = s"[iter=$iter ${new java.io.File(".").getAbsolutePath}] "
     val dir = Files.createTempDirectory("test-")
@@ -858,11 +867,10 @@ class ProcessTest {
         stderr
       )
     }
-
   }
 
   @Test def testGitLsFilesUsingScalaProcessBang(
-  ): Unit = (0 until gitTestIterations).foreach { iter =>
+  ): Unit = (0 until gitTestIterationsSmall).foreach { iter =>
 
     val prefix =
       s"[iter=$iter ${new java.io.File(".").getAbsolutePath}] `git ls-files`"
@@ -881,7 +889,7 @@ class ProcessTest {
   }
 
   @Test def testGitInitUsingScalaProcessBang(
-  ): Unit = (0 until gitTestIterations).foreach { iter =>
+  ): Unit = (0 until gitTestIterationsSmall).foreach { iter =>
 
     val prefix = s"[iter=$iter ${new java.io.File(".").getAbsolutePath}] "
     val dir = Files.createTempDirectory("test-")
@@ -959,11 +967,10 @@ class ProcessTest {
         stderr
       )
     }
-
   }
 
   @Test def testGitLsFilesUsingScalaProcessBangBang(
-  ): Unit = (0 until gitTestIterations).foreach { iter =>
+  ): Unit = (0 until gitTestIterationsSmall).foreach { iter =>
 
     val prefix =
       s"[iter=$iter ${new java.io.File(".").getAbsolutePath}] `git ls-files`"
@@ -981,7 +988,7 @@ class ProcessTest {
   }
 
   @Test def testGitInitUsingScalaProcessBangBang(
-  ): Unit = (0 until gitTestIterations).foreach { iter =>
+  ): Unit = (0 until gitTestIterationsSmall).foreach { iter =>
 
     val prefix = s"[iter=$iter ${new java.io.File(".").getAbsolutePath}] "
     val dir = Files.createTempDirectory("test-")
@@ -1063,7 +1070,6 @@ class ProcessTest {
         stderr
       )
     }
-
   }
 
 }


### PR DESCRIPTION
Several problems presented by javalib  `ProcessTest` are under active investigation.

CI failures in other PRs due to 'known to exist' `ProcessTest` problems  costs
time all around and delays finding and fixing the underling defect or defects in `Process`.

Reduce the sensitivity of some tests in CI. They can still be run at full sensitivity
by developers chasing defects.

The intermittent failures seem to involved timeouts due to unexpectedly long times taken 
for a process to exit and return a value to the SN code. A 'fat tail'
of latencies, possibly extending to Infinity.

The tests involved are intended to execute tests in a loop in order to detect
intermittent failures.   They are/were doing there job well and detecting failures.
How they were doing so in a neighborhood where such were not directly relevant.

These problems seem to more readily occur when `scala.sys.process` is used.  
