### PR TITLE
[codegen] Profile guided optimizations

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -36,7 +36,9 @@ private[codegen] abstract class AbstractCodeGen(
 
   private val copies = mutable.Map.empty[nir.Local, nir.Val]
   private val deps = mutable.Set.empty[nir.Global.Member]
+  deps.sizeHint(1024)
   private val generated = mutable.Set.empty[String]
+  generated.sizeHint(1024)
   private val externSigMembers = mutable.Map.empty[nir.Sig, nir.Global.Member]
 
   private def isGnu: Boolean = {

--- a/util/src/main/scala/scala/scalanative/util/ShowBuilder.scala
+++ b/util/src/main/scala/scala/scalanative/util/ShowBuilder.scala
@@ -9,6 +9,14 @@ sealed trait ShowBuilder {
 
   def str(v: Char): Unit = out.append(v)
   def str(v: CharSequence): Unit = out.append(v)
+  def str(value: Int): Unit =
+    out.append(java.lang.Integer.toString(value))
+  def str(value: Long): Unit =
+    out.append(java.lang.Long.toString(value))
+  def str(value: Short): Unit =
+    out.append(java.lang.Short.toString(value))
+  def str(value: Byte): Unit =
+    out.append(java.lang.Byte.toString(value))
   def str(value: Any): Unit =
     out.append(value.toString)
 
@@ -41,8 +49,10 @@ sealed trait ShowBuilder {
 
   def newline(): Unit = {
     out.append("\n")
-    for (_ <- 0.until(indentation)) {
+    var i = 0
+    while (i < indentation) {
       out.append("  ")
+      i += 1
     }
   }
 


### PR DESCRIPTION
- `deps` and `generated` grow to a big size, so we pass a `sizeHint` to avoid growing them many times
- `def str(value: Any): Unit` creates boxing every time we call `str` with `Int` or other primitives
- `newline` is called many times, we avoid Range allocations with `while`