### PR TITLE
avoid repeat O(n) descent into insts list

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -56,7 +56,7 @@ private[scalanative] object ControlFlow {
         insts.foreach { inst =>
           inst match {
             case inst: Inst.Label => entries(inst.id) = (i, inst)
-            case _ => ()
+            case _                => ()
           }
 
           i += 1


### PR DESCRIPTION
Also avoids the `unchecked`.  Did not have much measurable impact, but probably?

```
Jmh/run scala.scalanative.benchmarks.testinterface.CodeGen
```

Kept failing on me. So not too useful of a measure for me. Instead I measured the `releaseFull` compile of a program ( https://gitlab.com/coreyoconnor/wes ). 

prior:

- total: 244 + 250 + 270 = ~254
- "Generating intermediate code" 1: 47 + 47 + 45 = ~46
- "Generating intermediate code" 2: 86 + 84 + 87 = ~85

post:

- total: 230 + 230 + 229 ~ 230
- "Generating intermediate code" 1:49 + 43 + 51 = ~47
- "Generating intermediate code" 2:80 + 82 + 78 = ~80

Not sure where the 20s difference in `total` came from. I was expecting only impact on `Generating immediate code`. Perhaps I'm missing some use of `Graph` this impacts more?