### PR TITLE
Fix continuations support detection for unsupported architectures

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -50,7 +50,8 @@ object LinktimeInfo {
   @resolvedAtLinktime()
   def isContinuationsSupported: Boolean =
     (isLinux || isMac || isFreeBSD || isOpenBSD || isNetBSD) &&
-      (target.arch != "arm" && !is32BitPlatform)
+      !is32BitPlatform &&
+      (target.arch == "x86_64" || target.arch == "aarch64")
 
   @resolvedAtLinktime()
   def isVirtualThreadsSupported: Boolean =


### PR DESCRIPTION
I tried to upgrade scala-native to 0.5.12 and ran into an error targeting riscv64-linux:

```
delimcc.c:39:2: error: "Unsupported platform"
```

This PR excludes unsupported platforms (like riscv64) from the continuations support.

