### PR TITLE
Cleaner: define own subclass of WeakReference

### DIFF
--- a/javalib/src/main/scala/java/lang/ref/Cleaner.scala
+++ b/javalib/src/main/scala/java/lang/ref/Cleaner.scala
@@ -13,7 +13,7 @@ final class Cleaner private {
   def register(ref: AnyRef, action: Runnable): Cleaner.Cleanable = {
     val cleanable = new Cleaner.CleanableImpl(action)
     // registers itself in WeakReferenceRegistry
-    new WeakReference(ref) { postGCHandler = cleanable.clean }
+    new Cleaner.CleanableReference(ref, cleanable)
     cleanable
   }
 
@@ -39,6 +39,14 @@ object Cleaner {
         "Can't create Cleaner with a ThreadFactory"
       )
     create()
+  }
+
+  private class CleanableReference(ref: AnyRef, cleanable: Cleanable)
+      extends WeakReference[AnyRef](ref) {
+    override def clear(): Unit = {
+      super.clear()
+      cleanable.clean()
+    }
   }
 
   private class CleanableImpl(action: Runnable) extends Cleanable {

--- a/javalib/src/main/scala/java/lang/ref/WeakReference.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReference.scala
@@ -26,8 +26,6 @@ class WeakReference[T](
 
   // A next weak reference in the form linked-list used by WeakReferenceRegistry
   @volatile private[ref] var nextReference: WeakReference[_] = _
-  // Callback registered for given WeakReference, called after WeakReference pointee would be garbage collected
-  @volatile private[java] var postGCHandler: () => Unit = _
 
   override def get(): T = _gc_modified_referent
 

--- a/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
@@ -43,18 +43,6 @@ private[java] object WeakReferenceRegistry {
         if (null != current.get()) head
         else {
           current.enqueue()
-          val handler = current.postGCHandler
-          if (handler != null) {
-            current.postGCHandler = null
-            try handler()
-            catch {
-              case NonFatal(err) =>
-                val thread = Thread.currentThread()
-                thread
-                  .getUncaughtExceptionHandler()
-                  .uncaughtException(thread, err)
-            }
-          }
           if (prev == null) next
           else {
             prev.nextReference = next


### PR DESCRIPTION
This allows us to remove a "special" field within official WeakReference used for post-garbage-collection cleaning. Instead, this new subclass overrides the `clear()` method and calls the cleanable action.