### PR TITLE
WindowsProcessHandle: use ProcessExitChecker

### DIFF
--- a/javalib/src/main/scala/java/lang/process/ProcessExitChecker.scala
+++ b/javalib/src/main/scala/java/lang/process/ProcessExitChecker.scala
@@ -49,8 +49,8 @@ private[process] object ProcessExitChecker {
       Some(ProcessExitCheckerFreeBSD) // Other BSDs should work but untested
     else None
 
-  val factoryOpt: Option[Factory] =
-    if (LinktimeInfo.isWindows) None
-    else unixFactoryOpt.orElse(Some(ProcessExitCheckerWaitpid))
+  val factory: Factory =
+    if (LinktimeInfo.isWindows) WindowsProcessHandle.ProcessExitCheckerFactory
+    else unixFactoryOpt.getOrElse(ProcessExitCheckerWaitpid)
 
 }

--- a/javalib/src/main/scala/java/lang/process/ProcessRegistry.scala
+++ b/javalib/src/main/scala/java/lang/process/ProcessRegistry.scala
@@ -1,5 +1,12 @@
 package java.lang.process
 
 private[process] trait ProcessRegistry {
-  def completeWith(pid: Long)(ec: Int): Unit
+
+  /** Tries to complete the process.
+   *  @param ec
+   *    exit code, if non-negative; otherwise, request to check for it
+   *  @return
+   *    true if completed only now for non-negative [[ec]], and exited otherwise
+   */
+  def completeWith(pid: Long)(ec: Int): Boolean
 }


### PR DESCRIPTION
This now allows us to move to GenericProcessHandle the logic of waiting for the process to exit.