### PR TITLE
[nscplugin] Fix support for -Yfuture-lazy-vals in Scala 3.3.8

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -4,7 +4,7 @@ import dotty.tools._
 import dotty.tools.dotc._
 import dotty.tools.dotc.ast.tpd._
 import dotty.tools.dotc.config.*
-import dotty.tools.dotc.config.Settings
+import dotty.tools.dotc.config.Settings.Setting
 import scala.annotation.{threadUnsafe => tu}
 
 // This helper class is responsible for rewriting calls to scala.runtime.LazyVals with
@@ -41,7 +41,7 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
             None
           }
           .get
-          .asInstanceOf[Settings.Setting[Boolean]]
+          .asInstanceOf[Setting[Boolean]]
           .value
       case SpecificScalaVersion(3, minor, _, _) => minor >= 8
       case _                                    => false

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -24,10 +24,27 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
 
   def defn(using Context) = LazyValsDefns.get
 
-  private val compilerUsesVarHandles = ScalaVersion.current match {
-    case SpecificScalaVersion(3, minor, _, _) => minor >= 8
-    case _                                    => false
-  }
+  lazy val currentScalaVersion = ScalaVersion
+    .parse(Properties.versionNumberString) // Scala 3.1+ support
+    .toOption
+    .orElse(Some(ScalaVersion.current)) // Scala 3.8+ native
+
+  private def compilerUsesVarHandles(using Context) = currentScalaVersion
+    .exists {
+      case SpecificScalaVersion(3, 3, patch, _) if patch >= 8 =>
+        // For source compatibility we need cannot refer to the setting directlly, defined only in Scala 3.3 series starting with 3.3.8
+        ctx.settings.allSettings
+          .find(_.name == "-Yfuture-lazy-vals")
+          .orElse {
+            report.error("expected -Yfuture-lazy-vals setting not found")
+            None
+          }
+          .get
+          .asInstanceOf[Settings.Setting[Boolean]]
+          .value
+      case SpecificScalaVersion(3, minor, _, _) => minor >= 8
+      case _                                    => false
+    }
 
   private def isLazyFieldOffset(name: Name) =
     name.startsWith(nme.LAZY_FIELD_OFFSET.toString)
@@ -35,7 +52,7 @@ class AdaptLazyVals(defnNir: NirDefinitions) {
   private def isLazyFieldHandle(name: Name) =
     CompilerCompat.LazyValHandleNameCompat.exists(name.is(_))
 
-  private def isLazyFieldStore(name: Name) =
+  private def isLazyFieldStore(name: Name)(using Context) =
     if compilerUsesVarHandles then isLazyFieldHandle(name)
     else isLazyFieldOffset(name)
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -4,6 +4,7 @@ import dotty.tools._
 import dotty.tools.dotc._
 import dotty.tools.dotc.ast.tpd._
 import dotty.tools.dotc.config.*
+import dotty.tools.dotc.config.Settings
 import scala.annotation.{threadUnsafe => tu}
 
 // This helper class is responsible for rewriting calls to scala.runtime.LazyVals with

--- a/nscplugin/src/test/scala-3/scala/NativeCompilerTest.scala
+++ b/nscplugin/src/test/scala-3/scala/NativeCompilerTest.scala
@@ -3,6 +3,7 @@ package org.scalanative
 import java.nio.file.Files
 
 import org.junit.Assert._
+import org.junit.Assume._
 import org.junit.Test
 
 import scala.scalanative.api._
@@ -227,3 +228,33 @@ class NativeCompilerTest:
           |}
           |""".stripMargin
   )
+
+  @Test def issue4869(): Unit =
+    assumeTrue(
+      "Scala 3.3 LTS specific",
+      sys.props
+        .get("scalanative.scalaversion")
+        .map(_.split("[\\.-]").take(3).map(_.toInt))
+        .exists {
+          case Array(3, 3, patch) => patch >= 8
+          case _                  => false
+        }
+    )
+    assumeTrue(
+      "JDK 9+ specific",
+      sys.props
+        .get("java.specification.version")
+        .flatMap(_.toIntOption)
+        .exists(_ >= 9)
+    )
+    compileAll(scalacOptions = Seq("-release:9", "-Yfuture-lazy-vals"))(
+      "Test.scala" ->
+        s"""|trait A:
+            |  def b: String
+            |
+            |object A:
+            |  def a(s: String): A = new A {
+            |    override lazy val b: String = s
+            |  }
+            |""".stripMargin
+    )

--- a/nscplugin/src/test/scala-3/scala/NativeCompilerTest.scala
+++ b/nscplugin/src/test/scala-3/scala/NativeCompilerTest.scala
@@ -20,14 +20,19 @@ class NativeCompilerTest:
     }
   }
 
-  def compileAll(sources: (String, String)*): Unit = {
+  def compileAll(sources: (String, String)*): Unit =
+    compileAll(scalacOptions = Nil)(sources: _*)
+
+  def compileAll(
+      scalacOptions: Seq[String] = Nil
+  )(sources: (String, String)*): Unit = {
     Scope { implicit in =>
       val outDir = Files.createTempDirectory("native-test-out")
       val compiler = scalanative.NIRCompiler.getCompiler(outDir)
       val sourcesDir = scalanative.NIRCompiler.writeSources(sources.toMap)
       val dir = VirtualDirectory.real(outDir)
 
-      try scalanative.NIRCompiler(_.compile(sourcesDir))
+      try scalanative.NIRCompiler(_.compile(sourcesDir, scalacOptions.toArray))
       catch {
         case ex: CompilationFailedException =>
           fail(s"Failed to compile source: $ex")

--- a/nscplugin/src/test/scala-3/scala/NativeCompilerTest.scala
+++ b/nscplugin/src/test/scala-3/scala/NativeCompilerTest.scala
@@ -229,7 +229,7 @@ class NativeCompilerTest:
           |""".stripMargin
   )
 
-  @Test def issue4869(): Unit =
+  @Test def issue4869(): Unit = {
     assumeTrue(
       "Scala 3.3 LTS specific",
       sys.props
@@ -247,7 +247,7 @@ class NativeCompilerTest:
         .flatMap(_.toIntOption)
         .exists(_ >= 9)
     )
-    compileAll(scalacOptions = Seq("-release:9", "-Yfuture-lazy-vals"))(
+    val testSources = Seq(
       "Test.scala" ->
         s"""|trait A:
             |  def b: String
@@ -258,3 +258,11 @@ class NativeCompilerTest:
             |  }
             |""".stripMargin
     )
+    compileAll(scalacOptions = Seq())(testSources*)
+    compileAll(scalacOptions = Seq("-release:9", "-Yfuture-lazy-vals"))(
+      testSources*
+    )
+    compileAll(scalacOptions = Seq("-release:9", "-Ylegacy-lazy-vals"))(
+      testSources*
+    )
+  }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -147,7 +147,8 @@ object Build {
           Seq(
             "-Dscalanative.nscplugin.jar=" + nscCompilerJar,
             "-Dscalanative.testingcompiler.cp=" + testingCompilerCp,
-            "-Dscalanative.nativeruntime.cp=" + nativelibCp
+            "-Dscalanative.nativeruntime.cp=" + nativelibCp,
+            "-Dscalanative.scalaversion=" + scalaVersion.value
           )
         }
     }

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -38,7 +38,7 @@ object ScalaVersions {
 
   // Tested in scheduled nightly CI to check compiler plugins
   // List maintains only upcoming releases, removed from the list after reaching stable status
-  lazy val scala3RCVersions = List("3.8.4-RC1")
+  lazy val scala3RCVersions = List("3.3.8-RC1", "3.8.4-RC1")
 
   // List of nightly versions can be found here: https://repo.scala-lang.org/ui/native/maven-nightlies/org/scala-lang/scala3-compiler_3
   // or check outputs of `scala -O --version -S 3.nightly`

--- a/scalalib/overrides-3.3.7/scala/runtime/LazyVals.scala.patch
+++ b/scalalib/overrides-3.3.7/scala/runtime/LazyVals.scala.patch
@@ -1,6 +1,6 @@
---- 3.3.8-RC1/scala/runtime/LazyVals.scala
-+++ overrides-3/scala/runtime/LazyVals.scala
-@@ -4,45 +4,14 @@
+--- 3.3.7-RC1/scala/runtime/LazyVals.scala
++++ overrides-3.3/scala/runtime/LazyVals.scala
+@@ -4,44 +4,14 @@
  
  import scala.annotation.*
  
@@ -30,18 +30,17 @@
 -
 -  private[this] val base: Int = {
 -    val processors = java.lang.Runtime.getRuntime.nn.availableProcessors()
--    val rawSize = 8 * processors * processors
--    //find the next power of 2
--    1 << (32 - Integer.numberOfLeadingZeros(rawSize - 1))
+-    8 * processors * processors
 -  }
--  
--  private val mask: Int = base - 1
 -
 -  private[this] val monitors: Array[Object] =
 -    Array.tabulate(base)(_ => new Object)
 -
 -  private def getMonitor(obj: Object, fieldId: Int = 0) = {
--    monitors((java.lang.System.identityHashCode(obj) + fieldId) & mask)
+-    var id = (java.lang.System.identityHashCode(obj) + fieldId) % base
+-
+-    if (id < 0) id += base
+-    monitors(id)
 -  }
 -
    private final val LAZY_VAL_MASK = 3L
@@ -49,7 +48,7 @@
  
    /* ------------- Start of public API ------------- */
  
-@@ -64,6 +33,8 @@
+@@ -63,6 +33,8 @@
       * correct.
       */
      private def writeReplace(): Any = null
@@ -58,7 +57,7 @@
    }
  
    /**
-@@ -87,94 +58,47 @@
+@@ -86,94 +58,47 @@
  
    def STATE(cur: Long, ord: Int): Long = {
      val r = (cur >> (ord * BITS_PER_LAZY_VAL)) & LAZY_VAL_MASK

--- a/testing-compiler-interface/src/main/java/scala/scalanative/api/NIRCompiler.java
+++ b/testing-compiler-interface/src/main/java/scala/scalanative/api/NIRCompiler.java
@@ -18,6 +18,7 @@ public interface NIRCompiler {
 	 *         etc.)
 	 */
     public Path[] compile(String source);
+    public Path[] compile(String source, String[] scalacOptions); 
 
     /**
      * Compiles all the source files in `base` and returns all the files
@@ -28,4 +29,5 @@ public interface NIRCompiler {
      *         etc.)
      */
     public Path[] compile(Path base);
+    public Path[] compile(Path base, String[] scalacOptions);
 }

--- a/testing-compiler/src/main/scala-2/scalanative/NIRCompiler.scala
+++ b/testing-compiler/src/main/scala-2/scalanative/NIRCompiler.scala
@@ -18,22 +18,38 @@ class NIRCompiler(outputDir: Path) extends api.NIRCompiler {
 
   def this() = this(Files.createTempDirectory("scala-native-target"))
 
-  override def compile(code: String): Array[Path] = {
-    val source = new BatchSourceFile(NoFile, code)
-    compile(Seq(source)).toArray
-  }
+  override def compile(code: String): Array[Path] =
+    compile(code, Array.empty[String])
 
-  override def compile(base: Path): Array[Path] = {
+  override def compile(
+      code: String,
+      scalacOptions: Array[String]
+  ): Array[Path] = {
+    val source = new BatchSourceFile(NoFile, code)
+    compile(Seq(source), scalacOptions).toArray
+  }
+  override def compile(base: Path): Array[Path] =
+    compile(base, Array.empty[String])
+
+  override def compile(
+      base: Path,
+      scalacOptions: Array[String]
+  ): Array[Path] = {
     val sources = getFiles(base.toFile, _.getName endsWith ".scala")
     val sourceFiles = sources map { s =>
       val abstractFile = AbstractFile.getFile(s)
       new BatchSourceFile(abstractFile)
     }
-    compile(sourceFiles).toArray
+    compile(sourceFiles, scalacOptions).toArray
   }
 
-  private def compile(sources: Seq[SourceFile]): Seq[Path] = {
-    val global = getCompiler(options = ScalaNative)
+  private def compile(
+      sources: Seq[SourceFile],
+      scalacOptions: Seq[String]
+  ): Seq[Path] = {
+    val options: List[CompilerOption] =
+      ScalaNative :: scalacOptions.map(new CompilerOption(_)).toList
+    val global = getCompiler(options: _*)
     import global._
     val run = new Run
     run.compileSources(sources.toList)

--- a/testing-compiler/src/main/scala-3/scalanative/NIRCompiler.scala
+++ b/testing-compiler/src/main/scala-3/scalanative/NIRCompiler.scala
@@ -18,6 +18,12 @@ class NIRCompiler(outputDir: Path) extends api.NIRCompiler {
   def this() = this(Files.createTempDirectory("scala-native-target"))
 
   override def compile(code: String): Array[Path] = {
+    compile(code, Array.empty[String])
+  }
+  override def compile(
+      code: String,
+      scalacOptions: Array[String]
+  ): Array[Path] = {
     val file = AbstractFile.getFile(
       File.createTempFile("scala-native-input", ".scala").toPath
     )
@@ -25,19 +31,27 @@ class NIRCompiler(outputDir: Path) extends api.NIRCompiler {
     output.write(code.getBytes(StandardCharsets.UTF_8))
     output.close()
     val source = SourceFile(file, io.Codec.UTF8)
-    compile(Seq(source)).toArray
+    compile(Seq(source), scalacOptions).toArray
   }
 
-  override def compile(base: Path): Array[Path] = {
+  override def compile(base: Path): Array[Path] =
+    compile(base, Array.empty[String])
+  override def compile(
+      base: Path,
+      scalacOptions: Array[String]
+  ): Array[Path] = {
     val sources = getFiles(base.toFile, _.getName.endsWith(".scala"))
     val sourceFiles = sources.map { s =>
       val abstractFile = AbstractFile.getFile(s.toPath)
       SourceFile(abstractFile, io.Codec.default)
     }
-    compile(sourceFiles).toArray
+    compile(sourceFiles, scalacOptions).toArray
   }
 
-  private def compile(sources: Seq[SourceFile]): Seq[Path] = {
+  private def compile(
+      sources: Seq[SourceFile],
+      scalacOptions: Seq[String]
+  ): Seq[Path] = {
     val outPath = outputDir.toAbsolutePath
     val jarPath = sys.props("scalanative.nscplugin.jar")
     val classpath = List(sys.props("scalanative.nativeruntime.cp"))
@@ -49,7 +63,7 @@ class NIRCompiler(outputDir: Path) extends api.NIRCompiler {
         s"-d $outPath -Xplugin:$jarPath $classpath"
       )
 
-    val args = arguments ++ sources.map(_.file.absolutePath)
+    val args = arguments ++ scalacOptions ++ sources.map(_.file.absolutePath)
     val res = Driver().process(args.toArray, TestReporter(), null)
     res.allErrors.headOption.foreach { error =>
       throw api.CompilationFailedException(error.message)


### PR DESCRIPTION
* Extending testing compiler to that it's possible to pass custom scalacOptions 
* Add Scala 3.3.8-RC1 to the builds 
* Reproduce and fix #4869