### PR TITLE
tools: Exclude `/CONTRIBUTING` from embedded resources by default

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -38,6 +38,7 @@ private[scalanative] object ResourceEmbedder {
         "/scala-native/**",
         "/LICENSE",
         "/NOTICE",
+        "/CONTRIBUTING",
         "/library.properties",
         "/BUILD",
         "/rootdoc.txt",


### PR DESCRIPTION
The default resource-embedder exclusion list already covers `/LICENSE` and /NOTICE (files that show up at the root of some published JARs purely as licensing/attribution metadata). `/CONTRIBUTING` is in the same category: a few libraries (e.g. `com.comcast:ip4s-core`) ship it as an `unmanagedResource` alongside `LICENSE` and `NOTICE`, and there is probably no reason for it to end up in a linked native binary.