### PR TITLE
Add juc.TimeUnit methods defined in Java {9, 11} and supporting internal-only testExt infrastructure

### DIFF
--- a/javalib-ext-dummies/src/main/scala/java/00_SN_READ_ME.txt
+++ b/javalib-ext-dummies/src/main/scala/java/00_SN_READ_ME.txt
@@ -1,0 +1,17 @@
+javalib-ext-dummies/src/main/scala/java/00_SN_READ_ME.txt¹
+
+The Scala Native 'unit-tests-ext' project exists to internally test supported
+classes which themselves use unsupported features. See the 00_SN_READ_ME.txt
+in that project for additional details.
+
+This directory tree holds selected minimal implementations of Java API
+packages, classes, and methods to allow tests in 'unit-tests-ext' to link
+and execute. They are not supported outside the Scala Native project
+itself. The express intent is to keep the footprint small and, as
+always, correct within the defined context.
+
+
+1. 'javalib-ext-dummies' is the historical name of the project as it
+   was ported from Scala.js. Times change, a kinder reading is
+   'javalib-ext-mocks' as this is unlikely to give offensive to people
+   with disabilities.

--- a/javalib-ext-dummies/src/main/scala/java/time/Duration.scala
+++ b/javalib-ext-dummies/src/main/scala/java/time/Duration.scala
@@ -1,0 +1,58 @@
+package java.time
+
+/* This file is a near minimal implementation of java.time classes and
+ * methods for Scala Native internal tests, usually in unit-tests-ext.
+ * It contains declarations necessary for implementing the class and
+ * for resolving methods used by tests such as TimeUnitTestExt.
+ *
+ * 'toString()' and possibly a few other methods are added to ease
+ * SN development & verification.
+ *
+ * NOT ALL JAVA API METHODS ARE IMPLMENTED. This implementation is
+ * NOT INTENDED for use outside the testsExt project.
+ *
+ * Applications using java.time.Duration must have a dependency on
+ * a third party library, such as 'scala-java-time'.
+ */
+
+final class Duration(private val seconds: Long, private val nano: Int)
+    extends Comparable[Duration]
+    with java.io.Serializable {
+
+  override def compareTo(that: Duration): Int = {
+    val secondsCompare = seconds.compareTo(that.seconds)
+    if (secondsCompare == 0) {
+      nano.compareTo(that.nano)
+    } else secondsCompare
+  }
+
+  override def equals(that: Any): Boolean = that match {
+    case that: Duration =>
+      this.seconds == that.seconds &&
+        this.nano == that.nano
+    case _ =>
+      false
+  }
+
+  def getNano(): Int = nano
+
+  def getSeconds(): Long = seconds
+
+  override def hashCode(): Int =
+    java.lang.Long.hashCode(seconds) ^ java.lang.Integer.hashCode(nano)
+
+  // non compliant, for debugging purposes only
+  override def toString(): String =
+    "Duration(" + seconds + ", " + nano + ")"
+}
+
+object Duration {
+
+  def ofSeconds(seconds: Long, nanoAdjustment: Long): Duration = {
+    val adjustedSeconds =
+      Math.addExact(seconds, Math.floorDiv(nanoAdjustment, 1000000000L))
+    val adjustedNano = Math.floorMod(nanoAdjustment, 1000000000L).toInt
+
+    new Duration(adjustedSeconds, adjustedNano)
+  }
+}

--- a/javalib-ext-dummies/src/main/scala/java/time/temporal/ChronoUnit.scala
+++ b/javalib-ext-dummies/src/main/scala/java/time/temporal/ChronoUnit.scala
@@ -1,0 +1,43 @@
+package java.time.temporal
+
+// A near minimal implementation strictly for Scala Native internal testing.
+
+/* _Enum is a HACK to avoid having to have separate enum code for Scala 2 & 3.
+ * Original code is in java.lang. Cut & paste is "gag me with a spoon"
+ * ugly but I could not get an import of java.lang underbarEnum to work in
+ * this project within economic time.
+ */
+abstract class _Enum[E <: _Enum[E]] protected (_name: String, _ordinal: Int)
+    extends Comparable[E]
+    with java.io.Serializable {
+  def name(): String = _name
+  def ordinal(): Int = _ordinal
+  override def toString(): String = _name
+  final def compareTo(o: E): Int = _ordinal.compareTo(o.ordinal())
+}
+
+class ChronoUnit private (name: String, ordinal: Int)
+    extends _Enum[ChronoUnit](name, ordinal)
+    with TemporalUnit {
+
+  override def toString() = this.name
+}
+
+object ChronoUnit {
+  final val NANOS: ChronoUnit = new ChronoUnit("Nanos", 0)
+  final val MICROS: ChronoUnit = new ChronoUnit("Micros", 1)
+  final val MILLIS: ChronoUnit = new ChronoUnit("Millis", 2)
+  final val SECONDS: ChronoUnit = new ChronoUnit("Seconds", 3)
+  final val MINUTES: ChronoUnit = new ChronoUnit("Minutes", 4)
+  final val HOURS: ChronoUnit = new ChronoUnit("Hours", 5)
+  final val HALF_DAYS: ChronoUnit = new ChronoUnit("HalfDays", 6)
+  final val DAYS: ChronoUnit = new ChronoUnit("Days", 7)
+  final val WEEKS: ChronoUnit = new ChronoUnit("Weeks", 8)
+  final val MONTHS: ChronoUnit = new ChronoUnit("Months", 9)
+  final val YEARS: ChronoUnit = new ChronoUnit("Years", 10)
+  final val DECADES: ChronoUnit = new ChronoUnit("Decades", 11)
+  final val CENTURIES: ChronoUnit = new ChronoUnit("Centuries", 12)
+  final val MILLENNIA: ChronoUnit = new ChronoUnit("Millennia", 13)
+  final val ERAS: ChronoUnit = new ChronoUnit("Eras", 14)
+  final val FOREVER: ChronoUnit = new ChronoUnit("Forever", 15)
+}

--- a/javalib-ext-dummies/src/main/scala/java/time/temporal/TemporalUnit.scala
+++ b/javalib-ext-dummies/src/main/scala/java/time/temporal/TemporalUnit.scala
@@ -1,0 +1,17 @@
+package java.time.temporal
+
+// A near minimal implementation strictly for Scala Native internal testing.
+
+trait TemporalUnit {
+  def addTo[R <: Temporal](temporal: R, amount: Long): R = ???
+
+  def between(
+      temporal1Inclusive: Temporal,
+      temporal2Exclusive: Temporal
+  ): Long = ???
+
+  def getDuration(): java.time.Duration = ???
+  def isDateBased(): Boolean = ???
+  def isDurationEstimated(): Boolean = ???
+  def isTimeBased(): Boolean = ???
+}

--- a/javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
@@ -1,11 +1,20 @@
 package java.util.concurrent
 
 // Ported from Scala.js
+// Scala Native adds Java 9 and 11 methods.
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.Objects
+import java.{lang => jl}
 
 abstract class TimeUnit private (name: String, ordinal: Int)
     extends _Enum[TimeUnit](name, ordinal) {
 
   def convert(a: Long, u: TimeUnit): Long
+
+  def convert(duration: Duration): Long =
+    TimeUnit.convertDuration(duration, this)
 
   def toNanos(a: Long): Long
   def toMicros(a: Long): Long
@@ -21,6 +30,25 @@ abstract class TimeUnit private (name: String, ordinal: Int)
     if (timeout > 0) thread.join(toMillis(timeout))
   def timedWait(obj: Object, timeout: Long) =
     if (timeout > 0) obj.wait(toMillis(timeout))
+
+  def toChronoUnit(): ChronoUnit = {
+
+    this match {
+      case TimeUnit.NANOSECONDS => ChronoUnit.NANOS
+
+      case TimeUnit.MICROSECONDS => ChronoUnit.MICROS
+
+      case TimeUnit.MILLISECONDS => ChronoUnit.MILLIS
+
+      case TimeUnit.SECONDS => ChronoUnit.SECONDS
+
+      case TimeUnit.MINUTES => ChronoUnit.MINUTES
+
+      case TimeUnit.HOURS => ChronoUnit.HOURS
+
+      case TimeUnit.DAYS => ChronoUnit.DAYS
+    }
+  }
 }
 
 object TimeUnit {
@@ -134,5 +162,53 @@ object TimeUnit {
     if (a > max) MAX
     else if (a < -max) -MAX
     else a * b
+  }
+
+  def of(chronoUnit: ChronoUnit): TimeUnit = {
+    Objects.requireNonNull(chronoUnit, "chronoUnit")
+
+    chronoUnit match {
+      case ChronoUnit.NANOS =>
+        TimeUnit.NANOSECONDS
+
+      case ChronoUnit.MICROS =>
+        TimeUnit.MICROSECONDS
+
+      case ChronoUnit.MILLIS =>
+        TimeUnit.MILLISECONDS
+
+      case ChronoUnit.SECONDS =>
+        TimeUnit.SECONDS
+
+      case ChronoUnit.MINUTES =>
+        TimeUnit.MINUTES
+
+      case ChronoUnit.HOURS =>
+        TimeUnit.HOURS
+
+      case ChronoUnit.DAYS =>
+        TimeUnit.DAYS
+
+      case _ =>
+        throw new IllegalArgumentException(
+          s"No TimeUnit equivalent for ${chronoUnit}"
+        )
+    }
+  }
+
+  private def convertDuration(duration: Duration, unit: TimeUnit): Long = {
+    val seconds = duration.getSeconds()
+    val nano = duration.getNano()
+
+    val convertedSeconds = unit.convert(seconds, TimeUnit.SECONDS)
+    val convertedNano = unit.convert(nano, TimeUnit.NANOSECONDS)
+
+    try {
+      Math.addExact(convertedSeconds, convertedNano)
+    } catch {
+      case _: ArithmeticException =>
+        if (seconds > 0) jl.Long.MAX_VALUE
+        else jl.Long.MIN_VALUE
+    }
   }
 }

--- a/unit-tests-ext/shared/src/test/scala/org/scalanative/testsuite/javalib/00_SN_READ_ME.txt
+++ b/unit-tests-ext/shared/src/test/scala/org/scalanative/testsuite/javalib/00_SN_READ_ME.txt
@@ -1,0 +1,23 @@
+unit-tests-ext/shared/src/test/.../testsuite/javalib/00_SN_READ_ME.txt
+
+By design and intent, Scala Native javalib does not support some of
+the Java API (Application Programming Interface) packages, classes, and
+methods. Instead application developers are encouraged to use dedicated
+third-party implementations. For example, javalib does not implement
+'java.time' where the superior 'scala-java-time' and 'sjavatime'
+are both available.
+
+Some generally supported javalib classes, such as
+'java.util.concurrent.TimeUnit' have methods, such as
+'TimeUnit.convert(Duration)', which use some features which are themselves not
+supported.  These files will compile given a suitable
+JDK (Java Development Kit) version, but will fail to link with missing symbols
+if a third-party dependency is not supplied.
+
+The Scala Native 'unit-tests-ext' project exists to internally test supported
+classes which themselves use unsupported features.
+
+The 'javalib-ext-dummies' (sic) project supplies minimal implementations of
+otherwise unsupported Java methods used by this project.  This allows
+this project to avoid any dependency on a third-party library when
+testing methods supported for general use by javalib.

--- a/unit-tests-ext/shared/src/test/scala/org/scalanative/testsuite/javalib/time/TimeUnitTestExt.scala.DISABLED
+++ b/unit-tests-ext/shared/src/test/scala/org/scalanative/testsuite/javalib/time/TimeUnitTestExt.scala.DISABLED
@@ -1,0 +1,102 @@
+package org.scalanative.testsuite.javalib.time
+
+/* SN Devo Notes:
+ *
+ *  1) This is a set of manual tests for TimeUnit methods introduced
+ *     in Java 9 and 11. It a manual internal development test, not intended
+ *     for current Continuous Integration.
+ *
+ *     These tests require a JDK >= 11 in order to compile. The testsExt
+ *     project does not support the rich 'requires-*' tree available
+ *     in the "normal" units-tests environment. Implementing that tree
+ *     in testsExt is simply not economic.
+ *
+ *     The testsExt project adds the location of Scala Native internal
+ *     testing-only near minimal implementations to the build path.
+ *     This allows these tests to link when executed from that project:
+ *       a) Copy file to one with a .scala suffix, say TimeUnitTestExt.scala.
+ *       b) Ensure active JDK is >= 11.
+ *       b) sbt> testsExt3/testOnly *.TimeUnitTestExt 
+ *
+ *  2) When Scala Native requires a suitable JDK version, this test
+ *     can be moved to the "normal" 'tests' project.
+ */
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+/** Minimal tests for `java.time.TimeUnit` use of Scala Native dummy
+ *  implementations of java.time.Duration and java.time.ChronoUnit. Scala Native
+ *  javalib does not implement these methods and requires applictions use a
+ *  third party library.
+ */
+class TimeUnitTestExt {
+  @Test def testConvertDuration(): Unit = {
+    val NanosInMillisecond = 1000 * 1000
+    val MaxSubsecondNanos = (NanosInMillisecond * 1000) - 1
+
+    assertThrows(
+      classOf[NullPointerException],
+      TimeUnit.DAYS.convert(null.asInstanceOf[Duration])
+    )
+
+    // Java 26 Duration.MAX backfitted to JDK 9 &  11
+    val maxDuration = Duration.ofSeconds(jl.Long.MAX_VALUE, MaxSubsecondNanos)
+
+    assertEquals(
+      "expect saturation not ArithmeticException",
+      jl.Long.MAX_VALUE,
+      TimeUnit.NANOSECONDS.convert(maxDuration)
+    )
+
+    // In  the sweet bye-and-bye, implement the full NxM cross matrix.
+    assertEquals(
+      "convert milliseconds",
+      1,
+      TimeUnit.MILLISECONDS.convert(
+        Duration.ofSeconds(0, NanosInMillisecond)
+      )
+    )
+  }
+
+  @Test def testOfChronoUnit(): Unit = {
+
+    assertThrows(
+      classOf[NullPointerException],
+      TimeUnit.of(null.asInstanceOf[ChronoUnit])
+    )
+
+    assertThrows(
+      classOf[IllegalArgumentException],
+      TimeUnit.of(ChronoUnit.FOREVER)
+    )
+
+    assertEquals(
+      "convert microseconds",
+      TimeUnit.MICROSECONDS,
+      TimeUnit.of(ChronoUnit.MICROS)
+    )
+
+    assertNotEquals(
+      "micros-to-nanos conversion",
+      TimeUnit.NANOSECONDS,
+      TimeUnit.of(ChronoUnit.MICROS)
+    )
+  }
+
+  @Test def testToChronoUnit(): Unit = {
+
+    assertEquals(
+      "microseconds",
+      ChronoUnit.MICROS,
+      TimeUnit.MICROSECONDS.toChronoUnit()
+    )
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnitTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/TimeUnitTest.scala
@@ -1,5 +1,11 @@
 // Ported from Scala.js
 
+/* See also the Scala Native original tests for TimeUnit methods introduced
+ * in Java 9 and 11. They are located in:
+ * unit-tests-ext/shared/src/test/scala/org/scalanative/testsuite/javalib/time.
+ * The TimeUnitTestExt.scala file gives additional details.
+ */
+
 package org.scalanative.testsuite.javalib.util.concurrent
 
 import java.util._


### PR DESCRIPTION

Add javalib `java.util.concurrent.TimeUnit` methods which were introduced in JDK 9 and 11.

Scala Native requires applications which use packages and classes, such as `java.time.Duration`, to use a  
third party implementation to provide those classes. By long standing and documented intent, javalib does not
implement `java.time` for application use.

###### Behind the curtain 
The SN `testsExt` sub-project provides a way for developers to internally test supported javalib methods
which use publicly unsupported methods.

The `javalib-ext-dummies` (sic) sub-project provides near minimal mock implementations for non-supported
methods used by `testsExt`.

This PR provides files in each of these sub-projects so that the publicly available methods in `TimeUnit` can
be tested before release.

<hr>
PRs #4863 and #4866 address similar concerns.  The license/intellectual_property of that
code is unclear.  Was ChatGPT 5.5 trained on OpenJDK or similar code with license incompatible
to the Scala Native license?

<p>
<br />
 Merit and thanks to He-Pin for creating those PRs and motivating the discussion. My intent is 
to honor that contribution, not stomp on it.
</p>

This code, potential bugs and all, is written by a human who has signed the Scala Contributor's Agreement.
It follows Scala Native prior practice for testing code which relies upon third-party implementations. 

The `testExt` `java.time` minimal implementations should be useful when implementing the `Thread`
methods identified by ChatGPT as missing.