### PR TITLE
[codegen] Match clang's PIC/PIE module flags in NIR-emitted IR

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -64,7 +64,7 @@ private[codegen] abstract class AbstractCodeGen(
     dir.write(metadata) { metadataWriter =>
       implicit val metadata: MetadataCodeGen.Context =
         new MetadataCodeGen.Context(this, new FileShowBuilder(metadataWriter))
-      genDebugMetadata()
+      genPlatformMetadata()
 
       dir.write(body) { writer =>
         implicit val fsb: ShowBuilder = new FileShowBuilder(writer)
@@ -85,15 +85,23 @@ private[codegen] abstract class AbstractCodeGen(
     dir.merge(Seq(body, metadata), headers)
   }
 
-  private def genDebugMetadata()(implicit
+  private def genPlatformMetadata()(implicit
       ctx: MetadataCodeGen.Context
   ): Unit = {
     import Metadata.Constants._
     import Metadata.ModFlagBehavior._
-    dbg("llvm.module.flags")(
-      tuple(Max, "Dwarf Version", DWARF_VERSION),
-      tuple(Warning, "Debug Info Version", DEBUG_INFO_VERSION)
-    )
+    val flags = List.newBuilder[Metadata.Node]
+    if (!platform.targetsWindows) {
+      flags += tuple(Min, "PIC Level", PIC_LEVEL)
+      flags += tuple(Max, "PIE Level", PIE_LEVEL)
+    }
+    if (generateDebugMetadata) {
+      flags += tuple(Max, "Dwarf Version", DWARF_VERSION)
+      flags += tuple(Warning, "Debug Info Version", DEBUG_INFO_VERSION)
+    }
+    val result = flags.result()
+    if (result.nonEmpty)
+      emitNamedMetadata("llvm.module.flags")(result: _*)
   }
 
   private def genDeps()(implicit

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/Metadata.scala
@@ -300,6 +300,8 @@ private[codegen] object Metadata {
     val PRODUCER = "Scala Native"
     val DWARF_VERSION = 4
     val DEBUG_INFO_VERSION = 3
+    val PIC_LEVEL = 2
+    val PIE_LEVEL = 2
     final val SourceToDILineOffset = 1
     final val SourceToDIColumnOffset = 1
   }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -30,14 +30,17 @@ private[codegen] trait MetadataCodeGen { self: AbstractCodeGen =>
 
   /* Create a name debug metadata entry and write it on the metadata section */
   def dbg(name: => String)(values: Metadata.Node*)(implicit ctx: Context): Unit =
-    if (generateDebugMetadata) {
-      // Named metadata is always stored in metadata section
-      import ctx.sb._
-      values.foreach(Writer.ofNode.intern)
-      newline()
-      str(s"!$name = ")
-      Metadata.Tuple(values).write()
-    }
+    if (generateDebugMetadata) emitNamedMetadata(name)(values: _*)
+
+  def emitNamedMetadata(name: String)(values: Metadata.Node*)(implicit
+      ctx: Context
+  ): Unit = {
+    import ctx.sb._
+    values.foreach(Writer.ofNode.intern)
+    newline()
+    str(s"!$name = ")
+    Metadata.Tuple(values).write()
+  }
 
   def dbgUsing[T <: Metadata.Node: InternedWriter](
       v: => T

--- a/tools/src/test/scala/scala/scalanative/codegen/ModuleFlagsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/codegen/ModuleFlagsTest.scala
@@ -1,0 +1,46 @@
+package scala.scalanative.codegen
+
+import java.nio.file.Files
+
+import org.junit.Assert._
+import org.junit.Test
+
+class ModuleFlagsTest extends CodeGenSpec {
+
+  private val source = Map(
+    "Main.scala" ->
+      """|object Main {
+         |  def main(args: Array[String]): Unit = println("ok")
+         |}""".stripMargin
+  )
+
+  private val PicFlag = """!"PIC Level", i32 2"""
+  private val PieFlag = """!"PIE Level", i32 2"""
+
+  private def emittedIr(outfiles: Seq[java.nio.file.Path]): String =
+    outfiles.iterator
+      .map(p => new String(Files.readAllBytes(p)))
+      .mkString("\n")
+
+  @Test def emitsPicAndPieModuleFlagsOnElf(): Unit = codegen(
+    entry = "Main",
+    sources = source,
+    setupConfig = _.withTargetTriple("aarch64-unknown-linux-gnu")
+  ) {
+    case (_, _, outfiles) =>
+      val ir = emittedIr(outfiles)
+      assertTrue(s"Expected `$PicFlag` in emitted IR", ir.contains(PicFlag))
+      assertTrue(s"Expected `$PieFlag` in emitted IR", ir.contains(PieFlag))
+  }
+
+  @Test def omitsPicAndPieModuleFlagsOnWindows(): Unit = codegen(
+    entry = "Main",
+    sources = source,
+    setupConfig = _.withTargetTriple("x86_64-pc-windows-msvc")
+  ) {
+    case (_, _, outfiles) =>
+      val ir = emittedIr(outfiles)
+      assertFalse(s"PIC Level must not be emitted on Windows", ir.contains(PicFlag))
+      assertFalse(s"PIE Level must not be emitted on Windows", ir.contains(PieFlag))
+  }
+}

--- a/tools/src/test/scala/scala/scalanative/codegen/ModuleFlagsTest.scala
+++ b/tools/src/test/scala/scala/scalanative/codegen/ModuleFlagsTest.scala
@@ -40,7 +40,13 @@ class ModuleFlagsTest extends CodeGenSpec {
   ) {
     case (_, _, outfiles) =>
       val ir = emittedIr(outfiles)
-      assertFalse(s"PIC Level must not be emitted on Windows", ir.contains(PicFlag))
-      assertFalse(s"PIE Level must not be emitted on Windows", ir.contains(PieFlag))
+      assertFalse(
+        s"PIC Level must not be emitted on Windows",
+        ir.contains(PicFlag)
+      )
+      assertFalse(
+        s"PIE Level must not be emitted on Windows",
+        ir.contains(PieFlag)
+      )
   }
 }


### PR DESCRIPTION
Set `PIC Level = 2` and `PIE Level = 2` LLVM module flags from NIR's `.ll` writer on non-Windows targets, mirroring what `clang::CodeGenModule::Release` does for C/C++ sources. ThinLTO codegen needs these on the merged module to choose `Reloc::PIC_` over `Reloc::Static`; without them, AArch64 emits absolute-page relocations against externally-bound symbols and the link fails.

[See reproduction repo](https://github.com/arashi01/scala-native-lto-pic-reproduction)