### PR TITLE
Fixed a bug where `java.math.BigDecimal.toPlainString()` returned an incorrect result by discarding the integer part

### DIFF
--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -1555,7 +1555,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
           delta = begin - delta
 
           result
-            .append(CharZeros.substring(begin, delta))
+            .append(sb.substring(begin, delta))
             .append('.')
             .append(sb.substring(delta))
         }

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/math/BigDecimalConvertTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/math/BigDecimalConvertTest.scala
@@ -454,6 +454,40 @@ class BigDecimalConvertTest {
     assertTrue(aNumber.toPlainString() == result)
   }
 
+  @Test def testToPlainStringWithIntegerAndFractionalPart(): Unit = {
+    assertEquals("3.14", new BigDecimal("3.14").toPlainString())
+    assertEquals("3.140000", new BigDecimal("3.140000").toPlainString())
+    assertEquals("123.456", new BigDecimal("123.456").toPlainString())
+    assertEquals("1.0", new BigDecimal("1.0").toPlainString())
+    assertEquals("10.5", new BigDecimal("10.5").toPlainString())
+    assertEquals("100.01", new BigDecimal("100.01").toPlainString())
+  }
+
+  @Test def testToPlainStringNegativeWithIntegerAndFractionalPart(): Unit = {
+    assertEquals("-3.14", new BigDecimal("-3.14").toPlainString())
+    assertEquals("-123.456", new BigDecimal("-123.456").toPlainString())
+    assertEquals("-10.5", new BigDecimal("-10.5").toPlainString())
+  }
+
+  @Test def testToPlainStringAfterStripTrailingZeros(): Unit = {
+    assertEquals(
+      "3.14",
+      new BigDecimal("3.140000").stripTrailingZeros().toPlainString()
+    )
+    assertEquals(
+      "3.14",
+      new BigDecimal("3.1400").stripTrailingZeros().toPlainString()
+    )
+    assertEquals(
+      "-3.14",
+      new BigDecimal("-3.140000").stripTrailingZeros().toPlainString()
+    )
+    assertEquals(
+      "123.456",
+      new BigDecimal("123.45600").stripTrailingZeros().toPlainString()
+    )
+  }
+
   @Test def testToStringNeg(): Unit = {
     val a =
       "-123.4564563673567380964839238475457356735674573563567890295784902768787678287E-5"


### PR DESCRIPTION
Hello 👋
First of all, thank you for creating this project.


I am currently developing a MySQL-only client library called ldbc (https://github.com/takapi327/ldbc) that can also run on Scala Native. I am currently working on updating this library to Scala Native 0.5.x, and I encountered behavior that seems to be a bug. After fixing it locally and confirming it works as expected, I have submitted a pull request.


Here are the GitHub Actions logs from ldbc that demonstrate the bug:
https://github.com/takapi327/ldbc/actions/runs/24725333371/job/72331163666

**Test failure details*

```
==> X ldbc.connector.data.BinaryColumnValueDecoderTest.decodeString for MYSQL_TYPE_FLOAT
values are not the same
=> Obtained
0.14
=> Diff (- expected, + obtained)
-3.14
+0.14
```

CharZeros is a fixed string consisting of 100 zeros (0000...), and I believe sb is the string containing the actual numerical value (e.g., 314).


I believe the cause is that in the process of extracting the integer part, the code is incorrectly extracting from CharZeros (the sequence of zeros) instead of sb (the actual numerical value).


In this case, it should have extracted the first character of 314, but instead, it extracted the first character of 000..., which is 0. As a result, 3.14 became 0.14, causing the test in ldbc to fail because it did not match the intended result.

I'm uncertain if this is the correct fix or if I might have broken the original logic, so I'd really appreciate your feedback.