### PR TITLE
StackTrace: avoid NPE in early initialization

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/StackTrace.scala
@@ -43,6 +43,9 @@ private[runtime] object StackTrace {
     def emptyStackTrace = scala.Array.emptyLongArray
 
     val thread = NativeThread.currentNativeThread
+    if (null eq thread)
+      return emptyStackTrace
+
     if (thread.isFillingStackTrace)
       return emptyStackTrace
 
@@ -136,6 +139,8 @@ private[runtime] object StackTrace {
       .asInstanceOf[scala.Array[StackTraceElement]]
     // Used to prevent filling stacktraces inside `currentStackTrace` which might lead to infinite loop
     val thread = NativeThread.currentNativeThread
+    if (null eq thread)
+      return emptyStackTrace
     if (thread.isFillingStackTrace)
       return emptyStackTrace
     if (LinktimeInfo.asanEnabled)


### PR DESCRIPTION
There have been cases, such as with GC callback initialization in the wrong order, when an exception is thrown somewhat early, before a native thread is initialized, which causes this part of code throw an NPE, which in turn enters this same code for the NPE, and so on.