### PR TITLE
Fix #4743: javalib *Stream#distinct spliterator characteristics now match JVM.

### DIFF
--- a/javalib/src/main/scala/java/util/stream/IntStreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/IntStreamImpl.scala
@@ -264,13 +264,17 @@ private[stream] class IntStreamImpl(
 
     val seenElements = new ju.HashSet[scala.Int]()
 
-    // Some items may be dropped, so the estimated size is a high bound.
-    val estimatedSize = _spliter.estimateSize()
-
+    /* Create an unsized spliterator with characteristics matching JVM.
+     * One would expect DISTINCT here. JVM does that for streams of Object,
+     * but not for streams of primitives, double, int, long
+     */
     val spl =
       new Spliterators.AbstractIntSpliterator(
-        estimatedSize,
-        _spliter.characteristics()
+        Long.MaxValue,
+        Spliterators.maskOff(
+          _spliter.characteristics(),
+          Spliterators.sizedCharacteristicsMask | Spliterator.IMMUTABLE
+        )
       ) {
         def tryAdvance(action: IntConsumer): Boolean = {
           var success = false

--- a/javalib/src/main/scala/java/util/stream/StreamImpl.scala
+++ b/javalib/src/main/scala/java/util/stream/StreamImpl.scala
@@ -265,13 +265,14 @@ private[stream] class StreamImpl[T](
 
     val seenElements = new ju.HashSet[T]()
 
-    // Some items may be dropped, so the estimated size is a high bound.
-    val estimatedSize = _spliter.estimateSize()
-
+    // Create an unsized spliterator with characteristics matching JVM.
     val spl =
       new Spliterators.AbstractSpliterator[T](
-        estimatedSize,
-        _spliter.characteristics()
+        Long.MaxValue,
+        Spliterators.maskOff(
+          _spliter.characteristics(),
+          Spliterators.sizedCharacteristicsMask | Spliterator.IMMUTABLE
+        ) | Spliterator.DISTINCT
       ) {
         def tryAdvance(action: Consumer[_ >: T]): Boolean = {
           var success = false

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTestOnJDK16.scala
@@ -90,4 +90,28 @@ class DoubleStreamTestOnJDK16 {
     for (j <- 0 until expectedCount)
       assertEquals("contents j: $j", expectedData(j), filtered(j), 0.0)
   }
+
+  // SN Issue 4743
+  @Test def streamDistinct_ShrinkingDownstream(): Unit = {
+
+    val ds = DoubleStream.of(
+      5.5, 0.0, 4.4, -1.1, -1.1, 4.4, -2.2, -2.2, 3.3, 4.4
+    )
+
+    val expectedCount = 6
+
+    val expectedData = new Array[scala.Double](expectedCount)
+    expectedData(0) = 5.5
+    expectedData(1) = 0.0
+    expectedData(2) = 4.4
+    expectedData(3) = -1.1
+    expectedData(4) = -2.2
+    expectedData(5) = 3.3
+
+    val distinctElements: Array[scala.Double] = ds.distinct().toArray()
+
+    assertEquals("distinct size", expectedCount, distinctElements.size)
+    for (j <- 0 until expectedCount)
+      assertEquals("contents j: $j", expectedData(j), distinctElements(j), 0.0)
+  }
 }

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/IntStreamTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/IntStreamTestOnJDK16.scala
@@ -74,7 +74,7 @@ class IntStreamTestOnJDK16 {
   // SN Issue 4742
   @Test def streamFilter_ShrinkingDownstream(): Unit = {
 
-    val ds = IntStream.of(
+    val is = IntStream.of(
       55, 44, -11, 0, -22, 33
     )
 
@@ -84,10 +84,34 @@ class IntStreamTestOnJDK16 {
     expectedData(0) = -11
     expectedData(1) = -22
 
-    val filtered: Array[scala.Int] = ds.filter(i => i < 0).toArray()
+    val filtered: Array[scala.Int] = is.filter(i => i < 0).toArray()
 
     assertEquals("filtered size", expectedCount, filtered.size)
     for (j <- 0 until expectedCount)
       assertEquals("contents j: $j", expectedData(j), filtered(j))
+  }
+
+  // SN Issue 4743
+  @Test def streamDistinct_ShrinkingDownstream(): Unit = {
+
+    val is = IntStream.of(
+      55, 0, 44, -11, -11, 44, -22, -22, 33, 44
+    )
+
+    val expectedCount = 6
+
+    val expectedData = new Array[scala.Int](expectedCount)
+    expectedData(0) = 55
+    expectedData(1) = 0
+    expectedData(2) = 44
+    expectedData(3) = -11
+    expectedData(4) = -22
+    expectedData(5) = 33
+
+    val distinctElements: Array[scala.Int] = is.distinct().toArray()
+
+    assertEquals("distinct size", expectedCount, distinctElements.size)
+    for (j <- 0 until expectedCount)
+      assertEquals("contents j: $j", expectedData(j), distinctElements(j))
   }
 }

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/LongStreamTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/LongStreamTestOnJDK16.scala
@@ -74,7 +74,7 @@ class LongStreamTestOnJDK16 {
   // SN Issue 4742
   @Test def streamFilter_ShrinkingDownstream(): Unit = {
 
-    val ds = LongStream.of(
+    val ls = LongStream.of(
       55L, 44L, -11L, 0L, -22L, 33L
     )
 
@@ -84,10 +84,34 @@ class LongStreamTestOnJDK16 {
     expectedData(0) = -11
     expectedData(1) = -22
 
-    val filtered: Array[scala.Long] = ds.filter(i => i < 0L).toArray()
+    val filtered: Array[scala.Long] = ls.filter(i => i < 0L).toArray()
 
     assertEquals("filtered size", expectedCount, filtered.size)
     for (j <- 0 until expectedCount)
       assertEquals("contents j: $j", expectedData(j), filtered(j))
+  }
+
+  // SN Issue 4743
+  @Test def streamDistinct_ShrinkingDownstream(): Unit = {
+
+    val ls = LongStream.of(
+      55L, 0L, 44L, -11L, -11L, 44L, -22L, -22L, 33L, 44L
+    )
+
+    val expectedCount = 6
+
+    val expectedData = new Array[scala.Long](expectedCount)
+    expectedData(0) = 55L
+    expectedData(1) = 0L
+    expectedData(2) = 44L
+    expectedData(3) = -11L
+    expectedData(4) = -22L
+    expectedData(5) = 33L
+
+    val distinctElements: Array[scala.Long] = ls.distinct().toArray()
+
+    assertEquals("distinct size", expectedCount, distinctElements.size)
+    for (j <- 0 until expectedCount)
+      assertEquals("contents j: $j", expectedData(j), distinctElements(j))
   }
 }

--- a/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/StreamTestOnJDK16.scala
+++ b/unit-tests/shared/src/test/require-jdk16/org/scalanative/testsuite/javalib/util/stream/StreamTestOnJDK16.scala
@@ -248,8 +248,8 @@ class StreamTestOnJDK16 {
   }
 
   // SN Issue 4742
-  @Test def streamFilter_ToList(): Unit = {
-    /* Issue 4742 provided reproducion code which used Stream.toList().
+  @Test def streamFilter_ShrinkingDownstream(): Unit = {
+    /* Issue 4742 provided reproduction code which used Stream.toList().
      * That method was introduced in JDK 16. The fundamental defect
      * was in Stream.filter(), which goes back to JDK 8.  Exercise
      * the fix here, as well as in StreamTest. The Test here stays
@@ -261,7 +261,21 @@ class StreamTestOnJDK16 {
 
     val afterFilter = list.stream().filter(i => i.length < 3).toList()
 
-    assertEquals("filtered size", 3, afterFilter.size)
+    assertEquals("filtered size", expectedList.size, afterFilter.size)
     assertEquals("contents", expectedList, afterFilter)
+  }
+
+  // SN Issue 4743
+  @Test def streamDistinct_ShrinkingDownstream(): Unit = {
+    // See notes in streamFilter_ToList test. Same song, next verse.
+
+    val list = List.of("A", "D", "B", "C", "C", "B", "D", "E", "E")
+
+    val expectedList = List.of("A", "D", "B", "C", "E")
+
+    val distinctElements = list.stream().distinct().toList()
+
+    assertEquals("distinct size", expectedList.size, distinctElements.size)
+    assertEquals("contents", expectedList, distinctElements)
   }
 }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/DoubleStreamTest.scala
@@ -769,6 +769,23 @@ class DoubleStreamTest {
     assertTrue("expectedSet has remaining elements", expectedSet.isEmpty())
   }
 
+  // Issue #4743
+  @Test def doubleStreamDistinct_Characteristics(): Unit = {
+
+    val ds = DoubleStream.of(
+      5.5, 0.0, 4.4, -1.1, -1.1, 4.4, -2.2, -2.2, 3.3, 4.4
+    )
+
+    val spliter = ds.distinct().spliterator()
+
+    // No DISTINCT, inconsistent with Stream#distinct
+    StreamTestHelpers.verifyCharacteristics(
+      spliter,
+      Seq(Spliterator.ORDERED), // must be present
+      Seq(Spliterator.SIZED, Spliterator.SUBSIZED) // must be absent
+    )
+  }
+
   @Test def doubleStreamFindAny_Null(): Unit = {
     val s = DoubleStream.of(null.asInstanceOf[Double])
     // Double nulls get seen as 0.0

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/IntStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/IntStreamTest.scala
@@ -397,7 +397,7 @@ class IntStreamTest {
     assertFalse("stream should be empty", it.hasNext())
   }
 
-  @Test def doubleStreamGenerate(): Unit = {
+  @Test def intStreamGenerate(): Unit = {
     val nElements = 5
     val data = new Array[Int](nElements)
     data(0) = 0
@@ -870,6 +870,23 @@ class IntStreamTest {
     assertTrue("expectedSet has remaining elements", expectedSet.isEmpty())
   }
 
+  // Issue #4743
+  @Test def intStreamDistinct_Characteristics(): Unit = {
+
+    val is = IntStream.of(
+      55, 0, 44, -11, -11, 44, -22, -22, 33, 44
+    )
+
+    val spliter = is.distinct().spliterator()
+
+    // No DISTINCT, inconsistent with Stream#distinct
+    StreamTestHelpers.verifyCharacteristics(
+      spliter,
+      Seq(Spliterator.ORDERED), // must be present
+      Seq(Spliterator.SIZED, Spliterator.SUBSIZED) // must be absent
+    )
+  }
+
   @Test def intStreamFindAny_Null(): Unit = {
     val s = IntStream.of(null.asInstanceOf[Int])
     // Int nulls get seen as 0
@@ -935,12 +952,12 @@ class IntStreamTest {
   }
 
   // Issue #4742 - see also primary reproduction in IntStreamTestOnJDK16
-  @Test def doubleStreamFilter_Characteristics(): Unit = {
+  @Test def intStreamFilter_Characteristics(): Unit = {
     val expectedCount = 2
 
-    val ds = IntStream.of(55, 44, -11, 0, -22, 33)
+    val is = IntStream.of(55, 44, -11, 0, -22, 33)
 
-    val spliter = ds.filter((d: scala.Int) => d < 0).spliterator()
+    val spliter = is.filter((d: scala.Int) => d < 0).spliterator()
 
     StreamTestHelpers.verifyCharacteristics(
       spliter,

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/LongStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/LongStreamTest.scala
@@ -397,14 +397,14 @@ class LongStreamTest {
     assertFalse("stream should be empty", it.hasNext())
   }
 
-  @Test def doubleStreamGenerate(): Unit = {
+  @Test def longStreamGenerate(): Unit = {
     val nElements = 5
     val data = new Array[Long](nElements)
-    data(0) = 0
-    data(1) = 11
-    data(2) = 22
-    data(3) = 33
-    data(4) = 44
+    data(0) = 0L
+    data(1) = 11L
+    data(2) = 22L
+    data(3) = 33L
+    data(4) = 44L
 
     val src = new LongSupplier() {
       var count = -1
@@ -519,11 +519,11 @@ class LongStreamTest {
     assertEquals(s"unexpected range count", expectedCount, count)
   }
 
-  @Test def intStreamRangeClosed(): Unit = {
+  @Test def longStreamRangeClosed(): Unit = {
 
-    val startInclusive = 5
-    val endInclusive = 15
-    val expectedCount = endInclusive - startInclusive + 1
+    val startInclusive = 5L
+    val endInclusive = 15L
+    val expectedCount = endInclusive - startInclusive + 1L
 
     val s = LongStream.rangeClosed(startInclusive, endInclusive)
 
@@ -599,11 +599,11 @@ class LongStreamTest {
     assertFalse("unexpected predicate failure", matched)
   }
 
-  @Test def intStreamAsDoubleStream(): Unit = {
+  @Test def longStreamAsDoubleStream(): Unit = {
     val nElements = 4
     var count = 0
 
-    val s0 = LongStream.of(11, 22, 33, 44L)
+    val s0 = LongStream.of(11L, 22L, 33L, 44L)
 
     val s1 = s0.asDoubleStream()
 
@@ -842,6 +842,23 @@ class LongStreamTest {
     assertTrue("expectedSet has remaining elements", expectedSet.isEmpty())
   }
 
+  // Issue #4743
+  @Test def longStreamDistinct_Characteristics(): Unit = {
+
+    val ls = LongStream.of(
+      55L, 0L, 44L, -11L, -11L, 44L, -22L, -22L, 33L, 44L
+    )
+
+    val spliter = ls.distinct().spliterator()
+
+    // No DISTINCT, inconsistent with Stream#distinct
+    StreamTestHelpers.verifyCharacteristics(
+      spliter,
+      Seq(Spliterator.ORDERED), // must be present
+      Seq(Spliterator.SIZED, Spliterator.SUBSIZED) // must be absent
+    )
+  }
+
   @Test def longStreamFindAny_Null(): Unit = {
     val s = LongStream.of(null.asInstanceOf[Long])
     // Long nulls get seen as 0
@@ -907,14 +924,14 @@ class LongStreamTest {
   }
 
   // Issue #4742 - see also primary reproduction in LongStreamTestOnJDK16
-  @Test def doubleStreamFilter_Characteristics(): Unit = {
+  @Test def longStreamFilter_Characteristics(): Unit = {
     val expectedCount = 2
 
-    val ds = LongStream.of(
+    val ls = LongStream.of(
       55L, 44L, -11L, 0L, -22L, 33L
     )
 
-    val spliter = ds.filter((d: scala.Long) => d < 0L).spliterator()
+    val spliter = ls.filter((d: scala.Long) => d < 0L).spliterator()
 
     StreamTestHelpers.verifyCharacteristics(
       spliter,

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/stream/StreamTest.scala
@@ -712,6 +712,20 @@ class StreamTest {
     assertTrue("expectedSet has remaining elements", expectedSet.isEmpty())
   }
 
+  // Issue #4743
+  @Test def streamDistinct_Characteristics(): Unit = {
+
+    val s0 = jus.Stream.of[String]("AA", "B", "AA", "CC", "D", "EE", "F", "G")
+
+    val spliter = s0.distinct().spliterator()
+
+    StreamTestHelpers.verifyCharacteristics(
+      spliter,
+      Seq(Spliterator.DISTINCT, Spliterator.ORDERED), // must be present
+      Seq(Spliterator.SIZED, Spliterator.SUBSIZED) // must be absent
+    )
+  }
+
   @Test def streamFindAny_Null(): Unit = {
     val s = Stream.of(null.asInstanceOf[String], "NULL")
     assertThrows(classOf[NullPointerException], s.findAny())


### PR DESCRIPTION
Fix #4743

The characteristics of the spliterator of the stream returned by
javalib {Stream, DoubleStream, LongStream, IntStream}#double now matches those of the JVM.

See closely related PR #4744 for background & details.

* Also did some housekeeping such as  making variable and method names sensible for
  the file in which they occur and removing long cut & paste errors from when the original
  code was propagated from `Stream*`.