### PR TITLE
Optimize `Attrs.fromSeq`

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -378,27 +378,32 @@ object Attrs {
     val links = Seq.newBuilder[Attr.Link]
     val preprocessorDefinitions = Seq.newBuilder[Attr.Define]
 
-    attrs.foreach {
-      case attr: Inline     => inline = attr
-      case attr: Specialize => specialize = attr
-      case attr: Opt        => opt = attr
-      case attr: Alignment  =>
-        align = Some(attr)
-      case Extern(blocking) =>
-        isExtern = true
-        isBlocking = blocking
-      case Dyn                 => isDyn = true
-      case Stub                => isStub = true
-      case LinkCppRuntime      => linkCppRuntime = true
-      case link: Attr.Link     => links += link
-      case define: Attr.Define => preprocessorDefinitions += define
-      case Abstract            => isAbstract = true
-      case Volatile            => isVolatile = true
-      case Final               => isFinal = true
-      case SafePublish         => isSafePublish = true
+    // Manual iterator is used on purpose
+    // foreach would allocate a BooleanRef for every var.
+    val it = attrs.iterator
+    while (it.hasNext) {
+      it.next() match {
+        case attr: Inline     => inline = attr
+        case attr: Specialize => specialize = attr
+        case attr: Opt        => opt = attr
+        case attr: Alignment  =>
+          align = Some(attr)
+        case Extern(blocking) =>
+          isExtern = true
+          isBlocking = blocking
+        case Dyn                 => isDyn = true
+        case Stub                => isStub = true
+        case LinkCppRuntime      => linkCppRuntime = true
+        case link: Attr.Link     => links += link
+        case define: Attr.Define => preprocessorDefinitions += define
+        case Abstract            => isAbstract = true
+        case Volatile            => isVolatile = true
+        case Final               => isFinal = true
+        case SafePublish         => isSafePublish = true
 
-      case LinktimeResolved => isLinktimeResolved = true
-      case UsesIntrinsic    => isUsingIntrinsics = true
+        case LinktimeResolved => isLinktimeResolved = true
+        case UsesIntrinsic    => isUsingIntrinsics = true
+      }
     }
 
     new Attrs(


### PR DESCRIPTION
Noticed this while profiling allocations.
0.73% of allocations were coming from this method.


Before:

```java
public Attrs fromSeq(Seq<Attr> attrs) {
    ObjectRef<Attr.Inline> inline = ObjectRef.create(this.None().inlineHint());
    ObjectRef<Attr.Specialize> specialize = ObjectRef.create(this.None().specialize());
    ObjectRef<Attr.Opt> opt = ObjectRef.create(this.None().opt());
    ObjectRef<Option<Attr.Alignment>> align = ObjectRef.create(this.None().align());
    BooleanRef isExtern = BooleanRef.create(false);
    BooleanRef isDyn = BooleanRef.create(false);
    BooleanRef isStub = BooleanRef.create(false);
    BooleanRef linkCppRuntime = BooleanRef.create(false);
    BooleanRef isAbstract = BooleanRef.create(false);
    BooleanRef isBlocking = BooleanRef.create(false);
    BooleanRef isVolatile = BooleanRef.create(false);
    BooleanRef isFinal = BooleanRef.create(false);
    BooleanRef isSafePublish = BooleanRef.create(false);
    BooleanRef isLinktimeResolved = BooleanRef.create(false);
    BooleanRef isUsingIntrinsics = BooleanRef.create(false);
    Builder links = package$.MODULE$.Seq().newBuilder();
    Builder preprocessorDefinitions = package$.MODULE$.Seq().newBuilder();
    attrs.foreach((Function1<Attr, Object> & Serializable)x0$1 -> {
        Attr attr = x0$1;
        if (attr instanceof Attr.Inline) {
            Attr.Inline inline = (Attr.Inline)attr;
            inline$1.elem = inline;
            return BoxedUnit.UNIT;
        }
        if (attr instanceof Attr.Specialize) {
            Attr.Specialize specialize = (Attr.Specialize)attr;
            specialize$1.elem = specialize;
            return BoxedUnit.UNIT;
        }
        if (attr instanceof Attr.Opt) {
            Attr.Opt opt = (Attr.Opt)attr;
            opt$1.elem = opt;
            return BoxedUnit.UNIT;
        }
        if (attr instanceof Attr.Alignment) {
            Attr.Alignment alignment = (Attr.Alignment)attr;
            align$1.elem = new Some<Attr.Alignment>(alignment);
            return BoxedUnit.UNIT;
        }
        if (attr instanceof Attr.Extern) {
            Attr.Extern extern = (Attr.Extern)attr;
            boolean blocking = extern.blocking();
            isExtern$1.elem = true;
            isBlocking$1.elem = blocking;
            return BoxedUnit.UNIT;
        }
        if (Attr.Dyn$.MODULE$.equals(attr)) {
            isDyn$1.elem = true;
            return BoxedUnit.UNIT;
        }
        if (Attr.Stub$.MODULE$.equals(attr)) {
            isStub$1.elem = true;
            return BoxedUnit.UNIT;
        }
        if (Attr.LinkCppRuntime$.MODULE$.equals(attr)) {
            linkCppRuntime$1.elem = true;
            return BoxedUnit.UNIT;
        }
        if (attr instanceof Attr.Link) {
            Attr.Link link = (Attr.Link)attr;
            return links.$plus$eq(link);
        }
        if (attr instanceof Attr.Define) {
            Attr.Define define = (Attr.Define)attr;
            return preprocessorDefinitions.$plus$eq(define);
        }
        if (Attr.Abstract$.MODULE$.equals(attr)) {
            isAbstract$1.elem = true;
            return BoxedUnit.UNIT;
        }
        if (Attr.Volatile$.MODULE$.equals(attr)) {
            isVolatile$1.elem = true;
            return BoxedUnit.UNIT;
        }
        if (Attr.Final$.MODULE$.equals(attr)) {
            isFinal$1.elem = true;
            return BoxedUnit.UNIT;
        }
        if (Attr.SafePublish$.MODULE$.equals(attr)) {
            isSafePublish$1.elem = true;
            return BoxedUnit.UNIT;
        }
        if (Attr.LinktimeResolved$.MODULE$.equals(attr)) {
            isLinktimeResolved$1.elem = true;
            return BoxedUnit.UNIT;
        }
        if (Attr.UsesIntrinsic$.MODULE$.equals(attr)) {
            isUsingIntrinsics$1.elem = true;
            return BoxedUnit.UNIT;
        }
        throw new MatchError(attr);
    });
    return new Attrs((Attr.Inline)inline.elem, (Attr.Specialize)specialize.elem, (Attr.Opt)opt.elem, (Option)align.elem, isExtern.elem, isBlocking.elem, isDyn.elem, isStub.elem, isAbstract.elem, isVolatile.elem, isFinal.elem, isSafePublish.elem, isLinktimeResolved.elem, isUsingIntrinsics.elem, (Seq)links.result(), (Seq)preprocessorDefinitions.result(), linkCppRuntime.elem);
}
```

After:

```java
public Attrs fromSeq(Seq<Attr> attrs) {
    Attr.Inline inline = this.None().inlineHint();
    Attr.Specialize specialize = this.None().specialize();
    Attr.Opt opt = this.None().opt();
    Option<Attr.Alignment> align = this.None().align();
    boolean isExtern = false;
    boolean isDyn = false;
    boolean isStub = false;
    boolean linkCppRuntime = false;
    boolean isAbstract = false;
    boolean isBlocking = false;
    boolean isVolatile = false;
    boolean isFinal = false;
    boolean isSafePublish = false;
    boolean isLinktimeResolved = false;
    boolean isUsingIntrinsics = false;
    Builder links = package$.MODULE$.Seq().newBuilder();
    Builder preprocessorDefinitions = package$.MODULE$.Seq().newBuilder();
    Iterator it = attrs.iterator();
    while (it.hasNext()) {
        Attr attr = (Attr)it.next();
        if (attr instanceof Attr.Inline) {
            Attr.Inline inline2;
            inline = inline2 = (Attr.Inline)attr;
            continue;
        }
        if (attr instanceof Attr.Specialize) {
            Attr.Specialize specialize2;
            specialize = specialize2 = (Attr.Specialize)attr;
            continue;
        }
        if (attr instanceof Attr.Opt) {
            Attr.Opt opt2;
            opt = opt2 = (Attr.Opt)attr;
            continue;
        }
        if (attr instanceof Attr.Alignment) {
            Attr.Alignment alignment = (Attr.Alignment)attr;
            align = new Some<Attr.Alignment>(alignment);
            continue;
        }
        if (attr instanceof Attr.Extern) {
            Attr.Extern extern = (Attr.Extern)attr;
            boolean blocking = extern.blocking();
            isExtern = true;
            isBlocking = blocking;
            continue;
        }
        if (Attr.Dyn$.MODULE$.equals(attr)) {
            isDyn = true;
            continue;
        }
        if (Attr.Stub$.MODULE$.equals(attr)) {
            isStub = true;
            continue;
        }
        if (Attr.LinkCppRuntime$.MODULE$.equals(attr)) {
            linkCppRuntime = true;
            continue;
        }
        if (attr instanceof Attr.Link) {
            Attr.Link link = (Attr.Link)attr;
            links.$plus$eq(link);
            continue;
        }
        if (attr instanceof Attr.Define) {
            Attr.Define define = (Attr.Define)attr;
            preprocessorDefinitions.$plus$eq(define);
            continue;
        }
        if (Attr.Abstract$.MODULE$.equals(attr)) {
            isAbstract = true;
            continue;
        }
        if (Attr.Volatile$.MODULE$.equals(attr)) {
            isVolatile = true;
            continue;
        }
        if (Attr.Final$.MODULE$.equals(attr)) {
            isFinal = true;
            continue;
        }
        if (Attr.SafePublish$.MODULE$.equals(attr)) {
            isSafePublish = true;
            continue;
        }
        if (Attr.LinktimeResolved$.MODULE$.equals(attr)) {
            isLinktimeResolved = true;
            continue;
        }
        if (Attr.UsesIntrinsic$.MODULE$.equals(attr)) {
            isUsingIntrinsics = true;
            continue;
        }
        throw new MatchError(attr);
    }
    return new Attrs(inline, specialize, opt, align, isExtern, isBlocking, isDyn, isStub, isAbstract, isVolatile, isFinal, isSafePublish, isLinktimeResolved, isUsingIntrinsics, (Seq)links.result(), (Seq)preprocessorDefinitions.result(), linkCppRuntime);
}
```
