### PR TITLE
Add java.util.concurrent.Exchanger

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/Exchanger.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Exchanger.scala
@@ -1,0 +1,99 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.scalanative.annotation.safePublish
+
+class Exchanger[V] {
+
+  private final class Node(val item: V) {
+    var matched = false
+    var matchItem: V = _
+  }
+
+  @safePublish
+  private final val lock = new ReentrantLock()
+
+  private final val available = lock.newCondition()
+
+  private var slot: Node = _
+
+  @throws[InterruptedException]
+  def exchange(x: V): V = {
+    val lock = this.lock
+    lock.lockInterruptibly()
+    try {
+      val other = slot
+      if (other == null) {
+        val node = new Node(x)
+        slot = node
+        while (!node.matched) {
+          try available.await()
+          catch {
+            case ex: InterruptedException =>
+              if (!node.matched && (slot eq node)) {
+                slot = null
+                available.signalAll()
+                throw ex
+              }
+              Thread.currentThread().interrupt()
+          }
+        }
+        node.matchItem
+      } else {
+        slot = null
+        other.matchItem = x
+        other.matched = true
+        available.signalAll()
+        other.item
+      }
+    } finally lock.unlock()
+  }
+
+  @throws[InterruptedException]
+  @throws[TimeoutException]
+  def exchange(x: V, timeout: Long, unit: TimeUnit): V = {
+    var nanos = unit.toNanos(timeout)
+    val lock = this.lock
+    lock.lockInterruptibly()
+    try {
+      val other = slot
+      if (other == null) {
+        val node = new Node(x)
+        slot = node
+        while (!node.matched) {
+          if (nanos <= 0L) {
+            if (slot eq node) {
+              slot = null
+              available.signalAll()
+              throw new TimeoutException()
+            }
+          }
+          try nanos = available.awaitNanos(nanos)
+          catch {
+            case ex: InterruptedException =>
+              if (!node.matched && (slot eq node)) {
+                slot = null
+                available.signalAll()
+                throw ex
+              }
+              Thread.currentThread().interrupt()
+          }
+        }
+        node.matchItem
+      } else {
+        slot = null
+        other.matchItem = x
+        other.matched = true
+        available.signalAll()
+        other.item
+      }
+    } finally lock.unlock()
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExchangerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExchangerTest.scala
@@ -1,0 +1,152 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.{CountDownLatch, Exchanger, TimeoutException}
+
+import org.junit.Assert._
+import org.junit.Test
+
+class ExchangerTest extends JSR166Test {
+  import JSR166Test._
+
+  private val itemOne = itemFor(1)
+  private val itemTwo = itemFor(2)
+  private val itemThree = itemFor(3)
+
+  /** exchange exchanges objects across two threads */
+  @Test def testExchange(): Unit = {
+    val e = new Exchanger[Item]()
+    val t1 = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        assertSame(itemOne, e.exchange(itemTwo))
+        assertSame(itemTwo, e.exchange(itemOne))
+      }
+    })
+    val t2 = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        assertSame(itemTwo, e.exchange(itemOne))
+        assertSame(itemOne, e.exchange(itemTwo))
+      }
+    })
+
+    awaitTermination(t1)
+    awaitTermination(t2)
+  }
+
+  /** timed exchange exchanges objects across two threads */
+  @Test def testTimedExchange(): Unit = {
+    val e = new Exchanger[Item]()
+    val t1 = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        assertSame(itemOne, e.exchange(itemTwo, LONG_DELAY_MS, MILLISECONDS))
+        assertSame(itemTwo, e.exchange(itemOne, LONG_DELAY_MS, MILLISECONDS))
+      }
+    })
+    val t2 = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        assertSame(itemTwo, e.exchange(itemOne, LONG_DELAY_MS, MILLISECONDS))
+        assertSame(itemOne, e.exchange(itemTwo, LONG_DELAY_MS, MILLISECONDS))
+      }
+    })
+
+    awaitTermination(t1)
+    awaitTermination(t2)
+  }
+
+  /** interrupt during wait for exchange throws InterruptedException */
+  @Test def testExchange_InterruptedException(): Unit = {
+    val e = new Exchanger[Item]()
+    val threadStarted = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedInterruptedRunnable {
+      override def realRun(): Unit = {
+        threadStarted.countDown()
+        e.exchange(itemOne)
+        ()
+      }
+    })
+
+    await(threadStarted)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /** interrupt during wait for timed exchange throws InterruptedException */
+  @Test def testTimedExchange_InterruptedException(): Unit = {
+    val e = new Exchanger[Item]()
+    val threadStarted = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedInterruptedRunnable {
+      override def realRun(): Unit = {
+        threadStarted.countDown()
+        e.exchange(null, LONG_DELAY_MS, MILLISECONDS)
+        ()
+      }
+    })
+
+    await(threadStarted)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /** timeout during wait for timed exchange throws TimeoutException */
+  @Test def testExchange_TimeoutException(): Unit = {
+    val e = new Exchanger[Item]()
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        val startTime = System.nanoTime()
+        try {
+          e.exchange(null, timeoutMillis(), MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: TimeoutException =>
+        }
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+      }
+    })
+
+    awaitTermination(t)
+  }
+
+  /** If one exchanging thread is interrupted, another succeeds. */
+  @Test def testReplacementAfterExchange(): Unit = {
+    val e = new Exchanger[Item]()
+    val exchanged = new CountDownLatch(2)
+    val interrupted = new CountDownLatch(1)
+    val t1 = newStartedThread(new CheckedInterruptedRunnable {
+      override def realRun(): Unit = {
+        assertSame(itemTwo, e.exchange(itemOne))
+        exchanged.countDown()
+        e.exchange(itemTwo)
+        ()
+      }
+    })
+    val t2 = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        assertSame(itemOne, e.exchange(itemTwo))
+        exchanged.countDown()
+        await(interrupted)
+        assertSame(itemThree, e.exchange(itemOne))
+      }
+    })
+    val t3 = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        await(interrupted)
+        assertSame(itemOne, e.exchange(itemThree))
+      }
+    })
+
+    await(exchanged)
+    t1.interrupt()
+    awaitTermination(t1)
+    interrupted.countDown()
+    awaitTermination(t2)
+    awaitTermination(t3)
+  }
+}


### PR DESCRIPTION
## Motivation
scala-native lacks `java.util.concurrent.Exchanger`, and PR #4851 carries an implementation plus focused JSR166 tests that can stand alone.

## Modification
- Add `java.util.concurrent.Exchanger`.
- Support timed and interruptible exchange paths.
- Add focused public-domain JSR166 coverage.

## Result
`Exchanger` becomes available as an independent concurrent utility without requiring the rest of the JSR166 migration.

## Merge Order
- Stack position: 1, independent.
- Depends on: none.
- Can merge before or after #4856, #4857, #4858, #4859, and #4860.
- After merge: rebase #4851 and drop `Exchanger.scala` and `ExchangerTest.scala`.

## Verification
- `scripts/scalafmt --test`
- `sbt "javalib2_13/compile" "tests2_13/Test/compile"`

## References
- Split from #4851.
