### PR TITLE
Tighten ArrayList search and iterator bounds

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
+++ b/javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
@@ -13,6 +13,8 @@ private[util] abstract class AbstractRandomAccessListIterator[E](
     i < end
 
   def next(): E = {
+    if (!hasNext())
+      throw new NoSuchElementException
     last = i
     i += 1
     get(last)
@@ -22,14 +24,16 @@ private[util] abstract class AbstractRandomAccessListIterator[E](
     start < i
 
   def previous(): E = {
+    if (!hasPrevious())
+      throw new NoSuchElementException
     i -= 1
     last = i
     get(last)
   }
 
-  def nextIndex(): Int = i
+  def nextIndex(): Int = i - start
 
-  def previousIndex(): Int = i - 1
+  def previousIndex(): Int = i - start - 1
 
   override def remove(): Unit = {
     checkThatHasLast()

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -76,9 +76,23 @@ class ArrayList[E] private (
   // cannot link: @java.util.ArrayList::isEmpty_bool
   override def isEmpty(): Boolean = _size == 0
 
-  override def indexOf(o: Any): Int = inner.indexOf(o)
+  override def indexOf(o: Any): Int = {
+    var i = 0
+    while (i < _size) {
+      if (Objects.equals(o, inner(i))) return i
+      i += 1
+    }
+    -1
+  }
 
-  override def lastIndexOf(o: Any): Int = inner.lastIndexOf(o)
+  override def lastIndexOf(o: Any): Int = {
+    var i = _size - 1
+    while (i >= 0) {
+      if (Objects.equals(o, inner(i))) return i
+      i -= 1
+    }
+    -1
+  }
 
   // shallow-copy
   override def clone(): AnyRef = new ArrayList(inner.clone(), _size)
@@ -146,13 +160,13 @@ class ArrayList[E] private (
     removed
   }
 
-  override def remove(o: Any): Boolean =
-    inner.indexOf(o) match {
-      case -1  => false
-      case idx =>
-        remove(idx)
-        true
-    }
+  override def remove(o: Any): Boolean = {
+    val idx = indexOf(o)
+    if (idx >= 0) {
+      remove(idx)
+      true
+    } else false
+  }
 
   override def removeRange(fromIndex: Int, toIndex: Int): Unit = {
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArrayListTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/ArrayListTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Ported from JSR-166 TCK tests and released to the public domain, as
+ * explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * Modified for Scala Native.
+ */
+
+package org.scalanative.testsuite.javalib.util
+
+import java.util.{ArrayList, Arrays}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.javalib.util.concurrent.{Item, JSR166Test}
+
+class ArrayListTest extends JSR166Test {
+  import JSR166Test._
+
+  @Test def testClone(): Unit = {
+    val x = new ArrayList[Item]()
+    x.add(one)
+    x.add(two)
+    x.add(three)
+
+    val y = x.clone().asInstanceOf[ArrayList[Item]]
+    assertNotSame(y, x)
+    mustEqual(x, y)
+    mustEqual(y, x)
+    mustEqual(x.size(), y.size())
+    mustEqual(x.toString(), y.toString())
+    assertTrue(Arrays.equals(x.toArray(), y.toArray()))
+    while (!x.isEmpty()) {
+      assertFalse(y.isEmpty())
+      mustEqual(x.remove(0), y.remove(0))
+    }
+    assertTrue(y.isEmpty())
+  }
+}


### PR DESCRIPTION
## Motivation
PR #4851 includes `ArrayList` and random-access iterator fixes that are small enough to review independently.

## Modification
- Limit `indexOf`, `lastIndexOf`, and `remove(Object)` to the live `ArrayList` range.
- Make random-access list iterators enforce `next` / `previous` boundaries.
- Report sublist-relative iterator indexes.
- Add focused `ArrayList` coverage.

## Result
`ArrayList` behavior better matches Java collection contracts, with regression coverage kept in this minimal PR.

## Merge Order
- Stack position: 1, independent.
- Depends on: none.
- Can merge before or after #4856, #4857, #4858, and #4859.
- After merge: rebase #4851 and drop these `ArrayList` / iterator diffs.

## Verification
- `scripts/scalafmt --test`
- `sbt "javalib2_13/compile" "tests2_13/Test/compile"`

## References
- Split from #4851.
