### PR TITLE
[codegen] Optimize `AbstractCodeGen.genJustVal` with tag-based matching

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -7,6 +7,8 @@ import java.lang.Float.floatToRawIntBits
 /** A NIR value. */
 sealed abstract class Val {
 
+  private[scalanative] def tag: Byte
+
   /** The type of the value. */
   final def ty: Type = this match {
     case Val.Null =>
@@ -229,11 +231,41 @@ sealed abstract class Val {
 
 object Val {
 
+  private[scalanative] object Tags {
+    final val True = 0.toByte
+    final val False = 1.toByte
+    final val Null = 2.toByte
+    final val Zero = 3.toByte
+    final val Size = 4.toByte
+    final val Char = 5.toByte
+    final val Byte = 6.toByte
+    final val Short = 7.toByte
+    final val Int = 8.toByte
+    final val Long = 9.toByte
+    final val Float = 10.toByte
+    final val Double = 11.toByte
+    final val StructValue = 12.toByte
+    final val ArrayValue = 13.toByte
+    final val ByteString = 14.toByte
+    final val Local = 15.toByte
+    final val Global = 16.toByte
+    final val Unit = 17.toByte
+    final val Const = 18.toByte
+    final val String = 19.toByte
+    final val Virtual = 20.toByte
+    final val ClassOf = 21.toByte
+    final val Int128 = 22.toByte
+  }
+
   /** The constant Boolean 'true'. */
-  case object True extends Val
+  case object True extends Val {
+    private[scalanative] def tag = Tags.True
+  }
 
   /** The constant Boolean 'false'. */
-  case object False extends Val
+  case object False extends Val {
+    private[scalanative] def tag = Tags.False
+  }
 
   /** A Boolean constant. */
   object Bool extends (Boolean => Val) {
@@ -247,33 +279,51 @@ object Val {
   }
 
   /** The constant 'null' value. */
-  case object Null extends Val
+  case object Null extends Val {
+    private[scalanative] def tag = Tags.Null
+  }
 
   /** The "zero" value of the given NIR type. */
-  final case class Zero(of: nir.Type) extends Val
+  final case class Zero(of: nir.Type) extends Val {
+    private[scalanative] def tag = Tags.Zero
+  }
 
   /** A numerical value suitable to represent the size of a container. */
-  final case class Size(value: scala.Long) extends Val
+  final case class Size(value: scala.Long) extends Val {
+    private[scalanative] def tag = Tags.Size
+  }
 
   /** 16-bit unsigned Unicode character */
-  final case class Char(value: scala.Char) extends Val
+  final case class Char(value: scala.Char) extends Val {
+    private[scalanative] def tag = Tags.Char
+  }
 
   /** A 8-bit signed two’s complement integer. */
-  final case class Byte(value: scala.Byte) extends Val
+  final case class Byte(value: scala.Byte) extends Val {
+    private[scalanative] def tag = Tags.Byte
+  }
 
   /** A 16-bit signed two’s complement integer. */
-  final case class Short(value: scala.Short) extends Val
+  final case class Short(value: scala.Short) extends Val {
+    private[scalanative] def tag = Tags.Short
+  }
 
   /** A 32-bit signed two’s complement integer. */
-  final case class Int(value: scala.Int) extends Val
+  final case class Int(value: scala.Int) extends Val {
+    private[scalanative] def tag = Tags.Int
+  }
 
   /** A 64-bit signed two’s complement integer. */
-  final case class Long(value: scala.Long) extends Val
+  final case class Long(value: scala.Long) extends Val {
+    private[scalanative] def tag = Tags.Long
+  }
 
   /** A 128-bit signed two’s complement integer, encoded as two 64‑bit words.
    *  Not emmited by compiler!
    */
   final case class Int128(hi: scala.Long, lo: scala.Long) extends Val {
+    private[scalanative] def tag = Tags.Int128
+
     def bigIntValue: math.BigInt = {
       val hiPart = math.BigInt(hi) << 64
       val loPart = math.BigInt(lo & 0xffffffffffffffffL)
@@ -283,6 +333,8 @@ object Val {
 
   /** A 32-bit IEEE 754 single-precision float. */
   final case class Float(value: scala.Float) extends Val {
+    private[scalanative] def tag = Tags.Float
+
     override def equals(that: Any): Boolean = that match {
       case Float(thatValue) =>
         val theseBits = floatToRawIntBits(value)
@@ -294,6 +346,8 @@ object Val {
 
   /** A 64-bit IEEE 754 double-precision float. */
   final case class Double(value: scala.Double) extends Val {
+    private[scalanative] def tag = Tags.Double
+
     override def equals(that: Any): Boolean = that match {
       case Double(thatValue) =>
         val theseBits = doubleToRawLongBits(value)
@@ -304,10 +358,14 @@ object Val {
   }
 
   /** A heterogeneous collection of data members. */
-  final case class StructValue(values: Seq[Val]) extends Val
+  final case class StructValue(values: Seq[Val]) extends Val {
+    private[scalanative] def tag = Tags.StructValue
+  }
 
   /** A homogeneous collection of data members. */
-  final case class ArrayValue(elemty: nir.Type, values: Seq[Val]) extends Val
+  final case class ArrayValue(elemty: nir.Type, values: Seq[Val]) extends Val {
+    private[scalanative] def tag = Tags.ArrayValue
+  }
 
   /** A collection of bytes.
    *
@@ -316,17 +374,25 @@ object Val {
    *  be compiled to `c"a\0"`.
    */
   final case class ByteString(bytes: Array[scala.Byte]) extends Val {
+    private[scalanative] def tag = Tags.ByteString
+
     def byteCount: scala.Int = bytes.length + 1
   }
 
   /** A local SSA variable. */
-  final case class Local(id: nir.Local, valty: nir.Type) extends Val
+  final case class Local(id: nir.Local, valty: nir.Type) extends Val {
+    private[scalanative] def tag = Tags.Local
+  }
 
   /** A reference to a global variable, constant, or method. */
-  final case class Global(name: nir.Global, valty: nir.Type) extends Val
+  final case class Global(name: nir.Global, valty: nir.Type) extends Val {
+    private[scalanative] def tag = Tags.Global
+  }
 
   /** The unit value. */
-  case object Unit extends Val
+  case object Unit extends Val {
+    private[scalanative] def tag = Tags.Unit
+  }
 
   /** A constant.
    *
@@ -334,7 +400,9 @@ object Val {
    *  represented by `ByteString`, `Zero`, `Int`, etc. Instead, it represents a
    *  pointer to some constant value.
    */
-  final case class Const(value: Val) extends Val
+  final case class Const(value: Val) extends Val {
+    private[scalanative] def tag = Tags.Const
+  }
 
   /** A character string.
    *
@@ -342,14 +410,18 @@ object Val {
    *  compiled as global arrays of UTF-16 characters. Use `ByteString` to
    *  represent C-string literals.
    */
-  final case class String(value: java.lang.String) extends Val
+  final case class String(value: java.lang.String) extends Val {
+    private[scalanative] def tag = Tags.String
+  }
 
   /** A virtual value.
    *
    *  Virtual values only serve as placeholders during optimization. They are
    *  not serializable and are never emitted by the compiler plugin.
    */
-  final case class Virtual(key: scala.Long) extends Val
+  final case class Virtual(key: scala.Long) extends Val {
+    private[scalanative] def tag = Tags.Virtual
+  }
 
   /** A reference to `java.lang.Class[_]` of given symbol `name`.
    *
@@ -363,6 +435,8 @@ object Val {
    *  (specifically, `lockWord`), which contains an `ObjectMonitor` or a bit set
    *  of lock word.
    */
-  final case class ClassOf(name: nir.Global.Top) extends Val
+  final case class ClassOf(name: nir.Global.Top) extends Val {
+    private[scalanative] def tag = Tags.ClassOf
+  }
 
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -231,40 +231,14 @@ sealed abstract class Val {
 
 object Val {
 
-  private[scalanative] object Tags {
-    final val True = 0.toByte
-    final val False = 1.toByte
-    final val Null = 2.toByte
-    final val Zero = 3.toByte
-    final val Size = 4.toByte
-    final val Char = 5.toByte
-    final val Byte = 6.toByte
-    final val Short = 7.toByte
-    final val Int = 8.toByte
-    final val Long = 9.toByte
-    final val Float = 10.toByte
-    final val Double = 11.toByte
-    final val StructValue = 12.toByte
-    final val ArrayValue = 13.toByte
-    final val ByteString = 14.toByte
-    final val Local = 15.toByte
-    final val Global = 16.toByte
-    final val Unit = 17.toByte
-    final val Const = 18.toByte
-    final val String = 19.toByte
-    final val Virtual = 20.toByte
-    final val ClassOf = 21.toByte
-    final val Int128 = 22.toByte
-  }
-
   /** The constant Boolean 'true'. */
   case object True extends Val {
-    private[scalanative] def tag = Tags.True
+    private[scalanative] def tag = 0.toByte
   }
 
   /** The constant Boolean 'false'. */
   case object False extends Val {
-    private[scalanative] def tag = Tags.False
+    private[scalanative] def tag = 1.toByte
   }
 
   /** A Boolean constant. */
@@ -280,49 +254,49 @@ object Val {
 
   /** The constant 'null' value. */
   case object Null extends Val {
-    private[scalanative] def tag = Tags.Null
+    private[scalanative] def tag = 2.toByte
   }
 
   /** The "zero" value of the given NIR type. */
   final case class Zero(of: nir.Type) extends Val {
-    private[scalanative] def tag = Tags.Zero
+    private[scalanative] def tag = 3.toByte
   }
 
   /** A numerical value suitable to represent the size of a container. */
   final case class Size(value: scala.Long) extends Val {
-    private[scalanative] def tag = Tags.Size
+    private[scalanative] def tag = 4.toByte
   }
 
   /** 16-bit unsigned Unicode character */
   final case class Char(value: scala.Char) extends Val {
-    private[scalanative] def tag = Tags.Char
+    private[scalanative] def tag = 5.toByte
   }
 
   /** A 8-bit signed two’s complement integer. */
   final case class Byte(value: scala.Byte) extends Val {
-    private[scalanative] def tag = Tags.Byte
+    private[scalanative] def tag = 6.toByte
   }
 
   /** A 16-bit signed two’s complement integer. */
   final case class Short(value: scala.Short) extends Val {
-    private[scalanative] def tag = Tags.Short
+    private[scalanative] def tag = 7.toByte
   }
 
   /** A 32-bit signed two’s complement integer. */
   final case class Int(value: scala.Int) extends Val {
-    private[scalanative] def tag = Tags.Int
+    private[scalanative] def tag = 8.toByte
   }
 
   /** A 64-bit signed two’s complement integer. */
   final case class Long(value: scala.Long) extends Val {
-    private[scalanative] def tag = Tags.Long
+    private[scalanative] def tag = 9.toByte
   }
 
   /** A 128-bit signed two’s complement integer, encoded as two 64‑bit words.
    *  Not emmited by compiler!
    */
   final case class Int128(hi: scala.Long, lo: scala.Long) extends Val {
-    private[scalanative] def tag = Tags.Int128
+    private[scalanative] def tag = 22.toByte
 
     def bigIntValue: math.BigInt = {
       val hiPart = math.BigInt(hi) << 64
@@ -333,7 +307,7 @@ object Val {
 
   /** A 32-bit IEEE 754 single-precision float. */
   final case class Float(value: scala.Float) extends Val {
-    private[scalanative] def tag = Tags.Float
+    private[scalanative] def tag = 10.toByte
 
     override def equals(that: Any): Boolean = that match {
       case Float(thatValue) =>
@@ -346,7 +320,7 @@ object Val {
 
   /** A 64-bit IEEE 754 double-precision float. */
   final case class Double(value: scala.Double) extends Val {
-    private[scalanative] def tag = Tags.Double
+    private[scalanative] def tag = 11.toByte
 
     override def equals(that: Any): Boolean = that match {
       case Double(thatValue) =>
@@ -359,12 +333,12 @@ object Val {
 
   /** A heterogeneous collection of data members. */
   final case class StructValue(values: Seq[Val]) extends Val {
-    private[scalanative] def tag = Tags.StructValue
+    private[scalanative] def tag = 12.toByte
   }
 
   /** A homogeneous collection of data members. */
   final case class ArrayValue(elemty: nir.Type, values: Seq[Val]) extends Val {
-    private[scalanative] def tag = Tags.ArrayValue
+    private[scalanative] def tag = 13.toByte
   }
 
   /** A collection of bytes.
@@ -374,24 +348,24 @@ object Val {
    *  be compiled to `c"a\0"`.
    */
   final case class ByteString(bytes: Array[scala.Byte]) extends Val {
-    private[scalanative] def tag = Tags.ByteString
+    private[scalanative] def tag = 14.toByte
 
     def byteCount: scala.Int = bytes.length + 1
   }
 
   /** A local SSA variable. */
   final case class Local(id: nir.Local, valty: nir.Type) extends Val {
-    private[scalanative] def tag = Tags.Local
+    private[scalanative] def tag = 15.toByte
   }
 
   /** A reference to a global variable, constant, or method. */
   final case class Global(name: nir.Global, valty: nir.Type) extends Val {
-    private[scalanative] def tag = Tags.Global
+    private[scalanative] def tag = 16.toByte
   }
 
   /** The unit value. */
   case object Unit extends Val {
-    private[scalanative] def tag = Tags.Unit
+    private[scalanative] def tag = 17.toByte
   }
 
   /** A constant.
@@ -401,7 +375,7 @@ object Val {
    *  pointer to some constant value.
    */
   final case class Const(value: Val) extends Val {
-    private[scalanative] def tag = Tags.Const
+    private[scalanative] def tag = 18.toByte
   }
 
   /** A character string.
@@ -411,7 +385,7 @@ object Val {
    *  represent C-string literals.
    */
   final case class String(value: java.lang.String) extends Val {
-    private[scalanative] def tag = Tags.String
+    private[scalanative] def tag = 19.toByte
   }
 
   /** A virtual value.
@@ -420,7 +394,7 @@ object Val {
    *  not serializable and are never emitted by the compiler plugin.
    */
   final case class Virtual(key: scala.Long) extends Val {
-    private[scalanative] def tag = Tags.Virtual
+    private[scalanative] def tag = 20.toByte
   }
 
   /** A reference to `java.lang.Class[_]` of given symbol `name`.
@@ -436,7 +410,7 @@ object Val {
    *  of lock word.
    */
   final case class ClassOf(name: nir.Global.Top) extends Val {
-    private[scalanative] def tag = Tags.ClassOf
+    private[scalanative] def tag = 21.toByte
   }
 
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -551,51 +551,77 @@ private[codegen] abstract class AbstractCodeGen(
   )(implicit sb: ShowBuilder): Unit = {
     import sb._
 
-    deconstify(v) match {
-      case nir.Val.True     => str("true")
-      case nir.Val.False    => str("false")
-      case nir.Val.Null     => str("null")
-      case nir.Val.Unit     => str("void")
-      case nir.Val.Zero(ty) => str("zeroinitializer")
-      case nir.Val.Byte(v)  => str(v)
-      case nir.Val.Size(v)  =>
+    val value = deconstify(v)
+
+    value.tag match {
+      case nir.Val.Tags.True  => str("true")
+      case nir.Val.Tags.False => str("false")
+      case nir.Val.Tags.Null  => str("null")
+      case nir.Val.Tags.Unit  => str("void")
+      case nir.Val.Tags.Zero  => str("zeroinitializer")
+      case nir.Val.Tags.Byte  =>
+        val nir.Val.Byte(v) = value: @unchecked
+        str(v)
+      case nir.Val.Tags.Size =>
+        val nir.Val.Size(v) = value: @unchecked
         if (!platform.is32Bit) str(v)
         else if (v.toInt == v) str(v.toInt)
         else unsupported("Emitting size values that exceed the platform bounds")
-      case nir.Val.Char(v)         => str(v.toInt)
-      case nir.Val.Short(v)        => str(v)
-      case nir.Val.Int(v)          => str(v)
-      case nir.Val.Long(v)         => str(v)
-      case v: nir.Val.Int128       => str(v.bigIntValue)
-      case nir.Val.Float(v)        => genFloatHex(v)
-      case nir.Val.Double(v)       => genDoubleHex(v)
-      case nir.Val.StructValue(vs) =>
+      case nir.Val.Tags.Char =>
+        val nir.Val.Char(v) = value: @unchecked
+        str(v.toInt)
+      case nir.Val.Tags.Short =>
+        val nir.Val.Short(v) = value: @unchecked
+        str(v)
+      case nir.Val.Tags.Int =>
+        val nir.Val.Int(v) = value: @unchecked
+        str(v)
+      case nir.Val.Tags.Long =>
+        val nir.Val.Long(v) = value: @unchecked
+        str(v)
+      case nir.Val.Tags.Int128 =>
+        val v: nir.Val.Int128 = value.asInstanceOf
+        str(v.bigIntValue)
+      case nir.Val.Tags.Float =>
+        val nir.Val.Float(v) = value: @unchecked
+        genFloatHex(v)
+      case nir.Val.Tags.Double =>
+        val nir.Val.Double(v) = value: @unchecked
+        genDoubleHex(v)
+      case nir.Val.Tags.StructValue =>
+        val nir.Val.StructValue(vs) = value: @unchecked
         str("{ ")
         rep(vs, sep = ", ")(genVal)
         str(" }")
-      case nir.Val.ArrayValue(_, vs) =>
+      case nir.Val.Tags.ArrayValue =>
+        val nir.Val.ArrayValue(_, vs) = value: @unchecked
         str("[ ")
         rep(vs, sep = ", ")(genVal)
         str(" ]")
-      case nir.Val.ByteString(v) =>
+      case nir.Val.Tags.ByteString =>
+        val nir.Val.ByteString(v) = value: @unchecked
         genByteString(v)
-      case nir.Val.Local(n, ty) =>
+      case nir.Val.Tags.Local =>
+        val nir.Val.Local(n, ty) = value: @unchecked
         str("%")
         genLocal(n)
-      case nir.Val.Global(n: nir.Global.Member, ty) =>
-        if (useOpaquePointers) {
-          lookup(n)
-          str("@")
-          genGlobal(n)
-        } else {
-          str("bitcast (")
-          genType(lookup(n))
-          str("* @")
-          genGlobal(n)
-          str(" to i8*)")
+      case nir.Val.Tags.Global =>
+        value.asInstanceOf[nir.Val.Global].name match {
+          case n: nir.Global.Member =>
+            if (useOpaquePointers) {
+              lookup(n)
+              str("@")
+              genGlobal(n)
+            } else {
+              str("bitcast (")
+              genType(lookup(n))
+              str("* @")
+              genGlobal(n)
+              str(" to i8*)")
+            }
+          case _ => unsupported(v)
         }
-      case _: nir.Val.Global | _: nir.Val.Const | _: nir.Val.String |
-          _: nir.Val.Virtual | _: nir.Val.ClassOf =>
+      case _ =>
         unsupported(v)
     }
   }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -4,6 +4,7 @@ package llvm
 import java.nio.file.{Path, Paths}
 import java.{lang => jl}
 
+import scala.annotation.switch
 import scala.collection.mutable
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
@@ -553,59 +554,59 @@ private[codegen] abstract class AbstractCodeGen(
 
     val value = deconstify(v)
 
-    value.tag match {
-      case nir.Val.Tags.True  => str("true")
-      case nir.Val.Tags.False => str("false")
-      case nir.Val.Tags.Null  => str("null")
-      case nir.Val.Tags.Unit  => str("void")
-      case nir.Val.Tags.Zero  => str("zeroinitializer")
-      case nir.Val.Tags.Byte  =>
+    (value.tag: @switch) match {
+      case 0 /* True */  => str("true")
+      case 1 /* False */ => str("false")
+      case 2 /* Null */  => str("null")
+      case 17 /* Unit */ => str("void")
+      case 3 /* Zero */  => str("zeroinitializer")
+      case 6 /* Byte */  =>
         val nir.Val.Byte(v) = value: @unchecked
         str(v)
-      case nir.Val.Tags.Size =>
+      case 4 /* Size */ =>
         val nir.Val.Size(v) = value: @unchecked
         if (!platform.is32Bit) str(v)
         else if (v.toInt == v) str(v.toInt)
         else unsupported("Emitting size values that exceed the platform bounds")
-      case nir.Val.Tags.Char =>
+      case 5 /* Char */ =>
         val nir.Val.Char(v) = value: @unchecked
         str(v.toInt)
-      case nir.Val.Tags.Short =>
+      case 7 /* Short */ =>
         val nir.Val.Short(v) = value: @unchecked
         str(v)
-      case nir.Val.Tags.Int =>
+      case 8 /* Int */ =>
         val nir.Val.Int(v) = value: @unchecked
         str(v)
-      case nir.Val.Tags.Long =>
+      case 9 /* Long */ =>
         val nir.Val.Long(v) = value: @unchecked
         str(v)
-      case nir.Val.Tags.Int128 =>
+      case 22 /* Int128 */ =>
         val v: nir.Val.Int128 = value.asInstanceOf
         str(v.bigIntValue)
-      case nir.Val.Tags.Float =>
+      case 10 /* Float */ =>
         val nir.Val.Float(v) = value: @unchecked
         genFloatHex(v)
-      case nir.Val.Tags.Double =>
+      case 11 /* Double */ =>
         val nir.Val.Double(v) = value: @unchecked
         genDoubleHex(v)
-      case nir.Val.Tags.StructValue =>
+      case 12 /* StructValue */ =>
         val nir.Val.StructValue(vs) = value: @unchecked
         str("{ ")
         rep(vs, sep = ", ")(genVal)
         str(" }")
-      case nir.Val.Tags.ArrayValue =>
+      case 13 /* ArrayValue */ =>
         val nir.Val.ArrayValue(_, vs) = value: @unchecked
         str("[ ")
         rep(vs, sep = ", ")(genVal)
         str(" ]")
-      case nir.Val.Tags.ByteString =>
+      case 14 /* ByteString */ =>
         val nir.Val.ByteString(v) = value: @unchecked
         genByteString(v)
-      case nir.Val.Tags.Local =>
+      case 15 /* Local */ =>
         val nir.Val.Local(n, ty) = value: @unchecked
         str("%")
         genLocal(n)
-      case nir.Val.Tags.Global =>
+      case 16 /* Global */ =>
         value.asInstanceOf[nir.Val.Global].name match {
           case n: nir.Global.Member =>
             if (useOpaquePointers) {


### PR DESCRIPTION
This method appears as a hot spot when profiling the linking process. Big match statements create a long chain of if `instanceof` checks. This PR replaces them with matching on a `tag: Byte` which is added to the `Val` sealed hierarchy.

The change makes the method go from 1.69% to 0.27% of the total time spent in the linking process.

Which should reduce the overall linking time by about 1.42%.