### PR TITLE
perf: zero-copy StringBuilder.toString() when buffer is not wasted

### DIFF
--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -605,10 +605,13 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
     val wasted = value.length - count
     if (wasted >= 256 ||
         (wasted >= INITIAL_CAPACITY && wasted >= (count >> 1))) {
+      // Too much wasted space: copy the buffer to a right-sized array
       return new String(value, 0, count)
     }
+    // Share the buffer with the String (zero-copy). Set shared=true so that
+    // any subsequent modification to this StringBuilder triggers a copy-on-write.
     shared = true
-    return new String(value, 0, count)
+    new String(0, count, value)
   }
 
   def subSequence(start: scala.Int, end: scala.Int): CharSequence =


### PR DESCRIPTION
## Motivation

`StringBuilder.toString()` always copies the char array via `new String(value, 0, count)`, even when the buffer is not excessively wasted. This creates unnecessary allocation pressure for workloads that create many intermediate strings via StringBuilder.

## Key Design Decision

Use the `private[lang]` String constructor `new String(start, length, data)` that shares the char array without copying, instead of `new String(value, 0, count)` which always copies. Set `shared=true` so that any subsequent modification to the StringBuilder triggers copy-on-write.

## Modification

Changed `javalib/src/main/scala/java/lang/AbstractStringBuilder.scala`:
- In the `else` branch of `toString()` (when buffer is not wasted), use `new String(0, count, value)` instead of `new String(value, 0, count)`
- Set `shared = true` to enable copy-on-write for subsequent modifications

## Analysis

The `new String(value, 0, count)` constructor (line 105-115 of String.scala) always creates a copy:
```scala
def this(data: Array[Char], start: Int, length: Int) = {
  this()
  value = new Array[Char](length)
  System.arraycopy(data, start, value, 0, count)
}
```

The `private[lang] String(start, length, data)` constructor (line 129-134) shares the array:
```scala
private[lang] def this(start: Int, length: Int, data: Array[Char]) = {
  this()
  value = data
  offset = start
  count = length
}
```

By setting `shared = true`, any subsequent modification to the StringBuilder will check the flag and copy-on-write if needed (lines 233, 256, 366, 428, 446, 468, 553, 567).

## Result

- ✅ Zero-copy toString() when buffer is not wasted
- ✅ Copy-on-write preserves correctness
- ✅ Reduces allocation pressure for string-heavy workloads