### PR TITLE
[nscplugin] When testing isExtern check original owner instead of current one

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -24,8 +24,9 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
       (isScalaModule || sym.isTraitOrInterface) &&
         sym.annotations.exists(_.symbol == ExternClass)
 
-    def isExtern: Boolean = (sym.isExternType || sym.owner.isExternType) &&
-      !sym.annotations.exists(_.symbol == NonExternClass)
+    def isExtern: Boolean =
+      (sym.isExternType || sym.originalOwner.isExternType) &&
+        !sym.annotations.exists(_.symbol == NonExternClass)
 
     def isBlocking: Boolean =
       sym.annotations.exists(_.symbol == BlockingClass)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -49,7 +49,7 @@ trait NirGenType(using Context) {
       sym.is(JavaStatic) || sym.isScalaStatic || sym.isExtern
 
     def isExtern: Boolean = sym.exists && {
-      sym.owner.isExternType ||
+      sym.originalOwner.isExternType ||
       sym.hasAnnotation(defnNir.ExternClass) ||
       (sym.is(Accessor) && sym.field.isExtern)
       // NonExtern is added PrepNativeInterop

--- a/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/nscplugin/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -857,4 +857,19 @@ class NIRCompilerTest {
       )
     )
   }
+
+  @Test def issue4709(): Unit = {
+    // Crashed becouse clouse call to static method of non extern EasyBeast$BeastBody$anon was checked after moving it to owner EasyBeast$ which is extern
+    NIRCompiler(
+      _.compile(
+        """|import scala.scalanative.unsafe.extern
+           |@extern object EasyBeast {
+           |  object BeastBody {
+           |    def apply(arg: Option[Int]): Option[Int] = arg.map(_ + 1)
+           |  }
+           |}
+           |""".stripMargin
+      )
+    )
+  }
 }


### PR DESCRIPTION
The current owner of the method could have changed, for example anonynomous functions are moved from nested object to the top-level object. This lead to crash due to broken assertion

Fixes #4709

To be discussed if `@extern object` should be allowed to contain non-extern`object` - so far it does not seem to be an issue at runtime