### PR TITLE
Implement j.u.concurrent.atomic {Double, Long}Accumulator & corresponding Tests

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/DoubleAccumulator.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/DoubleAccumulator.scala
@@ -18,7 +18,7 @@ import java.io.Serializable
 import java.lang.Double.{doubleToRawLongBits, longBitsToDouble}
 import java.util.function.DoubleBinaryOperator;
 
-/** One or more variables that together maintain a running {@code double} value
+/* One or more variables that together maintain a running {@code double} value
  *  updated using a supplied function. When updates (method {@link #accumulate})
  *  are contended across threads, the set of variables may grow dynamically to
  *  reduce contention. Method {@link #get} (or, equivalently,
@@ -55,10 +55,14 @@ import java.util.function.DoubleBinaryOperator;
  *  @author
  *    Doug Lea
  */
-/** Scala Native Devo Notes:
+/* Scala Native Devo Notes:
  *
  *  1) DoubleAccumulator extends Serializable so that the signature matches but
  *  Serialization & SerializationProxy are not implemented.
+ *
+ *  2) Converted javadoc "/** */" comments to simple "/* */" block comments
+ *     since the former currently break SN doc generation. The original
+ *     JSR-166 comments are invaluable to javalib maintainers.
  */
 class DoubleAccumulator(
     accumulatorFunction: DoubleBinaryOperator,
@@ -73,7 +77,7 @@ class DoubleAccumulator(
   val identity = doubleToRawLongBits(_identity)
   base = this.identity
 
-  /** Updates with the given value.
+  /* Updates with the given value.
    *
    *  @param x
    *    the value
@@ -108,7 +112,7 @@ class DoubleAccumulator(
     }
   }
 
-  /** Returns the current value. The returned value is <em>NOT</em> an atomic
+  /* Returns the current value. The returned value is <em>NOT</em> an atomic
    *  snapshot; invocation in the absence of concurrent updates returns an
    *  accurate result, but concurrent updates that occur while the value is
    *  being calculated might not be incorporated.
@@ -132,7 +136,7 @@ class DoubleAccumulator(
     result
   }
 
-  /** Resets variables maintaining updates to the identity value. This method
+  /* Resets variables maintaining updates to the identity value. This method
    *  may be a useful alternative to creating a new updater, but is only
    *  effective if there are no concurrent updates. Because this method is
    *  intrinsically racy, it should only be used when it is known that no
@@ -151,7 +155,7 @@ class DoubleAccumulator(
     }
   }
 
-  /** Equivalent in effect to {@link #get} followed by {@link #reset}. This
+  /* Equivalent in effect to {@link #get} followed by {@link #reset}. This
    *  method may apply for example during quiescent points between multithreaded
    *  computations. If there are updates concurrent with this method, the
    *  returned value is <em>not</em> guaranteed to be the final value occurring
@@ -177,7 +181,7 @@ class DoubleAccumulator(
     result
   }
 
-  /** Returns the String representation of the current value.
+  /* Returns the String representation of the current value.
    *  @return
    *    the String representation of the current value
    */
@@ -185,7 +189,7 @@ class DoubleAccumulator(
   override def toString(): String =
     get().toString()
 
-  /** Equivalent to {@link #get}.
+  /* Equivalent to {@link #get}.
    *
    *  @return
    *    the current value
@@ -193,19 +197,19 @@ class DoubleAccumulator(
   def doubleValue(): scala.Double =
     get()
 
-  /** Returns the {@linkplain #get current value} as a {@code long} after a
+  /* Returns the {@linkplain #get current value} as a {@code long} after a
    *  narrowing primitive conversion.
    */
   def longValue(): scala.Long =
     get().toLong
 
-  /** Returns the {@linkplain #get current value} as an {@code int} after a
+  /* Returns the {@linkplain #get current value} as an {@code int} after a
    *  narrowing primitive conversion.
    */
   def intValue(): scala.Int =
     get().toInt
 
-  /** Returns the {@linkplain #get current value} as a {@code float} after a
+  /* Returns the {@linkplain #get current value} as a {@code float} after a
    *  narrowing primitive conversion.
    */
   def floatValue(): scala.Float =

--- a/javalib/src/main/scala/java/util/concurrent/atomic/LongAccumulator.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/LongAccumulator.scala
@@ -17,7 +17,7 @@ package java.util.concurrent.atomic
 import java.io.Serializable
 import java.util.function.LongBinaryOperator
 
-/** One or more variables that together maintain a running {@code long} value
+/* One or more variables that together maintain a running {@code long} value
  *  updated using a supplied function. When updates (method {@link #accumulate})
  *  are contended across threads, the set of variables may grow dynamically to
  *  reduce contention. Method {@link #get} (or, equivalently,
@@ -57,7 +57,7 @@ import java.util.function.LongBinaryOperator
  *    Doug Lea
  */
 
-/** Creates a new instance using the given accumulator function and identity
+/* Creates a new instance using the given accumulator function and identity
  *  element.
  *  @param accumulatorFunction
  *    a side-effect-free function of two arguments
@@ -65,10 +65,14 @@ import java.util.function.LongBinaryOperator
  *    identity (initial value) for the accumulator function
  */
 
-/** Scala Native Devo Notes:
+/* Scala Native Devo Notes:
  *
  *  1) LongAccumulator extends Serializable so that the signature matches but
  *  Serialization & SerializationProxy are not implemented.
+ *
+ *  2) Converted javadoc "/** */" comments to simple "/* */" block comments
+ *     since the former currently break SN doc generation. The original
+ *     JSR-166 comments are invaluable to javalib maintainers.
  */
 class LongAccumulator(
     accumulatorFunction: LongBinaryOperator,
@@ -81,7 +85,7 @@ class LongAccumulator(
 
   base = identity
 
-  /** Updates with the given value.
+  /* Updates with the given value.
    *
    *  @param x
    *    the value
@@ -111,7 +115,7 @@ class LongAccumulator(
     }
   }
 
-  /** Returns the current value. The returned value is <em>NOT</em> an atomic
+  /* Returns the current value. The returned value is <em>NOT</em> an atomic
    *  snapshot; invocation in the absence of concurrent updates returns an
    *  accurate result, but concurrent updates that occur while the value is
    *  being calculated might not be incorporated.
@@ -133,7 +137,7 @@ class LongAccumulator(
     result
   }
 
-  /** Resets variables maintaining updates to the identity value. This method
+  /* Resets variables maintaining updates to the identity value. This method
    *  may be a useful alternative to creating a new updater, but is only
    *  effective if there are no concurrent updates. Because this method is
    *  intrinsically racy, it should only be used when it is known that no
@@ -151,7 +155,7 @@ class LongAccumulator(
     }
   }
 
-  /** Equivalent in effect to {@link #get} followed by {@link #reset}. This
+  /* Equivalent in effect to {@link #get} followed by {@link #reset}. This
    *  method may apply for example during quiescent points between multithreaded
    *  computations. If there are updates concurrent with this method, the
    *  returned value is <em>not</em> guaranteed to be the final value occurring
@@ -177,14 +181,14 @@ class LongAccumulator(
     result
   }
 
-  /** Returns the String representation of the current value.
+  /* Returns the String representation of the current value.
    *  @return
    *    the String representation of the current value
    */
   override def toString(): String =
     get().toString()
 
-  /** Equivalent to {@link #get}.
+  /* Equivalent to {@link #get}.
    *
    *  @return
    *    the current value
@@ -192,19 +196,19 @@ class LongAccumulator(
   def longValue(): scala.Long =
     get()
 
-  /** Returns the {@linkplain #get current value} as an {@code int} after a
+  /* Returns the {@linkplain #get current value} as an {@code int} after a
    *  narrowing primitive conversion.
    */
   def intValue(): scala.Int =
     get().toInt
 
-  /** Returns the {@linkplain #get current value} as a {@code float} after a
+  /* Returns the {@linkplain #get current value} as a {@code float} after a
    *  widening primitive conversion.
    */
   def floatValue(): scala.Float =
     get().toFloat
 
-  /** Returns the {@linkplain #get current value} as a {@code double} after a
+  /* Returns the {@linkplain #get current value} as a {@code double} after a
    *  widening primitive conversion.
    */
   def doubleValue(): scala.Double =

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/DoubleAccumulatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/DoubleAccumulatorTest.scala
@@ -44,7 +44,7 @@ class DoubleAccumulatorTest extends JSR166Test {
       )
   }
 
-  /** accumulate accumulates given value to current, and get returns current
+  /* accumulate accumulates given value to current, and get returns current
    *  value
    */
   @Test def testAccumulateAndGet(): Unit = {
@@ -57,7 +57,7 @@ class DoubleAccumulatorTest extends JSR166Test {
     assertEquals("a3", 4.0, acc.get(), 0.0)
   }
 
-  /** reset() causes subsequent get() to return zero
+  /* reset() causes subsequent get() to return zero
    */
   @Test def testReset(): Unit = {
     val acc = new DoubleAccumulator(jl.Double.max, 0.0)
@@ -67,7 +67,7 @@ class DoubleAccumulatorTest extends JSR166Test {
     assertEquals("a2", 0.0, acc.get(), 0.0)
   }
 
-  /** getThenReset() returns current value; subsequent get() returns zero
+  /* getThenReset() returns current value; subsequent get() returns zero
    */
   @Test def testGetThenReset(): Unit = {
     val acc = new DoubleAccumulator(jl.Double.max, 0.0)
@@ -77,7 +77,7 @@ class DoubleAccumulatorTest extends JSR166Test {
     assertEquals("a3", 0.0, acc.get(), 0.0)
   }
 
-  /** toString returns current value.
+  /* toString returns current value.
    */
   @Test def testToString(): Unit = {
     val acc = new DoubleAccumulator(jl.Double.max, 0.0)
@@ -86,7 +86,7 @@ class DoubleAccumulatorTest extends JSR166Test {
     assertEquals("a2", jl.Double.toString(1.0), acc.toString())
   }
 
-  /** intValue returns current value.
+  /* intValue returns current value.
    */
   @Test def testIntValue(): Unit = {
     val acc = new DoubleAccumulator(jl.Double.max, 0.0)
@@ -95,7 +95,7 @@ class DoubleAccumulatorTest extends JSR166Test {
     assertEquals("a2", 1, acc.intValue())
   }
 
-  /** longValue returns current value.
+  /* longValue returns current value.
    */
   @Test def testLongValue(): Unit = {
     val acc = new DoubleAccumulator(jl.Double.max, 0.0)
@@ -104,7 +104,7 @@ class DoubleAccumulatorTest extends JSR166Test {
     assertEquals("a2", 1, acc.longValue())
   }
 
-  /** floatValue returns current value.
+  /* floatValue returns current value.
    */
   @Test def testFloatValue(): Unit = {
     val acc = new DoubleAccumulator(jl.Double.max, 0.0)
@@ -113,7 +113,7 @@ class DoubleAccumulatorTest extends JSR166Test {
     assertEquals("a2", 1.0f, acc.floatValue(), 0.0f)
   }
 
-  /** doubleValue returns current value.
+  /* doubleValue returns current value.
    */
   @Test def testDoubleValue(): Unit = {
     val acc = new DoubleAccumulator(jl.Double.max, 0.0)
@@ -122,7 +122,7 @@ class DoubleAccumulatorTest extends JSR166Test {
     assertEquals("a2", 1.0, acc.doubleValue(), 0.0)
   }
 
-  /** accumulates by multiple threads produce correct result
+  /* accumulates by multiple threads produce correct result
    */
   @Test def testAccumulateAndGetMT(): Unit = {
     val acc = new DoubleAccumulator((x, y) => x + y, 0.0)

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/LongAccumulatorTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/atomic/LongAccumulatorTest.scala
@@ -34,7 +34,7 @@ class LongAccumulatorTest extends JSR166Test {
       assertEquals(identity, new LongAccumulator(jl.Long.max, identity).get())
   }
 
-  /** accumulate accumulates given value to current, and get returns current
+  /* accumulate accumulates given value to current, and get returns current
    *  value
    */
   @Test def testAccumulateAndGet(): Unit = {
@@ -47,7 +47,7 @@ class LongAccumulatorTest extends JSR166Test {
     assertEquals("a3", 4, acc.get())
   }
 
-  /** reset() causes subsequent get() to return zero
+  /* reset() causes subsequent get() to return zero
    */
   @Test def testReset(): Unit = {
     val acc = new LongAccumulator(jl.Long.max, 0L)
@@ -57,7 +57,7 @@ class LongAccumulatorTest extends JSR166Test {
     assertEquals("a2", 0, acc.get())
   }
 
-  /** getThenReset() returns current value; subsequent get() returns zero
+  /* getThenReset() returns current value; subsequent get() returns zero
    */
   @Test def testGetThenReset(): Unit = {
     val acc = new LongAccumulator(jl.Long.max, 0L)
@@ -67,7 +67,7 @@ class LongAccumulatorTest extends JSR166Test {
     assertEquals("a3", 0, acc.get())
   }
 
-  /** toString returns current value.
+  /* toString returns current value.
    */
   @Test def testToString(): Unit = {
     val acc = new LongAccumulator(jl.Long.max, 0L)
@@ -76,7 +76,7 @@ class LongAccumulatorTest extends JSR166Test {
     assertEquals("a2", jl.Long.toString(1), acc.toString())
   }
 
-  /** intValue returns current value.
+  /* intValue returns current value.
    */
   @Test def testIntValue(): Unit = {
     val acc = new LongAccumulator(jl.Long.max, 0L)


### PR DESCRIPTION
Advance Issue #3155

Port Doug Lea Oswego CVS JSR-166 Java  `java.util.concurrent.atomic`  `DoubleAccumulator` and 
`LongAccumulator` classes and corresponding Tests.

Serialization is documented as 'not implemented'.  An exercise for the knowledgeable & keen. 

Marked as Draft until after PR #4801 merges.