### PR TITLE
Add @blocking annotation to unistd chdir & fchdir

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -50,9 +50,12 @@ object unistd {
   def access(pathname: CString, mode: CInt): CInt = extern
   def alarm(seconds: CUnsignedInt): CUnsignedInt = extern
 
+  @blocking
   def chdir(path: CString): CInt = extern
+
   @deprecated("Deprecated in POSIX standard", since = "POSIX.1-2001")
   def chroot(path: CString): CInt = extern
+
   def chown(path: CString, owner: uid_t, group: gid_t): CInt = extern
   def close(fildes: CInt): CInt = extern
   def confstr(name: CInt, buf: Ptr[CChar], len: size_t): size_t = extern
@@ -78,7 +81,10 @@ object unistd {
   def execvp(file: CString, argv: Ptr[CString]): CInt = extern
 
   def faccessat(fd: CInt, path: CString, amode: CInt, flag: CInt): CInt = extern
+
+  @blocking
   def fchdir(fildes: CInt): CInt = extern
+
   def fchown(filedes: CInt, owner: uid_t, group: gid_t): CInt = extern
   def fchownat(
       fd: CInt,


### PR DESCRIPTION
posixlib unistd.scala methods `chdir` and `fchdir` now bear an `@blocking` annotation.

Without the annotation `os-lib` code would fail intermittently, especially when stressed
by repeated invocations.  Sometimes the failure would occur after a few tens of iterations,
somtimes after a few hundred.  I never reached the 4000 iteration level that passed using
JVM.

It has taken 6+ months of concentrated effort to find this defect.

Next session I will start an Issue to track the question of if any other methods
in unistd.scala would benefit from `@blocking`.

##### Testing

1. Exiting CI `ProcessTest` code exercises at least the `chdir` change.

2. Manual `ProcessTest` runs using  this fix now succeed
    at a 1000+ iterations for each of usingJava and usingScala tests. In CI, the values for
    these had been reduced over the past few weeks to 20 and 1, because the latter was failing 
    so frequently. 

3. Manual tests of repeated iterations of `os-lib` `SubprocessTests` using this PR
    now succeed (on macOS)  at least the 4024 level.  

    Why 4000? Because it is more that twice the intermittent highwater mark and two orders of magnitude greater
    that the usual count to failure. 

    `os-lib` stress tests may yet reveal additional Scala Native bugs.
    
4. It is unclear to me exactly what was causing the hang.  Garbage collection could have been hitting 
    at exactly the wrong time. The problem only showed after a number (a hundred or so, per SN Runtime activation)
    of `Process`es had been created.  I do know that the hang ceased after I either commented out the 'chdir' or
    added `@blocking`.  I usually like to know the primal defect but I'll take a win here if I can get it.