### PR TITLE
[sbt-plugin] Deprecate LLVM older then 16

### DIFF
--- a/.github/actions/linux-setup-env/action.yml
+++ b/.github/actions/linux-setup-env/action.yml
@@ -9,6 +9,7 @@ inputs:
     default: "17"
   llvm-version:
     description: "LLVM toolchain version"
+    default: "16"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/macos-setup-env/action.yml
+++ b/.github/actions/macos-setup-env/action.yml
@@ -9,6 +9,7 @@ inputs:
     default: "17"
   llvm-version:
     description: "Custom version of LLVM to use"
+    default: "16"
   gc: 
     description: "Garbage collector used, might require installing dependencies"
 runs:

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -208,7 +208,7 @@ jobs:
       fail-fast: false
       matrix:
         scala: [3]
-        llvm: [14, 15, 16, 17, 18, 19] # Last 3 stable versions + available future versions
+        llvm: [17, 18, 19, 20, 21, latest] # Last 3 stable versions + available future versions
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/linux-setup-env

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         scala: [3]
-        llvm: [14, 15, 16, 17, 18, 19, 20, latest] # Latest version == 21
+        llvm: [17, 18, 19, 20, 21 latest] # Latest version == 22
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/macos-setup-env

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -155,7 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         scala: [3]
-        llvm: ["19.1.7", "20.1.4"] # Last 2 stable versions, LLVM 10 is minimal version able to compile current Windows SDK
+        llvm: ["19.1.7", "21.1.8", "22.1.0"] # LLVM 19 is the minimal version, 20 is the the defualt
     steps:
       - name: Setup git config
         run: git config --global core.autocrlf false

--- a/docs/contrib/build-setup.md
+++ b/docs/contrib/build-setup.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 -   Java 8 or newer
--   LLVM/Clang 15 or newer
+-   LLVM/Clang 16 or newer
 -   sbt
 
 ## Use nix / devenv.sh
@@ -46,5 +46,4 @@ nix flakes has contentious points but, arguably, is uniquely capable. For scala-
 work required to, for example, enable packages to depend on a nix scala-native compiler build. So this use of
 nix flakes here is more aspirational than immediately useful. The primary value is providing a reasonably nice
 developer experience for an automatic and correct developer environment.
-
 

--- a/docs/contrib/quickstart.md
+++ b/docs/contrib/quickstart.md
@@ -5,7 +5,7 @@ Document built:
 ## Requirements
 
 -   Java 8 or newer
--   LLVM/Clang 15 or newer
+-   LLVM/Clang 16 or newer
 -   sbt
 
 See [here for details on the build environment setup](./build-setup.md).

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -11,7 +11,7 @@ Scala Native has the following build dependencies:
 
 -   Java 8 or newer
 -   sbt 1.5.8 or newer
--   LLVM/Clang 6.0 or newer
+-   LLVM/Clang 6.0 or newer (LLVM/Clang 16 or newer is recommended; older versions are deprecated)
 
 And following completely optional runtime library dependencies:
 
@@ -49,10 +49,10 @@ pkg_add scala-sbt
 ## Installing clang and runtime dependencies
 
 Scala Native requires Clang, which is part of the
-[LLVM](https://llvm.org) toolchain. The recommended LLVM version is the
-most recent available for your system provided that it works with Scala
-Native. The Scala Native sbt plugin checks to ensure that
-`clang` is at least the minimum version shown above.
+[LLVM](https://llvm.org) toolchain. LLVM/Clang 16 is the default version
+used in CI and the recommended baseline for local development. Older
+versions remain supported down to the minimum version shown above, but
+they are deprecated and may cause issues with continuations.
 
 Scala Native uses the
 [Immix](https://www.cs.utexas.edu/users/speedway/DaCapo/papers/immix-pldi-2008.pdf)
@@ -181,9 +181,9 @@ Visual Studio install dialog showing options.
 
 2.  Download and install LLVM
 
-<https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.1>
+<https://github.com/llvm/llvm-project/releases>
 
-Select *LLVM-12.0.1-win64.exe* or newer. Digital signatures are
+Select an *LLVM-16.x-win64.exe* installer or newer. Digital signatures are
 provided.
 
 You may also install LLVM via the command line, and if needed, install
@@ -191,7 +191,7 @@ it into your `C:\Users\<login>\AppData\Local` directory. The
 installer will add *LLVM* and the associated directories and files.
 
 ``` powershell
-> .\LLVM-12.0.1-win64.exe
+> .\LLVM-<version>-win64.exe
 ```
 
 3.  Add the binary location to your PATH

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -43,6 +43,9 @@ object BinaryIncompatibilities {
     exclude[Problem]("scala.scalanative.build.Config*Impl*"),
     // Should have never been public in the first place - contains local classpaths
     exclude[MissingClassProblem]("scala.scalanative.buildinfo.ScalaNativeBuildInfo*"),
+    // Package private
+    exclude[DirectMissingMethodProblem]("scala.scalanative.build.Discover.checkClangVersion"),
+    exclude[DirectMissingMethodProblem]("scala.scalanative.build.Discover.clangMinVersion"),
   )
 
   final val NativeLib = Seq(

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -116,9 +116,10 @@ object ScalaNativePluginInternal {
    */
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
     nativeConfig := {
+      val logger = sLog.value.toLogger
       build.NativeConfig.empty
-        .withClang(interceptBuildException(Discover.clang()))
-        .withClangPP(interceptBuildException(Discover.clangpp()))
+        .withClang(interceptBuildException(Discover.clang(logger)))
+        .withClangPP(interceptBuildException(Discover.clangpp(logger)))
         .withCompileOptions(Discover.compileOptions())
         .withLinkingOptions(Discover.linkingOptions())
         .withLTO(Discover.LTO())

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -116,10 +116,9 @@ object ScalaNativePluginInternal {
    */
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
     nativeConfig := {
-      val logger = sLog.value.toLogger
       build.NativeConfig.empty
-        .withClang(interceptBuildException(Discover.clang(logger)))
-        .withClangPP(interceptBuildException(Discover.clangpp(logger)))
+        .withClang(interceptBuildException(Discover.clang()))
+        .withClangPP(interceptBuildException(Discover.clangpp()))
         .withCompileOptions(Discover.compileOptions())
         .withLinkingOptions(Discover.linkingOptions())
         .withLTO(Discover.LTO())

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -42,18 +42,16 @@ object Discover {
       .getOrElse(build.GC.default)
 
   /** Use the clang binary on the path or via LLVM_BIN env var. */
-  def clang(): Path = clang(Logger.nullLogger)
-  private[scalanative] def clang(logger: Logger): Path = {
+  def clang(): Path = {
     val path = discover("clang", "LLVM_BIN")
-    checkClangVersion(path, logger)
+    checkClangVersion(path, Logger.default)
     path
   }
 
   /** Use the clang++ binary on the path or via LLVM_BIN env var. */
-  def clangpp(): Path = clangpp(Logger.nullLogger)
-  private[scalanative] def clangpp(logger: Logger): Path = {
+  def clangpp(): Path = {
     val path = discover("clang++", "LLVM_BIN")
-    checkClangVersion(path, logger)
+    checkClangVersion(path, Logger.default)
     path
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -189,7 +189,7 @@ object Discover {
     }
     // Warn once about deprecated clang version (so that we don't spam users since nativeConfig is a task)
     if (majorVersion < WarnOnClangOlderThan &&
-        warnedAboutDeprecatedClangVersion.compareAndExchange(false, true)) {
+        warnedAboutDeprecatedClangVersion.compareAndSet(false, true)) {
       logger.warn(
         s"""|Using deprecated clang version '$version'.
             |Versions older than clang '$WarnOnClangOlderThan' can contain known bugs and runtime issues.

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -1,8 +1,9 @@
 package scala.scalanative
 package build
 
-import java.io.File
-import java.nio.file.{Files, Path, Paths}
+import java.io.{File, IOException}
+import java.nio.file.{Files, LinkOption, Path, Paths}
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.reflect.ClassTag
 import scala.sys.process._
@@ -41,16 +42,18 @@ object Discover {
       .getOrElse(build.GC.default)
 
   /** Use the clang binary on the path or via LLVM_BIN env var. */
-  def clang(): Path = {
+  def clang(): Path = clang(Logger.nullLogger)
+  private[scalanative] def clang(logger: Logger): Path = {
     val path = discover("clang", "LLVM_BIN")
-    checkClangVersion(path)
+    checkClangVersion(path, logger)
     path
   }
 
   /** Use the clang++ binary on the path or via LLVM_BIN env var. */
-  def clangpp(): Path = {
+  def clangpp(): Path = clangpp(Logger.nullLogger)
+  private[scalanative] def clangpp(logger: Logger): Path = {
     val path = discover("clang++", "LLVM_BIN")
-    checkClangVersion(path)
+    checkClangVersion(path, logger)
     path
   }
 
@@ -159,20 +162,60 @@ object Discover {
   /** Tests whether the clang compiler is greater or equal to the minumum
    *  version required.
    */
-  private[scalanative] def checkClangVersion(pathToClangBinary: Path): Unit = {
+  private[scalanative] def checkClangVersion(
+      pathToClangBinary: Path,
+      logger: Logger
+  ): Unit = {
     val ClangInfo(majorVersion, version, _) = clangInfo(pathToClangBinary)
+    resetWarningOnClangChange(pathToClangBinary)
+    checkClangVersion(
+      majorVersion,
+      version,
+      logger
+    )
+  }
 
-    if (majorVersion < clangMinVersion) {
+  private[scalanative] def checkClangVersion(
+      majorVersion: Int,
+      version: String,
+      logger: Logger
+  ): Unit = {
+    if (majorVersion < MinimumSupportedClangVersion) {
       throw new BuildException(
-        s"""|Minimum version of clang is '$clangMinVersion'.
+        s"""|Minimum version of clang is '$MinimumSupportedClangVersion'.
             |Discovered version '$version'.
             |Please refer to ($docSetup)""".stripMargin
+      )
+    }
+    if (majorVersion < WarnOnClangOlderThan) {
+      logger.warn(
+        s"""|Using deprecated clang version '$version'.
+            |Versions older than clang '$WarnOnClangOlderThan' can contain known bugs and runtime issues.
+            |Please upgrade to clang '$WarnOnClangOlderThan' or newer.
+            |Refer to ($docSetup)""".stripMargin
       )
     }
   }
 
   /** Minimum version of clang */
-  private[scalanative] final val clangMinVersion = 6
+  private[scalanative] final val MinimumSupportedClangVersion = 6
+
+  /** Minimum clang version that does not emit a deprecation warning. */
+  private[scalanative] final val WarnOnClangOlderThan = 16
+
+  private var lastCheckedClangPath: Option[Path] = None
+  private val warnedAboutDeprecatedClangVersion = new AtomicBoolean(false)
+  private def resetWarningOnClangChange(pathToClangBinary: Path): Unit =
+    try {
+      val llvmBinDir = pathToClangBinary.toRealPath().getParent()
+      if (!lastCheckedClangPath.contains(llvmBinDir)) {
+        lastCheckedClangPath = Some(llvmBinDir)
+        warnedAboutDeprecatedClangVersion.set(false)
+      }
+    } catch {
+      // ignore broken symlinks, we just want to check version
+      case _: IOException => ()
+    }
 
   /** Link to setup documentation */
   private[scalanative] val docSetup =

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -187,7 +187,9 @@ object Discover {
             |Please refer to ($docSetup)""".stripMargin
       )
     }
-    if (majorVersion < WarnOnClangOlderThan) {
+    // Warn once about deprecated clang version (so that we don't spam users since nativeConfig is a task)
+    if (majorVersion < WarnOnClangOlderThan &&
+        warnedAboutDeprecatedClangVersion.compareAndExchange(false, true)) {
       logger.warn(
         s"""|Using deprecated clang version '$version'.
             |Versions older than clang '$WarnOnClangOlderThan' can contain known bugs and runtime issues.

--- a/tools/src/main/scala/scala/scalanative/build/Validator.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Validator.scala
@@ -46,6 +46,7 @@ private[build] object Validator {
 
     if (!Files.exists(c.clang))
       issues += s"Provided clang path '${c.clang.toAbsolutePath()}' does not exist, specify a valid path to LLVM Toolchain distribution using config or LLVM_BIN environment variable"
+    else Discover.checkClangVersion(c.clang, config.logger)
     if (!Files.exists(c.clangPP))
       issues += s"Provided clang++ path '${c.clangPP.toAbsolutePath()}' does not exist, specify a valid path to LLVM Toolchain distribution using config or LLVM_BIN environment variable"
     // config.baseName provides default value when config.compileConfig.baseName is empty


### PR DESCRIPTION
When debugging #4793 after wasting XX hours I've discovered issues with continuations were present on LLVM 14-15, but same code worked fine on LLVM 16 - this seems to be a good opportunity to update recommended LLVM versions 

LLVM 13, 14, 15 is still the default in GitHub actions ubuntu-22 
while LLVM 16, 17, 18 is preinstalled on ubuntu-24 

Also updates the mininal used LLVM version to 16