### PR TITLE
Manually redirect out/err when running in SBT plugin

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/PipeOutputThread.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/PipeOutputThread.scala
@@ -1,0 +1,48 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+// This implementation was copied from Scala.js:
+// https://github.com/scala-js/scala-js/blob/35c206173ad3b6626a8bd02b687690fcfba93c31/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/PipeOutputThread.scala
+package scala.scalanative
+package sbtplugin
+
+import java.io._
+
+import scala.annotation.tailrec
+
+private[sbtplugin] object PipeOutputThread {
+  def start(from: InputStream, to: OutputStream): Thread = {
+    val thread = new PipeOutputThread(from, to)
+    thread.start()
+    thread
+  }
+}
+
+private final class PipeOutputThread(from: InputStream, to: OutputStream)
+    extends Thread {
+  override def run(): Unit = {
+    try {
+      val buffer = new Array[Byte](8192)
+      @tailrec def loop(): Unit = {
+        val byteCount = from.read(buffer)
+        if (byteCount > 0) {
+          to.write(buffer, 0, byteCount)
+          to.flush() // if the sender flushed (which we can't tell), we need to propagate the flush
+          loop()
+        }
+      }
+      loop()
+    } finally {
+      from.close()
+    }
+  }
+}


### PR DESCRIPTION
This ensures that the thin client (which becomes the default in SBT 2) sees the output correctly, because SBT sets System.in/System.out to support background runs.

The implementation is copied from Scala.js.

---

Previously, when running `sbtn run` on a Native project, you wouldn't see any output, because `inheritIO` used in the plugin does not work in client mode.

Now the output shows up. Unfortunately, I wasn't able to connect STDIN in a way that works – trying to use redirects on ProcessBuilder leads to a crash within the Scala Native process itself.

For code like this:

```scala
@main def hello =
  println("Let's throw!")
  sys.error("whoopsie daisy")
```

The thin client "run" is going more or less as expected (prior to this change you would only see output from the SBT server, and no output from the program itself):

```
> sbtn coreNative3/run
[info] Linking (multithreadingEnabled=detect) (301 ms)
[info] Discovered 922 classes and 5631 methods after classloading
[info] Checking intermediate code (quick) (3 ms)
[info] Multithreading was not explicitly enabled - initial class loading has not detected any usage of system threads. Multithreading support will be disabled to improve performance.
[info] Linking (multithreadingEnabled=false) (235 ms)
[info] Discovered 725 classes and 4146 methods after classloading
[info] Checking intermediate code (quick) (2 ms)
[info] Discovered 702 classes and 3116 methods after optimization
[info] Optimizing (debug mode) (154 ms)
[info] Produced 49 LLVM IR files
[info] Generating intermediate code (970 ms)
[info] Compiling to native code (902 ms)
[info] Linking with [pthread, dl, m]
[info] Linking native code (immix gc, none lto) (58 ms)
[info] Postprocessing (0 ms)
[info] Total (1868 ms)
Let's throw!
Exception in thread "main" java.lang.RuntimeException: whoopsie daisy
	at scala.sys.package$.error(Unknown Source)
	at main$package$.hello(Unknown Source)
	at hello.main(Unknown Source)
	at <none>.main(Unknown Source)
[error] java.lang.RuntimeException: Nonzero exit code: 1
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$.$anonfun$scalaNativeConfigSettings$19(ScalaNativePluginInternal.scala:334)
[error] 	at scala.Option.foreach(Option.scala:407)
[error] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$.$anonfun$scalaNativeConfigSettings$16(ScalaNativePluginInternal.scala:334)
[error] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$.$anonfun$scalaNativeConfigSettings$16$adapted(ScalaNativePluginInternal.scala:287)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] stack trace is suppressed; run 'last coreNative3 / Compile / run' for the full output
[error] elapsed: 2 s
[error] (coreNative3 / Compile / run) Nonzero exit code: 1

```
