### PR TITLE
Remove useless toList conversion

### DIFF
--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -297,13 +297,13 @@ object ReachabilityAnalysis {
           from: nir.Global.Member
       ): Boolean = {
         val todo = mutable.Queue.empty[nir.Global.Member]
-        methodDirectSymbolRefs.get(from).foreach(todo ++= _.toList)
+        methodDirectSymbolRefs.get(from).foreach(todo ++= _)
         val visited = mutable.HashSet.empty[nir.Global.Member]
         while (todo.nonEmpty) {
           val next = todo.dequeue()
           if (visited.add(next)) {
             if (next == symbol) return true
-            methodDirectSymbolRefs.get(next).foreach(todo ++= _.toList)
+            methodDirectSymbolRefs.get(next).foreach(todo ++= _)
           }
         }
         false


### PR DESCRIPTION
While checking some Java Flight Recordings I noticed this calls to `toList`.

From what I can tell, they are not needed. `mutable.Queue#++=` works just as well with `Set`, and the sets from `methodDirectSymbolRefs` seem immutable, so I think this was just iterating the data twice and allocating an extra List.

I admit that I did not benchmark nor tested the changes, as I'm not sure how to test this.

I just checked that the code still compiled and I'm assuming that if this breaks something the current unit tests will catch it.