### PR TITLE
Fix #4747: `genIf` incorrectly forces `Unit` type when only one branch is `Unit`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -234,7 +234,7 @@ object BooleanArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(1 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -305,7 +305,7 @@ object CharArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(2 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -376,7 +376,7 @@ object ByteArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(1 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -447,7 +447,7 @@ object ShortArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(2 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -518,7 +518,7 @@ object IntArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(4 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -589,7 +589,7 @@ object LongArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(8 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -660,7 +660,7 @@ object FloatArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(4 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -731,7 +731,7 @@ object DoubleArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(8 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -802,7 +802,7 @@ object ObjectArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(castRawSizeToInt(Intrinsics.sizeOf[RawPtr]) * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }
@@ -895,7 +895,7 @@ object BlobArray {
       val dst  = arr.atRawUnsafe(0)
       val src  = data
       val size = castIntToRawSizeUnsigned(1 * length)
-      ffi.memcpy(dst, src, size)
+      ffi.memcpy(dst, src, size): Unit
     }
     arr
   }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -215,7 +215,7 @@ package object unsafe extends unsafe.UnsafePackageCompat {
     // Set null termination bytes (z.alloc does not initialize memory)
     val cstrEndRaw = elemRawPtr(cstr.rawptr, size)
     if (charSize == 1) storeByte(cstrEndRaw, 0) // most common case
-    else ffi.memset(cstrEndRaw, 0, charSize.toRawSize)
+    else ffi.memset(cstrEndRaw, 0, charSize.toRawSize): Unit
 
     cstr
   }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -230,11 +230,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genIf(tree: If): nir.Val = {
       val If(cond, thenp, elsep) = tree
-      def isUnitType(tpe: Type) =
-        defn.isUnitType(tpe) || tpe =:= defn.BoxedUnitTpe
-      val retty =
-        if (isUnitType(thenp.tpe) || isUnitType(elsep.tpe)) nir.Type.Unit
-        else genType(tree.tpe)
+      val retty = genType(tree.tpe)
       genIf(retty, cond, thenp, elsep)(tree.pos.orElse(fallbackSourcePosition))
     }
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -479,33 +479,7 @@ trait NirGenExpr(using Context) {
     def genIf(tree: If): nir.Val = {
       given nir.SourcePosition = tree.span
       val If(cond, thenp, elsep) = tree
-      def isUnitType(tpe: Type) =
-        tpe =:= defn.UnitType || defn.isBoxedUnitClass(tpe.typeSymbol)
-
-      // Check if a type generates a non-reference NIR type that requires
-      // special handling when one if-branch is Unit.
-      def isNonCoercibleType(tpe: Type): Boolean = {
-        val sym = tpe.widenDealias.typeSymbol
-        sym == defnNir.RawPtrClass ||
-          sym == defnNir.RawSizeClass ||
-          defnNir.CStructClasses.contains(sym) ||
-          sym == defnNir.CArrayClass ||
-          sym.isCFuncPtrClass
-      }
-
-      // When one branch is Unit and the other is a non-coercible type (like Ptr),
-      // we must force Unit to avoid NIR type mismatches.
-      // When one branch is Unit and the other is a coercible type (like a class),
-      // we keep the tree's type to preserve runtime type information for pattern matching.
-      val retty =
-        if (isUnitType(tree.tpe)) nir.Type.Unit
-        else if (isUnitType(thenp.tpe) && isUnitType(elsep.tpe)) nir.Type.Unit
-        else if (isUnitType(thenp.tpe) && isNonCoercibleType(elsep.tpe))
-          nir.Type.Unit
-        else if (isNonCoercibleType(thenp.tpe) && isUnitType(elsep.tpe))
-          nir.Type.Unit
-        else genType(tree.tpe)
-
+      val retty = genType(tree.tpe)
       genIf(retty, cond, thenp, elsep)
     }
 


### PR DESCRIPTION
Fixes #4747. In `genIf`, the condition to force return type to `nir.Type.Unit` used `||` instead of `&&`. This caused union types like `Error | Unit` to lose type discrimination when one if-branch returns Unit - the entire expression was typed as Unit, discarding the non-Unit value.

Changed `isUnitType(thenp.tpe) || isUnitType(elsep.tpe)` to `isUnitType(thenp.tpe) && isUnitType(elsep.tpe)` so Unit is only forced when both branches are Unit. It looks like the change was introduced in #3644, so not sure if there is a specific use case that the current changes break.