### PR TITLE
juc.ThreadLocalRandom#nextGaussian now uses JDK 26 implementation

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -24,6 +24,7 @@ package java.util.concurrent
 import java.util._
 import java.util.concurrent.atomic._
 import java.util.function._
+import java.util.random.RandomGenerator
 
 import scala.scalanative.annotation.safePublish
 import scala.scalanative.meta.LinktimeInfo
@@ -117,7 +118,7 @@ object ThreadLocalRandom {
 }
 
 @SerialVersionUID(-5851777807851030925L)
-class ThreadLocalRandom extends Random {
+class ThreadLocalRandom extends Random with RandomGenerator {
 
   private var initialized = true
 
@@ -145,4 +146,13 @@ class ThreadLocalRandom extends Random {
 
   override def nextLong(): Long = ThreadLocalRandom.mix64(nextSeed())
 
+  /* @since JDK 26
+   *
+   * Method has existed since JDK 1.7 but has a complicated implementation
+   * history. Some JDK versions use original Box-Muller algorithm and
+   * some use McFarland's fast modified ziggurat algorithm as in
+   * RandomGenerator. Follow JDK 26 practice across the board.
+   */
+  override def nextGaussian(): Double =
+    super[RandomGenerator].nextGaussian()
 }


### PR DESCRIPTION

1) As of JDK  17 `java.util.concurrent.ThreadLocalRandom` extends `java.util.random.RandomGenerator`.
    Update the class to match.

2) The `ThreadLocalRandom#nextGaussian` method has been described since JDK 1.7. The 
     actual algorithm used as varied in a complicated way; sometimes being the original `Random` `Box-Muller` 
     and  sometimes being McFarland's ziggurat.  As of JDK 26, `ThreadLocalRandom#nextGaussian`
     consistently  delegates to `RandomGenerator#nextGaussian`.  

3) As of this PR, SN follows the JDK 26 approach on all Java versions.  This introduces some inconsistency
    in observed behavior on those versions of JDK where `Box-Muller` was mistakenly used.

4) SN Issue #4973 describes a defect where `RandomGenerator#nextGaussian` uses the wrong 
    algorithm. This PR will bring an observable benefit only after that Issue is resolved.