### PR TITLE
[build] Migrate to sbt 2.x

### DIFF
--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Compile everything
         # Publish 2.13.latest artifacts locally first, these are required by scalalib3
-        run: sbt "scalalib2_13/publishLocal;clean; ++2.13.8; all Test/compile Compile/doc; ++3.1.3; all Test/compile Compile/doc"
+        run: sbt "scalalib2_13/publishLocal;clean; ++2.13.9; all Test/compile Compile/doc; ++3.1.3; all Test/compile Compile/doc"
 
     
   test-scala-cross-build:

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ bin/
 
 # Build Server Protocol, used by sbt
 **/.bsp/
+**/*.semanticdb
 
 # scala-cli
 **/.scala-build

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -25,6 +25,7 @@ fileOverride {
   "glob:**/src/**/require-scala3*/**" = scala3
   "glob:**/src/**/scala-sbt-2/**" = scala3
   "glob:**/src/**/scala-3-compat/**" = scala3
+  "glob:**/project/**" = scala3
   "lang:scala-next" = scala3future
 }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,7 @@
 // scalafmt: { maxColumn = 120}
 package build
 
+import sbt.util.Digest
 import sbt.{given, *}
 
 import java.io.File.pathSeparator
@@ -60,6 +61,25 @@ object Build {
   lazy val testProjects =
     testMultiScalaProjects.flatMap(_.componentProjects) ::: testNoCrossProject
   lazy val allProjects = publishedProjects ::: testProjects
+
+  /** Path of the scalalib jar that `publishLocal` writes for a scala3lib dependency.
+   *
+   *  Scala 3.8+ depends on a self-contained scalalib artifact; older Scala 3 versions depend on the Scala 2.13
+   *  cross-built artifact instead.
+   */
+  private def expectedLocalScalalibJar(
+      org: String,
+      ivyHome: File,
+      selfContained: Boolean,
+      scalaVersion: String,
+      scalaBinVersion: String,
+      nativeVersion: String
+  ): File =
+    val (depScalaVersion, platformSuffix, artifactSuffix) =
+      if selfContained then (scalaVersion, scalaBinVersion, s"_$scalaBinVersion")
+      else (ScalaVersions.scala213, "2.13", "_2.13")
+    val revision = scalalibVersion(depScalaVersion, nativeVersion)
+    ivyHome / "local" / org / s"scalalib_native0.5_$platformSuffix" / revision / "jars" / s"scalalib$artifactSuffix.jar"
 
   private def setDependency[T](key: TaskKey[T], projects: Seq[Project]) = {
     key := Def.uncached {
@@ -665,15 +685,71 @@ object Build {
                   .cross(CrossVersion.for3Use2_13)
               }
             },
+            // scala3lib resolves scalalib from the local Ivy cache, not from this build's
+            // classpath. Ensure the artifact is published before `update`, but avoid
+            // repeating `publishLocal` on every compile when nothing relevant changed.
+            //
+            // The stamp file stores two lines:
+            //   1. a cache key derived from scalalib's scala version, compiler plugin,
+            //      and native toolchain settings
+            //   2. the absolute path of the published jar
+            //
+            // We republish when the cache key changes or when the stamped jar no longer
+            // exists (for example after cleaning ~/.ivy2/local).
+            publishScalalibLocal := Def.uncached {
+              Def.taskDyn {
+                val selfContained = usesSelfContainedStdlib(scalaVersion.value)
+                val scalalibProject =
+                  if selfContained then scalalib.forBinaryVersion(version)
+                  else scalalib.v2_13
+                val nscPluginProject =
+                  if selfContained then nscPlugin.forBinaryVersion(version)
+                  else nscPlugin.v2_13
+                val stampFile = crossTarget.value / "publish-scalalib-local.stamp"
+                val ivyHome = ivyPaths.value.ivyHome.map(file(_)).getOrElse(Path.userHome / ".ivy2")
+                val nativeVersion = (ThisBuild / Keys.version).value
+
+                val cacheCheck = Def.task {
+                  val sv = (scalalibProject / scalaVersion).value
+                  val pluginDigest = Digest.sha256Hash(
+                    (nscPluginProject / Compile / packageBin).value
+                      .contentHashStr()
+                      .getBytes("UTF-8")
+                  )
+                  val toolchainDigest = Digest.sha256Hash(
+                    (scalalibProject / nativeConfig).value.toString.getBytes("UTF-8")
+                  )
+                  val inputs = s"$sv:$pluginDigest:$toolchainDigest"
+                  val jar = expectedLocalScalalibJar(
+                    organization.value,
+                    ivyHome,
+                    selfContained,
+                    scalaVersion.value,
+                    scalaBinaryVersion.value,
+                    nativeVersion
+                  )
+                  val upToDate = stampFile.exists && {
+                    IO.read(stampFile).split("\n", 2) match
+                      case Array(storedInputs, storedJar) =>
+                        storedInputs == inputs && storedJar.nonEmpty && file(storedJar).exists()
+                      case _ => false
+                  }
+                  (upToDate, inputs, jar)
+                }
+
+                // taskDyn ensures only the selected scalalib project's publishLocal runs.
+                Def.taskDyn {
+                  val (upToDate, inputs, jar) = cacheCheck.value
+                  if upToDate then Def.task(())
+                  else
+                    (scalalibProject / Compile / publishLocal).map { _ =>
+                      IO.write(stampFile, s"$inputs\n${jar.getAbsolutePath}")
+                    }
+                }
+              }.value
+            },
             update := Def.uncached {
-              update
-                .dependsOn:
-                  Def.taskDyn:
-                    Def.cachedTask:
-                      if usesSelfContainedStdlib(scalaVersion.value) then
-                        scalalib.forBinaryVersion(version) / Compile / publishLocal
-                      else scalalib.v2_13 / Compile / publishLocal
-                .value
+              update.dependsOn(publishScalalibLocal).value
             }
           )
       }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,14 +1,13 @@
 // scalafmt: { maxColumn = 120}
 package build
 
-import sbt._
+import sbt.{given, *}
 
 import java.io.File.pathSeparator
 
 import scala.language.implicitConversions
 
 import com.jsuereth.sbtpgp.PgpKeys.publishSigned
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 import scala.scalanative.ScalaNativeBuildInfo
 import scala.scalanative.build._
@@ -48,7 +47,7 @@ object Build {
       tests, testsJVM, testsExt, testsExtJVM, sandbox,
       scalaPartest, scalaPartestRuntime,
       scalaPartestTests, scalaPartestJunitTests,
-      toolsBenchmarks
+      // toolsBenchmarks
     )
   lazy val testNoCrossProject = List(testingCompilerInterface)
 // format: on
@@ -63,7 +62,9 @@ object Build {
   lazy val allProjects = publishedProjects ::: testProjects
 
   private def setDependency[T](key: TaskKey[T], projects: Seq[Project]) = {
-    key := key.dependsOn(projects.map(_ / key): _*).value
+    key := Def.uncached {
+      key.dependsOn(projects.map(_ / key): _*).value
+    }
   }
 
   private def setDependencyForCurrentBinVersion[T](
@@ -71,19 +72,21 @@ object Build {
       projects: Seq[MultiScalaProject],
       includeNoCrossProjects: Boolean = true
   ) = {
-    key := Def.taskDyn {
-      val binVersion = scalaBinaryVersion.value
-      // There is only 1 not cross build project, it can be compiled with any version,
-      // We choose 2.12 for historical reasons and to ensure during release only 1 package published these:
-      // javalib-intf which contains only Java code and can be compiled with any version
-      val optNoCrossProjects = noCrossProjects.filter(_ => includeNoCrossProjects && binVersion == "2.12")
-      val dependencies =
-        optNoCrossProjects ++ projects.flatMap(_.forBinaryVersionIfDefined(binVersion))
-      val prev = key.value
-      Def
-        .task { prev }
-        .dependsOn(dependencies.map(_ / key): _*)
-    }.value
+    key := Def.uncached {
+      Def.taskDyn {
+        val binVersion = scalaBinaryVersion.value
+        // There is only 1 not cross build project, it can be compiled with any version,
+        // We choose 2.12 for historical reasons and to ensure during release only 1 package published these:
+        // javalib-intf which contains only Java code and can be compiled with any version
+        val optNoCrossProjects = noCrossProjects.filter(_ => includeNoCrossProjects && binVersion == "2.12")
+        val dependencies =
+          optNoCrossProjects ++ projects.flatMap(_.forBinaryVersionIfDefined(binVersion))
+        val prev = key.value
+        Def
+          .task { prev }
+          .dependsOn(dependencies.map(_ / key): _*)
+      }.value
+    }
   }
 
   lazy val root: Project =
@@ -134,16 +137,17 @@ object Build {
     .dependsOnSource(utilJVM)
     .zippedSettings(Seq("testingCompiler", "nativelib")) {
       case Seq(testingCompiler, nativelib) =>
-        Test / javaOptions ++= {
+        Test / javaOptions ++= Def.uncached {
           val nscCompilerJar =
-            (Compile / Keys.`package`).value.getAbsolutePath()
+            fileConverter.value.toPath((Compile / Keys.`package`).value).toAbsolutePath.toString
           val testingCompilerCp =
-            (testingCompiler / Compile / fullClasspath).value.files
-              .map(_.getAbsolutePath)
+            (testingCompiler / Compile / fullClasspath).value
+              .map(attr => fileConverter.value.toPath(attr.data).toAbsolutePath.toString)
               .mkString(pathSeparator)
-          val nativelibCp = (nativelib / Compile / fullClasspath).value.files
-            .map(_.getAbsolutePath)
-            .mkString(pathSeparator)
+          val nativelibCp =
+            (nativelib / Compile / fullClasspath).value
+              .map(attr => fileConverter.value.toPath(attr.data).toAbsolutePath.toString)
+              .mkString(pathSeparator)
           Seq(
             "-Dscalanative.nscplugin.jar=" + nscCompilerJar,
             "-Dscalanative.testingcompiler.cp=" + testingCompilerCp,
@@ -214,6 +218,7 @@ object Build {
         log.warn(
           "Unable to test tools using Scala Native yet - missing javalib dependencies / compiler integration"
         )
+        sbt.protocol.testing.TestResult.Empty
       }
     )
     .withJUnitPlugin
@@ -270,33 +275,38 @@ object Build {
       javalib: LocalProject,
       scalalib: LocalProject
   ) = {
-    buildInfoKeys ++= Seq[BuildInfoKey](
-      BuildInfoKey.map(scalaInstance) {
-        case (_, v) =>
-          "scalacJars" -> v.allJars
+    buildInfoKeys ++= Seq(
+      BuildInfoKey.map(BuildInfoKey(scalaInstance)) {
+        case (_, instance) =>
+          "scalacJars" -> instance.allJars
             .map(_.getAbsolutePath())
             .mkString(pathSeparator)
       },
-      BuildInfoKey.map(Compile / managedClasspath) {
-        case (_, v) =>
-          "compileClasspath" -> v.files
-            .map(_.getAbsolutePath())
-            .mkString(pathSeparator)
+      BuildInfoKey.map(BuildInfoKey(Compile / managedClasspath)) {
+        case (_, classpath) =>
+          "compileClasspath" ->
+            classpath
+              .map(_.data)
+              .map(fileConverter.value.toPath(_).toAbsolutePath)
+              .mkString(pathSeparator)
       },
-      BuildInfoKey.map(nscPlugin / Compile / Keys.`package`) {
-        case (_, v) =>
-          "pluginJar" -> v.getAbsolutePath()
+      BuildInfoKey.map(BuildInfoKey(nscPlugin / Compile / Keys.`package`)) {
+        case (_, jar) =>
+          "pluginJar" -> fileConverter.value.toPath(jar).toAbsolutePath
       },
       BuildInfoKey.map(
-        for {
-          scalalibCp <- (scalalib / Compile / fullClasspath).taskValue
-          javalibCp <- (javalib / Compile / fullClasspath).taskValue
-        } yield scalalibCp ++ javalibCp
+        sbtbuildinfo.Entry.TaskValue(
+          for {
+            scalalibCp <- (scalalib / Compile / fullClasspath).taskValue
+            javalibCp <- (javalib / Compile / fullClasspath).taskValue
+          } yield scalalibCp ++ javalibCp
+        )
       ) {
-        case (_, v) =>
+        case (_, classpath) =>
           "nativeRuntimeClasspath" ->
-            v.files
-              .map(_.getAbsolutePath)
+            classpath
+              .map(_.data)
+              .map(fileConverter.value.toPath(_).toAbsolutePath)
               .distinct
               .mkString(pathSeparator)
       }
@@ -313,9 +323,9 @@ object Build {
         inConfig(Jmh)(
           Def.settings(
             sourceDirectory := (Compile / sourceDirectory).value,
-            classDirectory := (Compile / classDirectory).value,
-            dependencyClasspath := (Compile / dependencyClasspath).value,
-            compile := (Jmh / compile).dependsOn(Compile / compile).value,
+            classDirectory := Def.uncached { (Compile / classDirectory).value },
+            dependencyClasspath := Def.uncached { (Compile / dependencyClasspath).value },
+            compile := Def.uncached { (Jmh / compile).dependsOn(Compile / compile).value },
             run := (Jmh / run).dependsOn(Jmh / compile).evaluated
           )
         )
@@ -327,9 +337,12 @@ object Build {
             // Compile / buildInfoObject := "TestSuiteBuildInfo",
             Compile / buildInfoPackage := "scala.scalanative.benchmarks",
             Compile / buildInfoKeys := List(
-              BuildInfoKey.map(testInterface / Test / fullClasspath) {
-                case (key, value) =>
-                  ("fullTestSuiteClasspath", value.toList.map(_.data))
+              BuildInfoKey.map(BuildInfoKey(testInterface / Test / fullClasspath)) {
+                case (_, classpath) =>
+                  "fullTestSuiteClasspath" -> classpath
+                    .map(_.data)
+                    .map(fileConverter.value.toPath(_).toAbsolutePath)
+                    .mkString(pathSeparator)
               }
             )
           )
@@ -645,21 +658,23 @@ object Build {
             libraryDependencies += {
               val nativeVersion = (ThisBuild / Keys.version).value
               if (usesSelfContainedStdlib(scalaVersion.value)) {
-                organization.value %%% "scalalib" % scalalibVersion(scalaVersion.value, nativeVersion)
+                organization.value %% "scalalib" % scalalibVersion(scalaVersion.value, nativeVersion)
               } else {
-                (organization.value %%% "scalalib" % scalalibVersion(ScalaVersions.scala213, nativeVersion))
+                (organization.value %% "scalalib" % scalalibVersion(ScalaVersions.scala213, nativeVersion))
                   .excludeAll(ExclusionRule(organization.value))
                   .cross(CrossVersion.for3Use2_13)
               }
             },
-            update := update.dependsOn {
-              Def.taskDyn {
-                if (usesSelfContainedStdlib(scalaVersion.value))
-                  scalalib.forBinaryVersion(version) / Compile / publishLocal
-                else
-                  scalalib.v2_13 / Compile / publishLocal
-              }
-            }.value
+            update := Def.uncached {
+              update.dependsOn {
+                Def.taskDyn {
+                  if (usesSelfContainedStdlib(scalaVersion.value))
+                    scalalib.forBinaryVersion(version) / Compile / publishLocal
+                  else
+                    scalalib.v2_13 / Compile / publishLocal
+                }
+              }.value
+            }
           )
       }
       .dependsOn(auxlib)
@@ -881,14 +896,15 @@ object Build {
         noPublishSettings,
         shouldPartestSetting,
         resolvers += Resolver.typesafeIvyRepo("releases"),
-        fetchScalaSource / artifactPath :=
-          baseDirectory.value.getParentFile / "fetchedSources" / scalaVersion.value,
-        fetchScalaSource := {
+        fetchScalaSource / artifactPath := fileConverter.value.toVirtualFile(
+          baseDirectory.value.getParentFile.toPath() / "fetchedSources" / scalaVersion.value
+        ),
+        fetchScalaSource := Def.uncached {
           import org.eclipse.jgit.api._
 
           val s = streams.value
           val ver = scalaVersion.value
-          val trgDir = (fetchScalaSource / artifactPath).value
+          val trgDir = fileConverter.value.toPath((fetchScalaSource / artifactPath).value).toFile
 
           val (repoURL, tag) = CrossVersion
             .partialVersion(ver)
@@ -898,7 +914,7 @@ object Build {
             }
             .getOrElse(throw new RuntimeException("Invalid Scala version"))
 
-          if (!trgDir.exists) {
+          if (!trgDir.exists()) {
             s.log.info(s"Fetching Scala source version $ver")
 
             // Make parent dirs and stuff
@@ -984,7 +1000,9 @@ object Build {
                 (auxlib / Compile / packageBin).value,
                 (scalalib / Compile / packageBin).value,
                 (scalaPartestRuntime / Compile / packageBin).value
-              ).map(_.absolutePath).mkString(pathSeparator)
+              )
+                .map(fileConverter.value.toPath(_).toAbsolutePath)
+                .mkString(pathSeparator)
 
               Tests.Argument(s"--nativeClasspath=$nativeCp")
             }
@@ -1118,7 +1136,7 @@ object Build {
     /** Uses the Scala Native compiler plugin. */
     def withNativeCompilerPlugin: MultiScalaProject = {
       if (isGeneratingForIDE) project
-      else project.dependsOn(nscPlugin % "plugin")
+      else project.dependsOn((nscPlugin % "plugin"))
     }.enablePlugins(MyScalaNativePlugin)
 
     def withJUnitPlugin: MultiScalaProject = {
@@ -1132,7 +1150,7 @@ object Build {
             Test / scalacOptions += Def.taskDyn {
               val pluginProject = junitPlugin.forBinaryVersion(version)
               (pluginProject / Compile / packageBin).map { jar =>
-                s"-Xplugin:$jar"
+                s"-Xplugin:${fileConverter.value.toPath(jar).toAbsolutePath}"
               }
             }.value
           )
@@ -1158,7 +1176,10 @@ object Build {
         .settings(
           buildInfoPackage := buildInfoPkg.getOrElse("scala.scalanative.buildinfo"),
           buildInfoObject := "ScalaNativeBuildInfo",
-          buildInfoKeys := Seq[BuildInfoKey](version, scalaVersion)
+          buildInfoKeys := Seq(
+            BuildInfoKey(version),
+            BuildInfoKey(scalaVersion)
+          )
         )
         .settings(
           configuration match {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -109,7 +109,8 @@ object Build {
     val git = Git.open(trgDir)
     if git.getRepository.findRef(ref) == null then
       log.info(s"Fetching tags from $repoURL")
-      git.fetch()
+      git
+        .fetch()
         .setRemote("origin")
         .setTagOpt(TagOpt.FETCH_TAGS)
         .call()

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,6 +16,7 @@ import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 import pl.project13.scala.sbt.JmhPlugin
 import sbtbuildinfo.BuildInfoKeys._
 import sbtbuildinfo._
+import xsbti.HashedVirtualFileRef
 
 import Keys._
 
@@ -207,6 +208,44 @@ object Build {
     "3" -> Map("scalalib" -> "scala3lib"),
     "3-next" -> Map("scalalib" -> "scala3lib")
   )
+
+  /** Cache publishLocal using content hashes; skips when stamp matches prior publish. */
+  private def cachedPublishLocalSettings(
+      stamp: Def.Initialize[Task[String]]
+  ): Seq[Setting[_]] = {
+    val publishLocalCacheBase = settingKey[File]("publishLocalCacheBase")
+    val upToDateCheck = Def.task {
+      val cacheBase = publishLocalCacheBase.value
+      IO.createDirectory(cacheBase)
+      val stampFile = cacheBase / "stamp"
+      val inputStamp = stamp.value
+      stampFile.exists() && IO.read(stampFile) == inputStamp
+    }
+    Seq(
+      publishLocalCacheBase := {
+        val scalaVer = scalaVersion.value
+        val nativeVer = (ThisBuild / Keys.version).value
+        (ThisBuild / baseDirectory).value / "target" / "published-local-stamps" / name.value / s"$scalaVer-$nativeVer"
+      },
+      publishLocal / skip := Def.uncached(upToDateCheck.value),
+      publishLocal := Def.uncached {
+        Def.task {
+          val s = streams.value
+          if (!upToDateCheck.value) {
+            s.log.info(
+              s"Publishing ${name.value} locally (scala ${scalaVersion.value}, native ${(ThisBuild / Keys.version).value})"
+            )
+            val conf = publishLocalConfiguration.value
+            val module = ivyModule.value
+            publisher.value.publish(module, conf, s.log)
+            val cacheBase = publishLocalCacheBase.value
+            IO.createDirectory(cacheBase)
+            IO.write(cacheBase / "stamp", stamp.value)
+          }
+        }.value
+      }
+    )
+  }
 
   lazy val tools = MultiScalaProject("tools", platform = MultiScalaProject.Native, idNoSuffix = true)
     .settings(
@@ -499,6 +538,24 @@ object Build {
           shouldAddDependencyForVersion = usesSelfContainedStdlib(_)
         )
       )
+      .settings(
+        cachedPublishLocalSettings(
+          Def.taskDyn {
+            val binVersion = scalaBinaryVersion.value
+            Def.task {
+              import sbt.io.Hash
+              def contentStamp(ref: HashedVirtualFileRef): String = {
+                val file = fileConverter.value.toPath(ref).toFile
+                s"$file:${Hash.toHex(Hash(file))}"
+              }
+              Seq(
+                contentStamp((Compile / packageBin).value),
+                contentStamp((nscPlugin.forBinaryVersion(binVersion) / Compile / Keys.`package`).value)
+              ).mkString("\n")
+            }
+          }
+        )
+      )
       .withNativeCompilerPlugin
       .withJUnitPlugin // no actual tests, used only in the CI
       .mapBinaryVersions {
@@ -664,17 +721,27 @@ object Build {
                   .excludeAll(ExclusionRule(organization.value))
                   .cross(CrossVersion.for3Use2_13)
               }
-            },
-            update := Def.uncached {
-              update.dependsOn {
-                Def.taskDyn {
-                  if (usesSelfContainedStdlib(scalaVersion.value))
-                    scalalib.forBinaryVersion(version) / Compile / publishLocal
-                  else
-                    scalalib.v2_13 / Compile / publishLocal
-                }
-              }.value
             }
+          ).settings(
+            cachedPublishLocalSettings(
+              Def.taskDyn {
+                val scalalibProject =
+                  if (usesSelfContainedStdlib(scalaVersion.value))
+                    scalalib.forBinaryVersion(version)
+                  else scalalib.v2_13
+                Def.task {
+                  import sbt.io.Hash
+                  def contentStamp(ref: HashedVirtualFileRef): String = {
+                    val file = fileConverter.value.toPath(ref).toFile
+                    s"$file:${Hash.toHex(Hash(file))}"
+                  }
+                  Seq(
+                    contentStamp((Compile / packageBin).value),
+                    contentStamp((scalalibProject / Compile / packageBin).value)
+                  ).mkString("\n")
+                }
+              }
+            )*
           )
       }
       .dependsOn(auxlib)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,6 @@ import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 import pl.project13.scala.sbt.JmhPlugin
 import sbtbuildinfo.BuildInfoKeys._
 import sbtbuildinfo._
-import xsbti.HashedVirtualFileRef
 
 import Keys._
 
@@ -208,44 +207,6 @@ object Build {
     "3" -> Map("scalalib" -> "scala3lib"),
     "3-next" -> Map("scalalib" -> "scala3lib")
   )
-
-  /** Cache publishLocal using content hashes; skips when stamp matches prior publish. */
-  private def cachedPublishLocalSettings(
-      stamp: Def.Initialize[Task[String]]
-  ): Seq[Setting[_]] = {
-    val publishLocalCacheBase = settingKey[File]("publishLocalCacheBase")
-    val upToDateCheck = Def.task {
-      val cacheBase = publishLocalCacheBase.value
-      IO.createDirectory(cacheBase)
-      val stampFile = cacheBase / "stamp"
-      val inputStamp = stamp.value
-      stampFile.exists() && IO.read(stampFile) == inputStamp
-    }
-    Seq(
-      publishLocalCacheBase := {
-        val scalaVer = scalaVersion.value
-        val nativeVer = (ThisBuild / Keys.version).value
-        (ThisBuild / baseDirectory).value / "target" / "published-local-stamps" / name.value / s"$scalaVer-$nativeVer"
-      },
-      publishLocal / skip := Def.uncached(upToDateCheck.value),
-      publishLocal := Def.uncached {
-        Def.task {
-          val s = streams.value
-          if (!upToDateCheck.value) {
-            s.log.info(
-              s"Publishing ${name.value} locally (scala ${scalaVersion.value}, native ${(ThisBuild / Keys.version).value})"
-            )
-            val conf = publishLocalConfiguration.value
-            val module = ivyModule.value
-            publisher.value.publish(module, conf, s.log)
-            val cacheBase = publishLocalCacheBase.value
-            IO.createDirectory(cacheBase)
-            IO.write(cacheBase / "stamp", stamp.value)
-          }
-        }.value
-      }
-    )
-  }
 
   lazy val tools = MultiScalaProject("tools", platform = MultiScalaProject.Native, idNoSuffix = true)
     .settings(
@@ -538,24 +499,6 @@ object Build {
           shouldAddDependencyForVersion = usesSelfContainedStdlib(_)
         )
       )
-      .settings(
-        cachedPublishLocalSettings(
-          Def.taskDyn {
-            val binVersion = scalaBinaryVersion.value
-            Def.task {
-              import sbt.io.Hash
-              def contentStamp(ref: HashedVirtualFileRef): String = {
-                val file = fileConverter.value.toPath(ref).toFile
-                s"$file:${Hash.toHex(Hash(file))}"
-              }
-              Seq(
-                contentStamp((Compile / packageBin).value),
-                contentStamp((nscPlugin.forBinaryVersion(binVersion) / Compile / Keys.`package`).value)
-              ).mkString("\n")
-            }
-          }
-        )
-      )
       .withNativeCompilerPlugin
       .withJUnitPlugin // no actual tests, used only in the CI
       .mapBinaryVersions {
@@ -721,27 +664,17 @@ object Build {
                   .excludeAll(ExclusionRule(organization.value))
                   .cross(CrossVersion.for3Use2_13)
               }
-            }
-          ).settings(
-            cachedPublishLocalSettings(
-              Def.taskDyn {
-                val scalalibProject =
+            },
+            update := Def.uncached {
+              update.dependsOn {
+                Def.taskDyn {
                   if (usesSelfContainedStdlib(scalaVersion.value))
-                    scalalib.forBinaryVersion(version)
-                  else scalalib.v2_13
-                Def.task {
-                  import sbt.io.Hash
-                  def contentStamp(ref: HashedVirtualFileRef): String = {
-                    val file = fileConverter.value.toPath(ref).toFile
-                    s"$file:${Hash.toHex(Hash(file))}"
-                  }
-                  Seq(
-                    contentStamp((Compile / packageBin).value),
-                    contentStamp((scalalibProject / Compile / packageBin).value)
-                  ).mkString("\n")
+                    scalalib.forBinaryVersion(version) / Compile / publishLocal
+                  else
+                    scalalib.v2_13 / Compile / publishLocal
                 }
-              }
-            )*
+              }.value
+            }
           )
       }
       .dependsOn(auxlib)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -666,14 +666,14 @@ object Build {
               }
             },
             update := Def.uncached {
-              update.dependsOn {
-                Def.taskDyn {
-                  if (usesSelfContainedStdlib(scalaVersion.value))
-                    scalalib.forBinaryVersion(version) / Compile / publishLocal
-                  else
-                    scalalib.v2_13 / Compile / publishLocal
-                }
-              }.value
+              update
+                .dependsOn:
+                  Def.taskDyn:
+                    Def.cachedTask:
+                      if usesSelfContainedStdlib(scalaVersion.value) then
+                        scalalib.forBinaryVersion(version) / Compile / publishLocal
+                      else scalalib.v2_13 / Compile / publishLocal
+                .value
             }
           )
       }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,6 +81,42 @@ object Build {
     val revision = scalalibVersion(depScalaVersion, nativeVersion)
     ivyHome / "local" / org / s"scalalib_native0.5_$platformSuffix" / revision / "jars" / s"scalalib$artifactSuffix.jar"
 
+  private def checkoutScalaUpstreamSources(
+      log: sbt.util.Logger,
+      trgDir: File,
+      repoURL: String,
+      ref: String
+  ): Unit =
+    import org.eclipse.jgit.api._
+    import org.eclipse.jgit.transport.TagOpt
+
+    def incompleteClone(dir: File): Boolean =
+      val objectsDir = dir / ".git" / "objects"
+      objectsDir.exists &&
+        Option(objectsDir.listFiles()).exists(_.exists(_.getName.startsWith("incoming_")))
+
+    if !trgDir.exists() || incompleteClone(trgDir) then
+      if trgDir.exists() then
+        log.warn(s"Removing incomplete Scala source checkout at $trgDir")
+        IO.delete(trgDir)
+      log.info(s"Cloning Scala sources from $repoURL")
+      IO.createDirectory(trgDir)
+      new CloneCommand()
+        .setDirectory(trgDir)
+        .setURI(repoURL)
+        .call()
+
+    val git = Git.open(trgDir)
+    if git.getRepository.findRef(ref) == null then
+      log.info(s"Fetching tags from $repoURL")
+      git.fetch()
+        .setRemote("origin")
+        .setTagOpt(TagOpt.FETCH_TAGS)
+        .call()
+
+    log.info(s"Checking out Scala source ref $ref")
+    git.checkout().setName(ref).call()
+
   private def setDependency[T](key: TaskKey[T], projects: Seq[Project]) = {
     key := Def.uncached {
       key.dependsOn(projects.map(_ / key): _*).value
@@ -976,13 +1012,11 @@ object Build {
           baseDirectory.value.getParentFile.toPath() / "fetchedSources" / scalaVersion.value
         ),
         fetchScalaSource := Def.uncached {
-          import org.eclipse.jgit.api._
-
           val s = streams.value
           val ver = scalaVersion.value
           val trgDir = fileConverter.value.toPath((fetchScalaSource / artifactPath).value).toFile
 
-          val (repoURL, tag) = CrossVersion
+          val (repoURL, ref) = CrossVersion
             .partialVersion(ver)
             .collect {
               case (2, _) => "https://github.com/scala/scala.git" -> s"v$ver"
@@ -990,25 +1024,7 @@ object Build {
             }
             .getOrElse(throw new RuntimeException("Invalid Scala version"))
 
-          if (!trgDir.exists()) {
-            s.log.info(s"Fetching Scala source version $ver")
-
-            // Make parent dirs and stuff
-            sbt.IO.createDirectory(trgDir)
-
-            // Clone scala source code
-            new CloneCommand()
-              .setDirectory(trgDir)
-              .setURI(repoURL)
-              .call()
-          }
-
-          // Checkout proper ref. We do this anyway so we fail if
-          // something is wrong
-          val git = Git.open(trgDir)
-          s.log.info(s"Checking out Scala source version $ver")
-          git.checkout().setName(tag).call()
-
+          checkoutScalaUpstreamSources(s.log, trgDir, repoURL, ref)
           trgDir
         },
         Compile / unmanagedSourceDirectories ++= {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -47,7 +47,7 @@ object Build {
       tests, testsJVM, testsExt, testsExtJVM, sandbox,
       scalaPartest, scalaPartestRuntime,
       scalaPartestTests, scalaPartestJunitTests,
-      // toolsBenchmarks
+      toolsBenchmarks
     )
   lazy val testNoCrossProject = List(testingCompilerInterface)
 // format: on

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -3,8 +3,6 @@ package build
 import sbt.Keys._
 import sbt._
 
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
-
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 
 object Deps {

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -1,6 +1,6 @@
 package build
 
-import sbt._
+import sbt.{given, *}
 
 import scala.language.implicitConversions
 
@@ -78,14 +78,18 @@ final case class MultiScalaProject private (
       }
     } else {
       def classpathDependency(d: ScopedMultiScalaProject) =
-        strictMapValues(d.project.projects)(
-          ClasspathDependency(_, d.configuration)
-        )
+        strictMapValues(d.project.projects) { p =>
+          ClasspathDependency(p, d.configuration)
+        }
 
       val depsByVersion: Map[String, Seq[ClasspathDependency]] =
-        strictMapValues(deps.flatMap(classpathDependency).groupBy(_._1))(
-          _.map(_._2)
-        )
+        strictMapValues(
+          deps
+            .flatMap(classpathDependency)
+            .groupBy((conf, _) => conf)
+        ) { values =>
+          values.collect { case (_, dep: ClasspathDependency) => dep }
+        }
       zipped(depsByVersion)(_.dependsOn(_: _*))
     }
   }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -782,9 +782,7 @@ object Settings {
       // than Scala.js. See commented starting with "SN Port:" below.
       libraryDependencies ++= {
         if (shouldAddDependencyForVersion(scalaVersion.value))
-          Some(
-            "org.scala-lang" % scalaStdLibraryName % scalaVersion.value classifier "sources"
-          )
+          Some("org.scala-lang" % scalaStdLibraryName % scalaVersion.value)
         else None
       },
       fetchScalaSource / artifactPath := fileConverter.value.toVirtualFile(
@@ -831,6 +829,7 @@ object Settings {
       // In theory we can enforce usage of latest version of Scala for compiling only scalalib module,
       // as we don't store .tasty or .class files. This solution however might be more complicated and usnafe
       fetchScalaSource := Def.uncached {
+        import lmcoursier.*
         val version = scalaVersion.value
         val trgDir = fileConverter.value
           .toPath((fetchScalaSource / artifactPath).value)
@@ -838,13 +837,23 @@ object Settings {
         val s = streams.value
         val cacheDir = s.cacheDirectory
         val report = (fetchScalaSource / update).value
-        val scalaLibSourcesJar = report
-          .select(
-            configuration = configurationFilter("compile"),
-            module = moduleFilter(name = scalaStdLibraryName),
-            artifact = artifactFilter(classifier = "sources")
+        val lm = CoursierDependencyResolution(CoursierConfiguration())
+
+        // coursierint.LMCoursier.
+        lazy val scalaLibSourcesJar = lm
+          .retrieve(
+            "org.scala-lang" % scalaStdLibraryName % version classifier "sources",
+            scalaModuleInfo = None,
+            retrieveDirectory = cacheDir,
+            log = s.log
           )
-          .headOption
+          .map(
+            _.find(
+              _.name.endsWith(s"${scalaStdLibraryName}-$version-sources.jar")
+            )
+          )
+          .toOption
+          .flatten
           .getOrElse {
             throw new Exception(
               s"Could not fetch ${scalaStdLibraryName} sources for version $version"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -957,12 +957,12 @@ object Settings {
             }
             val patchFile = sourcePath.toFile
             val patchLabel = patchFile.relativeTo(srcDir.getParentFile)
-            if (
-              outputFile.exists() &&
-              outputFile.lastModified() >= patchFile.lastModified() &&
-              outputFile.lastModified() >= scalaSourcePath.lastModified()
-            ) {
-              s.log.debug(s"Reusing cached patched source for $sourceName from $patchLabel")
+            if (outputFile.exists() &&
+                outputFile.lastModified() >= patchFile.lastModified() &&
+                outputFile.lastModified() >= scalaSourcePath.lastModified()) {
+              s.log.debug(
+                s"Reusing cached patched source for $sourceName from $patchLabel"
+              )
               return Some(outputFile)
             }
             // There is not a single JVM library for diff that can apply
@@ -973,12 +973,16 @@ object Settings {
             // mutated and concurrent or sequential patches cannot interfere.
             import java.nio.file.{Files => JFiles}
             val patchWorkRoot =
-              JFiles.createTempDirectory(crossTarget.value.toPath, "patch-work-").toFile()
+              JFiles
+                .createTempDirectory(crossTarget.value.toPath, "patch-work-")
+                .toFile()
             try {
               import scala.sys.process._
               def gitApply(args: String*)(cwd: File): Int =
                 Process(
-                  Seq("git", "apply") ++ args ++ Seq(patchFile.getAbsolutePath()),
+                  Seq("git", "apply") ++ args ++ Seq(
+                    patchFile.getAbsolutePath()
+                  ),
                   cwd = cwd
                 ).!(ProcessLogger(s.log.debug(_), s.log.debug(_)))
 
@@ -991,10 +995,13 @@ object Settings {
                 IO.delete(workSourcePath)
               }
               copy(scalaSourcePath, workSourcePath)
-              val canApplyForward = gitApply("--check", "--recount")(patchWorkRoot) == 0
+              val canApplyForward =
+                gitApply("--check", "--recount")(patchWorkRoot) == 0
               val alreadyPatched =
                 !canApplyForward &&
-                  gitApply("--reverse", "--check", "--recount")(patchWorkRoot) == 0
+                  gitApply("--reverse", "--check", "--recount")(
+                    patchWorkRoot
+                  ) == 0
               if (canApplyForward) {
                 val exitCode =
                   gitApply("--whitespace=fix", "--recount")(patchWorkRoot)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,6 +5,7 @@ import sbt._
 import sbt.nio.Keys.fileTreeView
 
 import java.io.File
+import java.net.URI
 import java.util.Locale
 
 import scala.collection.mutable
@@ -13,7 +14,6 @@ import com.jsuereth.sbtpgp.PgpKeys
 import com.jsuereth.sbtpgp.PgpKeys.publishSigned
 import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 // Hack warning: special object mimicking build-info plugin outputs, defined in project/ScalaNativeBuildInfo
 import scala.scalanative.ScalaNativeBuildInfo
@@ -21,6 +21,7 @@ import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 
 import build.ScalaVersions.sbt2Version
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
+import xsbti.HashedVirtualFileRef
 
 import MyScalaNativePlugin.isGeneratingForIDE
 import ScriptedPlugin.autoImport._
@@ -54,18 +55,26 @@ object Settings {
       v
     },
     Global / onLoad ~= { prev =>
-      if (!scala.util.Properties.isWin) {
+      if (!scala.util.Properties.isWin) try {
         import java.nio.file._
-        val prePush = Paths.get(".git", "hooks", "pre-push")
-        Files.createDirectories(prePush.getParent)
-        Files.write(
-          prePush,
-          """|#!/bin/sh
-             |set -eux
-             |CHECK_MODIFIED_ONLY=1 ./scripts/check-lint.sh
-             |""".stripMargin.getBytes()
-        )
-        prePush.toFile.setExecutable(true)
+        val gitPath = Paths.get(".git")
+        // git worktrees expose `.git` as a file pointing at the real git dir
+        if (Files.isDirectory(gitPath)) {
+          val hooksDir = gitPath.resolve("hooks")
+          val prePush = hooksDir.resolve("pre-push")
+          Files.createDirectories(hooksDir)
+          Files.write(
+            prePush,
+            """|#!/bin/sh
+               |set -eux
+               |CHECK_MODIFIED_ONLY=1 ./scripts/check-lint.sh
+               |""".stripMargin.getBytes()
+          )
+          prePush.toFile.setExecutable(true)
+        }
+      } catch {
+        case e: Exception =>
+          System.err.println(s"Error checking git hooks: ${e.getMessage}")
       }
       prev
     }
@@ -169,11 +178,10 @@ object Settings {
         case (3, _) => Seq.empty
       },
       // Add Java Scaladoc mapping
-      apiMappings ++= {
+      apiMappings ++= Def.uncached {
         val optRTJar = {
           val bootClasspath = System.getProperty("sun.boot.class.path")
           if (bootClasspath != null) {
-            // JDK <= 8, there is an rt.jar (or classes.jar) on the boot classpath
             val jars = bootClasspath.split(java.io.File.pathSeparator)
 
             def matches(path: String, name: String): Boolean =
@@ -183,23 +191,27 @@ object Settings {
               .find(matches(_, "rt")) // most JREs
               .map(file)
           } else {
-            // JDK >= 9, maybe sbt gives us a fake rt.jar in `scala.ext.dirs`
             val scalaExtDirs = Option(System.getProperty("scala.ext.dirs"))
             scalaExtDirs.map(extDirs => file(extDirs) / "rt.jar")
           }
         }
 
-        optRTJar.fold[Map[File, URL]] {
-          Map.empty
-        } { rtJar =>
-          assert(rtJar.exists, s"$rtJar does not exist")
-          Map(rtJar -> url(javaDocBaseURL))
+        optRTJar.fold(Map.empty[HashedVirtualFileRef, URI]) { rtJar =>
+          assert(rtJar.exists(), s"$rtJar does not exist")
+          Map(
+            fileConverter.value.toVirtualFile(rtJar.toPath) -> url(
+              javaDocBaseURL
+            )
+          )
         }
       },
       /* Add a second Java Scaladoc mapping for cases where Scala actually
        * understands the jrt:/ filesystem of Java 9.
        */
-      apiMappings += file("/modules/java.base") -> url(javaDocBaseURL),
+      apiMappings += Def.uncached {
+        val docsPath = file("/modules/java.base").toPath
+        fileConverter.value.toVirtualFile(docsPath) -> url(javaDocBaseURL)
+      },
       Compile / doc / sources := {
         val prev = (Compile / doc / sources).value
         val isWindows = System
@@ -242,7 +254,10 @@ object Settings {
     homepage := Some(url("http://www.scala-native.org")),
     startYear := Some(2015),
     licenses := Seq(
-      "BSD-like" -> url("http://www.scala-lang.org/downloads/license.html")
+      License(
+        "BSD-like",
+        url("http://www.scala-lang.org/downloads/license.html")
+      )
     ),
     developers := List(
       Developer(
@@ -330,9 +345,9 @@ object Settings {
   lazy val noPublishSettings = Def.settings(
     disabledDocsSettings,
     publishArtifact := false,
-    packagedArtifacts := Map.empty,
-    publish := {},
-    publishLocal := {},
+    packagedArtifacts := Def.uncached(Map.empty),
+    publish := Def.uncached(()),
+    publishLocal := Def.uncached(()),
     publish / skip := true
   )
 
@@ -352,14 +367,16 @@ object Settings {
     Test / testOptions ++= Seq(
       Tests.Argument(TestFrameworks.JUnit, "-a", "-s")
     ),
-    Test / envVars ++= Map(
-      "USER" -> System.getProperty("user.name"),
-      "HOME" -> System.getProperty("user.home"),
-      "SCALA_NATIVE_ENV_WITH_EQUALS" -> "1+1=2",
-      "SCALA_NATIVE_ENV_WITHOUT_VALUE" -> "",
-      "SCALA_NATIVE_ENV_WITH_UNICODE" -> 0x2192.toChar.toString,
-      "SCALA_NATIVE_USER_DIR" -> System.getProperty("user.dir")
-    ),
+    Test / envVars ++= Def.uncached {
+      Map(
+        "USER" -> System.getProperty("user.name"),
+        "HOME" -> System.getProperty("user.home"),
+        "SCALA_NATIVE_ENV_WITH_EQUALS" -> "1+1=2",
+        "SCALA_NATIVE_ENV_WITHOUT_VALUE" -> "",
+        "SCALA_NATIVE_ENV_WITH_UNICODE" -> 0x2192.toChar.toString,
+        "SCALA_NATIVE_USER_DIR" -> System.getProperty("user.dir")
+      )
+    },
     // Some of the tests are designed with an assumptions about default encoding
     // Make sure that tests run on JVM are using default defaults
     Test / javaOptions ++= Seq(
@@ -393,7 +410,8 @@ object Settings {
           testQuick / aggregate := false,
           testQuick := testsTaskUnsupported.value,
           executeTests / aggregate := false,
-          executeTests := testsTaskUnsupported[Tests.Output].value
+          executeTests := Def.uncached:
+            Tests.processResults(Seq.empty)
         )
       }
     )
@@ -416,7 +434,7 @@ object Settings {
 
   // Get all scala sources from a directory
   def allScalaFromDir(dir: File): Seq[(String, java.io.File)] =
-    (dir ** "*.scala").get.flatMap { file =>
+    (dir ** "*.scala").get().flatMap { file =>
       file.relativeTo(dir) match {
         case Some(rel) => List((rel.toString.replace('\\', '/'), file))
         case None      => Nil
@@ -534,8 +552,8 @@ object Settings {
             .foldLeft(IO.read(baseDir / relativePath.toString())) {
               case (source, jdkVersion) =>
                 source
-                  .replaceAllLiterally(s"/* >>REQUIRE-JDK-$jdkVersion", "")
-                  .replaceAllLiterally(s"<<REQUIRE-JDK-$jdkVersion */", "")
+                  .replace(s"/* >>REQUIRE-JDK-$jdkVersion", "")
+                  .replace(s"<<REQUIRE-JDK-$jdkVersion */", "")
             }
         )
         outFile
@@ -678,9 +696,9 @@ object Settings {
     CrossVersion
       .partialVersion(scalaVersion)
       .fold(Seq.empty[String]) {
-        case (2, 12) => Nil
         case (2, 13) => scala213StdLibDeprecations
         case (3, _)  => scala213StdLibDeprecations ++ scala3Deprecations
+        case _       => Nil
       }
   }
 
@@ -767,14 +785,19 @@ object Settings {
           Some("org.scala-lang" % scalaStdLibraryName % scalaVersion.value)
         else None
       },
-      fetchScalaSource / artifactPath :=
-        baseDirectory.value.getParentFile / "target" / "scalaSources" / scalaVersion.value,
+      fetchScalaSource / artifactPath := fileConverter.value.toVirtualFile(
+        baseDirectory.value.getParentFile
+          .toPath() / "target" / "scalaSources" / scalaVersion.value
+      ),
       // Create nir.SourceFile relative to Scala sources dir instead of root dir
       // It should use -sourcepath for both, but it fails to compile under Scala 2
-      scalacOptions ++=
+      scalacOptions ++= Def.uncached {
+        val sourcesPath =
+          fileConverter.value.toPath((fetchScalaSource / artifactPath).value)
         scalaNativeCompilerOptions(
-          s"positionRelativizationPaths:${crossTarget.value / "patched"};${(fetchScalaSource / artifactPath).value}"
-        ),
+          s"positionRelativizationPaths:${crossTarget.value / "patched"};${sourcesPath}"
+        )
+      },
       // Foreign sources, ignore all warnings and don't try to use custom -source version
       scalacOptions --= Seq(
         "-deprecation",
@@ -790,12 +813,14 @@ object Settings {
        * which we work around here by using `updateClassifiers` instead in
        * that case.
        */
-      fetchScalaSource / update := Def.taskDyn {
-        val version = scalaVersion.value
-        val usedScalaVersion = scala.util.Properties.versionNumberString
-        if (version == usedScalaVersion) updateClassifiers
-        else update
-      }.value,
+      fetchScalaSource / update := Def.uncached {
+        Def.taskDyn {
+          val version = scalaVersion.value
+          val usedScalaVersion = scala.util.Properties.versionNumberString
+          if (version == usedScalaVersion) updateClassifiers
+          else update
+        }.value
+      },
       // Scala.js always uses the same version of sources as used in the runtime
       // In Scala Native to 0.4.x we don't make a full cross version of Scala standard library
       // This means we need to have only 1 version of scalalib to not break current build tools
@@ -803,21 +828,18 @@ object Settings {
       // Becouse of that we compile Scala 3.2.x or newer sources with 3.1.3 compiler
       // In theory we can enforce usage of latest version of Scala for compiling only scalalib module,
       // as we don't store .tasty or .class files. This solution however might be more complicated and usnafe
-      fetchScalaSource := {
+      fetchScalaSource := Def.uncached {
+        import lmcoursier.*
         val version = scalaVersion.value
-        val trgDir = (fetchScalaSource / artifactPath).value
+        val trgDir = fileConverter.value
+          .toPath((fetchScalaSource / artifactPath).value)
+          .toFile()
         val s = streams.value
         val cacheDir = s.cacheDirectory
         val report = (fetchScalaSource / update).value
-        lazy val lm = {
-          import sbt.librarymanagement.ivy._
-          val ivyConfig = InlineIvyConfiguration()
-            .withLog(s.log)
-            .withResolvers(
-              resolvers.value.toVector ++ InlineIvyConfiguration().resolvers
-            )
-          IvyDependencyResolution(ivyConfig)
-        }
+        val lm = CoursierDependencyResolution(CoursierConfiguration())
+
+        // coursierint.LMCoursier.
         lazy val scalaLibSourcesJar = lm
           .retrieve(
             "org.scala-lang" % scalaStdLibraryName % version classifier "sources",
@@ -842,14 +864,15 @@ object Settings {
           cacheDir / s"fetchScalaSource-$version",
           FilesInfo.lastModified,
           FilesInfo.exists
-        ) { dependencies =>
+        ) { _ =>
           s.log.info(s"Unpacking Scala library sources to $trgDir...")
 
-          if (trgDir.exists)
+          if (trgDir.exists())
             IO.delete(trgDir)
           IO.createDirectory(trgDir)
           IO.unzip(scalaLibSourcesJar, trgDir)
         }(Set(scalaLibSourcesJar))
+
         trgDir
       },
       Compile / unmanagedSourceDirectories := scalaVersionDirectories(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -916,6 +916,11 @@ object Settings {
           "Matchable.scala"
         ).map(java.nio.file.Paths.get("scala", _))
         var failedToApplyPatches = false
+        val claimedPatchSources = mutable.Set.empty[String]
+        val stalePatchWork = crossTarget.value / "patch-work"
+        if (stalePatchWork.exists()) {
+          IO.delete(stalePatchWork)
+        }
         for {
           srcDir <- sourceDirectories
           normSrcDir = normPath(srcDir)
@@ -954,59 +959,82 @@ object Settings {
               )
               return None
             }
-            val scalaSourceCopyPath = scalaSrcDir / (sourceName + ".copy")
             val outputFile = crossTarget.value / "patched" / sourceName
             val outputDir = outputFile.getParentFile
             if (!outputDir.exists()) {
               IO.createDirectory(outputDir)
             }
+            val patchFile = sourcePath.toFile
+            val patchLabel = patchFile.relativeTo(srcDir.getParentFile)
+            if (
+              outputFile.exists() &&
+              outputFile.lastModified() >= patchFile.lastModified() &&
+              outputFile.lastModified() >= scalaSourcePath.lastModified()
+            ) {
+              s.log.debug(s"Reusing cached patched source for $sourceName from $patchLabel")
+              return Some(outputFile)
+            }
             // There is not a single JVM library for diff that can apply
             // patches in a fuzzy way (using context lines). We also
             // canot use jgit to apply patches - it fails due to "invalid hunk headers".
             // Becouse of that we use git apply instead.
-            // We need to create copy of original file and restore it after creating
-            // patched file to allow for recompilation of sources (re-applying patches)
-            // git apply command needs to be used from within fetchedScalaSource directory.
+            // Each patch uses its own temp tree so fetched Scala sources are never
+            // mutated and concurrent or sequential patches cannot interfere.
+            import java.nio.file.{Files => JFiles}
+            val patchWorkRoot =
+              JFiles.createTempDirectory(crossTarget.value.toPath, "patch-work-").toFile()
             try {
               import scala.sys.process._
-              copy(scalaSourcePath, scalaSourceCopyPath)
-              var hasErrors = false
-              Process(
-                command = Seq(
-                  "git",
-                  "apply",
-                  "--reject",
-                  "--whitespace=fix",
-                  "--recount",
-                  sourcePath.toAbsolutePath().toString()
-                ),
-                cwd = scalaSrcDir
-              ).!!(
-                ProcessLogger(
-                  stdout => (),
-                  stderr => {
-                    if (stderr.contains("error")) {
-                      hasErrors = true
-                    }
-                    if (hasErrors) s.log.warn(stderr)
-                    else s.log.debug(stderr)
-                  }
+              def gitApply(args: String*)(cwd: File): Int =
+                Process(
+                  Seq("git", "apply") ++ args ++ Seq(patchFile.getAbsolutePath()),
+                  cwd = cwd
+                ).!(ProcessLogger(s.log.debug(_), s.log.debug(_)))
+
+              val workSourcePath = patchWorkRoot / sourceName
+              val workSourceParent = workSourcePath.getParentFile
+              if (!workSourceParent.exists()) {
+                IO.createDirectory(workSourceParent)
+              }
+              if (workSourcePath.exists()) {
+                IO.delete(workSourcePath)
+              }
+              copy(scalaSourcePath, workSourcePath)
+              val canApplyForward = gitApply("--check", "--recount")(patchWorkRoot) == 0
+              val alreadyPatched =
+                !canApplyForward &&
+                  gitApply("--reverse", "--check", "--recount")(patchWorkRoot) == 0
+              if (canApplyForward) {
+                val exitCode =
+                  gitApply("--whitespace=fix", "--recount")(patchWorkRoot)
+                if (exitCode != 0) {
+                  failedToApplyPatches = true
+                  s.log.error(
+                    s"Cannot apply patch for $patchLabel (git apply exit $exitCode)"
+                  )
+                  return None
+                }
+              } else if (!alreadyPatched) {
+                failedToApplyPatches = true
+                s.log.error(
+                  s"Cannot apply patch for $patchLabel - source is neither pristine nor already patched"
                 )
-              )
-              copy(scalaSourcePath, outputFile)
+                return None
+              } else {
+                s.log.debug(
+                  s"Patch for $sourceName already applied, reusing patched source"
+                )
+              }
+              copy(workSourcePath, outputFile)
               Some(outputFile)
             } catch {
               case ex: Exception =>
                 // Postpone failing to check which other patches do not apply
                 failedToApplyPatches = true
-                val path = sourcePath.toFile.relativeTo(srcDir.getParentFile)
-                s.log.error(s"Cannot apply patch for $path - $ex")
+                s.log.error(s"Cannot apply patch for $patchLabel - $ex")
                 None
             } finally {
-              if (scalaSourceCopyPath.exists()) {
-                copy(scalaSourceCopyPath, scalaSourcePath)
-                scalaSourceCopyPath.delete()
-              }
+              IO.delete(patchWorkRoot)
             }
           }
 
@@ -1014,9 +1042,12 @@ object Settings {
             addSource(path)(Some(sourcePath.toFile))
           else {
             val sourceName = path.stripSuffix(".patch")
-            addSource(sourceName)(
-              tryApplyPatch(sourceName)
-            )
+            if (!claimedPatchSources.contains(sourceName)) {
+              claimedPatchSources += sourceName
+              addSource(sourceName)(
+                tryApplyPatch(sourceName)
+              )
+            }
           }
         }
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -782,7 +782,9 @@ object Settings {
       // than Scala.js. See commented starting with "SN Port:" below.
       libraryDependencies ++= {
         if (shouldAddDependencyForVersion(scalaVersion.value))
-          Some("org.scala-lang" % scalaStdLibraryName % scalaVersion.value)
+          Some(
+            "org.scala-lang" % scalaStdLibraryName % scalaVersion.value classifier "sources"
+          )
         else None
       },
       fetchScalaSource / artifactPath := fileConverter.value.toVirtualFile(
@@ -829,7 +831,6 @@ object Settings {
       // In theory we can enforce usage of latest version of Scala for compiling only scalalib module,
       // as we don't store .tasty or .class files. This solution however might be more complicated and usnafe
       fetchScalaSource := Def.uncached {
-        import lmcoursier.*
         val version = scalaVersion.value
         val trgDir = fileConverter.value
           .toPath((fetchScalaSource / artifactPath).value)
@@ -837,23 +838,13 @@ object Settings {
         val s = streams.value
         val cacheDir = s.cacheDirectory
         val report = (fetchScalaSource / update).value
-        val lm = CoursierDependencyResolution(CoursierConfiguration())
-
-        // coursierint.LMCoursier.
-        lazy val scalaLibSourcesJar = lm
-          .retrieve(
-            "org.scala-lang" % scalaStdLibraryName % version classifier "sources",
-            scalaModuleInfo = None,
-            retrieveDirectory = cacheDir,
-            log = s.log
+        val scalaLibSourcesJar = report
+          .select(
+            configuration = configurationFilter("compile"),
+            module = moduleFilter(name = scalaStdLibraryName),
+            artifact = artifactFilter(classifier = "sources")
           )
-          .map(
-            _.find(
-              _.name.endsWith(s"${scalaStdLibraryName}-$version-sources.jar")
-            )
-          )
-          .toOption
-          .flatten
+          .headOption
           .getOrElse {
             throw new Exception(
               s"Could not fetch ${scalaStdLibraryName} sources for version $version"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -2,7 +2,6 @@ package build
 
 import sbt.Keys._
 import sbt._
-import sbt.nio.Keys.fileTreeView
 
 import java.io.File
 import java.net.URI
@@ -781,9 +780,9 @@ object Settings {
       // Scala Native build.sbt uses a slightly different baseDirectory
       // than Scala.js. See commented starting with "SN Port:" below.
       libraryDependencies ++= {
-        if (shouldAddDependencyForVersion(scalaVersion.value))
-          Some("org.scala-lang" % scalaStdLibraryName % scalaVersion.value)
-        else None
+        Option.when(shouldAddDependencyForVersion(scalaVersion.value)) {
+          ("org.scala-lang" % scalaStdLibraryName % scalaVersion.value classifier "sources")
+        }
       },
       fetchScalaSource / artifactPath := fileConverter.value.toVirtualFile(
         baseDirectory.value.getParentFile
@@ -829,7 +828,6 @@ object Settings {
       // In theory we can enforce usage of latest version of Scala for compiling only scalalib module,
       // as we don't store .tasty or .class files. This solution however might be more complicated and usnafe
       fetchScalaSource := Def.uncached {
-        import lmcoursier.*
         val version = scalaVersion.value
         val trgDir = fileConverter.value
           .toPath((fetchScalaSource / artifactPath).value)
@@ -837,23 +835,17 @@ object Settings {
         val s = streams.value
         val cacheDir = s.cacheDirectory
         val report = (fetchScalaSource / update).value
-        val lm = CoursierDependencyResolution(CoursierConfiguration())
-
-        // coursierint.LMCoursier.
-        lazy val scalaLibSourcesJar = lm
-          .retrieve(
-            "org.scala-lang" % scalaStdLibraryName % version classifier "sources",
-            scalaModuleInfo = None,
-            retrieveDirectory = cacheDir,
-            log = s.log
+        val scalaLibSourcesJar = report
+          .select(
+            configuration = configurationFilter(Compile.name),
+            module = moduleFilter(
+              organization = "org.scala-lang",
+              name = scalaStdLibraryName,
+              revision = version
+            ),
+            artifact = artifactFilter(classifier = "sources")
           )
-          .map(
-            _.find(
-              _.name.endsWith(s"${scalaStdLibraryName}-$version-sources.jar")
-            )
-          )
-          .toOption
-          .flatten
+          .headOption
           .getOrElse {
             throw new Exception(
               s"Could not fetch ${scalaStdLibraryName} sources for version $version"
@@ -894,176 +886,227 @@ object Settings {
         def normPath(f: File): String =
           f.getPath.replace(java.io.File.separator, "/")
 
-        val sources = mutable.ListBuffer.empty[File]
-        val paths = mutable.Set.empty[String]
-
         val s = streams.value
-        val fileTree = fileTreeView.value
-        def listFilesInOrder(patterns: Glob*) =
-          patterns.flatMap(fileTree.list(_))
+        val cacheDir =
+          s.cacheDirectory / s"scalalib-sources-${scalaVersion.value}"
+        val manifestFile = crossTarget.value / "sources-manifest"
+        val patchedRoot = crossTarget.value / "patched"
+        val skippedRoot = crossTarget.value / "patched-skipped"
 
-        /* Exclude files coming from Scala's `library-aux` directory, as they are not
-         * meant to be compiled. They are part of the source jar since Scala 2.13.14.
-         */
-        val ignoredSourceFiles = Set(
-          "Any.scala",
-          "AnyRef.scala",
-          "Singleton.scala",
-          "Nothing.scala",
-          "Null.scala",
-          // Since 3.5.1
-          "AnyKind.scala",
-          "Matchable.scala"
-        ).map(java.nio.file.Paths.get("scala", _))
-        var failedToApplyPatches = false
-        val claimedPatchSources = mutable.Set.empty[String]
-        val stalePatchWork = crossTarget.value / "patch-work"
-        if (stalePatchWork.exists()) {
-          IO.delete(stalePatchWork)
+        def listScalaAndPatches(srcDir: File): Seq[java.nio.file.Path] = {
+          if (!srcDir.isDirectory) Nil
+          else {
+            import scala.jdk.CollectionConverters.*
+            val root = srcDir.toPath
+            val all = java.nio.file.Files
+              .walk(root)
+              .iterator()
+              .asScala
+              .filter(java.nio.file.Files.isRegularFile(_))
+              .toSeq
+              .sortBy(_.toString)
+            val scalaFiles = all.filter { p =>
+              val path = normPath(p.toFile)
+              path.endsWith(".scala") && !path.endsWith(".scala.patch")
+            }
+            val patchFiles =
+              all.filter(p => normPath(p.toFile).endsWith(".scala.patch"))
+            scalaFiles ++ patchFiles
+          }
         }
-        for {
-          srcDir <- sourceDirectories
-          normSrcDir = normPath(srcDir)
-          scalaGlob = srcDir.toGlob / ** / "*.scala"
-          patchGlob = srcDir.toGlob / ** / "*.scala.patch"
-          (sourcePath, _) <- listFilesInOrder(scalaGlob, patchGlob)
-          if !ignoredSourceFiles.exists(sourcePath.endsWith(_))
-          path = normPath(sourcePath.toFile).substring(normSrcDir.length)
-        } {
-          def addSource(path: String)(optSource: => Option[File]): Unit = {
-            if (paths.contains(path)) s.log.debug(s"not including $path")
+
+        def allFilesUnder(dir: File): Set[File] =
+          if (dir.isDirectory) dir.allPaths.get().filter(_.isFile).toSet
+          else Set.empty
+
+        val inputFiles =
+          sourceDirectories.flatMap(listScalaAndPatches).map(_.toFile).toSet ++
+            allFilesUnder(scalaSrcDir)
+
+        FileFunction.cached(
+          cacheDir,
+          FilesInfo.lastModified,
+          FilesInfo.exists
+        ) { _ =>
+          val sources = mutable.ListBuffer.empty[File]
+          val paths = mutable.Set.empty[String]
+
+          /* Exclude files coming from Scala's `library-aux` directory, as they are not
+           * meant to be compiled. They are part of the source jar since Scala 2.13.14.
+           */
+          val ignoredSourceFiles = Set(
+            "Any.scala",
+            "AnyRef.scala",
+            "Singleton.scala",
+            "Nothing.scala",
+            "Null.scala",
+            // Since 3.5.1
+            "AnyKind.scala",
+            "Matchable.scala"
+          ).map(java.nio.file.Paths.get("scala", _))
+          var failedToApplyPatches = false
+          val claimedPatchSources = mutable.Set.empty[String]
+          val stalePatchWork = crossTarget.value / "patch-work"
+          if (stalePatchWork.exists()) {
+            IO.delete(stalePatchWork)
+          }
+          for {
+            srcDir <- sourceDirectories
+            normSrcDir = normPath(srcDir)
+            sourcePath <- listScalaAndPatches(srcDir)
+            if !ignoredSourceFiles.exists(sourcePath.endsWith(_))
+            path = normPath(sourcePath.toFile).substring(normSrcDir.length)
+          } {
+            def addSource(path: String)(optSource: => Option[File]): Unit = {
+              if (paths.contains(path)) s.log.debug(s"not including $path")
+              else {
+                optSource.foreach { source =>
+                  paths += path
+                  sources += source
+                }
+              }
+            }
+
+            def copy(source: File, destination: File) = {
+              import java.nio.file.Files
+              import java.nio.file.StandardCopyOption.*
+              Files.copy(
+                source.toPath(),
+                destination.toPath(),
+                COPY_ATTRIBUTES,
+                REPLACE_EXISTING
+              )
+            }
+
+            def tryApplyPatch(sourceName: String): Option[File] = {
+              val scalaSourcePath = scalaSrcDir / sourceName
+              val patchFile = sourcePath.toFile
+              val patchLabel = patchFile.relativeTo(srcDir.getParentFile)
+              if (!scalaSourcePath.exists()) {
+                val skipStamp = skippedRoot / sourceName
+                if (!skipStamp.exists() ||
+                    skipStamp.lastModified() < patchFile.lastModified()) {
+                  s.log.warn(
+                    s"Not found matching source file $sourceName for patch in Scala ${scalaVersion.value} sources, skipped"
+                  )
+                  IO.createDirectory(skipStamp.getParentFile)
+                  IO.touch(skipStamp)
+                }
+                return None
+              }
+              val outputFile = patchedRoot / sourceName
+              val outputDir = outputFile.getParentFile
+              if (!outputDir.exists()) {
+                IO.createDirectory(outputDir)
+              }
+              if (outputFile.exists() &&
+                  outputFile.lastModified() >= patchFile.lastModified() &&
+                  outputFile.lastModified() >= scalaSourcePath.lastModified()) {
+                s.log.debug(
+                  s"Reusing cached patched source for $sourceName from $patchLabel"
+                )
+                return Some(outputFile)
+              }
+              // There is not a single JVM library for diff that can apply
+              // patches in a fuzzy way (using context lines). We also
+              // canot use jgit to apply patches - it fails due to "invalid hunk headers".
+              // Becouse of that we use git apply instead.
+              // Each patch uses its own temp tree so fetched Scala sources are never
+              // mutated and concurrent or sequential patches cannot interfere.
+              import java.nio.file.{Files => JFiles}
+              val patchWorkRoot =
+                JFiles
+                  .createTempDirectory(crossTarget.value.toPath, "patch-work-")
+                  .toFile()
+              try {
+                import scala.sys.process.*
+                def gitApply(args: String*)(cwd: File): Int =
+                  Process(
+                    Seq("git", "apply") ++ args ++ Seq(
+                      patchFile.getAbsolutePath()
+                    ),
+                    cwd = cwd
+                  ).!(ProcessLogger(s.log.debug(_), s.log.debug(_)))
+
+                val workSourcePath = patchWorkRoot / sourceName
+                val workSourceParent = workSourcePath.getParentFile
+                if (!workSourceParent.exists()) {
+                  IO.createDirectory(workSourceParent)
+                }
+                if (workSourcePath.exists()) {
+                  IO.delete(workSourcePath)
+                }
+                copy(scalaSourcePath, workSourcePath)
+                val canApplyForward =
+                  gitApply("--check", "--recount")(patchWorkRoot) == 0
+                val alreadyPatched =
+                  !canApplyForward &&
+                    gitApply("--reverse", "--check", "--recount")(
+                      patchWorkRoot
+                    ) == 0
+                if (canApplyForward) {
+                  val exitCode =
+                    gitApply("--whitespace=fix", "--recount")(patchWorkRoot)
+                  if (exitCode != 0) {
+                    failedToApplyPatches = true
+                    s.log.error(
+                      s"Cannot apply patch for $patchLabel (git apply exit $exitCode)"
+                    )
+                    return None
+                  }
+                } else if (!alreadyPatched) {
+                  failedToApplyPatches = true
+                  s.log.error(
+                    s"Cannot apply patch for $patchLabel - source is neither pristine nor already patched"
+                  )
+                  return None
+                } else {
+                  s.log.debug(
+                    s"Patch for $sourceName already applied, reusing patched source"
+                  )
+                }
+                copy(workSourcePath, outputFile)
+                Some(outputFile)
+              } catch {
+                case ex: Exception =>
+                  // Postpone failing to check which other patches do not apply
+                  failedToApplyPatches = true
+                  s.log.error(s"Cannot apply patch for $patchLabel - $ex")
+                  None
+              } finally {
+                IO.delete(patchWorkRoot)
+              }
+            }
+
+            if (!normPath(sourcePath.toFile).endsWith(".scala.patch"))
+              addSource(path)(Some(sourcePath.toFile))
             else {
-              optSource.foreach { source =>
-                paths += path
-                sources += source
+              val sourceName = path.stripSuffix(".patch")
+              if (!claimedPatchSources.contains(sourceName)) {
+                claimedPatchSources += sourceName
+                addSource(sourceName)(
+                  tryApplyPatch(sourceName)
+                )
               }
             }
           }
 
-          def copy(source: File, destination: File) = {
-            import java.nio.file.Files
-            import java.nio.file.StandardCopyOption._
-            Files.copy(
-              source.toPath(),
-              destination.toPath(),
-              COPY_ATTRIBUTES,
-              REPLACE_EXISTING
+          if (failedToApplyPatches) {
+            throw new Exception(
+              "Failed to apply some of scalalib patches, check logs for more information"
             )
           }
 
-          def tryApplyPatch(sourceName: String): Option[File] = {
-            val scalaSourcePath = scalaSrcDir / sourceName
-            if (!scalaSourcePath.exists()) {
-              s.log.warn(
-                s"Not found matching source file $sourceName for patch in Scala ${scalaVersion.value} sources, skipped"
-              )
-              return None
-            }
-            val outputFile = crossTarget.value / "patched" / sourceName
-            val outputDir = outputFile.getParentFile
-            if (!outputDir.exists()) {
-              IO.createDirectory(outputDir)
-            }
-            val patchFile = sourcePath.toFile
-            val patchLabel = patchFile.relativeTo(srcDir.getParentFile)
-            if (outputFile.exists() &&
-                outputFile.lastModified() >= patchFile.lastModified() &&
-                outputFile.lastModified() >= scalaSourcePath.lastModified()) {
-              s.log.debug(
-                s"Reusing cached patched source for $sourceName from $patchLabel"
-              )
-              return Some(outputFile)
-            }
-            // There is not a single JVM library for diff that can apply
-            // patches in a fuzzy way (using context lines). We also
-            // canot use jgit to apply patches - it fails due to "invalid hunk headers".
-            // Becouse of that we use git apply instead.
-            // Each patch uses its own temp tree so fetched Scala sources are never
-            // mutated and concurrent or sequential patches cannot interfere.
-            import java.nio.file.{Files => JFiles}
-            val patchWorkRoot =
-              JFiles
-                .createTempDirectory(crossTarget.value.toPath, "patch-work-")
-                .toFile()
-            try {
-              import scala.sys.process._
-              def gitApply(args: String*)(cwd: File): Int =
-                Process(
-                  Seq("git", "apply") ++ args ++ Seq(
-                    patchFile.getAbsolutePath()
-                  ),
-                  cwd = cwd
-                ).!(ProcessLogger(s.log.debug(_), s.log.debug(_)))
+          val resolved = sources.result()
+          IO.writeLines(manifestFile, resolved.map(_.getAbsolutePath))
+          resolved.filter { file =>
+            val path = file.getAbsolutePath
+            path.startsWith(patchedRoot.getAbsolutePath) ||
+              path.startsWith(skippedRoot.getAbsolutePath)
+          }.toSet + manifestFile
+        }(inputFiles)
 
-              val workSourcePath = patchWorkRoot / sourceName
-              val workSourceParent = workSourcePath.getParentFile
-              if (!workSourceParent.exists()) {
-                IO.createDirectory(workSourceParent)
-              }
-              if (workSourcePath.exists()) {
-                IO.delete(workSourcePath)
-              }
-              copy(scalaSourcePath, workSourcePath)
-              val canApplyForward =
-                gitApply("--check", "--recount")(patchWorkRoot) == 0
-              val alreadyPatched =
-                !canApplyForward &&
-                  gitApply("--reverse", "--check", "--recount")(
-                    patchWorkRoot
-                  ) == 0
-              if (canApplyForward) {
-                val exitCode =
-                  gitApply("--whitespace=fix", "--recount")(patchWorkRoot)
-                if (exitCode != 0) {
-                  failedToApplyPatches = true
-                  s.log.error(
-                    s"Cannot apply patch for $patchLabel (git apply exit $exitCode)"
-                  )
-                  return None
-                }
-              } else if (!alreadyPatched) {
-                failedToApplyPatches = true
-                s.log.error(
-                  s"Cannot apply patch for $patchLabel - source is neither pristine nor already patched"
-                )
-                return None
-              } else {
-                s.log.debug(
-                  s"Patch for $sourceName already applied, reusing patched source"
-                )
-              }
-              copy(workSourcePath, outputFile)
-              Some(outputFile)
-            } catch {
-              case ex: Exception =>
-                // Postpone failing to check which other patches do not apply
-                failedToApplyPatches = true
-                s.log.error(s"Cannot apply patch for $patchLabel - $ex")
-                None
-            } finally {
-              IO.delete(patchWorkRoot)
-            }
-          }
-
-          if (!patchGlob.matches(sourcePath))
-            addSource(path)(Some(sourcePath.toFile))
-          else {
-            val sourceName = path.stripSuffix(".patch")
-            if (!claimedPatchSources.contains(sourceName)) {
-              claimedPatchSources += sourceName
-              addSource(sourceName)(
-                tryApplyPatch(sourceName)
-              )
-            }
-          }
-        }
-
-        if (failedToApplyPatches) {
-          throw new Exception(
-            "Failed to apply some of scalalib patches, check logs for more information"
-          )
-        }
-        sources.result()
+        IO.readLines(manifestFile).map(file => new File(file))
       },
       // Don't include classfiles/tasty for scalalib in the packaged jar.
       Compile / packageBin / mappings := {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1048,12 +1048,17 @@ object Settings {
                 }
                 copy(scalaSourcePath, workSourcePath)
                 val canApplyForward =
-                  gitApply("--check", "--recount")(patchWorkRoot) == 0
+                  0 == gitApply("--check", "--whitespace=fix", "--recount")(
+                    patchWorkRoot
+                  )
                 val alreadyPatched =
                   !canApplyForward &&
-                    gitApply("--reverse", "--check", "--recount")(
-                      patchWorkRoot
-                    ) == 0
+                    gitApply(
+                      "--reverse",
+                      "--check",
+                      "--whitespace=fix",
+                      "--recount"
+                    )(patchWorkRoot) == 0
                 if (canApplyForward) {
                   val exitCode =
                     gitApply("--whitespace=fix", "--recount")(patchWorkRoot)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -30,6 +30,10 @@ object Settings {
     "Fetches the scala source for the current scala version"
   )
 
+  lazy val publishScalalibLocal = taskKey[Unit](
+    "Publish scalalib to the local Ivy cache for scala3lib dependency resolution"
+  )
+
   lazy val shouldPartest = settingKey[Boolean](
     "Whether we should partest the current scala version (or skip if we can't)"
   )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -244,7 +244,13 @@ object Settings {
       binCompatVersions
         .map { version =>
           ModuleID(organization.value, moduleName.value, version)
-            .cross(crossVersion.value)
+            .cross {
+              platform.value match
+                case ScalaNativePlatform =>
+                  ScalaNativeCrossVersion.scalaNativeMapped(crossVersion.value)
+                case _ => crossVersion.value
+            }
+
         }
     }
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.12.9
+sbt.version = 2.0.0-RC12

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 2.0.0-RC12
+sbt.version = 2.0.0-RC14

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -34,18 +34,18 @@ scalacOptions ++= Seq(
   "-feature",
   "-unchecked"
 ) ++ Seq(
-        // In 2.13 lineStream_! was replaced with lazyList_!.
-      "method lineStream_!",
-      // OpenHashMap is used with value class parameter type, we cannot replace it with AnyRefMap or LongMap
-      // Should not be replaced with HashMap due to performance reasons.
-      "class|object OpenHashMap",
-      "class Stream",
-      "method retain in trait SetOps",
-      "object AnyRefMap.*Use `scala.collection.mutable.HashMap` ",
+  // In 2.13 lineStream_! was replaced with lazyList_!.
+  "method lineStream_!",
+  // OpenHashMap is used with value class parameter type, we cannot replace it with AnyRefMap or LongMap
+  // Should not be replaced with HashMap due to performance reasons.
+  "class|object OpenHashMap",
+  "class Stream",
+  "method retain in trait SetOps",
+  "object AnyRefMap.*Use `scala.collection.mutable.HashMap` ",
 
-      "`= _` has been deprecated",
-      "`_` is deprecated for wildcard arguments of types",
-      /*The syntax `x: _* is */ "no longer supported for vararg splice",
-      "The syntax `<function> _` is no longer supported",
-      "Implicit parameters should be provided with a `using` clause"
-    ).map(msg => s"-Wconf:msg=$msg:s")
+  "`= _` has been deprecated",
+  "`_` is deprecated for wildcard arguments of types",
+  /*The syntax `x: _* is */ "no longer supported for vararg splice",
+  "The syntax `<function> _` is no longer supported",
+  "Implicit parameters should be provided with a `using` clause"
+).map(msg => s"-Wconf:msg=$msg:s")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -11,14 +11,13 @@ Compile / unmanagedSourceDirectories ++= {
   ).flatMap { dir =>
     Seq(
       root / s"$dir/src/main/scala",
-      root / s"$dir/src/main/scala-sbt-1.0",
+      root / s"$dir/src/main/scala-sbt-2",
       root / s"$dir/jvm/src/main/scala"
     )
   }
 }
 
-addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.2")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")
@@ -31,8 +30,22 @@ libraryDependencies += "me.bechberger" % "ap-loader-all" % "4.2-10"
 // A stricter set of Options is used in the project root build.sbt.
 scalacOptions ++= Seq(
   "-deprecation",
-  "-encoding",
-  "utf8",
+  "-encoding:utf8",
   "-feature",
   "-unchecked"
-)
+) ++ Seq(
+        // In 2.13 lineStream_! was replaced with lazyList_!.
+      "method lineStream_!",
+      // OpenHashMap is used with value class parameter type, we cannot replace it with AnyRefMap or LongMap
+      // Should not be replaced with HashMap due to performance reasons.
+      "class|object OpenHashMap",
+      "class Stream",
+      "method retain in trait SetOps",
+      "object AnyRefMap.*Use `scala.collection.mutable.HashMap` ",
+
+      "`= _` has been deprecated",
+      "`_` is deprecated for wildcard arguments of types",
+      /*The syntax `x: _* is */ "no longer supported for vararg splice",
+      "The syntax `<function> _` is no longer supported",
+      "Implicit parameters should be provided with a `using` clause"
+    ).map(msg => s"-Wconf:msg=$msg:s")

--- a/sbt-scala-native/src/main/scala-sbt-1.0/scala/scalanative/sbtplugin/PluginCompat.scala
+++ b/sbt-scala-native/src/main/scala-sbt-1.0/scala/scalanative/sbtplugin/PluginCompat.scala
@@ -25,6 +25,8 @@ private[scalanative] object PluginCompat {
     platformDepsCrossVersion := ScalaNativeCrossVersion.binary
   )
 
+  val incrementalTestSettings: Seq[Setting[_]] = Nil
+
   def crossScalaNative(module: ModuleID): ModuleID =
     module.cross(ScalaNativeCrossVersion.binary)
 

--- a/sbt-scala-native/src/main/scala-sbt-2/scala/scalanative/sbtplugin/NativeIncrementalTest.scala
+++ b/sbt-scala-native/src/main/scala-sbt-2/scala/scalanative/sbtplugin/NativeIncrementalTest.scala
@@ -11,18 +11,35 @@ import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.nativeLink
 /** sbt 2 incremental test digests for Scala Native projects. */
 private[scalanative] object NativeIncrementalTest {
 
+  private lazy val definedTestNamesInput = taskKey[Vector[String]](
+    "Defined test names used for incremental test digests"
+  )
+
+  private lazy val testOptionsDigest = taskKey[Seq[Digest]](
+    "Content digest of Test/testOptions"
+  )
+
+  private lazy val testResourcesDigest = taskKey[Seq[Digest]](
+    "Content digests of Test/resources"
+  )
+
+  private lazy val testEnvVarsDigest = taskKey[Digest](
+    "Content digest of Test/envVars"
+  )
+
+  private lazy val extraTestDigestsInput = taskKey[Seq[Digest]](
+    "Plugin-provided extra digests for incremental testing"
+  )
+
   def nativeDefinedTestDigestsTask: Initialize[Task[Map[String, Digest]]] =
     Def.cachedTask {
-      val testNames = definedTests.value.map(_.name).toVector.distinct
-      val opts = testOptionDigestsFromOptions(testOptions.value)
-      val rds = (Test / resources).value
-        .map(_.toPath)
-        .sortBy(_.toString)
-        .map(Digest.sha256Hash(_))
-      val extra = extraTestDigests.value
+      val testNames = definedTestNamesInput.value
+      val opts = testOptionsDigest.value
+      val rds = testResourcesDigest.value
+      val extra = extraTestDigestsInput.value
       val binaryDigest =
         Digest.sha256Hash(nativeLink.value.contentHashStr().getBytes("UTF-8"))
-      val envDigest = envVarsDigest((Test / envVars).value)
+      val envDigest = testEnvVarsDigest.value
 
       val sharedDigests: Seq[Digest] =
         Seq(binaryDigest, envDigest) ++ opts ++ rds ++ extra
@@ -37,23 +54,46 @@ private[scalanative] object NativeIncrementalTest {
       options: Seq[TestOption]
   ): Seq[Digest] =
     options.flatMap {
-      case Tests.Setup(_, digest)    => Seq(digest)
-      case Tests.Cleanup(_, digest)  => Seq(digest)
+      case Tests.Setup(_, digest)   => Seq(digest)
+      case Tests.Cleanup(_, digest) => Seq(digest)
       case Tests.Argument(fm, args) =>
         Seq(
           Digest.sha256Hash(
-            (fm.toSeq.map(_.toString) ++ args).mkString("\n").getBytes("UTF-8")
+            (fm.toSeq.map(_.toString) ++ args)
+              .mkString("\n")
+              .getBytes("UTF-8")
           )
         )
       case _ => Nil
     }
 
   private def envVarsDigest(envVars: Map[String, String]): Digest = {
-    val salt = envVars.toSeq.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString("\n")
+    val salt = envVars.toSeq
+      .sortBy(_._1)
+      .map { case (k, v) => s"$k=$v" }
+      .mkString("\n")
     Digest.sha256Hash(salt.getBytes("UTF-8"))
   }
 
   val incrementalTestSettings: Seq[Setting[?]] = Seq(
+    definedTestNamesInput := Def.uncached {
+      definedTests.value.map(_.name).toVector.distinct
+    },
+    testOptionsDigest := Def.uncached {
+      testOptionDigestsFromOptions(testOptions.value)
+    },
+    testResourcesDigest := Def.uncached {
+      resources.value
+        .map(_.toPath)
+        .sortBy(_.toString)
+        .map(Digest.sha256Hash(_))
+    },
+    testEnvVarsDigest := Def.uncached {
+      envVarsDigest(envVars.value)
+    },
+    extraTestDigestsInput := Def.uncached {
+      extraTestDigests.value
+    },
     definedTestDigests := nativeDefinedTestDigestsTask
       .triggeredBy(nativeLink)
       .value

--- a/sbt-scala-native/src/main/scala-sbt-2/scala/scalanative/sbtplugin/NativeIncrementalTest.scala
+++ b/sbt-scala-native/src/main/scala-sbt-2/scala/scalanative/sbtplugin/NativeIncrementalTest.scala
@@ -1,0 +1,61 @@
+package scala.scalanative.sbtplugin
+
+import sbt.*
+import sbt.Def.Initialize
+import sbt.Keys.*
+import sbt.util.CacheImplicits.given
+import sbt.util.Digest
+
+import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.nativeLink
+
+/** sbt 2 incremental test digests for Scala Native projects. */
+private[scalanative] object NativeIncrementalTest {
+
+  def nativeDefinedTestDigestsTask: Initialize[Task[Map[String, Digest]]] =
+    Def.cachedTask {
+      val testNames = definedTests.value.map(_.name).toVector.distinct
+      val opts = testOptionDigestsFromOptions(testOptions.value)
+      val rds = (Test / resources).value
+        .map(_.toPath)
+        .sortBy(_.toString)
+        .map(Digest.sha256Hash(_))
+      val extra = extraTestDigests.value
+      val binaryDigest =
+        Digest.sha256Hash(nativeLink.value.contentHashStr().getBytes("UTF-8"))
+      val envDigest = envVarsDigest((Test / envVars).value)
+
+      val sharedDigests: Seq[Digest] =
+        Seq(binaryDigest, envDigest) ++ opts ++ rds ++ extra
+
+      Map(testNames.map { name =>
+        val nameDigest = Digest.sha256Hash(name.getBytes("UTF-8"))
+        name -> Digest.sha256Hash((nameDigest +: sharedDigests)*)
+      }*)
+    }
+
+  private def testOptionDigestsFromOptions(
+      options: Seq[TestOption]
+  ): Seq[Digest] =
+    options.flatMap {
+      case Tests.Setup(_, digest)    => Seq(digest)
+      case Tests.Cleanup(_, digest)  => Seq(digest)
+      case Tests.Argument(fm, args) =>
+        Seq(
+          Digest.sha256Hash(
+            (fm.toSeq.map(_.toString) ++ args).mkString("\n").getBytes("UTF-8")
+          )
+        )
+      case _ => Nil
+    }
+
+  private def envVarsDigest(envVars: Map[String, String]): Digest = {
+    val salt = envVars.toSeq.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString("\n")
+    Digest.sha256Hash(salt.getBytes("UTF-8"))
+  }
+
+  val incrementalTestSettings: Seq[Setting[?]] = Seq(
+    definedTestDigests := nativeDefinedTestDigestsTask
+      .triggeredBy(nativeLink)
+      .value
+  )
+}

--- a/sbt-scala-native/src/main/scala-sbt-2/scala/scalanative/sbtplugin/PluginCompat.scala
+++ b/sbt-scala-native/src/main/scala-sbt-2/scala/scalanative/sbtplugin/PluginCompat.scala
@@ -82,6 +82,9 @@ private[scalanative] object PluginCompat:
     Keys.platform := ScalaNativePlatform.current
   )
 
+  val incrementalTestSettings: Seq[Setting[?]] =
+    NativeIncrementalTest.incrementalTestSettings
+
   def crossScalaNative(module: ModuleID): ModuleID =
     module.platform(ScalaNativePlatform.current)
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -14,6 +14,7 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic._
 import java.util.concurrent.locks.ReentrantLock
 
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.concurrent.*
 import scala.concurrent.duration.Duration
@@ -458,7 +459,7 @@ object ScalaNativePluginInternal {
                   util.Logger.Null
                 )
               )
-              .flatMap(_.right.toOption)
+              .flatMap(_.right.toOption: @nowarn)
               .flatMap(_.allFiles)
               .filter(_.name.endsWith("-sources.jar"))
               .map(_.toPath())

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -14,8 +14,7 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic._
 import java.util.concurrent.locks.ReentrantLock
 
-import scala.annotation.nowarn
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.concurrent.*
 import scala.concurrent.duration.Duration
 import scala.sys.process.Process
@@ -366,7 +365,7 @@ object ScalaNativePluginInternal {
             .triggeredBy(loadedTestFrameworks)
             .value
         }
-      )
+      ) ++ PluginCompat.incrementalTestSettings
 
   /** Called by overridden method in plugin
    *

--- a/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/package.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/benchmarks/package.scala
@@ -1,5 +1,8 @@
 package scala.scalanative
 
+import java.io.File.pathSeparator
+import java.nio.file.Paths
+
 import scala.scalanative.build._
 
 package object benchmarks {
@@ -10,7 +13,13 @@ package object benchmarks {
     .withLinkingOptions(Discover.linkingOptions())
 
   lazy val defaultConfig = Config.empty
-    .withClassPath(BuildInfo.fullTestSuiteClasspath.map(_.toPath))
+    .withClassPath(
+      BuildInfo.fullTestSuiteClasspath
+        .split(pathSeparator)
+        .filter(_.nonEmpty)
+        .map(Paths.get(_))
+        .toSeq
+    )
     .withLogger(Logger.nullLogger)
     .withCompilerConfig(defaultNativeConfig)
 

--- a/tools/src/main/scala/scala/scalanative/codegen/ITable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ITable.scala
@@ -71,7 +71,7 @@ private[codegen] object ITable {
     ITable(
       useFastITables,
       itables.size,
-      nir.Val.ArrayValue(ITableEntry, itables)
+      nir.Val.ArrayValue(ITableEntry, itables.toIndexedSeq)
     )
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/AbstractCodeGen.scala
@@ -598,7 +598,7 @@ private[codegen] abstract class AbstractCodeGen(
         rep(vs, sep = ", ")(genVal)
         str(" ]")
       case nir.Val.ByteString(v) =>
-        genByteString(v)
+        genByteString(v.toIndexedSeq)
       case nir.Val.Local(n, ty) =>
         str("%")
         genLocal(n)

--- a/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/llvm/MetadataCodeGen.scala
@@ -230,7 +230,7 @@ private[codegen] trait MetadataCodeGen { self: AbstractCodeGen =>
     import nir.Type._
     Seq(Byte, Char, Short, Int, Long, Size, Float, Double, Bool, Ptr).map { tpe =>
       val name = tpe.show
-      val nameCapitalize = name.head.toUpper + name.tail
+      val nameCapitalize = name.head.toUpper.toString + name.tail
       tpe -> DIBasicType(
         name = nameCapitalize,
         size = MemoryLayout.sizeOf(tpe).toDISize,


### PR DESCRIPTION
* Migrated build to use sbt 2 
* Fixes Scala Native sbt plugins when using tests in sbt 2.x for users - implements cusotm `testsDigest` required for incremental tests. The default implementaiton lead to StackOverflowError