### PR TITLE
javalib UnixProcessFactory now constructs proper argv & envp

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcessFactory.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcessFactory.scala
@@ -266,10 +266,11 @@ private[process] object UnixProcessFactory {
   )(implicit z: Zone) = {
     val res: Ptr[CString] = alloc[CString]((list.size() + 1))
     val li = list.listIterator()
-    while (li.hasNext())
-      !(res + li.nextIndex()) = toCString(li.next())
 
-    !(res + list.size()) = null // NULL ptr, not NUL character (ASCII 0)
+    while (li.hasNext())
+      res.update(li.nextIndex(), toCString(li.next()))
+
+    res.update(li.nextIndex(), null) // NULL ptr, not NUL character (ASCII 0)
     res
   }
 


### PR DESCRIPTION
unix-like systems pass argv and envp to posix_spawn and the exec* functions as an array of
pointers to char, where the final element of that array is a null pointer (not NUL char).

javalib UnixProcessFactory now constructs argv and envp to follow this long standing unix-like
practice.  

Previously, the final null pointer was not being set.   

This Heisenbug appears to have been present for a long time. I went as far back as February 2019
and it was present there.  From the coding style, it appears to long pre-date that.

I believe for a while 'alloc' was defined to return zero'd memory.  An intermediate re-write
would have been correct if/while that was true. 

 I believe that at some point 'alloc' was changed to the more efficient & reasonable 'undefined memory'.
The documentary history is lost to the mists of time and switches in repositories. 

When 'alloc' returns non-zeroed memory the contents of the  final position became unreliable.
When the Runtime is young, the contents of that memory are likely to be zero. As the Runtime
ages, it can recycle previously used non-zero memory. Can you say SEGV?

Heavier loads and longer Runtime lifetimes would have made this bug more likely to appear.  