### PR TITLE
perf: zero-copy StringBuilder.toString() when buffer is not wasted

### DIFF
--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -607,8 +607,7 @@ protected abstract class AbstractStringBuilder private (unit: Unit) {
         (wasted >= INITIAL_CAPACITY && wasted >= (count >> 1))) {
       return new String(value, 0, count)
     }
-    shared = true
-    return new String(value, 0, count)
+    new String(this, null)
   }
 
   def subSequence(start: scala.Int, end: scala.Int): CharSequence =

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -132,6 +132,14 @@ final class _String()
     count = length
   }
 
+  // Zero-copy: share the buffer with AbstractStringBuilder via copy-on-write.
+  private[lang] def this(asb: AbstractStringBuilder, sig: Void) = {
+    this()
+    value = asb.shareValue()
+    offset = 0
+    count = asb.length()
+  }
+
   def this(string: _String) = {
     this()
     value = string.value


### PR DESCRIPTION
## Motivation

`AbstractStringBuilder.toString()` has two issues in the else branch (when buffer is not excessively wasted):

1. It sets `shared = true` but then calls `new String(value, 0, count)` which **always copies** the array — the zero-copy intent is never realized
2. Setting `shared = true` without actually sharing causes **spurious copy-on-write** on subsequent StringBuilder modifications — an extra unnecessary copy

## Modification

- Add a `(AbstractStringBuilder, Void)` constructor to `String` that shares the char array via `shareValue()` (zero-copy with copy-on-write semantics)
- Use `new String(this, null)` in `AbstractStringBuilder.toString()` for the non-wasted branch, which calls `shareValue()` to correctly set the shared flag and share the backing array

## Benchmark Results

Tested on Apple Silicon, 1M ops/iteration, 10 iterations, median reported.

### Debug mode

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| Small toString (16 chars) | 214 ms | 163 ms | **+31% ops/s** |
| Medium toString (64 chars) | 1229 ms | 1084 ms | **+13% ops/s** |
| Large toString (1024 chars) | 603 ms | 511 ms | **+18% ops/s** |
| toString + continue append | 346 ms | 291 ms | **+19% ops/s** |

### Release-fast mode

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| Medium toString (64 chars) | 1080 ms | 1048 ms | +3% ops/s |
| Large toString (1024 chars) | 524 ms | 499 ms | **+5% ops/s** |
| toString + continue append | 291 ms | 283 ms | +3% ops/s |

## Result

- Zero-copy `toString()` when buffer is not excessively wasted
- Copy-on-write correctly triggers only when the array is actually shared
- Fixes the spurious COW bug in the existing code
- Reduces allocation pressure for string-heavy workloads