### PR TITLE
Fix #4760: os.arch system property mismatch with JVM now reports arm64 as aarch64

### DIFF
--- a/nativelib/src/main/resources/scala-native/platform/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform/platform.c
@@ -159,7 +159,7 @@ void scalanative_set_os_props(void (*add_prop)(const char *, const char *)) {
             arch = "amd64";
         }
 #endif
-// On JVM all arm64 architectures are reported as the formal aarch64
+        // On JVM all arm64 architectures are reported as the formal aarch64
         if (strcmp("arm64", arch) == 0) {
             arch = "aarch64";
         }


### PR DESCRIPTION
Doing a bit of research, it seems that `aarch64` is the formal designation for `arm64` name although many platforms report `arm64`.

JVM uses the formal name and for Windows the code is correct. See https://github.com/scala-native/scala-native/blob/main/nativelib/src/main/resources/scala-native/platform/platform.c#L142

Now we convert `arm64` to `aarch64` to report in Java System properties, `os.arch`. Note: Some Linux distributions report `arm64` via `uname` as well as on macOS.

Tested via sandbox on macOS M1 (arm64) with the following:
```scala
object Test {
  def main(args: Array[String]): Unit = {
    println("Hello, World!")
    println(s"Arch: ${System.getProperty("os.arch")}")
  }
}
```
Which reports:
```
Hello, World!
Arch: aarch64
```