### PR TITLE
Fix #4897: implement javalib concurrent.LinkedBlockingDeque & its Test

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/LinkedBlockingDeque.scala
+++ b/javalib/src/main/scala/java/util/concurrent/LinkedBlockingDeque.scala
@@ -1,0 +1,1563 @@
+/* Ported from JSR-166 Expert Group main CVS (Concurrent Versions System)
+ * repository as described at Doug Lea "Concurrency JSR-166 Interest Site"
+ *    https://gee.cs.oswego.edu/dl/concurrency-interest/.
+ *
+ *  file: src/main/java/util/concurrent/LinkedBlockingDeque.java
+ *  revision 1.83, dated: 2019-10-16
+ */
+
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package java.util.concurrent
+
+import java.util._
+import java.util.concurrent.locks.ReentrantLock
+import java.util.function.{Consumer, Predicate}
+
+import scala.scalanative.annotation.safePublish
+
+/*
+ * An optionally-bounded {@linkplain BlockingDeque blocking deque} based on
+ * linked nodes.
+ *
+ * <p>The optional capacity bound constructor argument serves as a
+ * way to prevent excessive expansion. The capacity, if unspecified,
+ * is equal to {@link Integer#MAX_VALUE}.  Linked nodes are
+ * dynamically created upon each insertion unless this would bring the
+ * deque above capacity.
+ *
+ * <p>Most operations run in constant time (ignoring time spent
+ * blocking).  Exceptions include {@link #remove(Object) remove},
+ * {@link #removeFirstOccurrence removeFirstOccurrence}, {@link
+ * #removeLastOccurrence removeLastOccurrence}, {@link #contains
+ * contains}, {@link #iterator iterator.remove()}, and the bulk
+ * operations, all of which run in linear time.
+ *
+ * <p>This class and its iterator implement all of the <em>optional</em>
+ * methods of the {@link Collection} and {@link Iterator} interfaces.
+ *
+ * <p>This class is a member of the
+ * <a href="{@docRoot}/java.base/java/util/package-summary.html#CollectionsFramework">
+ * Java Collections Framework</a>.
+ *
+ * @since 1.6
+ * @author  Doug Lea
+ * @param <E> the type of elements held in this deque
+ */
+
+@SerialVersionUID(-387911632671998426L)
+object LinkedBlockingDeque {
+  /*
+   * Implemented as a simple doubly-linked list protected by a
+   * single lock and using conditions to manage blocking.
+   *
+   * To implement weakly consistent iterators, it appears we need to
+   * keep all Nodes GC-reachable from a predecessor dequeued Node.
+   * That would cause two problems:
+   * - allow a rogue Iterator to cause unbounded memory retention
+   * - cause cross-generational linking of old Nodes to new Nodes if
+   *   a Node was tenured while live, which generational GCs have a
+   *   hard time dealing with, causing repeated major collections.
+   * However, only non-deleted Nodes need to be reachable from
+   * dequeued Nodes, and reachability does not necessarily have to
+   * be of the kind understood by the GC.  We use the trick of
+   * linking a Node that has just been dequeued to itself.  Such a
+   * self-link implicitly means to jump to "first" (for next links)
+   * or "last" (for prev links).
+   */
+
+  /*
+   * We have "diamond" multiple interface/abstract class inheritance
+   * here, and that introduces ambiguities. Often we want the
+   * BlockingDeque javadoc combined with the AbstractQueue
+   * implementation, so a lot of method specs are duplicated here.
+   */
+
+  /* Doubly-linked list node class */
+  private[concurrent] final class Node[E] private[concurrent] (var item: E) {
+    /*
+     * The item, or null if this node has been removed.
+     */
+
+    /*
+     * One of:
+     * - the real predecessor Node
+     * - this Node, meaning the predecessor is tail
+     * - null, meaning there is no predecessor
+     */
+    var prev: Node[E] = _
+
+    /*
+     * One of:
+     * - the real successor Node
+     * - this Node, meaning the successor is head
+     * - null, meaning there is no successor
+     */
+    var next: Node[E] = _
+  }
+}
+
+class LinkedBlockingDeque[E <: AnyRef](
+    val capacity: Int // Maximum number of items in the deque
+) extends AbstractQueue[E]
+    with BlockingQueue[E]
+    with Serializable {
+
+  import LinkedBlockingDeque._
+
+  /*
+   * Creates a {@code LinkedBlockingDeque} with the given (fixed) capacity.
+   *
+   * @param capacity the capacity of this deque
+   * @throws IllegalArgumentException if {@code capacity} is less than 1
+   */
+  // SN: see primary constructor
+
+  if (capacity <= 0)
+    throw new IllegalArgumentException
+
+  /*
+   * Creates a {@code LinkedBlockingDeque} with a capacity of
+   * {@link Integer#MAX_VALUE}.
+   */
+  def this() = this(Integer.MAX_VALUE)
+
+  /*
+   * Creates a {@code LinkedBlockingDeque} with a capacity of
+   * {@link Integer#MAX_VALUE}, initially containing the elements of
+   * the given collection, added in traversal order of the
+   * collection's iterator.
+   *
+   * @param c the collection of elements to initially contain
+   * @throws NullPointerException if the specified collection or any
+   *         of its elements are null
+   */
+  def this(c: Collection[_ <: E]) = {
+    this(Integer.MAX_VALUE)
+    addAll(c)
+  }
+
+  /*
+   * Pointer to first node.
+   * Invariant: (first == null && last == null) ||
+   *            (first.prev == null && first.item != null)
+   */
+  var first: Node[E] = null
+
+  /*
+   * Pointer to last node.
+   * Invariant: (first == null && last == null) ||
+   *            (last.next == null && last.item != null)
+   */
+  var last: Node[E] = null
+
+  /* SN: simple volatile is sufficient. 'count' is always accessed under
+   * this.lock and never used for CAS (CompareAndSet). Reduce allocations.
+   *
+   * This introduces a slight non-parallelism with the implementation of
+   * close sibling LinkedBlockingQueue. That implementation uses an
+   * AtomicInteger. It could almost certainly benefit from using 'volatile'
+   * as it also never uses CAS.  An exercise for the devoted, no time
+   * or heart for yak shaving now.
+   */
+  /* Number of items in the deque */
+  @volatile private var count = 0
+
+  /* Main lock guarding all access */
+  @safePublish
+  private final val lock = new ReentrantLock()
+
+  /* Condition for waiting takes */
+  @safePublish
+  private final val notEmpty = lock.newCondition()
+
+  /* Condition for waiting puts */
+  @safePublish
+  private final val notFull = lock.newCondition()
+
+  // Basic linking and unlinking operations, called only while holding lock
+
+  /*
+   * Links node as first element, or returns false if full.
+   */
+  private def linkFirst(node: Node[E]): Boolean = {
+    // assert lock.isHeldByCurrentThread()
+    if (count >= capacity)
+      return false
+    val f = first
+    node.next = f
+    first = node
+    if (last == null)
+      last = node
+    else
+      f.prev = node
+
+    count += 1
+    notEmpty.signal()
+    true
+  }
+
+  /*
+   * Links node as last element, or returns false if full.
+   */
+  private def linkLast(node: Node[E]): Boolean = {
+    // assert lock.isHeldByCurrentThread()
+    if (count >= capacity)
+      return false
+    val l = last
+    node.prev = l
+    last = node
+    if (first == null)
+      first = node
+    else
+      l.next = node
+
+    count += 1
+    notEmpty.signal()
+    true
+  }
+
+  /*
+   * Removes and returns first element, or null if empty.
+   */
+  private def unlinkFirst(): E = {
+    // assert lock.isHeldByCurrentThread()
+    val f = first
+    if (f == null)
+      return null.asInstanceOf[E]
+    val n = f.next
+    val item = f.item
+    f.item = null.asInstanceOf[E]
+    f.next = f // help GC
+    first = n
+    if (n == null)
+      last = null.asInstanceOf[Node[E]]
+    else
+      n.prev = null.asInstanceOf[Node[E]]
+
+    count -= 1
+    notFull.signal()
+    item
+  }
+
+  /*
+   * Removes and returns last element, or null if empty.
+   */
+  private def unlinkLast(): E = {
+    // assert lock.isHeldByCurrentThread()
+    val l = last
+    if (l == null)
+      return null.asInstanceOf[E]
+
+    val p = l.prev
+    val item = l.item
+    l.item = null.asInstanceOf[E]
+    l.prev = l // help GC
+    last = p
+    if (p == null)
+      first = null.asInstanceOf[Node[E]]
+    else
+      p.next = null.asInstanceOf[Node[E]]
+
+    count -= 1
+    notFull.signal()
+    item
+  }
+
+  /*
+   * Unlinks x.
+   */
+  def unlink(x: Node[E]): Unit = {
+    // assert lock.isHeldByCurrentThread()
+    // assert x.item != null
+    val p = x.prev
+    val n = x.next
+    if (p == null) {
+      unlinkFirst()
+    } else if (n == null) {
+      unlinkLast()
+    } else {
+      p.next = n
+      n.prev = p
+      x.item = null.asInstanceOf[E]
+
+      // Don't mess with x's links.  They may still be in use by
+      // an iterator.
+      count -= 1
+      notFull.signal()
+    }
+  }
+
+  // BlockingDeque methods
+
+  /*
+   * @throws IllegalStateException if this deque is full
+   * @throws NullPointerException {@inheritDoc}
+   */
+  def addFirst(e: E): Unit = {
+    if (!offerFirst(e))
+      throw new IllegalStateException("Deque full")
+  }
+
+  /*
+   * @throws IllegalStateException if this deque is full
+   * @throws NullPointerException  {@inheritDoc}
+   */
+  def addLast(e: E): Unit = {
+    if (!offerLast(e))
+      throw new IllegalStateException("Deque full")
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   */
+  def offerFirst(e: E): Boolean = {
+    if (e == null)
+      throw new NullPointerException()
+    val node = new Node[E](e)
+    val lock = this.lock
+    lock.lock()
+    try {
+      return linkFirst(node)
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   */
+  def offerLast(e: E): Boolean = {
+    if (e == null)
+      throw new NullPointerException()
+    val node = new Node[E](e)
+    val lock = this.lock
+    lock.lock()
+    try {
+      return linkLast(node)
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   * @throws InterruptedException {@inheritDoc}
+   */
+  def putFirst(e: E): Unit = {
+    if (e == null)
+      throw new NullPointerException()
+    val node = new Node[E](e)
+    val lock = this.lock
+    lock.lock()
+    try {
+      while (!linkFirst(node))
+        notFull.await()
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   * @throws InterruptedException {@inheritDoc}
+   */
+  def putLast(e: E): Unit = {
+    if (e == null)
+      throw new NullPointerException()
+    val node = new Node[E](e)
+    val lock = this.lock
+    lock.lock()
+    try {
+      while (!linkLast(node))
+        notFull.await()
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   * @throws InterruptedException {@inheritDoc}
+   */
+  def offerFirst(e: E, timeout: Long, unit: TimeUnit): Boolean = {
+    if (e == null)
+      throw new NullPointerException()
+    val node = new Node[E](e)
+    var nanos = unit.toNanos(timeout)
+    val lock = this.lock
+    lock.lockInterruptibly()
+    try {
+      while (!linkFirst(node)) {
+        if (nanos <= 0L)
+          return false
+        nanos = notFull.awaitNanos(nanos)
+      }
+      return true
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   * @throws InterruptedException {@inheritDoc}
+   */
+  def offerLast(e: E, timeout: Long, unit: TimeUnit): Boolean = {
+    if (e == null)
+      throw new NullPointerException()
+    val node = new Node[E](e)
+    var nanos = unit.toNanos(timeout)
+    val lock = this.lock
+    lock.lockInterruptibly()
+    try {
+      while (!linkLast(node)) {
+        if (nanos <= 0L)
+          return false
+        nanos = notFull.awaitNanos(nanos)
+      }
+      return true
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws NoSuchElementException {@inheritDoc}
+   */
+  def removeFirst(): E = {
+    val x = pollFirst()
+    if (x == null)
+      throw new NoSuchElementException()
+    x
+  }
+
+  /*
+   * @throws NoSuchElementException {@inheritDoc}
+   */
+  def removeLast(): E = {
+    val x = pollLast()
+    if (x == null)
+      throw new NoSuchElementException()
+    x
+  }
+
+  def pollFirst(): E = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return unlinkFirst()
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  def pollLast(): E = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return unlinkLast()
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  def takeFirst(): E = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      var x = null.asInstanceOf[E]
+      while (({ x = unlinkFirst(); x }) == null)
+        notEmpty.await()
+      return x
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  def takeLast(): E = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      var x = null.asInstanceOf[E]
+      while (({ x = unlinkLast(); x }) == null)
+        notEmpty.await()
+      return x
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  def pollFirst(timeout: Long, unit: TimeUnit): E = {
+    var nanos = unit.toNanos(timeout)
+    val lock = this.lock
+    lock.lockInterruptibly()
+    try {
+      var x = null.asInstanceOf[E]
+      while (({ x = unlinkFirst(); x }) == null) {
+        if (nanos <= 0L)
+          return null.asInstanceOf[E]
+        nanos = notEmpty.awaitNanos(nanos)
+      }
+      return x
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  def pollLast(timeout: Long, unit: TimeUnit): E = {
+    var nanos = unit.toNanos(timeout)
+    val lock = this.lock
+    lock.lockInterruptibly()
+    try {
+      var x = null.asInstanceOf[E]
+      while (({ x = unlinkLast(); x }) == null) {
+        if (nanos <= 0L)
+          return null.asInstanceOf[E]
+        nanos = notEmpty.awaitNanos(nanos)
+      }
+      return x
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws NoSuchElementException {@inheritDoc}
+   */
+  def getFirst(): E = {
+    val x = peekFirst()
+    if (x == null)
+      throw new NoSuchElementException()
+    x
+  }
+
+  /*
+   * @throws NoSuchElementException {@inheritDoc}
+   */
+  def getLast(): E = {
+    val x = peekLast()
+    if (x == null)
+      throw new NoSuchElementException()
+    x
+  }
+
+  def peekFirst(): E = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return if (first == null) null.asInstanceOf[E]
+      else first.item
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  def peekLast(): E = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return if (last == null) null.asInstanceOf[E]
+      else last.item
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  def removeFirstOccurrence(o: Object): Boolean = {
+    if (o == null)
+      return false
+
+    val lock = this.lock
+    lock.lock()
+    try {
+      var p = first
+      while (p != null) {
+        if (o.equals(p.item)) {
+          unlink(p)
+          return true
+        }
+        p = p.next
+      }
+      return false
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  def removeLastOccurrence(o: Object): Boolean = {
+    if (o == null)
+      return false
+
+    val lock = this.lock
+    lock.lock()
+    try {
+      var p = last
+      while (p != null) {
+        if (o.equals(p.item)) {
+          unlink(p)
+          return true
+        }
+        p = p.prev
+      }
+      return false
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  // BlockingQueue methods
+
+  /*
+   * Inserts the specified element at the end of this deque unless it would
+   * violate capacity restrictions.  When using a capacity-restricted deque,
+   * it is generally preferable to use method {@link #offer(Object) offer}.
+   *
+   * <p>This method is equivalent to {@link #addLast}.
+   *
+   * @throws IllegalStateException if this deque is full
+   * @throws NullPointerException if the specified element is null
+   */
+  override def add(e: E): Boolean = {
+    addLast(e)
+    true
+  }
+
+  /*
+   * @throws NullPointerException if the specified element is null
+   */
+  def offer(e: E): Boolean =
+    offerLast(e)
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   * @throws InterruptedException {@inheritDoc}
+   */
+  def put(e: E): Unit =
+    putLast(e)
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   * @throws InterruptedException {@inheritDoc}
+   */
+  def offer(e: E, timeout: Long, unit: TimeUnit): Boolean =
+    offerLast(e, timeout, unit)
+
+  /*
+   * Retrieves and removes the head of the queue represented by this deque.
+   * This method differs from {@link #poll() poll()} only in that it throws an
+   * exception if this deque is empty.
+   *
+   * <p>This method is equivalent to {@link #removeFirst() removeFirst}.
+   *
+   * @return the head of the queue represented by this deque
+   * @throws NoSuchElementException if this deque is empty
+   */
+  override def remove(): E =
+    removeFirst()
+
+  def poll(): E =
+    pollFirst()
+
+  def take(): E =
+    takeFirst()
+
+  def poll(timeout: Long, unit: TimeUnit): E =
+    pollFirst(timeout, unit)
+
+  /*
+   * Retrieves, but does not remove, the head of the queue represented by
+   * this deque.  This method differs from {@link #peek() peek()} only in that
+   * it throws an exception if this deque is empty.
+   *
+   * <p>This method is equivalent to {@link #getFirst() getFirst}.
+   *
+   * @return the head of the queue represented by this deque
+   * @throws NoSuchElementException if this deque is empty
+   */
+  override def element(): E =
+    getFirst()
+
+  def peek(): E =
+    peekFirst()
+
+  /*
+   * Returns the number of additional elements that this deque can ideally
+   * (in the absence of memory or resource constraints) accept without
+   * blocking. This is always equal to the initial capacity of this deque
+   * less the current {@code size} of this deque.
+   *
+   * <p>Note that you <em>cannot</em> always tell if an attempt to insert
+   * an element will succeed by inspecting {@code remainingCapacity}
+   * because it may be the case that another thread is about to
+   * insert or remove an element.
+   */
+  def remainingCapacity(): Int = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return capacity - count
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * @throws UnsupportedOperationException {@inheritDoc}
+   * @throws ClassCastException            {@inheritDoc}
+   * @throws NullPointerException          {@inheritDoc}
+   * @throws IllegalArgumentException      {@inheritDoc}
+   */
+  def drainTo(c: Collection[_ >: E]): Int =
+    drainTo(c, Integer.MAX_VALUE)
+
+  /*
+   * @throws UnsupportedOperationException {@inheritDoc}
+   * @throws ClassCastException            {@inheritDoc}
+   * @throws NullPointerException          {@inheritDoc}
+   * @throws IllegalArgumentException      {@inheritDoc}
+   */
+  def drainTo(c: Collection[_ >: E], maxElements: Int): Int = {
+    Objects.requireNonNull(c)
+    if (c == this)
+      throw new IllegalArgumentException()
+    if (maxElements <= 0)
+      return 0
+    val lock = this.lock
+    lock.lock()
+    try {
+      val n = Math.min(maxElements, count)
+      for (i <- 0 until n) {
+        c.add(first.item) // In this order, in case add() throws.
+        unlinkFirst()
+      }
+      return n
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  // Stack methods
+
+  /*
+   * @throws IllegalStateException if this deque is full
+   * @throws NullPointerException {@inheritDoc}
+   */
+  def push(e: E): Unit =
+    addFirst(e)
+
+  /*
+   * @throws NoSuchElementException {@inheritDoc}
+   */
+  def pop(): E =
+    removeFirst()
+
+  // Collection methods
+
+  /*
+   * Removes the first occurrence of the specified element from this deque.
+   * If the deque does not contain the element, it is unchanged.
+   * More formally, removes the first element {@code e} such that
+   * {@code o.equals(e)} (if such an element exists).
+   * Returns {@code true} if this deque contained the specified element
+   * (or equivalently, if this deque changed as a result of the call).
+   *
+   * <p>This method is equivalent to
+   * {@link #removeFirstOccurrence(Object) removeFirstOccurrence}.
+   *
+   * @param o element to be removed from this deque, if present
+   * @return {@code true} if this deque changed as a result of the call
+   */
+  override def remove(o: Any): Boolean =
+    removeFirstOccurrence(o.asInstanceOf[E])
+
+  /*
+   * Returns the number of elements in this deque.
+   *
+   * @return the number of elements in this deque
+   */
+  def size(): Int = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      return count
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Returns {@code true} if this deque contains the specified element.
+   * More formally, returns {@code true} if and only if this deque contains
+   * at least one element {@code e} such that {@code o.equals(e)}.
+   *
+   * @param o object to be checked for containment in this deque
+   * @return {@code true} if this deque contains the specified element
+   */
+  override def contains(o: Any): Boolean = {
+    if (o == null)
+      return false
+    val lock = this.lock
+    lock.lock()
+    try {
+      var p = first
+
+      while (p != null) {
+        if (o.equals(p.item))
+          return true
+        p = p.next
+      }
+      false
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Appends all of the elements in the specified collection to the end of
+   * this deque, in the order that they are returned by the specified
+   * collection's iterator.  Attempts to {@code addAll} of a deque to
+   * itself result in {@code IllegalArgumentException}.
+   *
+   * @param c the elements to be inserted into this deque
+   * @return {@code true} if this deque changed as a result of the call
+   * @throws NullPointerException if the specified collection or any
+   *         of its elements are null
+   * @throws IllegalArgumentException if the collection is this deque
+   * @throws IllegalStateException if this deque is full
+   * @see #add(Object)
+   */
+  override def addAll(c: Collection[_ <: E]): Boolean = {
+    Objects.requireNonNull(c, "c")
+
+    if (c == this)
+      // As historically specified in AbstractQueue#addAll
+      throw new IllegalArgumentException()
+
+    // Copy c into a private chain of Nodes
+    var beg = null.asInstanceOf[Node[E]]
+    var end = beg
+    var n = 0
+
+    c.forEach(e => {
+      Objects.requireNonNull(e)
+      n += 1
+      val newNode = new Node[E](e)
+      if (beg == null) {
+        beg = newNode
+        end = newNode
+      } else {
+        end.next = newNode
+        newNode.prev = end
+        end = newNode
+      }
+    })
+
+    if (beg == null)
+      return false
+
+    // Atomically append the chain at the end
+    val lock = this.lock
+    lock.lock()
+    try {
+      if (count + n <= capacity) {
+        beg.prev = last
+        if (first == null)
+          first = beg
+        else
+          last.next = beg
+        last = end
+        count += n
+        notEmpty.signalAll()
+        return true
+      }
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+    // Fall back to historic non-atomic implementation, failing
+    // with IllegalStateException when the capacity is exceeded.
+    super.addAll(c)
+  }
+
+  /*
+   * Returns an array containing all of the elements in this deque, in
+   * proper sequence (from first to last element).
+   *
+   * <p>The returned array will be "safe" in that no references to it are
+   * maintained by this deque.  (In other words, this method must allocate
+   * a new array).  The caller is thus free to modify the returned array.
+   *
+   * <p>This method acts as bridge between array-based and collection-based
+   * APIs.
+   *
+   * @return an array containing all of the elements in this deque
+   */
+  override def toArray(): Array[AnyRef] = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      val a = new Array[AnyRef](count)
+
+      var k = 0
+      var p = first
+      while (p != null) {
+        val idx = k
+        k += 1
+        a(idx) = p.item
+        p = p.next
+      }
+      a
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Returns an array containing all of the elements in this deque, in
+   * proper sequence; the runtime type of the returned array is that of
+   * the specified array.  If the deque fits in the specified array, it
+   * is returned therein.  Otherwise, a new array is allocated with the
+   * runtime type of the specified array and the size of this deque.
+   *
+   * <p>If this deque fits in the specified array with room to spare
+   * (i.e., the array has more elements than this deque), the element in
+   * the array immediately following the end of the deque is set to
+   * {@code null}.
+   *
+   * <p>Like the {@link #toArray()} method, this method acts as bridge between
+   * array-based and collection-based APIs.  Further, this method allows
+   * precise control over the runtime type of the output array, and may,
+   * under certain circumstances, be used to save allocation costs.
+   *
+   * <p>Suppose {@code x} is a deque known to contain only strings.
+   * The following code can be used to dump the deque into a newly
+   * allocated array of {@code String}:
+   *
+   * <pre> {@code String[] y = x.toArray(new String[0])}</pre>
+   *
+   * Note that {@code toArray(new Object[0])} is identical in function to
+   * {@code toArray()}.
+   *
+   * @param a the array into which the elements of the deque are to
+   *          be stored, if it is big enough; otherwise, a new array of the
+   *          same runtime type is allocated for this purpose
+   * @return an array containing all of the elements in this deque
+   * @throws ArrayStoreException if the runtime type of the specified array
+   *         is not a supertype of the runtime type of every element in
+   *         this deque
+   * @throws NullPointerException if the specified array is null
+   */
+  override def toArray[T <: AnyRef](_a: Array[T]): Array[T] = {
+    var a = _a
+
+    val lock = this.lock
+    lock.lock()
+    try {
+      val size = count
+      if (a.length < size)
+        a = java.lang.reflect.Array
+          .newInstance(a.getClass.getComponentType, size)
+          .asInstanceOf[Array[T]]
+
+      var k = 0
+      var p = first
+      while (p != null) {
+        val idx = k
+        k += 1
+        a(idx) = p.item.asInstanceOf[T]
+        p = p.next
+      }
+      if (a.length > k)
+        a(k) = null.asInstanceOf[T]
+      return a
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  override def toString(): String =
+    Helpers.collectionToString(this)
+
+  /*
+   * Atomically removes all of the elements from this deque.
+   * The deque will be empty after this call returns.
+   */
+  override def clear(): Unit = {
+    val lock = this.lock
+    lock.lock()
+    try {
+      var f = first
+      while (f != null) {
+        f.item = null.asInstanceOf[E]
+        val n = f.next
+        f.prev = null.asInstanceOf[Node[E]]
+        f.next = null.asInstanceOf[Node[E]]
+        f = n
+      }
+      first = null.asInstanceOf[Node[E]]
+      last = null.asInstanceOf[Node[E]]
+      count = 0
+      notFull.signalAll()
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+  }
+
+  /*
+   * Used for any element traversal that is not entirely under lock.
+   * Such traversals must handle both:
+   * - dequeued nodes (p.next == p)
+   * - (possibly multiple) interior removed nodes (p.item == null)
+   */
+  def succ(_p: Node[E]): Node[E] = {
+    var p = _p
+    if (p == ({ p = p.next; p }))
+      p = first
+    p
+  }
+
+  /*
+   * Returns an iterator over the elements in this deque in proper sequence.
+   * The elements will be returned in order from first (head) to last (tail).
+   *
+   * <p>The returned iterator is
+   * <a href="package-summary.html#Weakly"><i>weakly consistent</i></a>.
+   *
+   * @return an iterator over the elements in this deque in proper sequence
+   */
+  def iterator(): Iterator[E] =
+    new Itr()
+
+  /*
+   * Returns an iterator over the elements in this deque in reverse
+   * sequential order.  The elements will be returned in order from
+   * last (tail) to first (head).
+   *
+   * <p>The returned iterator is
+   * <a href="package-summary.html#Weakly"><i>weakly consistent</i></a>.
+   *
+   * @return an iterator over the elements in this deque in reverse order
+   */
+  def descendingIterator(): Iterator[E] =
+    new DescendingItr()
+
+  /*
+   * Base class for LinkedBlockingDeque iterators.
+   */
+  private abstract class AbstractItr extends Iterator[E] {
+    /*
+     * The next node to return in next().
+     */
+    var nextVar = null.asInstanceOf[Node[E]]
+
+    /*
+     * nextItem holds on to item fields because once we claim that
+     * an element exists in hasNext(), we must return item read
+     * under lock even if it was in the process of being removed
+     * when hasNext() was called.
+     */
+    var nextItem = null.asInstanceOf[E]
+
+    /*
+     * Node returned by most recent call to next. Needed by remove.
+     * Reset to null if this element is deleted by a call to remove.
+     */
+    private var lastRet = null.asInstanceOf[Node[E]]
+
+    def firstNode(): Node[E]
+    def nextNode(n: Node[E]): Node[E]
+
+    private def succ(_p: Node[E]): Node[E] = {
+      var p = _p
+      if (p == { p = nextNode(p); p })
+        p = firstNode()
+      p
+    }
+
+    // set to initial position
+    val lock = LinkedBlockingDeque.this.lock
+    lock.lock()
+    try {
+      if ({ nextVar = firstNode(); nextVar } != null)
+        nextItem = nextVar.item
+    } finally {
+      // checkInvariants()
+      lock.unlock()
+    }
+
+    def hasNext(): Boolean =
+      nextVar != null
+
+    def next(): E = {
+      var p = null.asInstanceOf[Node[E]]
+      if ({ p = nextVar; p } == null)
+        throw new NoSuchElementException()
+      lastRet = p
+      val x = nextItem
+      val lock = LinkedBlockingDeque.this.lock
+      lock.lock()
+      try {
+        var e = null.asInstanceOf[E]
+
+        p = nextNode(p)
+        while (p != null && { e = p.item; e } == null)
+          p = succ(p)
+
+        nextVar = p
+        nextItem = e
+      } finally {
+        // checkInvariants()
+        lock.unlock()
+      }
+
+      x
+    }
+
+    override def forEachRemaining(action: Consumer[_ >: E]): Unit = {
+      // A variant of forEachFrom
+      Objects.requireNonNull(action, "action")
+      var p = null.asInstanceOf[Node[E]]
+
+      if ({ p = nextVar; p } == null)
+        return
+
+      lastRet = p
+      nextVar = null.asInstanceOf[Node[E]]
+      val lock = LinkedBlockingDeque.this.lock
+      val batchSize = 64
+
+      var es = null.asInstanceOf[Array[Object]]
+      var len = 1
+      var n = 0
+
+      var breakSeen = false
+
+      while ({
+        lock.lock()
+        try {
+          if (es == null) {
+            p = nextNode(p)
+            var q = p
+            var breakSeen = false
+
+            while (!breakSeen && (q != null)) {
+              if (q.item != null && { len += 1; len } == batchSize)
+                breakSeen = true
+              if (!breakSeen)
+                q = succ(q)
+            }
+            es = new Array[Object](len)
+            es(0) = nextItem
+            nextItem = null.asInstanceOf[E]
+            n = 1
+          } else
+            n = 0
+          while (p != null && n < len) {
+            if ({ es(n) = p.item; es(n) } != null) {
+              lastRet = p
+              n += 1
+            }
+            p = succ(p)
+          }
+        } finally {
+          // checkInvariants()
+          lock.unlock()
+        }
+
+        for (i <- 0 until n)
+          action.accept(es(i).asInstanceOf[E])
+
+        n > 0 && p != null
+      }) ()
+
+    }
+
+    override def remove(): Unit = {
+      val n = lastRet
+      if (n == null)
+        throw new IllegalStateException()
+      lastRet = null
+      val lock = LinkedBlockingDeque.this.lock
+      lock.lock()
+      try {
+        if (n.item != null)
+          unlink(n)
+      } finally {
+        // checkInvariants()
+        lock.unlock()
+      }
+    }
+  }
+
+  /* Forward iterator */
+  private class Itr() extends AbstractItr {
+    def firstNode(): Node[E] =
+      first
+
+    def nextNode(n: Node[E]): Node[E] =
+      n.next
+  }
+
+  /* Descending iterator */
+  private class DescendingItr() extends AbstractItr {
+    def firstNode(): Node[E] =
+      last
+
+    def nextNode(n: Node[E]): Node[E] =
+      n.prev
+  }
+
+  /*
+   * A customized variant of Spliterators.IteratorSpliterator.
+   * Keep this class in sync with (very similar) LBQSpliterator.
+   */
+  private final class LBDSpliterator extends Spliterator[E] {
+    final val MAX_BATCH = 1 << 25 // max batch array size
+    // current node; null until initialized
+    var current = null.asInstanceOf[Node[E]]
+
+    /* SN: Editorial comment.
+     *   The implementation of this 'batch' variable is faithful to both
+     *   the .java original and the sibling LinkedBlockingQueue.scala.
+     *
+     *   That said, from tracing, the logic appears somewhat strange.
+     *   Batch does get larger the more times trySplit() is called on
+     *   the same class instance. However, it starts at 0 and grows to
+     *   MAX_BATCH. One would expect the progression to be descending,
+     *   so that the split had enough work to make parallelism worthwhile.
+     *   Probably some subtle behavior designed by the original JSR-166
+     *   authors, but astonishing enough to note here.
+     */
+    var batch = 0 // batch size for splits
+
+    var exhausted = true // true when no more nodes
+
+    var est: Long = size() // size estimate
+
+    def estimateSize(): Long = est
+
+    def trySplit(): Spliterator[E] = {
+      var h = null.asInstanceOf[Node[E]]
+
+      if (!exhausted &&
+          ({ h = current; h } != null || { h = first; h } != null)
+          && h.next != null) {
+        batch = Math.min(batch + 1, MAX_BATCH)
+        val n = batch
+        val a = new Array[Object](n)
+
+        val lock = LinkedBlockingDeque.this.lock
+        var i = 0
+        var p = current
+        lock.lock()
+        try {
+          if (p != null || { p = first; p } != null)
+            while (p != null && i < n) {
+              if ({ a(i) = p.item; a(i) } != null)
+                i += 1
+              p = succ(p)
+            }
+        } finally {
+          // checkInvariants()
+          lock.unlock()
+        }
+        if ({ current = p; current } == null) {
+          est = 0L
+          exhausted = true
+        } else if ({ est -= i; est } < 0L)
+          est = 0L
+        if (i > 0)
+          return Spliterators.spliterator[E](
+            a,
+            0,
+            i,
+            Spliterator.ORDERED | Spliterator.NONNULL |
+              Spliterator.CONCURRENT
+          )
+      }
+      return null
+    }
+
+    def tryAdvance(action: Consumer[_ >: E]): Boolean = {
+      Objects.requireNonNull(action)
+      if (!exhausted) {
+        var e = null.asInstanceOf[E]
+        val lock = LinkedBlockingDeque.this.lock
+        lock.lock()
+        try {
+          var p = null.asInstanceOf[Node[E]]
+          if ({ p = current; p } != null || { p = first; p } != null)
+            while ({
+              e = p.item
+              p = succ(p)
+              (e == null && p != null)
+            }) ()
+
+          if ({ current = p; p } == null)
+            exhausted = true
+        } finally {
+          // checkInvariants()
+          lock.unlock()
+        }
+        if (e != null) {
+          action.accept(e)
+          return true
+        }
+      }
+      false
+    }
+
+    override def forEachRemaining(action: Consumer[_ >: E]): Unit = {
+      Objects.requireNonNull(action)
+      if (!exhausted) {
+        exhausted = true
+        val p = current
+        current = null.asInstanceOf[Node[E]]
+        forEachFrom(action, p)
+      }
+    }
+
+    def characteristics(): Int =
+      (Spliterator.ORDERED | Spliterator.NONNULL | Spliterator.CONCURRENT)
+  }
+
+  /*
+   * Returns a {@link Spliterator} over the elements in this deque.
+   *
+   * <p>The returned spliterator is
+   * <a href="package-summary.html#Weakly"><i>weakly consistent</i></a>.
+   *
+   * <p>The {@code Spliterator} reports {@link Spliterator#CONCURRENT},
+   * {@link Spliterator#ORDERED}, and {@link Spliterator#NONNULL}.
+   *
+   * @implNote
+   * The {@code Spliterator} implements {@code trySplit} to permit limited
+   * parallelism.
+   *
+   * @return a {@code Spliterator} over the elements in this deque
+   * @since 1.8
+   */
+  override def spliterator(): Spliterator[E] =
+    new LBDSpliterator()
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   */
+  override def forEach(action: Consumer[_ >: E]): Unit = {
+    Objects.requireNonNull(action, "action")
+    forEachFrom(action, null)
+  }
+
+  /*
+   * Runs action on each element found during a traversal starting at p.
+   * If p is null, traversal starts at head.
+   */
+  def forEachFrom(action: Consumer[_ >: E], _p: Node[E]): Unit = {
+    var p = _p
+
+    // Extract batches of elements while holding the lock; then
+    // run the action on the elements while not
+    val lock = this.lock
+    val batchSize = 64 // max number of elements per batch
+    // container for batch of elements
+    var es = null.asInstanceOf[Array[Object]]
+    var len = 0
+    var n = 0
+
+    while ({
+      lock.lock()
+      try {
+        if (es == null) {
+          if (p == null)
+            p = first
+
+          var breakSeen = false
+          var q = p
+
+          while (!breakSeen && (q != null)) {
+            if (q.item != null && { len += 1; len } == batchSize)
+              breakSeen = true
+            if (!breakSeen)
+              q = succ(q)
+          }
+          es = new Array[Object](len)
+        }
+
+        n = 0
+
+        while ((p != null) && (n < len)) {
+          if ({ es(n) = p.item; es(n) } != null)
+            n += 1
+          p = succ(p)
+        }
+      } finally {
+        // checkInvariants()
+        lock.unlock()
+      }
+
+      for (i <- 0 until n)
+        action.accept(es(i).asInstanceOf[E])
+
+      (n > 0) && (p != null)
+    }) ()
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   */
+  override def removeIf(filter: Predicate[_ >: E]): Boolean = {
+    Objects.requireNonNull(filter, "filter")
+    bulkRemove(filter)
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   */
+  override def removeAll(c: Collection[_]): Boolean = {
+    Objects.requireNonNull(c, "c")
+    bulkRemove(e => c.contains(e))
+  }
+
+  /*
+   * @throws NullPointerException {@inheritDoc}
+   */
+  override def retainAll(c: Collection[_]): Boolean = {
+    Objects.requireNonNull(c, "c")
+    bulkRemove(e => !c.contains(e))
+  }
+
+  /* Implementation of bulk remove methods. */
+  private def bulkRemove(filter: Predicate[_ >: E]): Boolean = {
+    var removed = false
+    val lock = this.lock
+    var p = null.asInstanceOf[Node[E]]
+    var nodes = null.asInstanceOf[Array[Node[E]]]
+    var len = 0
+    var n = 0
+
+    while ({
+      // 1. Extract batch of up to 64 elements while holding the lock.
+      lock.lock()
+      try {
+        if (nodes == null) { // first batch; initialize
+          p = first
+
+          var breakSeen = false
+          var q = p
+
+          while (!breakSeen && (q != null)) {
+            if (q.item != null && { len += 1; len } == 64)
+              breakSeen = true
+            if (!breakSeen)
+              q = succ(q)
+          }
+          nodes = new Array[Node[E]](len)
+        }
+
+        n = 0
+
+        while (p != null && n < len) {
+          nodes(n) = p
+          p = succ(p)
+
+          n += 1
+        }
+      } finally {
+        // checkInvariants()
+        lock.unlock()
+      }
+
+      // 2. Run the filter on the elements while lock is free.
+      var deathRow = 0L // "bitset" of size 64
+
+      for (i <- 0 until n) {
+        val e = nodes(i).item
+        if ((e != null) && filter.test(e))
+          deathRow |= 1L << i
+      }
+
+      // 3. Remove any filtered elements while holding the lock.
+      if (deathRow != 0) {
+        lock.lock()
+        try {
+          for (i <- 0 until n) {
+            val q = nodes(i)
+            if ((deathRow & (1L << i)) != 0L
+                && (q.item != null)) {
+              unlink(q)
+              removed = true
+            }
+            nodes(i) = null.asInstanceOf[Node[E]] // help GC
+          }
+        } finally {
+          // checkInvariants()
+          lock.unlock()
+        }
+      }
+      ((n > 0) && (p != null))
+    }) ()
+
+    removed
+  }
+
+  /*
+   * Saves this deque to a stream (that is, serializes it).
+   *
+   * @param s the stream
+   * @throws java.io.IOException if an I/O error occurs
+   * @serialData The capacity (int), followed by elements (each an
+   * {@code Object}) in the proper order, followed by a null
+   */
+  // SN: Not implemented, Scala Native does not support serialization
+  // private void writeObject(java.io.ObjectOutputStream s)
+
+  /*
+   * Reconstitutes this deque from a stream (that is, deserializes it).
+   * @param s the stream
+   * @throws ClassNotFoundException if the class of a serialized object
+   *         could not be found
+   * @throws java.io.IOException if an I/O error occurs
+   */
+  // SN: Not implemented, Scala Native does not support serialization
+  // private void readObject(java.io.ObjectInputStream s)
+
+  def checkInvariants(): Unit = {
+    // assert lock.isHeldByCurrentThread()
+    // Nodes may get self-linked or lose their item, but only
+    // after being unlinked and becoming unreachable from first.
+    var p = first
+    while (p != null) {
+      // assert p.next != p
+      // assert p.item != null
+      p = p.next
+    }
+  }
+}

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/LinkedBlockingDequeTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/util/concurrent/LinkedBlockingDequeTest.scala
@@ -1,0 +1,1735 @@
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util._
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent._
+
+import org.junit.Assert._
+import org.junit.{Ignore, Test}
+
+object LinkedBlockingDequeTest {
+  import JSR166Test._
+
+  def populatedDeque(n: Int): LinkedBlockingDeque[Item] = {
+    val q = new LinkedBlockingDeque[Item](n)
+    assertTrue(q.isEmpty())
+    for (i <- 0 until n) mustOffer(q, i)
+    assertFalse(q.isEmpty())
+    mustEqual(0, q.remainingCapacity())
+    mustEqual(n, q.size())
+    mustEqual(0, q.peekFirst())
+    mustEqual(n - 1, q.peekLast())
+    q
+  }
+}
+
+class LinkedBlockingDequeUnboundedTest extends BlockingQueueTest {
+  override protected def emptyCollection(): BlockingQueue[Any] =
+    new LinkedBlockingDeque[Any]()
+}
+
+class LinkedBlockingDequeBoundedTest extends BlockingQueueTest {
+  override protected def emptyCollection(): BlockingQueue[Any] =
+    new LinkedBlockingDeque[Any](JSR166Test.SIZE)
+}
+
+class LinkedBlockingDequeTest extends JSR166Test {
+  import JSR166Test._
+  import LinkedBlockingDequeTest._
+
+  private def it(i: Int): Item = itemFor(i)
+  private val eightySix = itemFor(86)
+
+  /* isEmpty is true before add, false after */
+  @Test def testEmpty(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    assertTrue(q.isEmpty())
+    q.add(it(1))
+    assertFalse(q.isEmpty())
+    q.add(it(2))
+    q.removeFirst()
+    q.removeFirst()
+    assertTrue(q.isEmpty())
+  }
+
+  /* size changes when elements added and removed */
+  @Test def testSize(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(SIZE - i, q.size())
+      q.removeFirst()
+    }
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.size())
+      mustAdd(q, it(1))
+    }
+  }
+
+  /* offerFirst(null) throws NullPointerException */
+  @Test def testOfferFirstNull(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    try {
+      q.offerFirst(null)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* offerLast(null) throws NullPointerException */
+  @Test def testOfferLastNull(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    try {
+      q.offerLast(null)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* OfferFirst succeeds */
+  @Test def testOfferFirst(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    assertTrue(q.offerFirst(it(0)))
+    assertTrue(q.offerFirst(it(2)))
+  }
+
+  /* OfferLast succeeds */
+  @Test def testOfferLast(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    assertTrue(q.offerLast(it(0)))
+    assertTrue(q.offerLast(it(1)))
+  }
+
+  /* pollFirst succeeds unless empty */
+  @Test def testPollFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.pollFirst())
+    assertNull(q.pollFirst())
+  }
+
+  /* pollLast succeeds unless empty */
+  @Test def testPollLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- SIZE - 1 to 0 by -1) mustEqual(i, q.pollLast())
+    assertNull(q.pollLast())
+  }
+
+  /* peekFirst returns next element, or null if empty */
+  @Test def testPeekFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.peekFirst())
+      mustEqual(i, q.pollFirst())
+      assertTrue(q.peekFirst() == null || q.peekFirst() != itemFor(i))
+    }
+    assertNull(q.peekFirst())
+  }
+
+  /* peek returns next element, or null if empty */
+  @Test def testPeek(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.peek())
+      mustEqual(i, q.pollFirst())
+      assertTrue(q.peek() == null || q.peek() != itemFor(i))
+    }
+    assertNull(q.peek())
+  }
+
+  /* peekLast returns next element, or null if empty */
+  @Test def testPeekLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- SIZE - 1 to 0 by -1) {
+      mustEqual(i, q.peekLast())
+      mustEqual(i, q.pollLast())
+      assertTrue(q.peekLast() == null || q.peekLast() != itemFor(i))
+    }
+    assertNull(q.peekLast())
+  }
+
+  /* getFirst() returns first element, or throws NSEE if empty */
+  @Test def testFirstElement(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.getFirst())
+      mustEqual(i, q.pollFirst())
+    }
+    try {
+      q.getFirst()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+    assertNull(q.peekFirst())
+  }
+
+  /* getLast() returns last element, or throws NSEE if empty */
+  @Test def testLastElement(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- SIZE - 1 to 0 by -1) {
+      mustEqual(i, q.getLast())
+      mustEqual(i, q.pollLast())
+    }
+    try {
+      q.getLast()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+    assertNull(q.peekLast())
+  }
+
+  /* removeFirst() removes first element, or throws NSEE if empty */
+  @Test def testRemoveFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.removeFirst())
+    try {
+      q.removeFirst()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+    assertNull(q.peekFirst())
+  }
+
+  /* removeLast() removes last element, or throws NSEE if empty */
+  @Test def testRemoveLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- SIZE - 1 to 0 by -1) mustEqual(i, q.removeLast())
+    try {
+      q.removeLast()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+    assertNull(q.peekLast())
+  }
+
+  /* remove removes next element, or throws NSEE if empty */
+  @Test def testRemove(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.remove())
+    try {
+      q.remove()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+  }
+
+  /* removeFirstOccurrence(x) removes x and returns true if present */
+  @Test def testRemoveFirstOccurrence(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 1 until SIZE by 2)
+      assertTrue(q.removeFirstOccurrence(itemFor(i)))
+    for (i <- 0 until SIZE by 2) {
+      assertTrue(q.removeFirstOccurrence(itemFor(i)))
+      assertFalse(q.removeFirstOccurrence(itemFor(i + 1)))
+    }
+    assertTrue(q.isEmpty())
+  }
+
+  /* removeLastOccurrence(x) removes x and returns true if present */
+  @Test def testRemoveLastOccurrence(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 1 until SIZE by 2)
+      assertTrue(q.removeLastOccurrence(itemFor(i)))
+    for (i <- 0 until SIZE by 2) {
+      assertTrue(q.removeLastOccurrence(itemFor(i)))
+      assertFalse(q.removeLastOccurrence(itemFor(i + 1)))
+    }
+    assertTrue(q.isEmpty())
+  }
+
+  /* peekFirst returns element inserted with addFirst */
+  @Test def testAddFirst(): Unit = {
+    val q = populatedDeque(3)
+    q.pollLast()
+    q.addFirst(it(4))
+    assertSame(it(4), q.peekFirst())
+  }
+
+  /* peekLast returns element inserted with addLast */
+  @Test def testAddLast(): Unit = {
+    val q = populatedDeque(3)
+    q.pollLast()
+    q.addLast(it(4))
+    assertSame(it(4), q.peekLast())
+  }
+
+  /* A new deque has indicated capacity, or Integer.MAX_VALUE if none given */
+  @Test def testConstructor1(): Unit = {
+    mustEqual(SIZE, new LinkedBlockingDeque[Item](SIZE).remainingCapacity())
+    mustEqual(Int.MaxValue, new LinkedBlockingDeque[Item]().remainingCapacity())
+  }
+
+  /* Constructor throws IllegalArgumentException if capacity nonpositive */
+  @Test def testConstructor2(): Unit = {
+    try {
+      new LinkedBlockingDeque[Item](0)
+      shouldThrow()
+    } catch {
+      case _: IllegalArgumentException =>
+    }
+  }
+
+  /* Initializing from null Collection throws NullPointerException */
+  @Test def testConstructor3(): Unit = {
+    try {
+      new LinkedBlockingDeque[Item](null)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* Initializing from Collection of null elements throws NPE */
+  @Test def testConstructor4(): Unit = {
+    val elements: Collection[Item] = Arrays.asList(new Array[Item](SIZE): _*)
+    try {
+      new LinkedBlockingDeque[Item](elements)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* Initializing from Collection with some null elements throws NPE */
+  @Test def testConstructor5(): Unit = {
+    val items = new Array[Item](2)
+    items(0) = it(0)
+    val elements: Collection[Item] = Arrays.asList(items: _*)
+    try {
+      new LinkedBlockingDeque[Item](elements)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* Deque contains all elements of collection used to initialize */
+  @Test def testConstructor6(): Unit = {
+    val items = defaultItems
+    val q = new LinkedBlockingDeque[Item](Arrays.asList(items: _*))
+    for (i <- 0 until SIZE) mustEqual(items(i), q.poll())
+  }
+
+  /* Deque transitions from empty to full when elements added */
+  @Test def testEmptyFull(): Unit = {
+    val q = new LinkedBlockingDeque[Item](2)
+    assertTrue(q.isEmpty())
+    mustEqual(2, q.remainingCapacity())
+    q.add(it(1))
+    assertFalse(q.isEmpty())
+    q.add(it(2))
+    assertFalse(q.isEmpty())
+    mustEqual(0, q.remainingCapacity())
+    assertFalse(q.offer(it(3)))
+  }
+
+  /* remainingCapacity decreases on add, increases on remove */
+  @Test def testRemainingCapacity(): Unit = {
+    val q: BlockingQueue[Item] = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.remainingCapacity())
+      mustEqual(SIZE, q.size() + q.remainingCapacity())
+      mustEqual(i, q.remove())
+    }
+    for (i <- 0 until SIZE) {
+      mustEqual(SIZE - i, q.remainingCapacity())
+      mustEqual(SIZE, q.size() + q.remainingCapacity())
+      mustAdd(q, i)
+    }
+  }
+
+  /* push(null) throws NPE */
+  @Test def testPushNull(): Unit = {
+    val q = new LinkedBlockingDeque[Item](1)
+    try {
+      q.push(null)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* push succeeds if not full; throws IllegalStateException if full */
+  @Test def testPush(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    for (i <- 0 until SIZE) {
+      val x = itemFor(i)
+      q.push(x)
+      mustEqual(x, q.peek())
+    }
+    mustEqual(0, q.remainingCapacity())
+    try {
+      q.push(itemFor(SIZE))
+      shouldThrow()
+    } catch {
+      case _: IllegalStateException =>
+    }
+  }
+
+  /* peekFirst returns element inserted with push */
+  @Test def testPushWithPeek(): Unit = {
+    val q = populatedDeque(3)
+    q.pollLast()
+    q.push(it(4))
+    assertSame(it(4), q.peekFirst())
+  }
+
+  /* pop removes next element, or throws NSEE if empty */
+  @Test def testPop(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.pop())
+    try {
+      q.pop()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+  }
+
+  /* Offer succeeds if not full; fails if full */
+  @Test def testOffer(): Unit = {
+    val q = new LinkedBlockingDeque[Item](1)
+    assertTrue(q.offer(it(0)))
+    assertFalse(q.offer(it(1)))
+  }
+
+  /* add succeeds if not full; throws IllegalStateException if full */
+  @Test def testAdd(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    for (i <- 0 until SIZE) mustAdd(q, i)
+    mustEqual(0, q.remainingCapacity())
+    try {
+      q.add(itemFor(SIZE))
+      shouldThrow()
+    } catch {
+      case _: IllegalStateException =>
+    }
+  }
+
+  /* addAll(this) throws IllegalArgumentException */
+  @Test def testAddAllSelf(): Unit = {
+    val q = populatedDeque(SIZE)
+    try {
+      q.addAll(q)
+      shouldThrow()
+    } catch {
+      case _: IllegalArgumentException =>
+    }
+  }
+
+  /* addAll of a collection with any null elements throws NPE */
+  @Test def testAddAll3(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    val items = new Array[Item](2)
+    items(0) = it(0)
+    try {
+      q.addAll(Arrays.asList(items: _*))
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* addAll throws IllegalStateException if not enough room */
+  @Test def testAddAll4(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE - 1)
+    try {
+      q.addAll(Arrays.asList(defaultItems: _*))
+      shouldThrow()
+    } catch {
+      case _: IllegalStateException =>
+    }
+  }
+
+  /* Deque contains all elements, in traversal order, of successful addAll */
+  @Test def testAddAll5(): Unit = {
+    val empty = new Array[Item](0)
+    val items = defaultItems
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    assertFalse(q.addAll(Arrays.asList(empty: _*)))
+    assertTrue(q.addAll(Arrays.asList(items: _*)))
+    for (i <- 0 until SIZE) mustEqual(items(i), q.poll())
+  }
+
+  /* all elements successfully put are contained */
+  @Test def testPut(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    for (i <- 0 until SIZE) {
+      val x = itemFor(i)
+      q.put(x)
+      mustContain(q, x)
+    }
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* put blocks interruptibly if full */
+  @Test def testBlockingPut(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE) q.put(itemFor(i))
+        mustEqual(SIZE, q.size())
+        mustEqual(0, q.remainingCapacity())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.put(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.put(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    mustEqual(SIZE, q.size())
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* put blocks interruptibly waiting for take when full */
+  @Test def testPutWithTake(): Unit = {
+    val capacity = 2
+    val q = new LinkedBlockingDeque[Item](capacity)
+    val pleaseTake = new CountDownLatch(1)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until capacity) q.put(itemFor(i))
+        pleaseTake.countDown()
+        q.put(eightySix)
+
+        Thread.currentThread().interrupt()
+        try {
+          q.put(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.put(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseTake)
+    mustEqual(0, q.remainingCapacity())
+    mustEqual(0, q.take())
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* timed offer times out if full and elements not taken */
+  @Test def testTimedOffer(): Unit = {
+    val q = new LinkedBlockingDeque[Item](2)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        q.put(it(0))
+        q.put(it(1))
+        val startTime = System.nanoTime()
+
+        assertFalse(q.offer(it(2), timeoutMillis(), MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.offer(it(3), randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.offer(it(4), LONGER_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* take retrieves elements in FIFO order */
+  @Test def testTake(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.take())
+  }
+
+  /* take removes existing elements until empty, then blocks interruptibly */
+  @Test def testBlockingTake(): Unit = {
+    val q = populatedDeque(SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE) mustEqual(i, q.take())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.take()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.take()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* poll succeeds unless empty */
+  @Test def testPoll(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.poll())
+    assertNull(q.poll())
+  }
+
+  /* timed poll with zero timeout succeeds when non-empty, else times out */
+  @Test def testTimedPoll0(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.poll(0, MILLISECONDS))
+    assertNull(q.poll(0, MILLISECONDS))
+  }
+
+  /* timed poll with nonzero timeout succeeds when non-empty, else times out */
+  @Test def testTimedPoll(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      val startTime = System.nanoTime()
+      mustEqual(i, q.poll(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+    val startTime = System.nanoTime()
+    assertNull(q.poll(timeoutMillis(), MILLISECONDS))
+    assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    checkEmpty(q)
+  }
+
+  /* Interrupted timed poll throws InterruptedException */
+  @Test def testInterruptedTimedPoll(): Unit = {
+    val q: BlockingQueue[Item] = populatedDeque(SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE)
+          mustEqual(i, q.poll(LONG_DELAY_MS, MILLISECONDS))
+
+        Thread.currentThread().interrupt()
+        try {
+          q.poll(randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.poll(LONGER_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    checkEmpty(q)
+  }
+
+  /* putFirst(null) throws NPE */
+  @Test def testPutFirstNull(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    try {
+      q.putFirst(null)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* all elements successfully putFirst are contained */
+  @Test def testPutFirst(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    for (i <- 0 until SIZE) {
+      val x = itemFor(i)
+      q.putFirst(x)
+      mustContain(q, x)
+    }
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* putFirst blocks interruptibly if full */
+  @Test def testBlockingPutFirst(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE) q.putFirst(itemFor(i))
+        mustEqual(SIZE, q.size())
+        mustEqual(0, q.remainingCapacity())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.putFirst(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.putFirst(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    mustEqual(SIZE, q.size())
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* putFirst blocks interruptibly waiting for take when full */
+  @Test def testPutFirstWithTake(): Unit = {
+    val capacity = 2
+    val q = new LinkedBlockingDeque[Item](capacity)
+    val pleaseTake = new CountDownLatch(1)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until capacity) q.putFirst(itemFor(i))
+        pleaseTake.countDown()
+        q.putFirst(eightySix)
+
+        pleaseInterrupt.countDown()
+        try {
+          q.putFirst(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseTake)
+    mustEqual(0, q.remainingCapacity())
+    mustEqual(capacity - 1, q.take())
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* timed offerFirst times out if full and elements not taken */
+  @Test def testTimedOfferFirst(): Unit = {
+    val q = new LinkedBlockingDeque[Item](2)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        q.putFirst(it(0))
+        q.putFirst(it(1))
+        val startTime = System.nanoTime()
+
+        assertFalse(q.offerFirst(it(2), timeoutMillis(), MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.offerFirst(it(3), randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.offerFirst(it(4), LONGER_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* takeFirst retrieves elements in FIFO order */
+  @Test def testTakeFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.takeFirst())
+  }
+
+  /* takeFirst() blocks interruptibly when empty */
+  @Test def testTakeFirstFromEmptyBlocksInterruptibly(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    val threadStarted = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        threadStarted.countDown()
+        try {
+          q.takeFirst()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(threadStarted)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* takeFirst() throws InterruptedException immediately if interrupted */
+  @Test def testTakeFirstFromEmptyAfterInterrupt(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        Thread.currentThread().interrupt()
+        try {
+          q.takeFirst()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    awaitTermination(t)
+  }
+
+  /* takeLast() blocks interruptibly when empty */
+  @Test def testTakeLastFromEmptyBlocksInterruptibly(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    val threadStarted = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        threadStarted.countDown()
+        try {
+          q.takeLast()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(threadStarted)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* takeLast() throws InterruptedException immediately if interrupted */
+  @Test def testTakeLastFromEmptyAfterInterrupt(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        Thread.currentThread().interrupt()
+        try {
+          q.takeLast()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    awaitTermination(t)
+  }
+
+  /* takeFirst removes existing elements until empty, then blocks */
+  @Test def testBlockingTakeFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE) mustEqual(i, q.takeFirst())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.takeFirst()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.takeFirst()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* timed pollFirst with zero timeout succeeds when non-empty */
+  @Test def testTimedPollFirst0(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(i, q.pollFirst(0, MILLISECONDS))
+    assertNull(q.pollFirst(0, MILLISECONDS))
+  }
+
+  /* timed pollFirst with nonzero timeout succeeds when non-empty */
+  @Test def testTimedPollFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      val startTime = System.nanoTime()
+      mustEqual(i, q.pollFirst(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+    val startTime = System.nanoTime()
+    assertNull(q.pollFirst(timeoutMillis(), MILLISECONDS))
+    assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    checkEmpty(q)
+  }
+
+  /* Interrupted timed pollFirst throws InterruptedException */
+  @Test def testInterruptedTimedPollFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE)
+          mustEqual(i, q.pollFirst(LONG_DELAY_MS, MILLISECONDS))
+
+        Thread.currentThread().interrupt()
+        try {
+          q.pollFirst(randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.pollFirst(LONGER_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* timed pollFirst before and after offerFirst */
+  @Test def testTimedPollFirstWithOfferFirst(): Unit = {
+    val q = new LinkedBlockingDeque[Item](2)
+    val barrier = new CheckedBarrier(2)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        val startTime = System.nanoTime()
+        assertNull(q.pollFirst(timeoutMillis(), MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+
+        barrier.await()
+        assertSame(it(0), q.pollFirst(LONG_DELAY_MS, MILLISECONDS))
+
+        Thread.currentThread().interrupt()
+        try {
+          q.pollFirst(randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+
+        barrier.await()
+        try {
+          q.pollFirst(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+        assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+      }
+    })
+
+    barrier.await()
+    val startTime = System.nanoTime()
+    assertTrue(q.offerFirst(it(0), LONG_DELAY_MS, MILLISECONDS))
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    barrier.await()
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* putLast(null) throws NPE */
+  @Test def testPutLastNull(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    try {
+      q.putLast(null)
+      shouldThrow()
+    } catch {
+      case _: NullPointerException =>
+    }
+  }
+
+  /* all elements successfully putLast are contained */
+  @Test def testPutLast(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    for (i <- 0 until SIZE) {
+      val x = itemFor(i)
+      q.putLast(x)
+      mustContain(q, x)
+    }
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* putLast blocks interruptibly if full */
+  @Test def testBlockingPutLast(): Unit = {
+    val q = new LinkedBlockingDeque[Item](SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE) q.putLast(itemFor(i))
+        mustEqual(SIZE, q.size())
+        mustEqual(0, q.remainingCapacity())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.putLast(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.putLast(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    mustEqual(SIZE, q.size())
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* putLast blocks interruptibly waiting for take when full */
+  @Test def testPutLastWithTake(): Unit = {
+    val capacity = 2
+    val q = new LinkedBlockingDeque[Item](capacity)
+    val pleaseTake = new CountDownLatch(1)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until capacity) q.putLast(itemFor(i))
+        pleaseTake.countDown()
+        q.putLast(eightySix)
+
+        Thread.currentThread().interrupt()
+        try {
+          q.putLast(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.putLast(ninetynine)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseTake)
+    mustEqual(0, q.remainingCapacity())
+    mustEqual(0, q.take())
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    mustEqual(0, q.remainingCapacity())
+  }
+
+  /* timed offerLast times out if full and elements not taken */
+  @Test def testTimedOfferLast(): Unit = {
+    val q = new LinkedBlockingDeque[Item](2)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        q.putLast(it(0))
+        q.putLast(it(1))
+        val startTime = System.nanoTime()
+
+        assertFalse(q.offerLast(it(2), timeoutMillis(), MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.offerLast(it(3), randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+
+        pleaseInterrupt.countDown()
+        try {
+          q.offerLast(it(4), LONGER_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* takeLast retrieves elements in reverse FIFO order */
+  @Test def testTakeLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) mustEqual(SIZE - i - 1, q.takeLast())
+  }
+
+  /* takeLast removes existing elements until empty, then blocks */
+  @Test def testBlockingTakeLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE) mustEqual(SIZE - i - 1, q.takeLast())
+
+        Thread.currentThread().interrupt()
+        try {
+          q.takeLast()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.takeLast()
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* timed pollLast with zero timeout succeeds when non-empty */
+  @Test def testTimedPollLast0(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE)
+      mustEqual(SIZE - i - 1, q.pollLast(0, MILLISECONDS))
+    assertNull(q.pollLast(0, MILLISECONDS))
+  }
+
+  /* timed pollLast with nonzero timeout succeeds when non-empty */
+  @Test def testTimedPollLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      val startTime = System.nanoTime()
+      mustEqual(SIZE - i - 1, q.pollLast(LONG_DELAY_MS, MILLISECONDS))
+      assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+    }
+    val startTime = System.nanoTime()
+    assertNull(q.pollLast(timeoutMillis(), MILLISECONDS))
+    assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+    checkEmpty(q)
+  }
+
+  /* Interrupted timed pollLast throws InterruptedException */
+  @Test def testInterruptedTimedPollLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    val pleaseInterrupt = new CountDownLatch(1)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        for (i <- 0 until SIZE)
+          mustEqual(SIZE - i - 1, q.pollLast(LONG_DELAY_MS, MILLISECONDS))
+
+        Thread.currentThread().interrupt()
+        try {
+          q.pollLast(randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        pleaseInterrupt.countDown()
+        try {
+          q.pollLast(LONGER_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+      }
+    })
+
+    await(pleaseInterrupt)
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+    checkEmpty(q)
+  }
+
+  /* timed poll before and after offerLast */
+  @Test def testTimedPollWithOfferLast(): Unit = {
+    val q = new LinkedBlockingDeque[Item](2)
+    val barrier = new CheckedBarrier(2)
+    val t = newStartedThread(new CheckedRunnable {
+      override def realRun(): Unit = {
+        val startTime = System.nanoTime()
+        assertNull(q.poll(timeoutMillis(), MILLISECONDS))
+        assertTrue(millisElapsedSince(startTime) >= timeoutMillis())
+
+        barrier.await()
+        assertSame(it(0), q.poll(LONG_DELAY_MS, MILLISECONDS))
+
+        Thread.currentThread().interrupt()
+        try {
+          q.poll(randomTimeout(), randomTimeUnit())
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+
+        barrier.await()
+        try {
+          q.poll(LONG_DELAY_MS, MILLISECONDS)
+          shouldThrow()
+        } catch {
+          case _: InterruptedException =>
+        }
+        assertFalse(Thread.interrupted())
+        assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+      }
+    })
+
+    barrier.await()
+    val startTime = System.nanoTime()
+    assertTrue(q.offerLast(it(0), LONG_DELAY_MS, MILLISECONDS))
+    assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS)
+
+    barrier.await()
+    if (randomBoolean()) assertThreadBlocks(t, Thread.State.TIMED_WAITING)
+    t.interrupt()
+    awaitTermination(t)
+  }
+
+  /* element returns next element, or throws NSEE if empty */
+  @Test def testElement(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.element())
+      q.poll()
+    }
+    try {
+      q.element()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+  }
+
+  /* contains(x) reports true when elements added but not yet removed */
+  @Test def testContains(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustContain(q, i)
+      q.poll()
+      mustNotContain(q, i)
+    }
+  }
+
+  /* clear removes all elements */
+  @Test def testClear(): Unit = {
+    val q = populatedDeque(SIZE)
+    q.clear()
+    assertTrue(q.isEmpty())
+    mustEqual(0, q.size())
+    mustEqual(SIZE, q.remainingCapacity())
+    q.add(it(1))
+    assertFalse(q.isEmpty())
+    mustContain(q, it(1))
+    q.clear()
+    assertTrue(q.isEmpty())
+  }
+
+  /* containsAll(c) is true when c contains a subset of elements */
+  @Test def testContainsAll(): Unit = {
+    val q = populatedDeque(SIZE)
+    val p = new LinkedBlockingDeque[Item](SIZE)
+    for (i <- 0 until SIZE) {
+      assertTrue(q.containsAll(p))
+      assertFalse(p.containsAll(q))
+      mustAdd(p, i)
+    }
+    assertTrue(p.containsAll(q))
+  }
+
+  /* retainAll(c) retains only those elements of c */
+  @Test def testRetainAll(): Unit = {
+    val q = populatedDeque(SIZE)
+    val p = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      val changed = q.retainAll(p)
+      if (i == 0) assertFalse(changed)
+      else assertTrue(changed)
+
+      assertTrue(q.containsAll(p))
+      mustEqual(SIZE - i, q.size())
+      p.remove()
+    }
+  }
+
+  /* removeAll(c) removes only those elements of c */
+  @Test def testRemoveAll(): Unit = {
+    for (i <- 1 until SIZE) {
+      val q = populatedDeque(SIZE)
+      val p = populatedDeque(i)
+      assertTrue(q.removeAll(p))
+      mustEqual(SIZE - i, q.size())
+      for (_ <- 0 until i)
+        mustNotContain(q, p.remove())
+    }
+  }
+
+  /* toArray contains all elements in FIFO order */
+  @Test def testToArray(): Unit = {
+    val q = populatedDeque(SIZE)
+    val a = q.toArray()
+    assertSame(classOf[Array[AnyRef]], a.getClass())
+    a.foreach(o => assertSame(o, q.poll()))
+    assertTrue(q.isEmpty())
+  }
+
+  /* toArray(a) contains all elements in FIFO order */
+  @Test def testToArray2(): Unit = {
+    val q = populatedDeque(SIZE)
+    val items = new Array[Item](SIZE)
+    val array = q.toArray(items)
+    assertSame(items, array)
+    items.foreach(o => assertSame(o, q.remove()))
+    assertTrue(q.isEmpty())
+  }
+
+  /* toArray(incompatible array type) throws ArrayStoreException */
+  @Ignore(
+    "Scala Native reference arrays do not preserve runtime component types"
+  )
+  @Test def testToArray_incompatibleArrayType(): Unit = {
+    val q = populatedDeque(SIZE)
+    try {
+      q.toArray(new Array[String](10))
+      shouldThrow()
+    } catch {
+      case _: ArrayStoreException =>
+    }
+  }
+
+  /* iterator iterates through all elements */
+  @Test def testIterator(): Unit = {
+    val q = populatedDeque(SIZE)
+    var it = q.iterator()
+    var i = 0
+    while (it.hasNext()) {
+      mustContain(q, it.next())
+      i += 1
+    }
+    mustEqual(i, SIZE)
+    assertIteratorExhausted(it)
+
+    it = q.iterator()
+    i = 0
+    while (it.hasNext()) {
+      mustEqual(it.next(), q.take())
+      i += 1
+    }
+    mustEqual(i, SIZE)
+    assertIteratorExhausted(it)
+  }
+
+  /* iterator of empty collection has no elements */
+  @Test def testEmptyIterator(): Unit = {
+    val c = new LinkedBlockingDeque[Item]()
+    assertIteratorExhausted(c.iterator())
+    assertIteratorExhausted(c.descendingIterator())
+  }
+
+  /* iterator.remove removes current element */
+  @Test def testIteratorRemove(): Unit = {
+    val q = new LinkedBlockingDeque[Item](3)
+    q.add(it(2))
+    q.add(it(1))
+    q.add(it(3))
+
+    var iter = q.iterator()
+    iter.next()
+    iter.remove()
+
+    iter = q.iterator()
+    assertSame(iter.next(), it(1))
+    assertSame(iter.next(), it(3))
+    assertFalse(iter.hasNext())
+  }
+
+  /* iterator ordering is FIFO */
+  @Test def testIteratorOrdering(): Unit = {
+    val q = new LinkedBlockingDeque[Item](3)
+    q.add(it(1))
+    q.add(it(2))
+    q.add(it(3))
+    mustEqual(0, q.remainingCapacity())
+    var k = 0
+    val iter = q.iterator()
+    while (iter.hasNext()) {
+      k += 1
+      mustEqual(k, iter.next())
+    }
+    mustEqual(3, k)
+  }
+
+  /* Modifications do not cause iterators to fail */
+  @Test def testWeaklyConsistentIteration(): Unit = {
+    val q = new LinkedBlockingDeque[Item](3)
+    q.add(it(1))
+    q.add(it(2))
+    q.add(it(3))
+    val iter = q.iterator()
+    while (iter.hasNext()) {
+      q.remove()
+      iter.next()
+    }
+    mustEqual(0, q.size())
+  }
+
+  /* Descending iterator iterates through all elements */
+  @Test def testDescendingIterator(): Unit = {
+    val q = populatedDeque(SIZE)
+    var i = 0
+    val iter = q.descendingIterator()
+    while (iter.hasNext()) {
+      mustContain(q, iter.next())
+      i += 1
+    }
+    mustEqual(i, SIZE)
+    assertFalse(iter.hasNext())
+    try {
+      iter.next()
+      shouldThrow()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+  }
+
+  /* Descending iterator ordering is reverse FIFO */
+  @Test def testDescendingIteratorOrdering(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    for (_ <- 0 until 100) {
+      mustAdd(q, it(3))
+      mustAdd(q, it(2))
+      mustAdd(q, it(1))
+
+      var k = 0
+      val iter = q.descendingIterator()
+      while (iter.hasNext()) {
+        k += 1
+        mustEqual(k, iter.next())
+      }
+
+      mustEqual(3, k)
+      q.remove()
+      q.remove()
+      q.remove()
+    }
+  }
+
+  /* descendingIterator.remove removes current element */
+  @Test def testDescendingIteratorRemove(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    for (_ <- 0 until 100) {
+      mustAdd(q, it(3))
+      mustAdd(q, it(2))
+      mustAdd(q, it(1))
+      var iter = q.descendingIterator()
+      mustEqual(iter.next(), it(1))
+      iter.remove()
+      mustEqual(iter.next(), it(2))
+      iter = q.descendingIterator()
+      mustEqual(iter.next(), it(2))
+      mustEqual(iter.next(), it(3))
+      iter.remove()
+      assertFalse(iter.hasNext())
+      q.remove()
+    }
+  }
+
+  /* toString contains toStrings of elements */
+  @Test def testToString(): Unit = {
+    val q = populatedDeque(SIZE)
+    val s = q.toString()
+    for (i <- 0 until SIZE)
+      assertTrue(s.contains(String.valueOf(i)))
+  }
+
+  /* offer transfers elements across Executor tasks */
+  @Test def testOfferInExecutor(): Unit = {
+    val q = new LinkedBlockingDeque[Item](2)
+    q.add(it(1))
+    q.add(it(2))
+    val threadsStarted = new CheckedBarrier(2)
+    val executor = Executors.newFixedThreadPool(2)
+    usingPoolCleaner(executor) { executor =>
+      executor.execute(new CheckedRunnable {
+        override def realRun(): Unit = {
+          assertFalse(q.offer(it(3)))
+          threadsStarted.await()
+          assertTrue(q.offer(it(3), LONG_DELAY_MS, MILLISECONDS))
+          mustEqual(0, q.remainingCapacity())
+        }
+      })
+
+      executor.execute(new CheckedRunnable {
+        override def realRun(): Unit = {
+          threadsStarted.await()
+          assertSame(it(1), q.take())
+        }
+      })
+    }
+  }
+
+  /* timed poll retrieves elements across Executor threads */
+  @Test def testPollInExecutor(): Unit = {
+    val q = new LinkedBlockingDeque[Item](2)
+    val threadsStarted = new CheckedBarrier(2)
+    val executor = Executors.newFixedThreadPool(2)
+    usingPoolCleaner(executor) { executor =>
+      executor.execute(new CheckedRunnable {
+        override def realRun(): Unit = {
+          assertNull(q.poll())
+          threadsStarted.await()
+          assertSame(it(1), q.poll(LONG_DELAY_MS, MILLISECONDS))
+          checkEmpty(q)
+        }
+      })
+
+      executor.execute(new CheckedRunnable {
+        override def realRun(): Unit = {
+          threadsStarted.await()
+          q.put(it(1))
+        }
+      })
+    }
+  }
+
+  /* A deserialized/reserialized deque has same elements in same order */
+  @Ignore("scala-native#4852: ObjectInputStream is unsupported")
+  @Test def testSerialization(): Unit = {}
+
+  /* drainTo(c) empties deque into another collection c */
+  @Test def testDrainTo(): Unit = {
+    val q = populatedDeque(SIZE)
+    val l = new ArrayList[Item]()
+    q.drainTo(l)
+    mustEqual(0, q.size())
+    mustEqual(SIZE, l.size())
+    for (i <- 0 until SIZE) mustEqual(l.get(i), i)
+    q.add(it(0))
+    q.add(it(1))
+    assertFalse(q.isEmpty())
+    mustContain(q, it(0))
+    mustContain(q, it(1))
+    l.clear()
+    q.drainTo(l)
+    mustEqual(0, q.size())
+    mustEqual(2, l.size())
+    for (i <- 0 until 2) mustEqual(l.get(i), i)
+  }
+
+  /* drainTo empties full deque, unblocking a waiting put. */
+  @Test def testDrainToWithActivePut(): Unit = {
+    val q = populatedDeque(SIZE)
+    val t = new Thread(new CheckedRunnable {
+      override def realRun(): Unit = q.put(new Item(SIZE + 1))
+    })
+
+    t.start()
+    val l = new ArrayList[Item]()
+    q.drainTo(l)
+    assertTrue(l.size() >= SIZE)
+    for (i <- 0 until SIZE) mustEqual(l.get(i), i)
+    t.join()
+    assertTrue(q.size() + l.size() >= SIZE)
+  }
+
+  /* drainTo(c, n) empties first min(n, size) elements into c */
+  @Test def testDrainToN(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    for (i <- 0 until SIZE + 2) {
+      for (j <- 0 until SIZE) mustOffer(q, j)
+      val l = new ArrayList[Item]()
+      q.drainTo(l, i)
+      val k = if (i < SIZE) i else SIZE
+      mustEqual(k, l.size())
+      mustEqual(SIZE - k, q.size())
+      for (j <- 0 until k) mustEqual(l.get(j), j)
+      while (q.poll() != null) ()
+    }
+  }
+
+  /* remove(null), contains(null) always return false */
+  @Test def testNeverContainsNull(): Unit = {
+    val qs = Array(new LinkedBlockingDeque[Item](), populatedDeque(2))
+
+    for (q <- qs) {
+      assertFalse(q.contains(null))
+      assertFalse(q.remove(null))
+      assertFalse(q.removeFirstOccurrence(null))
+      assertFalse(q.removeLastOccurrence(null))
+    }
+  }
+
+  /* Spliterator.getComparator always throws IllegalStateException */
+  @Test def testSpliterator_getComparator(): Unit = {
+    assertThrows(
+      classOf[IllegalStateException],
+      () => new LinkedBlockingDeque[Item]().spliterator().getComparator()
+    )
+  }
+
+  /* Spliterator characteristics are as advertised */
+  @Test def testSpliterator_characteristics(): Unit = {
+    val q = new LinkedBlockingDeque[Item]()
+    val s = q.spliterator()
+    val characteristics = s.characteristics()
+    val required =
+      Spliterator.CONCURRENT | Spliterator.NONNULL | Spliterator.ORDERED
+    mustEqual(required, characteristics & required)
+    assertTrue(s.hasCharacteristics(required))
+    mustEqual(
+      0,
+      characteristics &
+        (Spliterator.DISTINCT | Spliterator.IMMUTABLE | Spliterator.SORTED)
+    )
+  }
+}


### PR DESCRIPTION
Fix #4897 

implement javalib concurrent.LinkedBlockingDeque & its Test.

Notes for reviewers:

* The `contains(e)`, `equals(e)`, and `remove(e)` methods in this PR are implemented
  using the `e: Any` definition inherited, through intermediate classes, ultimately from `Collection.scala`.
  I suggest that, once otherwise acceptable,  this class be merged using those definitions and
  that any correction to AnyRef from `Collection` on down be done in a separate, large, and
  unified PR.

* The original .java code used a `volatile` for the `count` value.  That value is only modified
  by code holding the lock of the class. That handles mutual excluson.
  There is never a CAS (CompareAndSet), so volatile is only for visibility.

  This is less expensive but slightly out-of-parallel with the existing  `LinkedBlockingQueue`
  implementation which uses an `AtomicInteger` in analogous  conditions.
 
<hr>
I will have to do a final accounting but on my mental running tab this is the last remaining JSR-166 
not-yet-implemented class. The rest either are implemented or have a PR in-flight.