### PR TITLE
fix: Reduce code size for `Tag`'s `offset`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala
@@ -58,17 +58,17 @@ final class CStruct1[T1] private[scalanative] (private[scalanative] val rawptr: 
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct1[T1]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct1[T1]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct1[T1]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
@@ -94,33 +94,33 @@ final class CStruct2[T1, T2] private[scalanative] (private[scalanative] val rawp
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct2[T1, T2]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct2[T1, T2]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct2[T1, T2]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct2[T1, T2]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct2[T1, T2]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct2[T1, T2]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
@@ -146,49 +146,49 @@ final class CStruct3[T1, T2, T3] private[scalanative] (private[scalanative] val 
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct3[T1, T2, T3]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct3[T1, T2, T3]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct3[T1, T2, T3]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
@@ -214,65 +214,65 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (private[scalanative] 
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
@@ -298,81 +298,81 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (private[scalanati
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
@@ -398,97 +398,97 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (private[scala
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
@@ -514,113 +514,113 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (private[s
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
@@ -646,129 +646,129 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (priva
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
@@ -794,145 +794,145 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (p
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
@@ -958,161 +958,161 @@ final class CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] private[scalanati
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
@@ -1138,177 +1138,177 @@ final class CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] private[scal
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
@@ -1334,193 +1334,193 @@ final class CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] private
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
@@ -1546,209 +1546,209 @@ final class CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13] pr
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
@@ -1774,225 +1774,225 @@ final class CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
@@ -2018,241 +2018,241 @@ final class CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T15] =
-    new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
 
   /** Load a value of a field number 15. */
   @alwaysinline def _15(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T15 = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
   @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
@@ -2278,257 +2278,257 @@ final class CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T15] =
-    new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
 
   /** Load a value of a field number 15. */
   @alwaysinline def _15(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T15 = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
   @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T16] =
-    new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
 
   /** Load a value of a field number 16. */
   @alwaysinline def _16(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T16 = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
   @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
@@ -2554,273 +2554,273 @@ final class CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T15] =
-    new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
 
   /** Load a value of a field number 15. */
   @alwaysinline def _15(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T15 = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
   @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T16] =
-    new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
 
   /** Load a value of a field number 16. */
   @alwaysinline def _16(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T16 = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
   @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T17] =
-    new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
 
   /** Load a value of a field number 17. */
   @alwaysinline def _17(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T17 = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
   @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
@@ -2846,289 +2846,289 @@ final class CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T15] =
-    new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
 
   /** Load a value of a field number 15. */
   @alwaysinline def _15(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T15 = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
   @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T16] =
-    new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
 
   /** Load a value of a field number 16. */
   @alwaysinline def _16(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T16 = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
   @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T17] =
-    new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
 
   /** Load a value of a field number 17. */
   @alwaysinline def _17(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T17 = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
   @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T18] =
-    new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
 
   /** Load a value of a field number 18. */
   @alwaysinline def _18(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T18 = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
   @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
@@ -3154,305 +3154,305 @@ final class CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T15] =
-    new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
 
   /** Load a value of a field number 15. */
   @alwaysinline def _15(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T15 = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
   @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T16] =
-    new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
 
   /** Load a value of a field number 16. */
   @alwaysinline def _16(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T16 = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
   @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T17] =
-    new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
 
   /** Load a value of a field number 17. */
   @alwaysinline def _17(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T17 = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
   @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T18] =
-    new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
 
   /** Load a value of a field number 18. */
   @alwaysinline def _18(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T18 = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
   @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
   /** Load a value of a field number 19. */
   @alwaysinline def at19(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T19] =
-    new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
 
   /** Load a value of a field number 19. */
   @alwaysinline def _19(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T19 = {
-    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
     ptr.unary_!(tag._19)
   }
 
   /** Store a value to a field number 19. */
   @alwaysinline def _19_=(value: T19)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
-    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
     ptr.`unary_!_=`(value)(tag._19)
   }
 
@@ -3478,321 +3478,321 @@ final class CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T15] =
-    new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
 
   /** Load a value of a field number 15. */
   @alwaysinline def _15(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T15 = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
   @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T16] =
-    new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
 
   /** Load a value of a field number 16. */
   @alwaysinline def _16(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T16 = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
   @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T17] =
-    new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
 
   /** Load a value of a field number 17. */
   @alwaysinline def _17(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T17 = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
   @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T18] =
-    new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
 
   /** Load a value of a field number 18. */
   @alwaysinline def _18(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T18 = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
   @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
   /** Load a value of a field number 19. */
   @alwaysinline def at19(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T19] =
-    new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
 
   /** Load a value of a field number 19. */
   @alwaysinline def _19(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T19 = {
-    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
     ptr.unary_!(tag._19)
   }
 
   /** Store a value to a field number 19. */
   @alwaysinline def _19_=(value: T19)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
     ptr.`unary_!_=`(value)(tag._19)
   }
 
   /** Load a value of a field number 20. */
   @alwaysinline def at20(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T20] =
-    new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
 
   /** Load a value of a field number 20. */
   @alwaysinline def _20(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T20 = {
-    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
     ptr.unary_!(tag._20)
   }
 
   /** Store a value to a field number 20. */
   @alwaysinline def _20_=(value: T20)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
-    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
     ptr.`unary_!_=`(value)(tag._20)
   }
 
@@ -3818,337 +3818,337 @@ final class CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T15] =
-    new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
 
   /** Load a value of a field number 15. */
   @alwaysinline def _15(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T15 = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
   @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T16] =
-    new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
 
   /** Load a value of a field number 16. */
   @alwaysinline def _16(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T16 = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
   @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T17] =
-    new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
 
   /** Load a value of a field number 17. */
   @alwaysinline def _17(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T17 = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
   @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T18] =
-    new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
 
   /** Load a value of a field number 18. */
   @alwaysinline def _18(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T18 = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
   @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
   /** Load a value of a field number 19. */
   @alwaysinline def at19(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T19] =
-    new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
 
   /** Load a value of a field number 19. */
   @alwaysinline def _19(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T19 = {
-    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
     ptr.unary_!(tag._19)
   }
 
   /** Store a value to a field number 19. */
   @alwaysinline def _19_=(value: T19)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
     ptr.`unary_!_=`(value)(tag._19)
   }
 
   /** Load a value of a field number 20. */
   @alwaysinline def at20(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T20] =
-    new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
 
   /** Load a value of a field number 20. */
   @alwaysinline def _20(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T20 = {
-    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
     ptr.unary_!(tag._20)
   }
 
   /** Store a value to a field number 20. */
   @alwaysinline def _20_=(value: T20)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
     ptr.`unary_!_=`(value)(tag._20)
   }
 
   /** Load a value of a field number 21. */
   @alwaysinline def at21(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T21] =
-    new Ptr[T21](elemRawPtr(rawptr, tag.offset(20)))
+    new Ptr[T21](elemRawPtr(rawptr, tag.offset20))
 
   /** Load a value of a field number 21. */
   @alwaysinline def _21(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T21 = {
-    val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20)))
+    val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset20))
     ptr.unary_!(tag._21)
   }
 
   /** Store a value to a field number 21. */
   @alwaysinline def _21_=(value: T21)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
-    val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20)))
+    val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset20))
     ptr.`unary_!_=`(value)(tag._21)
   }
 
@@ -4174,353 +4174,353 @@ final class CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T1
 
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T1] =
-    new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
 
   /** Load a value of a field number 1. */
   @alwaysinline def _1(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T1 = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
   @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0)))
+    val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset0))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T2] =
-    new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
 
   /** Load a value of a field number 2. */
   @alwaysinline def _2(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T2 = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
   @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1)))
+    val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset1))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T3] =
-    new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
 
   /** Load a value of a field number 3. */
   @alwaysinline def _3(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T3 = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
   @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2)))
+    val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset2))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T4] =
-    new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
 
   /** Load a value of a field number 4. */
   @alwaysinline def _4(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T4 = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
   @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3)))
+    val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset3))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T5] =
-    new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
 
   /** Load a value of a field number 5. */
   @alwaysinline def _5(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T5 = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
   @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4)))
+    val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset4))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T6] =
-    new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
 
   /** Load a value of a field number 6. */
   @alwaysinline def _6(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T6 = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
   @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5)))
+    val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset5))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T7] =
-    new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
 
   /** Load a value of a field number 7. */
   @alwaysinline def _7(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T7 = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
   @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6)))
+    val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset6))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T8] =
-    new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
 
   /** Load a value of a field number 8. */
   @alwaysinline def _8(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T8 = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
   @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7)))
+    val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset7))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T9] =
-    new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
 
   /** Load a value of a field number 9. */
   @alwaysinline def _9(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T9 = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
   @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8)))
+    val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset8))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T10] =
-    new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
 
   /** Load a value of a field number 10. */
   @alwaysinline def _10(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T10 = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
   @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9)))
+    val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset9))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T11] =
-    new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
 
   /** Load a value of a field number 11. */
   @alwaysinline def _11(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T11 = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
   @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10)))
+    val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset10))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T12] =
-    new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
 
   /** Load a value of a field number 12. */
   @alwaysinline def _12(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T12 = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
   @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11)))
+    val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset11))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T13] =
-    new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
 
   /** Load a value of a field number 13. */
   @alwaysinline def _13(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T13 = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
   @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12)))
+    val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset12))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T14] =
-    new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
 
   /** Load a value of a field number 14. */
   @alwaysinline def _14(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T14 = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
   @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13)))
+    val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset13))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T15] =
-    new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
 
   /** Load a value of a field number 15. */
   @alwaysinline def _15(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T15 = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
   @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14)))
+    val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset14))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T16] =
-    new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
 
   /** Load a value of a field number 16. */
   @alwaysinline def _16(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T16 = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
   @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15)))
+    val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset15))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T17] =
-    new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
 
   /** Load a value of a field number 17. */
   @alwaysinline def _17(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T17 = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
   @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16)))
+    val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset16))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T18] =
-    new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
 
   /** Load a value of a field number 18. */
   @alwaysinline def _18(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T18 = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
   @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17)))
+    val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset17))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
   /** Load a value of a field number 19. */
   @alwaysinline def at19(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T19] =
-    new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
 
   /** Load a value of a field number 19. */
   @alwaysinline def _19(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T19 = {
-    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
     ptr.unary_!(tag._19)
   }
 
   /** Store a value to a field number 19. */
   @alwaysinline def _19_=(value: T19)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18)))
+    val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset18))
     ptr.`unary_!_=`(value)(tag._19)
   }
 
   /** Load a value of a field number 20. */
   @alwaysinline def at20(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T20] =
-    new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
 
   /** Load a value of a field number 20. */
   @alwaysinline def _20(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T20 = {
-    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
     ptr.unary_!(tag._20)
   }
 
   /** Store a value to a field number 20. */
   @alwaysinline def _20_=(value: T20)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19)))
+    val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset19))
     ptr.`unary_!_=`(value)(tag._20)
   }
 
   /** Load a value of a field number 21. */
   @alwaysinline def at21(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T21] =
-    new Ptr[T21](elemRawPtr(rawptr, tag.offset(20)))
+    new Ptr[T21](elemRawPtr(rawptr, tag.offset20))
 
   /** Load a value of a field number 21. */
   @alwaysinline def _21(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T21 = {
-    val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20)))
+    val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset20))
     ptr.unary_!(tag._21)
   }
 
   /** Store a value to a field number 21. */
   @alwaysinline def _21_=(value: T21)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20)))
+    val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset20))
     ptr.`unary_!_=`(value)(tag._21)
   }
 
   /** Load a value of a field number 22. */
   @alwaysinline def at22(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T22] =
-    new Ptr[T22](elemRawPtr(rawptr, tag.offset(21)))
+    new Ptr[T22](elemRawPtr(rawptr, tag.offset21))
 
   /** Load a value of a field number 22. */
   @alwaysinline def _22(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T22 = {
-    val ptr = new Ptr[T22](elemRawPtr(rawptr, tag.offset(21)))
+    val ptr = new Ptr[T22](elemRawPtr(rawptr, tag.offset21))
     ptr.unary_!(tag._22)
   }
 
   /** Store a value to a field number 22. */
   @alwaysinline def _22_=(value: T22)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
-    val ptr = new Ptr[T22](elemRawPtr(rawptr, tag.offset(21)))
+    val ptr = new Ptr[T22](elemRawPtr(rawptr, tag.offset21))
     ptr.`unary_!_=`(value)(tag._22)
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb
@@ -41,18 +41,18 @@ final class CStruct${N}${Ts} private[scalanative] (private[scalanative] val rawp
 
   % for F in range(1, N + 1):
   /** Load a value of a field number ${F}. */
-  @alwaysinline def at${F}(implicit tag: Tag.CStruct${N}${Ts}): Ptr[T${F}] = 
-    new Ptr[T${F}](elemRawPtr(rawptr, tag.offset(${F - 1})))
+  @alwaysinline def at${F}(implicit tag: Tag.CStruct${N}${Ts}): Ptr[T${F}] =
+    new Ptr[T${F}](elemRawPtr(rawptr, tag.offset${F - 1}))
 
   /** Load a value of a field number ${F}. */
   @alwaysinline def _${F}(implicit tag: Tag.CStruct${N}${Ts}): T${F} = {
-    val ptr = new Ptr[T${F}](elemRawPtr(rawptr, tag.offset(${F - 1})))
+    val ptr = new Ptr[T${F}](elemRawPtr(rawptr, tag.offset${F - 1}))
     ptr.unary_!(tag._${F})
   }
 
   /** Store a value to a field number ${F}. */
   @alwaysinline def _${F}_=(value: T${F})(implicit tag: Tag.CStruct${N}${Ts}): Unit = {
-    val ptr = new Ptr[T${F}](elemRawPtr(rawptr, tag.offset(${F - 1})))
+    val ptr = new Ptr[T${F}](elemRawPtr(rawptr, tag.offset${F - 1}))
     ptr.`unary_!_=`(value)(tag._${F})
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
@@ -470,10 +470,10 @@ object Tag {
       res = res.max(_1.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
+      case 0 => offset0
       case _ =>
         throwUndefined()
     }
@@ -505,14 +505,13 @@ object Tag {
       res = res.max(_2.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
+      case 0 => offset0
+      case 1 => offset1
       case _ =>
         throwUndefined()
     }
@@ -546,19 +545,16 @@ object Tag {
       res = res.max(_3.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
       case _ =>
         throwUndefined()
     }
@@ -594,25 +590,19 @@ object Tag {
       res = res.max(_4.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
       case _ =>
         throwUndefined()
     }
@@ -650,32 +640,22 @@ object Tag {
       res = res.max(_5.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
       case _ =>
         throwUndefined()
     }
@@ -715,40 +695,25 @@ object Tag {
       res = res.max(_6.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
       case _ =>
         throwUndefined()
     }
@@ -790,49 +755,28 @@ object Tag {
       res = res.max(_7.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
       case _ =>
         throwUndefined()
     }
@@ -876,59 +820,31 @@ object Tag {
       res = res.max(_8.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
       case _ =>
         throwUndefined()
     }
@@ -974,70 +890,34 @@ object Tag {
       res = res.max(_9.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
       case _ =>
         throwUndefined()
     }
@@ -1085,82 +965,37 @@ object Tag {
       res = res.max(_10.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
       case _ =>
         throwUndefined()
     }
@@ -1210,95 +1045,40 @@ object Tag {
       res = res.max(_11.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
       case _ =>
         throwUndefined()
     }
@@ -1350,109 +1130,43 @@ object Tag {
       res = res.max(_12.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
       case _ =>
         throwUndefined()
     }
@@ -1506,124 +1220,46 @@ object Tag {
       res = res.max(_13.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
       case _ =>
         throwUndefined()
     }
@@ -1679,140 +1315,49 @@ object Tag {
       res = res.max(_14.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
       case _ =>
         throwUndefined()
     }
@@ -1870,157 +1415,52 @@ object Tag {
       res = res.max(_15.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
+    @alwaysinline final def offset14: Int =
+      align(offset13 + _14.size, _15.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
-      case 14 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        align(res, _15.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
+      case 14 => offset14
       case _ =>
         throwUndefined()
     }
@@ -2080,175 +1520,55 @@ object Tag {
       res = res.max(_16.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
+    @alwaysinline final def offset14: Int =
+      align(offset13 + _14.size, _15.alignment)
+    @alwaysinline final def offset15: Int =
+      align(offset14 + _15.size, _16.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
-      case 14 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        align(res, _15.alignment)
-      case 15 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        align(res, _16.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
+      case 14 => offset14
+      case 15 => offset15
       case _ =>
         throwUndefined()
     }
@@ -2310,194 +1630,58 @@ object Tag {
       res = res.max(_17.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
+    @alwaysinline final def offset14: Int =
+      align(offset13 + _14.size, _15.alignment)
+    @alwaysinline final def offset15: Int =
+      align(offset14 + _15.size, _16.alignment)
+    @alwaysinline final def offset16: Int =
+      align(offset15 + _16.size, _17.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
-      case 14 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        align(res, _15.alignment)
-      case 15 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        align(res, _16.alignment)
-      case 16 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        align(res, _17.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
+      case 14 => offset14
+      case 15 => offset15
+      case 16 => offset16
       case _ =>
         throwUndefined()
     }
@@ -2561,214 +1745,61 @@ object Tag {
       res = res.max(_18.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
+    @alwaysinline final def offset14: Int =
+      align(offset13 + _14.size, _15.alignment)
+    @alwaysinline final def offset15: Int =
+      align(offset14 + _15.size, _16.alignment)
+    @alwaysinline final def offset16: Int =
+      align(offset15 + _16.size, _17.alignment)
+    @alwaysinline final def offset17: Int =
+      align(offset16 + _17.size, _18.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
-      case 14 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        align(res, _15.alignment)
-      case 15 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        align(res, _16.alignment)
-      case 16 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        align(res, _17.alignment)
-      case 17 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        align(res, _18.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
+      case 14 => offset14
+      case 15 => offset15
+      case 16 => offset16
+      case 17 => offset17
       case _ =>
         throwUndefined()
     }
@@ -2834,235 +1865,64 @@ object Tag {
       res = res.max(_19.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
+    @alwaysinline final def offset14: Int =
+      align(offset13 + _14.size, _15.alignment)
+    @alwaysinline final def offset15: Int =
+      align(offset14 + _15.size, _16.alignment)
+    @alwaysinline final def offset16: Int =
+      align(offset15 + _16.size, _17.alignment)
+    @alwaysinline final def offset17: Int =
+      align(offset16 + _17.size, _18.alignment)
+    @alwaysinline final def offset18: Int =
+      align(offset17 + _18.size, _19.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
-      case 14 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        align(res, _15.alignment)
-      case 15 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        align(res, _16.alignment)
-      case 16 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        align(res, _17.alignment)
-      case 17 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        align(res, _18.alignment)
-      case 18 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        align(res, _19.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
+      case 14 => offset14
+      case 15 => offset15
+      case 16 => offset16
+      case 17 => offset17
+      case 18 => offset18
       case _ =>
         throwUndefined()
     }
@@ -3130,257 +1990,67 @@ object Tag {
       res = res.max(_20.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
+    @alwaysinline final def offset14: Int =
+      align(offset13 + _14.size, _15.alignment)
+    @alwaysinline final def offset15: Int =
+      align(offset14 + _15.size, _16.alignment)
+    @alwaysinline final def offset16: Int =
+      align(offset15 + _16.size, _17.alignment)
+    @alwaysinline final def offset17: Int =
+      align(offset16 + _17.size, _18.alignment)
+    @alwaysinline final def offset18: Int =
+      align(offset17 + _18.size, _19.alignment)
+    @alwaysinline final def offset19: Int =
+      align(offset18 + _19.size, _20.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
-      case 14 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        align(res, _15.alignment)
-      case 15 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        align(res, _16.alignment)
-      case 16 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        align(res, _17.alignment)
-      case 17 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        align(res, _18.alignment)
-      case 18 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        align(res, _19.alignment)
-      case 19 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        res = align(res, _19.alignment) + _19.size
-        align(res, _20.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
+      case 14 => offset14
+      case 15 => offset15
+      case 16 => offset16
+      case 17 => offset17
+      case 18 => offset18
+      case 19 => offset19
       case _ =>
         throwUndefined()
     }
@@ -3450,280 +2120,70 @@ object Tag {
       res = res.max(_21.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
+    @alwaysinline final def offset14: Int =
+      align(offset13 + _14.size, _15.alignment)
+    @alwaysinline final def offset15: Int =
+      align(offset14 + _15.size, _16.alignment)
+    @alwaysinline final def offset16: Int =
+      align(offset15 + _16.size, _17.alignment)
+    @alwaysinline final def offset17: Int =
+      align(offset16 + _17.size, _18.alignment)
+    @alwaysinline final def offset18: Int =
+      align(offset17 + _18.size, _19.alignment)
+    @alwaysinline final def offset19: Int =
+      align(offset18 + _19.size, _20.alignment)
+    @alwaysinline final def offset20: Int =
+      align(offset19 + _20.size, _21.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
-      case 14 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        align(res, _15.alignment)
-      case 15 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        align(res, _16.alignment)
-      case 16 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        align(res, _17.alignment)
-      case 17 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        align(res, _18.alignment)
-      case 18 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        align(res, _19.alignment)
-      case 19 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        res = align(res, _19.alignment) + _19.size
-        align(res, _20.alignment)
-      case 20 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        res = align(res, _19.alignment) + _19.size
-        res = align(res, _20.alignment) + _20.size
-        align(res, _21.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
+      case 14 => offset14
+      case 15 => offset15
+      case 16 => offset16
+      case 17 => offset17
+      case 18 => offset18
+      case 19 => offset19
+      case 20 => offset20
       case _ =>
         throwUndefined()
     }
@@ -3795,304 +2255,73 @@ object Tag {
       res = res.max(_22.alignment)
       res
     }
+    @alwaysinline final def offset0: Int =
+      align(0, _1.alignment)
+    @alwaysinline final def offset1: Int =
+      align(offset0 + _1.size, _2.alignment)
+    @alwaysinline final def offset2: Int =
+      align(offset1 + _2.size, _3.alignment)
+    @alwaysinline final def offset3: Int =
+      align(offset2 + _3.size, _4.alignment)
+    @alwaysinline final def offset4: Int =
+      align(offset3 + _4.size, _5.alignment)
+    @alwaysinline final def offset5: Int =
+      align(offset4 + _5.size, _6.alignment)
+    @alwaysinline final def offset6: Int =
+      align(offset5 + _6.size, _7.alignment)
+    @alwaysinline final def offset7: Int =
+      align(offset6 + _7.size, _8.alignment)
+    @alwaysinline final def offset8: Int =
+      align(offset7 + _8.size, _9.alignment)
+    @alwaysinline final def offset9: Int =
+      align(offset8 + _9.size, _10.alignment)
+    @alwaysinline final def offset10: Int =
+      align(offset9 + _10.size, _11.alignment)
+    @alwaysinline final def offset11: Int =
+      align(offset10 + _11.size, _12.alignment)
+    @alwaysinline final def offset12: Int =
+      align(offset11 + _12.size, _13.alignment)
+    @alwaysinline final def offset13: Int =
+      align(offset12 + _13.size, _14.alignment)
+    @alwaysinline final def offset14: Int =
+      align(offset13 + _14.size, _15.alignment)
+    @alwaysinline final def offset15: Int =
+      align(offset14 + _15.size, _16.alignment)
+    @alwaysinline final def offset16: Int =
+      align(offset15 + _16.size, _17.alignment)
+    @alwaysinline final def offset17: Int =
+      align(offset16 + _17.size, _18.alignment)
+    @alwaysinline final def offset18: Int =
+      align(offset17 + _18.size, _19.alignment)
+    @alwaysinline final def offset19: Int =
+      align(offset18 + _19.size, _20.alignment)
+    @alwaysinline final def offset20: Int =
+      align(offset19 + _20.size, _21.alignment)
+    @alwaysinline final def offset21: Int =
+      align(offset20 + _21.size, _22.alignment)
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
-      case 0 =>
-        var res = 0
-        align(res, _1.alignment)
-      case 1 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        align(res, _2.alignment)
-      case 2 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        align(res, _3.alignment)
-      case 3 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        align(res, _4.alignment)
-      case 4 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        align(res, _5.alignment)
-      case 5 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        align(res, _6.alignment)
-      case 6 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        align(res, _7.alignment)
-      case 7 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        align(res, _8.alignment)
-      case 8 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        align(res, _9.alignment)
-      case 9 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        align(res, _10.alignment)
-      case 10 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        align(res, _11.alignment)
-      case 11 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        align(res, _12.alignment)
-      case 12 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        align(res, _13.alignment)
-      case 13 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        align(res, _14.alignment)
-      case 14 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        align(res, _15.alignment)
-      case 15 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        align(res, _16.alignment)
-      case 16 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        align(res, _17.alignment)
-      case 17 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        align(res, _18.alignment)
-      case 18 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        align(res, _19.alignment)
-      case 19 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        res = align(res, _19.alignment) + _19.size
-        align(res, _20.alignment)
-      case 20 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        res = align(res, _19.alignment) + _19.size
-        res = align(res, _20.alignment) + _20.size
-        align(res, _21.alignment)
-      case 21 =>
-        var res = 0
-        res = align(res, _1.alignment) + _1.size
-        res = align(res, _2.alignment) + _2.size
-        res = align(res, _3.alignment) + _3.size
-        res = align(res, _4.alignment) + _4.size
-        res = align(res, _5.alignment) + _5.size
-        res = align(res, _6.alignment) + _6.size
-        res = align(res, _7.alignment) + _7.size
-        res = align(res, _8.alignment) + _8.size
-        res = align(res, _9.alignment) + _9.size
-        res = align(res, _10.alignment) + _10.size
-        res = align(res, _11.alignment) + _11.size
-        res = align(res, _12.alignment) + _12.size
-        res = align(res, _13.alignment) + _13.size
-        res = align(res, _14.alignment) + _14.size
-        res = align(res, _15.alignment) + _15.size
-        res = align(res, _16.alignment) + _16.size
-        res = align(res, _17.alignment) + _17.size
-        res = align(res, _18.alignment) + _18.size
-        res = align(res, _19.alignment) + _19.size
-        res = align(res, _20.alignment) + _20.size
-        res = align(res, _21.alignment) + _21.size
-        align(res, _22.alignment)
+      case 0 => offset0
+      case 1 => offset1
+      case 2 => offset2
+      case 3 => offset3
+      case 4 => offset4
+      case 5 => offset5
+      case 6 => offset6
+      case 7 => offset7
+      case 8 => offset8
+      case 9 => offset9
+      case 10 => offset10
+      case 11 => offset11
+      case 12 => offset12
+      case 13 => offset13
+      case 14 => offset14
+      case 15 => offset15
+      case 16 => offset16
+      case 17 => offset17
+      case 18 => offset18
+      case 19 => offset19
+      case 20 => offset20
+      case 21 => offset21
       case _ =>
         throwUndefined()
     }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
@@ -197,14 +197,17 @@ object Tag {
       % end
       res
     }
+    % for fld in range(1, N + 1):
+    @alwaysinline final def offset${fld - 1}: Int =
+      % if fld == 1:
+      align(0, _1.alignment)
+      % else:
+      align(offset${fld - 2} + _${fld - 1}.size, _${fld}.alignment)
+      % end
+    % end
     @alwaysinline override def offset(idx: Int): Int = idx.toInt match {
       % for fld in range(1, N + 1):
-      case ${fld - 1} =>
-        var res = 0
-        % for i in range(1, fld):
-        res = align(res, _${i}.alignment) + _${i}.size
-        % end
-        align(res, _${fld}.alignment)
+      case ${fld - 1} => offset${fld - 1}
       % end
       case _ =>
         throwUndefined()


### PR DESCRIPTION
Unfortunately, I don't notice a code size change, since the optimizer seems to lower to the same code.
I think the change is still mergeable since it generates less Scala code, faster to compile and easier to read.