### PR TITLE
Cleaner: use own thread, not shared ForkJoinPool

### DIFF
--- a/javalib/src/main/scala/java/lang/ref/Cleaner.scala
+++ b/javalib/src/main/scala/java/lang/ref/Cleaner.scala
@@ -4,41 +4,66 @@ import java.util.concurrent._
 
 import scala.scalanative.meta.LinktimeInfo
 
-final class Cleaner private {
+final class Cleaner private (executor: Executor) {
 
   /** Registers a destructor after `ref` has been garbage collected.
    *
    *  NB: the destructor may not refer to `ref`, or GC will never happen.
    */
-  def register(ref: AnyRef, action: Runnable): Cleaner.Cleanable = {
-    val cleanable = new Cleaner.CleanableImpl(action)
-    // registers itself in WeakReferenceRegistry
-    new Cleaner.CleanableReference(ref, cleanable)
-    cleanable
-  }
+  def register(ref: AnyRef, action: Runnable): Cleaner.Cleanable =
+    Cleaner.register(ref, action, executor)
 
 }
 
 object Cleaner {
 
+  private val defaultFactory =
+    if (LinktimeInfo.isMultithreadingEnabled && LinktimeInfo.isWeakReferenceSupported)
+      Thread
+        .ofPlatform()
+        .daemon()
+        .group(ThreadGroup.System)
+        .name("GC-WeakReferenceCleaner", 0)
+        .factory()
+    else null
+
+  private val parasiticExecutor = new Executor {
+    override def execute(action: Runnable): Unit =
+      try action.run()
+      catch {
+        case ex: Throwable if !ex.isInstanceOf[InterruptedException] =>
+      }
+  }
+
   trait Cleanable {
     def clean(): Unit
   }
 
-  def create(): Cleaner = {
+  def create(factory: ThreadFactory): Cleaner = {
     if (!LinktimeInfo.isWeakReferenceSupported)
       throw new UnsupportedOperationException(
         "Can't create Cleaner, not supported by this GC"
       )
-    new Cleaner
+
+    val executor: Executor =
+      if (factory eq null) parasiticExecutor
+      else {
+        val executor = Executors.newSingleThreadExecutor(factory)
+        // clean the executor as well
+        register(executor, () => executor.shutdown(), parasiticExecutor)
+        executor
+      }
+
+    new Cleaner(executor)
   }
 
-  def create(factory: ThreadFactory): Cleaner = {
-    if (null ne factory)
-      throw new UnsupportedOperationException(
-        "Can't create Cleaner with a ThreadFactory"
-      )
-    create()
+  def create(): Cleaner = create(defaultFactory)
+
+  private def register(ref: AnyRef, action: Runnable, executor: Executor) = {
+    val cleanable = new CleanableImpl(action, executor)
+    // registers itself in WeakReferenceRegistry
+    new CleanableReference(ref, cleanable)
+    cleanable
   }
 
   private class CleanableReference(ref: AnyRef, cleanable: Cleanable)
@@ -49,18 +74,13 @@ object Cleaner {
     }
   }
 
-  private class CleanableImpl(action: Runnable) extends Cleanable {
+  private class CleanableImpl(action: Runnable, executor: Executor)
+      extends Cleanable {
     private val done = new atomic.AtomicBoolean(false)
 
     override def clean(): Unit = {
       if (done.compareAndSet(expectedValue = false, newValue = true))
-        if (LinktimeInfo.isMultithreadingEnabled)
-          CompletableFuture.runAsync(action)
-        else
-          try action.run()
-          catch {
-            case ex: Throwable if !ex.isInstanceOf[InterruptedException] =>
-          }
+        executor.execute(action)
     }
   }
 


### PR DESCRIPTION
The typical approach is to have a single thread for all cleaning and not encroach on the shared pool.