### PR TITLE
[javalib] ForkJoinPool: Detect apparently active workers in the ForkJoinPool.canStop

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ForkJoinPool.scala
@@ -441,6 +441,28 @@ class ForkJoinPool private (
     0
   }
 
+  /** Detect workers that are running, scanning, or executing a task (including
+   *  inside blocking user code after the task was dequeued). Without this,
+   *  `hasTasks` and `RC_MASK` alone can read "empty" while a worker is still in
+   *  `doExec`, so `tryTerminate` wrongly sets STOP and interrupts orderly
+   *  shutdown (`ExecutorService.close`).
+   */
+  private def hasApparentlyActiveWorker(): Boolean = {
+    val qs = queues
+    val n = if (qs != null) qs.length else 0
+    var i = 1
+    while (i < n) {
+      qs(i) match {
+        case null => ()
+        case q    =>
+          if (q.owner != null && (q.phase & INACTIVE) == 0)
+            return true
+      }
+      i += 2
+    }
+    false
+  }
+
   /** Non-overridable version of isQuiescent. Returns true if quiescent or
    *  already terminating.
    */
@@ -449,7 +471,7 @@ class ForkJoinPool private (
     while ({
       if (runState < 0)
         return true
-      if ((c & RC_MASK) > 0L || hasTasks(false))
+      if ((c & RC_MASK) > 0L || hasTasks(false) || hasApparentlyActiveWorker())
         return false
       c != { c = ctl; c } // validate
     }) ()


### PR DESCRIPTION
Fixes #4820  
Stress tested locally, apparently this bug existed already in the JSR166 sources we ported as both implementaiton up to this point were mostly the same