### PR TITLE
Add Thread Duration overloads

### DIFF
--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -349,8 +349,9 @@ class Thread private[lang] (
       case Thread.State.NEW =>
         throw new IllegalThreadStateException("Cannot join unstarted thread")
       case _ =>
-        if (duration.isNegative() || duration.isZero()) {
-          join(duration.getSeconds() * 1000, duration.getNano())
+        if (!duration.isNegative() && !duration.isZero()) {
+          val (millis, nanos) = duration.toMillisAndNanos
+          join(millis, nanos)
         }
         getState() == Thread.State.TERMINATED
     }
@@ -611,8 +612,12 @@ object Thread {
   @throws[InterruptedException](
     "if the current thread is interrupted while sleeping"
   )
-  def sleep(duration: Duration): Unit =
-    sleep(millis = duration.getSeconds() * 1000, nanos = duration.getNano())
+  def sleep(duration: Duration): Unit = {
+    if (!duration.isNegative() && !duration.isZero()) {
+      val (millis, nanos) = duration.toMillisAndNanos
+      sleep(millis, nanos)
+    }
+  }
 
   def ofPlatform(): Builder.OfPlatform =
     new ThreadBuilders.PlatformThreadBuilder

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -378,6 +378,7 @@ class Thread private[lang] (
   )
   @throws[IllegalThreadStateException]("if this thread has not been started")
   final def join(duration: Duration): scala.Boolean = {
+    if (duration == null) throw new NullPointerException()
     threadState() match {
       case Thread.State.NEW =>
         throw new IllegalThreadStateException("Cannot join unstarted thread")
@@ -685,8 +686,13 @@ object Thread {
   @throws[InterruptedException](
     "if the current thread is interrupted while sleeping"
   )
-  def sleep(duration: Duration): Unit =
-    sleep(millis = duration.getSeconds() * 1000, nanos = duration.getNano())
+  def sleep(duration: Duration): Unit = {
+    if (duration == null) throw new NullPointerException()
+    if (!duration.isNegative())
+      duration.toMillisAndNanos match {
+        case (millis, nanos) => sleep(millis, nanos)
+      }
+  }
 
   def ofPlatform(): Builder.OfPlatform =
     new ThreadBuilders.PlatformThreadBuilder

--- a/javalib/src/main/scala/java/time/DateTimeException.scala
+++ b/javalib/src/main/scala/java/time/DateTimeException.scala
@@ -1,4 +1,3 @@
-// Ported from Scala.js, commit: 54648372, dated: 2020-09-24
 package java.time
 
 class DateTimeException(message: String, cause: Throwable)

--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -1,0 +1,120 @@
+package java.time
+
+import java.time.temporal.{ChronoUnit, TemporalUnit}
+
+final class Duration private (private val seconds: Long, private val nanos: Int)
+    extends Serializable {
+
+  def getSeconds(): Long = seconds
+
+  def getNano(): Int = nanos
+
+  def isZero(): Boolean =
+    seconds == 0L && nanos == 0
+
+  def isNegative(): Boolean =
+    seconds < 0L
+
+  def plus(amountToAdd: Long, unit: TemporalUnit): Duration =
+    Duration.fromTotalNanos(
+      toNanosBigInt + Duration.nanosFor(amountToAdd, unit)
+    )
+
+  def minus(amountToSubtract: Long, unit: TemporalUnit): Duration =
+    Duration.fromTotalNanos(
+      toNanosBigInt - Duration.nanosFor(amountToSubtract, unit)
+    )
+
+  private[java] def toNanosBigInt: BigInt =
+    BigInt(seconds) * Duration.NanosPerSecond + BigInt(nanos)
+
+  private[java] def toMillisAndNanos: (Long, Int) = {
+    val totalNanos = toNanosBigInt
+    val millis = totalNanos / Duration.NanosPerMilli
+    val nanos = totalNanos % Duration.NanosPerMilli
+    if (millis >= BigInt(Long.MaxValue)) (Long.MaxValue, 0)
+    else (millis.toLong, nanos.toInt)
+  }
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case that: Duration =>
+        seconds == that.seconds && nanos == that.nanos
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    (seconds ^ (seconds >>> 32)).toInt + 51 * nanos
+}
+
+object Duration {
+  private[time] final val NanosPerSecond = 1000000000L
+  private final val NanosPerMilli = 1000000L
+  private final val NanosPerMicro = 1000L
+  private final val SecondsPerMinute = 60L
+  private final val SecondsPerHour = 60L * SecondsPerMinute
+  private final val SecondsPerDay = 24L * SecondsPerHour
+
+  def ofNanos(nanos: Long): Duration =
+    fromTotalNanos(BigInt(nanos))
+
+  def ofMillis(millis: Long): Duration =
+    fromTotalNanos(BigInt(millis) * NanosPerMilli)
+
+  def ofSeconds(seconds: Long): Duration =
+    new Duration(seconds, 0)
+
+  def ofSeconds(seconds: Long, nanoAdjustment: Long): Duration =
+    fromTotalNanos(BigInt(seconds) * NanosPerSecond + BigInt(nanoAdjustment))
+
+  def ofMinutes(minutes: Long): Duration =
+    ofSecondsExact(minutes, SecondsPerMinute)
+
+  def ofHours(hours: Long): Duration =
+    ofSecondsExact(hours, SecondsPerHour)
+
+  def ofDays(days: Long): Duration =
+    ofSecondsExact(days, SecondsPerDay)
+
+  def of(amount: Long, unit: TemporalUnit): Duration =
+    fromTotalNanos(nanosFor(amount, unit))
+
+  private[time] def nanosFor(amount: Long, unit: TemporalUnit): BigInt = {
+    if (unit == null) throw new NullPointerException()
+    val perUnitNanos =
+      unit match {
+        case ChronoUnit.NANOS   => BigInt(1L)
+        case ChronoUnit.MICROS  => BigInt(NanosPerMicro)
+        case ChronoUnit.MILLIS  => BigInt(NanosPerMilli)
+        case ChronoUnit.SECONDS => BigInt(NanosPerSecond)
+        case ChronoUnit.MINUTES => BigInt(SecondsPerMinute) * NanosPerSecond
+        case ChronoUnit.HOURS   => BigInt(SecondsPerHour) * NanosPerSecond
+        case ChronoUnit.DAYS    => BigInt(SecondsPerDay) * NanosPerSecond
+        case _                  =>
+          throw new java.time.DateTimeException("Unsupported unit: " + unit)
+      }
+    BigInt(amount) * perUnitNanos
+  }
+
+  private def ofSecondsExact(amount: Long, secondsPerUnit: Long): Duration =
+    fromSeconds(BigInt(amount) * secondsPerUnit)
+
+  private def fromSeconds(seconds: BigInt): Duration = {
+    if (seconds < BigInt(Long.MinValue) || seconds > BigInt(Long.MaxValue))
+      throw new ArithmeticException("long overflow")
+    new Duration(seconds.toLong, 0)
+  }
+
+  private[time] def fromTotalNanos(totalNanos: BigInt): Duration = {
+    val nanosPerSecond = BigInt(NanosPerSecond)
+    var seconds = totalNanos / nanosPerSecond
+    var nanos = totalNanos % nanosPerSecond
+    if (nanos < 0) {
+      nanos += nanosPerSecond
+      seconds -= 1
+    }
+    if (seconds < BigInt(Long.MinValue) || seconds > BigInt(Long.MaxValue))
+      throw new ArithmeticException("long overflow")
+    new Duration(seconds.toLong, nanos.toInt)
+  }
+}

--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -55,6 +55,8 @@ object Duration {
   private final val SecondsPerHour = 60L * SecondsPerMinute
   private final val SecondsPerDay = 24L * SecondsPerHour
 
+  final val ZERO: Duration = new Duration(0, 0)
+
   def ofNanos(nanos: Long): Duration =
     fromTotalNanos(BigInt(nanos))
 

--- a/javalib/src/main/scala/java/time/temporal/ChronoUnit.scala
+++ b/javalib/src/main/scala/java/time/temporal/ChronoUnit.scala
@@ -1,0 +1,51 @@
+package java.time.temporal
+
+class ChronoUnit private (name: String, ordinal: Int)
+    extends _Enum[ChronoUnit](name, ordinal)
+    with TemporalUnit
+
+object ChronoUnit {
+  final val NANOS = new ChronoUnit("NANOS", 0)
+  final val MICROS = new ChronoUnit("MICROS", 1)
+  final val MILLIS = new ChronoUnit("MILLIS", 2)
+  final val SECONDS = new ChronoUnit("SECONDS", 3)
+  final val MINUTES = new ChronoUnit("MINUTES", 4)
+  final val HOURS = new ChronoUnit("HOURS", 5)
+  final val HALF_DAYS = new ChronoUnit("HALF_DAYS", 6)
+  final val DAYS = new ChronoUnit("DAYS", 7)
+  final val WEEKS = new ChronoUnit("WEEKS", 8)
+  final val MONTHS = new ChronoUnit("MONTHS", 9)
+  final val YEARS = new ChronoUnit("YEARS", 10)
+  final val DECADES = new ChronoUnit("DECADES", 11)
+  final val CENTURIES = new ChronoUnit("CENTURIES", 12)
+  final val MILLENNIA = new ChronoUnit("MILLENNIA", 13)
+  final val ERAS = new ChronoUnit("ERAS", 14)
+  final val FOREVER = new ChronoUnit("FOREVER", 15)
+
+  private val _values: Array[ChronoUnit] =
+    Array(
+      NANOS,
+      MICROS,
+      MILLIS,
+      SECONDS,
+      MINUTES,
+      HOURS,
+      HALF_DAYS,
+      DAYS,
+      WEEKS,
+      MONTHS,
+      YEARS,
+      DECADES,
+      CENTURIES,
+      MILLENNIA,
+      ERAS,
+      FOREVER
+    )
+
+  def values(): Array[ChronoUnit] = _values.clone()
+
+  def valueOf(name: String): ChronoUnit =
+    _values.find(_.name() == name).getOrElse {
+      throw new IllegalArgumentException("No enum const ChronoUnit." + name)
+    }
+}

--- a/javalib/src/main/scala/java/time/temporal/TemporalUnit.scala
+++ b/javalib/src/main/scala/java/time/temporal/TemporalUnit.scala
@@ -1,0 +1,3 @@
+package java.time.temporal
+
+trait TemporalUnit

--- a/javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
@@ -160,7 +160,7 @@ object TimeUnit {
 
   private def x(a: Long, b: Long, max: Long): Long = {
     if (a > max) MAX
-    else if (a < -max) -MAX
+    else if (a < -max) MIN
     else a * b
   }
 

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/ThreadDurationTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/ThreadDurationTestOnJDK19.scala
@@ -1,0 +1,35 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.lang.Thread
+import java.time.Duration
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform._
+
+class ThreadDurationTestOnJDK19 {
+  @Test def sleepDurationIsNoOpForNegativeDuration(): Unit = {
+    Thread.sleep(Duration.ofNanos(-1L))
+  }
+
+  @Test def joinDurationThrowsForUnstartedThread(): Unit = {
+    val thread = new Thread(() => ())
+    assertThrows(
+      classOf[IllegalThreadStateException],
+      thread.join(Duration.ofNanos(1L))
+    )
+  }
+
+  @Test def joinDurationReturnsTrueForTerminatedThread(): Unit = {
+    assumeTrue("requires multithreading", isMultithreadingEnabled)
+
+    val thread = new Thread(() => ())
+    thread.start()
+    thread.join()
+
+    assertTrue(thread.join(Duration.ofMillis(1L)))
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/ThreadDurationTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/lang/ThreadDurationTestOnJDK19.scala
@@ -4,15 +4,34 @@ import java.lang.Thread
 import java.time.Duration
 
 import org.junit.Assert._
-import org.junit.Assume._
 import org.junit.Test
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.Platform._
+
+import scala.scalanative.junit.utils.AssumesHelper
 
 class ThreadDurationTestOnJDK19 {
+  @Test def sleepDurationThrowsNullPointerException(): Unit = {
+    assertThrows(
+      classOf[NullPointerException],
+      Thread.sleep(null.asInstanceOf[Duration])
+    )
+  }
+
   @Test def sleepDurationIsNoOpForNegativeDuration(): Unit = {
     Thread.sleep(Duration.ofNanos(-1L))
+  }
+
+  @Test def sleepDurationAcceptsZeroDuration(): Unit = {
+    Thread.sleep(Duration.ZERO)
+  }
+
+  @Test def joinDurationThrowsNullPointerException(): Unit = {
+    val thread = new Thread(() => ())
+    assertThrows(
+      classOf[NullPointerException],
+      thread.join(null.asInstanceOf[Duration])
+    )
   }
 
   @Test def joinDurationThrowsForUnstartedThread(): Unit = {
@@ -24,7 +43,7 @@ class ThreadDurationTestOnJDK19 {
   }
 
   @Test def joinDurationReturnsTrueForTerminatedThread(): Unit = {
-    assumeTrue("requires multithreading", isMultithreadingEnabled)
+    AssumesHelper.assumeMultithreadingIsEnabled()
 
     val thread = new Thread(() => ())
     thread.start()


### PR DESCRIPTION
## Motivation
PR #4851 adds `Thread.sleep(Duration)` and `Thread.join(Duration)` support, which should be reviewed as a small follow-up to the minimal Duration API.

## Modification
- Use `Duration.toMillisAndNanos` for Thread sleep/join duration overloads.
- Preserve the required non-positive duration no-op behavior.
- Add JDK19-gated tests for the overload behavior.

## Result
Thread Duration overload behavior is available once the Duration foundation from #4863 is merged.

## Merge Order
- Stack position: 3, after #4863.
- Depends on: #4863, which depends on #4856.
- Parallel with: #4866; both depend on #4863 but do not depend on each other.
- Review note: until #4856 and #4863 merge, GitHub may show their parent diffs.
- After merge: rebase #4851 and drop this Thread duration diff.

## Verification
- `scripts/scalafmt --test`
- `sbt "javalib2_13/compile" "tests2_13/Test/compile"`

## References
- Split from #4851.
- Depends on #4863 and #4856.
