### PR TITLE
Implement JDK19 jl.Random#from; align with JDK 26

### DIFF
--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -1,6 +1,8 @@
 package java.util
 
 import java.util.random.{JuRandomFactory, RandomGenerator}
+import java.util.stream._
+import java.{lang => jl}
 
 import scala.annotation.tailrec
 
@@ -134,4 +136,177 @@ class Random(seed_in: Long)
     x * c
   }
 
+}
+
+object Random {
+
+  private final class RandomFromGenerator(generator: RandomGenerator)
+      extends Random {
+
+    /* protected def next(bits: Int): Int
+     * does not delegate to 'generator' because RandomGenerator does
+     * not have that method. This is not a problem, since the the method
+     * in this class can never be accessed outside of it.
+     * The super Random method can never is protected and this class is
+     * private final.
+     */
+
+    /* There must be a more elegant way of doing these declarations.
+     */
+
+    override def doubles(): DoubleStream =
+      generator.doubles()
+
+    override def doubles(
+        randomNumberOrigin: scala.Double,
+        randomNumberBound: scala.Double
+    ): DoubleStream =
+      generator.doubles(randomNumberOrigin, randomNumberBound)
+
+    override def doubles(streamSize: Long): DoubleStream =
+      generator.doubles(streamSize)
+
+    override def doubles(
+        streamSize: Long,
+        randomNumberOrigin: Double,
+        randomNumberBound: Double
+    ): DoubleStream =
+      generator.doubles(
+        streamSize,
+        randomNumberOrigin,
+        randomNumberBound
+      )
+
+    override def equiDoubles(
+        left: scala.Double,
+        right: scala.Double,
+        isLeftIncluded: Boolean,
+        isRightIncluded: Boolean
+    ): DoubleStream =
+      generator.equiDoubles(left, right, isLeftIncluded, isRightIncluded)
+
+    override def ints(): IntStream =
+      generator.ints()
+
+    override def ints(
+        randomNumberOrigin: Int,
+        randomNumberBound: Int
+    ): IntStream =
+      generator.ints(
+        randomNumberOrigin,
+        randomNumberBound
+      )
+
+    override def ints(streamSize: scala.Long): IntStream =
+      generator.ints(streamSize)
+
+    override def ints(
+        streamSize: scala.Long,
+        randomNumberOrigin: Int,
+        randomNumberBound: Int
+    ): IntStream =
+      generator.ints(
+        streamSize,
+        randomNumberOrigin,
+        randomNumberBound
+      )
+
+    override def isDeprecated() =
+      generator.isDeprecated()
+
+    override def longs(): LongStream =
+      generator.longs(jl.Long.MAX_VALUE)
+
+    override def longs(
+        randomNumberOrigin: scala.Long,
+        randomNumberBound: scala.Long
+    ): LongStream =
+      generator.longs(
+        randomNumberOrigin,
+        randomNumberBound
+      )
+
+    override def longs(streamSize: Long): LongStream =
+      generator.longs(streamSize)
+
+    override def longs(
+        streamSize: Long,
+        randomNumberOrigin: Long,
+        randomNumberBound: Long
+    ): LongStream =
+      generator.longs(
+        streamSize,
+        randomNumberOrigin,
+        randomNumberBound
+      )
+
+    override def nextBoolean(): Boolean =
+      generator.nextBoolean()
+
+    override def nextBytes(bytes: Array[Byte]): Unit =
+      generator.nextBytes(bytes)
+
+    override def nextDouble(): Double =
+      generator.nextDouble()
+
+    override def nextDouble(bound: scala.Double): scala.Double =
+      generator.nextDouble(bound)
+
+    override def nextDouble(
+        origin: scala.Double,
+        bound: scala.Double
+    ): scala.Double =
+      generator.nextDouble(origin, bound)
+
+    override def nextExponential(): scala.Double =
+      generator.nextExponential()
+
+    override def nextFloat(): Float =
+      generator.nextFloat()
+
+    override def nextFloat(bound: scala.Float): scala.Float =
+      generator.nextFloat(bound)
+
+    override def nextFloat(
+        origin: scala.Float,
+        bound: scala.Float
+    ): scala.Float =
+      generator.nextFloat(origin, bound)
+
+    override def nextGaussian(): Double =
+      generator.nextGaussian()
+
+    override def nextGaussian(
+        mean: scala.Double,
+        stddev: scala.Double
+    ): scala.Double =
+      generator.nextGaussian(mean, stddev)
+
+    override def nextInt(): Int =
+      generator.nextInt()
+
+    override def nextInt(n: Int): Int =
+      generator.nextInt(n)
+
+    override def nextInt(origin: Int, bound: Int): Int =
+      generator.nextInt(origin, bound)
+
+    override def nextLong(): Long =
+      generator.nextLong()
+
+    override def nextLong(bound: scala.Long): scala.Long =
+      generator.nextLong(bound)
+
+    override def nextLong(origin: scala.Long, bound: scala.Long): scala.Long =
+      generator.nextLong(origin, bound)
+
+    override def setSeed(seed: Long): Unit =
+      throw new java.lang.UnsupportedOperationException
+  }
+
+  /** Since: Java 19 */
+  def from(generator: RandomGenerator): Random = {
+    if (generator.isInstanceOf[Random]) generator.asInstanceOf[Random]
+    else new RandomFromGenerator(generator)
+  }
 }

--- a/javalib/src/main/scala/java/util/random/RandomGenerator.scala
+++ b/javalib/src/main/scala/java/util/random/RandomGenerator.scala
@@ -530,14 +530,25 @@ trait RandomGenerator {
     StreamSupport.doubleStream(downstreamSpliter, parallel = false)
   }
 
-  /*
-  // Since: Java 22
-   def equiDoubles(
-       left: scala.Double,
-       right: scala.Double,
-       isLeftIncluded: Boolean,
-      isRightIncluded: Boolean): DoubleStream
+  /* This implementation of equiDoubles() is scaffolding to allow
+   * implementation of Random.from() in a way that does not require
+   * re-visiting.  The intent is to provide a follow-on PR which
+   * implements the method correctly.
+   *
+   * Providing an empty stream is better than, say, calling doubles()
+   * because equiDoubles() is advertised as providing equidistant doubles
+   * to avoid known 'bunching' in doubles(). An empty stream makes
+   * the breakage evident.
    */
+
+  // Since: Java 22
+  def equiDoubles(
+      left: scala.Double,
+      right: scala.Double,
+      isLeftIncluded: Boolean,
+      isRightIncluded: Boolean
+  ): DoubleStream =
+    DoubleStream.empty() // Incorrect implementation.
 
   def ints(): IntStream =
     ints(jl.Long.MAX_VALUE)

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/RandomTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/RandomTestOnJDK19.scala
@@ -1,0 +1,38 @@
+package org.scalanative.testsuite.javalib.util
+
+// import java.util._
+// import java.util.function.{DoubleConsumer, IntConsumer, LongConsumer}
+
+import java.{lang => jl, util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class RandomTestOnJDK19 {
+
+  @Test def test_from_RandomClassRNG(): Unit = {
+
+    val srcRng = new ju.Random()
+    val uutRng = ju.Random.from(srcRng)
+
+    assertTrue("rngs should be reference equal", uutRng.eq(srcRng))
+
+    uutRng.setSeed(jl.Long.MAX_VALUE) // should not throw
+  }
+
+  @Test def test_from_NonRandomClassRNG(): Unit = {
+    val srcRng = ju.random.RandomGenerator.of("L32X64MixRandom")
+    val uutRng = ju.Random.from(srcRng)
+
+    assertFalse("rngs should not be reference equal", uutRng.eq(srcRng))
+
+    assertThrows(
+      classOf[UnsupportedOperationException],
+      uutRng.setSeed(jl.Long.MAX_VALUE)
+    )
+
+    // Someday, when time is abundant, test the various passthru methods.
+  }
+}


### PR DESCRIPTION
Implement javalib `java.lang``Random#from` JDK  19 method and associated Tests
This  brings that class to parity with JDK 26.

Previously unimplemented `RandomGenerator.equiDoubles()` is implemented as a minimal
method in order to work around apparent recent SN build symbol resolution changes.
Issue #4963 tracks the need for an eventual full implementation.
