### PR TITLE
Fix "`classFieldRawPtr` doesn't find inherited `var` if it's more than 1 level away #4777"

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2576,7 +2576,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
 
       val candidates =
-        (classInfo.decls ++ classInfoSym.parentSymbols.flatMap(_.info.decls))
+        classInfo.baseClasses
+          .flatMap(base => classInfo.baseType(base).decls)
           .filter(f => f.isField && matchesName(f))
 
       candidates.find(!_.isVar).foreach { f =>

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2673,7 +2673,8 @@ trait NirGenExpr(using Context) {
       }
 
       val allFields =
-        classInfoSym.info.fields ++ classInfoSym.info.parents.flatMap(_.fields)
+        classInfo.baseClasses
+          .flatMap(baseSym => classInfo.baseType(baseSym).fields)
       allFields
         .collectFirst {
           case f if matchesName(f) =>

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
@@ -269,4 +269,26 @@ class IntrinsicsTest {
     assertEquals("c1", 4, alignmentOf[C1])
   }
 
+  @Test def classFieldRawPtrDeepInheritance(): Unit = {
+    class A {
+      var a: Int = 42
+    }
+    class B extends A {
+      var b: Int = 52
+    }
+    class C extends B
+
+    val c = new C
+
+    val aPtr = fromRawPtr[Int](Intrinsics.classFieldRawPtr(c, "a"))
+    assertEquals(c.a, 42)
+    !aPtr = 10
+    assertEquals(c.a, 10)
+
+    val bPtr = fromRawPtr[Int](Intrinsics.classFieldRawPtr(c, "b"))
+    assertEquals(c.b, 52)
+    !bPtr = 20
+    assertEquals(c.b, 20)
+  }
+
 }


### PR DESCRIPTION
Fixes #4777