### PR TITLE
[interflow] Cache `obj.getClass` across poly-inline type switches

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -109,9 +109,13 @@ private[interflow] trait PolyInline { self: Interflow =>
       (0 until targets.size).map(i => impls.indexOf(targets(i)._2)).toIndexedSeq
     val mergeLabel = fresh()
 
-    val meth = emit.method(obj, nir.Rt.GetClassSig, nir.Next.None)
-    val methty = nir.Type.Function(Seq(nir.Rt.Object), nir.Rt.Class)
-    val objcls = emit.call(methty, meth, Seq(obj), nir.Next.None)
+    val objcls = state.getClassCache.getOrElseUpdate(
+      obj, {
+        val meth = emit.method(obj, nir.Rt.GetClassSig, nir.Next.None)
+        val methty = nir.Type.Function(Seq(nir.Rt.Object), nir.Rt.Class)
+        emit.call(methty, meth, Seq(obj), nir.Next.None)
+      }
+    )
 
     for (idx <- 0.until(checkLabels.length)) {
       val checkLabel = checkLabels(idx)

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -18,6 +18,11 @@ private[interflow] final class State(val blockId: nir.Local)(
   var delayed = mutable.AnyRefMap.empty[nir.Op, nir.Val]
   var emitted = mutable.AnyRefMap.empty[nir.Op, nir.Val.Local]
   var emit = new nir.InstructionBuilder()(fresh)
+  // Cache of `obj.getClass` materialized values, keyed by the SSA value of
+  // `obj`. Reused across polymorphic-inline type switches emitted into this
+  // state so that back-to-back virtual calls on the same receiver don't each
+  // re-emit a getClass call (and subsequent icmp eq's can be CSE'd by LLVM).
+  var getClassCache = mutable.AnyRefMap.empty[nir.Val, nir.Val]
 
   // Delayed init
   var localNames: mutable.OpenHashMap[nir.Local, String] = _
@@ -285,6 +290,8 @@ private[interflow] final class State(val blockId: nir.Local)(
     newstate.locals = locals.clone()
     newstate.delayed = delayed.clone()
     newstate.emitted = emitted.clone()
+    newstate.getClassCache = getClassCache.clone()
+
     if (preserveDebugInfo) {
       newstate.virtualNames = virtualNames.mapValuesNow(identity)
       newstate.localNames = localNames.clone()

--- a/tools/src/test/scala/scala/scalanative/optimizer/PolyInlineGetClassTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/PolyInlineGetClassTest.scala
@@ -1,0 +1,148 @@
+package scala.scalanative
+package optimizer
+
+import org.junit.Assert._
+import org.junit._
+
+import scala.scalanative.OptimizerSpec
+
+class PolyInlineGetClassTest extends OptimizerSpec {
+
+  /** Verifies that the poly-inline type-switch emits at most one
+   *  `Op.Method(receiver, GetClassSig)` per receiver SSA value. Back-to-back
+   *  virtual calls on the same receiver must share a single `getClass` load.
+   */
+  @Test def singleGetClassPerReceiver(): Unit = {
+    optimize(
+      entry = "Test",
+      sources = Map(
+        "Test.scala" ->
+          """|import scala.scalanative.annotation.nooptimize
+             |
+             |sealed trait Shape {
+             |  def area: Int
+             |  def perim: Int
+             |}
+             |final class Square(s: Int) extends Shape {
+             |  def area = s * s
+             |  def perim = 4 * s
+             |}
+             |final class Triangle(s: Int) extends Shape {
+             |  def area = s * s / 2
+             |  def perim = 3 * s
+             |}
+             |
+             |object Test {
+             |  // @nooptimize prevents interflow from discovering the exact
+             |  // class of the result, so the call sites on `shape` below
+             |  // remain polymorphic and trigger polyInline.
+             |  @nooptimize def pick(i: Int): Shape =
+             |    if ((i & 1) == 0) new Square(i) else new Triangle(-i)
+             |
+             |  def main(args: Array[String]): Unit = {
+             |    val shape = pick(args.length)
+             |    println(shape.area)
+             |    println(shape.perim)
+             |  }
+             |}
+             |""".stripMargin
+      ),
+      setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFast)
+    ) {
+      case (_, result) =>
+        findEntry(result.defns).foreach { defn =>
+          val getClassByReceiver = defn.insts
+            .collect {
+              case nir.Inst.Let(_, nir.Op.Method(obj, sig), _)
+                  if sig == nir.Rt.GetClassSig =>
+                obj
+            }
+            .groupBy(identity)
+            .map { case (obj, occurrences) => obj -> occurrences.size }
+
+          // The test is only meaningful if polyInline actually fired on at
+          // least one receiver; otherwise the assertion below is vacuous and
+          // the regression we care about can't be caught.
+          assertTrue(
+            "Expected at least one Op.Method(_, GetClassSig) in the " +
+              "optimized entry - polyInline did not fire; adjust the fixture " +
+              "so that a polymorphic call survives interflow.",
+            getClassByReceiver.nonEmpty
+          )
+
+          getClassByReceiver.foreach {
+            case (obj, count) =>
+              assertEquals(
+                s"Op.Method(_, GetClassSig) must appear at most once per " +
+                  s"receiver, got $count occurrences for receiver $obj",
+                1,
+                count
+              )
+          }
+        }
+    }
+  }
+
+  @Test def distinctReceiversGetDistinctGetClass(): Unit = {
+    optimize(
+      entry = "Test",
+      sources = Map(
+        "Test.scala" ->
+          """|import scala.scalanative.annotation.nooptimize
+             |
+             |sealed trait Shape {
+             |  def area: Int
+             |}
+             |final class Square(s: Int) extends Shape {
+             |  def area = s * s
+             |}
+             |final class Triangle(s: Int) extends Shape {
+             |  def area = s * s / 2
+             |}
+             |
+             |object Test {
+             |  @nooptimize def pickA(i: Int): Shape =
+             |    if ((i & 1) == 0) new Square(i) else new Triangle(-i)
+             |
+             |  @nooptimize def pickB(i: Int): Shape =
+             |    if ((i & 2) == 0) new Triangle(i) else new Square(-i)
+             |
+             |  def main(args: Array[String]): Unit = {
+             |    val a = pickA(args.length)
+             |    val b = pickB(args.length)
+             |    println(a.area)
+             |    println(b.area)
+             |  }
+             |}
+             |""".stripMargin
+      ),
+      setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFast)
+    ) {
+      case (_, result) =>
+        findEntry(result.defns).foreach { defn =>
+          val receivers = defn.insts.collect {
+            case nir.Inst.Let(_, nir.Op.Method(obj, sig), _)
+                if sig == nir.Rt.GetClassSig =>
+              obj
+          }
+
+          // Sanity: polyInline actually fired for both receivers.
+          assertTrue(
+            "Expected at least two Op.Method(_, GetClassSig) occurrences " +
+              s"(one per independent receiver); got: $receivers",
+            receivers.size >= 2
+          )
+
+          // Different receivers must NOT be collapsed into a single
+          // getClass - the cache is keyed per SSA receiver value, not
+          // per call site.
+          val distinctReceivers = receivers.distinct
+          assertTrue(
+            "Distinct receivers must each have their own " +
+              s"Op.Method(_, GetClassSig); got receivers: $receivers",
+            distinctReceivers.size >= 2
+          )
+        }
+    }
+  }
+}


### PR DESCRIPTION
When `PolyInline` emits a type-switch for a polymorphic call, it loads the receiver's class via `Object.getClass` and compares it against each candidate implementation's type. Until now, every polymorphic call site re-emitted this `getClass` load, so back-to-back virtual calls on the same receiver (e.g. `shape.area` followed by `shape.perim`) produced duplicate `call @Object.getClass` instructions in the generated LLVM IR. LLVM could not always CSE these across basic-block boundaries, leaving the redundancy in the final binary.
This change adds a per-`State` cache, keyed on the receiver's SSA value, that remembers the materialized `getClass` result. The second poly-inline on the same receiver reuses it instead of emitting a new `Op.Method` / `Op.Call` pair, which lets the downstream icmp-eq checks collapse naturally.
The cache is cloned in `State.fullClone` so branches of the optimizer keep correct per-path state, and it is only populated at the point `polyInline` actually emits the load (so distinct receivers keep their own independent `getClass` calls).
Adds two NIR-level tests in `tools/src/test/.../optimizer/`:
  - `singleGetClassPerReceiver`: two virtual calls on the same receiver must share exactly one `Op.Method(_, GetClassSig)`.
  - `distinctReceiversGetDistinctGetClass`: two unrelated receivers must each keep their own `Op.Method(_, GetClassSig)` (guarding against an over-eager cache).


Tested on a http4s server:
```
25688 -rwxr-xr-x@ 1 lorenzo  staff  13151000 Apr 17 21:23 before*
25304 -rwxr-xr-x@ 1 lorenzo  staff  12954152 Apr 17 22:18 after*
```

1.49% binary size reduction.

This pull request was made with moderate help from a LLM.
