### PR TITLE
Fix Ryu float trailing zeros bug in dvIsTrailingZeros condition

### DIFF
--- a/javalib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
+++ b/javalib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
@@ -308,7 +308,14 @@ object RyuFloat {
       }
       e10 = q + e2 // Note: e2 and e10 are both negative here.
       dpIsTrailingZeros = 1 >= q
-      dvIsTrailingZeros = (q < FLOAT_MANTISSA_BITS) &&
+      // (q - 1 < FLOAT_MANTISSA_BITS + 2)
+      // LHS: checking if mv is divisible by 2^(q-1)
+      // RHS: mv is 4 * m, where m is the 23-bit mantissa.
+      //      which means mv <= 4 * (2^23 - 1) = 2^25 - 4
+      //      So, mv can be divisible by up to 2^24.
+      //      q-1 < 25 is the right restriction here.
+      // see https://github.com/ulfjack/ryu/issues/243
+      dvIsTrailingZeros = (q < FLOAT_MANTISSA_BITS + 3) &&
         (mv & ((1 << (q - 1)) - 1)) == 0
       dmIsTrailingZeros = (if (mm % 2 == 1) 0 else 1) >= q
     }

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloatTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloatTest.scala
@@ -112,6 +112,13 @@ class RyuFloatTest {
     assertF2sEquals("3.4366718E10", 3.4366717e10f)
   }
 
+  @Test def lotsOfTrailingZeros(): Unit = {
+    assertF2sEquals("2.4414062E-4", 2.4414062e-4f)
+    assertF2sEquals("0.0024414062", 2.4414062e-3f)
+    assertF2sEquals("0.0043945312", 4.3945312e-3f)
+    assertF2sEquals("0.0063476562", 6.3476562e-3f)
+  }
+
   @Test def roundingEvenIfTied(): Unit = {
     assertF2sEquals("0.33007812", 0.33007812f)
   }


### PR DESCRIPTION
I found an issue in original Ryu Java implementation for Float, porting the fix to scala-native. See https://github.com/ulfjack/ryu/issues/243

The condition for calculating `dvIsTrailingZeros` was too restrictive, which causes incorrect rounding when the last removed digit equals 5 and the remaining number is even.

With mv = 41943040, e2 = -34, and q = 23, the condition (q < 23) evaluated to false, incorrectly setting dvIsTrailingZeros = false.

Since mv is 4 * m where m is the 23-bit mantissa, mv can be divisible by up to 2^24, so q < 25 (FLOAT_MANTISSA_BITS + 3) is the correct bound.