### PR TITLE
Fix #4872: Port java JSR-166 DelayQueue and implement JDK 21 remove() override 

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/DelayQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/DelayQueue.scala
@@ -455,14 +455,14 @@ class DelayQueue[E <: Delayed] extends AbstractQueue[E] with BlockingQueue[E] {
   /*
    * Identity-based version for use in Itr.remove.
    */
-  def removeEQ(o: Any): Unit = {
+  private def removeEQ(o: AnyRef): Unit = {
     val lock = this.lock
     lock.lock()
     try {
       val it = q.iterator()
       var breakSeen = false
       while (it.hasNext() && !breakSeen) {
-        if (o == it.next()) {
+        if (o.eq(it.next())) {
           it.remove()
           breakSeen = true
         }

--- a/javalib/src/main/scala/java/util/concurrent/DelayQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/DelayQueue.scala
@@ -1,0 +1,515 @@
+/* Ported from JSR-166 Expert Group main CVS (Concurrent Versions System)
+ * repository as described at Doug Lea "Concurrency JSR-166 Interest Site"
+ *    https://gee.cs.oswego.edu/dl/concurrency-interest/.
+ *
+ *  file: src/main/java/util/concurrent/DelayQueue.java
+ *  revision 1.78, dated: 2018-09-30
+ */
+
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+import java.util.concurrent.TimeUnit.NANOSECONDS
+import java.util.concurrent.locks.ReentrantLock
+import java.util.{
+  AbstractQueue, Collection, Iterator, NoSuchElementException, Objects,
+  PriorityQueue
+}
+
+/*
+ * An unbounded {@linkplain BlockingQueue blocking queue} of
+ * {@code Delayed} elements, in which an element can only be taken
+ * when its delay has expired.  The <em>head</em> of the queue is that
+ * {@code Delayed} element whose delay expired furthest in the
+ * past.  If no delay has expired there is no head and {@code poll}
+ * will return {@code null}. Expiration occurs when an element's
+ * {@code getDelay(TimeUnit.NANOSECONDS)} method returns a value less
+ * than or equal to zero.  Even though unexpired elements cannot be
+ * removed using {@code take} or {@code poll}, they are otherwise
+ * treated as normal elements. For example, the {@code size} method
+ * returns the count of both expired and unexpired elements.
+ * This queue does not permit null elements.
+ *
+ * <p>This class and its iterator implement all of the <em>optional</em>
+ * methods of the {@link Collection} and {@link Iterator} interfaces.
+ * The Iterator provided in method {@link #iterator()} is <em>not</em>
+ * guaranteed to traverse the elements of the DelayQueue in any
+ * particular order.
+ *
+ * <p>This class is a member of the
+ * <a href="{@docRoot}/java.base/java/util/package-summary.html#CollectionsFramework">
+ * Java Collections Framework</a>.
+ *
+ * @since 1.5
+ * @author Doug Lea
+ * @param <E> the type of elements held in this queue
+ */
+
+class DelayQueue[E <: Delayed] extends AbstractQueue[E] with BlockingQueue[E] {
+  private val lock = new ReentrantLock()
+  private val q = new PriorityQueue[E]()
+
+  // A new DelayQueue is initially empty
+
+  /*
+   * Thread designated to wait for the element at the head of
+   * the queue.  This variant of the Leader-Follower pattern
+   * (http://www.cs.wustl.edu/~schmidt/POSA/POSA2/) serves to
+   * minimize unnecessary timed waiting.  When a thread becomes
+   * the leader, it waits only for the next delay to elapse, but
+   * other threads await indefinitely.  The leader thread must
+   * signal some other thread before returning from take() or
+   * poll(...), unless some other thread becomes leader in the
+   * interim.  Whenever the head of the queue is replaced with
+   * an element with an earlier expiration time, the leader
+   * field is invalidated by being reset to null, and some
+   * waiting thread, but not necessarily the current leader, is
+   * signalled.  So waiting threads must be prepared to acquire
+   * and lose leadership while waiting.
+   */
+  private var leader: Thread = _
+
+  /*
+   * Condition signalled when a newer element becomes available
+   * at the head of the queue or a new thread may need to
+   * become leader.
+   */
+  private val available = lock.newCondition()
+
+  /*
+   * Creates a {@code DelayQueue} initially containing the elements of the
+   * given collection of {@link Delayed} instances.
+   *
+   * @param c the collection of elements to initially contain
+   * @throws NullPointerException if the specified collection or any
+   *         of its elements are null
+   */
+  def this(c: Collection[_ <: E]) = {
+    this()
+    this.addAll(c)
+  }
+
+  /*
+   * Inserts the specified element into this delay queue.
+   *
+   * @param e the element to add
+   * @return {@code true} (as specified by {@link Collection#add})
+   * @throws NullPointerException if the specified element is null
+   */
+  override def add(e: E): Boolean =
+    offer(e)
+
+  /*
+   * Inserts the specified element into this delay queue.
+   *
+   * @param e the element to add
+   * @return {@code true}
+   * @throws NullPointerException if the specified element is null
+   */
+  def offer(e: E): Boolean = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      q.offer(e)
+      if (q.peek() == e) {
+        leader = null
+        available.signal()
+      }
+      true
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Inserts the specified element into this delay queue. As the queue is
+   * unbounded this method will never block.
+   *
+   * @param e the element to add
+   * @throws NullPointerException {@inheritDoc}
+   */
+  def put(e: E): Unit =
+    offer(e)
+  /*
+   * Inserts the specified element into this delay queue. As the queue is
+   * unbounded this method will never block.
+   *
+   * @param e the element to add
+   * @param timeout This parameter is ignored as the method never blocks
+   * @param unit This parameter is ignored as the method never blocks
+   * @return {@code true}
+   * @throws NullPointerException {@inheritDoc}
+   */
+  def offer(e: E, timeout: Long, unit: TimeUnit): Boolean =
+    offer(e)
+
+  /*
+   * Retrieves and removes the head of this queue, or returns {@code null}
+   * if this queue has no elements with an expired delay.
+   *
+   * @return the head of this queue, or {@code null} if this
+   *         queue has no elements with an expired delay
+   */
+  def poll(): E = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      val first = q.peek()
+      if (first == null || first.getDelay(NANOSECONDS) > 0)
+        null.asInstanceOf[E]
+      else
+        q.poll()
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Retrieves and removes the head of this queue, waiting if necessary
+   * until an element with an expired delay is available on this queue.
+   *
+   * @return the head of this queue
+   * @throws InterruptedException {@inheritDoc}
+   */
+  def take(): E = {
+    val lock = this.lock
+    lock.lockInterruptibly()
+    try {
+      while (true) {
+        var first = q.peek()
+        if (first == null)
+          available.await()
+        else {
+          val delay = first.getDelay(NANOSECONDS)
+          if (delay <= 0L)
+            return q.poll()
+          // don't retain ref while waiting
+          first = null.asInstanceOf[E]
+          if (leader != null)
+            available.await()
+          else {
+            val thisThread = Thread.currentThread()
+            leader = thisThread
+            try {
+              available.awaitNanos(delay)
+            } finally {
+              if (leader == thisThread)
+                leader = null
+            }
+          }
+        }
+      }
+      null.asInstanceOf[E] // should never get here
+    } finally {
+      if (leader == null && q.peek() != null)
+        available.signal()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Retrieves and removes the head of this queue, waiting if necessary
+   * until an element with an expired delay is available on this queue,
+   * or the specified wait time expires.
+   *
+   * @return the head of this queue, or {@code null} if the
+   *         specified waiting time elapses before an element with
+   *         an expired delay becomes available
+   * @throws InterruptedException {@inheritDoc}
+   */
+  def poll(timeout: Long, unit: TimeUnit): E = {
+    var nanos = unit.toNanos(timeout)
+    val lock = this.lock
+    lock.lockInterruptibly()
+    try {
+      while (true) {
+        var first = q.peek()
+        if (first == null) {
+          if (nanos <= 0L)
+            return null.asInstanceOf[E]
+          else
+            nanos = available.awaitNanos(nanos)
+        } else {
+          val delay = first.getDelay(NANOSECONDS)
+          if (delay <= 0L)
+            return q.poll()
+          if (nanos <= 0L)
+            return null.asInstanceOf[E]
+          // don't retain ref while waiting
+          first = null.asInstanceOf[E]
+          if (nanos < delay || leader != null)
+            nanos = available.awaitNanos(nanos);
+          else {
+            val thisThread = Thread.currentThread();
+            leader = thisThread
+            try {
+              val timeLeft = available.awaitNanos(delay)
+              nanos -= delay - timeLeft
+            } finally {
+              if (leader == thisThread)
+                leader = null
+            }
+          }
+        }
+      }
+      null.asInstanceOf[E] // should never get here
+    } finally {
+      if (leader == null && q.peek() != null)
+        available.signal();
+      lock.unlock();
+    }
+  }
+
+  /*
+   * Retrieves, but does not remove, the head of this queue, or
+   * returns {@code null} if this queue is empty.  Unlike
+   * {@code poll}, if no expired elements are available in the queue,
+   * this method returns the element that will expire next,
+   * if one exists.
+   *
+   * @return the head of this queue, or {@code null} if this
+   *         queue is empty
+   */
+  def peek(): E = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return q.peek()
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  def size(): Int = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return q.size()
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws UnsupportedOperationException {@inheritDoc}
+   * @throws ClassCastException            {@inheritDoc}
+   * @throws NullPointerException          {@inheritDoc}
+   * @throws IllegalArgumentException      {@inheritDoc}
+   */
+  def drainTo(c: Collection[_ >: E]): Int =
+    return drainTo(c, Integer.MAX_VALUE)
+
+  /*
+   * @throws UnsupportedOperationException {@inheritDoc}
+   * @throws ClassCastException            {@inheritDoc}
+   * @throws NullPointerException          {@inheritDoc}
+   * @throws IllegalArgumentException      {@inheritDoc}
+   */
+  def drainTo(c: Collection[? >: E], maxElements: Int): Int = {
+    Objects.requireNonNull(c)
+    if (c == this)
+      throw new IllegalArgumentException()
+    if (maxElements <= 0)
+      return 0
+    val lock = this.lock
+    lock.lock()
+    try {
+      var n = 0
+      var first: E = null.asInstanceOf[E]
+
+      while (n < maxElements
+          && ({ first = q.peek(); first }) != null
+          && first.getDelay(NANOSECONDS) <= 0) {
+        c.add(first) // In this order, in case add() throws.
+        q.poll()
+        n += 1
+      }
+      return n
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Atomically removes all of the elements from this delay queue.
+   * The queue will be empty after this call returns.
+   * Elements with an unexpired delay are not waited for; they are
+   * simply discarded from the queue.
+   */
+  override def clear(): Unit = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      q.clear()
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Always returns {@code Integer.MAX_VALUE} because
+   * a {@code DelayQueue} is not capacity constrained.
+   *
+   * @return {@code Integer.MAX_VALUE}
+   */
+  def remainingCapacity(): Int =
+    Integer.MAX_VALUE
+
+  /*
+   * Returns an array containing all of the elements in this queue.
+   * The returned array elements are in no particular order.
+   *
+   * <p>The returned array will be "safe" in that no references to it are
+   * maintained by this queue.  (In other words, this method must allocate
+   * a new array).  The caller is thus free to modify the returned array.
+   *
+   * <p>This method acts as bridge between array-based and collection-based
+   * APIs.
+   *
+   * @return an array containing all of the elements in this queue
+   */
+  override def toArray(): Array[Object] = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return q.toArray()
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Returns an array containing all of the elements in this queue; the
+   * runtime type of the returned array is that of the specified array.
+   * The returned array elements are in no particular order.
+   * If the queue fits in the specified array, it is returned therein.
+   * Otherwise, a new array is allocated with the runtime type of the
+   * specified array and the size of this queue.
+   *
+   * <p>If this queue fits in the specified array with room to spare
+   * (i.e., the array has more elements than this queue), the element in
+   * the array immediately following the end of the queue is set to
+   * {@code null}.
+   *
+   * <p>Like the {@link #toArray()} method, this method acts as bridge between
+   * array-based and collection-based APIs.  Further, this method allows
+   * precise control over the runtime type of the output array, and may,
+   * under certain circumstances, be used to save allocation costs.
+   *
+   * <p>The following code can be used to dump a delay queue into a newly
+   * allocated array of {@code Delayed}:
+   *
+   * <pre> {@code Delayed[] a = q.toArray(new Delayed[0]);}</pre>
+   *
+   * Note that {@code toArray(new Object[0])} is identical in function to
+   * {@code toArray()}.
+   *
+   * @param a the array into which the elements of the queue are to
+   *          be stored, if it is big enough; otherwise, a new array of the
+   *          same runtime type is allocated for this purpose
+   * @return an array containing all of the elements in this queue
+   * @throws ArrayStoreException if the runtime type of the specified array
+   *         is not a supertype of the runtime type of every element in
+   *         this queue
+   * @throws NullPointerException if the specified array is null
+   */
+  override def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return q.toArray(a)
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /* @since JDK 21 */
+  override def remove(): E = {
+    val h = poll()
+
+    if (h == null.asInstanceOf[E])
+      throw new NoSuchElementException()
+    else
+      h
+  }
+
+  /*
+   * Removes a single instance of the specified element from this
+   * queue, if it is present, whether or not it has expired.
+   */
+  override def remove(o: Any): Boolean = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return q.remove(o)
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Identity-based version for use in Itr.remove.
+   */
+  def removeEQ(o: Any): Unit = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      val it = q.iterator()
+      var breakSeen = false
+      while (it.hasNext() && !breakSeen) {
+        if (o == it.next()) {
+          it.remove()
+          breakSeen = true
+        }
+      }
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Returns an iterator over all the elements (both expired and
+   * unexpired) in this queue. The iterator does not return the
+   * elements in any particular order.
+   *
+   * <p>The returned iterator is
+   * <a href="package-summary.html#Weakly"><i>weakly consistent</i></a>.
+   *
+   * @return an iterator over the elements in this queue
+   */
+  def iterator(): Iterator[E] =
+    new Itr(toArray())
+
+  /*
+   * Snapshot iterator that works off copy of underlying q array.
+   */
+  private class Itr(array: Array[Object]) extends Iterator[E] {
+    // Array of all elements
+    var cursor = 0 // index of next element to return
+    var lastRet = -1 // index of last element, or -1 if no such
+
+    def hasNext(): Boolean = {
+      cursor < array.length
+    }
+
+    def next(): E = {
+      if (cursor >= array.length)
+        throw new NoSuchElementException()
+      lastRet = cursor
+      cursor += 1
+      array(lastRet).asInstanceOf[E]
+    }
+
+    override def remove(): Unit = {
+      if (lastRet < 0)
+        throw new IllegalStateException()
+      removeEQ(array(lastRet))
+      lastRet = -1
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/concurrent/DelayQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/DelayQueue.scala
@@ -116,7 +116,7 @@ class DelayQueue[E <: Delayed] extends AbstractQueue[E] with BlockingQueue[E] {
     lock.lock()
     try {
       q.offer(e)
-      if (q.peek() == e) {
+      if (q.peek().eq(e)) { // reference quality: exact element just inserted
         leader = null
         available.signal()
       }

--- a/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/concurrent/DelayQueueTestOnJDK21.scala
+++ b/unit-tests/shared/src/test/require-jdk21/org/scalanative/testsuite/javalib/util/concurrent/DelayQueueTestOnJDK21.scala
@@ -1,0 +1,103 @@
+/* The Java 8 unit-tests DelayQueueTest was ported from
+ * JSR-166 Expert Group main CVS (Concurrent Versions System)
+ * repository as described at Doug Lea "Concurrency JSR-166 Interest Site"
+ *
+ *    https://gee.cs.oswego.edu/dl/concurrency-interest/.
+ *
+ * file: Unknown, chosen by ChatGPT 5.5.
+ * revision Unknown, dated: Unknown
+ *
+ * This file contains original 'post JSR-166' tests for the
+ * 'DelayQueue#remove()' overload introduced in JDK 21.
+ */
+
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.{DelayQueue, Delayed, TimeUnit}
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+object DelayQueueTestOnJDK21 {
+  import JSR166Test._
+
+  /* SN JDK21: Make class abstract so that Tests below can
+   * tune getDelay() to expired or not. Class was final in JSR-166.
+   *
+   * Rest of class is identical to JDK 8 DelayQueueTest. Leaving the
+   * majority of the declaration the same aids tracing if such becomes
+   * necessary.
+   */
+  abstract class PDelay(val pseudodelay: Int) extends Delayed {
+    override def compareTo(y: Delayed): Int =
+      Integer.compare(this.pseudodelay, y.asInstanceOf[PDelay].pseudodelay)
+
+    override def equals(other: Any): Boolean =
+      other.isInstanceOf[PDelay] &&
+        this.pseudodelay == other.asInstanceOf[PDelay].pseudodelay
+
+    override def hashCode(): Int = pseudodelay
+
+    override def getDelay(unit: TimeUnit): Long
+    Int.MinValue.toLong + pseudodelay
+
+    override def toString(): String = String.valueOf(pseudodelay)
+  }
+}
+
+class DelayQueueTestOnJDK21 extends JSR166Test {
+  import DelayQueueTestOnJDK21._
+  import JSR166Test._
+
+  /* From the JDK 26 API documentation:
+   *   Retrieves and removes the expired head of this queue, or throws
+   *   an exception if this queue has no expired elements.
+   */
+
+  @Test def testRemoveJdk21Overload_ExpiredHeadTrue(): Unit = {
+    val q = new DelayQueue[PDelay]()
+
+    val pd_1 = new PDelay(1) {
+      override def getDelay(unit: TimeUnit): Long =
+        jl.Long.MIN_VALUE + 1
+    }
+
+    val pd_0 = new PDelay(0) {
+      override def getDelay(unit: TimeUnit): Long =
+        jl.Long.MIN_VALUE
+    }
+
+    // Insert in reverse delay order to check that priority sort is done.
+    assertTrue("offer(pd_1)", q.offer(pd_1))
+    assertTrue("offer(pd_0)", q.offer(pd_0))
+
+    mustEqual(pd_0, q.remove())
+  }
+
+  @Test def testRemoveJdk21OverloadExpiredHeadFalse(): Unit = {
+    val q = new DelayQueue[PDelay]()
+
+    val pd = new PDelay(0) {
+      override def getDelay(unit: TimeUnit): Long =
+        jl.Long.MAX_VALUE
+    }
+
+    assertTrue("offer(pd)", q.offer(pd))
+
+    try {
+      q.remove()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/DelayQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/DelayQueueTest.scala
@@ -1,0 +1,734 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util._
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent._
+
+import org.junit.Assert._
+import org.junit.{Ignore, Test}
+
+object DelayQueueTest {
+  import JSR166Test._
+
+  final class PDelay(val pseudodelay: Int) extends Delayed {
+    override def compareTo(y: Delayed): Int =
+      Integer.compare(this.pseudodelay, y.asInstanceOf[PDelay].pseudodelay)
+
+    override def equals(other: Any): Boolean =
+      other.isInstanceOf[PDelay] &&
+        this.pseudodelay == other.asInstanceOf[PDelay].pseudodelay
+
+    override def hashCode(): Int = pseudodelay
+
+    override def getDelay(unit: TimeUnit): Long =
+      Int.MinValue.toLong + pseudodelay
+
+    override def toString(): String = String.valueOf(pseudodelay)
+  }
+
+  final class NanoDelay(delayNanos: Long) extends Delayed {
+    private val trigger = System.nanoTime() + delayNanos
+
+    override def compareTo(y: Delayed): Int =
+      java.lang.Long.compare(trigger, y.asInstanceOf[NanoDelay].trigger)
+
+    override def equals(other: Any): Boolean =
+      other.isInstanceOf[NanoDelay] &&
+        this.trigger == other.asInstanceOf[NanoDelay].trigger
+
+    override def hashCode(): Int = trigger.toInt
+
+    override def getDelay(unit: TimeUnit): Long =
+      unit.convert(trigger - System.nanoTime(), TimeUnit.NANOSECONDS)
+
+    def getTriggerTime(): Long = trigger
+
+    override def toString(): String = String.valueOf(trigger)
+  }
+
+  def populatedQueue(n: Int): DelayQueue[PDelay] = {
+    val q = new DelayQueue[PDelay]()
+    assertTrue(q.isEmpty())
+    var i = n - 1
+    while (i >= 0) {
+      assertTrue(q.offer(new PDelay(i)))
+      i -= 2
+    }
+    i = n & 1
+    while (i < n) {
+      assertTrue(q.offer(new PDelay(i)))
+      i += 2
+    }
+    assertFalse(q.isEmpty())
+    mustEqual(Int.MaxValue, q.remainingCapacity())
+    mustEqual(n, q.size())
+    mustEqual(new PDelay(0), q.peek())
+    q
+  }
+}
+
+class DelayQueueTest extends JSR166Test {
+  import DelayQueueTest._
+  import JSR166Test._
+
+  /* A new queue has unbounded capacity */
+  @Test def testConstructor1(): Unit = {
+    mustEqual(Int.MaxValue, new DelayQueue[PDelay]().remainingCapacity())
+  }
+
+  /* Initializing from null Collection throws NPE */
+  @Test def testConstructor3(): Unit = {
+    try {
+      new DelayQueue[PDelay](null)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* Initializing from Collection of null elements throws NPE */
+  @Test def testConstructor4(): Unit = {
+    try {
+      new DelayQueue[PDelay](Arrays.asList(new Array[PDelay](SIZE): _*))
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* Initializing from Collection with some null elements throws NPE */
+  @Test def testConstructor5(): Unit = {
+    val a = new Array[PDelay](SIZE)
+    for (i <- 0 until SIZE - 1) a(i) = new PDelay(i)
+    try {
+      new DelayQueue[PDelay](Arrays.asList(a: _*))
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* Queue contains all elements of collection used to initialize */
+  @Test def testConstructor6(): Unit = {
+    val items = new Array[PDelay](SIZE)
+    for (i <- 0 until SIZE) items(i) = new PDelay(i)
+    val q = new DelayQueue[PDelay](Arrays.asList(items: _*))
+    for (i <- 0 until SIZE) mustEqual(items(i), q.poll())
+  }
+
+  /* isEmpty is true before add, false after */
+  @Test def testEmpty(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    assertTrue(q.isEmpty())
+    mustEqual(Int.MaxValue, q.remainingCapacity())
+    q.add(new PDelay(1))
+    assertFalse(q.isEmpty())
+    q.add(new PDelay(2))
+    q.remove()
+    q.remove()
+    assertTrue(q.isEmpty())
+  }
+
+  /* remainingCapacity() always returns Integer.MAX_VALUE */
+  @Test def testRemainingCapacity(): Unit = {
+    val q: BlockingQueue[PDelay] = populatedQueue(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(Int.MaxValue, q.remainingCapacity())
+      mustEqual(SIZE - i, q.size())
+      assertTrue(q.remove().isInstanceOf[PDelay])
+    }
+    for (i <- 0 until SIZE) {
+      mustEqual(Int.MaxValue, q.remainingCapacity())
+      mustEqual(i, q.size())
+      assertTrue(q.add(new PDelay(i)))
+    }
+  }
+
+  /* offer non-null succeeds */
+  @Test def testOffer(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    assertTrue(q.offer(new PDelay(0)))
+    assertTrue(q.offer(new PDelay(1)))
+  }
+
+  /* add succeeds */
+  @Test def testAdd(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.size())
+      assertTrue(q.add(new PDelay(i)))
+    }
+  }
+
+  /* addAll(this) throws IllegalArgumentException */
+  @Test def testAddAllSelf(): Unit = {
+    val q = populatedQueue(SIZE)
+    try {
+      q.addAll(q)
+      shouldThrow()
+    } catch {
+      case _: IllegalArgumentException =>
+    }
+  }
+
+  /* addAll of a collection with any null elements throws NPE */
+  @Test def testAddAll3(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    val a = new Array[PDelay](SIZE)
+    for (i <- 0 until SIZE - 1) a(i) = new PDelay(i)
+    try {
+      q.addAll(Arrays.asList(a: _*))
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* Queue contains all elements of successful addAll */
+  @Test def testAddAll5(): Unit = {
+    val empty = new Array[PDelay](0)
+    val items = new Array[PDelay](SIZE)
+    for (i <- SIZE - 1 to 0 by -1) items(i) = new PDelay(i)
+    val q = new DelayQueue[PDelay]()
+    assertFalse(q.addAll(Arrays.asList(empty: _*)))
+    assertTrue(q.addAll(Arrays.asList(items: _*)))
+    for (i <- 0 until SIZE) mustEqual(items(i), q.poll())
+  }
+
+  /* all elements successfully put are contained */
+  @Test def testPut(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    for (i <- 0 until SIZE) {
+      val x = new PDelay(i)
+      q.put(x)
+      assertTrue(q.contains(x))
+    }
+    mustEqual(SIZE, q.size())
+  }
+
+  /* put doesn't block waiting for take */
+  @Test def testPutWithTake(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        q.put(new PDelay(0))
+        q.put(new PDelay(0))
+        q.put(new PDelay(0))
+        q.put(new PDelay(0))
+      }
+    })
+
+    awaitTermination(t)
+    mustEqual(4, q.size()) // Will fail CI if realRun did not succeed
+  }
+
+  /* Queue is unbounded, so timed offer never times out */
+  @Test def testTimedOffer(): Unit = {
+    @volatile var realRunSuccess = false
+
+    val q = new DelayQueue[PDelay]()
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        q.put(new PDelay(0))
+        q.put(new PDelay(0))
+        assertTrue(q.offer(new PDelay(0), SHORT_DELAY_MS, MILLISECONDS))
+        assertTrue(q.offer(new PDelay(0), LONG_DELAY_MS, MILLISECONDS))
+        realRunSuccess = true
+      }
+    })
+
+    awaitTermination(t)
+
+    if (!realRunSuccess)
+      fail("realRun failed") // Tell CI
+  }
+
+  /* take retrieves elements in priority order */
+  @Test def testTake(): Unit = {
+    val q = populatedQueue(SIZE)
+    for (i <- 0 until SIZE)
+      mustEqual(new PDelay(i), q.take())
+  }
+
+  /* take signals another waiting taker when more expired elements remain */
+  @Test def testTakeSignalsNextExpiredElement(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    val threadsStarted = new CountDownLatch(2)
+    val done = new CountDownLatch(2)
+    val taken = Collections.synchronizedList(new ArrayList[PDelay]())
+
+    val taker = new CheckedRunnable {
+      override def realRun(): Unit = {
+        threadsStarted.countDown()
+        taken.add(q.take())
+        done.countDown()
+      }
+    }
+
+    val t1 = newStartedThread(taker)
+    val t2 = newStartedThread(taker)
+    try {
+      await(threadsStarted)
+      waitForThreadToEnterWaitState(t1)
+      waitForThreadToEnterWaitState(t2)
+
+      q.put(new PDelay(0))
+      q.put(new PDelay(1))
+
+      await(done)
+      awaitTermination(t1)
+      awaitTermination(t2)
+      mustEqual(2, taken.size())
+      assertTrue(q.isEmpty())
+    } finally {
+      t1.interrupt()
+      t2.interrupt()
+    }
+  }
+
+  /* Take removes existing elements until empty, then blocks interruptibly */
+  @Test def testBlockingTake(): Unit = {
+    @volatile var realRunSuccess = false
+
+    val q = populatedQueue(SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE) mustEqual(new PDelay(i), q.take())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.take()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.take()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+        realRunSuccess = true
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+
+    if (!realRunSuccess)
+      fail("realRun failed") // Tell CI
+  }
+
+  /* poll succeeds unless empty */
+  @Test def testPoll(): Unit = {
+    val q = populatedQueue(SIZE)
+    for (i <- 0 until SIZE) mustEqual(new PDelay(i), q.poll())
+    assertNull(q.poll())
+  }
+
+  /* timed poll with zero timeout succeeds when non-empty, else times out */
+  @Test def testTimedPoll0(): Unit = {
+    val q = populatedQueue(SIZE)
+    for (i <- 0 until SIZE)
+      mustEqual(new PDelay(i), q.poll(0, MILLISECONDS))
+    assertNull(q.poll(0, MILLISECONDS))
+  }
+
+  /* timed poll with nonzero timeout succeeds when non-empty, else times out */
+  @Test def testTimedPoll(): Unit = {
+    val q = populatedQueue(SIZE)
+    for (i <- 0 until SIZE) {
+      val startTime = System.nanoTime()
+      mustEqual(new PDelay(i), q.poll(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+    val startTime = System.nanoTime()
+    assertNull(q.poll(timeoutMillis(), MILLISECONDS))
+    assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    checkEmpty(q)
+  }
+
+  /* Interrupted timed poll throws InterruptedException */
+  @Test def testInterruptedTimedPoll(): Unit = {
+    @volatile var realRunSuccess = false
+
+    val pleaseInterrupt = new CountDownLatch(1)
+    val q = populatedQueue(SIZE)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE)
+          mustEqual(new PDelay(i), q.poll(LONG_DELAY_MS, MILLISECONDS))
+
+        Thread.currentThread().interrupt()
+        try {
+          q.poll(randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.poll(LONGER_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+        realRunSuccess = true
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+
+    if (!realRunSuccess)
+      fail("realRun failed") // Tell CI
+    checkEmpty(q)
+  }
+
+  /* peek returns next element, or null if empty */
+  @Test def testPeek(): Unit = {
+    val q = populatedQueue(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(new PDelay(i), q.peek())
+      mustEqual(new PDelay(i), q.poll())
+      if (q.isEmpty()) assertNull(q.peek())
+      else assertFalse(new PDelay(i).equals(q.peek()))
+    }
+    assertNull(q.peek())
+  }
+
+  /* element returns next element, or throws NSEE if empty */
+  @Test def testElement(): Unit = {
+    val q = populatedQueue(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(new PDelay(i), q.element())
+      q.poll()
+    }
+    try {
+      q.element()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+  }
+
+  /* SN:
+   *   On JDKs < 21, DelayQueue remove(), no arguments, executes
+   *   AbstractQueue#remove(), which unconditionally removes the head,
+   *   if any, expired or not. The is the behavior the the original
+   *   JSR-166 test was constructed to test.
+   *
+   *   JDK 21 introduced a DelayQueue#remove(), which will only remove
+   *   an _expired_ head, if any, else throw.
+   *
+   *   The PDelay class in this file is the JSR-166 original which
+   *   sets all elements to be expired.
+   *
+   *   That means that this test will/should pass when run on any
+   *   JDK version 8 or greater (exercised to JDK 26) but will silently
+   *   exercise different methods with different behaviors.
+   *   A false positive for JDK >= 21.
+   *
+   *   Data in the wild will probably not be always expired.
+   *
+   *   DelayQueueTestOnJDK21 contains two tests to exercise cases which
+   *   would fail on JDK 8 but should succeed in JDK 21 and higher.
+   */
+  /* remove removes next element, or throws NSEE if empty */
+  @Test def testRemove(): Unit = {
+    val q = populatedQueue(SIZE)
+    for (i <- 0 until SIZE)
+      mustEqual(new PDelay(i), q.remove())
+    try {
+      q.remove()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+  }
+
+  /* contains(x) reports true when elements added but not yet removed */
+  @Test def testContains(): Unit = {
+    val q = populatedQueue(SIZE)
+    for (i <- 0 until SIZE) {
+      assertTrue(q.contains(new PDelay(i)))
+      q.poll()
+      assertFalse(q.contains(new PDelay(i)))
+    }
+  }
+
+  /* clear removes all elements */
+  @Test def testClear(): Unit = {
+    val q = populatedQueue(SIZE)
+    q.clear()
+    assertTrue(q.isEmpty())
+    mustEqual(0, q.size())
+    mustEqual(Int.MaxValue, q.remainingCapacity())
+    val x = new PDelay(1)
+    q.add(x)
+    assertFalse(q.isEmpty())
+    assertTrue(q.contains(x))
+    q.clear()
+    assertTrue(q.isEmpty())
+  }
+
+  /* containsAll(c) is true when c contains a subset of elements */
+  @Test def testContainsAll(): Unit = {
+    val q = populatedQueue(SIZE)
+    val p = new DelayQueue[PDelay]()
+    for (i <- 0 until SIZE) {
+      assertTrue(q.containsAll(p))
+      assertFalse(p.containsAll(q))
+      p.add(new PDelay(i))
+    }
+    assertTrue(p.containsAll(q))
+  }
+
+  /* retainAll(c) retains only those elements of c */
+  @Test def testRetainAll(): Unit = {
+    val q = populatedQueue(SIZE)
+    val p = populatedQueue(SIZE)
+    for (i <- 0 until SIZE) {
+      val changed = q.retainAll(p)
+      if (i == 0) assertFalse(changed)
+      else assertTrue(changed)
+
+      assertTrue(q.containsAll(p))
+      mustEqual(SIZE - i, q.size())
+      p.remove()
+    }
+  }
+
+  /* removeAll(c) removes only those elements of c */
+  @Test def testRemoveAll(): Unit = {
+    for (i <- 1 until SIZE) {
+      val q = populatedQueue(SIZE)
+      val p = populatedQueue(i)
+      assertTrue(q.removeAll(p))
+      mustEqual(SIZE - i, q.size())
+      for (_ <- 0 until i)
+        assertFalse(q.contains(p.remove()))
+    }
+  }
+
+  /* toArray contains all elements */
+  @Test def testToArray(): Unit = {
+    val q = populatedQueue(SIZE)
+    val a = q.toArray()
+    assertSame(classOf[Array[AnyRef]], a.getClass())
+    Arrays.sort(a)
+    a.foreach(o => assertSame(o, q.take()))
+    assertTrue(q.isEmpty())
+  }
+
+  /* toArray(a) contains all elements */
+  @Test def testToArray2(): Unit = {
+    val q = populatedQueue(SIZE)
+    val items = new Array[PDelay](SIZE)
+    val array = q.toArray(items)
+    assertSame(items, array)
+    Arrays.sort(items.asInstanceOf[Array[AnyRef]])
+    items.foreach(o => assertSame(o, q.remove()))
+    assertTrue(q.isEmpty())
+  }
+
+  /* toArray(incompatible array type) throws ArrayStoreException */
+  @Ignore(
+    "Scala Native reference arrays do not preserve runtime component types"
+  )
+  @Test def testToArray_incompatibleArrayType(): Unit = {
+    val q = populatedQueue(SIZE)
+    try {
+      q.toArray(new Array[String](10))
+      shouldThrow()
+    } catch {
+      case _: ArrayStoreException =>
+    }
+  }
+
+  /* iterator iterates through all elements */
+  @Test def testIterator(): Unit = {
+    val q = populatedQueue(SIZE)
+    var i = 0
+    val it = q.iterator()
+    while (it.hasNext()) {
+      assertTrue(q.contains(it.next()))
+      i += 1
+    }
+    mustEqual(i, SIZE)
+    assertIteratorExhausted(it)
+  }
+
+  /* iterator of empty collection has no elements */
+  @Test def testEmptyIterator(): Unit = {
+    assertIteratorExhausted(new DelayQueue[PDelay]().iterator())
+  }
+
+  /* iterator.remove removes current element */
+  @Test def testIteratorRemove(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    q.add(new PDelay(2))
+    q.add(new PDelay(1))
+    q.add(new PDelay(3))
+    var it = q.iterator()
+    it.next()
+    it.remove()
+    it = q.iterator()
+    mustEqual(new PDelay(2), it.next())
+    mustEqual(new PDelay(3), it.next())
+    assertFalse(it.hasNext())
+  }
+
+  /* toString contains toStrings of elements */
+  @Test def testToString(): Unit = {
+    val q = populatedQueue(SIZE)
+    val s = q.toString()
+    val it = q.iterator()
+    while (it.hasNext())
+      assertTrue(s.contains(it.next().toString()))
+  }
+
+  /* timed poll transfers elements across Executor tasks */
+  @Test def testPollInExecutor(): Unit = {
+    // SN: This may need a realRun check but it is complicated.
+
+    val q = new DelayQueue[PDelay]()
+    val threadsStarted = new CheckedBarrier(2)
+    val executor = Executors.newFixedThreadPool(2)
+    usingPoolCleaner(executor) { executor =>
+      executor.execute(new CheckedRunnable {
+        override def realRun(): Unit = {
+          assertNull(q.poll())
+          threadsStarted.await()
+          assertNotNull(q.poll(LONG_DELAY_MS, MILLISECONDS))
+          checkEmpty(q)
+        }
+      })
+
+      executor.execute(new CheckedRunnable {
+        override def realRun(): Unit = {
+          threadsStarted.await()
+          q.put(new PDelay(1))
+        }
+      })
+    }
+  }
+
+  /* Delayed actions do not occur until their delay elapses */
+  @Test def testDelay(): Unit = {
+    val q = new DelayQueue[NanoDelay]()
+    for (i <- 0 until SIZE)
+      q.add(new NanoDelay(1000000L * (SIZE - i)))
+
+    var last = 0L
+    for (i <- 0 until SIZE) {
+      val e = q.take()
+      val tt = e.getTriggerTime()
+      assertTrue(System.nanoTime() - tt >= 0)
+      if (i != 0) assertTrue(tt >= last)
+      last = tt
+    }
+    assertTrue(q.isEmpty())
+  }
+
+  /* peek of a non-empty queue returns non-null even if not expired */
+  @Test def testPeekDelayed(): Unit = {
+    val q = new DelayQueue[NanoDelay]()
+    q.add(new NanoDelay(Long.MaxValue))
+    assertNotNull(q.peek())
+  }
+
+  /* poll of a non-empty queue returns null if no expired elements. */
+  @Test def testPollDelayed(): Unit = {
+    val q = new DelayQueue[NanoDelay]()
+    q.add(new NanoDelay(Long.MaxValue))
+    assertNull(q.poll())
+  }
+
+  /* timed poll of a non-empty queue returns null if no expired elements. */
+  @Test def testTimedPollDelayed(): Unit = {
+    val q = new DelayQueue[NanoDelay]()
+    q.add(new NanoDelay(LONG_DELAY_MS * 1000000L))
+    val startTime = System.nanoTime()
+    assertNull(q.poll(timeoutMillis(), MILLISECONDS))
+    assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+  }
+
+  /* drainTo(c) empties queue into another collection c */
+  @Test def testDrainTo(): Unit = {
+    val q = new DelayQueue[PDelay]()
+    val elems = new Array[PDelay](SIZE)
+    for (i <- 0 until SIZE) {
+      elems(i) = new PDelay(i)
+      q.add(elems(i))
+    }
+    val l = new ArrayList[PDelay]()
+    q.drainTo(l)
+    mustEqual(0, q.size())
+    for (i <- 0 until SIZE) mustEqual(elems(i), l.get(i))
+    q.add(elems(0))
+    q.add(elems(1))
+    assertFalse(q.isEmpty())
+    assertTrue(q.contains(elems(0)))
+    assertTrue(q.contains(elems(1)))
+    l.clear()
+    q.drainTo(l)
+    mustEqual(0, q.size())
+    mustEqual(2, l.size())
+    for (i <- 0 until 2) mustEqual(elems(i), l.get(i))
+  }
+
+  /* drainTo empties queue */
+  @Test def testDrainToWithActivePut(): Unit = {
+    val q = populatedQueue(SIZE)
+    val t = new Thread(new CheckedRunnable {
+      override def realRun(): Unit = q.put(new PDelay(SIZE + 1))
+    })
+
+    t.start()
+    val l = new ArrayList[PDelay]()
+    q.drainTo(l)
+    assertTrue(l.size() >= SIZE)
+    t.join()
+    assertTrue(q.size() + l.size() >= SIZE)
+  }
+
+  /* drainTo(c, n) empties first min(n, size) elements of queue into c */
+  @Test def testDrainToN(): Unit = {
+    for (i <- 0 until SIZE + 2) {
+      val q = populatedQueue(SIZE)
+      val l = new ArrayList[PDelay]()
+      q.drainTo(l, i)
+      val k = if (i < SIZE) i else SIZE
+      mustEqual(SIZE - k, q.size())
+      mustEqual(k, l.size())
+    }
+  }
+
+  /* remove(null), contains(null) always return false */
+  @Test def testNeverContainsNull(): Unit = {
+    val q: Collection[_] = populatedQueue(SIZE)
+    assertFalse(q.contains(null))
+    assertFalse(q.remove(null))
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/DelayQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/DelayQueueTest.scala
@@ -258,42 +258,6 @@ class DelayQueueTest extends JSR166Test {
       mustEqual(new PDelay(i), q.take())
   }
 
-  /* take signals another waiting taker when more expired elements remain */
-  @Test def testTakeSignalsNextExpiredElement(): Unit = {
-    val q = new DelayQueue[PDelay]()
-    val threadsStarted = new CountDownLatch(2)
-    val done = new CountDownLatch(2)
-    val taken = Collections.synchronizedList(new ArrayList[PDelay]())
-
-    val taker = new CheckedRunnable {
-      override def realRun(): Unit = {
-        threadsStarted.countDown()
-        taken.add(q.take())
-        done.countDown()
-      }
-    }
-
-    val t1 = newStartedThread(taker)
-    val t2 = newStartedThread(taker)
-    try {
-      await(threadsStarted)
-      waitForThreadToEnterWaitState(t1)
-      waitForThreadToEnterWaitState(t2)
-
-      q.put(new PDelay(0))
-      q.put(new PDelay(1))
-
-      await(done)
-      awaitTermination(t1)
-      awaitTermination(t2)
-      mustEqual(2, taken.size())
-      assertTrue(q.isEmpty())
-    } finally {
-      t1.interrupt()
-      t2.interrupt()
-    }
-  }
-
   /* Take removes existing elements until empty, then blocks interruptibly */
   @Test def testBlockingTake(): Unit = {
     @volatile var realRunSuccess = false


### PR DESCRIPTION
Fix #4872:

This is an evolution of Draft PR #4862 and, when ready for review, should supersede  it.
PR #4862 varied from the JSR-166 original and was missing at least `leader` handling.

Credit to He-Pin for motivating this port.

* Port Java JSR-166 `DelayQueue` class in a way that is close to the original .java source.

  * `DelayQueueTest` is taken, by kind permission, from the prior #4862. The source, but not 
     exact CVS version id, is known for that test and the generated code is quite close to the
     Java  original. Capturing the value of the prior PR saved significant development time.

  * Several `DelayQueutTest` tests which use `Runnables` and which use assertions in `realRun()`
    were modified so that failures in any of those assertions will cause the unit-test to noticeably
    fail in CI. 

    Previously the raw port of the JSR-166 code for that class could fail an assertion or failure in a `Runnable` 
    but CI would falsely pass.

  * The test ` testPollInExecutor()` may need modification to prevent CI false positives if
    experience demands.  That test is pretty complicated and the surgery to introduce CI 
    robustness is invasive and could not be implemented in the time available.
   
    Hint: an additional `runSuccess` variable and a  additional `CountDownLatch` awaiting it may be useful. 
    
* Implement an override of `remove()` which was introduced in JDK 21 and an associated
  unit-test.

  * There is a line of reasoning which would suggest that the JDK 21 change be in a separate 
    PR. 

    The change in JDK 21 was a change to the behavior of an existing method rather than
    a removal of that method or the introduction of a new overload or method.  That means
    that some data sets which previously passed on JDK < 21 might now start failing, depending
    upon the backing JVM. The single PR approach is taken here to eliminate this possibility of
    astonishment and misadventure, especially if the author gets hit by a bus before a hypothetical
   second PR.

