### PR TITLE
Manually update sbt 1 version

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -54,14 +54,9 @@ object ScalaVersions {
   val scala213PublishVersion = crossScala213.head
 
   // minimum version rationale:
-  //   1.5 is required for Scala 3 and
-  //   1.5.8 has log4j vulnerability fixed
-  //   1.9.0 is required in order to use Java >= 21
-  //   1.9.4 fixes (Common Vulnerabilities and Exposures) CVE-2022-46751
-  //   1.9.7 fixes sbt IO.unzip vulnerability described in sbt release notes.
-  //   1.10.7 Latest sbt version, 1.10.2 had bug, see comment in SN Issue #4126
   //   1.11.5 Scala 3.8 standard library changes support
-  val sbt10Version: String = "1.11.5"
+  //   1.12.9 Latest sbt version after 1.12.8 which fixed Windows CVE.
+  val sbt10Version: String = "1.12.9"
   val sbt10ScalaVersion: String = scala212
 
   val sbt2Version: String = "2.0.0-RC10"

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -54,8 +54,8 @@ object ScalaVersions {
   val scala213PublishVersion = crossScala213.head
 
   // minimum version rationale:
-  //   1.11.5 Scala 3.8 standard library changes support
-  //   1.12.9 Latest sbt version after 1.12.8 which fixed Windows CVE.
+  //   An sbt version after 1.12.8, which fixed a CVE on Windows.
+
   val sbt10Version: String = "1.12.9"
   val sbt10ScalaVersion: String = scala212
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.12.1
+sbt.version = 1.12.9


### PR DESCRIPTION
Fix #4828 

Manually update the sbt 1 version used by Scala Native to build itself.

For a number of months scala-steward was updating the sbt version
but this appears to not be happening.  The version before this 
PR was 1.2.1, which was months ago.  

If I ever get a free cycle, I may try to figure out if scala-steward is 
running and, if it is, why it appears to be skipping updating the
SN sbt version.  Problem for another day. Not having to 
spend time manually updating was nice.

Although the Scala Native build is not known to be sensitive to the CVE
fixed in sbt, the SN .g8 template is used by and audience which might well be.
This PR restores the situation where the sbt version recommended by
the .g8 template is less-than-or-equal to the version used by the SN build itself.
This means that the recommended version is well exercised in the SN context.
Yes, there will be a universe or two of contexts where it has not been exercised
but the "central tendency" should hold. 
