### PR TITLE
Add minimal java.time.Duration support

### DIFF
--- a/javalib/src/main/scala/java/time/DateTimeException.scala
+++ b/javalib/src/main/scala/java/time/DateTimeException.scala
@@ -1,4 +1,3 @@
-// Ported from Scala.js, commit: 54648372, dated: 2020-09-24
 package java.time
 
 class DateTimeException(message: String, cause: Throwable)

--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -1,0 +1,120 @@
+package java.time
+
+import java.time.temporal.{ChronoUnit, TemporalUnit}
+
+final class Duration private (private val seconds: Long, private val nanos: Int)
+    extends Serializable {
+
+  def getSeconds(): Long = seconds
+
+  def getNano(): Int = nanos
+
+  def isZero(): Boolean =
+    seconds == 0L && nanos == 0
+
+  def isNegative(): Boolean =
+    seconds < 0L
+
+  def plus(amountToAdd: Long, unit: TemporalUnit): Duration =
+    Duration.fromTotalNanos(
+      toNanosBigInt + Duration.nanosFor(amountToAdd, unit)
+    )
+
+  def minus(amountToSubtract: Long, unit: TemporalUnit): Duration =
+    Duration.fromTotalNanos(
+      toNanosBigInt - Duration.nanosFor(amountToSubtract, unit)
+    )
+
+  private[java] def toNanosBigInt: BigInt =
+    BigInt(seconds) * Duration.NanosPerSecond + BigInt(nanos)
+
+  private[java] def toMillisAndNanos: (Long, Int) = {
+    val totalNanos = toNanosBigInt
+    val millis = totalNanos / Duration.NanosPerMilli
+    val nanos = totalNanos % Duration.NanosPerMilli
+    if (millis >= BigInt(Long.MaxValue)) (Long.MaxValue, 0)
+    else (millis.toLong, nanos.toInt)
+  }
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case that: Duration =>
+        seconds == that.seconds && nanos == that.nanos
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    (seconds ^ (seconds >>> 32)).toInt + 51 * nanos
+}
+
+object Duration {
+  private[time] final val NanosPerSecond = 1000000000L
+  private final val NanosPerMilli = 1000000L
+  private final val NanosPerMicro = 1000L
+  private final val SecondsPerMinute = 60L
+  private final val SecondsPerHour = 60L * SecondsPerMinute
+  private final val SecondsPerDay = 24L * SecondsPerHour
+
+  def ofNanos(nanos: Long): Duration =
+    fromTotalNanos(BigInt(nanos))
+
+  def ofMillis(millis: Long): Duration =
+    fromTotalNanos(BigInt(millis) * NanosPerMilli)
+
+  def ofSeconds(seconds: Long): Duration =
+    new Duration(seconds, 0)
+
+  def ofSeconds(seconds: Long, nanoAdjustment: Long): Duration =
+    fromTotalNanos(BigInt(seconds) * NanosPerSecond + BigInt(nanoAdjustment))
+
+  def ofMinutes(minutes: Long): Duration =
+    ofSecondsExact(minutes, SecondsPerMinute)
+
+  def ofHours(hours: Long): Duration =
+    ofSecondsExact(hours, SecondsPerHour)
+
+  def ofDays(days: Long): Duration =
+    ofSecondsExact(days, SecondsPerDay)
+
+  def of(amount: Long, unit: TemporalUnit): Duration =
+    fromTotalNanos(nanosFor(amount, unit))
+
+  private[time] def nanosFor(amount: Long, unit: TemporalUnit): BigInt = {
+    if (unit == null) throw new NullPointerException()
+    val perUnitNanos =
+      unit match {
+        case ChronoUnit.NANOS   => BigInt(1L)
+        case ChronoUnit.MICROS  => BigInt(NanosPerMicro)
+        case ChronoUnit.MILLIS  => BigInt(NanosPerMilli)
+        case ChronoUnit.SECONDS => BigInt(NanosPerSecond)
+        case ChronoUnit.MINUTES => BigInt(SecondsPerMinute) * NanosPerSecond
+        case ChronoUnit.HOURS   => BigInt(SecondsPerHour) * NanosPerSecond
+        case ChronoUnit.DAYS    => BigInt(SecondsPerDay) * NanosPerSecond
+        case _                  =>
+          throw new java.time.DateTimeException("Unsupported unit: " + unit)
+      }
+    BigInt(amount) * perUnitNanos
+  }
+
+  private def ofSecondsExact(amount: Long, secondsPerUnit: Long): Duration =
+    fromSeconds(BigInt(amount) * secondsPerUnit)
+
+  private def fromSeconds(seconds: BigInt): Duration = {
+    if (seconds < BigInt(Long.MinValue) || seconds > BigInt(Long.MaxValue))
+      throw new ArithmeticException("long overflow")
+    new Duration(seconds.toLong, 0)
+  }
+
+  private[time] def fromTotalNanos(totalNanos: BigInt): Duration = {
+    val nanosPerSecond = BigInt(NanosPerSecond)
+    var seconds = totalNanos / nanosPerSecond
+    var nanos = totalNanos % nanosPerSecond
+    if (nanos < 0) {
+      nanos += nanosPerSecond
+      seconds -= 1
+    }
+    if (seconds < BigInt(Long.MinValue) || seconds > BigInt(Long.MaxValue))
+      throw new ArithmeticException("long overflow")
+    new Duration(seconds.toLong, nanos.toInt)
+  }
+}

--- a/javalib/src/main/scala/java/time/temporal/ChronoUnit.scala
+++ b/javalib/src/main/scala/java/time/temporal/ChronoUnit.scala
@@ -1,0 +1,51 @@
+package java.time.temporal
+
+class ChronoUnit private (name: String, ordinal: Int)
+    extends _Enum[ChronoUnit](name, ordinal)
+    with TemporalUnit
+
+object ChronoUnit {
+  final val NANOS = new ChronoUnit("NANOS", 0)
+  final val MICROS = new ChronoUnit("MICROS", 1)
+  final val MILLIS = new ChronoUnit("MILLIS", 2)
+  final val SECONDS = new ChronoUnit("SECONDS", 3)
+  final val MINUTES = new ChronoUnit("MINUTES", 4)
+  final val HOURS = new ChronoUnit("HOURS", 5)
+  final val HALF_DAYS = new ChronoUnit("HALF_DAYS", 6)
+  final val DAYS = new ChronoUnit("DAYS", 7)
+  final val WEEKS = new ChronoUnit("WEEKS", 8)
+  final val MONTHS = new ChronoUnit("MONTHS", 9)
+  final val YEARS = new ChronoUnit("YEARS", 10)
+  final val DECADES = new ChronoUnit("DECADES", 11)
+  final val CENTURIES = new ChronoUnit("CENTURIES", 12)
+  final val MILLENNIA = new ChronoUnit("MILLENNIA", 13)
+  final val ERAS = new ChronoUnit("ERAS", 14)
+  final val FOREVER = new ChronoUnit("FOREVER", 15)
+
+  private val _values: Array[ChronoUnit] =
+    Array(
+      NANOS,
+      MICROS,
+      MILLIS,
+      SECONDS,
+      MINUTES,
+      HOURS,
+      HALF_DAYS,
+      DAYS,
+      WEEKS,
+      MONTHS,
+      YEARS,
+      DECADES,
+      CENTURIES,
+      MILLENNIA,
+      ERAS,
+      FOREVER
+    )
+
+  def values(): Array[ChronoUnit] = _values.clone()
+
+  def valueOf(name: String): ChronoUnit =
+    _values.find(_.name() == name).getOrElse {
+      throw new IllegalArgumentException("No enum const ChronoUnit." + name)
+    }
+}

--- a/javalib/src/main/scala/java/time/temporal/TemporalUnit.scala
+++ b/javalib/src/main/scala/java/time/temporal/TemporalUnit.scala
@@ -1,0 +1,3 @@
+package java.time.temporal
+
+trait TemporalUnit


### PR DESCRIPTION
## Motivation
Thread and `TimeUnit` follow-up APIs need a small `java.time.Duration` foundation, and PR #4851 currently bundles that foundation with unrelated JSR166 work.

## Modification
- Add `java.time.Duration`.
- Add minimal `java.time.temporal.ChronoUnit` and `TemporalUnit` support used by follow-up APIs.
- Stack this on the `DateTimeException` move from #4856.

## Result
Duration construction, supported-unit arithmetic, equality, hashing, and internal millis/nanos conversion are available for downstream time API PRs.

## Merge Order
- Stack position: 2, after #4856.
- Depends on: #4856, because `Duration` in `javalib` references `java.time.DateTimeException`.
- Follow-ups: #4864 for `Thread` Duration overloads, and #4866 for `TimeUnit` Duration / `ChronoUnit` APIs.
- Review note: until #4856 merges, GitHub may show the parent `DateTimeException` move in this diff.
- After merge: rebase #4851 and drop `Duration.scala`, `ChronoUnit.scala`, and `TemporalUnit.scala`.

## Verification
- `scripts/scalafmt --test`
- `sbt "javalib2_13/compile"`

## References
- Split from #4851.
- Depends on #4856.
