### PR TITLE
[runtime] Improvements towards stability of trap-based GC yieldpoints

### DIFF
--- a/docs/contrib/gc-safepoint-trampoline.md
+++ b/docs/contrib/gc-safepoint-trampoline.md
@@ -1,0 +1,51 @@
+# GC safepoint trap and deferred trampoline (Immix / Commix)
+
+This note describes how **trap-based yield points** stop mutator threads for stop-the-world (STW) collection on **POSIX** when `SCALANATIVE_GC_USE_YIELDPOINT_TRAPS` is enabled (Immix or Commix, multithreaded builds). It is aimed at contributors debugging safepoints, signals, or deadlocks.
+
+The design is described in terms of a well-known **polling-page safepoint** idea familiar from JVM implementations (e.g. the **OpenJDK HotSpot** VM). The trap-based yieldpoints are based on https://dl.acm.org/doi/10.1145/2887746.2754187 
+
+## What the mutator does at a yield point
+
+The compiler lowers `scalanative_GC_yield` (when traps are on) to a **volatile load** through the thread-local pointer `scalanative_GC_yieldpoint_trap`. That pointer refers to a small mapping: readable while idle, **`PROT_NONE` while the GC wants a safepoint**, so the load faults.
+
+See `tools/.../AbstractCodeGen.scala` (GC yield lowering) and `gc/shared/YieldPointTrap.c` (`mprotect` arm/disarm).
+
+## Why not call `Synchronizer_yield()` inside the signal handler?
+
+POSIX limits which library calls are **async-signal-safe** inside a signal handler. `Synchronizer_yield()` uses atomics, `sigwait`, and other runtime that is not in that set. Calling it directly from `sigaction` works on many platforms in practice but is fragile.
+
+In that family of VMs, the usual approach is: in the handler, **only** classify the fault, then **resume in normal thread context** at a small stub (or generated entry) that performs the real safepoint work—rather than running the full safepoint logic inside the async-signal handler.
+
+Scala Native follows the same *idea* on POSIX (with its own `ucontext` + assembly trampoline):
+
+1. **`SafepointTrapHandler`** (in `gc/immix/Synchronizer.c` and `gc/commix/Synchronizer.c`) decides whether `SIGSEGV` / `SIGBUS` (macOS) is our trap fault (page match, etc.).
+2. **`scalanative_gc_safepoint_prepare_redirect(uap, mutator)`** (`gc/shared/SafepointPollTrampoline.c`) stores the faulting **instruction pointer** in `MutatorThread.safepointResumePc` and sets the **`ucontext` PC** to **`scalanative_gc_safepoint_poll_trampoline`**.
+3. When the kernel returns from the signal, the thread runs the **assembly trampoline**, which saves registers, calls **`Synchronizer_yield()`** via `scalanative_gc_safepoint_poll_run_yield`, restores registers, and **branches to `safepointResumePc`**. By then the trap is disarmed, so the retried volatile load succeeds.
+
+Windows uses the **vectored exception** path and still runs `Synchronizer_yield()` from the filter (no `ucontext`); the trampoline header stubs `prepare_redirect` to a no-op there.
+
+## Source layout
+
+| Piece | Role |
+| --- | --- |
+| `gc/shared/SafepointPollTrampoline.h` | Public C API between synchronizer and trampoline |
+| `gc/shared/SafepointPollTrampoline.c` | `ucontext` PC get/set, `prepare_redirect`, small C helpers for the asm |
+| `gc/shared/SafepointPollTrampoline-x86_64.S` | Trampoline: XMM0–15 + GPRs, then yield, resume |
+| `gc/shared/SafepointPollTrampoline-aarch64.S` | Trampoline: Q0–Q7 + X0–X30, then yield, resume |
+| `gc/immix/Synchronizer.c`, `gc/commix/Synchronizer.c` | Install trap handler; call `prepare_redirect` or fall back to in-handler yield |
+
+## Platform support
+
+- **Redirect + trampoline:** Linux and Apple **x86_64** and **aarch64** (when the preprocessor in `SafepointPollTrampoline.c` defines `SN_UC_GET_PC` / `SN_UC_SET_PC`).
+- **Fallback:** If `prepare_redirect` returns `false` (unsupported OS/arch or missing `ucontext` layout), the handler calls **`Synchronizer_yield()`** directly, as before.
+- **Darwin:** `ucontext.h` requires **`_XOPEN_SOURCE`** before include; `SafepointPollTrampoline.c` defines `_XOPEN_SOURCE` to `700` in the trap build.
+
+## Limitations and future work
+
+- **x86_64:** The trampoline saves **XMM0–15** (128-bit lanes). It does **not** save **YMM/ZMM** upper lanes, **MXCSR**, or x87 state. Poll sites that rely on wider AVX across the fault are theoretically at risk; extending the frame would follow the same pattern.
+- **aarch64:** **Q0–Q7** are saved (typical caller-saved SIMD). **Callee-saved** `d8`–`d15` / `q8`–`q15` follow the AAPCS64 callee rules for the C code we call. Full FP control registers are not saved.
+- **Other Unixes** (e.g. *BSD) may need extra `ucontext` field mappings to enable redirect; until then they use the in-handler fallback.
+
+## Related user-facing behavior
+
+STW timeouts and warnings (`SCALANATIVE_GC_SYNC_TIMEOUT_MS`, etc.) are documented in [Runtime](../user/runtime.md) under Immix/Commix. Trap faults are one way threads reach a safepoint; threads blocked in native code without `@blocking` may still never fault and can trigger those diagnostics.

--- a/nativelib/src/main/resources/scala-native/gc/commix/MutatorThread.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/MutatorThread.c
@@ -13,6 +13,10 @@
 #include <signal.h>
 #endif
 
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+#include "shared/YieldPointTrap.h"
+#endif
+
 static rwlock_t threadListsModificationLock;
 
 void MutatorThread_init(Field_t *stackbottom) {
@@ -51,6 +55,12 @@ void MutatorThread_init(Field_t *stackbottom) {
     self->thread = pthread_self();
 #endif
 
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+    self->yieldpointTrap = YieldPointTrap_init();
+    YieldPointTrap_disarm(self->yieldpointTrap);
+    scalanative_GC_yieldpoint_trap = self->yieldpointTrap;
+#endif
+
     MutatorThread_switchState(self, GC_MutatorThreadState_Managed);
     Allocator_Init(&self->allocator, &blockAllocator, heap.bytemap,
                    heap.blockMetaStart, heap.heapStart);
@@ -81,6 +91,10 @@ void MutatorThread_delete(MutatorThread *self) {
     CloseHandle(self->wakeupEvent);
 #endif
 #endif // WIN32
+
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+    YieldPointTrap_free(self->yieldpointTrap);
+#endif
 
     free(self);
 }

--- a/nativelib/src/main/resources/scala-native/gc/commix/MutatorThread.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/MutatorThread.h
@@ -30,6 +30,11 @@ typedef struct {
     thread_t thread; // pthread_t - used for liveness check and signals
 #endif
     ThreadInfo *threadInfo;
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+    /* Per-mutator trap cell (distinct VM page); mirrored in TLS
+     * scalanative_GC_yieldpoint_trap for generated yieldpoint loads. */
+    void **yieldpointTrap;
+#endif
 } MutatorThread;
 
 typedef struct MutatorThreadNode {

--- a/nativelib/src/main/resources/scala-native/gc/commix/MutatorThread.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/MutatorThread.h
@@ -9,6 +9,7 @@
 #include <shared/ThreadUtil.h>
 #include "immix_commix/RegistersCapture.h"
 #include "nativeThreadTLS.h"
+#include <stdint.h>
 
 typedef struct {
     _Atomic(GC_MutatorThreadState) state;
@@ -34,6 +35,8 @@ typedef struct {
     /* Per-mutator trap cell (distinct VM page); mirrored in TLS
      * scalanative_GC_yieldpoint_trap for generated yieldpoint loads. */
     void **yieldpointTrap;
+    /* Faulting PC when using deferred safepoint trampoline (POSIX). */
+    uintptr_t safepointResumePc;
 #endif
 } MutatorThread;
 

--- a/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
@@ -85,12 +85,23 @@ static void Synchronizer_WaitForResumption(MutatorThread *selfThread);
 #include <errhandlingapi.h>
 #else
 #include <pthread.h>
-#include <sys/mman.h>
 #include <sys/time.h>
 #include <unistd.h>
 #endif
 
-void **scalanative_GC_yieldpoint_trap;
+SN_ThreadLocal void **scalanative_GC_yieldpoint_trap;
+
+static void YieldPointTrap_armAllMutators(void) {
+    MutatorThreads_foreach(mutatorThreads, node) {
+        YieldPointTrap_arm(node->value->yieldpointTrap);
+    }
+}
+
+static void YieldPointTrap_disarmAllMutators(void) {
+    MutatorThreads_foreach(mutatorThreads, node) {
+        YieldPointTrap_disarm(node->value->yieldpointTrap);
+    }
+}
 
 #ifdef _WIN32
 static LONG WINAPI SafepointTrapHandler(EXCEPTION_POINTERS *ex) {
@@ -98,7 +109,7 @@ static LONG WINAPI SafepointTrapHandler(EXCEPTION_POINTERS *ex) {
         switch (ex->ExceptionRecord->ExceptionCode) {
         case EXCEPTION_ACCESS_VIOLATION:
             ULONG_PTR addr = ex->ExceptionRecord->ExceptionInformation[1];
-            if ((void *)addr == scalanative_GC_yieldpoint_trap) {
+            if ((void *)addr == (void *)scalanative_GC_yieldpoint_trap) {
                 Synchronizer_yield();
                 return EXCEPTION_CONTINUE_EXECUTION;
             }
@@ -124,8 +135,16 @@ static sigset_t threadWakupSignals = {};
 
 static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
     int old_errno = errno;
-    if (signal == SAFEPOINT_TRAP_SIGNAL &&
-        siginfo->si_addr == scalanative_GC_yieldpoint_trap) {
+    void *trapCell = NULL;
+    MutatorThread *self = currentMutatorThread;
+    if (self != NULL) {
+        trapCell = (void *)self->yieldpointTrap;
+    }
+    if (trapCell == NULL) {
+        trapCell = (void *)scalanative_GC_yieldpoint_trap;
+    }
+    if (signal == SAFEPOINT_TRAP_SIGNAL && trapCell != NULL &&
+        siginfo->si_addr == trapCell) {
         Synchronizer_yield();
         errno = old_errno;
         return;
@@ -216,11 +235,11 @@ static void Synchronizer_ResumeThread(MutatorThread *thread) {
 static void Synchronizer_SuspendThreads(void) {
     atomic_store_explicit(&Synchronizer_stopThreads, true,
                           memory_order_release);
-    YieldPointTrap_arm(scalanative_GC_yieldpoint_trap);
+    YieldPointTrap_armAllMutators();
 }
 
 static void Synchronizer_ResumeThreads(void) {
-    YieldPointTrap_disarm(scalanative_GC_yieldpoint_trap);
+    YieldPointTrap_disarmAllMutators();
     atomic_store_explicit(&Synchronizer_stopThreads, false,
                           memory_order_release);
     MutatorThreads_foreach(mutatorThreads, node) {
@@ -292,8 +311,6 @@ static void Synchronizer_ResumeThreads(void) {
 void Synchronizer_init(void) {
     mutex_init(&synchronizerLock);
 #ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
-    scalanative_GC_yieldpoint_trap = YieldPointTrap_init();
-    YieldPointTrap_disarm(scalanative_GC_yieldpoint_trap);
     SetupYieldPointTrapHandler();
 #else
 #ifdef _WIN32

--- a/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
@@ -81,6 +81,7 @@ static void Synchronizer_WaitForResumption(MutatorThread *selfThread);
 #include "shared/YieldPointTrap.h"
 #include "StackTrace.h"
 #include <errno.h>
+#include <stdint.h>
 #ifdef _WIN32
 #include <errhandlingapi.h>
 #else
@@ -124,14 +125,40 @@ static LONG WINAPI SafepointTrapHandler(EXCEPTION_POINTERS *ex) {
     return EXCEPTION_CONTINUE_SEARCH;
 }
 #else
-#ifdef __APPLE__
-#define SAFEPOINT_TRAP_SIGNAL SIGBUS
-#else
-#define SAFEPOINT_TRAP_SIGNAL SIGSEGV
-#endif
 #define THREAD_WAKEUP_SIGNAL SIGCONT
-static struct sigaction previousSignalHandler = {};
 static sigset_t threadWakupSignals = {};
+static struct sigaction previousSigsegvHandler = {};
+#ifdef __APPLE__
+static struct sigaction previousSigbusHandler = {};
+#endif
+
+static bool isSafepointTrapSignal(int signal) {
+#ifdef __APPLE__
+    return signal == SIGBUS || signal == SIGSEGV;
+#else
+    return signal == SIGSEGV;
+#endif
+}
+
+static bool isTrapFaultAddress(const void *faultAddress, const void *trapCell) {
+    if (faultAddress == NULL || trapCell == NULL) {
+        return false;
+    }
+    uintptr_t pageSize = (uintptr_t)getpagesize();
+    uintptr_t faultPage = ((uintptr_t)faultAddress) / pageSize;
+    uintptr_t trapPage = ((uintptr_t)trapCell) / pageSize;
+    return faultPage == trapPage;
+}
+
+static struct sigaction *previousSignalHandlerFor(int signal) {
+    if (signal == SIGSEGV)
+        return &previousSigsegvHandler;
+#ifdef __APPLE__
+    if (signal == SIGBUS)
+        return &previousSigbusHandler;
+#endif
+    return NULL;
+}
 
 static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
     int old_errno = errno;
@@ -143,24 +170,27 @@ static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
     if (trapCell == NULL) {
         trapCell = (void *)scalanative_GC_yieldpoint_trap;
     }
-    if (signal == SAFEPOINT_TRAP_SIGNAL && trapCell != NULL &&
-        siginfo->si_addr == trapCell) {
+    if (isSafepointTrapSignal(signal) && trapCell != NULL &&
+        isTrapFaultAddress(siginfo->si_addr, trapCell)) {
         Synchronizer_yield();
         errno = old_errno;
         return;
     }
 
     // Try call other handlers
-    if (previousSignalHandler.sa_handler != NULL) {
-        void *handler = previousSignalHandler.sa_handler;
+    struct sigaction *previousSignalHandler = previousSignalHandlerFor(signal);
+    if (previousSignalHandler != NULL &&
+        previousSignalHandler->sa_handler != NULL) {
+        void *handler = previousSignalHandler->sa_handler;
         if (handler != SIG_DFL && handler != SIG_IGN && handler != SIG_ERR &&
             handler != SafepointTrapHandler) {
-            if (previousSignalHandler.sa_flags & SA_SIGINFO) {
+            if (previousSignalHandler->sa_flags & SA_SIGINFO) {
                 void (*sigInfoHandler)(int, siginfo_t *, void *) = (void (*)(
-                    int, siginfo_t *, void *))previousSignalHandler.sa_handler;
+                    int, siginfo_t *,
+                    void *))previousSignalHandler->sa_handler;
                 return sigInfoHandler(signal, siginfo, uap);
             } else {
-                return previousSignalHandler.sa_handler(signal);
+                return previousSignalHandler->sa_handler(signal);
             }
         }
         return;
@@ -189,11 +219,20 @@ static void SetupYieldPointTrapHandler(void) {
     sigemptyset(&sa.sa_mask);
     sa.sa_sigaction = &SafepointTrapHandler;
     sa.sa_flags = SA_SIGINFO | SA_RESTART;
-    if (sigaction(SAFEPOINT_TRAP_SIGNAL, &sa, &previousSignalHandler) == -1) {
-        GC_LOG_ERROR("Cannot setup safepoint synchronization handler: %s",
+    if (sigaction(SIGSEGV, &sa, &previousSigsegvHandler) == -1) {
+        GC_LOG_ERROR("Cannot setup safepoint synchronization handler for "
+                     "SIGSEGV: %s",
                      strerror(errno));
         exit(errno);
     }
+#ifdef __APPLE__
+    if (sigaction(SIGBUS, &sa, &previousSigbusHandler) == -1) {
+        GC_LOG_ERROR("Cannot setup safepoint synchronization handler for "
+                     "SIGBUS: %s",
+                     strerror(errno));
+        exit(errno);
+    }
+#endif
 #endif
 }
 

--- a/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
@@ -235,6 +235,7 @@ static void Synchronizer_ResumeThread(MutatorThread *thread) {
 static void Synchronizer_SuspendThreads(void) {
     atomic_store_explicit(&Synchronizer_stopThreads, true,
                           memory_order_release);
+    YieldPointTrap_resetTaskMachBadAccessPorts();
     YieldPointTrap_armAllMutators();
 }
 
@@ -393,6 +394,9 @@ bool Synchronizer_acquire(void) {
                             "(%.1fs elapsed)",
                             activeThreads, elapsed / 1000.0);
                 Synchronizer_diagnoseStuckThreads(self, activeThreads);
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+                YieldPointTrap_resetTaskMachBadAccessPorts();
+#endif
             }
 
             // Check for timeout (0 = disabled)

--- a/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Synchronizer.c
@@ -77,8 +77,14 @@ static void Synchronizer_WaitForResumption(MutatorThread *selfThread);
 // =============================================================================
 // Uses signal handlers for low-overhead yieldpoints
 // See: https://dl.acm.org/doi/10.1145/2887746.2754187
+//
+// POSIX: On a matching fault, prefer scalanative_gc_safepoint_prepare_redirect
+// so Synchronizer_yield runs from the asm trampoline (normal context), not
+// inside the signal handler. See docs/contrib/gc-safepoint-trampoline.md.
+// Windows: still yields from the exception filter.
 #ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
 #include "shared/YieldPointTrap.h"
+#include "shared/SafepointPollTrampoline.h"
 #include "StackTrace.h"
 #include <errno.h>
 #include <stdint.h>
@@ -172,7 +178,13 @@ static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
     }
     if (isSafepointTrapSignal(signal) && trapCell != NULL &&
         isTrapFaultAddress(siginfo->si_addr, trapCell)) {
+#ifdef _WIN32
         Synchronizer_yield();
+#else
+        if (!scalanative_gc_safepoint_prepare_redirect(uap, self)) {
+            Synchronizer_yield();
+        }
+#endif
         errno = old_errno;
         return;
     }
@@ -186,8 +198,7 @@ static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
             handler != SafepointTrapHandler) {
             if (previousSignalHandler->sa_flags & SA_SIGINFO) {
                 void (*sigInfoHandler)(int, siginfo_t *, void *) = (void (*)(
-                    int, siginfo_t *,
-                    void *))previousSignalHandler->sa_handler;
+                    int, siginfo_t *, void *))previousSignalHandler->sa_handler;
                 return sigInfoHandler(signal, siginfo, uap);
             } else {
                 return previousSignalHandler->sa_handler(signal);

--- a/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.c
@@ -13,6 +13,10 @@
 #include <signal.h>
 #endif
 
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+#include "shared/YieldPointTrap.h"
+#endif
+
 static mutex_t threadListsModificationLock;
 
 void MutatorThread_init(Field_t *stackbottom) {
@@ -50,6 +54,12 @@ void MutatorThread_init(Field_t *stackbottom) {
     self->thread = pthread_self();
 #endif
 
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+    self->yieldpointTrap = YieldPointTrap_init();
+    YieldPointTrap_disarm(self->yieldpointTrap);
+    scalanative_GC_yieldpoint_trap = self->yieldpointTrap;
+#endif
+
     MutatorThread_switchState(self, GC_MutatorThreadState_Managed);
     Allocator_Init(&self->allocator, &blockAllocator, heap.bytemap,
                    heap.blockMetaStart, heap.heapStart);
@@ -78,6 +88,10 @@ void MutatorThread_delete(MutatorThread *self) {
     CloseHandle(self->wakeupEvent);
 #endif
 #endif // WIN32
+
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+    YieldPointTrap_free(self->yieldpointTrap);
+#endif
 
     free(self);
 }

--- a/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.h
@@ -7,6 +7,7 @@
 #include <stdatomic.h>
 #include <stdbool.h>
 #include "nativeThreadTLS.h"
+#include <stdint.h>
 
 typedef struct {
     _Atomic(GC_MutatorThreadState) state;
@@ -32,6 +33,8 @@ typedef struct {
     ThreadInfo *threadInfo;
 #ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
     void **yieldpointTrap;
+    /* Faulting PC when using deferred safepoint trampoline (POSIX). */
+    uintptr_t safepointResumePc;
 #endif
 } MutatorThread;
 

--- a/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/MutatorThread.h
@@ -30,6 +30,9 @@ typedef struct {
     LargeAllocator largeAllocator;
 
     ThreadInfo *threadInfo;
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+    void **yieldpointTrap;
+#endif
 } MutatorThread;
 
 typedef struct MutatorThreadNode {

--- a/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
@@ -75,8 +75,14 @@ static void Synchronizer_WaitForResumption(MutatorThread *selfThread);
 // =============================================================================
 // Uses signal handlers for low-overhead yieldpoints
 // See: https://dl.acm.org/doi/10.1145/2887746.2754187
+//
+// POSIX: On a matching fault, prefer scalanative_gc_safepoint_prepare_redirect
+// so Synchronizer_yield runs from the asm trampoline (normal context), not
+// inside the signal handler. See docs/contrib/gc-safepoint-trampoline.md.
+// Windows: still yields from the exception filter.
 #ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
 #include "shared/YieldPointTrap.h"
+#include "shared/SafepointPollTrampoline.h"
 #include "StackTrace.h"
 #include <errno.h>
 #include <stdint.h>
@@ -170,7 +176,13 @@ static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
     }
     if (isSafepointTrapSignal(signal) && trapCell != NULL &&
         isTrapFaultAddress(siginfo->si_addr, trapCell)) {
+#ifdef _WIN32
         Synchronizer_yield();
+#else
+        if (!scalanative_gc_safepoint_prepare_redirect(uap, self)) {
+            Synchronizer_yield();
+        }
+#endif
         errno = old_errno;
         return;
     }
@@ -184,8 +196,7 @@ static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
             handler != SafepointTrapHandler) {
             if (previousSignalHandler->sa_flags & SA_SIGINFO) {
                 void (*sigInfoHandler)(int, siginfo_t *, void *) = (void (*)(
-                    int, siginfo_t *,
-                    void *))previousSignalHandler->sa_handler;
+                    int, siginfo_t *, void *))previousSignalHandler->sa_handler;
                 return sigInfoHandler(signal, siginfo, uap);
             } else {
                 return previousSignalHandler->sa_handler(signal);

--- a/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
@@ -232,6 +232,7 @@ static void Synchronizer_ResumeThread(MutatorThread *thread) {
 static void Synchronizer_SuspendThreads(void) {
     atomic_store_explicit(&Synchronizer_stopThreads, true,
                           memory_order_release);
+    YieldPointTrap_resetTaskMachBadAccessPorts();
     YieldPointTrap_armAllMutators();
 }
 
@@ -390,6 +391,9 @@ bool Synchronizer_acquire(void) {
                             "(%.1fs elapsed)",
                             activeThreads, elapsed / 1000.0);
                 Synchronizer_diagnoseStuckThreads(self, activeThreads);
+#ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
+                YieldPointTrap_resetTaskMachBadAccessPorts();
+#endif
             }
 
             // Check for timeout (0 = disabled)

--- a/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
@@ -83,12 +83,23 @@ static void Synchronizer_WaitForResumption(MutatorThread *selfThread);
 #include <errhandlingapi.h>
 #else
 #include <pthread.h>
-#include <sys/mman.h>
 #include <sys/time.h>
 #include <unistd.h>
 #endif
 
-void **scalanative_GC_yieldpoint_trap;
+SN_ThreadLocal void **scalanative_GC_yieldpoint_trap;
+
+static void YieldPointTrap_armAllMutators(void) {
+    MutatorThreads_foreach(mutatorThreads, node) {
+        YieldPointTrap_arm(node->value->yieldpointTrap);
+    }
+}
+
+static void YieldPointTrap_disarmAllMutators(void) {
+    MutatorThreads_foreach(mutatorThreads, node) {
+        YieldPointTrap_disarm(node->value->yieldpointTrap);
+    }
+}
 
 #ifdef _WIN32
 static LONG WINAPI SafepointTrapHandler(EXCEPTION_POINTERS *ex) {
@@ -96,7 +107,7 @@ static LONG WINAPI SafepointTrapHandler(EXCEPTION_POINTERS *ex) {
         switch (ex->ExceptionRecord->ExceptionCode) {
         case EXCEPTION_ACCESS_VIOLATION:
             ULONG_PTR addr = ex->ExceptionRecord->ExceptionInformation[1];
-            if ((void *)addr == scalanative_GC_yieldpoint_trap) {
+            if ((void *)addr == (void *)scalanative_GC_yieldpoint_trap) {
                 Synchronizer_yield();
                 return EXCEPTION_CONTINUE_EXECUTION;
             }
@@ -122,8 +133,16 @@ static sigset_t threadWakupSignals;
 
 static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
     int old_errno = errno;
-    if (signal == SAFEPOINT_TRAP_SIGNAL &&
-        siginfo->si_addr == scalanative_GC_yieldpoint_trap) {
+    void *trapCell = NULL;
+    MutatorThread *self = currentMutatorThread;
+    if (self != NULL) {
+        trapCell = (void *)self->yieldpointTrap;
+    }
+    if (trapCell == NULL) {
+        trapCell = (void *)scalanative_GC_yieldpoint_trap;
+    }
+    if (signal == SAFEPOINT_TRAP_SIGNAL && trapCell != NULL &&
+        siginfo->si_addr == trapCell) {
         Synchronizer_yield();
         errno = old_errno;
         return;
@@ -213,11 +232,11 @@ static void Synchronizer_ResumeThread(MutatorThread *thread) {
 static void Synchronizer_SuspendThreads(void) {
     atomic_store_explicit(&Synchronizer_stopThreads, true,
                           memory_order_release);
-    YieldPointTrap_arm(scalanative_GC_yieldpoint_trap);
+    YieldPointTrap_armAllMutators();
 }
 
 static void Synchronizer_ResumeThreads(void) {
-    YieldPointTrap_disarm(scalanative_GC_yieldpoint_trap);
+    YieldPointTrap_disarmAllMutators();
     atomic_store_explicit(&Synchronizer_stopThreads, false,
                           memory_order_release);
     MutatorThreads_foreach(mutatorThreads, node) {
@@ -289,8 +308,6 @@ static void Synchronizer_ResumeThreads(void) {
 void Synchronizer_init(void) {
     mutex_init(&synchronizerLock);
 #ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
-    scalanative_GC_yieldpoint_trap = YieldPointTrap_init();
-    YieldPointTrap_disarm(scalanative_GC_yieldpoint_trap);
     SetupYieldPointTrapHandler();
 #else
 #ifdef _WIN32

--- a/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Synchronizer.c
@@ -79,6 +79,7 @@ static void Synchronizer_WaitForResumption(MutatorThread *selfThread);
 #include "shared/YieldPointTrap.h"
 #include "StackTrace.h"
 #include <errno.h>
+#include <stdint.h>
 #ifdef _WIN32
 #include <errhandlingapi.h>
 #else
@@ -122,14 +123,40 @@ static LONG WINAPI SafepointTrapHandler(EXCEPTION_POINTERS *ex) {
     return EXCEPTION_CONTINUE_SEARCH;
 }
 #else
-#ifdef __APPLE__
-#define SAFEPOINT_TRAP_SIGNAL SIGBUS
-#else
-#define SAFEPOINT_TRAP_SIGNAL SIGSEGV
-#endif
 #define THREAD_WAKEUP_SIGNAL SIGCONT
-static struct sigaction previousSignalHandler = {};
 static sigset_t threadWakupSignals;
+static struct sigaction previousSigsegvHandler = {};
+#ifdef __APPLE__
+static struct sigaction previousSigbusHandler = {};
+#endif
+
+static bool isSafepointTrapSignal(int signal) {
+#ifdef __APPLE__
+    return signal == SIGBUS || signal == SIGSEGV;
+#else
+    return signal == SIGSEGV;
+#endif
+}
+
+static bool isTrapFaultAddress(const void *faultAddress, const void *trapCell) {
+    if (faultAddress == NULL || trapCell == NULL) {
+        return false;
+    }
+    uintptr_t pageSize = (uintptr_t)getpagesize();
+    uintptr_t faultPage = ((uintptr_t)faultAddress) / pageSize;
+    uintptr_t trapPage = ((uintptr_t)trapCell) / pageSize;
+    return faultPage == trapPage;
+}
+
+static struct sigaction *previousSignalHandlerFor(int signal) {
+    if (signal == SIGSEGV)
+        return &previousSigsegvHandler;
+#ifdef __APPLE__
+    if (signal == SIGBUS)
+        return &previousSigbusHandler;
+#endif
+    return NULL;
+}
 
 static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
     int old_errno = errno;
@@ -141,24 +168,27 @@ static void SafepointTrapHandler(int signal, siginfo_t *siginfo, void *uap) {
     if (trapCell == NULL) {
         trapCell = (void *)scalanative_GC_yieldpoint_trap;
     }
-    if (signal == SAFEPOINT_TRAP_SIGNAL && trapCell != NULL &&
-        siginfo->si_addr == trapCell) {
+    if (isSafepointTrapSignal(signal) && trapCell != NULL &&
+        isTrapFaultAddress(siginfo->si_addr, trapCell)) {
         Synchronizer_yield();
         errno = old_errno;
         return;
     }
 
     // Try call other handlers
-    if (previousSignalHandler.sa_handler != NULL) {
-        void *handler = previousSignalHandler.sa_handler;
+    struct sigaction *previousSignalHandler = previousSignalHandlerFor(signal);
+    if (previousSignalHandler != NULL &&
+        previousSignalHandler->sa_handler != NULL) {
+        void *handler = previousSignalHandler->sa_handler;
         if (handler != SIG_DFL && handler != SIG_IGN && handler != SIG_ERR &&
             handler != SafepointTrapHandler) {
-            if (previousSignalHandler.sa_flags & SA_SIGINFO) {
+            if (previousSignalHandler->sa_flags & SA_SIGINFO) {
                 void (*sigInfoHandler)(int, siginfo_t *, void *) = (void (*)(
-                    int, siginfo_t *, void *))previousSignalHandler.sa_handler;
+                    int, siginfo_t *,
+                    void *))previousSignalHandler->sa_handler;
                 return sigInfoHandler(signal, siginfo, uap);
             } else {
-                return previousSignalHandler.sa_handler(signal);
+                return previousSignalHandler->sa_handler(signal);
             }
         }
         return;
@@ -186,11 +216,20 @@ static void SetupYieldPointTrapHandler(void) {
     sigemptyset(&sa.sa_mask);
     sa.sa_sigaction = &SafepointTrapHandler;
     sa.sa_flags = SA_SIGINFO | SA_RESTART;
-    if (sigaction(SAFEPOINT_TRAP_SIGNAL, &sa, &previousSignalHandler) == -1) {
-        GC_LOG_ERROR("Cannot setup safepoint synchronization handler: %s",
+    if (sigaction(SIGSEGV, &sa, &previousSigsegvHandler) == -1) {
+        GC_LOG_ERROR("Cannot setup safepoint synchronization handler for "
+                     "SIGSEGV: %s",
                      strerror(errno));
         exit(errno);
     }
+#ifdef __APPLE__
+    if (sigaction(SIGBUS, &sa, &previousSigbusHandler) == -1) {
+        GC_LOG_ERROR("Cannot setup safepoint synchronization handler for "
+                     "SIGBUS: %s",
+                     strerror(errno));
+        exit(errno);
+    }
+#endif
 #endif
 }
 

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/Synchronizer.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/Synchronizer.h
@@ -6,8 +6,8 @@
 
 extern atomic_bool Synchronizer_stopThreads;
 #ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
-// Should be defined in implementing source
-extern void **scalanative_GC_yieldpoint_trap;
+#include "shared/ThreadUtil.h"
+extern SN_ThreadLocal void **scalanative_GC_yieldpoint_trap;
 #endif
 
 void Synchronizer_init();

--- a/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline-aarch64.S
+++ b/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline-aarch64.S
@@ -1,0 +1,91 @@
+/* clang-format off */
+/*
+ * POSIX aarch64: same role as SafepointPollTrampoline-x86_64.S.
+ * Saves Q0–Q7 and X0–X30, calls run_yield + load_resume_pc, br to resume.
+ * See docs/contrib/gc-safepoint-trampoline.md.
+ */
+#if defined(SCALANATIVE_MULTITHREADING_ENABLED) &&                              \
+    defined(SCALANATIVE_GC_USE_YIELDPOINT_TRAPS) && !defined(_WIN32) &&         \
+    defined(__aarch64__) && (defined(__linux__) || defined(__APPLE__))
+
+/* q0–q7 caller-saved (128 B) + x0–x30 + resume + pad */
+#define SFPT_FRAME 384
+
+.text
+.balign 16
+
+#if defined(__APPLE__)
+#    define RUN_YIELD _scalanative_gc_safepoint_poll_run_yield
+#    define LOAD_RESUME _scalanative_gc_safepoint_load_resume_pc
+.globl scalanative_gc_safepoint_poll_trampoline
+.globl _scalanative_gc_safepoint_poll_trampoline
+scalanative_gc_safepoint_poll_trampoline:
+_scalanative_gc_safepoint_poll_trampoline:
+#else
+#    define RUN_YIELD scalanative_gc_safepoint_poll_run_yield
+#    define LOAD_RESUME scalanative_gc_safepoint_load_resume_pc
+.globl scalanative_gc_safepoint_poll_trampoline
+.type scalanative_gc_safepoint_poll_trampoline, @function
+scalanative_gc_safepoint_poll_trampoline:
+#endif
+    sub sp, sp, #SFPT_FRAME
+
+    stp q0, q1, [sp, #0]
+    stp q2, q3, [sp, #32]
+    stp q4, q5, [sp, #64]
+    stp q6, q7, [sp, #96]
+
+    stp x0, x1, [sp, #128]
+    stp x2, x3, [sp, #144]
+    stp x4, x5, [sp, #160]
+    stp x6, x7, [sp, #176]
+    stp x8, x9, [sp, #192]
+    stp x10, x11, [sp, #208]
+    stp x12, x13, [sp, #224]
+    stp x14, x15, [sp, #240]
+    stp x16, x17, [sp, #256]
+    stp x18, x19, [sp, #272]
+    stp x20, x21, [sp, #288]
+    stp x22, x23, [sp, #304]
+    stp x24, x25, [sp, #320]
+    stp x26, x27, [sp, #336]
+    stp x28, x29, [sp, #352]
+    str x30, [sp, #368]
+
+    bl RUN_YIELD
+    bl LOAD_RESUME
+    str x0, [sp, #376]
+
+    ldr x30, [sp, #368]
+    ldp x28, x29, [sp, #352]
+    ldp x26, x27, [sp, #336]
+    ldp x24, x25, [sp, #320]
+    ldp x22, x23, [sp, #304]
+    ldp x20, x21, [sp, #288]
+    ldp x18, x19, [sp, #272]
+    ldp x16, x17, [sp, #256]
+    ldp x14, x15, [sp, #240]
+    ldp x12, x13, [sp, #224]
+    ldp x10, x11, [sp, #208]
+    ldp x8, x9, [sp, #192]
+    ldp x6, x7, [sp, #176]
+    ldp x4, x5, [sp, #160]
+    ldp x2, x3, [sp, #144]
+    ldp x0, x1, [sp, #128]
+
+    ldp q6, q7, [sp, #96]
+    ldp q4, q5, [sp, #64]
+    ldp q2, q3, [sp, #32]
+    ldp q0, q1, [sp, #0]
+
+    ldr x16, [sp, #376]
+    add sp, sp, #SFPT_FRAME
+    br x16
+
+#else
+.text
+.balign 4
+.globl scalanative_gc_safepoint_trampoline_aarch64_skipped
+scalanative_gc_safepoint_trampoline_aarch64_skipped:
+    ret
+#endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline-x86_64.S
+++ b/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline-x86_64.S
@@ -1,0 +1,114 @@
+/* clang-format off */
+/*
+ * POSIX x86_64: normal-context stub after a yield-point page fault.
+ * Saves XMM0-15 and GPRs, calls scalanative_gc_safepoint_poll_run_yield (C),
+ * loads resume PC from scalanative_gc_safepoint_load_resume_pc, jmp to it.
+ * See SafepointPollTrampoline.c and docs/contrib/gc-safepoint-trampoline.md.
+ */
+#if defined(SCALANATIVE_MULTITHREADING_ENABLED) &&                              \
+    defined(SCALANATIVE_GC_USE_YIELDPOINT_TRAPS) && !defined(_WIN32) &&         \
+    defined(__x86_64__) && (defined(__linux__) || defined(__APPLE__))
+
+/* Frame: 16 XMM (256 B) + 8 resume + 15 GPR (120 B) + pad = 400 B */
+#define SFPT_FRAME 400
+
+.text
+.balign 16
+
+#if defined(__APPLE__)
+#    define RUN_YIELD _scalanative_gc_safepoint_poll_run_yield
+#    define LOAD_RESUME _scalanative_gc_safepoint_load_resume_pc
+.globl scalanative_gc_safepoint_poll_trampoline
+.globl _scalanative_gc_safepoint_poll_trampoline
+scalanative_gc_safepoint_poll_trampoline:
+_scalanative_gc_safepoint_poll_trampoline:
+#else
+#    define RUN_YIELD scalanative_gc_safepoint_poll_run_yield
+#    define LOAD_RESUME scalanative_gc_safepoint_load_resume_pc
+.globl scalanative_gc_safepoint_poll_trampoline
+.type scalanative_gc_safepoint_poll_trampoline, @function
+scalanative_gc_safepoint_poll_trampoline:
+#endif
+    subq $SFPT_FRAME, %rsp
+
+    movdqa %xmm0, 0(%rsp)
+    movdqa %xmm1, 16(%rsp)
+    movdqa %xmm2, 32(%rsp)
+    movdqa %xmm3, 48(%rsp)
+    movdqa %xmm4, 64(%rsp)
+    movdqa %xmm5, 80(%rsp)
+    movdqa %xmm6, 96(%rsp)
+    movdqa %xmm7, 112(%rsp)
+    movdqa %xmm8, 128(%rsp)
+    movdqa %xmm9, 144(%rsp)
+    movdqa %xmm10, 160(%rsp)
+    movdqa %xmm11, 176(%rsp)
+    movdqa %xmm12, 192(%rsp)
+    movdqa %xmm13, 208(%rsp)
+    movdqa %xmm14, 224(%rsp)
+    movdqa %xmm15, 240(%rsp)
+
+    movq %rax, 272(%rsp)
+    movq %rbx, 280(%rsp)
+    movq %rcx, 288(%rsp)
+    movq %rdx, 296(%rsp)
+    movq %rsi, 304(%rsp)
+    movq %rdi, 312(%rsp)
+    movq %r8,  320(%rsp)
+    movq %r9,  328(%rsp)
+    movq %r10, 336(%rsp)
+    movq %r11, 344(%rsp)
+    movq %rbp, 352(%rsp)
+    movq %r12, 360(%rsp)
+    movq %r13, 368(%rsp)
+    movq %r14, 376(%rsp)
+    movq %r15, 384(%rsp)
+
+    call RUN_YIELD
+    call LOAD_RESUME
+    movq %rax, 256(%rsp)
+
+    movq 384(%rsp), %r15
+    movq 376(%rsp), %r14
+    movq 368(%rsp), %r13
+    movq 360(%rsp), %r12
+    movq 352(%rsp), %rbp
+    movq 344(%rsp), %r11
+    movq 336(%rsp), %r10
+    movq 328(%rsp), %r9
+    movq 320(%rsp), %r8
+    movq 312(%rsp), %rdi
+    movq 304(%rsp), %rsi
+    movq 296(%rsp), %rdx
+    movq 288(%rsp), %rcx
+    movq 280(%rsp), %rbx
+    movq 272(%rsp), %rax
+
+    movdqa 240(%rsp), %xmm15
+    movdqa 224(%rsp), %xmm14
+    movdqa 208(%rsp), %xmm13
+    movdqa 192(%rsp), %xmm12
+    movdqa 176(%rsp), %xmm11
+    movdqa 160(%rsp), %xmm10
+    movdqa 144(%rsp), %xmm9
+    movdqa 128(%rsp), %xmm8
+    movdqa 112(%rsp), %xmm7
+    movdqa 96(%rsp), %xmm6
+    movdqa 80(%rsp), %xmm5
+    movdqa 64(%rsp), %xmm4
+    movdqa 48(%rsp), %xmm3
+    movdqa 32(%rsp), %xmm2
+    movdqa 16(%rsp), %xmm1
+    movdqa 0(%rsp), %xmm0
+
+    movq 256(%rsp), %r10
+    addq $SFPT_FRAME, %rsp
+    jmp *%r10
+
+#else
+.text
+.balign 4
+.globl scalanative_gc_safepoint_trampoline_x86_64_skipped
+scalanative_gc_safepoint_trampoline_x86_64_skipped:
+    ret
+#endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline.c
@@ -1,0 +1,97 @@
+#if defined(SCALANATIVE_MULTITHREADING_ENABLED) &&                             \
+    defined(SCALANATIVE_GC_USE_YIELDPOINT_TRAPS) && !defined(_WIN32)
+
+/*
+ * Implements ucontext PC redirection and tiny C helpers used by
+ * SafepointPollTrampoline-{x86_64,aarch64}.S.
+ *
+ * Flow: SafepointTrapHandler -> prepare_redirect() -> [kernel returns] ->
+ * scalanative_gc_safepoint_poll_trampoline -> run_yield() -> branch to
+ * safepointResumePc. Unsupported OS/arch: prepare_redirect returns false and
+ * the handler calls Synchronizer_yield() directly.
+ */
+
+/* Darwin ucontext.h requires a POSIX feature macro before inclusion. */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+#endif
+
+#include "SafepointPollTrampoline.h"
+#include "immix_commix/Synchronizer.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <ucontext.h>
+
+#if defined(SCALANATIVE_GC_IMMIX)
+#include "immix/State.h"
+#include "immix/MutatorThread.h"
+#elif defined(SCALANATIVE_GC_COMMIX)
+#include "commix/State.h"
+#include "commix/MutatorThread.h"
+#else
+#error "SafepointPollTrampoline requires immix or commix"
+#endif
+
+void scalanative_gc_safepoint_poll_run_yield(void) { Synchronizer_yield(); }
+
+uintptr_t scalanative_gc_safepoint_load_resume_pc(void) {
+    MutatorThread *self = currentMutatorThread;
+    return (self != NULL) ? self->safepointResumePc : (uintptr_t)0;
+}
+
+void scalanative_gc_safepoint_poll_trampoline(void);
+
+#if defined(__x86_64__)
+
+#if defined(__APPLE__)
+#define SN_UC_GET_PC(uc) ((uintptr_t)(uc)->uc_mcontext->__ss.__rip)
+#define SN_UC_SET_PC(uc, addr)                                                 \
+    ((uc)->uc_mcontext->__ss.__rip = (__uint64_t)(uintptr_t)(addr))
+#elif defined(__linux__)
+#include <signal.h>
+#define SN_UC_GET_PC(uc) ((uintptr_t)(uc)->uc_mcontext.gregs[REG_RIP])
+#define SN_UC_SET_PC(uc, addr)                                                 \
+    ((uc)->uc_mcontext.gregs[REG_RIP] = (greg_t)(uintptr_t)(addr))
+#else
+#define SN_UC_UNSUPPORTED 1
+#endif
+
+#elif defined(__aarch64__)
+
+#if defined(__APPLE__)
+#define SN_UC_GET_PC(uc) ((uintptr_t)(uc)->uc_mcontext->__ss.__pc)
+#define SN_UC_SET_PC(uc, addr)                                                 \
+    ((uc)->uc_mcontext->__ss.__pc = (__uint64_t)(uintptr_t)(addr))
+#elif defined(__linux__)
+#define SN_UC_GET_PC(uc) ((uintptr_t)(uc)->uc_mcontext.pc)
+#define SN_UC_SET_PC(uc, addr)                                                 \
+    ((uc)->uc_mcontext.pc = (uint64_t)(uintptr_t)(addr))
+#else
+#define SN_UC_UNSUPPORTED 1
+#endif
+
+#else
+#define SN_UC_UNSUPPORTED 1
+#endif
+
+bool scalanative_gc_safepoint_prepare_redirect(void *uap, void *mutatorThread) {
+#ifndef SN_UC_UNSUPPORTED
+    MutatorThread *self = (MutatorThread *)mutatorThread;
+    if (uap == NULL || self == NULL)
+        return false;
+    ucontext_t *uc = (ucontext_t *)uap;
+    self->safepointResumePc = SN_UC_GET_PC(uc);
+    SN_UC_SET_PC(uc, (void *)scalanative_gc_safepoint_poll_trampoline);
+    return true;
+#else
+    (void)uap;
+    (void)mutatorThread;
+    return false;
+#endif
+}
+
+#else /* !multithreading || !traps || windows */
+
+typedef int scalanative_gc_safepoint_poll_trampoline_unused_typedef;
+
+#endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline.c
@@ -11,9 +11,21 @@
  * the handler calls Synchronizer_yield() directly.
  */
 
+#if defined(__APPLE__)
 /* Darwin ucontext.h requires a POSIX feature macro before inclusion. */
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 700
+#endif
+#elif defined(__linux__)
+/* glibc: x86_64 uc_mcontext.gregs / REG_RIP are GNU extensions. With only
+ * _XOPEN_SOURCE, mcontext_t has no gregs */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#else
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+#endif
 #endif
 
 #include "SafepointPollTrampoline.h"
@@ -49,6 +61,7 @@ void scalanative_gc_safepoint_poll_trampoline(void);
     ((uc)->uc_mcontext->__ss.__rip = (__uint64_t)(uintptr_t)(addr))
 #elif defined(__linux__)
 #include <signal.h>
+#include <sys/reg.h>
 #define SN_UC_GET_PC(uc) ((uintptr_t)(uc)->uc_mcontext.gregs[REG_RIP])
 #define SN_UC_SET_PC(uc, addr)                                                 \
     ((uc)->uc_mcontext.gregs[REG_RIP] = (greg_t)(uintptr_t)(addr))

--- a/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/SafepointPollTrampoline.h
@@ -1,0 +1,41 @@
+#ifndef SAFEPOINT_POLL_TRAMPOLINE_H
+#define SAFEPOINT_POLL_TRAMPOLINE_H
+
+/*
+ * Deferred safepoint trampoline (POSIX, Immix/Commix, trap yield points).
+ *
+ * The SIGSEGV/SIGBUS handler must not run Synchronizer_yield() in async-signal
+ * context. prepare_redirect() stores the faulting PC on the MutatorThread and
+ * points ucontext at scalanative_gc_safepoint_poll_trampoline (asm); that stub
+ * saves/restores registers, calls Synchronizer_yield(), then resumes at the
+ * saved PC. See docs/contrib/gc-safepoint-trampoline.md.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(SCALANATIVE_MULTITHREADING_ENABLED) &&                             \
+    defined(SCALANATIVE_GC_USE_YIELDPOINT_TRAPS) && !defined(_WIN32)
+
+/* Entry from modified ucontext PC after a trap fault; implemented in .S */
+void scalanative_gc_safepoint_poll_trampoline(void);
+
+/* uap: third argument to SA_SIGINFO handler (ucontext_t *). mutatorThread:
+ * MutatorThread * (void * to keep this header independent of GC typedefs). */
+bool scalanative_gc_safepoint_prepare_redirect(void *uap, void *mutatorThread);
+
+void scalanative_gc_safepoint_poll_run_yield(void);
+uintptr_t scalanative_gc_safepoint_load_resume_pc(void);
+
+#else
+
+static inline bool
+scalanative_gc_safepoint_prepare_redirect(void *uap, void *mutatorThread) {
+    (void)uap;
+    (void)mutatorThread;
+    return false;
+}
+
+#endif
+
+#endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/ScalaNativeGC.h
@@ -90,12 +90,11 @@ void scalanative_GC_set_mutator_thread_state(GC_MutatorThreadState);
 // Check for StopTheWorld event and wait for its end if needed
 void scalanative_GC_yield();
 #ifdef SCALANATIVE_GC_USE_YIELDPOINT_TRAPS
-// Conditionally protected memory address used for STW events polling
-// Scala Native compiler would introduce load/store operations to location
-// pointed by this field. Under active StopTheWorld event these would trigger
-// thread execution suspension via exception handling mechanism
-// (signals/exceptionHandler)
-extern void **scalanative_GC_yieldpoint_trap;
+#include "shared/ThreadUtil.h"
+// Thread-local pointer to this mutator's own trap page (see MutatorThread).
+// Each pthread mmap/VirtualAlloc's a private page; the GC arms every mutator's
+// page during STW so faulting loads do not share one TLB/mprotect target.
+extern SN_ThreadLocal void **scalanative_GC_yieldpoint_trap;
 #endif
 
 void scalanative_GC_add_roots(void *addr_low, void *addr_high);

--- a/nativelib/src/main/resources/scala-native/gc/shared/YieldPointTrap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/YieldPointTrap.c
@@ -97,4 +97,20 @@ void YieldPointTrap_disarm(safepoint_t ref) {
     }
 }
 
+void YieldPointTrap_free(safepoint_t ref) {
+    if (ref == NULL) {
+        return;
+    }
+#ifdef _WIN32
+    if (!VirtualFree((LPVOID)ref, 0, MEM_RELEASE)) {
+        GC_LOG_WARN("Failed to release GC safepoint trap memory: %lu",
+                    GetLastError());
+    }
+#else
+    if (munmap((void *)ref, sizeof(safepoint_t)) != 0) {
+        GC_LOG_WARN("Failed to unmap GC safepoint trap: %s", strerror(errno));
+    }
+#endif
+}
+
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/YieldPointTrap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/YieldPointTrap.c
@@ -28,6 +28,25 @@
 #include <mach/mach.h>
 #endif
 
+void YieldPointTrap_resetTaskMachBadAccessPorts(void) {
+#if defined(__APPLE__)
+    /* LLDB and some frameworks install task-wide Mach exception handlers for
+     * EXC_BAD_ACCESS. XNU delivers Mach exceptions to those handlers before
+     * translating the fault to SIGBUS, so a mutator can fault on a PROT_NONE
+     * yield trap and never run our POSIX safepoint handler. Clearing the task
+     * exception port for this mask restores the signal path. Call from init
+     * and again before arming traps (e.g. each GC) because dylibs may
+     * reinstall handlers after startup. */
+    kern_return_t kr = task_set_exception_ports(
+        mach_task_self(), EXC_MASK_BAD_ACCESS, MACH_PORT_NULL,
+        EXCEPTION_STATE_IDENTITY, MACHINE_THREAD_STATE);
+    if (kr != KERN_SUCCESS)
+        GC_LOG_WARN("Failed to reset GC safepoint Mach EXC_BAD_ACCESS ports "
+                    "(kern_return_t=%d)",
+                    (int)kr);
+#endif
+}
+
 safepoint_t YieldPointTrap_init() {
     bool allocated;
     void *addr =
@@ -46,22 +65,7 @@ safepoint_t YieldPointTrap_init() {
     }
 
 #if defined(__APPLE__)
-    /* LLDB installs task-wide Mach exception handlers. XNU dispatches Mach
-     * exceptions first to any registered "activation" handler and then to
-     * any registered task handler before dispatching the exception to a
-     * host-wide Mach exception handler that does translation to POSIX
-     * signals. This makes it impossible to use LLDB with safepoints;
-     * continuing execution after LLDB
-     * traps an EXC_BAD_ACCESS will result in LLDB's EXC_BAD_ACCESS handler
-     * being invoked again. Work around this here by
-     * installing a no-op task-wide Mach exception handler for
-     * EXC_BAD_ACCESS.
-     */
-    kern_return_t kr = task_set_exception_ports(
-        mach_task_self(), EXC_MASK_BAD_ACCESS, MACH_PORT_NULL,
-        EXCEPTION_STATE_IDENTITY, MACHINE_THREAD_STATE);
-    if (kr != KERN_SUCCESS)
-        GC_LOG_WARN("Failed to create GC safepoint bad access handler");
+    YieldPointTrap_resetTaskMachBadAccessPorts();
 #endif
     return addr;
 }

--- a/nativelib/src/main/resources/scala-native/gc/shared/YieldPointTrap.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/YieldPointTrap.h
@@ -2,8 +2,9 @@
 #define YieldPointTrap_H
 
 typedef void **safepoint_t;
-safepoint_t YieldPointTrap_init();
+safepoint_t YieldPointTrap_init(void);
 void YieldPointTrap_arm(safepoint_t ref);
 void YieldPointTrap_disarm(safepoint_t ref);
+void YieldPointTrap_free(safepoint_t ref);
 
 #endif

--- a/nativelib/src/main/resources/scala-native/gc/shared/YieldPointTrap.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/YieldPointTrap.h
@@ -3,6 +3,9 @@
 
 typedef void **safepoint_t;
 safepoint_t YieldPointTrap_init(void);
+/** macOS: clear task EXC_BAD_ACCESS Mach exception ports so faults reach
+ *  SIGBUS/SIGSEGV; no-op elsewhere. Safe to call before each GC suspend. */
+void YieldPointTrap_resetTaskMachBadAccessPorts(void);
 void YieldPointTrap_arm(safepoint_t ref);
 void YieldPointTrap_disarm(safepoint_t ref);
 void YieldPointTrap_free(safepoint_t ref);

--- a/nativelib/src/main/resources/scala-native/stackOverflowGuards.c
+++ b/nativelib/src/main/resources/scala-native/stackOverflowGuards.c
@@ -295,8 +295,8 @@ void scalanative_StackOverflowGuards_setup(bool isMainThread) {
         setupSignalHandler(SIGSEGV);
 #if (defined(__APPLE__) && defined(__MACH__))
         setupSignalHandler(SIGBUS);
-        isHandlerConfigured = true;
 #endif // Apple
+        isHandlerConfigured = true;
     }
 }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -119,13 +119,9 @@ object GC {
   @name("scalanative_GC_yield")
   private[runtime] def `yield`(): Unit = extern
 
-  /** Address of yield point trap - conditionally protected memory address used
-   *  for polling StopTheWorld event. Lowering phase would introduce write/read
-   *  instruction to this address to check if it should stop execution of the
-   *  thread. Upon write/read to protected memory special signal handler (UNIX)
-   *  or exceptions filter (Windows) would be triggered leading to stopping
-   *  execution of the thread. Used only in release mode for low-overhead
-   *  yieldpoints
+  /** Thread-local pointer to this mutator's trap page (distinct per pthread).
+   *  The GC mprotects each mutator's page during STW. Used only with
+   *  trap-based yieldpoints in multithreaded release-style builds.
    */
   @name("scalanative_GC_yieldpoint_trap")
   private[runtime] var yieldPointTrap: RawPtr = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -121,10 +121,11 @@ object GC {
 
   /** Thread-local pointer to this mutator's trap page (distinct per pthread).
    *  The GC mprotects each mutator's page during STW. Used only with trap-based
-   *  yieldpoints in multithreaded release-style builds.
+   *  yieldpoints when multithreading is enabled (same condition as the
+   *  `SCALANATIVE_GC_USE_YIELDPOINT_TRAPS` nativelib define).
    */
   @name("scalanative_GC_yieldpoint_trap")
-  private[runtime] var yieldPointTrap: RawPtr = extern
+  private[runtime] var yieldPointTrap: /* thread local */ RawPtr = extern
 
   /** Notify the Garbage Collector about the range of memory which should be
    *  scanned when marking the objects. The range should contain only memory NOT

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -120,8 +120,8 @@ object GC {
   private[runtime] def `yield`(): Unit = extern
 
   /** Thread-local pointer to this mutator's trap page (distinct per pthread).
-   *  The GC mprotects each mutator's page during STW. Used only with
-   *  trap-based yieldpoints in multithreaded release-style builds.
+   *  The GC mprotects each mutator's page during STW. Used only with trap-based
+   *  yieldpoints in multithreaded release-style builds.
    */
   @name("scalanative_GC_yieldpoint_trap")
   private[runtime] var yieldPointTrap: RawPtr = extern

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -187,13 +187,19 @@ sealed trait Config {
   // see https://no-color.org/
   private[scalanative] lazy val noColor: Boolean = sys.env.contains("NO_COLOR")
 
+  /** Trap-based safepoints coordinate STW across mutators; they require
+    * multithreaded linking and must stay off when `multithreadingSupport` is
+    * false so nativelib and LLVM agree with [[codegen.Lower.depends]].
+    */
   private[scalanative] lazy val useTrapBasedGCYieldPoints =
     compilerConfig.gc match {
       case GC.Immix | GC.Commix | GC.Experimental =>
-        sys.env
-          .get("SCALANATIVE_GC_TRAP_BASED_YIELDPOINTS")
-          .map(_ == "1")
-          .getOrElse(compilerConfig.mode.isInstanceOf[Mode.Release])
+        compilerConfig.multithreadingSupport && {
+          sys.env
+            .get("SCALANATIVE_GC_TRAP_BASED_YIELDPOINTS")
+            .map(_ == "1")
+            .getOrElse(compilerConfig.mode.isInstanceOf[Mode.Release])
+        }
       case _ => false
     }
 

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -188,9 +188,9 @@ sealed trait Config {
   private[scalanative] lazy val noColor: Boolean = sys.env.contains("NO_COLOR")
 
   /** Trap-based safepoints coordinate STW across mutators; they require
-    * multithreaded linking and must stay off when `multithreadingSupport` is
-    * false so nativelib and LLVM agree with [[codegen.Lower.depends]].
-    */
+   *  multithreaded linking and must stay off when `multithreadingSupport` is
+   *  false so nativelib and LLVM agree with [[codegen.Lower.depends]].
+   */
   private[scalanative] lazy val useTrapBasedGCYieldPoints =
     compilerConfig.gc match {
       case GC.Immix | GC.Commix | GC.Experimental =>

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -873,7 +873,6 @@ private[scalanative] object Lower {
       }
       private val multithreadingEnabled = meta.platform.isMultithreadingEnabled
       private val usesGCYieldPoints = multithreadingEnabled && supportedGC
-      private val useYieldPointTraps = platform.useGCYieldPointTraps
 
       def apply(defn: nir.Defn.Define): Boolean = {
         if (!usesGCYieldPoints) false

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
 import scala.scalanative.build.Discover
 import scala.scalanative.codegen.llvm.Metadata.conversions._
 import scala.scalanative.codegen.llvm.compat.os.OsCompat
-import scala.scalanative.codegen.{Metadata => CodeGenMetadata}
+import scala.scalanative.codegen.{Lower, Metadata => CodeGenMetadata}
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir.ControlFlow.{Block, Graph => CFG}
 import scala.scalanative.nir.Defn.Define.DebugInfo
@@ -213,6 +213,12 @@ private[codegen] abstract class AbstractCodeGen(
       unsupported(defn)
   }
 
+  // Currently we have a single usage for interaction with GC
+  private def isThreadLocal(name: nir.Global): Boolean =
+    (name eq Lower.GCYieldPointTrapName) &&
+      platform.isMultithreadingEnabled &&
+      platform.useGCYieldPointTraps
+
   private[codegen] def genGlobalDefn(
       attrs: nir.Attrs,
       name: nir.Global,
@@ -225,6 +231,9 @@ private[codegen] abstract class AbstractCodeGen(
     genGlobal(name)
     str(" = ")
     str(if (attrs.isExtern) "external " else "hidden ")
+    if (attrs.isExtern && isThreadLocal(name)) {
+      str("thread_local ")
+    }
     str(if (isConst) "constant" else "global")
     str(" ")
     if (attrs.isExtern) {

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -215,7 +215,7 @@ private[codegen] abstract class AbstractCodeGen(
 
   // Currently we have a single usage for interaction with GC
   private def isThreadLocal(name: nir.Global): Boolean =
-    (name eq Lower.GCYieldPointTrapName) &&
+    (name == Lower.GCYieldPointTrapName) &&
       platform.isMultithreadingEnabled &&
       platform.useGCYieldPointTraps
 

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/loops/TSPExchangerTest.scala
@@ -399,7 +399,7 @@ object TSPExchangerTest {
         jl.Double.valueOf(secs),
         jl.Double.valueOf(best),
         jl.Double.valueOf(worst),
-        jl.Double.valueOf(xs),
+        jl.Integer.valueOf(xs),
         jl.Long.valueOf(rate)
       )
       // JSR-166 orignal comments


### PR DESCRIPTION
Fixes #4871 (tested locally macos / arm64) 
Should fix #4826 

A dedicated tests on different machines (Windows, Linux) should be also performed

With a shared trap page, fault/signal delivery and TLB/protection visibility across many oversubscribed threads proved unreliable in practice: a thread could remain effectively stuck at the faulting instruction without consistently entering the handler, so it never transitioned to “at safepoint” and the GC could not proceed. 

The issue was addressed by switching to thread-local yieldpoints: each mutator gets its own trap/polling location (or equivalent per-thread state) instead of everyone faulting on one global page.