### PR TITLE
[CI]: Enforce the requested LLVM version is actually used

### DIFF
--- a/.github/actions/linux-setup-env/action.yml
+++ b/.github/actions/linux-setup-env/action.yml
@@ -49,3 +49,12 @@ runs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         (yes "" || true) | sudo ./llvm.sh ${{ inputs.llvm-version }}
+        # Prefer apt.llvm.org install over /usr/bin/clang (Discover uses LLVM_BIN / PATH).
+        LLVM_TOOLCHAIN="/usr/lib/llvm-${{ inputs.llvm-version }}/bin"
+        if [[ -d "$LLVM_TOOLCHAIN" ]]; then
+          echo "LLVM_BIN=$LLVM_TOOLCHAIN" >> "$GITHUB_ENV"
+          echo "$LLVM_TOOLCHAIN" >> "$GITHUB_PATH"
+          echo "Using toolchain: $("$LLVM_TOOLCHAIN/clang" --version | head -1)"
+        else
+          echo "::warning::No directory $LLVM_TOOLCHAIN (e.g. llvm-version=latest); set LLVM_BIN on the step if needed."
+        fi

--- a/.github/actions/macos-setup-env/action.yml
+++ b/.github/actions/macos-setup-env/action.yml
@@ -43,8 +43,18 @@ runs:
       if: ${{ inputs.llvm-version != '' }}
       run: |
         brew install lld
-        if [[ "${{ inputs.llvm-version }}" == "latest" ]]; then 
+        if [[ "${{ inputs.llvm-version }}" == "latest" ]]; then
           brew install llvm
-        else 
+          LLVM_TOOLCHAIN="$(brew --prefix llvm)/bin"
+        else
           brew install llvm@${{ inputs.llvm-version }}
+          LLVM_TOOLCHAIN="$(brew --prefix llvm@${{ inputs.llvm-version }})/bin"
+        fi
+        # Prefer Homebrew LLVM over Xcode clang (Discover uses LLVM_BIN / PATH).
+        if [[ -d "$LLVM_TOOLCHAIN" ]]; then
+          echo "LLVM_BIN=$LLVM_TOOLCHAIN" >> "$GITHUB_ENV"
+          echo "$LLVM_TOOLCHAIN" >> "$GITHUB_PATH"
+          echo "Using toolchain: $("$LLVM_TOOLCHAIN/clang" --version | head -1)"
+        else
+          echo "::warning::No directory $LLVM_TOOLCHAIN; set LLVM_BIN on the step if needed."
         fi

--- a/.github/actions/windows-setup-env/action.yml
+++ b/.github/actions/windows-setup-env/action.yml
@@ -101,9 +101,19 @@ runs:
             }
         }
 
-    - name: Add LLVM on Path
+    - name: Expose LLVM to Scala Native (PATH and LLVM_BIN)
       shell: pwsh
-      run: echo "${env:ProgramFiles}\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      run: |
+        $llvmBin = Join-Path (Join-Path $env:ProgramFiles 'LLVM') 'bin'
+        $clang = Join-Path $llvmBin 'clang.exe'
+        if (Test-Path -LiteralPath $clang) {
+          Add-Content -Path $env:GITHUB_ENV -Value "LLVM_BIN=$llvmBin"
+          $llvmBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $verLine = (& $clang --version | Select-Object -First 1)
+          Write-Host "Using toolchain: $verLine"
+        } else {
+          Write-Host "::warning::No clang.exe under $llvmBin; set LLVM_BIN on the step if needed."
+        }
 
     - name: Assert clang installed and on path
       shell: pwsh

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -221,7 +221,6 @@ jobs:
         env:
           SCALANATIVE_MODE: release-fast
           SCALANATIVE_LTO: thin
-          LLVM_BIN: "/usr/lib/llvm-${{ matrix.llvm }}/bin"
           SCALANATIVE_TEST_PREFETCH_DEBUG_INFO: 1
         run: sbt "test-runtime ${{ matrix.scala }}"
 

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -199,9 +199,7 @@ jobs:
           SCALANATIVE_MODE: release-fast
           SCALANATIVE_GC: immix
           SCALANATIVE_OPTIMIZE: true
-        run: |
-          export LLVM_BIN=$(dirname $(readlink -f /usr/bin/clang))
-          sbt "test-scripted ${{matrix.scala}}"
+        run: sbt "test-scripted ${{matrix.scala}}"
 
   test-llvm-versions:
     if: ((github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native') || (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') && contains(github.event.pull_request.body, '[test-extended]'))

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -120,10 +120,7 @@ jobs:
             junitTestOutputsJVM${{env.project-version}}/test;
             junitTestOutputsNative${{env.project-version}}/test;
             scalaPartestJunitTests${{env.project-version}}/test
-        run: |
-          export LLVM_BIN="$(brew --prefix llvm)/bin"
-          $LLVM_BIN/clang --version
-          sbt -J-Xmx5G "${TEST_COMMAND}"
+        run: sbt -J-Xmx5G "${TEST_COMMAND}"
 
   run-scripted-tests:
     name: Scripted tests
@@ -141,10 +138,7 @@ jobs:
           llvm-version: latest
 
       - name: Test scripted
-        run: |
-          export LLVM_BIN=$(brew --prefix llvm)/bin
-          $LLVM_BIN/clang --version
-          sbt "test-scripted ${{matrix.scala}}"
+        run: sbt "test-scripted ${{matrix.scala}}"
 
   test-llvm-versions:
     if: ((github.event_name == 'schedule' || github.event_name == 'workflow_call')  && github.repository == 'scala-native/scala-native') || (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') && contains(github.event.pull_request.body, '[test-extended]'))
@@ -166,12 +160,4 @@ jobs:
         # env:
         #   SCALANATIVE_MODE: release-fast
         #   SCALANATIVE_LTO: thin
-        run: |
-          if [[ "${{ matrix.llvm }}" == "latest" ]]; then 
-            export LLVM_BIN=$(brew --prefix llvm)/bin
-          else 
-            export LLVM_BIN=$(brew --prefix llvm@${{ matrix.llvm }})/bin
-          fi
-          echo "LLVM_BIN=${LLVM_BIN}"
-          $LLVM_BIN/clang --version
-          sbt "test-runtime ${{ matrix.scala }}"
+        run: sbt "test-runtime ${{ matrix.scala }}"

--- a/javalib/src/main/resources/scala-native/lang/javalib_spawn.c
+++ b/javalib/src/main/resources/scala-native/lang/javalib_spawn.c
@@ -42,10 +42,11 @@ bool hasFileActionsAddChdir() {
 
 #if (__MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_11_1)
     result = true;
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 260000
-// earlier uses _np form, introduced in approx macOS 11.1, released 2020-12-20
-#define SCALANATIVE_JAVALIB_HAVE_POSIX_CHDIR 1
 #endif
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) &&                                \
+    (__MAC_OS_X_VERSION_MIN_REQUIRED >= 260000)
+/* Standard addchdir is macOS 26+; below that use addchdir_np (unguarded SDK). */
+#define SCALANATIVE_JAVALIB_HAVE_POSIX_CHDIR 1
 #endif
 
 #elif defined(__NetBSD__)

--- a/javalib/src/main/resources/scala-native/lang/javalib_spawn.c
+++ b/javalib/src/main/resources/scala-native/lang/javalib_spawn.c
@@ -45,7 +45,8 @@ bool hasFileActionsAddChdir() {
 #endif
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) &&                                \
     (__MAC_OS_X_VERSION_MIN_REQUIRED >= 260000)
-/* Standard addchdir is macOS 26+; below that use addchdir_np (unguarded SDK). */
+/* Standard addchdir is macOS 26+; below that use addchdir_np (unguarded SDK).
+ */
 #define SCALANATIVE_JAVALIB_HAVE_POSIX_CHDIR 1
 #endif
 

--- a/nativelib/src/main/resources/scala-native/nativeThreadTLS.c
+++ b/nativelib/src/main/resources/scala-native/nativeThreadTLS.c
@@ -59,19 +59,18 @@ size_t scalanative_mainThreadMaxStackSize() {
 
 static bool approximateStackBounds(void *stackBottom, size_t stackSize,
                                    ThreadInfo *threadInfo) {
-    size_t pageSize = resolvePageSize();
-    abort();
-
     // Align stack bottom to page size
-    currentThreadInfo.stackBottom = alignToNextPage(stackBottom);
-    assert((uintptr_t)currentThreadInfo.stackBottom >= (uintptr_t)stackBottom);
+    threadInfo->stackBottom = alignToNextPage(stackBottom);
+    assert((uintptr_t)threadInfo->stackBottom >= (uintptr_t)stackBottom);
 
-    currentThreadInfo.stackSize = currentThreadInfo.maxStackSize;
-    assert(currentThreadInfo.stackSize > 0);
+    threadInfo->stackSize = threadInfo->maxStackSize;
+    if (stackSize > 0 && threadInfo->stackSize > stackSize) {
+        threadInfo->stackSize = stackSize;
+    }
+    assert(threadInfo->stackSize > 0);
 
-    currentThreadInfo.stackTop =
-        (void *)((uintptr_t)currentThreadInfo.stackBottom -
-                 currentThreadInfo.stackSize);
+    threadInfo->stackTop =
+        (void *)((uintptr_t)threadInfo->stackBottom - threadInfo->stackSize);
     return true;
 }
 
@@ -177,9 +176,7 @@ fallback:;
         }
     }
     fclose(maps);
-#elif (defined(__APPLE__) && defined(__MACH__)) &&                             \
-    defined(__MAC_OS_X_VERSION_MIN_REQUIRED) &&                                \
-    __MAC_OS_X_VERSION_MIN_REQUIRED >= 1040
+#elif defined(__APPLE__) && defined(__MACH__)
     // No way to get thread-specific guard size
     // Use the default one
     size_t guardSize = 0;

--- a/scripted-tests/run/gc-deadlock-detection/src/main/resources/scala-native/zombie_thread.c
+++ b/scripted-tests/run/gc-deadlock-detection/src/main/resources/scala-native/zombie_thread.c
@@ -6,11 +6,17 @@
  * without cleanup.
  */
 
+#ifndef _WIN32
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 199309L
+#endif
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <pthread.h>
-#include <unistd.h>
+#include <time.h>
 #endif
 
 #include <stdio.h>
@@ -44,6 +50,9 @@ void zombie_thread_native_sleep_ms(int ms) {
 #ifdef _WIN32
     Sleep(ms);
 #else
-    usleep(ms * 1000);
+    struct timespec ts;
+    ts.tv_sec = ms / 1000;
+    ts.tv_nsec = (ms % 1000) * 1000000;
+    nanosleep(&ts, NULL);
 #endif
 }

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -91,23 +91,35 @@ object Discover {
 
   /** Find default options passed to the system's native linker. */
   def linkingOptions(): Seq[String] = {
-    val libs = {
-      val llvmLibDir =
-        Try(Process(s"$llvmConfigCLI --libdir").lineStream_!.toSeq)
-          .getOrElse(Seq.empty)
+    val llvmLibDirs =
+      Try(Process(s"$llvmConfigCLI --libdir").lineStream_!.toSeq)
+        .getOrElse(Seq.empty)
 
-      val libDirs =
-        getenv("SCALANATIVE_LIB_DIRS")
-          .map(_.split(File.pathSeparatorChar).toSeq)
-          .getOrElse(
-            filterExisting(
-              Seq("/usr/local/lib", "/opt/local/lib", "/opt/homebrew/lib")
-            )
+    val libDirs =
+      getenv("SCALANATIVE_LIB_DIRS")
+        .map(_.split(File.pathSeparatorChar).toSeq)
+        .getOrElse(
+          filterExisting(
+            Seq("/usr/local/lib", "/opt/local/lib", "/opt/homebrew/lib")
           )
+        )
 
-      (libDirs ++ llvmLibDir).map(s => s"-L$s")
-    }
-    libs
+    defaultLinkingOptions(
+      libDirs = libDirs,
+      llvmLibDirs = llvmLibDirs,
+      targetsMac = Platform.isMac
+    )
+  }
+
+  private[scalanative] def defaultLinkingOptions(
+      libDirs: Seq[String],
+      llvmLibDirs: Seq[String],
+      targetsMac: Boolean
+  ): Seq[String] = {
+    // On Darwin, adding LLVM's own libdir pollutes application links with
+    // Homebrew runtime libraries such as libunwind and produces linker noise.
+    val extraLibDirs = if (targetsMac) Nil else llvmLibDirs
+    (libDirs ++ extraLibDirs).map(s => s"-L$s")
   }
 
   private case class ClangInfo(


### PR DESCRIPTION
Previously the default clang installation was prefered unless explicitlly requested with LLVM_BIN. 
Now we're setting LLVM_BIN automatically