### PR TITLE
ReferenceQueue: `timeout == 0` should be infinite

### DIFF
--- a/javalib/src/main/scala/java/lang/ref/ReferenceQueue.scala
+++ b/javalib/src/main/scala/java/lang/ref/ReferenceQueue.scala
@@ -23,7 +23,7 @@ class ReferenceQueue[T] {
   def remove(): Reference[_ <: T] = remove(None)
   def remove(timeout: Long): Reference[_ <: T] = {
     if (timeout < 0) throw new IllegalArgumentException()
-    remove(Some(timeout))
+    remove(if (timeout == 0) None else Some(timeout))
   }
 
   private def remove(timeout: Option[Long]): Reference[_ <: T] =


### PR DESCRIPTION
Improve JDK compliance by treating timeout of 0 as no timeout.