### PR TITLE
feat: add Random.from adapter

### DIFF
--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -1,6 +1,7 @@
 package java.util
 
 import java.util.random.{JuRandomFactory, RandomGenerator}
+import java.util.stream.{DoubleStream, IntStream, LongStream}
 
 import scala.annotation.tailrec
 
@@ -134,4 +135,136 @@ class Random(seed_in: Long)
     x * c
   }
 
+}
+
+object Random {
+  def from(generator: RandomGenerator): Random = {
+    Objects.requireNonNull(generator)
+
+    generator match {
+      case random: Random => random
+      case _              => new DelegatingRandom(generator)
+    }
+  }
+
+  private final class DelegatingRandom(generator: RandomGenerator)
+      extends Random(0L) {
+
+    override def setSeed(seed: Long): Unit =
+      throw new UnsupportedOperationException()
+
+    override protected def next(bits: Int): Int =
+      generator.nextInt() >>> (32 - bits)
+
+    override def nextBoolean(): Boolean =
+      generator.nextBoolean()
+
+    override def nextBytes(bytes: Array[Byte]): Unit =
+      generator.nextBytes(bytes)
+
+    override def nextDouble(): Double =
+      generator.nextDouble()
+
+    override def nextDouble(bound: Double): Double =
+      generator.nextDouble(bound)
+
+    override def nextDouble(origin: Double, bound: Double): Double =
+      generator.nextDouble(origin, bound)
+
+    override def nextExponential(): Double =
+      generator.nextExponential()
+
+    override def nextFloat(): Float =
+      generator.nextFloat()
+
+    override def nextFloat(bound: Float): Float =
+      generator.nextFloat(bound)
+
+    override def nextFloat(origin: Float, bound: Float): Float =
+      generator.nextFloat(origin, bound)
+
+    override def nextGaussian(): Double =
+      generator.nextGaussian()
+
+    override def nextGaussian(mean: Double, stddev: Double): Double =
+      generator.nextGaussian(mean, stddev)
+
+    override def nextInt(): Int =
+      generator.nextInt()
+
+    override def nextInt(bound: Int): Int =
+      generator.nextInt(bound)
+
+    override def nextInt(origin: Int, bound: Int): Int =
+      generator.nextInt(origin, bound)
+
+    override def nextLong(): Long =
+      generator.nextLong()
+
+    override def nextLong(bound: Long): Long =
+      generator.nextLong(bound)
+
+    override def nextLong(origin: Long, bound: Long): Long =
+      generator.nextLong(origin, bound)
+
+    override def doubles(): DoubleStream =
+      generator.doubles()
+
+    override def doubles(
+        randomNumberOrigin: Double,
+        randomNumberBound: Double
+    ): DoubleStream =
+      generator.doubles(randomNumberOrigin, randomNumberBound)
+
+    override def doubles(streamSize: Long): DoubleStream =
+      generator.doubles(streamSize)
+
+    override def doubles(
+        streamSize: Long,
+        randomNumberOrigin: Double,
+        randomNumberBound: Double
+    ): DoubleStream =
+      generator.doubles(streamSize, randomNumberOrigin, randomNumberBound)
+
+    override def ints(): IntStream =
+      generator.ints()
+
+    override def ints(
+        randomNumberOrigin: Int,
+        randomNumberBound: Int
+    ): IntStream =
+      generator.ints(randomNumberOrigin, randomNumberBound)
+
+    override def ints(streamSize: Long): IntStream =
+      generator.ints(streamSize)
+
+    override def ints(
+        streamSize: Long,
+        randomNumberOrigin: Int,
+        randomNumberBound: Int
+    ): IntStream =
+      generator.ints(streamSize, randomNumberOrigin, randomNumberBound)
+
+    override def isDeprecated(): Boolean =
+      generator.isDeprecated()
+
+    override def longs(): LongStream =
+      generator.longs()
+
+    override def longs(
+        randomNumberOrigin: Long,
+        randomNumberBound: Long
+    ): LongStream =
+      generator.longs(randomNumberOrigin, randomNumberBound)
+
+    override def longs(streamSize: Long): LongStream =
+      generator.longs(streamSize)
+
+    override def longs(
+        streamSize: Long,
+        randomNumberOrigin: Long,
+        randomNumberBound: Long
+    ): LongStream =
+      generator.longs(streamSize, randomNumberOrigin, randomNumberBound)
+  }
 }

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/RandomTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/RandomTestOnJDK19.scala
@@ -1,0 +1,108 @@
+package org.scalanative.testsuite.javalib.util
+
+import java.util.random.RandomGenerator
+import java.util.{Random => JuRandom}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class RandomTestOnJDK19 {
+
+  @Test def fromRejectsNullGenerator(): Unit = {
+    assertThrows(
+      classOf[NullPointerException],
+      JuRandom.from(null.asInstanceOf[RandomGenerator])
+    )
+  }
+
+  @Test def fromReturnsRandomGeneratorUnchanged(): Unit = {
+    val random = new JuRandom(123456789L)
+
+    assertSame(random, JuRandom.from(random))
+  }
+
+  @Test def fromDelegatesGeneratorMethods(): Unit = {
+    val generator = new TrackingGenerator
+    val random = JuRandom.from(generator)
+
+    assertEquals(0x13579bdf, random.nextInt())
+    assertEquals(17, random.nextInt(23))
+    assertEquals(7, random.nextInt(5, 11))
+
+    assertEquals(0x123456789abcdef0L, random.nextLong())
+    assertEquals(37L, random.nextLong(41L))
+    assertEquals(103L, random.nextLong(101L, 109L))
+
+    assertTrue(random.nextBoolean())
+    assertEquals(0.25f, random.nextFloat(), 0.0f)
+    assertEquals(3.5f, random.nextFloat(7.0f), 0.0f)
+    assertEquals(2.5f, random.nextFloat(2.0f, 3.0f), 0.0f)
+
+    assertEquals(0.5, random.nextDouble(), 0.0)
+    assertEquals(4.5, random.nextDouble(9.0), 0.0)
+    assertEquals(12.25, random.nextDouble(12.0, 13.0), 0.0)
+
+    assertEquals(-0.75, random.nextGaussian(), 0.0)
+    assertEquals(42.0, random.nextGaussian(40.0, 2.0), 0.0)
+    assertEquals(0.125, random.nextExponential(), 0.0)
+
+    val bytes = new Array[Byte](4)
+    random.nextBytes(bytes)
+    assertArrayEquals(Array[Byte](1, 2, 3, 4), bytes)
+  }
+
+  @Test def fromDelegatingRandomDoesNotSupportSetSeed(): Unit = {
+    val random = JuRandom.from(new TrackingGenerator)
+
+    assertThrows(classOf[UnsupportedOperationException], random.setSeed(1L))
+  }
+
+  private final class TrackingGenerator extends RandomGenerator {
+    override def nextBoolean(): Boolean = true
+
+    override def nextBytes(bytes: Array[Byte]): Unit = {
+      var i = 0
+      while (i < bytes.length) {
+        bytes(i) = (i + 1).toByte
+        i += 1
+      }
+    }
+
+    override def nextDouble(): Double = 0.5
+
+    override def nextDouble(bound: Double): Double = bound / 2.0
+
+    override def nextDouble(origin: Double, bound: Double): Double =
+      origin + ((bound - origin) / 4.0)
+
+    override def nextExponential(): Double = 0.125
+
+    override def nextFloat(): Float = 0.25f
+
+    override def nextFloat(bound: Float): Float = bound / 2.0f
+
+    override def nextFloat(origin: Float, bound: Float): Float =
+      origin + ((bound - origin) / 2.0f)
+
+    override def nextGaussian(): Double = -0.75
+
+    override def nextGaussian(mean: Double, stddev: Double): Double =
+      mean + stddev
+
+    override def nextInt(): Int = 0x13579bdf
+
+    override def nextInt(bound: Int): Int = bound - 6
+
+    override def nextInt(origin: Int, bound: Int): Int = origin + 2
+
+    override def nextLong(): Long = 0x123456789abcdef0L
+
+    override def nextLong(bound: Long): Long = bound - 4L
+
+    override def nextLong(origin: Long, bound: Long): Long = origin + 2L
+
+    override def isDeprecated(): Boolean = false
+  }
+}


### PR DESCRIPTION
## Summary

- add `java.util.Random.from(RandomGenerator)`
- return `Random` inputs unchanged and delegate all `Random`/`RandomGenerator` methods for other generators
- add JDK 19 shared direction tests for null handling, identity behavior, delegation, and unsupported `setSeed`

## Review notes

- implementation is clean-room from the Java 25 Javadoc contract, not copied from OpenJDK sources
- cross-review found no behavior issues; one suggested explicit `Objects` import was tested and rejected because Scala 2.12 reports it as hidden by the same-package `Objects` definition

## Tests

- `./scripts/scalafmt --check javalib/src/main/scala/java/util/Random.scala unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/RandomTestOnJDK19.scala`
- `sbt "tests3/testOnly org.scalanative.testsuite.javalib.util.RandomTestOnJDK19"`
- `sbt "testsJVM3/testOnly org.scalanative.testsuite.javalib.util.RandomTestOnJDK19"`
- `sbt "tests2_12/testOnly org.scalanative.testsuite.javalib.util.RandomTestOnJDK19"`
- `sbt "javalib2_13/compile" "testsJVM2_13/testOnly org.scalanative.testsuite.javalib.util.RandomTestOnJDK19"`

Note: `tests2_13/testOnly org.scalanative.testsuite.javalib.util.RandomTestOnJDK19` currently reaches native link and fails on unrelated `ConcurrentSkipListMap` unreachable symbols (`NavigableMap.$init$` / `ConcurrentNavigableMap.$init$`).

Closes #4929
