### PR TITLE
Fix #4841: Port JSR-166 concurrent.Exchanger class & tests

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/Exchanger.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Exchanger.scala
@@ -1,0 +1,728 @@
+/* Ported from JSR-166 Expert Group main CVS (Concurrent Versions System)
+ * repository as described at Doug Lea "Concurrency JSR-166 Interest Site"
+ *    https://gee.cs.oswego.edu/dl/concurrency-interest/.
+ *
+ *  file: src/main/java/util/concurrent/Exchanger.java
+ *  revision 1.85, dated: 2020-11-27
+ */
+
+/*
+ * Written by Doug Lea, Bill Scherer, and Michael Scott with
+ * assistance from members of JCP JSR-166 Expert Group and released to
+ * the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+import java.util.concurrent.locks.LockSupport
+
+import scala.scalanative.annotation.alwaysinline
+import scala.scalanative.libc.stdatomic.memory_order.{
+  memory_order_acquire, memory_order_release
+}
+import scala.scalanative.libc.stdatomic.{AtomicInt, AtomicRef}
+import scala.scalanative.runtime.{Intrinsics, ObjectArray, fromRawPtr}
+import scala.scalanative.unsafe.Ptr
+/*
+ * A synchronization point at which threads can pair and swap elements
+ * within pairs.  Each thread presents some object on entry to the
+ * {@link #exchange exchange} method, matches with a partner thread,
+ * and receives its partner's object on return.  An Exchanger may be
+ * viewed as a bidirectional form of a {@link SynchronousQueue}.
+ * Exchangers may be useful in applications such as genetic algorithms
+ * and pipeline designs.
+ *
+ * <p><b>Sample Usage:</b>
+ * Here are the highlights of a class that uses an {@code Exchanger}
+ * to swap buffers between threads so that the thread filling the
+ * buffer gets a freshly emptied one when it needs it, handing off the
+ * filled one to the thread emptying the buffer.
+ * <pre> {@code
+ * class FillAndEmpty {
+ *   Exchanger<DataBuffer> exchanger = new Exchanger<>();
+ *   DataBuffer initialEmptyBuffer = ...; // a made-up type
+ *   DataBuffer initialFullBuffer = ...;
+ *
+ *   class FillingLoop implements Runnable {
+ *     public void run() {
+ *       DataBuffer currentBuffer = initialEmptyBuffer;
+ *       try {
+ *         while (currentBuffer != null) {
+ *           addToBuffer(currentBuffer);
+ *           if (currentBuffer.isFull())
+ *             currentBuffer = exchanger.exchange(currentBuffer);
+ *         }
+ *       } catch (InterruptedException ex) { ... handle ...}
+ *     }
+ *   }
+ *
+ *   class EmptyingLoop implements Runnable {
+ *     public void run() {
+ *       DataBuffer currentBuffer = initialFullBuffer;
+ *       try {
+ *         while (currentBuffer != null) {
+ *           takeFromBuffer(currentBuffer);
+ *           if (currentBuffer.isEmpty())
+ *             currentBuffer = exchanger.exchange(currentBuffer);
+ *         }
+ *       } catch (InterruptedException ex) { ... handle ...}
+ *     }
+ *   }
+ *
+ *   void start() {
+ *     new Thread(new FillingLoop()).start();
+ *     new Thread(new EmptyingLoop()).start();
+ *   }
+ * }}</pre>
+ *
+ * <p>Memory consistency effects: For each pair of threads that
+ * successfully exchange objects via an {@code Exchanger}, actions
+ * prior to the {@code exchange()} in each thread
+ * <a href="package-summary.html#MemoryVisibility"><i>happen-before</i></a>
+ * those subsequent to a return from the corresponding {@code exchange()}
+ * in the other thread.
+ *
+ * @since 1.5
+ * @author Doug Lea and Bill Scherer and Michael Scott
+ * @param <V> The type of objects that may be exchanged
+ */
+
+object Exchanger {
+
+  // SN: see near essential original "Overview" note preserved at top of
+  //     companion class below.
+
+  /*
+   * The index distance (as a shift value) between any two used slots
+   * in the arena, spacing them out to avoid false sharing.
+   */
+  private final val ASHIFT = 5
+
+  /*
+   * The maximum supported arena index. The maximum allocatable
+   * arena size is MMASK + 1. Must be a power of two minus one, less
+   * than (1<<(31-ASHIFT)). The cap of 255 (0xff) more than suffices
+   * for the expected scaling limits of the main algorithms.
+   */
+  private final val MMASK = 0xff
+
+  /*
+   * Unit for sequence/version bits of bound field. Each successful
+   * change to the bound also adds SEQ.
+   */
+  private final val SEQ = MMASK + 1
+
+  /* The number of CPUs, for sizing and spin control */
+  private final val NCPU = Runtime.getRuntime().availableProcessors()
+
+  /*
+   * The maximum slot index of the arena: The number of slots that
+   * can in principle hold all threads without contention, or at
+   * most the maximum indexable value.
+   */
+  final val FULL =
+    if (NCPU >= (MMASK << 1)) MMASK
+    else NCPU >>> 1
+
+  /*
+   * The bound for spins while waiting for a match. The actual
+   * number of iterations will on average be about twice this value
+   * due to randomization. Note: Spinning is disabled when NCPU==1.
+   */
+  private final val SPINS = 1 << 10
+
+  /*
+   * Value representing null arguments/returns from public
+   * methods. Needed because the API originally didn't disallow null
+   * arguments, which it should have.
+   */
+  private final val NULL_ITEM = new Object()
+
+  /*
+   * Sentinel value returned by internal exchange methods upon
+   * timeout, to avoid need for separate timed versions of these
+   * methods.
+   */
+  private final val TIMED_OUT = new Object();
+
+  // SN addition
+  private type Contended = scala.scalanative.annotation.align
+
+  /*
+   * Nodes hold partially exchanged data, plus other per-thread
+   * bookkeeping. Padded via @Contended to reduce memory contention.
+   */
+  @Contended()
+  final class Node {
+    var index: Int = _ // Arena index
+    var bound: Int = _ // Last recorded value of Exchanger.bound
+    var collides: Int = _ // Number of CAS failures at current bound
+    var hash: Int = _ // Pseudo-random for spins
+    var item: Object = _ // This thread's current item
+
+    // Item provided by releasing thread
+    @volatile var `match`: Object = _
+
+    @alwaysinline private[Exchanger] def atomicMatch = new AtomicRef[Object](
+      fromRawPtr(Intrinsics.classFieldRawPtr(this, "match"))
+    )
+
+    def setMatchRelease(v: Object): Unit = {
+      atomicMatch.store(v, memory_order_release)
+    }
+
+    // Set to this thread when parked, else null
+    @volatile var parked: Thread = _
+  }
+
+  /* The corresponding thread local class */
+  final class Participant extends ThreadLocal[Node] {
+    override def initialValue(): Node =
+      new Node()
+  }
+}
+
+class Exchanger[V <: AnyRef] {
+  import Exchanger._
+
+  /*
+   * Overview: The core algorithm is, for an exchange "slot",
+   * and a participant (caller) with an item:
+   *
+   * for (;;) {
+   *   if (slot is empty) {                       // offer
+   *     place item in a Node;
+   *     if (can CAS slot from empty to node) {
+   *       wait for release;
+   *       return matching item in node;
+   *     }
+   *   }
+   *   else if (can CAS slot from node to empty) { // release
+   *     get the item in node;
+   *     set matching item in node;
+   *     release waiting thread;
+   *   }
+   *   // else retry on CAS failure
+   * }
+   *
+   * This is among the simplest forms of a "dual data structure" --
+   * see Scott and Scherer's DISC 04 paper and
+   * http://www.cs.rochester.edu/research/synchronization/pseudocode/duals.html
+   *
+   * This works great in principle. But in practice, like many
+   * algorithms centered on atomic updates to a single location, it
+   * scales horribly when there are more than a few participants
+   * using the same Exchanger. So the implementation instead uses a
+   * form of elimination arena, that spreads out this contention by
+   * arranging that some threads typically use different slots,
+   * while still ensuring that eventually, any two parties will be
+   * able to exchange items. That is, we cannot completely partition
+   * across threads, but instead give threads arena indices that
+   * will on average grow under contention and shrink under lack of
+   * contention. We approach this by defining the Nodes that we need
+   * anyway as ThreadLocals, and include in them per-thread index
+   * and related bookkeeping state. (We can safely reuse per-thread
+   * nodes rather than creating them fresh each time because slots
+   * alternate between pointing to a node vs null, so cannot
+   * encounter ABA problems. However, we do need some care in
+   * resetting them between uses.)
+   *
+   * Implementing an effective arena requires allocating a bunch of
+   * space, so we only do so upon detecting contention (except on
+   * uniprocessors, where they wouldn't help, so aren't used).
+   * Otherwise, exchanges use the single-slot slotExchange method.
+   * On contention, not only must the slots be in different
+   * locations, but the locations must not encounter memory
+   * contention due to being on the same cache line (or more
+   * generally, the same coherence unit).  Because, as of this
+   * writing, there is no way to determine cacheline size, we define
+   * a value that is enough for common platforms.  Additionally,
+   * extra care elsewhere is taken to avoid other false/unintended
+   * sharing and to enhance locality, including adding padding (via
+   * @Contended) to Nodes, embedding "bound" as an Exchanger field.
+   *
+   * The arena starts out with only one used slot. We expand the
+   * effective arena size by tracking collisions; i.e., failed CASes
+   * while trying to exchange. By nature of the above algorithm, the
+   * only kinds of collision that reliably indicate contention are
+   * when two attempted releases collide -- one of two attempted
+   * offers can legitimately fail to CAS without indicating
+   * contention by more than one other thread. (Note: it is possible
+   * but not worthwhile to more precisely detect contention by
+   * reading slot values after CAS failures.)  When a thread has
+   * collided at each slot within the current arena bound, it tries
+   * to expand the arena size by one. We track collisions within
+   * bounds by using a version (sequence) number on the "bound"
+   * field, and conservatively reset collision counts when a
+   * participant notices that bound has been updated (in either
+   * direction).
+   *
+   * The effective arena size is reduced (when there is more than
+   * one slot) by giving up on waiting after a while and trying to
+   * decrement the arena size on expiration. The value of "a while"
+   * is an empirical matter.  We implement by piggybacking on the
+   * use of spin->yield->block that is essential for reasonable
+   * waiting performance anyway -- in a busy exchanger, offers are
+   * usually almost immediately released, in which case context
+   * switching on multiprocessors is extremely slow/wasteful.  Arena
+   * waits just omit the blocking part, and instead cancel. The spin
+   * count is empirically chosen to be a value that avoids blocking
+   * 99% of the time under maximum sustained exchange rates on a
+   * range of test machines. Spins and yields entail some limited
+   * randomness (using a cheap xorshift) to avoid regular patterns
+   * that can induce unproductive grow/shrink cycles. (Using a
+   * pseudorandom also helps regularize spin cycle duration by
+   * making branches unpredictable.)  Also, during an offer, a
+   * waiter can "know" that it will be released when its slot has
+   * changed, but cannot yet proceed until match is set.  In the
+   * mean time it cannot cancel the offer, so instead spins/yields.
+   * Note: It is possible to avoid this secondary check by changing
+   * the linearization point to be a CAS of the match field (as done
+   * in one case in the Scott & Scherer DISC paper), which also
+   * increases asynchrony a bit, at the expense of poorer collision
+   * detection and inability to always reuse per-thread nodes. So
+   * the current scheme is typically a better tradeoff.
+   *
+   * On collisions, indices traverse the arena cyclically in reverse
+   * order, restarting at the maximum index (which will tend to be
+   * sparsest) when bounds change. (On expirations, indices instead
+   * are halved until reaching 0.) It is possible (and has been
+   * tried) to use randomized, prime-value-stepped, or double-hash
+   * style traversal instead of simple cyclic traversal to reduce
+   * bunching.  But empirically, whatever benefits these may have
+   * don't overcome their added overhead: We are managing operations
+   * that occur very quickly unless there is sustained contention,
+   * so simpler/faster control policies work better than more
+   * accurate but slower ones.
+   *
+   * Because we use expiration for arena size control, we cannot
+   * throw TimeoutExceptions in the timed version of the public
+   * exchange method until the arena size has shrunken to zero (or
+   * the arena isn't enabled). This may delay response to timeout
+   * but is still within spec.
+   *
+   * Essentially all of the implementation is in methods
+   * slotExchange and arenaExchange. These have similar overall
+   * structure, but differ in too many details to combine. The
+   * slotExchange method uses the single Exchanger field "slot"
+   * rather than arena array elements. However, it still needs
+   * minimal collision detection to trigger arena construction.
+   * (The messiest part is making sure interrupt status and
+   * InterruptedExceptions come out right during transitions when
+   * both methods may be called. This is done by using null return
+   * as a sentinel to recheck interrupt status.)
+   *
+   * As is too common in this sort of code, methods are monolithic
+   * because most of the logic relies on reads of fields that are
+   * maintained as local variables so can't be nicely factored --
+   * mainly, here, bulky spin->yield->block/cancel code.  Note that
+   * field Node.item is not declared as volatile even though it is
+   * read by releasing threads, because they only do so after CAS
+   * operations that must precede access, and all uses by the owning
+   * thread are otherwise acceptably ordered by other operations.
+   * (Because the actual points of atomicity are slot CASes, it
+   * would also be legal for the write to Node.match in a release to
+   * be weaker than a full volatile write. However, this is not done
+   * because it could allow further postponement of the write,
+   * delaying progress.)
+   */
+
+  /** Per-thread state.
+   */
+  private final val participant: Participant = new Participant()
+
+  /*
+   * Elimination array; null until enabled (within slotExchange).
+   * Element accesses use emulation of volatile gets and CAS.
+   */
+  @volatile private[Exchanger] var arena: Array[Node] = _
+
+  @alwaysinline
+  private def arrayGetAtomicRef[E <: AnyRef](
+      a: Array[E],
+      i: Int
+  ): AtomicRef[E] = {
+    val elemRef = a.asInstanceOf[ObjectArray].at(i).asInstanceOf[Ptr[E]]
+    new AtomicRef[E](elemRef)
+  }
+
+  @alwaysinline
+  private def arrayCompareAndSet[E <: AnyRef](
+      a: Array[E],
+      i: Int,
+      e: E,
+      v: E
+  ): Boolean =
+    arrayGetAtomicRef(a, i).compareExchangeStrong(e, v)
+
+  @alwaysinline
+  private def arrayGetAcquire[E <: AnyRef](a: Array[E], i: Int): E =
+    arrayGetAtomicRef(a, i).load(memory_order_acquire)
+
+  /*
+   * Slot used until contention detected.
+   */
+  @volatile private[Exchanger] var slot: Node = _
+
+  @alwaysinline private def atomicSlot = new AtomicRef[Node](
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "slot"))
+  )
+
+  /*
+   * The index of the largest valid arena position, OR'ed with SEQ
+   * number in high bits, incremented on each update.  The initial
+   * update from 0 to SEQ is used to ensure that the arena array is
+   * constructed only once.
+   */
+  @volatile private[Exchanger] var bound: Int = _
+
+  @alwaysinline private def atomicBound = new AtomicInt(
+    fromRawPtr(Intrinsics.classFieldRawPtr(this, "bound"))
+  )
+
+  /*
+   * Exchange function when arenas enabled. See above for explanation.
+   *
+   * @param item the (non-null) item to exchange
+   * @param timed true if the wait is timed
+   * @param ns if timed, the maximum wait time, else 0L
+   * @return the other thread's item; or null if interrupted; or
+   * TIMED_OUT if timed and timed out
+   */
+  private final def arenaExchange(
+      item: Object,
+      timed: Boolean,
+      ns: Long
+  ): Object = {
+
+    var nanos = ns
+    val a = arena
+    val alen = a.length
+    val p = participant.get() // Probably will need to be var.
+
+    var i = p.index
+
+    while (true) { // access slot at i
+      var b = 0
+      var m = 0
+      var c = 0
+
+      var j = (i << ASHIFT) + ((1 << ASHIFT) - 1)
+      if (j < 0 || j >= alen)
+        j = alen - 1;
+      val q = arrayGetAcquire(a, j)
+      if (q != null && arrayCompareAndSet(a, j, q, null)) {
+        val v = q.item // release
+        q.`match` = item
+        val w = q.parked
+        if (w != null)
+          LockSupport.unpark(w)
+        return v
+      } else if (i <= { m = { b = bound; b } & MMASK; m } && (q == null)) {
+        p.item = item; // offer
+
+        if (arrayCompareAndSet(a, j, null, p)) {
+          val end =
+            if (timed && m == 0) System.nanoTime() + nanos
+            else 0L
+
+          val t = Thread.currentThread() // wait
+          var h = p.hash
+          var spins = SPINS
+
+          var breakSeen = false
+          while (!breakSeen) {
+            val v = p.`match`
+            if (v != null) {
+              p.setMatchRelease(null)
+              p.item = null // clear for next use
+              p.hash = h
+              return v
+            } else if (spins > 0) {
+              h ^= h << 1; h ^= h >>> 3; h ^= h << 10 // xorshift
+              if (h == 0) // initialize hash
+                h = SPINS | t.threadId().toInt
+              else if (h < 0 && // approx 50% true
+                  ({ spins -= 1; spins }
+                    & ((SPINS >>> 1) - 1)) == 0)
+                Thread.`yield`() // two yields per wait
+            } else if (arrayGetAcquire(a, j) != p)
+              spins = SPINS // releaser hasn't set match yet
+            else if (!t.isInterrupted() && m == 0 &&
+                (!timed ||
+                { nanos = end - System.nanoTime(); nanos } > 0L)) {
+              p.parked = t // minimize window
+
+              if (arrayGetAcquire(a, j) == p) {
+                if (nanos == 0L)
+                  LockSupport.park(this)
+                else
+                  LockSupport.parkNanos(this, nanos)
+              }
+              p.parked = null
+            } else if (arrayGetAcquire(a, j) == p &&
+                arrayCompareAndSet(a, j, p, null)) {
+              if (m != 0) // try to shrink
+                atomicBound.compareExchangeStrong(b, b + SEQ - 1)
+              p.item = null
+              p.hash = h
+              i = { p.index >>>= 1; p.index } // descend
+
+              if (Thread.interrupted())
+                return null
+              if (timed && m == 0 && nanos <= 0L)
+                return TIMED_OUT
+
+              breakSeen = true // expired; restart
+            }
+          }
+        } else
+          p.item = null // clear offer
+      } else {
+        if (p.bound != b) { // stale; reset
+          p.bound = b
+          p.collides = 0
+          i =
+            if (i != m || m == 0) m
+            else m - 1
+        } else if ({ c = p.collides; c } < m || m == FULL ||
+            atomicBound.compareExchangeStrong(b, b + SEQ + 1)) {
+
+          p.collides = c + 1
+          i =
+            if (i == 0) m
+            else i - 1 // cyclically traverse
+        } else
+          i = m + 1 // grow
+
+        p.index = i
+      }
+    }
+
+    null // Should never get here
+  }
+
+  /*
+   * Exchange function used until arenas enabled. See above for explanation.
+   *
+   * @param item the item to exchange
+   * @param timed true if the wait is timed
+   * @param ns if timed, the maximum wait time, else 0L
+   * @return the other thread's item; or null if either the arena
+   * was enabled or the thread was interrupted before completion; or
+   * TIMED_OUT if timed and timed out
+   */
+  private final def slotExchange(
+      item: Object,
+      timed: Boolean,
+      ns: Long
+  ): Object = {
+    var nanos = ns
+
+    val p = participant.get()
+    val t = Thread.currentThread()
+    if (t.isInterrupted()) // preserve interrupt status so caller can recheck
+      return null
+
+    var q: Node = null
+    var breakSeen = false
+
+    while (!breakSeen) {
+      if ({ q = slot; q } != null) {
+        if (atomicSlot.compareExchangeStrong(q, null)) {
+          val v = q.item
+          q.`match` = item
+          val w = q.parked
+          if (w != null)
+            LockSupport.unpark(w)
+          return v
+        }
+
+        // create arena on contention, but continue until slot null
+        if (NCPU > 1 && bound == 0 &&
+            atomicBound.compareExchangeStrong(0, SEQ)) {
+          arena = new Array[Node]({ (FULL + 2) << ASHIFT })
+        }
+      } else if (arena != null) {
+        return null // caller must reroute to arenaExchange
+      } else {
+        p.item = item
+        if (atomicSlot.compareExchangeStrong(null.asInstanceOf[Node], p))
+          breakSeen = true
+        else
+          p.item = null
+      }
+    }
+
+    // await release
+    var h = p.hash
+
+    val end =
+      if (timed) System.nanoTime() + nanos
+      else 0L
+
+    var spins =
+      if (NCPU > 1) SPINS
+      else 1
+
+    var v: Object = null
+
+    breakSeen = false
+
+    while (!breakSeen && { v = p.`match`; v } == null) {
+      if (spins > 0) {
+        h ^= h << 1; h ^= h >>> 3; h ^= h << 10
+        if (h == 0)
+          h = SPINS | t.threadId().toInt
+        else if (h < 0 && ({ spins -= 1; spins } & ((SPINS >>> 1) - 1)) == 0)
+          Thread.`yield`()
+      } else if (slot != p)
+        spins = SPINS
+      else if (!t.isInterrupted() && arena == null &&
+          (!timed ||
+          { nanos = end - System.nanoTime(); nanos } > 0L)) {
+        p.parked = t
+        if (slot == p) {
+          if (nanos == 0L)
+            LockSupport.park(this)
+          else
+            LockSupport.parkNanos(this, nanos)
+        }
+        p.parked = null
+      } else if (atomicSlot.compareExchangeStrong(p, null)) {
+        v =
+          if (timed && nanos <= 0L && !t.isInterrupted()) TIMED_OUT
+          else null
+
+        breakSeen = true
+      }
+    }
+
+    p.setMatchRelease(null)
+    p.item = null
+    p.hash = h
+    v
+  }
+
+  /*
+   * Waits for another thread to arrive at this exchange point (unless
+   * the current thread is {@linkplain Thread#interrupt interrupted}),
+   * and then transfers the given object to it, receiving its object
+   * in return.
+   *
+   * <p>If another thread is already waiting at the exchange point then
+   * it is resumed for thread scheduling purposes and receives the object
+   * passed in by the current thread.  The current thread returns immediately,
+   * receiving the object passed to the exchange by that other thread.
+   *
+   * <p>If no other thread is already waiting at the exchange then the
+   * current thread is disabled for thread scheduling purposes and lies
+   * dormant until one of two things happens:
+   * <ul>
+   * <li>Some other thread enters the exchange; or
+   * <li>Some other thread {@linkplain Thread#interrupt interrupts}
+   * the current thread.
+   * </ul>
+   * <p>If the current thread:
+   * <ul>
+   * <li>has its interrupted status set on entry to this method; or
+   * <li>is {@linkplain Thread#interrupt interrupted} while waiting
+   * for the exchange,
+   * </ul>
+   * then {@link InterruptedException} is thrown and the current thread's
+   * interrupted status is cleared.
+   *
+   * @param x the object to exchange
+   * @return the object provided by the other thread
+   * @throws InterruptedException if the current thread was
+   *         interrupted while waiting
+   */
+
+  def exchange(x: V): V = {
+    var v: Object = null
+
+    val item =
+      if (x == null) NULL_ITEM
+      else x // translate null args
+
+    if ((arena != null ||
+          ({ v = slotExchange(item, false, 0L); v }) == null) &&
+        (Thread.interrupted() ||
+        ({ v = arenaExchange(item, false, 0L); v }) == null))
+      throw new InterruptedException()
+
+    val result =
+      if (v == NULL_ITEM) null
+      else v
+
+    result.asInstanceOf[V]
+  }
+
+  /*
+   * Waits for another thread to arrive at this exchange point (unless
+   * the current thread is {@linkplain Thread#interrupt interrupted} or
+   * the specified waiting time elapses), and then transfers the given
+   * object to it, receiving its object in return.
+   *
+   * <p>If another thread is already waiting at the exchange point then
+   * it is resumed for thread scheduling purposes and receives the object
+   * passed in by the current thread.  The current thread returns immediately,
+   * receiving the object passed to the exchange by that other thread.
+   *
+   * <p>If no other thread is already waiting at the exchange then the
+   * current thread is disabled for thread scheduling purposes and lies
+   * dormant until one of three things happens:
+   * <ul>
+   * <li>Some other thread enters the exchange; or
+   * <li>Some other thread {@linkplain Thread#interrupt interrupts}
+   * the current thread; or
+   * <li>The specified waiting time elapses.
+   * </ul>
+   * <p>If the current thread:
+   * <ul>
+   * <li>has its interrupted status set on entry to this method; or
+   * <li>is {@linkplain Thread#interrupt interrupted} while waiting
+   * for the exchange,
+   * </ul>
+   * then {@link InterruptedException} is thrown and the current thread's
+   * interrupted status is cleared.
+   *
+   * <p>If the specified waiting time elapses then {@link
+   * TimeoutException} is thrown.  If the time is less than or equal
+   * to zero, the method will not wait at all.
+   *
+   * @param x the object to exchange
+   * @param timeout the maximum time to wait
+   * @param unit the time unit of the {@code timeout} argument
+   * @return the object provided by the other thread
+   * @throws InterruptedException if the current thread was
+   *         interrupted while waiting
+   * @throws TimeoutException if the specified waiting time elapses
+   *         before another thread enters the exchange
+   */
+  def exchange(x: V, timeout: Long, unit: TimeUnit): V = {
+    var v: Object = null
+
+    val item =
+      if (x == null) NULL_ITEM
+      else x
+
+    val ns = unit.toNanos(timeout)
+
+    if ((arena != null ||
+          ({ v = slotExchange(item, true, ns); v }) == null) &&
+        (Thread.interrupted() ||
+        ({ v = arenaExchange(item, true, ns); v } == null)))
+      throw new InterruptedException()
+
+    if (v == TIMED_OUT)
+      throw new TimeoutException()
+
+    val result =
+      if (v == NULL_ITEM) null
+      else v
+
+    result.asInstanceOf[V]
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExchangerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/ExchangerTest.scala
@@ -1,0 +1,246 @@
+/* Ported from JSR-166 Expert Group main CVS (Concurrent Versions System)
+ * repository as described at Doug Lea "Concurrency JSR-166 Interest Site"
+ *    https://gee.cs.oswego.edu/dl/concurrency-interest/.
+ *
+ *  file: jsr166/src/test/tck/ExchangerTest.java
+ *  revision 1.27, dated: 2021-01-26
+ */
+
+/* Scala Native Notes
+ *
+ *   1. Shield your eyes: This code is intended to be Scala which stays very
+ *      close to JSR-166 .java original. This aids detecting porting errors.
+ *      It is _Not_Intended_ to be idiomatic Scala.
+ *
+ *   2. The JSR-166 code used 'Arrays.asList(ar)' in a number of tests.
+ *      For Scala, the varargs slice required by a direct translation
+ *      differs on Scala 2 & 3.  For Scala 2 it is 'Arrays.asList(ar: _*).
+ *      On Scala 3 it is 'Arrays.asList(ar*)'. Early Scala 3 versions
+ *      tolerate the former ': _*' but announce that such tolerance
+ *      will cease in some future version.
+ *
+ *      This code uses a non-obvious and somewhat runtime expression to
+ *      void the need for creating and maintaining variants for Scala version:
+ *      'Arrays.stream(ar).collect(Collectors.toList())'.
+ *
+ *  3.  Extra is taken for so that assertion and other failures in Runnables
+ *      cause the CI run for this class to fail. This eliminates
+ *      an entire class of false positive results.
+ */
+
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{CountDownLatch, Exchanger, TimeoutException}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ExchangerTest extends JSR166Test {
+  import JSR166Test._
+
+  /*  SN: JSR-166 code used [Item] but SN defines Item different to
+   *      JSR-166, so use SN definition of Integer.
+   *      This is OK, because Integer is still an Object/AnyRef and
+   *      not a primitive.
+   */
+
+  type SnItemType = Integer
+
+  /* SN: Ensure that failures in Runnables get reported to overall CI.
+   */
+
+  private def ciAwaitTermination(
+      thread: Thread,
+      threadSuccess: AtomicBoolean,
+      timeoutMillis: Long = LONG_DELAY_MS
+  ) = {
+    awaitTermination(thread)
+    if (!threadSuccess.get())
+      fail(s"Failure in $thread, check log for cause or stacktrace.")
+  }
+
+  /** exchange exchanges objects across two threads
+   */
+  @Test def testExchange(): Unit = {
+    val t1Success = new AtomicBoolean()
+
+    val e = new Exchanger[SnItemType]()
+    val t1 = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        assertSame(one, e.exchange(two))
+        assertSame(two, e.exchange(one))
+        t1Success.set(true)
+      }
+    })
+
+    val t2Success = new AtomicBoolean()
+
+    val t2 = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        assertSame(two, e.exchange(one))
+        assertSame(one, e.exchange(two))
+        t2Success.set(true)
+      }
+    })
+
+    ciAwaitTermination(t1, t1Success)
+    ciAwaitTermination(t2, t2Success)
+  }
+
+  /** timed exchange exchanges objects across two threads
+   */
+  @Test def testTimedExchange(): Unit = {
+    val t1Success = new AtomicBoolean()
+
+    val e = new Exchanger[SnItemType]()
+    val t1 = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        assertSame(one, e.exchange(two, LONG_DELAY_MS, MILLISECONDS))
+        assertSame(two, e.exchange(one, LONG_DELAY_MS, MILLISECONDS))
+        t1Success.set(true)
+      }
+    })
+
+    val t2Success = new AtomicBoolean()
+
+    val t2 = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        assertSame(two, e.exchange(one, LONG_DELAY_MS, MILLISECONDS))
+        assertSame(one, e.exchange(two, LONG_DELAY_MS, MILLISECONDS))
+        t2Success.set(true)
+      }
+    })
+
+    ciAwaitTermination(t1, t1Success)
+    ciAwaitTermination(t2, t2Success)
+  }
+
+  /** interrupt during wait for exchange throws InterruptedException
+   */
+  @Test def testExchange_InterruptedException(): Unit = {
+    /* This test gives CI a clear CountDownLatch timeout failure, so no
+     * special CI handling is needed.
+     */
+
+    val e = new Exchanger[SnItemType]()
+    val threadStarted = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedInterruptedRunnable() {
+      def realRun(): Unit = {
+        threadStarted.countDown()
+        e.exchange(one)
+      }
+    })
+
+    await(threadStarted)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /** interrupt during wait for timed exchange throws InterruptedException
+   */
+  @Test def testTimedExchange_InterruptedException(): Unit = {
+    /* SN: This test differs from others in the class in that it
+     *     does not need ciAwaitTermination(). If the tested condition,
+     *     'interrupt', does not cause the exchange() to return, a
+     *     normal awaitTermination() will report a timeout error and
+     *     visibly fail CI for this class.
+     */
+
+    val e = new Exchanger[SnItemType]()
+
+    val threadStarted = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedInterruptedRunnable() {
+      def realRun(): Unit = {
+        threadStarted.countDown()
+        e.exchange(null, LONG_DELAY_MS, MILLISECONDS)
+      }
+    })
+
+    await(threadStarted)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /** timeout during wait for timed exchange throws TimeoutException
+   */
+  @Test def testExchange_TimeoutException(): Unit = {
+    val tSuccess = new AtomicBoolean()
+
+    val e = new Exchanger[SnItemType]()
+    val t = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        val startTime = System.nanoTime()
+
+        assertThrows(
+          "a1",
+          classOf[TimeoutException],
+          e.exchange(null, timeoutMillis(), MILLISECONDS)
+        )
+
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+        tSuccess.set(true)
+      }
+    })
+
+    ciAwaitTermination(t, tSuccess)
+  }
+
+  /** If one exchanging thread is interrupted, another succeeds.
+   */
+  @Test def testReplacementAfterExchange(): Unit = {
+    // t1 failures are evident in CI as CountDownLatch or other timeouts.
+    val t2Success = new AtomicBoolean()
+    val t3Success = new AtomicBoolean()
+
+    val e = new Exchanger[SnItemType]()
+
+    val exchanged = new CountDownLatch(2)
+    val interrupted = new CountDownLatch(1)
+    val t1 = newStartedThread(new CheckedInterruptedRunnable() {
+      def realRun(): Unit = {
+        assertSame(two, e.exchange(one))
+        exchanged.countDown()
+        e.exchange(two)
+      }
+    })
+
+    val t2 = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        assertSame(one, e.exchange(two))
+        exchanged.countDown()
+        await(interrupted)
+        assertSame(three, e.exchange(one))
+        t2Success.set(true)
+      }
+    })
+
+    val t3 = newStartedThread(new CheckedRunnable() {
+      def realRun(): Unit = {
+        await(interrupted)
+        assertSame(one, e.exchange(three))
+        t3Success.set(true)
+      }
+    })
+
+    await(exchanged)
+    t1.interrupt()
+    awaitTermination(t1)
+
+    interrupted.countDown()
+
+    ciAwaitTermination(t2, t2Success)
+    ciAwaitTermination(t3, t3Success)
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala
@@ -9,7 +9,7 @@
 /* Scala Native Notes for Travelling Salesperson Problem (TSP) ExchangerTest:
  *
  *   0. BEWARE! This code currently reveals a GC-crash bug as
- *      described in SN Issue #TBD.  To run to completion, it
+ *      described in SN Issue #4871.  To run to completion, it
  *      should be built with mode=debug. Note well that the
  *      execution speed when built with mode=debug and a SN backend
  *      is 15 or more times slower than with a JVM backend.

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala
@@ -16,7 +16,7 @@
  *
  *      This BUG manifests itself when DEFAULT_MAX_THREADS > NCPUS.
  *      To use mode=release-fast, say for execution timing studies,
- *      One can edit this file and reduce DEFAULT_MAX_THREADS to or below
+ *      one can edit this file and reduce DEFAULT_MAX_THREADS to or below
  *      NCPUS. Of course, doing so limits the available parallelism.
  *      Nasty bug!
  *

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala
@@ -1,0 +1,832 @@
+/* Ported from JSR-166 Expert Group main CVS (Concurrent Versions System)
+ * repository as described at Doug Lea "Concurrency JSR-166 Interest Site"
+ *    https://gee.cs.oswego.edu/dl/concurrency-interest/.
+ *
+ *  file: src/test/loops/TSPExchangerTest.java
+ *  revision 1.19, dated: 2015-09-13
+ */
+
+/* Scala Native Notes for Travelling Salesperson Problem (TSP) ExchangerTest:
+ *
+ *   0. BEWARE! This code currently reveals a GC-crash bug as
+ *      described in SN Issue #TBD.  To run to completion, it
+ *      should be built with mode=debug. Note well that the
+ *      execution speed when built with mode=debug and a SN backend
+ *      is 15 or more times slower than with a JVM backend.
+ *
+ *      This BUG manifests itself when DEFAULT_MAX_THREADS > NCPUS.
+ *      To use mode=release-fast, say for execution timing studies,
+ *      One can edit this file and reduce DEFAULT_MAX_THREADS to or below
+ *      NCPUS. Of course, doing so limits the available parallelism.
+ *      Nasty bug!
+ *
+ *      This code does not encounter this bug when run with a JVM
+ *      background. That gives evidence that the port, by itself, is not
+ *      deadlocking or in an infinite loop or two. By original JSR-166
+ *      design it _is_ in a number of CPU intensive threads.
+ *
+ *   1. This test is intended as a manual test for Exploring the behavior
+ *      of Exchanger.scala. Because the results require validation which
+ *      is hard to automate and because it is CPU intensive at scale,
+ *      it is not intended for regular Continuous Integration (CI) use.
+ *
+ *      It has been manually exercised using Scala 3.8.3 on macOS 26.4.
+ *
+ *      It is particularly useful for long duration runs and inserting
+ *      debugging printf to ensure that invariants hold.  It can also
+ *      be used with care to compare execution times between .java
+ *      original, this code run on Java, and this code run on Scala Native.
+ *
+ *      Two other Exchanger related tests exist in CVS src/test/loops/.
+ *      Porting them is left as an exercise for the reader.
+ *
+ *   2a. The direction of goodness for best case (B:) and worst case (W:)
+ *       is towards zero: smaller is better.
+ *
+ *   2b. After the starting array fill,  the invariant  best_case <= worst_case
+ *       should always hold in printed results.
+ *
+ *   3a. The output from this program compiled for Scala and run on JVM and
+ *       Scala Native is approximately/visually the same (same order and
+ *       direction of magnitude, and within a few decimal places)
+ *
+ *   3b. When build mode=release_fast and run with a JVM or SN backend
+ *       the execution times approximately equal that of the .java
+ *       original.
+ *
+ *   4. The 'n' in the banner "Replication: n" is indexed [0, n) in
+ *      the JSR-166 .java code.
+ *
+ *      So do not be concerned wondering when examining the tail
+ *      of the output, wondering what happened to the last iteration.
+ *
+ *      An index starting at 0 is how one knows that one is doing
+ *      Computer Science.
+ *
+ *   5. System.out.printf() statements use explicit conversions to Objects
+ *      so that Scala 2.12 CI will compile.
+ */
+
+/*
+ * Written by Doug Lea and Bill Scherer with assistance from members
+ * of JCP JSR-166 Expert Group and released to the public domain, as
+ * explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+import java.util._
+import java.util.concurrent._
+import java.util.concurrent.atomic._
+import java.util.concurrent.locks._
+import java.{lang => jl}
+
+/*
+ * A parallel Traveling Salesperson Problem (TSP) program based on a
+ * genetic algorithm using an Exchanger.  A population of chromosomes is
+ * distributed among "subpops".  Each chromosomes represents a tour,
+ * and its fitness is the total tour length.
+ *
+ * A set of worker threads perform updates on subpops. The basic
+ * update step is:
+ * <ol>
+ *   <li>Select a breeder b from the subpop
+ *   <li>Create a strand of its tour with a random starting point and length
+ *   <li>Offer the strand to the exchanger, receiving a strand from
+ *       another subpop
+ *   <li>Combine b and the received strand using crossing function to
+ *       create new chromosome c.
+ *   <li>Replace a chromosome in the subpop with c.
+ * </ol>
+ *
+ * This continues for a given number of generations per subpop.
+ * Because there are normally more subpops than threads, each worker
+ * thread performs small (randomly sized) run of updates for one
+ * subpop and then selects another. A run continues until there is at
+ * most one remaining thread performing updates.
+ *
+ * See below for more details.
+ */
+object TSPExchangerTest {
+  private final val NCPUS = Runtime.getRuntime().availableProcessors()
+
+  /* Runs start with two threads, increasing by two through max */
+  private final val DEFAULT_MAX_THREADS = Math.max(4, NCPUS + NCPUS / 2)
+
+  /* The number of replication runs per thread value */
+  private final val DEFAULT_REPLICATIONS = 3
+
+  /* If true, print statistics in SNAPSHOT_RATE intervals */
+  private var verbose = true
+  private final val SNAPSHOT_RATE = 10 * 1000L // in milliseconds
+
+  /*
+   * The problem size. Each city is a random point. The goal is to
+   * find a tour among them with smallest total Euclidean distance.
+   */
+  private final val DEFAULT_CITIES = 144
+
+  // Tuning parameters.
+
+  /*
+   * The number of chromosomes per subpop. Must be a power of two.
+   *
+   * Smaller values lead to faster iterations but poorer quality
+   * results
+   */
+  private final val DEFAULT_SUBPOP_SIZE = 32
+
+  /*
+   * The number of iterations per subpop. Convergence appears
+   * to be roughly proportional to #cities-squared
+   */
+  private final val DEFAULT_GENERATIONS = DEFAULT_CITIES * DEFAULT_CITIES
+
+  /*
+   * The number of subpops. The total population is #subpops * subpopSize,
+   * which should be roughly on the order of #cities-squared
+   *
+   * Smaller values lead to faster total runs but poorer quality
+   * results
+   */
+  private final val DEFAULT_NSUBPOPS = DEFAULT_GENERATIONS / DEFAULT_SUBPOP_SIZE
+
+  /*
+   * The minimum length for a random chromosome strand.
+   * Must be at least 1.
+   */
+  private final val MIN_STRAND_LENGTH = 3
+
+  /*
+   * The probability mask value for creating random strands,
+   * that have lengths at least MIN_STRAND_LENGTH, and grow
+   * with exponential decay 2^(-(1/(RANDOM_STRAND_MASK + 1)
+   * Must be 1 less than a power of two.
+   */
+  private final val RANDOM_STRAND_MASK = 7
+
+  /*
+   * Probability control for selecting breeders.
+   * Breeders are selected starting at the best-fitness chromosome,
+   * with exponentially decaying probability
+   * 1 / (subpopSize >>> BREEDER_DECAY).
+   *
+   * Larger values usually cause faster convergence but poorer
+   * quality results
+   */
+  private final val BREEDER_DECAY = 1
+
+  /*
+   * Probability control for selecting dyers.
+   * Dyers are selected starting at the worst-fitness chromosome,
+   * with exponentially decaying probability
+   * 1 / (subpopSize >>> DYER_DECAY)
+   *
+   * Larger values usually cause faster convergence but poorer
+   * quality results
+   */
+  private final val DYER_DECAY = 1
+
+  /*
+   * The set of cities. Created once per program run, to
+   * make it easier to compare solutions across different runs.
+   */
+  private var cities: CitySet = null
+
+  def main(args: Array[String]): Unit = {
+    var maxThreads = DEFAULT_MAX_THREADS
+    var nCities = DEFAULT_CITIES
+    var subpopSize = DEFAULT_SUBPOP_SIZE
+    var nGen = nCities * nCities
+    var nSubpops = nCities * nCities / subpopSize
+    var nReps = DEFAULT_REPLICATIONS
+
+    try {
+      var argc = 0
+      while (argc < args.length) {
+        val option = args(argc)
+        argc += 1
+
+        if (option.equals("-c")) {
+          nCities = Integer.parseInt(args(argc))
+          nGen = nCities * nCities
+          nSubpops = nCities * nCities / subpopSize
+        } else if (option.equals("-p"))
+          subpopSize = Integer.parseInt(args(argc))
+        else if (option.equals("-g"))
+          nGen = Integer.parseInt(args(argc))
+        else if (option.equals("-n"))
+          nSubpops = Integer.parseInt(args(argc))
+        else if (option.equals("-q")) {
+          verbose = false
+          argc -= 1
+        } else if (option.equals("-r"))
+          nReps = Integer.parseInt(args(argc))
+        else
+          maxThreads = Integer.parseInt(option)
+        argc += 1
+      }
+    } catch {
+      case e: Exception =>
+        reportUsageErrorAndDie()
+    }
+
+    System.out.print(s"\nTSPExchangerTest")
+    System.out.print(" -c " + nCities)
+    System.out.print(" -g " + nGen)
+    System.out.print(" -p " + subpopSize)
+    System.out.print(" -n " + nSubpops)
+    System.out.print(" -r " + nReps)
+    System.out.print(" max threads " + maxThreads)
+    System.out.println()
+
+    cities = new CitySet(nCities)
+
+    if (false && NCPUS > 4) {
+      val h = NCPUS / 2
+      System.out.printf("Threads: %4d Warmup\n", jl.Integer.valueOf(h))
+      oneRun(h, nSubpops, subpopSize, nGen)
+      Thread.sleep(500)
+    }
+
+    val maxt =
+      if (maxThreads < nSubpops) maxThreads
+      else nSubpops
+
+    for (j <- 0 until nReps) {
+      for (i <- 2 to maxt by 2) {
+        if (verbose)
+          System.out.printf("\n")
+        System.out.printf(
+          "Threads: %4d Replication: %2d\n",
+          jl.Integer.valueOf(i),
+          jl.Integer.valueOf(j)
+        )
+
+        oneRun(i, nSubpops, subpopSize, nGen)
+        Thread.sleep(500)
+      }
+    }
+  }
+
+  private def reportUsageErrorAndDie(): Unit = {
+    System.out.print("usage: TSPExchangerTest")
+    System.out.print(" [-c #cities]")
+    System.out.print(" [-p #subpopSize]")
+    System.out.print(" [-g #generations]")
+    System.out.print(" [-n #subpops]")
+    System.out.print(" [-r #replications]")
+    System.out.print(" [-q <quiet>]")
+    System.out.print(" #threads]")
+    System.out.println()
+    System.exit(0)
+  }
+
+  /*
+   * Performs one run with the given parameters.  Each run completes
+   * when there are fewer than 2 active threads.  When there is
+   * only one remaining thread, it will have no one to exchange
+   * with, so it is terminated (via interrupt).
+   */
+
+  private def oneRun(
+      nThreads: Int,
+      nSubpops: Int,
+      subpopSize: Int,
+      nGen: Int
+  ): Unit = {
+    val p = new Population(nThreads, nSubpops, subpopSize, nGen)
+    var mon: ProgressMonitor = null
+    if (verbose) {
+      p.printSnapshot(0)
+      mon = new ProgressMonitor(p)
+      mon.start()
+    }
+    val startTime = System.nanoTime()
+    p.start()
+    p.awaitDone()
+    val stopTime = System.nanoTime()
+    if (mon != null)
+      mon.interrupt()
+    p.shutdown()
+    //        Thread.sleep(100); // JSR-166 original commenting out sleep()
+
+    val elapsed = stopTime - startTime
+    val secs = elapsed / 1000000000.0
+    p.printSnapshot(secs)
+  }
+
+  /*
+   * A Population creates the subpops, subpops, and threads for a run
+   * and has control methods to start, stop, and report progress.
+   */
+  private final class Population(
+      nThreads: Int,
+      nSubpops: Int,
+      val subpopSize: Int,
+      nGen: Int
+  ) {
+    final val threads = new Array[Worker](nThreads)
+    final val subpops = new Array[Subpop](nSubpops)
+    final val exchanger = new Exchanger[Strand]
+    final val done = new CountDownLatch(nThreads - 1)
+
+    for (i <- 0 until nSubpops)
+      subpops(i) = new Subpop(this)
+
+    val maxExchanges = nGen * nSubpops / nThreads
+    for (i <- 0 until nThreads)
+      threads(i) = new Worker(this, maxExchanges)
+
+    def start(): Unit = {
+      for (i <- 0 until nThreads)
+        threads(i).start()
+    }
+
+    /* Stop the tasks */
+    def shutdown(): Unit = {
+      for (i <- 0 until threads.length)
+        threads(i).interrupt()
+    }
+
+    def threadDone(): Unit =
+      done.countDown()
+
+    /* Wait for tasks to complete */
+    def awaitDone(): Unit =
+      done.await()
+
+    def totalExchanges(): Int = {
+      var xs = 0
+      for (i <- 0 until threads.length)
+        xs += threads(i).exchanges
+      xs
+    }
+
+    /*
+     * Prints statistics, including best and worst tour lengths
+     * for points scaled in [0,1), scaled by the square root of
+     * number of points. This simplifies checking results.  The
+     * expected optimal TSP for random points is believed to be
+     * around 0.76 * sqrt(N). For papers discussing this, see
+     * http://www.densis.fee.unicamp.br/~moscato/TSPBIB_home.html
+     */
+    def printSnapshot(secs: Double): Unit = {
+      val xs = totalExchanges()
+      val rate =
+        if (xs == 0) 0L
+        else ((secs * 1000000000.0) / xs).toLong
+
+      var bestc = subpops(0).chromosomes(0)
+      var worstc = bestc
+
+      for (k <- 0 until subpops.length) {
+        val cs = subpops(k).chromosomes
+        if (cs(0).fitness < bestc.fitness)
+          bestc = cs(0)
+        // SN: val 'w' is in .java original but apparently unused.
+        // val w = cs(cs.length - 1).fitness;
+        if (cs(cs.length - 1).fitness > worstc.fitness)
+          worstc = cs(cs.length - 1)
+      }
+
+      val sqrtn = Math.sqrt(cities.length)
+      val best = bestc.unitTourLength() / sqrtn
+      val worst = worstc.unitTourLength() / sqrtn
+
+      // jl.mumble explicit conversions are required by Scala 2.12 CI
+      java.lang.System.out.printf(
+        "N:%4d T:%8.3f B:%6.3f W:%6.3f X:%9d R:%7d\n",
+        jl.Integer.valueOf(nThreads),
+        jl.Double.valueOf(secs),
+        jl.Double.valueOf(best),
+        jl.Double.valueOf(worst),
+        jl.Double.valueOf(xs),
+        jl.Long.valueOf(rate)
+      )
+      // JSR-166 orignal comments
+      //            exchanger.printStats();
+      //            System.out.print(" s: " + exchanger.aveSpins());
+      //            System.out.print(" p: " + exchanger.aveParks());
+
+    }
+  }
+
+  /*
+   * Worker threads perform updates on subpops.
+   */
+  private final class Worker(pop: Population, maxExchanges: Int)
+      extends Thread {
+
+    var exchanges = 0
+    final val rng = new RNG()
+
+    /*
+     * Repeatedly, find a subpop that is not being updated by
+     * another thread, and run a random number of updates on it.
+     */
+    override def run(): Unit = {
+      try {
+        val len = pop.subpops.length
+        var pos = (rng.next() & 0x7fffffff) % len
+        while (exchanges < maxExchanges) {
+          val s = pop.subpops(pos)
+          val busy = s.busy
+          if (!busy.get() && busy.compareAndSet(false, true)) {
+            exchanges += s.runUpdates()
+            busy.set(false)
+            pos = (rng.next() & 0x7fffffff) % len
+          } else if ({ pos += 1; pos } >= len)
+            pos = 0
+        }
+        pop.threadDone()
+      } catch {
+        case e: InterruptedException =>
+      }
+    }
+  }
+
+  /*
+   * A Subpop maintains a set of chromosomes.
+   */
+  private final class Subpop(pop: Population) {
+    /* pop: The parent population */
+
+    /* Reservation bit for worker threads */
+    final val busy = new AtomicBoolean(false)
+
+    /* The common exchanger, same for all subpops */
+    final val exchanger = pop.exchanger
+
+    private val length = cities.length
+
+    /* The current strand being exchanged */
+    var strand = new Strand(length)
+
+    /* Bitset used in cross */
+    final val inTour = new Array[Int]((length >>> 5) + 1)
+
+    final val rng = new RNG()
+
+    final val subpopSize = pop.subpopSize
+
+    /* The chromosomes, kept in sorted order */
+    final val chromosomes = new Array[Chromosome](subpopSize)
+
+    for (j <- 0 until subpopSize)
+      chromosomes(j) = new Chromosome(length, rng)
+
+    Arrays.sort(chromosomes.asInstanceOf[Array[Object]])
+
+    /*
+     * Run a random number of updates.  The number of updates is
+     * at least 1 and no more than subpopSize.  This
+     * controls the granularity of multiplexing subpop updates on
+     * to threads. It is small enough to balance out updates
+     * across tasks, but large enough to avoid having runs
+     * dominated by subpop selection. It is randomized to avoid
+     * long runs where pairs of subpops exchange only with each
+     * other.  It is hardwired because small variations of it
+     * don't matter much.
+     *
+     * @param g the first generation to run
+     */
+
+    def runUpdates(): Int = {
+      val n = 1 + (rng.next() & ((subpopSize << 1) - 1))
+
+      for (i <- 0 until n)
+        update()
+
+      n
+    }
+
+    /*
+     * Chooses a breeder, exchanges strand with another subpop, and
+     * crosses them to create new chromosome to replace a chosen
+     * dyer.
+     */
+    def update(): Unit = {
+      val b = chooseBreeder()
+      val d = chooseDyer(b)
+      val breeder = chromosomes(b)
+      val child = chromosomes(d)
+
+      chooseStrand(breeder)
+      strand = exchanger.exchange(strand)
+      cross(breeder, child)
+      fixOrder(child, d)
+    }
+
+    /*
+     * Chooses a breeder, with exponentially decreasing probability
+     * starting at best.
+     * @return index of selected breeder
+     */
+    def chooseBreeder(): Int = {
+      val mask = (subpopSize >>> BREEDER_DECAY) - 1
+      var b = 0
+      while ((rng.next() & mask) != mask) {
+        if ({ b += 1; b } >= subpopSize)
+          b = 0
+      }
+
+      b
+    }
+
+    /*
+     * Chooses a chromosome that will be replaced, with
+     * exponentially decreasing probability starting at
+     * worst, ignoring the excluded index.
+     * @param exclude index to ignore; use -1 to not exclude any
+     * @return index of selected dyer
+     */
+    def chooseDyer(exclude: Int): Int = {
+      val mask = (subpopSize >>> DYER_DECAY) - 1
+      var d = subpopSize - 1
+      while (d == exclude || (rng.next() & mask) != mask) {
+        if ({ d -= 1; d } < 0)
+          d = subpopSize - 1
+      }
+
+      d
+    }
+
+    /*
+     * Select a random strand of b's.
+     * @param breeder the breeder
+     */
+
+    def chooseStrand(breeder: Chromosome): Unit = {
+      val bs = breeder.alleles
+      val length = bs.length
+      var strandLength = MIN_STRAND_LENGTH
+      while (strandLength < length &&
+          (rng.next() & RANDOM_STRAND_MASK) != RANDOM_STRAND_MASK)
+        strandLength += 1
+
+      strand.strandLength = strandLength
+      val ss = strand.alleles
+      var k = (rng.next() & 0x7fffffff) % length
+
+      for (i <- 0 until strandLength) {
+        ss(i) = bs(k)
+        if ({ k += 1; k } >= length) k = 0
+      }
+    }
+
+    /*
+     * Copies current strand to start of c's, and then appends all
+     * remaining b's that aren't in the strand.
+     * @param breeder the breeder
+     * @param child the child
+     */
+
+    def cross(breeder: Chromosome, child: Chromosome): Unit = {
+
+      for (k <- 0 until inTour.length) // clear bitset
+        inTour(k) = 0
+
+      // Copy current strand to c
+      val cs = child.alleles
+      val ssize = strand.strandLength
+      val ss = strand.alleles
+      var i = 0
+
+      for (idx <- 0 until ssize) {
+        val x = ss(idx)
+        cs(idx) = x
+        inTour(x >>> 5) |= 1 << (x & 31) // record in bit set
+        i += 1
+      }
+
+      // Find index of matching origin in b
+      val first = cs(0)
+      var j = 0
+      val bs = breeder.alleles
+
+      while (bs(j) != first)
+        j += 1
+
+      // Append remaining b's that aren't already in tour
+      while (i < cs.length) {
+        if ({ j += 1; j } >= bs.length) j = 0
+        val x = bs(j)
+        if ((inTour(x >>> 5) & (1 << (x & 31))) == 0) {
+          cs(i) = x
+          i += 1
+        }
+      }
+    }
+
+    /*
+     * Fixes the sort order of a changed Chromosome c at position k.
+     * @param c the chromosome
+     * @param k the index
+     */
+    def fixOrder(c: Chromosome, k: Int): Unit = {
+      val cs = chromosomes
+      val oldFitness = c.fitness
+
+      c.recalcFitness()
+
+      val newFitness = c.fitness
+
+      if (newFitness < oldFitness) {
+        var j = k
+        var p = j - 1
+        while (p >= 0 && cs(p).fitness > newFitness) {
+          cs(j) = cs(p)
+          j = p
+          p -= 1
+        }
+        cs(j) = c
+      } else if (newFitness > oldFitness) {
+        var j = k
+        var n = j + 1
+        while (n < cs.length && cs(n).fitness < newFitness) {
+          cs(j) = cs(n)
+          j = n
+          n += 1
+        }
+        cs(j) = c
+      }
+    }
+  }
+
+  /*
+   * A Chromosome is a candidate TSP tour.
+   */
+  private final class Chromosome(length: Int, random: RNG)
+      extends Comparable[Chromosome] {
+
+    /* Index of cities in tour order */
+    val alleles = new Array[Int](length)
+
+    /* Total tour length */
+    var fitness = 0
+
+    /*
+     * Initializes to random tour.
+     */
+    for (i <- 0 until length)
+      alleles(i) = i
+
+    for (i <- (length - 1) until 0 by -1) {
+      val idx = (random.next() & 0x7fffffff) % alleles.length
+      val tmp = alleles(i)
+      alleles(i) = alleles(idx)
+      alleles(idx) = tmp
+    }
+
+    recalcFitness()
+
+    def compareTo(x: Chromosome): Int = { // to enable sorting
+      val xf = x.fitness
+      val f = fitness
+      if (f == xf) 0
+      else if (f < xf) -1
+      else 1
+    }
+
+    def recalcFitness(): Unit = {
+      val a = alleles
+      val len = a.length
+      var p = a(0)
+      var f: Long = cities.distanceBetween(a(len - 1), p) // Avoid Int overflow
+
+      for (i <- 1 until len) {
+        val n = a(i)
+        // SN: be stricter than JSR-166 about detecting overflow.
+        f = Math.addExact(f, cities.distanceBetween(p, n))
+        p = n
+      }
+
+      fitness = (f / len).toInt
+    }
+
+    /*
+     * Returns tour length for points scaled in [0, 1).
+     */
+    def unitTourLength(): Double = {
+      val a = alleles
+      val len = a.length
+      var p = a(0)
+      var f = cities.unitDistanceBetween(a(len - 1), p)
+
+      for (i <- 1 until len) {
+        val n = a(i)
+        f += cities.unitDistanceBetween(p, n)
+        p = n
+      }
+
+      f
+    }
+
+    /*
+     * Checks that this tour visits each city.
+     */
+    def validate(): Unit = {
+      val len = alleles.length
+      val used = new Array[Boolean](len)
+
+      for (i <- 0 until len)
+        used(alleles(i)) = true
+
+      for (i <- 0 until len)
+        if (!used(i))
+          throw new Error("Bad tour")
+    }
+  }
+
+  /*
+   * A Strand is a random sub-sequence of a Chromosome.  Each subpop
+   * creates only one strand, and then trades it with others,
+   * refilling it on each iteration.
+   */
+  private final class Strand(length: Int) {
+    final val alleles = new Array[Int](length)
+    var strandLength = 0
+  }
+
+  /*
+   * A collection of (x,y) points that represent cities.
+   */
+  private final class CitySet(n: Int) {
+    final val length = n
+    final val xPts = new Array[Int](n)
+    final val yPts = new Array[Int](n)
+    final val distances = Array.ofDim[Int](n, n)
+
+    val random = new RNG()
+
+    for (i <- 0 until n) {
+      xPts(i) = (random.next() & 0x7fffffff)
+      yPts(i) = (random.next() & 0x7fffffff)
+    }
+
+    for (i <- 0 until n) {
+      for (j <- 0 until n) {
+        val dx = xPts(i).toDouble - xPts(j).toDouble
+        val dy = yPts(i).toDouble - yPts(j).toDouble
+        val dd = Math.hypot(dx, dy) / 2.0
+        val ld = Math.round(dd)
+        distances(i)(j) =
+          if (ld >= Integer.MAX_VALUE) Integer.MAX_VALUE
+          else ld.toInt
+      }
+    }
+
+    /*
+     * Returns the cached distance between a pair of cities.
+     */
+    def distanceBetween(i: Int, j: Int): Int =
+      distances(i)(j)
+
+    // Scale ints to doubles in [0,1)
+    private final val PSCALE = 0x80000000L.toDouble
+
+    /*
+     * Returns distance for points scaled in [0,1). This simplifies
+     * checking results.  The expected optimal TSP for random
+     * points is believed to be around 0.76 * sqrt(N). For papers
+     * discussing this, see
+     * http://www.densis.fee.unicamp.br/~moscato/TSPBIB_home.html
+     */
+    def unitDistanceBetween(i: Int, j: Int): Double = {
+      val dx = (xPts(i).toDouble - xPts(j).toDouble) / PSCALE
+      val dy = (yPts(i).toDouble - yPts(j).toDouble) / PSCALE
+      Math.hypot(dx, dy)
+    }
+  }
+
+  /*
+   * Cheap XorShift random number generator
+   */
+  private final class RNG(private var seed: Int) {
+    /* Seed generator for XorShift RNGs */
+    def this() = this((new Random()).nextInt | 1)
+
+    def next(): Int = {
+      var x = seed
+      x ^= x << 6
+      x ^= x >>> 21
+      x ^= x << 7
+      seed = x
+      x
+    }
+  }
+
+  private final class ProgressMonitor(pop: Population) extends Thread {
+    override def run(): Unit = {
+      var time = 0.0
+      try {
+        while (!Thread.interrupted()) {
+          Thread.sleep(SNAPSHOT_RATE)
+          time += SNAPSHOT_RATE
+          pop.printSnapshot(time / 1000.0)
+        }
+      } catch {
+        case e: InterruptedException => {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
TFix #4841

Port JSR-166 `java.util.concurrent.Exchanger` class, its unit-test, and a manual stress test.

The checkbox in SN Issue  #3165 can be ticked closed after this PR merges.

`ExchangeTest` is carefully crafted so that assertion failures in separate thread
`run()` methods cause CI to fail. This was not true in a straight forward port of the JSR-166
tests. One could and did get false positive passing CI runs, where the failing traceback was
revealed only in the log file.
<hr>

This PR differs from PR #4861 in that this PR stays close to the JSR-166 .java source and is lock free. The earlier PR uses a lock which defeats the purpose.

<hr>
This PR contains a manual stress test `testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala`.
When compiled mode=release-fast, that test reveals GC problems to be described in SN Issue #4871.
When compiled mode=debug, it passes approx 4 hours of cpu intensive testing, 50 repetitions without
a GC crash. I tested shorter runs and the SN variant provides results equivalent to both the .java and 
Scala JVM runs.

