### PR TITLE
Fix service providers table alignment with `NoProviders`

### DIFF
--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
@@ -136,14 +136,21 @@ private[scala] object LinktimeIntrinsicCallsResolver {
         val dashlineLength = serviceNameWidth + provideNameWidth + stateWidth + 8 // extra padding columns
         builder += s"|${"-" * dashlineLength}|"
       }
+      def centerPad(value: String, width: Int) = {
+        val totalPadding = width - value.length
+        val leftPadding = totalPadding / 2
+        // Keep remaining padding on the right when split is uneven.
+        val rightPadding = totalPadding - leftPadding
+        s"${" " * leftPadding}$value${" " * rightPadding}"
+      }
       def addEntry(entry: Entry, statusColor: String, skipServiceName: Boolean) = {
         val (serviceName, providerName, status) = entry
         import ServiceProviderStatus._
         val serviceNameOrBlank = if (skipServiceName) "" else serviceName
-        val servicePadded = serviceNameOrBlank.padTo(serviceNameWidth, ' ')
-        val providerPadded = providerName.padTo(provideNameWidth, ' ')
+        val servicePadded = centerPad(serviceNameOrBlank, serviceNameWidth)
+        val providerPadded = centerPad(providerName, provideNameWidth)
         val statusPadded =
-          s"$statusColor${status.toString.padTo(stateWidth, ' ')}${if (statusColor.nonEmpty) RESET else ""}"
+          s"$statusColor${centerPad(status, stateWidth)}${if (statusColor.nonEmpty) RESET else ""}"
         builder += s"| $servicePadded | $providerPadded | $statusPadded |"
       }
 

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeIntrinsicCallsResolver.scala
@@ -114,7 +114,14 @@ private[scala] object LinktimeIntrinsicCallsResolver {
       val builder = Seq.newBuilder[String]
       val header: Entry = ("Service", "Service Provider", "Status")
       val entryPadding = 3
-      val (serviceNameWidth, provideNameWidth, stateWidth) = serviceProviders
+
+      val normalizedServiceProviders = serviceProviders.toSeq.sortBy(_._1).map {
+        case (serviceName, providers) =>
+          serviceName -> (if (providers.nonEmpty) providers.sortBy(_.name)
+                          else Seq(FoundServiceProvider("---", NoProviders)))
+      }
+
+      val (serviceNameWidth, provideNameWidth, stateWidth) = normalizedServiceProviders
         .foldLeft(header._1.length(), header._2.length(), header._3.length()) {
           case ((maxServiceName, maxProviderName, maxStateName), (serviceName, providers)) =>
             val longestProviderName = providers.foldLeft(0) { _ max _.name.length }
@@ -146,11 +153,9 @@ private[scala] object LinktimeIntrinsicCallsResolver {
       addEntry(header, statusColor = "", skipServiceName = false)
       addLine()
       for {
-        ((serviceName, providers), serviceIdx) <- serviceProviders.toSeq.sortBy(_._1).zipWithIndex
+        ((serviceName, providers), serviceIdx) <- normalizedServiceProviders.zipWithIndex
 
-        (provider, providerIdx) <-
-          if (providers.nonEmpty) providers.sortBy(_.name).zipWithIndex
-          else Seq(FoundServiceProvider("---", NoProviders) -> 0)
+        (provider, providerIdx) <- providers.zipWithIndex
         statusColor = provider.status match {
           case _ if noColor                             => ""
           case Loaded                                   => GREEN

--- a/tools/src/test/scala/scala/scalanative/linker/FoundServiceProvidersTableTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/FoundServiceProvidersTableTest.scala
@@ -28,11 +28,11 @@ class FoundServiceProvidersTableTest extends LinkerSpec {
 
     val expected = Seq(
       "|----------------------------------------------------------------------------------|",
-      "| Service                  | Service Provider                        | Status      |",
+      "|         Service          |            Service Provider             |   Status    |",
       "|----------------------------------------------------------------------------------|",
-      s"| Service 1 very long name | Service 1 very long implementation name | ${AnsiColor.GREEN}Loaded     ${AnsiColor.RESET} |",
+      s"| Service 1 very long name | Service 1 very long implementation name | ${AnsiColor.GREEN}  Loaded   ${AnsiColor.RESET} |",
       "|                          |                                         |             |",
-      s"| Service 2                | ---                                     | ${AnsiColor.YELLOW}NoProviders${AnsiColor.RESET} |",
+      s"|        Service 2         |                   ---                   | ${AnsiColor.YELLOW}NoProviders${AnsiColor.RESET} |",
       "|----------------------------------------------------------------------------------|"
     )
 
@@ -52,9 +52,9 @@ class FoundServiceProvidersTableTest extends LinkerSpec {
 
     val expected = Seq(
       "|-----------------------------------------------------------------------|",
-      "| Service                              | Service Provider | Status      |",
+      "|               Service                | Service Provider |   Status    |",
       "|-----------------------------------------------------------------------|",
-      s"| java.nio.charset.spi.CharsetProvider | ---              | ${AnsiColor.YELLOW}NoProviders${AnsiColor.RESET} |",
+      s"| java.nio.charset.spi.CharsetProvider |       ---        | ${AnsiColor.YELLOW}NoProviders${AnsiColor.RESET} |",
       "|-----------------------------------------------------------------------|"
     )
 

--- a/tools/src/test/scala/scala/scalanative/linker/FoundServiceProvidersTableTest.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/FoundServiceProvidersTableTest.scala
@@ -41,4 +41,26 @@ class FoundServiceProvidersTableTest extends LinkerSpec {
         assertEquals(expectedLine, actualLine)
     }
   }
+
+  @Test def correctFormattingWithNoProviders(): Unit = {
+    val actual = new LinktimeIntrinsicCallsResolver.FoundServiceProviders(
+      Map(
+        "java.nio.charset.spi.CharsetProvider" -> Seq.empty
+      )
+    )
+      .asTable(noColor = false)
+
+    val expected = Seq(
+      "|-----------------------------------------------------------------------|",
+      "| Service                              | Service Provider | Status      |",
+      "|-----------------------------------------------------------------------|",
+      s"| java.nio.charset.spi.CharsetProvider | ---              | ${AnsiColor.YELLOW}NoProviders${AnsiColor.RESET} |",
+      "|-----------------------------------------------------------------------|"
+    )
+
+    expected.zip(actual).foreach {
+      case (expectedLine, actualLine) =>
+        assertEquals(expectedLine, actualLine)
+    }
+  }
 }


### PR DESCRIPTION
The second commit makes the text center-aligned.

### Before
```
[info] Linking (multithreadingEnabled=detect) (2866 ms)
[info] Discovered 6399 classes and 39264 methods after classloading
[info] Loaded 0 service provider(s) for 1 referenced service(s):
[info] |------------------------------------------------------------------|
[info] | Service                              | Service Provider | Status |
[info] |------------------------------------------------------------------|
[info] | java.nio.charset.spi.CharsetProvider | ---              | NoProviders |
[info] |------------------------------------------------------------------|
[info] Checking intermediate code (quick) (307 ms)
[info] Discovered 5745 classes and 20071 methods after optimization
[info] Optimizing (release-size mode) (8105 ms)
[info] Produced 149 LLVM IR files
[info] Generating intermediate code (8625 ms)
[info] Compiling to native code (6438 ms)
[info] Linking with [pthread, dl, m, crypto]
[info] Linking native code (immix gc, none lto) (216 ms)
[info] Postprocessing (0 ms)
[info] Total (22108 ms)
```

### After
```
[info] Linking (multithreadingEnabled=detect) (2705 ms)
[info] Discovered 6399 classes and 39257 methods after classloading
[info] Loaded 0 service provider(s) for 1 referenced service(s):
[info] |-----------------------------------------------------------------------|
[info] |               Service                | Service Provider |   Status    |
[info] |-----------------------------------------------------------------------|
[info] | java.nio.charset.spi.CharsetProvider |       ---        | NoProviders |
[info] |-----------------------------------------------------------------------|
[info] Checking intermediate code (quick) (189 ms)
[info] Discovered 5745 classes and 20061 methods after optimization
[info] Optimizing (release-size mode) (8049 ms)
[info] Produced 149 LLVM IR files
[info] Generating intermediate code (7640 ms)
[info] Compiling to native code (6353 ms)
[info] Linking with [pthread, dl, m, crypto]
[info] Linking native code (immix gc, none lto) (311 ms)
[info] Postprocessing (0 ms)
[info] Total (20782 ms)
```