### PR TITLE
Implement javalib JDK24  Process.waitfor(Duration) method

### DIFF
--- a/javalib-ext-dummies/src/main/scala/java/time/Duration.scala
+++ b/javalib-ext-dummies/src/main/scala/java/time/Duration.scala
@@ -19,6 +19,8 @@ final class Duration(private val seconds: Long, private val nano: Int)
     extends Comparable[Duration]
     with java.io.Serializable {
 
+  import Duration._
+
   override def compareTo(that: Duration): Int = {
     val secondsCompare = seconds.compareTo(that.seconds)
     if (secondsCompare == 0) {
@@ -41,12 +43,37 @@ final class Duration(private val seconds: Long, private val nano: Int)
   override def hashCode(): Int =
     java.lang.Long.hashCode(seconds) ^ java.lang.Integer.hashCode(nano)
 
+  def toNanos(): scala.Long = {
+    val nanosFromSeconds = Math.multiplyExact(this.seconds, NANOS_PER_SECOND)
+    Math.addExact(nanosFromSeconds, this.nano)
+  }
+
   // non compliant, for debugging purposes only
   override def toString(): String =
     "Duration(" + seconds + ", " + nano + ")"
 }
 
 object Duration {
+
+  private final val MILLIS_PER_SECOND = 1000L
+  private final val NANOS_PER_SECOND = 1000L * 1000L * 1000L
+
+  def ofMillis(millis: Long): Duration = {
+    val nanosPart = (millis % MILLIS_PER_SECOND).toInt
+    val secondsPart = millis / MILLIS_PER_SECOND
+
+    new Duration(secondsPart, nanosPart)
+  }
+
+  def ofNanos(nanos: Long): Duration = {
+    val nanosPart = (nanos % NANOS_PER_SECOND).toInt
+    val secondsPart = nanos / NANOS_PER_SECOND
+
+    new Duration(secondsPart, nanosPart)
+  }
+
+  def ofSeconds(seconds: Long): Duration =
+    new Duration(seconds, 0)
 
   def ofSeconds(seconds: Long, nanoAdjustment: Long): Duration = {
     val adjustedSeconds =

--- a/javalib/src/main/scala/java/lang/Process.scala
+++ b/javalib/src/main/scala/java/lang/Process.scala
@@ -1,6 +1,7 @@
 package java.lang
 
 import java.io.{InputStream, OutputStream}
+import java.time.Duration
 import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util.stream.Stream
 
@@ -52,5 +53,7 @@ abstract class Process {
   def waitFor(): Int
 
   def waitFor(timeout: scala.Long, unit: TimeUnit): scala.Boolean
+
+  def waitFor(duration: Duration): scala.Boolean
 
 }

--- a/javalib/src/main/scala/java/lang/process/GenericProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcess.scala
@@ -1,6 +1,7 @@
 package java.lang.process
 
 import java.io.{FileDescriptor, InputStream, OutputStream}
+import java.time.Duration
 import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util.stream.Stream
 
@@ -63,6 +64,9 @@ private[process] abstract class GenericProcess(val handle: GenericProcessHandle)
 
   override final def waitFor(timeout: scala.Long, unit: TimeUnit): Boolean =
     handle.waitFor(timeout, unit)
+
+  override final def waitFor(duration: Duration): Boolean =
+    handle.waitFor(duration)
 
   override def equals(that: Any): Boolean = that match {
     case other: GenericProcess => handle.compareTo(other.handle) == 0

--- a/javalib/src/main/scala/java/lang/process/GenericProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcessHandle.scala
@@ -1,5 +1,6 @@
 package java.lang.process
 
+import java.time.Duration
 import java.util.concurrent.{CompletableFuture, TimeUnit, TimeoutException}
 import java.util.stream.Stream
 import java.util.{Optional, function}
@@ -104,11 +105,31 @@ private[process] abstract class GenericProcessHandle(
     hasExited || destroyImpl(force = force)
 
   private def waitForWith(check: => Boolean) = hasExited || check && hasExited
+
   def waitFor(): Boolean = waitForWith(exitChecker.waitAndReapSome(0, None))
+
   def waitFor(timeout: scala.Long, unit: TimeUnit): Boolean =
     waitForWith(
       timeout > 0L && exitChecker.waitAndReapSome(timeout, Some(unit))
     )
+
+  def waitFor(duration: java.time.Duration): Boolean = {
+    // Be robust to SN CI uncertainty, use only JDK 8 methods
+    val (timeout, unit) =
+      try {
+        (duration.toNanos(), TimeUnit.NANOSECONDS)
+      } catch {
+        /* Note: nanoseconds < 1 second will be lost
+         * after approx 292 years, 3 months, 9.7 days and change.
+         * Avoiding that loss is an exercise for the reader.
+         * Good problem to have when your machine stays up that long.
+         */
+        case _: ArithmeticException =>
+          (duration.getSeconds(), TimeUnit.SECONDS)
+      }
+
+    waitFor(timeout, unit)
+  }
 
   override def onExit(): CompletableFuture[ProcessHandle] =
     onExitApply(_ => this: ProcessHandle)

--- a/javalib/src/main/scala/java/lang/process/GenericProcessHandle.scala
+++ b/javalib/src/main/scala/java/lang/process/GenericProcessHandle.scala
@@ -115,9 +115,12 @@ private[process] abstract class GenericProcessHandle(
 
   def waitFor(duration: java.time.Duration): Boolean = {
     // Be robust to SN CI uncertainty, use only JDK 8 methods
-    val (timeout, unit) =
+
+    var unit = TimeUnit.NANOSECONDS
+
+    val timeout: scala.Long =
       try {
-        (duration.toNanos(), TimeUnit.NANOSECONDS)
+        duration.toNanos()
       } catch {
         /* Note: nanoseconds < 1 second will be lost
          * after approx 292 years, 3 months, 9.7 days and change.
@@ -125,7 +128,8 @@ private[process] abstract class GenericProcessHandle(
          * Good problem to have when your machine stays up that long.
          */
         case _: ArithmeticException =>
-          (duration.getSeconds(), TimeUnit.SECONDS)
+          unit = TimeUnit.SECONDS
+          duration.getSeconds()
       }
 
     waitFor(timeout, unit)

--- a/unit-tests-ext/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK24.scala.DISABLED
+++ b/unit-tests-ext/shared/src/test/scala/org/scalanative/testsuite/javalib/lang/ProcessTestOnJDK24.scala.DISABLED
@@ -1,0 +1,181 @@
+package org.scalanative.testsuite.javalib.lang
+
+/* 2026-06-13
+ *
+ * This File is provided to allow manual testing of Process methods
+ * which use Duration.
+ *
+ * It is marked .DISABLED since it requires JDK 24 and the unit-tests-ext
+ * project currently runs in CI on an earlier version. unit-tests-ext does
+ * not have the useful but elaborated 'require-jdkN' feature of unit-tests.
+ */
+
+import java.time.Duration
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+class ProcessTestOnJDK24 {
+  import ProcessUtils.processSleep
+
+  /* These Tests are the similar Tests from Process scala adapted
+   * to use Duration rather than TimeUnit.
+   */
+
+  @Test def waitForWithDurationTimeoutCompletes(): Unit = {
+    val proc = processSleep(0.1).start()
+
+    /* This is another Receiver Operating Characteristic (ROC) curve
+     * decision, where one tries to balance the rates of true failure
+     * and false failure detection.
+     *
+     * On contemporary machines, even virtual machines, a process should
+     * take only a few seconds to exit. Then there is Windows. Many CI
+     * failures having nothing to do with the PR under test have been seen,
+     * mostly on Windows, to have failed here with the previous
+     * "reasonable & conservative" value of 4. No best guess long survives
+     * first contact with the facts on the ground (actually, I think that
+     * was a 10th, or more, best guess).
+     */
+
+    val timeout = 30
+
+    assertTrue(
+      s"process should have exited but timed out (limit: ${timeout} seconds)",
+      proc.waitFor(Duration.ofSeconds(timeout))
+    )
+    assertEquals(0, proc.exitValue)
+  }
+
+  // See timing 'Design Notes' in ProcessTest.scala. Same considerations
+  // apply here.
+
+  @Test def waitForWithDurationTimeoutTimesOut(): Unit = {
+    val proc = processSleep(2.0).start()
+
+    val timeout = 500 // Make message distinguished.
+    assertTrue(
+      "process should have timed out but exited" +
+        s" (limit: ${timeout} milliseconds)",
+      !proc.waitFor(Duration.ofMillis(timeout))
+    )
+    assertTrue("process should be alive", proc.isAlive)
+
+    // await exit code to release resources. Attempt to force
+    // hanging processes to exit.
+    if (!proc.waitFor(Duration.ofSeconds(10)))
+      proc.destroyForcibly()
+  }
+
+  // Defensive code for Issue 3944
+  @Test def waitForWithDurationTimeoutIsRobustAfterProcessExit(): Unit = {
+    /* Check that waitFor(timeout) can safely be called more than once after a
+     * process exits. Both waitFor(timout) calls will probably return
+     * immediatly.
+     *
+     * The idea is to exercise the internals of the second call. How does it
+     * respond to a now invalid process id.
+     */
+
+    val proc = processSleep(0.1).start()
+
+    try {
+      val timeout = 30
+      assertTrue(
+        s"process should have exited but timed out (limit: ${timeout} seconds)",
+        proc.waitFor(Duration.ofSeconds(timeout))
+      )
+
+      /* DO NOT do the usual & expected 'assertEquals(0, proc.exitValue)' here.
+       * That would set the internal cached exitValue. Not doing that
+       * call here allows checking if waitFor() is caching that value
+       * to protect itself against a second call.
+       */
+
+      assertTrue(
+        s"Second waitFor after process exit should be robust.)",
+        proc.waitFor(Duration.ofSeconds(timeout))
+      )
+
+    } finally {
+      proc.destroyForcibly() // Let OS eliminate any child process still alive.
+    }
+  }
+
+  // Issue 3944, part 2
+  @Test def waitForWithDurationTimeoutAcceptsLargeMilliseconds(): Unit = {
+    val proc = processSleep(2.0).start()
+
+    try {
+      // for context: https://github.com/scala-native/scala-native/issues/3944
+      val timeout = 30 * 1000
+
+      /*  Exception before fix, where nnnn is a pid number:
+       *
+       *  Linux & non-BSD kin:
+       *   java.io.IOException: wait pid=nnnn, ppoll failed: 22
+       *
+       *  macOS, FreeBSD:
+       *   java.io.IOException: wait pid=nnnn, kevent failed: Invalid argument
+       *
+       *  After the corresponding PR, the messages should never be seen.
+       *  If one is, the Linux case should look like the macOS case.
+       *
+       *  A TimeUnit larger than MILLISECONDS will not trigger the I3944
+       *  defect.
+       *
+       *  The number of that unit needs to be more than those in a second.
+       *  say 1001 for MILLISECONDS. That gives a large number of
+       *  nanoseconds after full seconds (in nanos) have been subtracted off.
+       *  Be generous here, use the value from the Issue,  and not try to
+       *  find too fine an edge of failure.
+       */
+
+      assertTrue(
+        s"process should have exited but timed out (limit: ${timeout} millis)",
+        proc.waitFor(Duration.ofMillis(timeout))
+      )
+
+      assertFalse("process should have exited", proc.isAlive)
+      assertEquals(0, proc.exitValue)
+    } finally {
+      proc.destroyForcibly() // Let OS eliminate any child process still alive.
+    }
+  }
+}
+
+/* ProcessUtils.scala
+ */
+import java.util.concurrent.TimeUnit
+
+import scala.scalanative.runtime.Platform
+
+/* This is an adapted cut & paste from
+ * unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/lang.
+ * Bad devo, no cookie!  The proper import from unit-tests-ext is too complex
+ * for available time and patience.
+ *
+ * It is in the same file as ProcessTestOnJDK24 to make it easier to
+ * Enable/DISABLE that Test.
+ */
+
+object ProcessUtils {
+
+  def processForCommand(args: String*): ProcessBuilder = {
+    if (Platform.isWindows())
+      new ProcessBuilder((Seq("cmd", "/c") ++ args): _*)
+    else
+      new ProcessBuilder(args: _*)
+  }
+
+  def processSleep(seconds: Double): ProcessBuilder = {
+    if (Platform.isWindows())
+      // Use Powershell Start-Sleep, cmd timeout can cause problems and
+      // does support only integer seconds arguments
+      new ProcessBuilder(
+        Seq("powershell", "Start-Sleep", "-Seconds", seconds.toString()): _*
+      )
+    else processForCommand("sleep", seconds.toString())
+  }
+}


### PR DESCRIPTION
Implement javalib JDK24  Process.waitfor(Duration) method and associated Tests.

Because SN does not directly support `java.time.Duration` the test is in the `unit-tests-ext`
project.

`ProcessTestOnJDK24.scala.DISABLED` is a manual test and is marked DISABLED because
it requires JDK 24 and some CI  runs currently run with JDK  17 or less.  `unit-tests-ext` does
not have  the useful but expensive `require-jdkN` configuration widely used by `unit-tests`.

The correctness of `Process.waitfor(duration: Duration)` depends upon the correctness of 
`waitFor(long timeout, TimeUnit unit)`; see Issue #4965.