### PR TITLE
Add TimeUnit Duration and ChronoUnit APIs

### DIFF
--- a/javalib/src/main/scala/java/nio/file/attribute/FileTime.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/FileTime.scala
@@ -44,16 +44,25 @@ final class FileTime private (
     val fromDaysOverflow =
       fromDays == Long.MaxValue || fromDays <= -Long.MaxValue
 
-    if (fromDaysOverflow) fromDays
+    if (fromDaysOverflow) toSaturated(unit)
     else {
       try {
         Math.addExact(fromDays, fromNanos)
       } catch {
-        case _: ArithmeticException =>
-          if (fromDays > 0) Long.MaxValue
-          else Long.MinValue
+        case _: ArithmeticException => toSaturated(unit)
       }
     }
+  }
+
+  private def toSaturated(unit: TimeUnit): Long = {
+    val unitNanos = unit.toNanos(1L)
+    val totalNanos =
+      (BigInt(epochDays) * BigInt(NanosInDay)) + BigInt(dayNanos)
+    val converted = totalNanos / BigInt(unitNanos)
+
+    if (converted > BigInt(Long.MaxValue)) Long.MaxValue
+    else if (converted < BigInt(Long.MinValue)) Long.MinValue
+    else converted.toLong
   }
 
   def toMillis(): Long = to(TimeUnit.MILLISECONDS)

--- a/javalib/src/main/scala/java/time/DateTimeException.scala
+++ b/javalib/src/main/scala/java/time/DateTimeException.scala
@@ -1,4 +1,3 @@
-// Ported from Scala.js, commit: 54648372, dated: 2020-09-24
 package java.time
 
 class DateTimeException(message: String, cause: Throwable)

--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -1,0 +1,120 @@
+package java.time
+
+import java.time.temporal.{ChronoUnit, TemporalUnit}
+
+final class Duration private (private val seconds: Long, private val nanos: Int)
+    extends Serializable {
+
+  def getSeconds(): Long = seconds
+
+  def getNano(): Int = nanos
+
+  def isZero(): Boolean =
+    seconds == 0L && nanos == 0
+
+  def isNegative(): Boolean =
+    seconds < 0L
+
+  def plus(amountToAdd: Long, unit: TemporalUnit): Duration =
+    Duration.fromTotalNanos(
+      toNanosBigInt + Duration.nanosFor(amountToAdd, unit)
+    )
+
+  def minus(amountToSubtract: Long, unit: TemporalUnit): Duration =
+    Duration.fromTotalNanos(
+      toNanosBigInt - Duration.nanosFor(amountToSubtract, unit)
+    )
+
+  private[java] def toNanosBigInt: BigInt =
+    BigInt(seconds) * Duration.NanosPerSecond + BigInt(nanos)
+
+  private[java] def toMillisAndNanos: (Long, Int) = {
+    val totalNanos = toNanosBigInt
+    val millis = totalNanos / Duration.NanosPerMilli
+    val nanos = totalNanos % Duration.NanosPerMilli
+    if (millis >= BigInt(Long.MaxValue)) (Long.MaxValue, 0)
+    else (millis.toLong, nanos.toInt)
+  }
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case that: Duration =>
+        seconds == that.seconds && nanos == that.nanos
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    (seconds ^ (seconds >>> 32)).toInt + 51 * nanos
+}
+
+object Duration {
+  private[time] final val NanosPerSecond = 1000000000L
+  private final val NanosPerMilli = 1000000L
+  private final val NanosPerMicro = 1000L
+  private final val SecondsPerMinute = 60L
+  private final val SecondsPerHour = 60L * SecondsPerMinute
+  private final val SecondsPerDay = 24L * SecondsPerHour
+
+  def ofNanos(nanos: Long): Duration =
+    fromTotalNanos(BigInt(nanos))
+
+  def ofMillis(millis: Long): Duration =
+    fromTotalNanos(BigInt(millis) * NanosPerMilli)
+
+  def ofSeconds(seconds: Long): Duration =
+    new Duration(seconds, 0)
+
+  def ofSeconds(seconds: Long, nanoAdjustment: Long): Duration =
+    fromTotalNanos(BigInt(seconds) * NanosPerSecond + BigInt(nanoAdjustment))
+
+  def ofMinutes(minutes: Long): Duration =
+    ofSecondsExact(minutes, SecondsPerMinute)
+
+  def ofHours(hours: Long): Duration =
+    ofSecondsExact(hours, SecondsPerHour)
+
+  def ofDays(days: Long): Duration =
+    ofSecondsExact(days, SecondsPerDay)
+
+  def of(amount: Long, unit: TemporalUnit): Duration =
+    fromTotalNanos(nanosFor(amount, unit))
+
+  private[time] def nanosFor(amount: Long, unit: TemporalUnit): BigInt = {
+    if (unit == null) throw new NullPointerException()
+    val perUnitNanos =
+      unit match {
+        case ChronoUnit.NANOS   => BigInt(1L)
+        case ChronoUnit.MICROS  => BigInt(NanosPerMicro)
+        case ChronoUnit.MILLIS  => BigInt(NanosPerMilli)
+        case ChronoUnit.SECONDS => BigInt(NanosPerSecond)
+        case ChronoUnit.MINUTES => BigInt(SecondsPerMinute) * NanosPerSecond
+        case ChronoUnit.HOURS   => BigInt(SecondsPerHour) * NanosPerSecond
+        case ChronoUnit.DAYS    => BigInt(SecondsPerDay) * NanosPerSecond
+        case _                  =>
+          throw new java.time.DateTimeException("Unsupported unit: " + unit)
+      }
+    BigInt(amount) * perUnitNanos
+  }
+
+  private def ofSecondsExact(amount: Long, secondsPerUnit: Long): Duration =
+    fromSeconds(BigInt(amount) * secondsPerUnit)
+
+  private def fromSeconds(seconds: BigInt): Duration = {
+    if (seconds < BigInt(Long.MinValue) || seconds > BigInt(Long.MaxValue))
+      throw new ArithmeticException("long overflow")
+    new Duration(seconds.toLong, 0)
+  }
+
+  private[time] def fromTotalNanos(totalNanos: BigInt): Duration = {
+    val nanosPerSecond = BigInt(NanosPerSecond)
+    var seconds = totalNanos / nanosPerSecond
+    var nanos = totalNanos % nanosPerSecond
+    if (nanos < 0) {
+      nanos += nanosPerSecond
+      seconds -= 1
+    }
+    if (seconds < BigInt(Long.MinValue) || seconds > BigInt(Long.MaxValue))
+      throw new ArithmeticException("long overflow")
+    new Duration(seconds.toLong, nanos.toInt)
+  }
+}

--- a/javalib/src/main/scala/java/time/temporal/ChronoUnit.scala
+++ b/javalib/src/main/scala/java/time/temporal/ChronoUnit.scala
@@ -1,0 +1,51 @@
+package java.time.temporal
+
+class ChronoUnit private (name: String, ordinal: Int)
+    extends _Enum[ChronoUnit](name, ordinal)
+    with TemporalUnit
+
+object ChronoUnit {
+  final val NANOS = new ChronoUnit("NANOS", 0)
+  final val MICROS = new ChronoUnit("MICROS", 1)
+  final val MILLIS = new ChronoUnit("MILLIS", 2)
+  final val SECONDS = new ChronoUnit("SECONDS", 3)
+  final val MINUTES = new ChronoUnit("MINUTES", 4)
+  final val HOURS = new ChronoUnit("HOURS", 5)
+  final val HALF_DAYS = new ChronoUnit("HALF_DAYS", 6)
+  final val DAYS = new ChronoUnit("DAYS", 7)
+  final val WEEKS = new ChronoUnit("WEEKS", 8)
+  final val MONTHS = new ChronoUnit("MONTHS", 9)
+  final val YEARS = new ChronoUnit("YEARS", 10)
+  final val DECADES = new ChronoUnit("DECADES", 11)
+  final val CENTURIES = new ChronoUnit("CENTURIES", 12)
+  final val MILLENNIA = new ChronoUnit("MILLENNIA", 13)
+  final val ERAS = new ChronoUnit("ERAS", 14)
+  final val FOREVER = new ChronoUnit("FOREVER", 15)
+
+  private val _values: Array[ChronoUnit] =
+    Array(
+      NANOS,
+      MICROS,
+      MILLIS,
+      SECONDS,
+      MINUTES,
+      HOURS,
+      HALF_DAYS,
+      DAYS,
+      WEEKS,
+      MONTHS,
+      YEARS,
+      DECADES,
+      CENTURIES,
+      MILLENNIA,
+      ERAS,
+      FOREVER
+    )
+
+  def values(): Array[ChronoUnit] = _values.clone()
+
+  def valueOf(name: String): ChronoUnit =
+    _values.find(_.name() == name).getOrElse {
+      throw new IllegalArgumentException("No enum const ChronoUnit." + name)
+    }
+}

--- a/javalib/src/main/scala/java/time/temporal/TemporalUnit.scala
+++ b/javalib/src/main/scala/java/time/temporal/TemporalUnit.scala
@@ -1,0 +1,3 @@
+package java.time.temporal
+
+trait TemporalUnit

--- a/javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
@@ -1,11 +1,15 @@
 package java.util.concurrent
 
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
 // Ported from Scala.js
 
 abstract class TimeUnit private (name: String, ordinal: Int)
     extends _Enum[TimeUnit](name, ordinal) {
 
   def convert(a: Long, u: TimeUnit): Long
+  def convert(duration: Duration): Long
 
   def toNanos(a: Long): Long
   def toMicros(a: Long): Long
@@ -14,6 +18,7 @@ abstract class TimeUnit private (name: String, ordinal: Int)
   def toMinutes(a: Long): Long
   def toHours(a: Long): Long
   def toDays(a: Long): Long
+  def toChronoUnit(): ChronoUnit
 
   def sleep(timeout: Long): Unit =
     if (timeout > 0) Thread.sleep(toMillis(timeout))
@@ -26,6 +31,7 @@ abstract class TimeUnit private (name: String, ordinal: Int)
 object TimeUnit {
   final val NANOSECONDS: TimeUnit = new TimeUnit("NANOSECONDS", 0) {
     def convert(a: Long, u: TimeUnit): Long = u.toNanos(a)
+    def convert(duration: Duration): Long = convertDuration(duration, this)
     def toNanos(a: Long): Long = a
     def toMicros(a: Long): Long = a / (C1 / C0)
     def toMillis(a: Long): Long = a / (C2 / C0)
@@ -33,10 +39,12 @@ object TimeUnit {
     def toMinutes(a: Long): Long = a / (C4 / C0)
     def toHours(a: Long): Long = a / (C5 / C0)
     def toDays(a: Long): Long = a / (C6 / C0)
+    def toChronoUnit(): ChronoUnit = ChronoUnit.NANOS
   }
 
   final val MICROSECONDS: TimeUnit = new TimeUnit("MICROSECONDS", 1) {
     def convert(a: Long, u: TimeUnit): Long = u.toMicros(a)
+    def convert(duration: Duration): Long = convertDuration(duration, this)
     def toNanos(a: Long): Long = x(a, C1 / C0, MAX / (C1 / C0))
     def toMicros(a: Long): Long = a
     def toMillis(a: Long): Long = a / (C2 / C1)
@@ -44,10 +52,12 @@ object TimeUnit {
     def toMinutes(a: Long): Long = a / (C4 / C1)
     def toHours(a: Long): Long = a / (C5 / C1)
     def toDays(a: Long): Long = a / (C6 / C1)
+    def toChronoUnit(): ChronoUnit = ChronoUnit.MICROS
   }
 
   final val MILLISECONDS: TimeUnit = new TimeUnit("MILLISECONDS", 2) {
     def convert(a: Long, u: TimeUnit): Long = u.toMillis(a)
+    def convert(duration: Duration): Long = convertDuration(duration, this)
     def toNanos(a: Long): Long = x(a, C2 / C0, MAX / (C2 / C0))
     def toMicros(a: Long): Long = x(a, C2 / C1, MAX / (C2 / C1))
     def toMillis(a: Long): Long = a
@@ -55,10 +65,12 @@ object TimeUnit {
     def toMinutes(a: Long): Long = a / (C4 / C2)
     def toHours(a: Long): Long = a / (C5 / C2)
     def toDays(a: Long): Long = a / (C6 / C2)
+    def toChronoUnit(): ChronoUnit = ChronoUnit.MILLIS
   }
 
   final val SECONDS: TimeUnit = new TimeUnit("SECONDS", 3) {
     def convert(a: Long, u: TimeUnit): Long = u.toSeconds(a)
+    def convert(duration: Duration): Long = convertDuration(duration, this)
     def toNanos(a: Long): Long = x(a, C3 / C0, MAX / (C3 / C0))
     def toMicros(a: Long): Long = x(a, C3 / C1, MAX / (C3 / C1))
     def toMillis(a: Long): Long = x(a, C3 / C2, MAX / (C3 / C2))
@@ -66,10 +78,12 @@ object TimeUnit {
     def toMinutes(a: Long): Long = a / (C4 / C3)
     def toHours(a: Long): Long = a / (C5 / C3)
     def toDays(a: Long): Long = a / (C6 / C3)
+    def toChronoUnit(): ChronoUnit = ChronoUnit.SECONDS
   }
 
   final val MINUTES: TimeUnit = new TimeUnit("MINUTES", 4) {
     def convert(a: Long, u: TimeUnit): Long = u.toMinutes(a)
+    def convert(duration: Duration): Long = convertDuration(duration, this)
     def toNanos(a: Long): Long = x(a, C4 / C0, MAX / (C4 / C0))
     def toMicros(a: Long): Long = x(a, C4 / C1, MAX / (C4 / C1))
     def toMillis(a: Long): Long = x(a, C4 / C2, MAX / (C4 / C2))
@@ -77,10 +91,12 @@ object TimeUnit {
     def toMinutes(a: Long): Long = a
     def toHours(a: Long): Long = a / (C5 / C4)
     def toDays(a: Long): Long = a / (C6 / C4)
+    def toChronoUnit(): ChronoUnit = ChronoUnit.MINUTES
   }
 
   final val HOURS: TimeUnit = new TimeUnit("HOURS", 5) {
     def convert(a: Long, u: TimeUnit): Long = u.toHours(a)
+    def convert(duration: Duration): Long = convertDuration(duration, this)
     def toNanos(a: Long): Long = x(a, C5 / C0, MAX / (C5 / C0))
     def toMicros(a: Long): Long = x(a, C5 / C1, MAX / (C5 / C1))
     def toMillis(a: Long): Long = x(a, C5 / C2, MAX / (C5 / C2))
@@ -88,10 +104,12 @@ object TimeUnit {
     def toMinutes(a: Long): Long = x(a, C5 / C4, MAX / (C5 / C4))
     def toHours(a: Long): Long = a
     def toDays(a: Long): Long = a / (C6 / C5)
+    def toChronoUnit(): ChronoUnit = ChronoUnit.HOURS
   }
 
   final val DAYS: TimeUnit = new TimeUnit("DAYS", 6) {
     def convert(a: Long, u: TimeUnit): Long = u.toDays(a)
+    def convert(duration: Duration): Long = convertDuration(duration, this)
     def toNanos(a: Long): Long = x(a, C6 / C0, MAX / (C6 / C0))
     def toMicros(a: Long): Long = x(a, C6 / C1, MAX / (C6 / C1))
     def toMillis(a: Long): Long = x(a, C6 / C2, MAX / (C6 / C2))
@@ -99,6 +117,7 @@ object TimeUnit {
     def toMinutes(a: Long): Long = x(a, C6 / C4, MAX / (C6 / C4))
     def toHours(a: Long): Long = x(a, C6 / C5, MAX / (C6 / C5))
     def toDays(a: Long): Long = a
+    def toChronoUnit(): ChronoUnit = ChronoUnit.DAYS
   }
 
   private val _values: Array[TimeUnit] =
@@ -130,9 +149,47 @@ object TimeUnit {
     }
   }
 
+  def of(chronoUnit: ChronoUnit): TimeUnit =
+    chronoUnit match {
+      case null                => throw new NullPointerException()
+      case ChronoUnit.NANOS    => NANOSECONDS
+      case ChronoUnit.MICROS   => MICROSECONDS
+      case ChronoUnit.MILLIS   => MILLISECONDS
+      case ChronoUnit.SECONDS  => SECONDS
+      case ChronoUnit.MINUTES  => MINUTES
+      case ChronoUnit.HOURS    => HOURS
+      case ChronoUnit.DAYS     => DAYS
+      case unsupported: AnyRef =>
+        throw new IllegalArgumentException(
+          "No TimeUnit equivalent for " + unsupported
+        )
+    }
+
   private def x(a: Long, b: Long, max: Long): Long = {
     if (a > max) MAX
-    else if (a < -max) -MAX
+    else if (a < -max) Long.MinValue
     else a * b
+  }
+
+  private def convertDuration(duration: Duration, unit: TimeUnit): Long = {
+    if (duration == null) throw new NullPointerException()
+    var seconds = duration.getSeconds()
+    var nanos = duration.getNano()
+    if (seconds < 0 && nanos > 0) {
+      seconds += 1L
+      nanos = nanos - C3.toInt
+    }
+
+    val convertedSeconds = unit.convert(seconds, SECONDS)
+    if (convertedSeconds == Long.MinValue || convertedSeconds == Long.MaxValue)
+      convertedSeconds
+    else
+      saturatingAdd(convertedSeconds, unit.convert(nanos.toLong, NANOSECONDS))
+  }
+
+  private def saturatingAdd(a: Long, b: Long): Long = {
+    if (b > 0L && a > Long.MaxValue - b) Long.MaxValue
+    else if (b < 0L && a < Long.MinValue - b) Long.MinValue
+    else a + b
   }
 }

--- a/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnit8TestPlatform.scala
+++ b/unit-tests/jvm/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnit8TestPlatform.scala
@@ -1,0 +1,77 @@
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.lang.reflect.InvocationTargetException
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+import org.junit.Assume.assumeTrue
+
+object TimeUnit8TestPlatform {
+  private val convertDurationMethod =
+    try Some(classOf[TimeUnit].getMethod("convert", classOf[Duration]))
+    catch {
+      case _: NoSuchMethodException => None
+    }
+
+  private val toChronoUnitMethod =
+    try Some(classOf[TimeUnit].getMethod("toChronoUnit"))
+    catch {
+      case _: NoSuchMethodException => None
+    }
+
+  private val timeUnitOfMethod =
+    try Some(classOf[TimeUnit].getMethod("of", classOf[ChronoUnit]))
+    catch {
+      case _: NoSuchMethodException => None
+    }
+
+  def hasTimeUnitOf: Boolean =
+    timeUnitOfMethod.isDefined
+
+  def assumeConvertDuration(): Unit =
+    assumeTrue(
+      "TimeUnit.convert(Duration) requires JDK 11+",
+      convertDurationMethod.isDefined
+    )
+
+  def assumeToChronoUnit(): Unit =
+    assumeTrue(
+      "TimeUnit.toChronoUnit requires JDK 9+",
+      toChronoUnitMethod.isDefined
+    )
+
+  def assumeTimeUnitOf(): Unit =
+    assumeTrue("TimeUnit.of requires JDK 9+", hasTimeUnitOf)
+
+  def convertDuration(unit: TimeUnit, duration: Duration): Long =
+    try
+      convertDurationMethod.get
+        .invoke(unit, duration)
+        .asInstanceOf[java.lang.Long]
+        .longValue()
+    catch {
+      case e: InvocationTargetException =>
+        throw e.getCause()
+    }
+
+  def toChronoUnit(unit: TimeUnit): ChronoUnit =
+    try
+      toChronoUnitMethod.get
+        .invoke(unit)
+        .asInstanceOf[ChronoUnit]
+    catch {
+      case e: InvocationTargetException =>
+        throw e.getCause()
+    }
+
+  def timeUnitOf(chronoUnit: ChronoUnit): TimeUnit =
+    try
+      timeUnitOfMethod.get
+        .invoke(null, chronoUnit.asInstanceOf[AnyRef])
+        .asInstanceOf[TimeUnit]
+    catch {
+      case e: InvocationTargetException =>
+        throw e.getCause()
+    }
+}

--- a/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnit8TestPlatform.scala
+++ b/unit-tests/native/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnit8TestPlatform.scala
@@ -1,0 +1,69 @@
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+object TimeUnit8TestPlatform {
+  private final val NanosPerSecond = 1000000000L
+
+  def hasTimeUnitOf: Boolean =
+    true
+
+  def assumeConvertDuration(): Unit = ()
+
+  def assumeToChronoUnit(): Unit = ()
+
+  def assumeTimeUnitOf(): Unit = ()
+
+  def convertDuration(unit: TimeUnit, duration: Duration): Long = {
+    if (duration == null) throw new NullPointerException()
+    var seconds = duration.getSeconds()
+    var nanos = duration.getNano()
+    if (seconds < 0L && nanos > 0) {
+      seconds += 1L
+      nanos -= NanosPerSecond.toInt
+    }
+
+    val convertedSeconds = unit.convert(seconds, TimeUnit.SECONDS)
+    if (convertedSeconds == Long.MinValue || convertedSeconds == Long.MaxValue)
+      convertedSeconds
+    else
+      saturatingAdd(
+        convertedSeconds,
+        unit.convert(nanos.toLong, TimeUnit.NANOSECONDS)
+      )
+  }
+
+  def toChronoUnit(unit: TimeUnit): ChronoUnit =
+    unit match {
+      case TimeUnit.NANOSECONDS  => ChronoUnit.NANOS
+      case TimeUnit.MICROSECONDS => ChronoUnit.MICROS
+      case TimeUnit.MILLISECONDS => ChronoUnit.MILLIS
+      case TimeUnit.SECONDS      => ChronoUnit.SECONDS
+      case TimeUnit.MINUTES      => ChronoUnit.MINUTES
+      case TimeUnit.HOURS        => ChronoUnit.HOURS
+      case TimeUnit.DAYS         => ChronoUnit.DAYS
+    }
+
+  def timeUnitOf(chronoUnit: ChronoUnit): TimeUnit =
+    chronoUnit match {
+      case null               => throw new NullPointerException()
+      case ChronoUnit.NANOS   => TimeUnit.NANOSECONDS
+      case ChronoUnit.MICROS  => TimeUnit.MICROSECONDS
+      case ChronoUnit.MILLIS  => TimeUnit.MILLISECONDS
+      case ChronoUnit.SECONDS => TimeUnit.SECONDS
+      case ChronoUnit.MINUTES => TimeUnit.MINUTES
+      case ChronoUnit.HOURS   => TimeUnit.HOURS
+      case ChronoUnit.DAYS    => TimeUnit.DAYS
+      case unsupported        =>
+        throw new IllegalArgumentException(
+          "No TimeUnit equivalent for " + unsupported
+        )
+    }
+
+  private def saturatingAdd(a: Long, b: Long): Long =
+    if (b > 0L && a > Long.MaxValue - b) Long.MaxValue
+    else if (b < 0L && a < Long.MinValue - b) Long.MinValue
+    else a + b
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnit8Test.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnit8Test.scala
@@ -1,0 +1,258 @@
+/*
+ * Ported from JSR-166 TCK tests and released to the public domain, as
+ * explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * Modified for Scala Native.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit._
+import java.util.concurrent.{ThreadLocalRandom, TimeUnit}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class TimeUnit8Test extends JSR166Test {
+  @Test def testToChronoUnit(): Unit = {
+    TimeUnit8TestPlatform.assumeToChronoUnit()
+
+    assertSame(
+      ChronoUnit.NANOS,
+      TimeUnit8TestPlatform.toChronoUnit(NANOSECONDS)
+    )
+    assertSame(
+      ChronoUnit.MICROS,
+      TimeUnit8TestPlatform.toChronoUnit(MICROSECONDS)
+    )
+    assertSame(
+      ChronoUnit.MILLIS,
+      TimeUnit8TestPlatform.toChronoUnit(MILLISECONDS)
+    )
+    assertSame(ChronoUnit.SECONDS, TimeUnit8TestPlatform.toChronoUnit(SECONDS))
+    assertSame(ChronoUnit.MINUTES, TimeUnit8TestPlatform.toChronoUnit(MINUTES))
+    assertSame(ChronoUnit.HOURS, TimeUnit8TestPlatform.toChronoUnit(HOURS))
+    assertSame(ChronoUnit.DAYS, TimeUnit8TestPlatform.toChronoUnit(DAYS))
+
+    if (TimeUnit8TestPlatform.hasTimeUnitOf) {
+      TimeUnit.values().foreach { x =>
+        assertSame(
+          x,
+          TimeUnit8TestPlatform
+            .timeUnitOf(TimeUnit8TestPlatform.toChronoUnit(x))
+        )
+      }
+    }
+  }
+
+  @Test def testTimeUnitOf(): Unit = {
+    TimeUnit8TestPlatform.assumeTimeUnitOf()
+    assertSame(NANOSECONDS, TimeUnit8TestPlatform.timeUnitOf(ChronoUnit.NANOS))
+    assertSame(
+      MICROSECONDS,
+      TimeUnit8TestPlatform.timeUnitOf(ChronoUnit.MICROS)
+    )
+    assertSame(
+      MILLISECONDS,
+      TimeUnit8TestPlatform.timeUnitOf(ChronoUnit.MILLIS)
+    )
+    assertSame(SECONDS, TimeUnit8TestPlatform.timeUnitOf(ChronoUnit.SECONDS))
+    assertSame(MINUTES, TimeUnit8TestPlatform.timeUnitOf(ChronoUnit.MINUTES))
+    assertSame(HOURS, TimeUnit8TestPlatform.timeUnitOf(ChronoUnit.HOURS))
+    assertSame(DAYS, TimeUnit8TestPlatform.timeUnitOf(ChronoUnit.DAYS))
+
+    assertThrows(
+      classOf[NullPointerException],
+      TimeUnit8TestPlatform.timeUnitOf(null)
+    )
+
+    ChronoUnit.values().foreach { cu =>
+      try {
+        val tu = TimeUnit8TestPlatform.timeUnitOf(cu)
+        assertSame(cu, TimeUnit8TestPlatform.toChronoUnit(tu))
+      } catch {
+        case _: IllegalArgumentException => ()
+      }
+    }
+  }
+
+  @Test def testConvertDuration_roundtripDurationOf(): Unit = {
+    TimeUnit8TestPlatform.assumeConvertDuration()
+
+    var n = ThreadLocalRandom.current().nextLong()
+
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(NANOSECONDS, Duration.ofNanos(n))
+    )
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(
+        NANOSECONDS,
+        Duration.of(n, ChronoUnit.NANOS)
+      )
+    )
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(MILLISECONDS, Duration.ofMillis(n))
+    )
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(
+        MILLISECONDS,
+        Duration.of(n, ChronoUnit.MILLIS)
+      )
+    )
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(SECONDS, Duration.ofSeconds(n))
+    )
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(
+        SECONDS,
+        Duration.of(n, ChronoUnit.SECONDS)
+      )
+    )
+    n /= 60L
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(MINUTES, Duration.ofMinutes(n))
+    )
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(
+        MINUTES,
+        Duration.of(n, ChronoUnit.MINUTES)
+      )
+    )
+    n /= 60L
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(HOURS, Duration.ofHours(n))
+    )
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(
+        HOURS,
+        Duration.of(n, ChronoUnit.HOURS)
+      )
+    )
+    n /= 24L
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(DAYS, Duration.ofDays(n))
+    )
+    assertEquals(
+      n,
+      TimeUnit8TestPlatform.convertDuration(
+        DAYS,
+        Duration.of(n, ChronoUnit.DAYS)
+      )
+    )
+  }
+
+  @Test def testConvertDuration_roundtripDurationOfNanos(): Unit = {
+    TimeUnit8TestPlatform.assumeConvertDuration()
+
+    val unitNanos = TimeUnit.values().map(_.toNanos(1L))
+    val baseValues = unitNanos ++ Array(Long.MaxValue, Long.MinValue)
+    for {
+      n0 <- baseValues
+      n1 <- Array(n0, n0 + 1L, n0 - 1L)
+      n2 <- Array(n1, n1 + 1000000000L, n1 - 1000000000L)
+      n <- Array(n2, -n2)
+      u <- TimeUnit.values()
+    } {
+      assertEquals(
+        u.convert(n, NANOSECONDS),
+        TimeUnit8TestPlatform.convertDuration(u, Duration.ofNanos(n))
+      )
+    }
+  }
+
+  @Test def testConvertDuration_nearOverflow(): Unit = {
+    TimeUnit8TestPlatform.assumeConvertDuration()
+    TimeUnit8TestPlatform.assumeToChronoUnit()
+
+    val nanos = ChronoUnit.NANOS
+    val maxDuration = Duration.ofSeconds(Long.MaxValue, 999999999L)
+    val minDuration = Duration.ofSeconds(Long.MinValue, 0L)
+
+    TimeUnit.values().foreach { u =>
+      val cu = TimeUnit8TestPlatform.toChronoUnit(u)
+      val r =
+        if (u.toNanos(1L) > SECONDS.toNanos(1L)) {
+          val ratio = u.toNanos(1L) / SECONDS.toNanos(1L)
+          assertThrows(
+            classOf[ArithmeticException],
+            Duration.of(Long.MaxValue, cu)
+          )
+          assertThrows(
+            classOf[ArithmeticException],
+            Duration.of(Long.MinValue, cu)
+          )
+          ratio
+        } else {
+          val max = Duration.of(Long.MaxValue, cu)
+          val min = Duration.of(Long.MinValue, cu)
+          assertEquals(
+            Long.MaxValue,
+            TimeUnit8TestPlatform.convertDuration(u, max)
+          )
+          assertEquals(
+            Long.MaxValue - 1L,
+            TimeUnit8TestPlatform.convertDuration(u, max.minus(1L, nanos))
+          )
+          assertEquals(
+            Long.MaxValue - 1L,
+            TimeUnit8TestPlatform.convertDuration(u, max.minus(1L, cu))
+          )
+          assertEquals(
+            Long.MinValue,
+            TimeUnit8TestPlatform.convertDuration(u, min)
+          )
+          assertEquals(
+            Long.MinValue + 1L,
+            TimeUnit8TestPlatform.convertDuration(u, min.plus(1L, nanos))
+          )
+          assertEquals(
+            Long.MinValue + 1L,
+            TimeUnit8TestPlatform.convertDuration(u, min.plus(1L, cu))
+          )
+          assertEquals(
+            Long.MaxValue,
+            TimeUnit8TestPlatform.convertDuration(u, max.plus(1L, nanos))
+          )
+          if (u != SECONDS) {
+            assertEquals(
+              Long.MaxValue,
+              TimeUnit8TestPlatform.convertDuration(u, max.plus(1L, cu))
+            )
+            assertEquals(
+              Long.MinValue,
+              TimeUnit8TestPlatform.convertDuration(u, min.minus(1L, nanos))
+            )
+            assertEquals(
+              Long.MinValue,
+              TimeUnit8TestPlatform.convertDuration(u, min.minus(1L, cu))
+            )
+          }
+          1L
+        }
+
+      assertEquals(
+        Long.MaxValue / r,
+        TimeUnit8TestPlatform.convertDuration(u, maxDuration)
+      )
+      assertEquals(
+        Long.MinValue / r,
+        TimeUnit8TestPlatform.convertDuration(u, minDuration)
+      )
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnitTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnitTest.scala
@@ -1,126 +1,363 @@
-// Ported from Scala.js
+/*
+ * Ported from JSR-166 TCK tests and released to the public domain, as
+ * explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * Modified for Scala Native.
+ */
 
 package org.scalanative.testsuite.javalib.util.concurrent
 
-import java.util._
-import java.util.concurrent._
+import java.util.concurrent.TimeUnit._
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Ignore, Test}
 
-class TimeUnitTest {
+class TimeUnitTest extends JSR166Test {
+  import JSR166Test._
 
-  @Test def toNanos(): Unit = {
-    assertTrue(42L == TimeUnit.NANOSECONDS.toNanos(42L))
-    assertTrue(42000L == TimeUnit.MICROSECONDS.toNanos(42L))
-    assertTrue(42000000L == TimeUnit.MILLISECONDS.toNanos(42L))
-    assertTrue(42000000000L == TimeUnit.SECONDS.toNanos(42L))
-    assertTrue(2520000000000L == TimeUnit.MINUTES.toNanos(42L))
-    assertTrue(151200000000000L == TimeUnit.HOURS.toNanos(42L))
-    assertTrue(3628800000000000L == TimeUnit.DAYS.toNanos(42L))
+  private def testConversion(
+      x: TimeUnit,
+      y: TimeUnit,
+      n: Long,
+      expected: Long
+  ): Unit = {
+    assertEquals(expected, x.convert(n, y))
+    x match {
+      case NANOSECONDS  => assertEquals(expected, y.toNanos(n))
+      case MICROSECONDS => assertEquals(expected, y.toMicros(n))
+      case MILLISECONDS => assertEquals(expected, y.toMillis(n))
+      case SECONDS      => assertEquals(expected, y.toSeconds(n))
+      case MINUTES      => assertEquals(expected, y.toMinutes(n))
+      case HOURS        => assertEquals(expected, y.toHours(n))
+      case DAYS         => assertEquals(expected, y.toDays(n))
+      case _            => throw new AssertionError()
+    }
+
+    if (n > 0L) testConversion(x, y, -n, -expected)
   }
 
-  @Test def toMicros(): Unit = {
-    assertTrue(0L == TimeUnit.NANOSECONDS.toMicros(42L))
-    assertTrue(42L == TimeUnit.NANOSECONDS.toMicros(42123L))
-    assertTrue(42L == TimeUnit.MICROSECONDS.toMicros(42L))
-    assertTrue(42000L == TimeUnit.MILLISECONDS.toMicros(42L))
-    assertTrue(42000000L == TimeUnit.SECONDS.toMicros(42L))
-    assertTrue(2520000000L == TimeUnit.MINUTES.toMicros(42L))
-    assertTrue(151200000000L == TimeUnit.HOURS.toMicros(42L))
-    assertTrue(3628800000000L == TimeUnit.DAYS.toMicros(42L))
+  private def testConversion(x: TimeUnit, y: TimeUnit): Unit = {
+    val ratio = x.toNanos(1L) / y.toNanos(1L)
+    assertTrue(ratio > 0L)
+    val ns = Array(0L, 1L, 2L, Long.MaxValue / ratio, Long.MinValue / ratio)
+    ns.foreach { n =>
+      testConversion(y, x, n, n * ratio)
+      Array(n * ratio, n * ratio + 1L, n * ratio - 1L).foreach { k =>
+        testConversion(x, y, k, k / ratio)
+      }
+    }
   }
 
-  @Test def toMillis(): Unit = {
-    assertTrue(0L == TimeUnit.NANOSECONDS.toMillis(42L))
-    assertTrue(42L == TimeUnit.NANOSECONDS.toMillis(42000123L))
-    assertTrue(0L == TimeUnit.MICROSECONDS.toMillis(42L))
-    assertTrue(42L == TimeUnit.MICROSECONDS.toMillis(42123L))
-    assertTrue(42L == TimeUnit.MILLISECONDS.toMillis(42L))
-    assertTrue(42000L == TimeUnit.SECONDS.toMillis(42L))
-    assertTrue(2520000L == TimeUnit.MINUTES.toMillis(42L))
-    assertTrue(151200000L == TimeUnit.HOURS.toMillis(42L))
-    assertTrue(3628800000L == TimeUnit.DAYS.toMillis(42L))
+  @Test def testConversions(): Unit = {
+    assertEquals(1L, NANOSECONDS.toNanos(1L))
+    assertEquals(1000L * NANOSECONDS.toNanos(1L), MICROSECONDS.toNanos(1L))
+    assertEquals(1000L * MICROSECONDS.toNanos(1L), MILLISECONDS.toNanos(1L))
+    assertEquals(1000L * MILLISECONDS.toNanos(1L), SECONDS.toNanos(1L))
+    assertEquals(60L * SECONDS.toNanos(1L), MINUTES.toNanos(1L))
+    assertEquals(60L * MINUTES.toNanos(1L), HOURS.toNanos(1L))
+    assertEquals(24L * HOURS.toNanos(1L), DAYS.toNanos(1L))
+
+    TimeUnit.values().foreach { x =>
+      assertEquals(x.toNanos(1L), NANOSECONDS.convert(1L, x))
+    }
+
+    for {
+      x <- TimeUnit.values()
+      y <- TimeUnit.values()
+      if x.toNanos(1L) >= y.toNanos(1L)
+    } testConversion(x, y)
   }
 
-  @Test def toSeconds(): Unit = {
-    assertTrue(0L == TimeUnit.NANOSECONDS.toSeconds(42L))
-    assertTrue(42L == TimeUnit.NANOSECONDS.toSeconds(42000000123L))
-    assertTrue(0L == TimeUnit.MICROSECONDS.toSeconds(42L))
-    assertTrue(42L == TimeUnit.MICROSECONDS.toSeconds(42000123L))
-    assertTrue(0L == TimeUnit.MILLISECONDS.toSeconds(42L))
-    assertTrue(42L == TimeUnit.MILLISECONDS.toSeconds(42123L))
-    assertTrue(42L == TimeUnit.SECONDS.toSeconds(42L))
-    assertTrue(2520L == TimeUnit.MINUTES.toSeconds(42L))
-    assertTrue(151200L == TimeUnit.HOURS.toSeconds(42L))
-    assertTrue(3628800L == TimeUnit.DAYS.toSeconds(42L))
+  @Test def testConvertSaturate(): Unit = {
+    assertEquals(
+      Long.MaxValue,
+      NANOSECONDS.convert(Long.MaxValue / 2L, SECONDS)
+    )
+    assertEquals(
+      Long.MinValue,
+      NANOSECONDS.convert(-Long.MaxValue / 4L, SECONDS)
+    )
+    assertEquals(
+      Long.MaxValue,
+      NANOSECONDS.convert(Long.MaxValue / 2L, MINUTES)
+    )
+    assertEquals(
+      Long.MinValue,
+      NANOSECONDS.convert(-Long.MaxValue / 4L, MINUTES)
+    )
+    assertEquals(Long.MaxValue, NANOSECONDS.convert(Long.MaxValue / 2L, HOURS))
+    assertEquals(Long.MinValue, NANOSECONDS.convert(-Long.MaxValue / 4L, HOURS))
+    assertEquals(Long.MaxValue, NANOSECONDS.convert(Long.MaxValue / 2L, DAYS))
+    assertEquals(Long.MinValue, NANOSECONDS.convert(-Long.MaxValue / 4L, DAYS))
+
+    for {
+      x <- TimeUnit.values()
+      y <- TimeUnit.values()
+    } {
+      val ratio = x.toNanos(1L) / y.toNanos(1L)
+      if (ratio >= 1L) {
+        assertEquals(ratio, y.convert(1L, x))
+        assertEquals(1L, x.convert(ratio, y))
+        val max = Long.MaxValue / ratio
+        assertEquals(max * ratio, y.convert(max, x))
+        assertEquals(-max * ratio, y.convert(-max, x))
+        assertEquals(max, x.convert(max * ratio, y))
+        assertEquals(-max, x.convert(-max * ratio, y))
+        if (max < Long.MaxValue) {
+          assertEquals(Long.MaxValue, y.convert(max + 1L, x))
+          assertEquals(Long.MinValue, y.convert(-max - 1L, x))
+          assertEquals(Long.MinValue, y.convert(Long.MinValue + 1L, x))
+        }
+        assertEquals(Long.MaxValue, y.convert(Long.MaxValue, x))
+        assertEquals(Long.MinValue, y.convert(Long.MinValue, x))
+      }
+    }
   }
 
-  @Test def toMinutes(): Unit = {
-    assertTrue(0L == TimeUnit.NANOSECONDS.toMinutes(42L))
-    assertTrue(42L == TimeUnit.NANOSECONDS.toMinutes(2520000007380L))
-    assertTrue(0L == TimeUnit.MICROSECONDS.toMinutes(42L))
-    assertTrue(42L == TimeUnit.MICROSECONDS.toMinutes(2520007380L))
-    assertTrue(0L == TimeUnit.MILLISECONDS.toMinutes(42L))
-    assertTrue(42L == TimeUnit.MILLISECONDS.toMinutes(2520738L))
-    assertTrue(0L == TimeUnit.SECONDS.toMinutes(42L))
-    assertTrue(42L == TimeUnit.SECONDS.toMinutes(2520L))
-    assertTrue(42L == TimeUnit.MINUTES.toMinutes(42L))
-    assertTrue(2520L == TimeUnit.HOURS.toMinutes(42L))
-    assertTrue(60480L == TimeUnit.DAYS.toMinutes(42L))
+  @Test def testToNanosSaturate(): Unit = {
+    assertEquals(Long.MaxValue, MILLISECONDS.toNanos(Long.MaxValue / 2L))
+    assertEquals(Long.MinValue, MILLISECONDS.toNanos(-Long.MaxValue / 3L))
+
+    TimeUnit.values().foreach { x =>
+      val ratio = x.toNanos(1L) / NANOSECONDS.toNanos(1L)
+      if (ratio >= 1L) {
+        val max = Long.MaxValue / ratio
+        Array(0L, 1L, -1L, max, -max).foreach { z =>
+          assertEquals(z * ratio, x.toNanos(z))
+        }
+        if (max < Long.MaxValue) {
+          assertEquals(Long.MaxValue, x.toNanos(max + 1L))
+          assertEquals(Long.MinValue, x.toNanos(-max - 1L))
+          assertEquals(Long.MinValue, x.toNanos(Long.MinValue + 1L))
+        }
+        assertEquals(Long.MaxValue, x.toNanos(Long.MaxValue))
+        assertEquals(Long.MinValue, x.toNanos(Long.MinValue))
+        if (max < Int.MaxValue) {
+          assertEquals(Long.MaxValue, x.toNanos(Int.MaxValue.toLong))
+          assertEquals(Long.MinValue, x.toNanos(Int.MinValue.toLong))
+        }
+      }
+    }
   }
 
-  @Test def toHours(): Unit = {
-    assertTrue(0L == TimeUnit.NANOSECONDS.toHours(42L))
-    assertTrue(42L == TimeUnit.NANOSECONDS.toHours(151200000442800L))
-    assertTrue(0L == TimeUnit.MICROSECONDS.toHours(42L))
-    assertTrue(42L == TimeUnit.MICROSECONDS.toHours(151200442800L))
-    assertTrue(0L == TimeUnit.MILLISECONDS.toHours(42L))
-    assertTrue(42L == TimeUnit.MILLISECONDS.toHours(151244280L))
-    assertTrue(0L == TimeUnit.SECONDS.toHours(42L))
-    assertTrue(42L == TimeUnit.SECONDS.toHours(151200L))
-    assertTrue(0L == TimeUnit.MINUTES.toHours(42L))
-    assertTrue(42L == TimeUnit.MINUTES.toHours(2520L))
-    assertTrue(42L == TimeUnit.HOURS.toHours(42L))
-    assertTrue(1008L == TimeUnit.DAYS.toHours(42L))
+  @Test def testToMicrosSaturate(): Unit =
+    testSaturatingTo(MICROSECONDS, _.toMicros(_))
+
+  @Test def testToMillisSaturate(): Unit =
+    testSaturatingTo(MILLISECONDS, _.toMillis(_))
+
+  @Test def testToSecondsSaturate(): Unit =
+    testSaturatingTo(SECONDS, _.toSeconds(_))
+
+  private def testSaturatingTo(
+      target: TimeUnit,
+      convert: (TimeUnit, Long) => Long
+  ): Unit = {
+    TimeUnit.values().foreach { x =>
+      val ratio = x.toNanos(1L) / target.toNanos(1L)
+      if (ratio >= 1L) {
+        val max = Long.MaxValue / ratio
+        Array(0L, 1L, -1L, max, -max).foreach { z =>
+          assertEquals(z * ratio, convert(x, z))
+        }
+        if (max < Long.MaxValue) {
+          assertEquals(Long.MaxValue, convert(x, max + 1L))
+          assertEquals(Long.MinValue, convert(x, -max - 1L))
+          assertEquals(Long.MinValue, convert(x, Long.MinValue + 1L))
+        }
+        assertEquals(Long.MaxValue, convert(x, Long.MaxValue))
+        assertEquals(Long.MinValue, convert(x, Long.MinValue))
+        if (max < Int.MaxValue) {
+          assertEquals(Long.MaxValue, convert(x, Int.MaxValue.toLong))
+          assertEquals(Long.MinValue, convert(x, Int.MinValue.toLong))
+        }
+      }
+    }
   }
 
-  @Test def toDays(): Unit = {
-    assertTrue(0L == TimeUnit.NANOSECONDS.toDays(42L))
-    assertTrue(42L == TimeUnit.NANOSECONDS.toDays(3628800010627200L))
-    assertTrue(0L == TimeUnit.MICROSECONDS.toDays(42L))
-    assertTrue(42L == TimeUnit.MICROSECONDS.toDays(3628810627200L))
-    assertTrue(0L == TimeUnit.MILLISECONDS.toDays(42L))
-    assertTrue(42L == TimeUnit.MILLISECONDS.toDays(3629862720L))
-    assertTrue(0L == TimeUnit.SECONDS.toDays(42L))
-    assertTrue(42L == TimeUnit.SECONDS.toDays(3628800L))
-    assertTrue(0L == TimeUnit.MINUTES.toDays(42L))
-    assertTrue(42L == TimeUnit.MINUTES.toDays(60480L))
-    assertTrue(1L == TimeUnit.HOURS.toDays(42L))
-    assertTrue(42L == TimeUnit.HOURS.toDays(1008L))
-    assertTrue(42L == TimeUnit.DAYS.toDays(42L))
+  @Test def testToMinutesSaturate(): Unit = {
+    TimeUnit.values().foreach { x =>
+      val ratio = x.toNanos(1L) / MINUTES.toNanos(1L)
+      if (ratio > 1L) {
+        val max = Long.MaxValue / ratio
+        Array(0L, 1L, -1L, max, -max).foreach { z =>
+          assertEquals(z * ratio, x.toMinutes(z))
+        }
+        assertEquals(Long.MaxValue, x.toMinutes(max + 1L))
+        assertEquals(Long.MinValue, x.toMinutes(-max - 1L))
+        assertEquals(Long.MaxValue, x.toMinutes(Long.MaxValue))
+        assertEquals(Long.MinValue, x.toMinutes(Long.MinValue))
+        assertEquals(Long.MinValue, x.toMinutes(Long.MinValue + 1L))
+      }
+    }
   }
 
-  @Test def values(): Unit = {
-    val values = TimeUnit.values()
-
-    assertTrue(7 == values.length)
-    assertTrue(TimeUnit.NANOSECONDS == values(0))
-    assertTrue(TimeUnit.MICROSECONDS == values(1))
-    assertTrue(TimeUnit.MILLISECONDS == values(2))
-    assertTrue(TimeUnit.SECONDS == values(3))
-    assertTrue(TimeUnit.MINUTES == values(4))
-    assertTrue(TimeUnit.HOURS == values(5))
-    assertTrue(TimeUnit.DAYS == values(6))
+  @Test def testToHoursSaturate(): Unit = {
+    TimeUnit.values().foreach { x =>
+      val ratio = x.toNanos(1L) / HOURS.toNanos(1L)
+      if (ratio >= 1L) {
+        val max = Long.MaxValue / ratio
+        Array(0L, 1L, -1L, max, -max).foreach { z =>
+          assertEquals(z * ratio, x.toHours(z))
+        }
+        if (max < Long.MaxValue) {
+          assertEquals(Long.MaxValue, x.toHours(max + 1L))
+          assertEquals(Long.MinValue, x.toHours(-max - 1L))
+          assertEquals(Long.MinValue, x.toHours(Long.MinValue + 1L))
+        }
+        assertEquals(Long.MaxValue, x.toHours(Long.MaxValue))
+        assertEquals(Long.MinValue, x.toHours(Long.MinValue))
+      }
+    }
   }
 
-  @Test def valueOf(): Unit = {
-    assertTrue(TimeUnit.NANOSECONDS == TimeUnit.valueOf("NANOSECONDS"))
-    assertTrue(TimeUnit.MICROSECONDS == TimeUnit.valueOf("MICROSECONDS"))
-    assertTrue(TimeUnit.MILLISECONDS == TimeUnit.valueOf("MILLISECONDS"))
-    assertTrue(TimeUnit.SECONDS == TimeUnit.valueOf("SECONDS"))
-    assertTrue(TimeUnit.MINUTES == TimeUnit.valueOf("MINUTES"))
-    assertTrue(TimeUnit.HOURS == TimeUnit.valueOf("HOURS"))
-    assertTrue(TimeUnit.DAYS == TimeUnit.valueOf("DAYS"))
+  @Test def testToString(): Unit = {
+    assertEquals("NANOSECONDS", NANOSECONDS.toString())
+    assertEquals("MICROSECONDS", MICROSECONDS.toString())
+    assertEquals("MILLISECONDS", MILLISECONDS.toString())
+    assertEquals("SECONDS", SECONDS.toString())
+    assertEquals("MINUTES", MINUTES.toString())
+    assertEquals("HOURS", HOURS.toString())
+    assertEquals("DAYS", DAYS.toString())
   }
+
+  @Test def testName(): Unit = {
+    TimeUnit.values().foreach { x =>
+      assertEquals(x.toString(), x.name())
+    }
+  }
+
+  @Ignore("scala-native#4847")
+  @Test def testTimedWait_IllegalMonitorException(): Unit = {
+    val t = newStartedThread(new CheckedRunnable {
+      override protected def realRun(): Unit = {
+        val o = new Object()
+        try {
+          MILLISECONDS.timedWait(o, LONGER_DELAY_MS)
+          threadShouldThrow()
+        } catch {
+          case _: IllegalMonitorStateException => ()
+        }
+      }
+    })
+
+    awaitTermination(t)
+  }
+
+  @Ignore("scala-native#4847")
+  @Test def testTimedWait_Interruptible(): Unit = {
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override protected def realRun(): Unit = {
+        val o = new Object()
+
+        Thread.currentThread().interrupt()
+        try {
+          o.synchronized {
+            MILLISECONDS.timedWait(o, LONGER_DELAY_MS)
+          }
+          shouldThrow()
+        } catch {
+          case _: InterruptedException => ()
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          o.synchronized {
+            MILLISECONDS.timedWait(o, LONGER_DELAY_MS)
+          }
+          shouldThrow()
+        } catch {
+          case _: InterruptedException => ()
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  @Test def testTimedJoin_Interruptible(): Unit = {
+    val pleaseInterrupt = new CountDownLatch(1)
+    val s = newStartedThread(new CheckedInterruptedRunnable {
+      override protected def realRun(): Unit = {
+        Thread.sleep(LONGER_DELAY_MS)
+      }
+    })
+    val t = newStartedThread(new CheckedRunnable {
+      override protected def realRun(): Unit = {
+        Thread.currentThread().interrupt()
+        try {
+          MILLISECONDS.timedJoin(s, LONGER_DELAY_MS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException => ()
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          MILLISECONDS.timedJoin(s, LONGER_DELAY_MS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException => ()
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    s.interrupt()
+    awaitTermination(s)
+  }
+
+  @Test def testTimedSleep_Interruptible(): Unit = {
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override protected def realRun(): Unit = {
+        Thread.currentThread().interrupt()
+        try {
+          MILLISECONDS.sleep(LONGER_DELAY_MS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException => ()
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          MILLISECONDS.sleep(LONGER_DELAY_MS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException => ()
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  @Test def testTimedSleep_nonPositive(): Unit = {
+    val interrupt = randomBoolean()
+    if (interrupt) Thread.currentThread().interrupt()
+    randomTimeUnit().sleep(0L)
+    randomTimeUnit().sleep(-1L)
+    randomTimeUnit().sleep(Long.MinValue)
+    if (interrupt) assertTrue(Thread.interrupted())
+  }
+
+  @Ignore("scala-native#4852: ObjectInputStream is unsupported")
+  @Test def testSerialization(): Unit = ()
 }


### PR DESCRIPTION
## Motivation
PR #4851 includes `TimeUnit` JDK9+ interop work that depends on Duration but does not need to stay bundled with the rest of JSR166.

## Modification
- Add `TimeUnit.convert(Duration)`.
- Add `TimeUnit.toChronoUnit()` and `TimeUnit.of(ChronoUnit)`.
- Align overflow saturation behavior.
- Add JVM / Native platform helpers for API availability differences.
- Add focused TimeUnit tests.

## Result
`TimeUnit` exposes Duration and ChronoUnit interop APIs as a focused follow-up to the minimal Duration support in #4863.

## Merge Order
- Stack position: 3, after #4863 and #4858.
- Depends on: #4863, which depends on #4856.
- Also depends on: #4858, because this PR aligns negative overflow saturation to `Long.MinValue`, and the existing `FileTime.to(unit)` implementation needs the #4858 saturation fix for JDK compliance.
- Parallel with: #4864; both depend on #4863 but do not depend on each other.
- Review note: until #4856, #4863, and #4858 merge, GitHub may show their parent diffs or fail `FileTimeTest.handlesLargeValues` in full JDK compliance.
- After merge: rebase #4851 and drop the TimeUnit-related diffs.

## Verification
- `scripts/scalafmt --test`
- `sbt "javalib2_13/compile" "tests2_13/Test/compile"`

## References
- Split from #4851.
- Depends on #4863, #4858, and #4856.
