### PR TITLE
Check Iterable.forEach action for null

### DIFF
--- a/javalib/src/main/scala/java/lang/Iterable.scala
+++ b/javalib/src/main/scala/java/lang/Iterable.scala
@@ -4,12 +4,13 @@
 package java.lang
 
 import java.util.function.Consumer
-import java.util.{Iterator, Spliterator, Spliterators}
+import java.util.{Iterator, Objects, Spliterator, Spliterators}
 
 trait Iterable[T] {
   def iterator(): Iterator[T]
 
   def forEach(action: Consumer[_ >: T]): Unit = {
+    Objects.requireNonNull(action)
     val iter = iterator()
     while (iter.hasNext())
       action.accept(iter.next())

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/IterableTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/IterableTest.scala
@@ -11,6 +11,8 @@ import scala.reflect.ClassTag
 import org.junit.Assert._
 import org.junit.Test
 
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
 /** Tests the implementation of the java standard library Iterable
  */
 trait IterableTest {
@@ -33,6 +35,14 @@ trait IterableTest {
       def accept(x: Int): Unit = sum = sum + x
     })
     assertEquals(268, sum)
+  }
+
+  @Test def forEachThrowsNullPointerException(): Unit = {
+    val iter = factory.fromElements[Int](1)
+    assertThrows(
+      classOf[NullPointerException],
+      iter.forEach(null.asInstanceOf[Consumer[Int]])
+    )
   }
 }
 


### PR DESCRIPTION
Summary
- add the JDK-compatible null check to `java.lang.Iterable.forEach`
- add focused coverage for `forEach(null)`

Verification
- `./scripts/scalafmt --test javalib/src/main/scala/java/lang/Iterable.scala unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/IterableTest.scala`
- `git diff --check`
- `sbt "tests2_13/testOnly org.scalanative.testsuite.javalib.lang.IterableDefaultTest"`

Split out of #4851 to reduce the JSR166 migration PR surface.