### PR TITLE
Fix #4603: Remove sphinx-markdown-tables to fix broken footnote links in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ rst_epilog = f"""
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 # myst_parser provides support for '.md' files
-extensions = ['myst_parser', 'sphinx_last_updated_by_git', 'sphinx_markdown_tables']
+extensions = ['myst_parser', 'sphinx_last_updated_by_git']
 
 # Enable substitution extension for myst-parser
 myst_enable_extensions = ["substitution"]


### PR DESCRIPTION
## Summary
- Footnote links (`[^1]`, `[^2]`, etc.) in markdown docs were rendered as plain text instead of clickable links
- Root cause: `sphinx-markdown-tables` converts tables to raw HTML before myst-parser processes them, stripping footnote syntax
- Fix: Remove `sphinx-markdown-tables` from Sphinx extensions — myst-parser v3 has built-in table support, making it redundant
- Fixes footnotes in `interop.md`, `posixlib.md`, and `build.md`
- All existing tables continue to render correctly

## Test plan
- [x] Built docs locally with `make html` — build succeeds
- [x] Verified footnotes render as clickable links in all 3 affected files
- [x] Verified all 11 markdown files with tables still render correctly