### PR TITLE
Avoid allocating a distinct collection in mergePhi

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -104,12 +104,18 @@ private[interflow] final class MergeProcessor(
         val mergeEmitted = mutable.AnyRefMap.empty[nir.Op, nir.Val.Local]
         val newEscapes = mutable.Set.empty[Addr]
 
+        def isSingleValue(values: Seq[nir.Val]): Boolean =
+          if (values.nonEmpty) {
+            val h = values.head
+            values.forall(_ == h)
+          } else false
+
         def mergePhi(
             values: Seq[nir.Val],
             bound: Option[nir.Type],
             localName: Option[String] = None
         ): nir.Val = {
-          if (values.distinct.size == 1) values.head
+          if (isSingleValue(values)) values.head
           else {
             val materialized = states.zip(values).map {
               case (s, v) =>


### PR DESCRIPTION
While running JFR during a compilation, I noticed that a significant amount of time was spent calling distinct in `mergePhi`.

<img width="1620" height="622" alt="image" src="https://github.com/user-attachments/assets/e6a284c7-977c-4f8b-b758-50c4dde5ea47" />

This is only called to check if all entries are the same, so we should be able to do a similar check without allocating an HashSet and with short circuiting.

Some naive benchmarks:

```scala
def benchmark(f: => Unit): Long = {
  val start = System.currentTimeMillis()
  (1 until 10000).foreach(_ => f)
  System.currentTimeMillis() - start
}

val smallListSingle = List.fill(100)(1)
val smallListDifferent =  2 :: smallListSingle
val bigListSingle = List.fill(10000)(1)
val bigListDifferent = 2 :: bigListSingle

def isSingleValueOld(values: Seq[Int]): Boolean =
  values.distinct.size == 1
def isSingleValueNew(values: Seq[Int]): Boolean =
  if (values.nonEmpty) {
    val h = values.head
    values.forall(_ == h)
  } else false

println("New")
println(benchmark(isSingleValueNew(smallListSingle)))
println(benchmark(isSingleValueNew(smallListDifferent)))
println(benchmark(isSingleValueNew(bigListSingle)))
println(benchmark(isSingleValueNew(bigListDifferent)))

println("--------------------")

println("Old")
println(benchmark(isSingleValueOld(smallListSingle)))
println(benchmark(isSingleValueOld(smallListDifferent)))
println(benchmark(isSingleValueOld(bigListSingle)))
println(benchmark(isSingleValueOld(bigListDifferent)))
```

Output:

```
New
16
2
170
1
--------------------
Old
17
5
307
307
```

As expected, there's not much of a difference in small collections, but on large collections it can make a big difference, especially if things can be short circuited.