### PR TITLE
Move DateTimeException into javalib

### DIFF
--- a/javalib/src/main/scala/java/time/DateTimeException.scala
+++ b/javalib/src/main/scala/java/time/DateTimeException.scala
@@ -1,4 +1,3 @@
-// Ported from Scala.js, commit: 54648372, dated: 2020-09-24
 package java.time
 
 class DateTimeException(message: String, cause: Throwable)


### PR DESCRIPTION
## Motivation
PR #4851 needs `java.time.DateTimeException` in `javalib` before `Duration` and downstream time APIs can be reviewed outside the large JSR166 branch.

## Modification
- Move `java.time.DateTimeException` from `javalib-ext-dummies` to `javalib`.
- Keep the class implementation unchanged.

## Result
`javalib` now owns the exception type required by the follow-up time API PRs, and this dependency move can be reviewed independently.

## Merge Order
- Stack position: 1, base dependency for the Duration chain.
- Depends on: none.
- Follow-ups: #4863, then #4864 and #4866.
- After merge: rebase #4851 and drop this file move from the large branch.

## Verification
- `scripts/scalafmt --test`
- `sbt "javalib2_13/compile" "javalibExtDummies2_13/compile"`

## References
- Split from #4851.
