### PR TITLE
Correct a math defect in j.n.c.FileChannelImpl#transferTo

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -532,7 +532,7 @@ private[java] final class FileChannelImpl(
           } else {
             buf.flip()
             while (buf.hasRemaining())
-              totalWritten += totalWritten + target.write(buf)
+              totalWritten += target.write(buf)
             buf.flip()
           }
         }


### PR DESCRIPTION
In PR #4733,  user lilac reported a math error  in javalib `java.nio.channels.FileChannelImpl#transferTo` and
provided a fix.  That user declined to proceed with that PR.  A decent interval has passed, so that PR can
be considered abandoned.  This PR is an independent implementation based on that code.

Merit & thanks to user lilac to finding the blunder.

* I did  a 'due diligence' search of the file to see if  I had made the same mistake elsewhere. The other
  uses of '+=' appeared correct.

* Because that method uses an 8K buffer, the underlying error would have shown up only if the file being 
  transferred from was larger than 8K.  The `FileChannelTest` for  `transferTo` did not detect the defect
  because the file it transfers is smaller than 8K.  