### PR TITLE
use vector for initial instruction toSeq

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/InstructionBuilder.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/InstructionBuilder.scala
@@ -11,7 +11,7 @@ class InstructionBuilder(implicit fresh: Fresh) {
   def ++=(insts: Seq[Inst]): Unit = buffer ++= insts
   def ++=(other: InstructionBuilder): Unit = buffer ++= other.buffer
 
-  def toSeq: Seq[Inst] = buffer.toSeq
+  def toSeq: Seq[Inst] = buffer.toVector
   def size: Int = buffer.size
   def foreach(fn: Inst => Unit) = buffer.foreach(fn)
   def exists(pred: Inst => Boolean) = buffer.exists(pred)


### PR DESCRIPTION
`slice` was highlighted as a potential hotspot. Looks like the initial `inst` sequence is a `List`. Tried using a vector for improved performance.

As measured on `wes` `clean ; show stage`:

prior:

- total: 230 + 230 + 229 = ~230
- "Generating intermediate code" 1: 49 + 43 + 51 = ~47
- "Generating intermediate code" 2: 80 + 82 + 78 = ~80

post:

- total: 206 + 198 + 199 = ~200
- "Generating intermediate code" 1: 29 + 26 + 25 = ~ 27
- "Generating intermediate code" 2: 53 + 53 + 46 = ~ 51

Which indicates a nice speedup.
