### PR TITLE
fix[nscplugin] Help detect missing annotation classpath when using relfection instantiation

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -280,7 +280,13 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val sym = cd.symbol
       val enableReflectiveInstantiation = {
         (sym :: sym.ancestors).exists { ancestor =>
-          ancestor.hasAnnotation(EnableReflectiveInstantiationAnnotation)
+          ancestor.hasAnnotation(EnableReflectiveInstantiationAnnotation) || {
+            // Force loading of the symbol info - allows to detect missing classpath entries
+            // Otherwise check can fail silently
+            ancestor.annotations.exists(
+              _.symbol.tpe.dealias.typeSymbol == EnableReflectiveInstantiationAnnotation
+            )
+          }
         }
       }
 


### PR DESCRIPTION
Based on portable-scala-reflect issue - otherwise `hasAnnotation` check can silently return false in cases when classpath does not contain `provided` dependencies