### PR TITLE
Port Java JSR-166 StampedLock and its unit test

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/locks/StampedLock.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/StampedLock.scala
@@ -18,7 +18,7 @@
  *     documented on the web (but not Wikipedia).
  *
  *   * Remaining issues
- *       ? how to translate '@ReservedStackAccess'??
+ *       ? how to translate '@ReservedStackAccess'?
  *       ? check with a guru about handling of SerialVersionUID?
  */
 

--- a/javalib/src/main/scala/java/util/concurrent/locks/StampedLock.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/StampedLock.scala
@@ -1,0 +1,1701 @@
+/* Ported from JSR-166 Expert Group main CVS (Concurrent Versions System)
+ * repository as described at Doug Lea "Concurrency JSR-166 Interest Site"
+ *    https://gee.cs.oswego.edu/dl/concurrency-interest/.
+ *
+ *  file: src/main/java/util/concurrent/locks/StampedLock.java
+ *  revision 1.118, dated: 2022-03-18
+ */
+
+/* Scala Native (SN) Notes:
+ *
+ *   * Shield your eyes: This code is intended to be Scala which stays very
+ *     close to JSR-166 .java original. This aids detecting porting errors.
+ *     It is _Not_Intended_ to be idiomatic Scala.
+ *
+ *   * For the curious, or those debugging cleanQueue() loop bugs,
+ *     the CLH queue mentioned above headAtomic is a
+ *     CLH (Craig, Landin, and Hagersten) queue. The algorithm is
+ *     documented on the web (but not Wikipedia).
+ *
+ *   * Remaining issues
+ *       ? how to translate '@ReservedStackAccess'?
+ *       ? check with a guru about handling of SerialVersionUID?
+ */
+
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent.locks
+
+import java.util.concurrent.TimeUnit
+
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.libc.stdatomic
+import scala.scalanative.libc.stdatomic.memory_order.{
+  memory_order_acquire, memory_order_relaxed, memory_order_release
+}
+import scala.scalanative.libc.stdatomic.{AtomicInt, AtomicLongLong, AtomicRef}
+import scala.scalanative.runtime.{Intrinsics, fromRawPtr}
+
+/*
+ * A capability-based lock with three modes for controlling read/write
+ * access.  The state of a StampedLock consists of a version and mode.
+ * Lock acquisition methods return a stamp that represents and
+ * controls access with respect to a lock state; "try" versions of
+ * these methods may instead return the special value zero to
+ * represent failure to acquire access. Lock release and conversion
+ * methods require stamps as arguments, and fail if they do not match
+ * the state of the lock. The three modes are:
+ *
+ * <ul>
+ *
+ *  <li><b>Writing.</b> Method {@link #writeLock} possibly blocks
+ *   waiting for exclusive access, returning a stamp that can be used
+ *   in method {@link #unlockWrite} to release the lock. Untimed and
+ *   timed versions of {@code tryWriteLock} are also provided. When
+ *   the lock is held in write mode, no read locks may be obtained,
+ *   and all optimistic read validations will fail.
+ *
+ *  <li><b>Reading.</b> Method {@link #readLock} possibly blocks
+ *   waiting for non-exclusive access, returning a stamp that can be
+ *   used in method {@link #unlockRead} to release the lock. Untimed
+ *   and timed versions of {@code tryReadLock} are also provided.
+ *
+ *  <li><b>Optimistic Reading.</b> Method {@link #tryOptimisticRead}
+ *   returns a non-zero stamp only if the lock is not currently held in
+ *   write mode.  Method {@link #validate} returns true if the lock has not
+ *   been acquired in write mode since obtaining a given stamp, in which
+ *   case all actions prior to the most recent write lock release
+ *   happen-before actions following the call to {@code tryOptimisticRead}.
+ *   This mode can be thought of as an extremely weak version of a
+ *   read-lock, that can be broken by a writer at any time.  The use of
+ *   optimistic read mode for short read-only code segments often reduces
+ *   contention and improves throughput.  However, its use is inherently
+ *   fragile.  Optimistic read sections should only read fields and hold
+ *   them in local variables for later use after validation. Fields read
+ *   while in optimistic read mode may be wildly inconsistent, so usage
+ *   applies only when you are familiar enough with data representations to
+ *   check consistency and/or repeatedly invoke method {@code validate()}.
+ *   For example, such steps are typically required when first reading an
+ *   object or array reference, and then accessing one of its fields,
+ *   elements or methods.
+ *
+ * </ul>
+ *
+ * <p>This class also supports methods that conditionally provide
+ * conversions across the three modes. For example, method {@link
+ * #tryConvertToWriteLock} attempts to "upgrade" a mode, returning
+ * a valid write stamp if (1) already in writing mode (2) in reading
+ * mode and there are no other readers or (3) in optimistic read mode
+ * and the lock is available. The forms of these methods are designed to
+ * help reduce some of the code bloat that otherwise occurs in
+ * retry-based designs.
+ *
+ * <p>StampedLocks are designed for use as internal utilities in the
+ * development of thread-safe components. Their use relies on
+ * knowledge of the internal properties of the data, objects, and
+ * methods they are protecting.  They are not reentrant, so locked
+ * bodies should not call other unknown methods that may try to
+ * re-acquire locks (although you may pass a stamp to other methods
+ * that can use or convert it).  The use of read lock modes relies on
+ * the associated code sections being side-effect-free.  Unvalidated
+ * optimistic read sections cannot call methods that are not known to
+ * tolerate potential inconsistencies.  Stamps use finite
+ * representations, and are not cryptographically secure (i.e., a
+ * valid stamp may be guessable). Stamp values may recycle after (no
+ * sooner than) one year of continuous operation. A stamp held without
+ * use or validation for longer than this period may fail to validate
+ * correctly.  StampedLocks are serializable, but always deserialize
+ * into initial unlocked state, so they are not useful for remote
+ * locking.
+ *
+ * <p>Like {@link java.util.concurrent.Semaphore Semaphore}, but unlike most
+ * {@link Lock} implementations, StampedLocks have no notion of ownership.
+ * Locks acquired in one thread can be released or converted in another.
+ *
+ * <p>The scheduling policy of StampedLock does not consistently
+ * prefer readers over writers or vice versa.  All "try" methods are
+ * best-effort and do not necessarily conform to any scheduling or
+ * fairness policy. A zero return from any "try" method for acquiring
+ * or converting locks does not carry any information about the state
+ * of the lock; a subsequent invocation may succeed.
+ *
+ * <p>Because it supports coordinated usage across multiple lock
+ * modes, this class does not directly implement the {@link Lock} or
+ * {@link ReadWriteLock} interfaces. However, a StampedLock may be
+ * viewed {@link #asReadLock()}, {@link #asWriteLock()}, or {@link
+ * #asReadWriteLock()} in applications requiring only the associated
+ * set of functionality.
+ *
+ * <p><b>Memory Synchronization.</b> Methods with the effect of
+ * successfully locking in any mode have the same memory
+ * synchronization effects as a <em>Lock</em> action, as described in
+ * Chapter 17 of <cite>The Java Language Specification</cite>.
+ * Methods successfully unlocking in write mode have the same memory
+ * synchronization effects as an <em>Unlock</em> action.  In optimistic
+ * read usages, actions prior to the most recent write mode unlock action
+ * are guaranteed to happen-before those following a tryOptimisticRead
+ * only if a later validate returns true; otherwise there is no guarantee
+ * that the reads between tryOptimisticRead and validate obtain a
+ * consistent snapshot.
+ *
+ * <p><b>Sample Usage.</b> The following illustrates some usage idioms
+ * in a class that maintains simple two-dimensional points. The sample
+ * code illustrates some try/catch conventions even though they are
+ * not strictly needed here because no exceptions can occur in their
+ * bodies.
+ *
+ * <pre> {@code
+ * class Point {
+ *   private double x, y;
+ *   private final StampedLock sl = new StampedLock();
+ *
+ *   // an exclusively locked method
+ *   void move(double deltaX, double deltaY) {
+ *     long stamp = sl.writeLock();
+ *     try {
+ *       x += deltaX;
+ *       y += deltaY;
+ *     } finally {
+ *       sl.unlockWrite(stamp);
+ *     }
+ *   }
+ *
+ *   // a read-only method
+ *   // upgrade from optimistic read to read lock
+ *   double distanceFromOrigin() {
+ *     long stamp = sl.tryOptimisticRead();
+ *     try {
+ *       retryHoldingLock: for (;; stamp = sl.readLock()) {
+ *         if (stamp == 0L)
+ *           continue retryHoldingLock;
+ *         // possibly racy reads
+ *         double currentX = x;
+ *         double currentY = y;
+ *         if (!sl.validate(stamp))
+ *           continue retryHoldingLock;
+ *         return Math.hypot(currentX, currentY);
+ *       }
+ *     } finally {
+ *       if (StampedLock.isReadLockStamp(stamp))
+ *         sl.unlockRead(stamp);
+ *     }
+ *   }
+ *
+ *   // upgrade from optimistic read to write lock
+ *   void moveIfAtOrigin(double newX, double newY) {
+ *     long stamp = sl.tryOptimisticRead();
+ *     try {
+ *       retryHoldingLock: for (;; stamp = sl.writeLock()) {
+ *         if (stamp == 0L)
+ *           continue retryHoldingLock;
+ *         // possibly racy reads
+ *         double currentX = x;
+ *         double currentY = y;
+ *         if (!sl.validate(stamp))
+ *           continue retryHoldingLock;
+ *         if (currentX != 0.0 || currentY != 0.0)
+ *           break;
+ *         stamp = sl.tryConvertToWriteLock(stamp);
+ *         if (stamp == 0L)
+ *           continue retryHoldingLock;
+ *         // exclusive access
+ *         x = newX;
+ *         y = newY;
+ *         return;
+ *       }
+ *     } finally {
+ *       if (StampedLock.isWriteLockStamp(stamp))
+ *         sl.unlockWrite(stamp);
+ *     }
+ *   }
+ *
+ *   // upgrade read lock to write lock
+ *   void moveIfAtOrigin2(double newX, double newY) {
+ *     long stamp = sl.readLock();
+ *     try {
+ *       while (x == 0.0 && y == 0.0) {
+ *         long ws = sl.tryConvertToWriteLock(stamp);
+ *         if (ws != 0L) {
+ *           stamp = ws;
+ *           x = newX;
+ *           y = newY;
+ *           break;
+ *         }
+ *         else {
+ *           sl.unlockRead(stamp);
+ *           stamp = sl.writeLock();
+ *         }
+ *       }
+ *     } finally {
+ *       sl.unlock(stamp);
+ *     }
+ *   }
+ * }}</pre>
+ *
+ * @jls 17.4 Memory Model
+ * @since 1.8
+ * @author Doug Lea
+ */
+@SerialVersionUID(-6001602636862214147L)
+class StampedLock extends Serializable {
+  import StampedLock.*
+
+  /*
+   * Algorithmic notes:
+   *
+   * The design employs elements of Sequence locks
+   * (as used in linux kernels; see Lameter's
+   * http://www.lameter.com/gelato2005.pdf
+   * and elsewhere; see
+   * Boehm's http://www.hpl.hp.com/techreports/2012/HPL-2012-68.html)
+   * and Ordered RW locks (see Shirako et al
+   * http://dl.acm.org/citation.cfm?id=2312015)
+   *
+   * Conceptually, the primary state of the lock includes a sequence
+   * number that is odd when write-locked and even otherwise.
+   * However, this is offset by a reader count that is non-zero when
+   * read-locked.  The read count is ignored when validating
+   * "optimistic" seqlock-reader-style stamps.  Because we must use
+   * a small finite number of bits (currently 7) for readers, a
+   * supplementary reader overflow word is used when the number of
+   * readers exceeds the count field. We do this by treating the max
+   * reader count value (RBITS) as a spinlock protecting overflow
+   * updates.
+   *
+   * Waiters use a modified form of CLH lock used in
+   * AbstractQueuedSynchronizer (AQS; see its internal documentation
+   * for a fuller account), where each node is either a ReaderNode
+   * or WriterNode. Implementation of queued Writer mode is
+   * identical to AQS except for lock-state operations.  Sets of
+   * waiting readers are grouped (linked) under a common node (field
+   * cowaiters) so act as a single node with respect to most CLH
+   * mechanics.  This simplifies the scheduling policy to a
+   * mainly-FIFO scheme that incorporates elements of Phase-Fair
+   * locks (see Brandenburg & Anderson, especially
+   * http://www.cs.unc.edu/~bbb/diss/).  Method release does not
+   * itself wake up cowaiters. This is done by the primary thread,
+   * but helped by other cowaiters as they awaken.
+   *
+   * These rules apply to threads actually queued. Threads may also
+   * try to acquire locks before or in the process of enqueueing
+   * regardless of preference rules, and so may "barge" their way
+   * in.  Methods writeLock and readLock (but not the other variants
+   * of each) first unconditionally try to CAS state, falling back
+   * to test-and-test-and-set retries on failure, slightly shrinking
+   * race windows on initial attempts, thus making success more
+   * likely. Also, when some threads cancel (via interrupt or
+   * timeout), phase-fairness is at best roughly approximated.
+   *
+   * Nearly all of these mechanics are carried out in methods
+   * acquireWrite and acquireRead, that, as typical of such code,
+   * sprawl out because actions and retries rely on consistent sets
+   * of locally cached reads.
+   *
+   * For an explanation of the use of acquireFence, see
+   * http://gee.cs.oswego.edu/dl/html/j9mm.html as well as Boehm's
+   * paper (above). Note that sequence validation (mainly method
+   * validate()) requires stricter ordering rules than apply to
+   * normal volatile reads (of "state").  To ensure that writeLock
+   * acquisitions strictly precede subsequent writes in cases where
+   * this is not already forced, we use a storeStoreFence.
+   *
+   * The memory layout keeps lock state and queue pointers together
+   * (normally on the same cache line). This usually works well for
+   * read-mostly loads. In most other cases, the natural tendency of
+   * CLH locks to reduce memory contention lessens motivation to
+   * further spread out contended locations, but might be subject to
+   * future improvements.
+   */
+
+  /* Head of CLH queue */
+  @alwaysinline private def headAtomic = new AtomicRef[Node](
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "head"))
+  )
+  @transient @volatile private var head: Node = _
+
+  /* Tail (last) of CLH queue */
+  @alwaysinline private def tailAtomic = new AtomicRef[Node](
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "tail"))
+  )
+  @transient @volatile private var tail: Node = _
+
+  // views
+  @transient var readLockView: ReadLockView = _
+  @transient var writeLockView: WriteLockView = _
+  @transient var readWriteLockView: ReadWriteLockView = _
+
+  /* Lock sequence/state */
+
+  // A new lock is initially in unlocked state.
+
+  // private[locks] makes var visibile to classFieldRawPtr but not to world.
+  @transient @volatile private[locks] var state: Long = ORIGIN
+
+  /* extra reader count when state read count saturated */
+  @transient private var readerOverflow = 0
+
+  // internal lock methods
+
+  @alwaysinline private def stateAtomic = new AtomicLongLong(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "state"))
+  )
+
+  private def casState(expect: Long, update: Long): Boolean =
+    stateAtomic.compareExchangeStrong(expect, update)
+
+  // @ReservedStackAccess
+  private def tryAcquireWrite(): Long = {
+    val s = state
+    val nextState = s | WBIT
+
+    if (((s & ABITS) == 0L) && casState(s, nextState)) {
+      stdatomic.atomic_thread_fence(memory_order_release)
+      nextState
+    } else 0L
+  }
+
+  // @ReservedStackAccess
+  private def tryAcquireRead(): Long = {
+    while (true) {
+      val s = state
+      val m = s & ABITS
+      var nextState = s + RUNIT
+
+      if (m < RFULL) {
+        if (casState(s, nextState)) {
+          return nextState
+        }
+      } else if (m == WBIT) {
+        return 0L
+      } else {
+        if (({ nextState = tryIncReaderOverflow(s); nextState }) != 0L)
+          return nextState
+      }
+    }
+
+    0L // Should never get here, keep compiler happy.
+  }
+
+  /*
+   * Returns an unlocked state, incrementing the version and
+   * avoiding special failure value 0L.
+   *
+   * @param s a write-locked state (or stamp)
+   */
+  private def unlockWriteState(s: Long): Long = {
+    val sPlus = s + WBIT
+    if (sPlus == 0L) ORIGIN
+    else sPlus
+  }
+
+  private def releaseWrite(s: Long): Long = {
+    val nextState = { state = unlockWriteState(s); state }
+    signalNext(head)
+    nextState
+  }
+
+  /*
+   * Exclusively acquires the lock, blocking if necessary
+   * until available.
+   *
+   * @return a write stamp that can be used to unlock or convert mode
+   */
+  // @ReservedStackAccess
+  def writeLock(): Long = {
+    // try unconditional CAS confirming weak read
+    val s = stateAtomic.load(memory_order_relaxed) & ~ABITS
+    val nextState = s | WBIT
+
+    if (casState(s, nextState)) {
+      stateAtomic.store(nextState, memory_order_relaxed)
+      nextState
+    } else {
+      acquireWrite(false, false, 0L)
+    }
+  }
+
+  /*
+   * Exclusively acquires the lock if it is immediately available.
+   *
+   * @return a write stamp that can be used to unlock or convert mode,
+   * or zero if the lock is not available
+   */
+  def tryWriteLock(): Long =
+    tryAcquireWrite()
+
+  /*
+   * Exclusively acquires the lock if it is available within the
+   * given time and the current thread has not been interrupted.
+   * Behavior under timeout and interruption matches that specified
+   * for method {@link Lock#tryLock(long,TimeUnit)}.
+   *
+   * @param time the maximum time to wait for the lock
+   * @param unit the time unit of the {@code time} argument
+   * @return a write stamp that can be used to unlock or convert mode,
+   * or zero if the lock is not available
+   * @throws InterruptedException if the current thread is interrupted
+   * before acquiring the lock
+   */
+  def tryWriteLock(time: Long, unit: TimeUnit): Long = {
+    val nanos = unit.toNanos(time)
+
+    if (!Thread.interrupted()) {
+      var nextState = tryAcquireWrite()
+
+      if (nextState != 0L)
+        return nextState
+      if (nanos <= 0L)
+        return 0L
+
+      nextState = acquireWrite(true, true, System.nanoTime() + nanos)
+      if (nextState != INTERRUPTED)
+        return nextState
+    }
+
+    throw new InterruptedException()
+  }
+
+  /*
+   * Exclusively acquires the lock, blocking if necessary
+   * until available or the current thread is interrupted.
+   * Behavior under interruption matches that specified
+   * for method {@link Lock#lockInterruptibly()}.
+   *
+   * @return a write stamp that can be used to unlock or convert mode
+   * @throws InterruptedException if the current thread is interrupted
+   * before acquiring the lock
+   */
+  def writeLockInterruptibly(): Long = {
+    var nextState = 0L
+
+    if (!Thread.interrupted() &&
+        ({ nextState = tryAcquireWrite(); nextState } != 0L ||
+        ({
+          nextState = acquireWrite(true, false, 0L); nextState
+        } != INTERRUPTED)))
+      return nextState
+
+    throw new InterruptedException()
+  }
+
+  /*
+   * Non-exclusively acquires the lock, blocking if necessary
+   * until available.
+   *
+   * @return a read stamp that can be used to unlock or convert mode
+   */
+  // @ReservedStackAccess
+  def readLock(): Long = {
+    // unconditionally optimistically try non-overflow case once
+    val s = stateAtomic.load(memory_order_relaxed) & RSAFE
+    val nextState = s + RUNIT
+
+    if (casState(s, nextState))
+      nextState
+    else
+      acquireRead(false, false, 0L)
+  }
+
+  /*
+   * Non-exclusively acquires the lock if it is immediately available.
+   *
+   * @return a read stamp that can be used to unlock or convert mode,
+   * or zero if the lock is not available
+   */
+  def tryReadLock(): Long =
+    tryAcquireRead()
+
+  /*
+   * Non-exclusively acquires the lock if it is available within the
+   * given time and the current thread has not been interrupted.
+   * Behavior under timeout and interruption matches that specified
+   * for method {@link Lock#tryLock(long,TimeUnit)}.
+   *
+   * @param time the maximum time to wait for the lock
+   * @param unit the time unit of the {@code time} argument
+   * @return a read stamp that can be used to unlock or convert mode,
+   * or zero if the lock is not available
+   * @throws InterruptedException if the current thread is interrupted
+   * before acquiring the lock
+   */
+  def tryReadLock(time: Long, unit: TimeUnit): Long = {
+    val nanos = unit.toNanos(time)
+
+    if (!Thread.interrupted()) {
+      var nextState = tryAcquireRead()
+
+      if ((tail == head) && nextState != 0L)
+        return nextState
+      if (nanos <= 0L)
+        return 0L
+
+      nextState = acquireRead(true, true, System.nanoTime() + nanos)
+      if (nextState != INTERRUPTED)
+        return nextState
+    }
+
+    throw new InterruptedException()
+  }
+
+  /*
+   * Non-exclusively acquires the lock, blocking if necessary
+   * until available or the current thread is interrupted.
+   * Behavior under interruption matches that specified
+   * for method {@link Lock#lockInterruptibly()}.
+   *
+   * @return a read stamp that can be used to unlock or convert mode
+   * @throws InterruptedException if the current thread is interrupted
+   * before acquiring the lock
+   */
+  def readLockInterruptibly(): Long = {
+    var nextState = 0L
+
+    if (!Thread.interrupted() &&
+        (({ nextState = tryAcquireRead(); nextState } != 0L) ||
+        ({
+          nextState = acquireRead(true, false, 0L); nextState
+        }) != INTERRUPTED))
+      return nextState
+
+    throw new InterruptedException()
+  }
+
+  /*
+   * Returns a stamp that can later be validated, or zero
+   * if exclusively locked.
+   *
+   * @return a valid optimistic read stamp, or zero if exclusively locked
+   */
+  def tryOptimisticRead(): Long = {
+    val s = state
+    if ((state & WBIT) == 0L) (s & SBITS)
+    else 0L
+  }
+
+  /*
+   * Returns true if the lock has not been exclusively acquired
+   * since issuance of the given stamp. Always returns false if the
+   * stamp is zero. Always returns true if the stamp represents a
+   * currently held lock. Invoking this method with a value not
+   * obtained from {@link #tryOptimisticRead} or a locking method
+   * for this lock has no defined effect or result.
+   *
+   * @param stamp a stamp
+   * @return {@code true} if the lock has not been exclusively acquired
+   * since issuance of the given stamp; else false
+   */
+  def validate(stamp: Long): Boolean = {
+    stdatomic.atomic_thread_fence(memory_order_acquire)
+    (stamp & SBITS) == (state & SBITS)
+  }
+
+  /*
+   * If the lock state matches the given stamp, releases the
+   * exclusive lock.
+   *
+   * @param stamp a stamp returned by a write-lock operation
+   * @throws IllegalMonitorStateException if the stamp does
+   * not match the current state of this lock
+   */
+  // @ReservedStackAccess
+  def unlockWrite(stamp: Long): Unit = {
+    if (state != stamp || (stamp & WBIT) == 0L)
+      throw new IllegalMonitorStateException()
+    releaseWrite(stamp)
+  }
+
+  /*
+   * If the lock state matches the given stamp, releases the
+   * non-exclusive lock.
+   *
+   * @param stamp a stamp returned by a read-lock operation
+   * @throws IllegalMonitorStateException if the stamp does
+   * not match the current state of this lock
+   */
+  // @ReservedStackAccess
+  def unlockRead(stamp: Long): Unit = {
+    if ((stamp & RBITS) != 0L) {
+      var s = 0L
+      var m = 0L
+      while (({ s = state; state } & SBITS) == (stamp & SBITS) &&
+          ({ m = s & RBITS; m } != 0L)) {
+        if (m < RFULL) {
+          if (casState(s, s - RUNIT)) {
+            if (m == RUNIT)
+              signalNext(head)
+            return
+          }
+        } else if (tryDecReaderOverflow(s) != 0L)
+          return
+      }
+    }
+
+    throw new IllegalMonitorStateException()
+  }
+
+  /*
+   * If the lock state matches the given stamp, releases the
+   * corresponding mode of the lock.
+   *
+   * @param stamp a stamp returned by a lock operation
+   * @throws IllegalMonitorStateException if the stamp does
+   * not match the current state of this lock
+   */
+  def unlock(stamp: Long): Unit = {
+    if ((stamp & WBIT) != 0L)
+      unlockWrite(stamp)
+    else
+      unlockRead(stamp)
+  }
+
+  /*
+   * If the lock state matches the given stamp, atomically performs one of
+   * the following actions. If the stamp represents holding a write
+   * lock, returns it.  Or, if a read lock, if the write lock is
+   * available, releases the read lock and returns a write stamp.
+   * Or, if an optimistic read, returns a write stamp only if
+   * immediately available. This method returns zero in all other
+   * cases.
+   *
+   * @param stamp a stamp
+   * @return a valid write stamp, or zero on failure
+   */
+  def tryConvertToWriteLock(stamp: Long): Long = {
+    val a = stamp & ABITS
+    var m = 0L
+    var s = 0L
+    var nextState = 0L
+
+    var done = false
+
+    while (!done
+        && (({ s = state; s } & SBITS) == (stamp & SBITS))) {
+      if ({ m = s & ABITS; m } == 0L) {
+        if (a != 0L)
+          done = true
+        else if (casState(s, { nextState = s | WBIT; nextState })) {
+          stdatomic.atomic_thread_fence(memory_order_release)
+          return nextState
+        }
+      } else if (m == WBIT) {
+        if (a != m)
+          done = true
+        else
+          return stamp
+      } else if (m == RUNIT && a != 0L) {
+        if (casState(s, { nextState = s - RUNIT + WBIT; nextState }))
+          return nextState
+      } else
+        done = true
+    }
+
+    0L
+  }
+
+  /*
+   * If the lock state matches the given stamp, atomically performs one of
+   * the following actions. If the stamp represents holding a write
+   * lock, releases it and obtains a read lock.  Or, if a read lock,
+   * returns it. Or, if an optimistic read, acquires a read lock and
+   * returns a read stamp only if immediately available. This method
+   * returns zero in all other cases.
+   *
+   * @param stamp a stamp
+   * @return a valid read stamp, or zero on failure
+   */
+  def tryConvertToReadLock(stamp: Long): Long = {
+    var a = 0L
+    var s = 0L
+    var nextState = 0L
+
+    var done = false
+
+    while (!done
+        && (({ s = state; s } & SBITS) == (stamp & SBITS))) {
+      if ({ a = stamp & ABITS; a } >= WBIT) {
+        if (s != stamp) // write stamp
+          done = true
+        else {
+          state = unlockWriteState(s) + RUNIT
+          nextState = state
+          signalNext(head)
+          return nextState
+        }
+      } else if (a == 0L) { // optimistic read stamp
+        if ((s & ABITS) < RFULL) {
+          if (casState(s, { nextState = s + RUNIT; nextState }))
+            return nextState
+        } else if (({ nextState = tryIncReaderOverflow(s); nextState }) != 0L)
+          return nextState
+      } else { // already a read stamp
+        if ((s & ABITS) == 0L)
+          done = true
+        else
+          return stamp
+      }
+    }
+
+    0L
+  }
+
+  /*
+   * If the lock state matches the given stamp then, atomically, if the stamp
+   * represents holding a lock, releases it and returns an
+   * observation stamp.  Or, if an optimistic read, returns it if
+   * validated. This method returns zero in all other cases, and so
+   * may be useful as a form of "tryUnlock".
+   *
+   * @param stamp a stamp
+   * @return a valid optimistic read stamp, or zero on failure
+   */
+  def tryConvertToOptimisticRead(stamp: Long): Long = {
+    var a = 0L
+    var m = 0L
+    var s = 0L
+    var nextState = 0L
+
+    stdatomic.atomic_thread_fence(memory_order_acquire)
+
+    var done = false
+
+    while (!done
+        && (({ s = state; s } & SBITS) == (stamp & SBITS))) {
+      if ({ a = stamp & ABITS; a } >= WBIT) {
+        if (s != stamp) // write stamp
+          done = true
+        else
+          return releaseWrite(s)
+      } else if (a == 0L) { // already an optimistic read stamp
+        return stamp
+      } else if ({ m = s & ABITS; m } == 0L) { // invalid read stamp
+        done = true
+      } else if (m < RFULL) {
+        if (casState(s, { nextState = s - RUNIT; nextState })) {
+          if (m == RUNIT)
+            signalNext(head)
+          return nextState & SBITS
+        }
+      } else if (({ nextState = tryDecReaderOverflow(s); nextState }) != 0L)
+        return nextState & SBITS
+    }
+
+    0L
+  }
+
+  /*
+   * Releases the write lock if it is held, without requiring a
+   * stamp value. This method may be useful for recovery after
+   * errors.
+   *
+   * @return {@code true} if the lock was held, else false
+   */
+  // @ReservedStackAccess
+  def tryUnlockWrite(): Boolean = {
+    val s = state
+
+    if ((s & WBIT) != 0L) {
+      releaseWrite(s)
+      true
+    } else {
+      false
+    }
+  }
+
+  /*
+   * Releases one hold of the read lock if it is held, without
+   * requiring a stamp value. This method may be useful for recovery
+   * after errors.
+   *
+   * @return {@code true} if the read lock was held, else false
+   */
+  // @ReservedStackAccess
+  def tryUnlockRead(): Boolean = {
+    var s = 0L
+    var m = 0L
+
+    while (({ m = { s = state; s } & ABITS; m } != 0L) && (m < WBIT)) {
+      if (m < RFULL) {
+        if (casState(s, s - RUNIT)) {
+          if (m == RUNIT)
+            signalNext(head)
+          return true
+        }
+      } else if (tryDecReaderOverflow(s) != 0L)
+        return true
+    }
+
+    false
+  }
+
+  // status monitoring methods
+
+  /*
+   * Returns combined state-held and overflow read count for given
+   * state s.
+   */
+  def getReadLockCount(s: Long): Int = {
+    var readers = s & RBITS
+
+    if (readers >= RFULL)
+      readers = RFULL + readerOverflow
+
+    readers.toInt
+  }
+
+  /*
+   * Returns {@code true} if the lock is currently held exclusively.
+   *
+   * @return {@code true} if the lock is currently held exclusively
+   */
+  def isWriteLocked(): Boolean =
+    (state & WBIT) != 0L
+
+  /*
+   * Returns {@code true} if the lock is currently held non-exclusively.
+   *
+   * @return {@code true} if the lock is currently held non-exclusively
+   */
+  def isReadLocked(): Boolean =
+    (state & RBITS) != 0L
+
+  /*
+   * Queries the number of read locks held for this lock. This
+   * method is designed for use in monitoring system state, not for
+   * synchronization control.
+   * @return the number of read locks held
+   */
+  def getReadLockCount(): Int =
+    getReadLockCount(state)
+
+  /*
+   * Returns a string identifying this lock, as well as its lock
+   * state.  The state, in brackets, includes the String {@code
+   * "Unlocked"} or the String {@code "Write-locked"} or the String
+   * {@code "Read-locks:"} followed by the current number of
+   * read-locks held.
+   *
+   * @return a string identifying this lock, as well as its lock state
+   */
+  override def toString(): String = {
+    val s = state
+    val suffix =
+      if ((s & ABITS) == 0L) "[Unlocked]"
+      else if ((s & WBIT) != 0L) "[Write-locked]"
+      else s"[Read-locks:${getReadLockCount(s)}]"
+    s"${super.toString()}${suffix}"
+  }
+
+  // views
+
+  /*
+   * Returns a plain {@link Lock} view of this StampedLock in which
+   * the {@link Lock#lock} method is mapped to {@link #readLock},
+   * and similarly for other methods. The returned Lock does not
+   * support a {@link Condition}; method {@link Lock#newCondition()}
+   * throws {@code UnsupportedOperationException}.
+   *
+   * @return the lock
+   */
+  def asReadLock(): Lock = {
+    val v = readLockView
+    if (v != null) v
+    else {
+      readLockView = new ReadLockView
+      readLockView
+    }
+  }
+
+  /*
+   * Returns a plain {@link Lock} view of this StampedLock in which
+   * the {@link Lock#lock} method is mapped to {@link #writeLock},
+   * and similarly for other methods. The returned Lock does not
+   * support a {@link Condition}; method {@link Lock#newCondition()}
+   * throws {@code UnsupportedOperationException}.
+   *
+   * @return the lock
+   */
+  def asWriteLock(): Lock = {
+    val v = writeLockView
+    if (v != null) v
+    else {
+      writeLockView = new WriteLockView
+      writeLockView
+    }
+  }
+
+  /*
+   * Returns a {@link ReadWriteLock} view of this StampedLock in
+   * which the {@link ReadWriteLock#readLock()} method is mapped to
+   * {@link #asReadLock()}, and {@link ReadWriteLock#writeLock()} to
+   * {@link #asWriteLock()}.
+   *
+   * @return the lock
+   */
+  def asReadWriteLock(): ReadWriteLock = {
+    val v = readWriteLockView
+    if (v != null) v
+    else {
+      readWriteLockView = new ReadWriteLockView
+      readWriteLockView
+    }
+  }
+
+  // view classes
+
+  final class ReadLockView extends Lock {
+    def lock(): Unit =
+      readLock()
+
+    def lockInterruptibly(): Unit =
+      readLockInterruptibly()
+
+    def tryLock(): Boolean =
+      tryReadLock() != 0L
+
+    def tryLock(time: Long, unit: java.util.concurrent.TimeUnit): Boolean =
+      tryReadLock(time, unit) != 0L
+
+    def unlock(): Unit =
+      unstampedUnlockRead()
+
+    def newCondition(): java.util.concurrent.locks.Condition =
+      throw new UnsupportedOperationException()
+  }
+
+  final class WriteLockView extends Lock {
+    def lock(): Unit =
+      writeLock()
+
+    def lockInterruptibly(): Unit =
+      writeLockInterruptibly()
+
+    def tryLock(): Boolean =
+      tryWriteLock() != 0L
+
+    def tryLock(time: Long, unit: java.util.concurrent.TimeUnit): Boolean =
+      tryWriteLock(time, unit) != 0L
+
+    def unlock(): Unit =
+      unstampedUnlockWrite()
+
+    def newCondition(): java.util.concurrent.locks.Condition =
+      throw new UnsupportedOperationException()
+  }
+
+  final class ReadWriteLockView extends ReadWriteLock {
+    def readLock(): Lock =
+      asReadLock()
+
+    def writeLock(): Lock =
+      asWriteLock()
+  }
+
+  // Unlock methods without stamp argument checks for view classes.
+  // Needed because view-class lock methods throw away stamps.
+
+  final def unstampedUnlockWrite(): Unit = {
+    val s = state
+    if ((s & WBIT) == 0L)
+      throw new IllegalMonitorStateException()
+    releaseWrite(s)
+  }
+
+  final def unstampedUnlockRead(): Unit = {
+    val s = state
+    val m = s & RBITS
+
+    while (m > 0L) {
+      if (m < RFULL) {
+        if (casState(s, s - RUNIT)) {
+          if (m == RUNIT)
+            signalNext(head)
+          return
+        }
+      } else if (tryDecReaderOverflow(s) != 0L)
+        return
+    }
+
+    throw new IllegalMonitorStateException()
+  }
+
+  // Scala Native does not support ObjectInputStream.
+  //  private def readObject(s: ObjectInputStream): Unit
+
+  // overflow handling methods
+
+  /*
+   * Tries to increment readerOverflow by first setting state
+   * access bits value to RBITS, indicating hold of spinlock,
+   * then updating, then releasing.
+   *
+   * @param s a reader overflow stamp: (s & ABITS) >= RFULL
+   * @return new stamp on success, else zero
+   */
+  private def tryIncReaderOverflow(s: Long): Long = {
+    // assert (s & ABITS) >= RFULL
+
+    if ((s & ABITS) != RFULL) {
+      Thread.onSpinWait()
+    } else if (casState(s, s | RBITS)) {
+      readerOverflow += 1
+      return { state = s; s }
+    }
+
+    0L
+  }
+
+  /*
+   * Tries to decrement readerOverflow.
+   *
+   * @param s a reader overflow stamp: (s & ABITS) >= RFULL
+   * @return new stamp on success, else zero
+   */
+  private def tryDecReaderOverflow(s: Long): Long = {
+    // assert (s & ABITS) >= RFULL
+
+    if ((s & ABITS) != RFULL)
+      Thread.onSpinWait()
+    else if (casState(s, s | RBITS)) {
+      val r = readerOverflow
+      var nextState = 0L
+
+      if (r > 0) {
+        readerOverflow = r - 1
+        nextState = s
+      } else {
+        nextState = s - RUNIT
+      }
+
+      return { state = nextState; state }
+    }
+
+    0L
+  }
+
+  // queue link methods
+  private def casTail(c: Node, v: Node): Boolean =
+    tailAtomic.compareExchangeStrong(c, v)
+
+  /* tries once to CAS a new dummy node for head */
+  private def tryInitializeHead(): Unit = {
+    val h = new WriterNode()
+
+    if (headAtomic.compareExchangeStrong(null.asInstanceOf[WriterNode], h))
+      tail = h
+  }
+
+  /*
+   * For explanation, see above and AbstractQueuedSynchronizer
+   * internal documentation.
+   *
+   * @param interruptible true if should check interrupts and if so
+   * return INTERRUPTED
+   * @param timed if true use timed waits
+   * @param time the System.nanoTime value to timeout at (and return zero)
+   * @return next state, or INTERRUPTED
+   */
+  private def acquireWrite(
+      interruptible: Boolean,
+      timed: Boolean,
+      time: Long
+  ): Long = {
+    // retries upon unpark of first thread
+    var spins = 0
+    var postSpins = 0
+    var interrupted = false
+    var first = false
+    var node: WriterNode = null
+
+    var breakSeen = false
+
+    while (!breakSeen) {
+      var continueSeen = false
+
+      val pred: Node =
+        if (node == null) null
+        else node.prev
+
+      if (!first && pred != null &&
+          ! { first = (head == pred); first }) {
+        if (pred.status < 0) {
+          cleanQueue() // predecessor cancelled
+          continueSeen = true
+        } else if (pred.prev == null) {
+          Thread.onSpinWait() // ensure serialization
+          continueSeen = true
+        }
+      }
+
+      if (!continueSeen) {
+        val s = state
+        val nextState = s | WBIT
+
+        if ((first || pred == null) && (s & ABITS) == 0L &&
+            casState(s, nextState)) {
+          stdatomic.atomic_thread_fence(memory_order_release)
+          if (first) {
+            node.prev = null
+            head = node
+            pred.next = null
+            node.waiter = null
+            if (interrupted)
+              Thread.currentThread().interrupt()
+          }
+          return nextState
+        } else if (node == null) { // retry before enqueuing
+          node = new WriterNode()
+        } else if (pred == null) { // try to enqueue
+          val t = tail
+          node.setPrevRelaxed(t)
+          if (t == null)
+            tryInitializeHead()
+          else if (!casTail(t, node))
+            node.setPrevRelaxed(null); // back out
+          else
+            t.next = node;
+        } else if (first && spins != 0) { // reduce unfairness
+          spins -= 1
+          Thread.onSpinWait()
+        } else if (node.status == 0) { // enable signal
+          if (node.waiter == null)
+            node.waiter = Thread.currentThread()
+          node.status = WAITING
+        } else {
+          var nanos = 0L
+          postSpins = ((postSpins << 1) | 1)
+          spins = postSpins
+          if (!timed)
+            LockSupport.park(this)
+          else if ({ nanos = time - System.nanoTime(); nanos } > 0L)
+            LockSupport.parkNanos(this, nanos)
+          else
+            breakSeen = true
+
+          node.clearStatus()
+
+          interrupted |= Thread.interrupted()
+          if (interrupted && interruptible)
+            breakSeen = true
+        }
+      }
+
+    }
+
+    cancelAcquire(node, interrupted)
+  }
+
+  /*
+   * See above for explanation.
+   *
+   * @param interruptible true if should check interrupts and if so
+   * return INTERRUPTED
+   * @param timed if true use timed waits
+   * @param time the System.nanoTime value to timeout at (and return zero)
+   * @return next state, or INTERRUPTED
+   */
+  private def acquireRead(
+      interruptible: Boolean,
+      timed: Boolean,
+      time: Long
+  ): Long = {
+    var interrupted = false
+    var node: ReaderNode = null
+
+    /*
+     * Loop:
+     *   if empty, try to acquire
+     *   if tail is Reader, try to cowait; restart if leader stale or cancels
+     *   else try to create and enqueue node, and wait in 2nd loop below
+     */
+
+    var nextState = 0L
+    var breakSeen = false
+
+    while (!breakSeen) {
+      var leader: ReaderNode = null
+      var tailPred: Node = null
+      val t = tail
+
+      if ((t == null || { tailPred = t.prev; tailPred } == null) &&
+          ({
+            nextState = tryAcquireRead(); nextState
+          }) != 0L) { // try now if empty
+        return nextState
+      } else if (t == null) {
+        tryInitializeHead()
+      } else if (tailPred == null || !(t.isInstanceOf[ReaderNode])) {
+        if (node == null)
+          node = new ReaderNode()
+
+        if (tail == t) {
+          node.setPrevRelaxed(t)
+          if (casTail(t, node)) {
+            t.next = node
+            breakSeen = true // node is leader; wait in loop below
+          } else {
+            node.setPrevRelaxed(null)
+          }
+        }
+      } else if (({ leader = t.asInstanceOf[ReaderNode]; leader }) == tail) {
+        // try to cowait
+        var attached = false
+        var done = false
+
+        while (!done) {
+          if (leader.status < 0 || leader.prev == null)
+            done = true
+          else if (node == null)
+            node = new ReaderNode()
+          else if (node.waiter == null)
+            node.waiter = Thread.currentThread()
+          else if (!attached) {
+            val c = leader.cowaiters.asInstanceOf[ReaderNode]
+            node.setCowaitersRelaxed(c)
+            attached = leader.casCowaiters(c, node)
+            if (!attached)
+              node.setCowaitersRelaxed(null)
+          } else {
+            var nanos = 0L
+
+            if (!timed)
+              LockSupport.park(this)
+            else if ({ nanos = time - System.nanoTime(); nanos } > 0L)
+              LockSupport.parkNanos(this, nanos)
+            interrupted |= Thread.interrupted()
+            if ((interrupted && interruptible) ||
+                (timed && nanos <= 0L))
+              return cancelCowaiter(node, leader, interrupted);
+          }
+        }
+
+        if (node != null)
+          node.waiter = null;
+        val ns = tryAcquireRead()
+        signalCowaiters(leader)
+        if (interrupted)
+          Thread.currentThread().interrupt()
+
+        if (ns != 0L)
+          return ns
+
+        node = null // restart if stale, missed, or leader cancelled
+      }
+    }
+
+    // node is leader of a cowait group; almost same as acquireWrite
+
+    // retries upon unpark of first thread
+    var spins = 0
+    var postSpins = 0
+
+    var first = false
+    var pred: Node = null
+
+    nextState = 0L
+    breakSeen = false
+
+    while (!breakSeen) {
+      var continueSeen = false
+
+      if (!first && ({ pred = node.prev; pred } != null) &&
+          ! { first = (head == pred); first }) {
+        if (pred.status < 0) {
+          cleanQueue() // predecessor cancelled
+          continueSeen = true
+        } else if (pred.prev == null) {
+          Thread.onSpinWait(); // ensure serialization
+          continueSeen = true
+        }
+      }
+
+      if (!continueSeen) {
+        if ((first || pred == null) &&
+            { nextState = tryAcquireRead(); nextState } != 0L) {
+          if (first) {
+            node.prev = null
+            head = node
+            pred.next = null
+            node.waiter = null
+          }
+          signalCowaiters(node)
+          if (interrupted)
+            Thread.currentThread().interrupt()
+          return nextState
+        } else if (first && spins != 0) {
+          spins -= 1
+          Thread.onSpinWait()
+        } else if (node.status == 0) {
+          if (node.waiter == null)
+            node.waiter = Thread.currentThread()
+          node.status = WAITING
+        } else {
+          var nanos = 0L
+          postSpins = ((postSpins << 1) | 1)
+          spins = postSpins
+          if (!timed)
+            LockSupport.park(this)
+          else if ({ nanos = time - System.nanoTime(); nanos } > 0L)
+            LockSupport.parkNanos(this, nanos)
+          else
+            breakSeen = true
+
+          if (!breakSeen) {
+            node.clearStatus()
+
+            interrupted |= Thread.interrupted()
+            if (interrupted && interruptible)
+              breakSeen = true
+          }
+        }
+      }
+    }
+
+    cancelAcquire(node, interrupted);
+  }
+
+  // Cancellation support
+
+  /*
+   * Possibly repeatedly traverses from tail, unsplicing cancelled
+   * nodes until none are found. Unparks nodes that may have been
+   * relinked to be next eligible acquirer.
+   */
+  private def cleanQueue(): Unit = {
+    while (true) { // restart point
+      var q: Node = tail
+      var p: Node = null
+      var s: Node = null
+      var n: Node = null
+
+      var breakSeen = false
+
+      while (!breakSeen) { // (p, q, s) triples
+        if (q == null || { p = q.prev; p } == null)
+          return // end of list
+
+        val inconsistent =
+          if (s == null)
+            tail != q
+          else
+            (s.prev != q || s.status < 0)
+
+        if (inconsistent)
+          breakSeen = true // inconsistent
+
+        if (!breakSeen && (q.status < 0)) { // cancelled
+          val casNextResult =
+            if (s == null) casTail(q, p)
+            else s.casPrev(q, p)
+
+          if (casNextResult && (q.prev == p)) {
+            p.casNext(q, s) // OK if fails
+            if (p.prev == null)
+              signalNext(p)
+          }
+
+          breakSeen = true
+        }
+
+        if (!breakSeen && ({ n = p.next; n } != q)) { // help finish
+          if (n != null && q.prev == p && q.status >= 0) {
+            p.casNext(n, q)
+            if (p.prev == null)
+              signalNext(p)
+          }
+          breakSeen = true
+        }
+
+        if (!breakSeen) {
+          s = q
+          q = q.prev
+        }
+      } // inner
+    } // outer
+  }
+
+  /*
+   * If leader exists, possibly repeatedly traverses cowaiters,
+   * unsplicing the given cancelled node until not found.
+   */
+  private def unlinkCowaiter(node: ReaderNode, leader: ReaderNode): Unit = {
+    if (leader != null) {
+      while (leader.prev != null && leader.status >= 0) {
+        var p: ReaderNode = leader
+        var q: ReaderNode = null
+
+        while (true) {
+          if (({ q = p.cowaiters; q }) == null)
+            return
+          if (q == node) {
+            p.casCowaiters(q, q.cowaiters)
+            // recheck even if succeeded
+          } else {
+            p = q
+          }
+        }
+      }
+    }
+  }
+
+  /*
+   * If node non-null, forces cancel status and unsplices it from
+   * queue, wakes up any cowaiters, and possibly wakes up successor
+   * to recheck status.
+   *
+   * @param node the waiter (may be null if not yet enqueued)
+   * @param interrupted if already interrupted
+   * @return INTERRUPTED if interrupted or Thread.interrupted, else zero
+   */
+  private def cancelAcquire(node: Node, interrupted: Boolean): Long = {
+    if (node != null) {
+      node.waiter = null
+      node.status = CANCELLED
+      cleanQueue()
+      if (node.isInstanceOf[ReaderNode])
+        signalCowaiters(node.asInstanceOf[ReaderNode])
+    }
+
+    if (interrupted || Thread.interrupted()) INTERRUPTED
+    else 0L
+  }
+
+  /*
+   * If node non-null, forces cancel status and unsplices from
+   * leader's cowaiters list unless/until it is also cancelled.
+   *
+   * @param node if non-null, the waiter
+   * @param leader if non-null, the node heading cowaiters list
+   * @param interrupted if already interrupted
+   * @return INTERRUPTED if interrupted or Thread.interrupted, else zero
+   */
+  private def cancelCowaiter(
+      node: ReaderNode,
+      leader: ReaderNode,
+      interrupted: Boolean
+  ): Long = {
+    if (node != null) {
+      node.waiter = null;
+      node.status = CANCELLED;
+      unlinkCowaiter(node, leader);
+    }
+
+    if (interrupted || Thread.interrupted()) INTERRUPTED
+    else 0L
+  }
+}
+
+@SerialVersionUID(-6001602636862214147L)
+object StampedLock {
+
+  /* SN: Note well the notes at top of companion class, especially the
+   * 'memory layout' section.
+   */
+
+  /* The number o bits to use for reader count before overflowing */
+  final val LG_READERS = 7 // 127 readers
+
+  // Values for lock state and stamp operations
+  final val RUNIT = 1L
+  final val WBIT = 1L << LG_READERS
+  final val RBITS = WBIT - 1L
+  final val RFULL = RBITS - 1L
+  final val ABITS = RBITS | WBIT
+  final val SBITS = ~RBITS // note overlap with ABITS
+  // not writing and conservatively non-overflowing
+  final val RSAFE = ~(3L << (LG_READERS - 1))
+
+  /*
+   * 3 stamp modes can be distinguished by examining (m = stamp & ABITS):
+   * write mode: m == WBIT
+   * optimistic read mode: m == 0L (even when read lock is held)
+   * read mode: m > 0L && m <= RFULL (the stamp is a copy of state, but the
+   * read hold count in the stamp is unused other than to determine mode)
+   *
+   * This differs slightly from the encoding of state:
+   * (state & ABITS) == 0L indicates the lock is currently unlocked.
+   * (state & ABITS) == RBITS is a special transient value
+   * indicating spin-locked to manipulate reader bits overflow.
+   */
+
+  /* Initial value for lock state; avoids failure value zero. */
+  final val ORIGIN = WBIT << 1
+
+  // Special value from cancelled acquire methods so caller can throw IE
+  final val INTERRUPTED = 1L
+
+  // Bits for Node.status
+  final val WAITING = 1
+  final val CANCELLED = 0x80000000 // must be negative
+
+  /* CLH nodes */
+  abstract class Node {
+    @volatile var prev: Node = _ // initially attached via casTail
+    @volatile var next: Node = _ // visibly nonnull when signallable
+    var waiter: Thread = _ // visibly nonnull when enqueued
+    @volatile var status: Int = 0 // written by owner, atomic bit ops by others
+
+    @alwaysinline private def prevAtomic = new AtomicRef[Node](
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "prev"))
+    )
+
+    @alwaysinline private def nextAtomic = new AtomicRef[Node](
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "next"))
+    )
+
+    @alwaysinline private def statusAtomic = new AtomicInt(
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "status"))
+    )
+
+    final def casPrev(c: Node, v: Node): Boolean = // for cleanQueue
+      prevAtomic.compareExchangeWeak(c, v)
+
+    final def casNext(c: Node, v: Node): Boolean = // for cleanQueue
+      nextAtomic.compareExchangeWeak(c, v)
+
+    final def getAndUnsetStatus(v: Int): Int = // for signalling
+      statusAtomic.fetchAnd(~v)
+
+    final def setPrevRelaxed(p: Node): Unit = // for off-queue assignment
+      prevAtomic.store(p)
+
+    final def setStatusRelaxed(s: Int) = // for off-queue assignment
+      statusAtomic.store(s)
+
+    final def clearStatus(): Unit = // for reducing unneeded signals
+      statusAtomic.store(0, memory_order_relaxed) // U.putIntOpaque
+  }
+
+  final class WriterNode extends Node {} // node for writers
+
+  final class ReaderNode extends Node { // node for readers
+    @volatile var cowaiters: ReaderNode = _ // list of linked readers
+
+    @alwaysinline private def cowaitersAtomic = new AtomicRef[ReaderNode](
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "cowaiters"))
+    )
+
+    final def casCowaiters(c: ReaderNode, v: ReaderNode): Boolean =
+      cowaitersAtomic.compareExchangeWeak(c, v)
+
+    final def setCowaitersRelaxed(p: ReaderNode): Unit =
+      cowaitersAtomic.store(p, memory_order_relaxed)
+  }
+
+  // status monitoring methods
+  /*
+   * Tells whether a stamp represents holding a lock exclusively.
+   * This method may be useful in conjunction with
+   * {@link #tryConvertToWriteLock}, for example: <pre> {@code
+   * long stamp = sl.tryOptimisticRead();
+   * try {
+   *   ...
+   *   stamp = sl.tryConvertToWriteLock(stamp);
+   *   ...
+   * } finally {
+   *   if (StampedLock.isWriteLockStamp(stamp))
+   *     sl.unlockWrite(stamp);
+   * }}</pre>
+   *
+   * @param stamp a stamp returned by a previous StampedLock operation
+   * @return {@code true} if the stamp was returned by a successful
+   *   write-lock operation
+   * @since 10
+   */
+  def isWriteLockStamp(stamp: Long): Boolean =
+    (stamp & ABITS) == WBIT
+
+  /*
+   * Tells whether a stamp represents holding a lock non-exclusively.
+   * This method may be useful in conjunction with
+   * {@link #tryConvertToReadLock}, for example: <pre> {@code
+   * long stamp = sl.tryOptimisticRead();
+   * try {
+   *   ...
+   *   stamp = sl.tryConvertToReadLock(stamp);
+   *   ...
+   * } finally {
+   *   if (StampedLock.isReadLockStamp(stamp))
+   *     sl.unlockRead(stamp);
+   * }}</pre>
+   *
+   * @param stamp a stamp returned by a previous StampedLock operation
+   * @return {@code true} if the stamp was returned by a successful
+   *   read-lock operation
+   * @since 10
+   */
+  def isReadLockStamp(stamp: Long): Boolean =
+    (stamp & RBITS) != 0L
+
+  /*
+   * Tells whether a stamp represents holding a lock.
+   * This method may be useful in conjunction with
+   * {@link #tryConvertToReadLock} and {@link #tryConvertToWriteLock},
+   * for example: <pre> {@code
+   * long stamp = sl.tryOptimisticRead();
+   * try {
+   *   ...
+   *   stamp = sl.tryConvertToReadLock(stamp);
+   *   ...
+   *   stamp = sl.tryConvertToWriteLock(stamp);
+   *   ...
+   * } finally {
+   *   if (StampedLock.isLockStamp(stamp))
+   *     sl.unlock(stamp);
+   * }}</pre>
+   *
+   * @param stamp a stamp returned by a previous StampedLock operation
+   * @return {@code true} if the stamp was returned by a successful
+   *   read-lock or write-lock operation
+   * @since 10
+   */
+  def isLockStamp(stamp: Long): Boolean =
+    (stamp & ABITS) != 0L
+
+  /*
+   * Tells whether a stamp represents a successful optimistic read.
+   *
+   * @param stamp a stamp returned by a previous StampedLock operation
+   * @return {@code true} if the stamp was returned by a successful
+   *   optimistic read operation, that is, a non-zero return from
+   *   {@link #tryOptimisticRead()} or
+   *   {@link #tryConvertToOptimisticRead(long)}
+   * @since 10
+   */
+  def isOptimisticReadStamp(stamp: Long): Boolean =
+    (stamp & ABITS) == 0L && (stamp != 0L)
+
+  // release methods
+
+  /*
+   * Wakes up the successor of given node, if one exists, and unsets its
+   * WAITING status to avoid park race. This may fail to wake up an
+   * eligible thread when one or more have been cancelled, but
+   * cancelAcquire ensures liveness.
+   */
+  final def signalNext(h: Node): Unit = {
+    if (h != null) {
+      val s = h.next
+      if ((s != null) && (s.status > 0)) {
+        s.getAndUnsetStatus(WAITING);
+        LockSupport.unpark(s.waiter);
+      }
+    }
+  }
+
+  /*
+   * Removes and unparks all cowaiters of node, if it exists.
+   */
+  final def signalCowaiters(node: ReaderNode): Unit = {
+    if (node != null) {
+      var c: ReaderNode = null
+      while ({ c = node.cowaiters; c } != null) {
+        if (node.casCowaiters(c, c.cowaiters))
+          LockSupport.unpark(c.waiter)
+      }
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/concurrent/locks/StampedLock.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/StampedLock.scala
@@ -18,7 +18,7 @@
  *     documented on the web (but not Wikipedia).
  *
  *   * Remaining issues
- *       ? how to translate '@ReservedStackAccess'?
+ *       ? how to translate '@ReservedStackAccess'??
  *       ? check with a guru about handling of SerialVersionUID?
  */
 

--- a/unit-tests/shared/src/test/require-jdk10/org/scalanative/testsuite/javalib/util/concurrent/locks/StampedLockTestOnJDK10.scala
+++ b/unit-tests/shared/src/test/require-jdk10/org/scalanative/testsuite/javalib/util/concurrent/locks/StampedLockTestOnJDK10.scala
@@ -1,0 +1,1740 @@
+/* Ported from JSR-166 Expert Group main CVS (Concurrent Versions System)
+ * repository as described at Doug Lea "Concurrency JSR-166 Interest Site"
+ *    https://gee.cs.oswego.edu/dl/concurrency-interest/.
+ *
+ *  file: /src/test/tck/StampedLongTest
+ *  revision 1.47, dated: 2021-01-26
+ */
+
+/* Scala Native (SN) Notes:
+ *
+ *   1) StampedLock was introduced in Java 8. This Test is under
+ *     'require-jdk10' because several tests such as testSampleUsage
+ *     testConcurrentAccess, use the is* stamp inspection methods introduced
+ *     in Java 10.
+ */
+
+/*
+ * Written by Doug Lea and Martin Buchholz
+ * with assistance from members of JCP JSR-166 Expert Group and
+ * released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+package locks
+
+import java.util.concurrent.TimeUnit.{DAYS, MILLISECONDS}
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.StampedLock.{
+  isLockStamp, isOptimisticReadStamp, isReadLockStamp, isWriteLockStamp
+}
+import java.util.concurrent.locks.{Lock, StampedLock}
+import java.util.concurrent.{
+  Callable, CompletableFuture, CountDownLatch, Future, ThreadLocalRandom,
+  TimeUnit
+}
+import java.util.function.{BiConsumer, Consumer}
+import java.util.{ArrayList, List}
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.javalib.util.concurrent.JSR166Test
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class StampedLockTestOnJDK10 extends JSR166Test {
+  import JSR166Test._
+
+  /* Releases write lock, checking isWriteLocked before and after
+   */
+  private def releaseWriteLock(lock: StampedLock, stamp: scala.Long): Unit = {
+    assertTrue("a1", lock.isWriteLocked())
+    assertValid(lock, stamp)
+    lock.unlockWrite(stamp)
+    assertFalse("a2", lock.isWriteLocked())
+    assertFalse("a3", lock.validate(stamp))
+  }
+
+  /* Releases read lock, checking isReadLocked before and after
+   */
+  private def releaseReadLock(lock: StampedLock, stamp: scala.Long): Unit = {
+    assertTrue("a1", lock.isReadLocked())
+    assertValid(lock, stamp)
+    lock.unlockRead(stamp)
+    assertFalse("a2", lock.isReadLocked())
+    assertTrue("a3", lock.validate(stamp))
+  }
+
+  private def assertNonZero(v: scala.Long): scala.Long = {
+    assertTrue(v != 0L)
+    v
+  }
+
+  private def assertValid(lock: StampedLock, stamp: scala.Long): scala.Long = {
+    assertTrue("a1", stamp != 0L)
+    assertTrue("a2", lock.validate(stamp))
+    stamp
+  }
+
+  private def assertUnlocked(lock: StampedLock): Unit = {
+    assertFalse("a1", lock.isReadLocked())
+    assertFalse("a2", lock.isWriteLocked())
+    assertEquals(0, lock.getReadLockCount())
+    assertValid(lock, lock.tryOptimisticRead())
+  }
+
+  /* makeBiConsumer() and makeConsumer() are used below when creating
+   * Lists of BiConsumer or Consumer. This usage allows Scala 2.12 to
+   * pass type checking. It is ugly and not idiomatic but tolerated
+   * by Scala 3.
+   */
+
+  private def makeBiConsumer[T, U](f: (T, U) => Unit): BiConsumer[T, U] = {
+    new BiConsumer[T, U] {
+      def accept(t: T, u: U): Unit = f(t, u)
+    }
+  }
+
+  def makeConsumer[T](f: T => Unit): Consumer[T] = {
+    new Consumer[T] {
+      def accept(t: T): Unit = f(t)
+    }
+  }
+
+  def lockLockers(lock: Lock): List[Action] =
+    List.of(
+      () => lock.lock(),
+      () => lock.lockInterruptibly(),
+      () => { lock.tryLock(); () },
+      () => { lock.tryLock(jl.Long.MIN_VALUE, DAYS); () },
+      () => { lock.tryLock(0L, DAYS); () },
+      () => { lock.tryLock(jl.Long.MAX_VALUE, DAYS); () }
+    )
+
+  def readLockers(): List[(StampedLock) => scala.Long] =
+    List.of(
+      (sl: StampedLock) => sl.readLock(),
+      (sl: StampedLock) => sl.tryReadLock(),
+      (sl: StampedLock) => readLockInterruptiblyUninterrupted(sl),
+      (sl: StampedLock) =>
+        tryReadLockUninterrupted(sl, jl.Long.MIN_VALUE, DAYS),
+      (sl: StampedLock) => tryReadLockUninterrupted(sl, 0L, DAYS),
+      (sl: StampedLock) => sl.tryConvertToReadLock(sl.tryOptimisticRead())
+    )
+
+  def readUnlockers(): List[BiConsumer[StampedLock, scala.Long]] =
+    List.of(
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, stamp: Long) =>
+        sl.unlockRead(stamp)
+      ),
+
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, _: Long) =>
+        assertTrue(sl.tryUnlockRead())
+      ),
+
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, _: Long) =>
+        sl.asReadLock().unlock()
+      ),
+
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, stamp: Long) =>
+        sl.unlock(stamp)
+      ),
+
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, stamp: Long) =>
+        assertValid(sl, sl.tryConvertToOptimisticRead(stamp))
+      )
+    )
+
+  def writeLockers(): List[(StampedLock) => scala.Long] =
+    List.of(
+      (sl: StampedLock) => sl.writeLock(),
+      (sl: StampedLock) => sl.tryWriteLock(),
+      (sl: StampedLock) => writeLockInterruptiblyUninterrupted(sl),
+      (sl: StampedLock) =>
+        tryWriteLockUninterrupted(sl, jl.Long.MIN_VALUE, DAYS),
+      (sl: StampedLock) => tryWriteLockUninterrupted(sl, 0L, DAYS),
+      (sl: StampedLock) => sl.tryConvertToWriteLock(sl.tryOptimisticRead())
+    )
+
+  def writeUnlockers(): List[BiConsumer[StampedLock, scala.Long]] =
+    List.of(
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, stamp: Long) =>
+        sl.unlockWrite(stamp)
+      ),
+
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, _: Long) =>
+        assertTrue(sl.tryUnlockWrite())
+      ),
+
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, _: Long) =>
+        sl.asWriteLock().unlock()
+      ),
+
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, stamp: Long) =>
+        sl.unlock(stamp)
+      ),
+
+      makeBiConsumer[StampedLock, scala.Long]((sl: StampedLock, stamp: Long) =>
+        assertValid(sl, sl.tryConvertToOptimisticRead(stamp))
+      )
+    )
+
+  /* // FIXME Scala 2.12 Start
+  def writeUnlockers(): List[BiConsumer[StampedLock, scala.Long]] = {
+    List.of(
+      (sl: StampedLock, stamp: Long) => sl.unlockWrite(stamp),
+      (sl: StampedLock, _: Long) => assertTrue(sl.tryUnlockWrite()),
+      (sl: StampedLock, _: Long) => sl.asWriteLock().unlock(),
+      (sl: StampedLock, stamp: Long) => sl.unlock(stamp),
+      (sl: StampedLock, stamp: Long) => assertValid(sl, sl.tryConvertToOptimisticRead(stamp))
+    )
+  }
+   */ // FIXME Scala 2.12 Start
+
+  def writeLockInterruptiblyUninterrupted(sl: StampedLock): scala.Long = {
+    try { sl.writeLockInterruptibly() }
+    catch {
+      case ex: InterruptedException => throw new AssertionError(ex)
+    }
+  }
+
+  def tryWriteLockUninterrupted(
+      sl: StampedLock,
+      time: scala.Long,
+      unit: TimeUnit
+  ): scala.Long = {
+    try {
+      sl.tryWriteLock(time, unit)
+    } catch {
+      case ex: InterruptedException => throw new AssertionError(ex)
+    }
+  }
+
+  def readLockInterruptiblyUninterrupted(sl: StampedLock): scala.Long = {
+    try {
+      sl.readLockInterruptibly()
+    } catch {
+      case ex: InterruptedException => throw new AssertionError(ex)
+    }
+  }
+
+  def tryReadLockUninterrupted(
+      sl: StampedLock,
+      time: scala.Long,
+      unit: TimeUnit
+  ): scala.Long = {
+    try {
+      sl.tryReadLock(time, unit)
+    } catch {
+      case ex: InterruptedException => throw new AssertionError(ex)
+    }
+  }
+
+  /* Constructed StampedLock is in unlocked state
+   */
+  @Test def testConstructor(): Unit =
+    assertUnlocked(new StampedLock())
+
+  /* write-locking, then unlocking, an unlocked lock succeed
+   */
+  @Test def testWriteLock_lockUnlock(): Unit = {
+    val lock = new StampedLock()
+
+    writeLockers().forEach(writeLocker =>
+      writeUnlockers().forEach(writeUnlocker => {
+        assertFalse(lock.isWriteLocked())
+        assertFalse(lock.isReadLocked())
+        assertEquals(0, lock.getReadLockCount())
+
+        val s = writeLocker.apply(lock)
+        assertValid(lock, s)
+        assertTrue(lock.isWriteLocked())
+        assertFalse(lock.isReadLocked())
+        assertEquals(0, lock.getReadLockCount())
+        writeUnlocker.accept(lock, s)
+        assertUnlocked(lock)
+      })
+    )
+  }
+
+  /* read-locking, then unlocking, an unlocked lock succeed
+   */
+  @Test def testReadLock_lockUnlock(): Unit = {
+    val lock = new StampedLock()
+
+    readLockers().forEach(readLocker =>
+      readUnlockers().forEach(readUnlocker => {
+        var s = 42L
+
+        for (i <- 0 until 2) {
+          s = assertValid(lock, readLocker.apply(lock))
+          assertFalse(lock.isWriteLocked())
+          assertTrue(lock.isReadLocked())
+          assertEquals(i + 1, lock.getReadLockCount())
+        }
+
+        for (i <- 0 until 2) {
+          assertFalse(lock.isWriteLocked())
+          assertTrue(lock.isReadLocked())
+          assertEquals(2 - i, lock.getReadLockCount())
+          readUnlocker.accept(lock, s)
+        }
+        assertUnlocked(lock)
+      })
+    )
+  }
+
+  /* tryUnlockWrite fails if not write locked
+   */
+  @Test def testTryUnlockWrite_failure(): Unit = {
+    val lock = new StampedLock()
+    assertFalse("a1", lock.tryUnlockWrite())
+
+    readLockers().forEach(readLocker =>
+      readUnlockers().forEach(readUnlocker => {
+        val s = assertValid(lock, readLocker.apply(lock))
+        assertFalse("a2", lock.tryUnlockWrite())
+        assertTrue("a3", lock.isReadLocked())
+        readUnlocker.accept(lock, s)
+        assertUnlocked(lock)
+      })
+    )
+  }
+
+  /* tryUnlockRead fails if not read locked
+   */
+  @Test def testTryUnlockRead_failure(): Unit = {
+    val lock = new StampedLock()
+    assertFalse(lock.tryUnlockRead())
+
+    writeLockers().forEach(writeLocker =>
+      writeUnlockers().forEach(writeUnlocker => {
+        val s = writeLocker.apply(lock)
+        assertFalse(lock.tryUnlockRead())
+        assertTrue(lock.isWriteLocked())
+        writeUnlocker.accept(lock, s)
+        assertUnlocked(lock)
+      })
+    )
+  }
+
+  /* validate(0L) fails
+   */
+  @Test def testValidate0(): Unit = {
+    val lock = new StampedLock()
+    assertFalse(lock.validate(0L))
+  }
+
+  /* A stamp obtained from a successful lock operation validates while the lock
+   *  is held
+   */
+  @Test def testValidate(): Unit = {
+    val lock = new StampedLock()
+
+    readLockers().forEach(readLocker =>
+      readUnlockers().forEach(readUnlocker => {
+
+        val s = assertNonZero(readLocker.apply(lock))
+        assertTrue(lock.validate(s))
+        readUnlocker.accept(lock, s)
+      })
+    )
+
+    writeLockers().forEach(writeLocker =>
+      writeUnlockers().forEach(writeUnlocker => {
+        val s = assertNonZero(writeLocker.apply(lock))
+        assertTrue(lock.validate(s))
+        writeUnlocker.accept(lock, s)
+      })
+    )
+  }
+
+  /* A stamp obtained from an unsuccessful lock operation does not validate
+   */
+  @Test def testValidate2(): Unit = {
+    val lock = new StampedLock()
+    val s = assertNonZero(lock.writeLock())
+    assertTrue("a1", lock.validate(s))
+    assertFalse("a2", lock.validate(lock.tryWriteLock()))
+    assertFalse(
+      "a3",
+      lock.validate(lock.tryWriteLock(randomExpiredTimeout(), randomTimeUnit()))
+    )
+    assertFalse("a4", lock.validate(lock.tryReadLock()))
+    assertFalse(
+      "a5",
+      lock.validate(lock.tryWriteLock(randomExpiredTimeout(), randomTimeUnit()))
+    )
+    assertFalse("a6", lock.validate(lock.tryOptimisticRead()))
+    lock.unlockWrite(s)
+  }
+
+  def assertThrowInterruptedExceptionWhenPreInterrupted(
+      actions: Array[Action]
+  ): Unit = {
+    actions.foreach(action => {
+      Thread.currentThread().interrupt()
+      try {
+        action.run()
+        shouldThrow()
+      } catch {
+        case _: InterruptedException => // do nothing, success
+        case fail: Throwable         => threadUnexpectedException(fail)
+      }
+
+      assertFalse(Thread.interrupted())
+    })
+  }
+
+  /* interruptible operations throw InterruptedException when pre-interrupted
+   */
+  @Test def testInterruptibleOperationsThrowInterruptedExceptionWhenPreInterrupted()
+      : Unit = {
+    val lock = new StampedLock()
+
+    val interruptibleLockActions = Array[Action](
+      () => lock.writeLockInterruptibly(),
+      () => lock.tryWriteLock(jl.Long.MIN_VALUE, DAYS),
+      () => lock.tryWriteLock(jl.Long.MAX_VALUE, DAYS),
+      () => lock.readLockInterruptibly(),
+      () => lock.tryReadLock(jl.Long.MIN_VALUE, DAYS),
+      () => lock.tryReadLock(jl.Long.MAX_VALUE, DAYS),
+      () => lock.asWriteLock().lockInterruptibly(),
+      () => lock.asWriteLock().tryLock(0L, DAYS),
+      () => lock.asWriteLock().tryLock(jl.Long.MAX_VALUE, DAYS),
+      () => lock.asReadLock().lockInterruptibly(),
+      () => lock.asReadLock().tryLock(0L, DAYS),
+      () => lock.asReadLock().tryLock(jl.Long.MAX_VALUE, DAYS)
+    )
+
+    shuffle(interruptibleLockActions)
+
+    assertThrowInterruptedExceptionWhenPreInterrupted(interruptibleLockActions)
+
+    locally {
+      val s = lock.writeLock()
+      assertThrowInterruptedExceptionWhenPreInterrupted(
+        interruptibleLockActions
+      )
+      lock.unlockWrite(s)
+    }
+
+    locally {
+      val s = lock.readLock()
+      assertThrowInterruptedExceptionWhenPreInterrupted(
+        interruptibleLockActions
+      )
+      lock.unlockRead(s)
+    }
+  }
+
+  def assertThrowInterruptedExceptionWhenInterrupted(
+      actions: Array[Action]
+  ): Unit = {
+    val n = actions.length
+    val futures = new Array[Future[_]](n)
+
+    val threadsStarted = new CountDownLatch(n)
+    val done = new CountDownLatch(n)
+
+    for (i <- 0 until n) {
+      val action = actions(i)
+      futures(i) = cachedThreadPool.submit(new CheckedRunnable() {
+        override def realRun(): Unit = {
+          threadsStarted.countDown()
+          try {
+            action.run()
+            shouldThrow()
+          } catch {
+            case _: InterruptedException => // do nothing, success
+            case fail: Throwable         => threadUnexpectedException(fail)
+          }
+
+          assertFalse(Thread.interrupted())
+          done.countDown()
+        }
+      })
+    }
+
+    await(threadsStarted)
+    assertEquals(n, done.getCount())
+
+    for (i <- 0 until n) // Interrupt all the tasks
+      futures(i).cancel(true)
+
+    await(done)
+  }
+
+  /* interruptible operations throw InterruptedException when write locked and
+   *  interrupted
+   */
+  @Test def testInterruptibleOperationsThrowInterruptedExceptionWriteLockedInterrupted()
+      : Unit = {
+    val lock = new StampedLock()
+    val stamp = lock.writeLock()
+
+    val interruptibleLockBlockingActions = Array[Action](
+      () => lock.writeLockInterruptibly(),
+      () => lock.tryWriteLock(jl.Long.MAX_VALUE, DAYS),
+      () => lock.readLockInterruptibly(),
+      () => lock.tryReadLock(jl.Long.MAX_VALUE, DAYS),
+      () => lock.asWriteLock().lockInterruptibly(),
+      () => lock.asWriteLock().tryLock(jl.Long.MAX_VALUE, DAYS),
+      () => lock.asReadLock().lockInterruptibly(),
+      () => lock.asReadLock().tryLock(jl.Long.MAX_VALUE, DAYS)
+    )
+
+    shuffle(interruptibleLockBlockingActions)
+
+    assertThrowInterruptedExceptionWhenInterrupted(
+      interruptibleLockBlockingActions
+    )
+
+    releaseWriteLock(lock, stamp)
+  }
+
+  /* interruptible operations throw InterruptedException when read locked and
+   *  interrupted
+   */
+  @Test def testInterruptibleOperationsThrowInterruptedExceptionReadLockedInterrupted()
+      : Unit = {
+    val lock = new StampedLock()
+    val stamp = lock.readLock()
+
+    val interruptibleLockBlockingActions = Array[Action](
+      () => lock.writeLockInterruptibly(),
+      () => lock.tryWriteLock(jl.Long.MAX_VALUE, DAYS),
+      () => lock.asWriteLock().lockInterruptibly(),
+      () => lock.asWriteLock().tryLock(jl.Long.MAX_VALUE, DAYS)
+    )
+
+    shuffle(interruptibleLockBlockingActions)
+
+    assertThrowInterruptedExceptionWhenInterrupted(
+      interruptibleLockBlockingActions
+    )
+
+    releaseReadLock(lock, stamp)
+  }
+
+  /* Non-interruptible operations ignore and preserve interrupt status
+   */
+  @Test def testNonInterruptibleOperationsIgnoreInterrupts(): Unit = {
+    val lock = new StampedLock()
+    Thread.currentThread().interrupt()
+
+    readUnlockers().forEach(readUnlocker => {
+      var s = assertValid(lock, lock.readLock())
+      readUnlocker.accept(lock, s)
+      s = assertValid(lock, lock.tryReadLock())
+      readUnlocker.accept(lock, s)
+    })
+
+    lock.asReadLock().lock()
+    lock.asReadLock().unlock()
+
+    writeUnlockers().forEach(writeUnlocker => {
+      var s = assertValid(lock, lock.writeLock())
+      writeUnlocker.accept(lock, s)
+      s = assertValid(lock, lock.tryWriteLock())
+      writeUnlocker.accept(lock, s)
+    })
+
+    lock.asWriteLock().lock()
+    lock.asWriteLock().unlock()
+
+    assertTrue(Thread.interrupted())
+  }
+
+  /* tryWriteLock on an unlocked lock succeeds
+   */
+  @Test def testTryWriteLock(): Unit = {
+    val lock = new StampedLock()
+    val s = lock.tryWriteLock()
+    assertTrue("a1", s != 0L)
+    assertTrue("a2", lock.isWriteLocked())
+    assertEquals("a3", 0L, lock.tryWriteLock())
+    releaseWriteLock(lock, s)
+  }
+
+  /* tryWriteLock fails if locked
+   */
+  @Test def testTryWriteLockWhenLocked(): Unit = {
+    val lock = new StampedLock()
+    val s = lock.writeLock()
+    val t = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        assertEquals(0L, lock.tryWriteLock())
+      }
+    })
+
+    assertEquals(0L, lock.tryWriteLock())
+    awaitTermination(t)
+    releaseWriteLock(lock, s)
+  }
+
+  /* tryReadLock fails if write-locked
+   */
+  @Test def testTryReadLockWhenLocked(): Unit = {
+    val lock = new StampedLock()
+    val s = lock.writeLock()
+    val t = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        assertEquals(0L, lock.tryReadLock())
+      }
+    })
+
+    assertEquals(0L, lock.tryReadLock())
+    awaitTermination(t)
+    releaseWriteLock(lock, s)
+  }
+
+  /* Multiple threads can hold a read lock when not write-locked
+   */
+  @Test def testMultipleReadLocks(): Unit = {
+    val lock = new StampedLock()
+    val s = lock.readLock()
+    val t = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        val s2 = lock.tryReadLock()
+        assertValid(lock, s2)
+        lock.unlockRead(s2)
+        val s3 = lock.tryReadLock(LONG_DELAY_MS, MILLISECONDS)
+        assertValid(lock, s3)
+        lock.unlockRead(s3)
+        val s4 = lock.readLock()
+        assertValid(lock, s4)
+        lock.unlockRead(s4)
+        lock.asReadLock().lock()
+        lock.asReadLock().unlock()
+        lock.asReadLock().lockInterruptibly()
+        lock.asReadLock().unlock()
+        lock.asReadLock().tryLock(jl.Long.MIN_VALUE, DAYS)
+        lock.asReadLock().unlock()
+      }
+    })
+
+    awaitTermination(t)
+    lock.unlockRead(s)
+  }
+
+  /* writeLock() succeeds only after a reading thread unlocks
+   */
+  @Test def testWriteAfterReadLock(): Unit = {
+    val aboutToLock = new CountDownLatch(1)
+    val lock = new StampedLock()
+    val rs = lock.readLock()
+    val t = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        aboutToLock.countDown()
+        val s = lock.writeLock()
+        assertTrue(lock.isWriteLocked())
+        assertFalse(lock.isReadLocked())
+        lock.unlockWrite(s)
+      }
+    })
+
+    await(aboutToLock)
+    assertThreadBlocks(t, Thread.State.WAITING)
+    assertFalse("a1", lock.isWriteLocked())
+    assertTrue("a2", lock.isReadLocked())
+    lock.unlockRead(rs)
+    awaitTermination(t)
+    assertUnlocked(lock)
+  }
+
+  /* writeLock() succeeds only after reading threads unlock
+   */
+  @Test def testWriteAfterMultipleReadLocks(): Unit = {
+    val lock = new StampedLock()
+    val s = lock.readLock()
+    val t1 = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        val rs = lock.readLock()
+        lock.unlockRead(rs)
+      }
+    })
+
+    awaitTermination(t1)
+
+    val t2 = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        val ws = lock.writeLock()
+        lock.unlockWrite(ws)
+      }
+    })
+
+    assertTrue("a1", lock.isReadLocked())
+    assertFalse("a2", lock.isWriteLocked())
+    lock.unlockRead(s)
+    awaitTermination(t2)
+    assertUnlocked(lock)
+  }
+
+  /* readLock() succeed only after a writing thread unlocks
+   */
+  @Test def testReadAfterWriteLock(): Unit = {
+    val lock = new StampedLock()
+    val threadsStarted = new CountDownLatch(2)
+    val s = lock.writeLock()
+    val acquireReleaseReadLock = new CheckedRunnable() {
+      def realRun(): Unit = {
+        threadsStarted.countDown()
+        val rs = lock.readLock()
+        assertTrue(lock.isReadLocked())
+        assertFalse(lock.isWriteLocked())
+        lock.unlockRead(rs)
+      }
+    }
+
+    val t1 = newStartedThread(acquireReleaseReadLock)
+    val t2 = newStartedThread(acquireReleaseReadLock)
+
+    await(threadsStarted)
+    assertThreadBlocks(t1, Thread.State.WAITING)
+    assertThreadBlocks(t2, Thread.State.WAITING)
+    assertTrue("a1", lock.isWriteLocked())
+    assertFalse("a2", lock.isReadLocked())
+    releaseWriteLock(lock, s)
+    awaitTermination(t1)
+    awaitTermination(t2)
+    assertUnlocked(lock)
+  }
+
+  /* tryReadLock succeeds if read locked but not write locked
+   */
+  @Test def testTryLockWhenReadLocked(): Unit = {
+    val lock = new StampedLock()
+    val s = lock.readLock()
+    val t = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        val rs = lock.tryReadLock()
+        assertValid(lock, rs)
+        lock.unlockRead(rs)
+      }
+    })
+
+    awaitTermination(t)
+    lock.unlockRead(s)
+  }
+
+  /* tryWriteLock fails when read locked
+   */
+  @Test def testTryWriteLockWhenReadLocked(): Unit = {
+    val lock = new StampedLock()
+    val s = lock.readLock()
+    val t = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        assertEquals(0L, lock.tryWriteLock())
+      }
+    })
+
+    awaitTermination(t)
+    lock.unlockRead(s)
+  }
+
+  /* timed lock operations time out if lock not available
+   */
+  @Test def testTimedLock_Timeout(): Unit = {
+    val futures = new ArrayList[Future[_]]()
+
+    // Write locked
+    val lock = new StampedLock()
+    val stamp = lock.writeLock()
+    assertEquals("a1", 0L, lock.tryReadLock(0L, DAYS))
+    assertEquals("a2", 0L, lock.tryReadLock(jl.Long.MIN_VALUE, DAYS))
+    assertFalse("a3", lock.asReadLock().tryLock(0L, DAYS))
+    assertFalse("a4", lock.asReadLock().tryLock(jl.Long.MIN_VALUE, DAYS))
+    assertEquals("a5", 0L, lock.tryWriteLock(0L, DAYS))
+    assertEquals("a6", 0L, lock.tryWriteLock(jl.Long.MIN_VALUE, DAYS))
+    assertFalse("a7", lock.asWriteLock().tryLock(0L, DAYS))
+    assertFalse("a8", lock.asWriteLock().tryLock(jl.Long.MIN_VALUE, DAYS))
+
+    futures.add(cachedThreadPool.submit(new CheckedRunnable() {
+      def realRun(): Unit = {
+        val startTime = System.nanoTime()
+        assertEquals(0L, lock.tryWriteLock(timeoutMillis(), MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      }
+    }))
+
+    futures.add(cachedThreadPool.submit(new CheckedRunnable() {
+      def realRun(): Unit = {
+        val startTime = System.nanoTime()
+        assertEquals(0L, lock.tryReadLock(timeoutMillis(), MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      }
+    }))
+
+    // Read locked
+    val lock2 = new StampedLock()
+    val stamp2 = lock2.readLock()
+    assertEquals("a9", 0L, lock2.tryWriteLock(0L, DAYS))
+    assertEquals("a10", 0L, lock2.tryWriteLock(jl.Long.MIN_VALUE, DAYS))
+    assertFalse("a11", lock2.asWriteLock().tryLock(0L, DAYS))
+    assertFalse("a12", lock2.asWriteLock().tryLock(jl.Long.MIN_VALUE, DAYS))
+
+    futures.add(cachedThreadPool.submit(new CheckedRunnable() {
+      def realRun(): Unit = {
+        val startTime = System.nanoTime()
+        assertEquals(0L, lock2.tryWriteLock(timeoutMillis(), MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      }
+    }))
+
+    futures.forEach(future => assertNull(future.get()))
+
+    releaseWriteLock(lock, stamp)
+    releaseReadLock(lock2, stamp2)
+  }
+
+  /* writeLockInterruptibly succeeds if unlocked
+   */
+  @Test def testWriteLockInterruptibly(): Unit = {
+    val lock = new StampedLock()
+    val s = lock.writeLockInterruptibly()
+    assertTrue(lock.isWriteLocked())
+    releaseWriteLock(lock, s)
+  }
+
+  /* readLockInterruptibly succeeds if lock free
+   */
+  @Test def testReadLockInterruptibly(): Unit = {
+    val lock = new StampedLock()
+
+    val s = assertValid(lock, lock.readLockInterruptibly())
+    assertTrue(lock.isReadLocked())
+    lock.unlockRead(s)
+
+    lock.asReadLock().lockInterruptibly()
+    assertTrue(lock.isReadLocked())
+    lock.asReadLock().unlock()
+  }
+
+  /* // Serialization is not supported by Scala Native port
+    /*
+   * A serialized lock deserializes as unlocked
+   */
+    @Test def testSerialization(): Unit = {
+        val lock = new StampedLock()
+        lock.writeLock()
+        StampedLock clone = serialClone(lock)
+        assertTrue(lock.isWriteLocked())
+        assertFalse(clone.isWriteLocked())
+        long s = clone.writeLock()
+        assertTrue(clone.isWriteLocked())
+        clone.unlockWrite(s)
+        assertFalse(clone.isWriteLocked())
+    }
+   */ // Serialization is not supported by Scala Native port
+
+  /* toString indicates current lock state
+   */
+  @Test def testToString(): Unit = {
+    val lock = new StampedLock()
+    assertTrue("a1", lock.toString().contains("Unlocked"))
+    var s = lock.writeLock()
+    assertTrue("a2", lock.toString().contains("Write-locked"))
+    lock.unlockWrite(s)
+    s = lock.readLock()
+    assertTrue("a3", lock.toString().contains("Read-locks"))
+    releaseReadLock(lock, s)
+  }
+
+  /* tryOptimisticRead succeeds and validates if unlocked, fails if exclusively
+   *  locked
+   */
+  @Test def testValidateOptimistic(): Unit = {
+    val lock = new StampedLock()
+
+    assertValid(lock, lock.tryOptimisticRead())
+
+    writeLockers().forEach(writeLocker => {
+      val s = assertValid(lock, writeLocker.apply(lock))
+      assertEquals(0L, lock.tryOptimisticRead())
+      releaseWriteLock(lock, s)
+    })
+
+    readLockers().forEach(readLocker => {
+      val s = assertValid(lock, readLocker.apply(lock))
+      val p = assertValid(lock, lock.tryOptimisticRead())
+      releaseReadLock(lock, s)
+      assertTrue(lock.validate(p))
+    })
+
+    assertValid(lock, lock.tryOptimisticRead())
+  }
+
+  /* tryOptimisticRead stamp does not validate if a write lock intervenes
+   */
+  @Test def testValidateOptimisticWriteLocked(): Unit = {
+    val lock = new StampedLock()
+    val p = assertValid(lock, lock.tryOptimisticRead())
+    val s = assertValid(lock, lock.writeLock())
+    assertFalse(lock.validate(p))
+    assertEquals(0L, lock.tryOptimisticRead())
+    assertTrue(lock.validate(s))
+    lock.unlockWrite(s)
+  }
+
+  /* tryOptimisticRead stamp does not validate if a write lock intervenes in
+   *  another thread
+   */
+  @Test def testValidateOptimisticWriteLocked2(): Unit = {
+    val locked = new CountDownLatch(1)
+    val lock = new StampedLock()
+    val p = assertValid(lock, lock.tryOptimisticRead())
+
+    val t = newStartedThread(new CheckedInterruptedRunnable() {
+      def realRun(): Unit = {
+        lock.writeLockInterruptibly()
+        locked.countDown()
+        lock.writeLockInterruptibly()
+      }
+    })
+
+    await(locked)
+    assertFalse("a1", lock.validate(p))
+    assertEquals("a2", 0L, lock.tryOptimisticRead())
+    assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    assertTrue("a3", lock.isWriteLocked())
+  }
+
+  /* tryConvertToOptimisticRead succeeds and validates if successfully locked
+   */
+  @Test def testTryConvertToOptimisticRead(): Unit = {
+    val lock = new StampedLock()
+    var s = -1L
+    var p = -1L
+    var q = -1L
+
+    assertEquals("a1", 0L, lock.tryConvertToOptimisticRead(0L))
+
+    s = assertValid(lock, lock.tryOptimisticRead())
+    assertEquals("a2", s, lock.tryConvertToOptimisticRead(s))
+    assertTrue("a3", lock.validate(s))
+
+    writeLockers().forEach(writeLocker => {
+      s = assertValid(lock, writeLocker.apply(lock))
+      p = assertValid(lock, lock.tryConvertToOptimisticRead(s))
+      assertFalse("a4", lock.validate(s))
+      assertTrue("a5", lock.validate(p))
+      assertUnlocked(lock)
+    })
+
+    readLockers().forEach(readLocker => {
+      s = assertValid(lock, readLocker.apply(lock))
+      q = assertValid(lock, lock.tryOptimisticRead())
+      assertEquals("a6", q, lock.tryConvertToOptimisticRead(q))
+      assertTrue("a7", lock.validate(q))
+      assertTrue("a8", lock.isReadLocked())
+      p = assertValid(lock, lock.tryConvertToOptimisticRead(s))
+      assertTrue("a9", lock.validate(p))
+      assertTrue("a10", lock.validate(s))
+      assertUnlocked(lock)
+      assertEquals("a11", q, lock.tryConvertToOptimisticRead(q))
+      assertTrue("a12", lock.validate(q))
+    })
+  }
+
+  /* tryConvertToReadLock succeeds for valid stamps
+   */
+  @Test def testTryConvertToReadLock(): Unit = {
+    val lock = new StampedLock()
+    var s = -1L
+    var p = -1L
+
+    assertEquals("a1", 0L, lock.tryConvertToReadLock(0L))
+
+    s = assertValid(lock, lock.tryOptimisticRead())
+    p = assertValid(lock, lock.tryConvertToReadLock(s))
+    assertTrue("a1", lock.isReadLocked())
+    assertEquals("a2", 1, lock.getReadLockCount())
+    assertTrue("a3", lock.validate(s))
+    lock.unlockRead(p)
+
+    s = assertValid(lock, lock.tryOptimisticRead())
+    lock.readLock()
+    p = assertValid(lock, lock.tryConvertToReadLock(s))
+    assertTrue("a4", lock.isReadLocked())
+    assertEquals("a5", 2, lock.getReadLockCount())
+    lock.unlockRead(p)
+    lock.unlockRead(p)
+    assertUnlocked(lock)
+
+    readUnlockers().forEach(readUnlocker => {
+      writeLockers().forEach(writeLocker => {
+        s = assertValid(lock, writeLocker.apply(lock))
+        p = assertValid(lock, lock.tryConvertToReadLock(s))
+        assertFalse("a6", lock.validate(s))
+        assertTrue("a7", lock.isReadLocked())
+        assertEquals("a8", 1, lock.getReadLockCount())
+        readUnlocker.accept(lock, p)
+      })
+
+      readLockers().forEach(readLocker => {
+        s = assertValid(lock, readLocker.apply(lock))
+        assertEquals("a9", s, lock.tryConvertToReadLock(s))
+        assertTrue("a10", lock.validate(s))
+        assertTrue("a11", lock.isReadLocked())
+        assertEquals("a12", 1, lock.getReadLockCount())
+        readUnlocker.accept(lock, s)
+      })
+    })
+  }
+
+  /* tryConvertToWriteLock succeeds if lock available; fails if multiply read
+   *  locked
+   */
+  @Test def testTryConvertToWriteLock(): Unit = {
+    val lock = new StampedLock()
+    var s = -1L
+    var p = -1L
+
+    assertEquals("a1", 0L, lock.tryConvertToWriteLock(0L))
+
+    assertTrue("a2", { s = lock.tryOptimisticRead(); s } != 0L)
+    assertTrue("a3", { p = lock.tryConvertToWriteLock(s); p } != 0L)
+    assertTrue("a4", lock.isWriteLocked())
+    lock.unlockWrite(p)
+
+    writeUnlockers().forEach(writeUnlocker => {
+      writeLockers().forEach(writeLocker => {
+        s = assertValid(lock, writeLocker.apply(lock))
+        assertEquals("a5", s, lock.tryConvertToWriteLock(s))
+        assertTrue("a6", lock.validate(s))
+        assertTrue("a7", lock.isWriteLocked())
+        writeUnlocker.accept(lock, s)
+      })
+
+      readLockers().forEach(readLocker => {
+        s = assertValid(lock, readLocker.apply(lock))
+        p = assertValid(lock, lock.tryConvertToWriteLock(s))
+        assertFalse("a8", lock.validate(s))
+        assertTrue("a9", lock.validate(p))
+        assertTrue("a10", lock.isWriteLocked())
+        writeUnlocker.accept(lock, p)
+      })
+    })
+
+    // failure if multiply read locked
+    readLockers().forEach(readLocker => {
+      s = assertValid(lock, readLocker.apply(lock))
+      p = assertValid(lock, readLocker.apply(lock))
+      assertEquals(0L, lock.tryConvertToWriteLock(s))
+      assertTrue("a11", lock.validate(s))
+      assertTrue("a12", lock.validate(p))
+      assertEquals("a13", 2, lock.getReadLockCount())
+      lock.unlock(p)
+      lock.unlock(s)
+      assertUnlocked(lock)
+    })
+  }
+
+  /* asWriteLock can be locked and unlocked
+   */
+  @Test def testAsWriteLock(): Unit = {
+    val sl = new StampedLock()
+    val lock = sl.asWriteLock()
+
+    lockLockers(lock).forEach(locker => {
+      locker.run()
+      assertTrue("a1", sl.isWriteLocked())
+      assertFalse("a2", sl.isReadLocked())
+      assertFalse("a3", lock.tryLock())
+      lock.unlock()
+      assertUnlocked(sl)
+    })
+  }
+
+  /* asReadLock can be locked and unlocked
+   */
+  @Test def testAsReadLock(): Unit = {
+    val sl = new StampedLock()
+    val lock = sl.asReadLock()
+
+    lockLockers(lock).forEach(locker => {
+      locker.run()
+      assertTrue("a1", sl.isReadLocked())
+      assertFalse("a2", sl.isWriteLocked())
+      assertEquals("a3", 1, sl.getReadLockCount())
+      locker.run()
+      assertTrue("a4", sl.isReadLocked())
+      assertEquals(2, sl.getReadLockCount())
+      lock.unlock()
+      lock.unlock()
+      assertUnlocked(sl)
+    })
+  }
+
+  /* asReadWriteLock.writeLock can be locked and unlocked
+   */
+  @Test def testAsReadWriteLockWriteLock(): Unit = {
+    val sl = new StampedLock()
+    val lock = sl.asReadWriteLock().writeLock()
+
+    lockLockers(lock).forEach(locker => {
+      locker.run()
+      assertTrue("a1", sl.isWriteLocked())
+      assertFalse("a2", sl.isReadLocked())
+      assertFalse("a3", lock.tryLock())
+      lock.unlock()
+      assertUnlocked(sl)
+    })
+  }
+
+  /* asReadWriteLock.readLock can be locked and unlocked
+   */
+  @Test def testAsReadWriteLockReadLock(): Unit = {
+    val sl = new StampedLock()
+    val lock = sl.asReadWriteLock().readLock()
+
+    lockLockers(lock).forEach(locker => {
+
+      locker.run()
+      assertTrue("a1", sl.isReadLocked())
+      assertFalse("a2", sl.isWriteLocked())
+      assertEquals("a3", 1, sl.getReadLockCount())
+      locker.run()
+      assertTrue("a4", sl.isReadLocked())
+      assertEquals("a5", 2, sl.getReadLockCount())
+      lock.unlock()
+      lock.unlock()
+      assertUnlocked(sl)
+    })
+  }
+
+  /* Lock.newCondition throws UnsupportedOperationException
+   */
+  @Test def testLockViewsDoNotSupportConditions(): Unit = {
+    val sl = new StampedLock()
+    assertThrows(
+      classOf[UnsupportedOperationException],
+      sl.asWriteLock().newCondition()
+    )
+
+    assertThrows(
+      classOf[UnsupportedOperationException],
+      sl.asReadLock().newCondition()
+    )
+
+    assertThrows(
+      classOf[UnsupportedOperationException],
+      sl.asReadWriteLock().writeLock().newCondition()
+    )
+
+    assertThrows(
+      classOf[UnsupportedOperationException],
+      sl.asReadWriteLock().readLock().newCondition()
+    )
+
+  }
+
+  /* Passing optimistic read stamps to unlock operations result in
+   *  IllegalMonitorStateException
+   */
+  @Test def testCannotUnlockOptimisticReadStamps(): Unit = {
+    locally {
+      val sl = new StampedLock()
+      val stamp = assertValid(sl, sl.tryOptimisticRead())
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlockRead(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryOptimisticRead()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlock(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryOptimisticRead()
+      sl.writeLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlock(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      sl.readLock()
+      val stamp = assertValid(sl, sl.tryOptimisticRead())
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlockRead(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      sl.readLock()
+      val stamp = assertValid(sl, sl.tryOptimisticRead())
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlock(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.writeLock())
+      assertValid(sl, stamp)
+      sl.writeLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlockWrite(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.writeLock())
+      sl.writeLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlock(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.writeLock())
+      sl.readLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlockRead(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.writeLock())
+      sl.readLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlock(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.readLock())
+      assertValid(sl, stamp)
+      sl.writeLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlockWrite(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.readLock())
+      sl.writeLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlock(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.readLock())
+      sl.readLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlockRead(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      sl.readLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.readLock())
+      assertValid(sl, stamp)
+      sl.readLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlockRead(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.readLock())
+      sl.readLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlock(stamp))
+    }
+
+    locally {
+      val sl = new StampedLock()
+      sl.readLock()
+      val stamp = sl.tryConvertToOptimisticRead(sl.readLock())
+      sl.readLock()
+      assertThrows(classOf[IllegalMonitorStateException], sl.unlock(stamp))
+    }
+  }
+
+  /* Invalid stamps result in IllegalMonitorStateException
+   */
+  @Test def testInvalidStampsThrowIllegalMonitorStateException(): Unit = {
+    val sl = new StampedLock()
+
+    assertThrows(
+      classOf[IllegalMonitorStateException],
+      sl.unlockWrite(0L)
+    )
+
+    assertThrows(
+      classOf[IllegalMonitorStateException],
+      sl.unlockRead(0L)
+    )
+
+    assertThrows(
+      classOf[IllegalMonitorStateException],
+      sl.unlock(0L)
+    )
+
+    val optimisticStamp = sl.tryOptimisticRead()
+    val readStamp = sl.readLock()
+    sl.unlockRead(readStamp)
+
+    val writeStamp = sl.writeLock()
+    sl.unlockWrite(writeStamp)
+    assertTrue(
+      "a1",
+      optimisticStamp != 0L && readStamp != 0L && writeStamp != 0L
+    )
+
+    val noLongerValidStamps = Array(optimisticStamp, readStamp, writeStamp)
+
+    val assertNoLongerValidStampsThrow: Runnable = () => {
+      noLongerValidStamps.foreach(noLongerValidStamp => {
+        assertThrows(
+          classOf[IllegalMonitorStateException],
+          sl.unlockWrite(noLongerValidStamp)
+        )
+        assertThrows(
+          classOf[IllegalMonitorStateException],
+          sl.unlockRead(noLongerValidStamp)
+        )
+        assertThrows(
+          classOf[IllegalMonitorStateException],
+          sl.unlock(noLongerValidStamp)
+        )
+      })
+    }
+
+    assertNoLongerValidStampsThrow.run()
+
+    readLockers().forEach(readLocker =>
+      readUnlockers().forEach(readUnlocker => {
+        val stamp = readLocker.apply(sl)
+        assertValid(sl, stamp)
+        assertNoLongerValidStampsThrow.run()
+        assertThrows(
+          classOf[IllegalMonitorStateException],
+          sl.unlockWrite(stamp)
+        )
+        assertThrows(
+          classOf[IllegalMonitorStateException],
+          sl.unlockRead(sl.tryOptimisticRead())
+        )
+        assertThrows(classOf[IllegalMonitorStateException], sl.unlockRead(0L))
+
+        readUnlocker.accept(sl, stamp)
+        assertUnlocked(sl)
+        assertNoLongerValidStampsThrow.run()
+      })
+    )
+
+    writeLockers().forEach(writeLocker =>
+      writeUnlockers().forEach(writeUnlocker => {
+        val stamp = writeLocker.apply(sl)
+        assertValid(sl, stamp)
+        assertNoLongerValidStampsThrow.run()
+        assertThrows(
+          classOf[IllegalMonitorStateException],
+          sl.unlockRead(stamp)
+        )
+        assertThrows(
+          classOf[IllegalMonitorStateException],
+          sl.unlockWrite(0L)
+        )
+        writeUnlocker.accept(sl, stamp)
+        assertUnlocked(sl)
+        assertNoLongerValidStampsThrow.run()
+      })
+    )
+  }
+
+  /* Read locks can be very deeply nested
+   */
+  @Test def testDeeplyNestedReadLocks(): Unit = {
+    val lock = new StampedLock()
+    val depth = 300
+    val stamps = new Array[scala.Long](depth)
+
+    val readLockerz = readLockers()
+    val readUnlockerz = readUnlockers()
+
+    for (i <- 0 until depth) {
+      val readLocker = readLockerz.get(i % readLockerz.size())
+      val stamp = readLocker.apply(lock)
+      assertEquals("a1", i + 1, lock.getReadLockCount())
+      assertTrue("a2", lock.isReadLocked())
+      stamps(i) = stamp
+    }
+
+    for (i <- 0 until depth) {
+      val readUnlocker = readUnlockerz.get(i % readUnlockerz.size())
+      assertEquals("a3", depth - i, lock.getReadLockCount())
+      assertTrue("a4", lock.isReadLocked())
+      readUnlocker.accept(lock, stamps(depth - 1 - i))
+    }
+
+    assertUnlocked(lock)
+  }
+
+  /* Stamped locks are not reentrant.
+   */
+  @Test def testNonReentrant(): Unit = {
+    val lock = new StampedLock()
+    var stamp = lock.writeLock()
+
+    assertValid(lock, stamp)
+    assertEquals("a1", 0L, lock.tryWriteLock(0L, DAYS))
+    assertEquals("a2", 0L, lock.tryReadLock(0L, DAYS))
+    assertValid(lock, stamp)
+    lock.unlockWrite(stamp)
+
+    stamp = lock.tryWriteLock(1L, DAYS)
+    assertEquals("a3", 0L, lock.tryWriteLock(0L, DAYS))
+    assertValid(lock, stamp)
+    lock.unlockWrite(stamp)
+
+    stamp = lock.readLock()
+    assertEquals("a4", 0L, lock.tryWriteLock(0L, DAYS))
+    assertValid(lock, stamp)
+    lock.unlockRead(stamp)
+  }
+
+  /* """StampedLocks have no notion of ownership. Locks acquired in one thread
+   *  can be released or converted in another."""
+   */
+  @Test def testNoOwnership(): Unit = {
+    val futures = new ArrayList[Future[_]]()
+
+    writeLockers().forEach(writeLocker =>
+      writeUnlockers().forEach(writeUnlocker => {
+        val lock = new StampedLock()
+        val stamp = writeLocker.apply(lock)
+        futures.add(cachedThreadPool.submit(new CheckedRunnable() {
+          def realRun(): Unit = {
+            writeUnlocker.accept(lock, stamp)
+            assertUnlocked(lock)
+            assertFalse(lock.validate(stamp))
+          }
+        }))
+      })
+    )
+
+    futures.forEach(future => assertNull(future.get()))
+  }
+
+  /* Tries out sample usage code from StampedLock javadoc. */
+  @Test def testSampleUsage(): Unit = {
+    class Point {
+      private var x = 0.0
+      private var y = 0.0
+      private val sl = new StampedLock()
+
+      def move(deltaX: scala.Double, deltaY: scala.Double): Unit = { // an exclusively locked method
+        val stamp = sl.writeLock()
+        try {
+          x += deltaX;
+          y += deltaY;
+        } finally {
+          sl.unlockWrite(stamp)
+        }
+      }
+
+      def distanceFromOrigin(): scala.Double = { // A read-only method
+        var currentX = 0.0
+        var currentY = 0.0
+        var stamp = sl.tryOptimisticRead()
+
+        while ({
+          if (stamp == 0L)
+            stamp = sl.readLock()
+          try {
+            // possibly racy reads
+            currentX = x;
+            currentY = y;
+          } finally {
+            stamp = sl.tryConvertToOptimisticRead(stamp)
+          }
+
+          stamp == 0
+        }) ()
+
+        Math.hypot(currentX, currentY)
+      }
+
+      /* SN: This method is highly modified. The Java original example used,
+       *     and was proud of using, a 'continue' statement with a label.
+       *     OK  for Java but Yeech! for Scala.
+       */
+      def distanceFromOrigin2(): scala.Double = {
+        if (true)
+          distanceFromOrigin()
+        else {
+          var currentX = 0.0
+          var currentY = 0.0
+          var stamp = sl.tryOptimisticRead()
+          try {
+            var done = false
+            while (!done) {
+              // possibly racy reads
+              currentX = x
+              currentY = y
+
+              if (sl.validate(stamp))
+                done = true
+              else {
+                stamp = sl.readLock()
+              }
+            }
+
+            Math.hypot(currentX, currentY)
+
+          } finally {
+            if (StampedLock.isReadLockStamp(stamp))
+              sl.unlockRead(stamp)
+          }
+        }
+      }
+
+      def moveIfAtOrigin(newX: scala.Double, newY: scala.Double): Unit = {
+        var stamp = sl.readLock()
+
+        var done = false
+
+        try {
+          while ((x == 0.0 && y == 0.0) && !done) {
+            val ws = sl.tryConvertToWriteLock(stamp)
+            if (ws != 0L) {
+              stamp = ws
+              x = newX
+              y = newY
+              done = true
+            } else {
+              sl.unlockRead(stamp)
+              stamp = sl.writeLock()
+            }
+          }
+        } finally {
+          sl.unlock(stamp)
+        }
+      }
+    }
+
+    val p = new Point()
+    p.move(3.0, 4.0)
+    assertEquals("a1", 5.0, p.distanceFromOrigin(), 0.0)
+    p.moveIfAtOrigin(5.0, 12.0)
+    assertEquals("a2", 5.0, p.distanceFromOrigin2(), 0.0)
+  }
+
+  /* Stamp inspection methods work as expected, and do not inspect the state of
+   *  the lock itself.
+   */
+  @Test def testStampStateInspectionMethods(): Unit = {
+    val lock = new StampedLock()
+
+    assertFalse("a1", isWriteLockStamp(0L))
+    assertFalse("a2", isReadLockStamp(0L))
+    assertFalse("a3", isLockStamp(0L))
+    assertFalse("a4", isOptimisticReadStamp(0L))
+
+    locally {
+      val stamp = lock.writeLock()
+      for (i <- 0 until 2) {
+        assertTrue("a5", isWriteLockStamp(stamp))
+        assertFalse("a6", isReadLockStamp(stamp))
+        assertTrue("a7", isLockStamp(stamp))
+        assertFalse("a8", isOptimisticReadStamp(stamp))
+        if (i == 0)
+          lock.unlockWrite(stamp)
+      }
+    }
+
+    locally {
+      val stamp = lock.readLock()
+      for (i <- 0 until 2) {
+        assertFalse("a9", isWriteLockStamp(stamp))
+        assertTrue("a10", isReadLockStamp(stamp))
+        assertTrue("a11", isLockStamp(stamp))
+        assertFalse(isOptimisticReadStamp(stamp))
+        if (i == 0)
+          lock.unlockRead(stamp)
+      }
+    }
+
+    locally {
+      val optimisticStamp = lock.tryOptimisticRead()
+      val readStamp = lock.tryConvertToReadLock(optimisticStamp)
+      val writeStamp = lock.tryConvertToWriteLock(readStamp)
+      for (i <- 0 until 2) {
+        assertFalse("a12", isWriteLockStamp(optimisticStamp))
+        assertFalse("a13", isReadLockStamp(optimisticStamp))
+        assertFalse("a14", isLockStamp(optimisticStamp))
+        assertTrue("a15", isOptimisticReadStamp(optimisticStamp))
+
+        assertFalse("a16", isWriteLockStamp(readStamp))
+        assertTrue("a17", isReadLockStamp(readStamp))
+        assertTrue("a18", isLockStamp(readStamp))
+        assertFalse("a19", isOptimisticReadStamp(readStamp))
+
+        assertTrue("a20", isWriteLockStamp(writeStamp))
+        assertFalse("a21", isReadLockStamp(writeStamp))
+        assertTrue("a22", isLockStamp(writeStamp))
+        assertFalse("a23", isOptimisticReadStamp(writeStamp))
+        if (i == 0)
+          lock.unlockWrite(writeStamp)
+      }
+    }
+  }
+
+  /* Multiple threads repeatedly contend for the same lock.
+   */
+  @Test def testConcurrentAccess(): Unit = {
+    val sl = new StampedLock()
+    val wl = sl.asWriteLock()
+    val rl = sl.asReadLock()
+
+    val testDurationMillis = if (expensiveTests) 1000 else 2
+    val nTasks = ThreadLocalRandom.current().nextInt(1, 10)
+    val done = new AtomicBoolean(false)
+    val futures = new ArrayList[Future[_]]()
+
+    val stampedWriteLockers: List[Callable[Long]] = List.of(
+      () => sl.writeLock(),
+      () => writeLockInterruptiblyUninterrupted(sl),
+      () => tryWriteLockUninterrupted(sl, LONG_DELAY_MS, MILLISECONDS),
+      () => {
+        var stamp = 0L
+
+        while ({
+          stamp = sl.tryConvertToWriteLock(sl.tryOptimisticRead())
+          stamp == 0L
+        }) ()
+
+        stamp
+      },
+      () => {
+        var stamp = 0L
+
+        // do { stamp = sl.tryWriteLock() } while (stamp == 0L)
+        while ({
+          stamp = sl.tryWriteLock()
+          stamp == 0L
+        }) ()
+
+        stamp
+      },
+
+      () => {
+        var stamp = 0L
+
+        // do { stamp = sl.tryWriteLock(0L, DAYS) } while (stamp == 0L)
+        while ({
+          stamp = sl.tryWriteLock(0L, DAYS)
+          stamp == 0L
+        }) ()
+
+        stamp
+      }
+    )
+
+    val stampedReadLockers: List[Callable[Long]] = List.of(
+      () => sl.readLock(),
+      () => readLockInterruptiblyUninterrupted(sl),
+      () => tryReadLockUninterrupted(sl, LONG_DELAY_MS, MILLISECONDS),
+      () => {
+        var stamp = 0L
+
+        while ({
+          stamp = sl.tryConvertToReadLock(sl.tryOptimisticRead())
+          stamp == 0L
+        }) ()
+
+        stamp
+      },
+      () => {
+        var stamp = 0L
+
+        while ({
+          stamp = sl.tryReadLock()
+          stamp == 0L
+        }) ()
+
+        stamp
+      },
+      () => {
+        var stamp = 0L
+
+        while ({
+          stamp = sl.tryReadLock(0L, DAYS)
+          stamp == 0L
+        }) ()
+
+        stamp
+      }
+    )
+
+    val stampedWriteUnlockers: List[Consumer[Long]] = List.of(
+      makeConsumer[scala.Long]((stamp: Long) => sl.unlockWrite(stamp)),
+      makeConsumer[scala.Long]((stamp: Long) => sl.unlock(stamp)),
+      makeConsumer[scala.Long]((_: Long) => assertTrue(sl.tryUnlockWrite())),
+      makeConsumer[scala.Long]((_: Long) => wl.unlock()),
+      makeConsumer[scala.Long]((stamp: Long) =>
+        sl.tryConvertToOptimisticRead(stamp)
+      )
+    )
+
+    val stampedReadUnlockers: List[Consumer[Long]] = List.of(
+      makeConsumer[scala.Long]((stamp: Long) => sl.unlockRead(stamp)),
+      makeConsumer[scala.Long]((stamp: Long) => sl.unlock(stamp)),
+      makeConsumer[scala.Long]((_: Long) => assertTrue(sl.tryUnlockRead())),
+      makeConsumer[scala.Long]((_: Long) => rl.unlock()),
+      makeConsumer[scala.Long]((stamp: Long) =>
+        sl.tryConvertToOptimisticRead(stamp)
+      )
+    )
+
+    val writer: Action = () => {
+      // repeatedly acquires write lock
+      val locker = chooseRandomly(stampedWriteLockers)
+      val unlocker = chooseRandomly(stampedWriteUnlockers)
+      while (!done.getAcquire()) {
+        val stamp = locker.call()
+        try {
+          assertTrue(isWriteLockStamp(stamp))
+          assertTrue(sl.isWriteLocked())
+          assertFalse(isReadLockStamp(stamp))
+          assertFalse(sl.isReadLocked())
+          assertEquals(0, sl.getReadLockCount())
+          assertTrue(sl.validate(stamp))
+        } finally {
+          unlocker.accept(stamp)
+        }
+      }
+    }
+
+    val reader: Action = () => {
+      // repeatedly acquires read lock
+      val locker = chooseRandomly(stampedReadLockers)
+      val unlocker = chooseRandomly(stampedReadUnlockers)
+      while (!done.getAcquire()) {
+        val stamp = locker.call()
+        try {
+          assertFalse(isWriteLockStamp(stamp))
+          assertFalse(sl.isWriteLocked())
+          assertTrue(isReadLockStamp(stamp))
+          assertTrue(sl.isReadLocked())
+          assertTrue(sl.getReadLockCount() > 0)
+          assertTrue(sl.validate(stamp))
+        } finally {
+          unlocker.accept(stamp)
+        }
+      }
+    }
+
+    for (_ <- nTasks until 0 by -1) {
+      /* SN: List.of() works around a chooseRandomly() varargs overload
+       *     which is missing in JSR166Test.scala.
+       */
+      val task = chooseRandomly(List.of(writer, reader))
+      futures.add(CompletableFuture.runAsync(checkedRunnable(task)))
+    }
+
+    Thread.sleep(testDurationMillis)
+
+    done.setRelease(true)
+    for (i <- 0 until futures.size())
+      futures.get(i).cancel(true)
+  }
+}


### PR DESCRIPTION
Fix #4803
Once this PR is merged, the corresponding checkbox in Issue #3165 can be ticked.

Port Java JSR-166 `java.util.concurrent.locks.StampedLock` and its corresponding unit-test. 

<hr>
###### Notes for Reviewers & Readers

2026-05-02  Moving from "Draft" to "Ready to Review".   It would be good to get 
                     definitive answers to the two issue below. I believe that both
                     are OK as is.  `@SerialVersionUID` is handled the way it 
                     is in the rest of the project.  Stack problems will reveal themselves
                     with use.
 
Two small issues  need resolution before this PR can be moved from Draft to 'ready for review'.
I appreciate and am thankful for improvements.

* The `@SerialVersionUID` handling is "monkey see, monkey do". It would benefit
   from someone knowing what they are doing looking at it and confirming the
   implementation or suggesting a better approach or that it can be deleted as unnecessary.

* The Java code uses the  `@ReservedStackAccess` annotation to provide extra
  stack space and temporarily delay reaching  `StackOverflow`.  After study, I
  could find no obvious counterpart in either Scala or Scala Native. Understandable.
  
  Within the past year or so, the stack size on Scala Native has been drastically
  reduced.  The ported unit test passes but there might be fragility in an Industrial
  setting.
 
  Is there any obvious, to some, action needed here or will experience manifest
  any need for action?

  I do not want  to be unleashing a problem which shows only in production settings
