### PR TITLE
[codegen] Remove redundant `bitcast ptr %x to ptr` with opaque pointers

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1523,9 +1523,19 @@ private[scalanative] object Lower {
 
           label(resultL, Seq(nir.Val.Local(n, op.resty)))
 
+        // Remove redundant `bitcast ptr %x to ptr`
+        case nir.Op.Conv(nir.Conv.Bitcast, toty, value) if platform.useOpaquePointers && isPtrInLLVM(toty) && isPtrInLLVM(value.ty) =>
+          let(n, nir.Op.Copy(genVal(buf, value)), unwind)
+
         case nir.Op.Conv(conv, ty, value) =>
           let(n, nir.Op.Conv(conv, ty, genVal(buf, value)), unwind)
       }
+    }
+
+    private def isPtrInLLVM(ty: nir.Type): Boolean = ty match {
+      case nir.Type.Unit                                         => false
+      case _: nir.Type.RefKind | nir.Type.Ptr | nir.Type.Nothing => true
+      case _                                                     => false
     }
 
     def genBinOp(

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -489,10 +489,11 @@ private[codegen] abstract class AbstractCodeGen(
   private[codegen] def genType(ty: nir.Type)(implicit sb: ShowBuilder): Unit = {
     import sb._
     ty match {
-      case nir.Type.Vararg => str("...")
-      case nir.Type.Unit   => str("void")
-      case _: nir.Type.RefKind | nir.Type.Ptr | nir.Type.Null |
-          nir.Type.Nothing =>
+      case nir.Type.Vararg =>
+        str("...")
+      case nir.Type.Unit =>
+        str("void")
+      case _: nir.Type.RefKind | nir.Type.Ptr | nir.Type.Nothing =>
         str(pointerType)
       case nir.Type.Bool          => str("i1")
       case i: nir.Type.FixedSizeI => str("i"); str(i.width)

--- a/tools/src/test/scala/scala/scalanative/codegen/LoweringTest.scala
+++ b/tools/src/test/scala/scala/scalanative/codegen/LoweringTest.scala
@@ -40,8 +40,7 @@ class LoweringTest extends CodeGenSpec {
            |    println(s.size)
            |  }
            |}""".stripMargin
-    ),
-    setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFast)
+    )
   ) {
     case (_, _, outfiles) =>
       val pattern = """bitcast ptr %\S+ to ptr\b""".r

--- a/tools/src/test/scala/scala/scalanative/codegen/LoweringTest.scala
+++ b/tools/src/test/scala/scala/scalanative/codegen/LoweringTest.scala
@@ -1,5 +1,7 @@
 package scala.scalanative.codegen
 
+import java.nio.file.Files
+
 import org.junit.Assert._
 import org.junit.Test
 
@@ -22,5 +24,37 @@ class LoweringTest extends CodeGenSpec {
     case (config, result, _) =>
       assertFalse(config.compilerConfig.optimize)
       assertTrue(result.isSuccessful)
+  }
+
+  // With opaque pointers, `bitcast ptr %x to ptr` is a no-op and should not be
+  // emitted by the code generator. Lower rewrites such redundant bitcasts as
+  // copies which are elided at codegen time.
+  @Test def noRedundantPtrBitcast(): Unit = codegen(
+    entry = "Main",
+    sources = Map(
+      "Main.scala" ->
+        """|
+           |object Main {
+           |  def main(args: Array[String]): Unit = {
+           |    val s = Set(1, 2, 3) ++ Set(3, 4, 5)
+           |    println(s.size)
+           |  }
+           |}""".stripMargin
+    ),
+    setupConfig = _.withMode(scala.scalanative.build.Mode.releaseFast)
+  ) {
+    case (_, _, outfiles) =>
+      val pattern = """bitcast ptr %\S+ to ptr\b""".r
+      val offending =
+        outfiles.iterator.flatMap { path =>
+          val content = new String(Files.readAllBytes(path))
+          pattern
+            .findAllMatchIn(content)
+            .map(m => s"${path.getFileName}: ${m.matched}")
+        }.toList
+      assertTrue(
+        s"Found redundant `bitcast ptr %x to ptr` in generated IR:\n${offending.mkString("\n")}",
+        offending.isEmpty
+      )
   }
 }


### PR DESCRIPTION
With opaque pointers every reference/pointer NIR type lowers to LLVM `ptr`, so a `Conv.Bitcast` between two such types (emitted for instance by `PolyInline` when coercing argument types) produces a no-op `bitcast ptr %x to ptr` in the generated IR. LLVM folds it, but it bloats the output.
Rewrite these redundant bitcasts in `Lower` as `Op.Copy`, which is already tracked by `AbstractCodeGen`'s `copies` map and elided at codegen time. The rewrite is gated on `useOpaquePointers` so legacy targets keep the original bitcast.
Also drop the now-redundant `nir.Type.Null` case in `genType` (`Null` is a `RefKind` and is already handled).