### PR TITLE
Reduce unproductive delay time in Java 'ProcessTestOnJDK9#runPingWith'

### DIFF
--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK9.scala
@@ -155,7 +155,7 @@ class ProcessTestOnJDK9 {
   }
 
   private def runPingWith(redirect: ProcessBuilder.Redirect): String = {
-    // Child sends one ping packet to IPv4 localhost and returns the output.
+    // Child sends one ping packet to IPv4 localhost; then returns the output.
     val countOption = if (Platform.isWindows) "-n" else "-c"
     val argv = Seq("ping", countOption, "1", "127.0.0.1")
 


### PR DESCRIPTION
Only one request-response cycle is needed in order to satisfy the intent of the Tests 
using Java `ProcessTestOnJDK9#runPingWith'. Any time spent waiting or delayed
in the child process after that yields no information and is wasted.

Twenty-ish seconds saved is twenty-ish seconds earned. Pretty soon you will 
have an eon, especially if you are running the tests Interactively.

Also provided a timeout for `waitfor()` at the bottom of the method. The timeout lays a trap for process exit logic 
which take an apparently in-ordinate amount of time.  Agreed, a slight deviation from the design center of 
'unity of purpose'  for a good test.

If a 5 second delay proves not sufficient, that is probably revealing one or more 'tail latency'
problems in the `Process` logic, probably it Future completion and or pipe draining & closing logic.
We probably want to know about that, __not increase the timeout__.