### PR TITLE
Add experimental config hasher merkle tree

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -207,6 +207,7 @@ object Build {
     .settings(
       // Multiple check warnings due to usage of self-types
       nativeConfig ~= { _.withCheckFatalWarnings(false) },
+      libraryDependencies += "com.indoorvivants" %% "merkle" % "0.1.0",
       // One of the biggest blockers is lack of ZipFileSystemProvider required to operate on JARs
       Test / test := {
         val log = streams.value.log
@@ -233,6 +234,7 @@ object Build {
     MultiScalaProject("tools", platform = MultiScalaProject.JVM)
       .settings(
         libraryDependencies ++= Deps.JUnitJvm,
+        libraryDependencies += "com.indoorvivants" %% "merkle" % "0.1.0",
         Test / fork := true
       )
       .withCommonTools

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -25,6 +25,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "5.13.3.202401111512-r"
 libraryDependencies += "me.bechberger" % "ap-loader-all" % "4.2-10"
+libraryDependencies += "com.indoorvivants" %% "merkle" % "0.1.0"
 
 // scalacOptions used to bootstrap to sbt prompt.
 // In particular, no "-Xfatal-warnings"

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -37,22 +37,55 @@ object Build {
   )(implicit scope: Scope, ec: ExecutionContext): Future[Path] = {
     val checksumPath = config.workDir.resolve("build-checksum")
 
+    val configChecksum = checkSum(config)
+
     if (Files.exists(config.artifactPath) &&
-        IO.readFully(checksumPath).contains(checkSum(config).toString)) {
+        IO.readFully(checksumPath).contains(configChecksum)) {
       config.logger.info(
         "Build skipped: No changes detected in build configuration and class path contents since last build."
       )
       Future.successful(config.artifactPath)
     } else {
+      if (Files.exists(checksumPath)) {
+        import merkle.*
+        val result = for {
+          oldChecksumLines <- IO
+            .readFully(checksumPath)
+            .map(_.split("\n").toVector)
+            .toRight(s"${checksumPath} does not exist")
+          read <- MerkleTree.deserialise(oldChecksumLines).toEither
+          dt <- DiffTree.create(read, ConfigHasher(config)).toEither
+        } yield dt
+
+        result.fold(
+          err => config.logger.error(s"Failed to diff the build config: $err"),
+          dt => {
+            config.logger.info("Build config has changed:")
+            config.logger.info(dt.renderToString(true))
+          }
+        )
+      }
+
       build(config).andThen {
         case Success(_) =>
           // Need to re-calculate the checksum because the content of `output` have changed.
           IO.write(
             path = checksumPath,
-            content = checkSum(config).toString
+            // Recalculate the config hash because it includes the path to the output artifact, we need to capture its mtime
+            content = checkSum(config)
           )
       }
     }
+  }
+
+  private def gitDiff(old: Path, recent: Path) = {
+    import scala.sys.process.*
+    val sb = new StringBuilder
+    val logger = ProcessLogger(s => sb.append(s + "\n"))
+    val diff =
+      s"git diff --no-index ${old} ${recent} -U1 --no-prefix".!(logger)
+
+    sb.result()
   }
 
   /** Run the complete Scala Native pipeline, LLVM optimizer and system linker,
@@ -251,18 +284,19 @@ object Build {
     }
 
   /** Returns a checksum of a compilation pipeline with the given `config`. */
-  private def checkSum(config: Config): Int = {
+  private def checkSum(config: Config): String = {
+    ConfigHasher(config).serialiseToString().getOrThrow()
     // skip the whole nativeLink process if the followings are unchanged since the previous build
     // - build configuration
     // - class paths' mtime
     // - the output native binary ('s mtime)
     // Since the NIR code is shipped in jars, we should be able to detect the changes in NIRs.
     // One thing we miss is, we cannot detect changes in c libraries somewhere in `/usr/lib`.
-    (
-      config,
-      config.classPath.map(getLastModifiedChild(_)),
-      getLastModified(config.artifactPath)
-    ).hashCode()
+    // (
+    //   config,
+    //   config.classPath.map(getLastModifiedChild(_)),
+    //   getLastModified(config.artifactPath)
+    // ).hashCode()
   }
 
   /** Finds and compiles native libaries.

--- a/tools/src/main/scala/scala/scalanative/build/ConfigHasher.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ConfigHasher.scala
@@ -1,0 +1,75 @@
+package scala.scalanative.build
+
+import java.nio.file.{FileVisitOption, Files, Path, Paths}
+import java.security.MessageDigest
+
+object ConfigHasher {
+  import merkle.*
+
+  def apply(c: Config): MerkleTree = hasher(c)
+
+  private val helper =
+    new merkle.Builder(merkle.Hasher.messageDigest("SHA-256"))
+
+  import helper.*
+
+  private val hasher = nest[Config]("Config") { c =>
+    Seq(
+      string("baseDir", c.baseDir.toString),
+      bool("testConfig", c.testConfig),
+      string("workDir", c.workDir.toString),
+      string("moduleName", c.moduleName),
+      string("baseName", c.baseName),
+      string("artifactName", c.artifactName),
+      path("artifactPath", c.artifactPath, ToBytes.FileMtime),
+      string("buildPath", c.buildPath.toString()),
+      sortedPaths("classpath", c.classPath, ToBytes.TreeMtime),
+      string("mainClass", c.mainClass.getOrElse("<none>")),
+      nativeConfigBuilder(c.compilerConfig)
+    )
+  }
+
+  private val nativeConfigBuilder = nest[NativeConfig]("NativeConfig") { nc =>
+    Seq(
+      string("gc", nc.gc.name),
+      string("mode", nc.mode.name.toString),
+      string("clang", nc.clang.toString),
+      string("clangPP", nc.clangPP.toString),
+      strings("linkingOptions", nc.linkingOptions),
+      strings("compileOptions", nc.compileOptions),
+      strings("cOptions", nc.cOptions),
+      strings("cppOptions", nc.cppOptions),
+      string("largetTriple", nc.targetTriple.getOrElse("<none>")),
+      string("buildTarget", nc.buildTarget.toString),
+      bool("linkStubs", nc.linkStubs),
+      string("LTO", nc.lto.toString),
+      bool("check", nc.check),
+      bool("dump", nc.dump),
+      bool("checkFeatures", nc.checkFeatures),
+      bool("checkFatalWarnings", nc.checkFatalWarnings),
+      bool("optimize", nc.optimize),
+      bool("useIncrementalCompilation", nc.useIncrementalCompilation),
+      string("sanitizer", nc.sanitizer.map(_.name).getOrElse("<none>")),
+      string("multithreading", nc.multithreading.toString),
+      bool("embedResources", nc.embedResources),
+      strings("resourceIncludePatterns", nc.resourceIncludePatterns),
+      strings("resourceExcludePatterns", nc.resourceExcludePatterns),
+      mapOfAny("linktimeProperties", nc.linktimeProperties)
+      // TODO: handle optimizerConfig
+      // TODO: handle semanticsConfig
+      // TODO: handle sourceLevelDebuggingConfig
+    )
+  }
+
+  private def mapOfAny(label: String, m: Map[String, Any]) = {
+    node(
+      label,
+      m.toList.sortBy(_._1).map {
+        case (name, value) =>
+          leaf(name, value.toString.getBytes, ToBytes.Str)
+      }
+    )
+
+  }
+
+}


### PR DESCRIPTION
Context: in some of my projects (sn-bindgen and sn-bindgen-web) I often see re-linking happening when nothing has changed in the config.

As the config is quite vast, it's hard to figure out what actually triggered it – especially given that information gets lost by `.hashCode`.

I propose an explicit Merkle tree based hashing of the config parts, which can provide rich feedback when the config has changed:

<img width="2300" height="170" alt="CleanShot 2026-04-06 at 22 44 19@2x" src="https://github.com/user-attachments/assets/0f6bf1f8-268d-4a5e-a866-f24f4dc1b1c2" />

The implementation itself is in a separate repository: https://github.com/indoorvivants/merkle

I wanted to raise this PR to gauge interest in such a mechanism, and if there is interest, I can in-source and permissively license the the original implementation.