### PR TITLE
Fix #4819: Use finer java.nio file times on non-Windows

### DIFF
--- a/javalib/src/main/scala/java/nio/file/attribute/FileTime.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/FileTime.scala
@@ -3,6 +3,11 @@ package java.nio.file.attribute
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
+import scalanative.posix.{time, timeOps}
+import scalanative.unsafe._
+
+import timeOps.timespecOps
+
 final class FileTime private (
     private val epochDays: Long,
     private val dayNanos: Long
@@ -28,8 +33,8 @@ final class FileTime private (
 
   /* From JDK 8 API
    *
-   * Conversion from a coarser granularity that would numerically overflow saturate to Long.MIN_VALUE if negative
-   * or Long.MAX_VALUE if positive.
+   * Conversion from a coarser granularity that would numerically overflow
+   * saturate to Long.MIN_VALUE if negative or Long.MAX_VALUE if positive.
    */
   def to(unit: TimeUnit): Long = {
     val fromDays = unit.convert(epochDays, TimeUnit.DAYS)
@@ -69,6 +74,16 @@ final class FileTime private (
   }
 
   override def toString(): String = s"FileTime($epochDays, $dayNanos)"
+
+  // Fill and return the provided timespec
+  private[attribute] def toTimespec(
+      tsPtr: Ptr[time.timespec]
+  ): Ptr[time.timespec] = {
+    tsPtr.tv_sec = to(TimeUnit.SECONDS).toSize
+    tsPtr.tv_nsec = Math.floorMod(dayNanos, NanosToSecond).toSize
+
+    tsPtr
+  }
 }
 
 object FileTime {
@@ -90,6 +105,22 @@ object FileTime {
     val days = Math.floorDiv(s, SecondsInDay)
     val daySeconds = Math.floorMod(s, SecondsInDay)
     val dayNanos = (daySeconds * NanosToSecond) + instant.getNano
+    new FileTime(days, dayNanos)
+  }
+
+  // Pre-condition: POSIX timespec st_mtim.tv_nsec guarantees nanos < 1 second
+  private[attribute] def from(
+      seconds: scala.Long,
+      nanos: scala.Long
+  ): FileTime = {
+    /* Math is similar to that in method 'from(instant)' above.
+     * Open code to preserve full range of File time and
+     * avoid SN java.time support complexity.
+     */
+    val days = Math.floorDiv(seconds, SecondsInDay)
+    val daySeconds = Math.floorMod(seconds, SecondsInDay)
+    val dayNanos = (daySeconds * NanosToSecond) + nanos
+
     new FileTime(days, dayNanos)
   }
 }

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -10,6 +10,7 @@ import java.{lang => jl, util => ju}
 import scala.scalanative.posix.{errno => posixErrno}
 import scalanative.posix._
 import scalanative.posix.sys.stat
+import scalanative.posix.timeOps._
 import scalanative.unsafe._
 import scalanative.unsigned._
 
@@ -28,18 +29,28 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       lastAccessTime: FileTime,
       createTime: FileTime
   ): Unit = Zone.acquire { implicit z =>
-    import scala.scalanative.posix.sys.statOps.statOps
-    val sb = getStat()
+    val times = stackalloc[time.timespec](2)
 
-    val buf = alloc[utime.utimbuf]()
-    buf._1 =
-      if (lastAccessTime != null) lastAccessTime.to(TimeUnit.SECONDS).toSize
-      else sb.st_atime
-    buf._2 =
-      if (lastModifiedTime != null) lastModifiedTime.to(TimeUnit.SECONDS).toSize
-      else sb.st_mtime
+    if (lastAccessTime == null)
+      times(0).tv_nsec = stat.UTIME_OMIT
+    else
+      lastAccessTime.toTimespec(times)
+
+    if (lastModifiedTime == null)
+      times(1).tv_nsec = stat.UTIME_OMIT
+    else
+      lastModifiedTime.toTimespec(times + 1)
+
     // createTime is ignored: No posix-y way to set it.
-    if (utime.utime(toCString(path.toString), buf) != 0)
+
+    val status = stat.utimensat(
+      fcntl.AT_FDCWD,
+      toCString(path.toString),
+      times,
+      0 // JVM default is to follow symlinks; do the same here.
+    )
+
+    if (status != 0)
       throwIOException()
   }
 
@@ -84,7 +95,6 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
     }
 
 //  override def readAttributes(): BasicFileAttributes = attributes
-//  override def readAttributes(): PosixFileAttributes = attributes
 
   def readAttributes(): PosixFileAttributes = attributes
 
@@ -120,8 +130,13 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       private var st_uid: stat.uid_t = _
       private var st_gid: stat.gid_t = _
       private var st_size: stat.off_t = _
-      private var st_atime: time.time_t = _
-      private var st_mtime: time.time_t = _
+
+      private var st_atim_seconds: Long = 0
+      private var st_atim_nanos: Long = 0
+
+      private var st_mtim_seconds: Long = 0
+      private var st_mtim_nanos: Long = 0
+
       private var st_mode: stat.mode_t = _
 
       Zone.acquire { implicit z =>
@@ -134,8 +149,10 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
         st_uid = buf.st_uid
         st_gid = buf.st_gid
         st_size = buf.st_size
-        st_atime = buf.st_atime
-        st_mtime = buf.st_mtime
+        st_atim_seconds = buf.st_atim.tv_sec.toLong
+        st_atim_nanos = buf.st_atim.tv_nsec.toLong
+        st_mtim_seconds = buf.st_mtim.tv_sec.toLong
+        st_mtim_nanos = buf.st_mtim.tv_nsec.toLong
         st_mode = buf.st_mode
       }
 
@@ -156,11 +173,11 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       override def isOther() =
         !isDirectory() && !isRegularFile() && !isSymbolicLink()
 
-      override def lastAccessTime() =
-        FileTime.from(st_atime.toLong, TimeUnit.SECONDS)
+      override def lastAccessTime(): FileTime =
+        FileTime.from(st_atim_seconds.toLong, st_atim_nanos.toLong)
 
-      override def lastModifiedTime() =
-        FileTime.from(st_mtime.toLong, TimeUnit.SECONDS)
+      override def lastModifiedTime(): FileTime =
+        FileTime.from(st_mtim_seconds.toLong, st_mtim_nanos.toLong)
 
       override def creationTime() = {
         // True file creationTime is not accessible in Posix.
@@ -169,7 +186,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
         // for creationTime(). It allows the use of  last-modified-time
         // as a fallback when the true creationTime is unobtainable.
 
-        FileTime.from(st_mtime.toLong, TimeUnit.SECONDS)
+        FileTime.from(st_mtim_seconds.toLong, st_mtim_nanos.toLong)
       }
 
       override def group(): PosixGroupPrincipal =

--- a/posixlib/src/main/resources/scala-native/fcntl.c
+++ b/posixlib/src/main/resources/scala-native/fcntl.c
@@ -55,6 +55,8 @@ int scalanative_o_rdwr() { return O_RDWR; }
 
 int scalanative_o_wronly() { return O_WRONLY; }
 
+int scalanative_at_fdcwd() { return AT_FDCWD; }
+
 struct scalanative_flock {
     off_t l_start; /* starting offset */
     off_t l_len;   /* len = 0 means until end of file */

--- a/posixlib/src/main/resources/scala-native/sys/stat.c
+++ b/posixlib/src/main/resources/scala-native/sys/stat.c
@@ -81,6 +81,17 @@ int scalanative_fstat(int fildes, struct scalanative_stat *buf) {
     }
 }
 
+int scalanative_fstatat(int fildes, char *path, struct scalanative_stat *buf,
+                        int flag) {
+    struct stat orig_buf;
+    if (fstatat(fildes, path, &orig_buf, flag) == 0) {
+        scalanative_stat_init(&orig_buf, buf);
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
 int scalanative_lstat(char *path, struct scalanative_stat *buf) {
     struct stat orig_buf;
     if (lstat(path, &orig_buf) == 0) {
@@ -128,6 +139,10 @@ int scalanative_s_isfifo(mode_t mode) { return S_ISFIFO(mode); }
 int scalanative_s_islnk(mode_t mode) { return S_ISLNK(mode); }
 
 int scalanative_s_issock(mode_t mode) { return S_ISSOCK(mode); }
+
+int scalanative_utime_now() { return UTIME_NOW; }
+
+int scalanative_utime_omit() { return UTIME_OMIT; }
 
 #endif // Unix or Mac OS
 #endif

--- a/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -106,6 +106,9 @@ object fcntl {
 
   @name("scalanative_o_wronly")
   def O_WRONLY: CInt = extern
+
+  @name("scalanative_at_fdcwd")
+  def AT_FDCWD: CInt = extern
 }
 
 object fcntlOps {

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -97,6 +97,12 @@ object stat {
   @name("scalanative_fstat")
   def fstat(fildes: CInt, buf: Ptr[stat]): CInt = extern
 
+  /** Open Group Issue 7 or greater.
+   */
+  @name("scalanative_fstatat")
+  def fstatat(fildes: CInt, path: CString, buf: Ptr[stat], flag: CInt): CInt =
+    extern
+
   /** similar to [[stat]], but different in that `lstat` gets stat of the link
    *  itself instead of that of file the link refers to when path points to
    *  link.
@@ -104,10 +110,34 @@ object stat {
   @name("scalanative_lstat")
   def lstat(path: CString, buf: Ptr[stat]): CInt = extern
 
-  // mkdir(), chmod(), & fchmod() are straight passthrough; "glue" needed.
-  def mkdir(path: CString, mode: mode_t): CInt = extern
+  // The methods below are all straight passthrough; no "glue" needed.
   def chmod(pathname: CString, mode: mode_t): CInt = extern
+
   def fchmod(fd: CInt, mode: mode_t): CInt = extern
+  def fchmodat(fd: CInt, path: CString, mode: mode_t, flag: CInt): CInt = extern
+  def futimens(fd: CInt, times: Ptr[timespec]): CInt = extern
+
+  def mkdir(path: CString, mode: mode_t): CInt = extern
+  def mkdirat(dirfd: CInt, path: CString, mode: mode_t): CInt = extern
+  def mkfifo(path: CString, mode: mode_t): CInt = extern
+  def mkfifoat(dirfd: CInt, path: CString, mode: mode_t): CInt = extern
+
+  /** XSI
+   */
+  def mknod(path: CString, mode: mode_t, dev: dev_t): CInt = extern
+
+  /** XSI
+   */
+  def mknodat(dirfd: CInt, path: CString, mode: mode_t, dev: dev_t): CInt =
+    extern
+
+  def umask(mode: mode_t): mode_t = extern
+  def utimensat(
+      dirfd: CInt,
+      path: CString,
+      times: Ptr[timespec],
+      flags: Int
+  ): CInt = extern
 
   @name("scalanative_s_isdir")
   def S_ISDIR(mode: mode_t): CInt = extern
@@ -166,6 +196,11 @@ object stat {
   @name("scalanative_s_ixoth")
   def S_IXOTH: mode_t = extern
 
+  @name("scalanative_utime_now")
+  def UTIME_NOW: CInt = extern
+
+  @name("scalanative_utime_omit")
+  def UTIME_OMIT: CInt = extern
 }
 
 object statOps {

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -172,6 +172,13 @@ object timeOps {
     def tv_nsec_=(v: CLong): Unit = ptr._2 = v
   }
 
+  implicit class timespecValueOps(val ts: timespec) extends AnyVal {
+    def tv_sec: time_t = ts._1
+    def tv_nsec: CLong = ts._2
+    def tv_sec_=(v: time_t): Unit = ts._1 = v
+    def tv_nsec_=(v: CLong): Unit = ts._2 = v
+  }
+
   implicit class tmOps(val ptr: Ptr[tm]) extends AnyVal {
     def tm_sec: CInt = ptr._1
     def tm_min: CInt = ptr._2

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -327,18 +327,6 @@ class FilesTest {
 
       val copyAttrs = Files.readAttributes(fooCopy, attrsCls)
 
-      // Note Well:
-      //   If/When attempting to verify the matches below by using
-      //   the operating system stat command or equivalent, be
-      //   aware that many Scala Native versions truncate
-      //   file times to seconds. The operating system may report
-      //   microseconds or nanoseconds. The assertions below may
-      //   pass when, at first blush, a visual inspection would lead
-      //   one to wonder why they were passing.
-      //
-      //   File times as seconds can lead to other visual anomalies,
-      //   such as lastModified times being before birth times. Go figure!
-
       assertEquals(
         "lastModifiedTime",
         attrs.lastModifiedTime,
@@ -1955,6 +1943,42 @@ class FilesTest {
         referenceMs / lastModifiedResolution,
         filetimeMs / lastModifiedResolution
       )
+    }
+  }
+
+  // Issue 4819
+  @Test def filesGetLastModifiedTimeUsesMilliseconds(): Unit = {
+    withTemporaryDirectory { dirFile =>
+      val dir = dirFile.toPath()
+      val path = dir.resolve("myfile")
+
+      Files.write(
+        path,
+        "howdy".getBytes(),
+        StandardOpenOption.CREATE_NEW,
+        StandardOpenOption.SYNC
+      )
+
+      val now = System.currentTimeMillis()
+
+      val before = Files.getLastModifiedTime(path).toMillis()
+
+      // Detect & report wildly out of range lastModifiedTime values.
+      assertEquals(
+        "unreasonable lastModifiedTime",
+        now.toDouble,
+        before.toDouble,
+        10.0 // an arbitrary, small value for sloow CI machines
+      )
+
+      // Sleep so that the modified time is definitely different
+      Thread.sleep(500L)
+
+      Files.write(path, "byebyebye".getBytes(), StandardOpenOption.SYNC)
+
+      val after = Files.getLastModifiedTime(path).toMillis()
+
+      assertNotEquals(s"before and after are the same", before, after)
     }
   }
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/nio/file/FilesTest.scala
@@ -1963,12 +1963,17 @@ class FilesTest {
 
       val before = Files.getLastModifiedTime(path).toMillis()
 
-      // Detect & report wildly out of range lastModifiedTime values.
+      /* Detect & report wildly out of range lastModifiedTime values.
+       * An instance of the classic ROC (Receiver Operating Characteristics)
+       * decision choice. Pick a value which is small enough to detect
+       * true failures but large enough to avoid failures due to
+       * vagaries in CI execution.
+       */
       assertEquals(
         "unreasonable lastModifiedTime",
         now.toDouble,
         before.toDouble,
-        10.0 // an arbitrary, small value for sloow CI machines
+        500.0 // an arbitrary, small value for slooow CI machines
       )
 
       // Sleep so that the modified time is definitely different


### PR DESCRIPTION
Fix #4819

On not-Windows/posix-like systems, javalib `FileTime` `lastAccessTime`, `lastModifiedTime`, and `setTimes`
methods now align with JVM practice of using the finest time granularity, up to and including nanoseconds,
that the operating system reports.

##### Notes:
* This change means that some `FileTime` comparisons which had previously succeeded due to
rounding or truncation (usually to full seconds) now fail and _visa versa_.

* The implementation to change a single timestamp should be faster (no 'stat()' call) and less
  subject to clobbering external changes to the file being changed.  This may affect existing
  code in unlikely situations.

<hr>

Some Open Group (a.k.a POSIX) changes were added to `fcntl.scala` and `stat.scala` but
limited time prevented bringing those files into full compliance.

An Scala extension method was added to `time.h` to allow using `tv_sec` and `tv_nsec` fields
of a `timespec` instance and not requite a `Ptr[timespec]`. This allow easier sight reading and
verification of code using `timespec` instances.  The extension method may be more generally
useful as other files using `timespec` instances are created or maintained.





