### PR TITLE
nativeConfig sbt cache dependent on env

### DIFF
--- a/docs/contrib/quickstart.md
+++ b/docs/contrib/quickstart.md
@@ -58,7 +58,7 @@ as expected.
     of the sbt plugin (this takes a while and requires local publish of artifacts).
     Build against Scala 2.12 uses sbt 1.x, while Scala 3 uses sbt 2.x. Other versions are not supported.
 
--  `test-scritped <scala-binary-version> <optional-test-filters>` - run specific scripted tests of the sbt plugin. e.g. `test-scripted 3 run/backtrace`:
+-  `test-scripted <scala-binary-version> <optional-test-filters>` - run specific scripted tests of the sbt plugin. e.g. `test-scripted 3 run/backtrace`:
         -   Scripted tests are used when you need to interact with the
             file system, networking, or the build system that cannot be
             done with a unit test.

--- a/docs/contrib/quickstart.md
+++ b/docs/contrib/quickstart.md
@@ -53,12 +53,12 @@ as expected.
 -   `toolsJVM3/test` - run the unit tests of the tools: ScalaNative
     backend
 
--   `test-scritped <scala-binary-version>`, eg `test-scripted 2.12` - run all [scripted
+-   `test-scripted <scala-binary-version>`, eg `test-scripted 2.12` - run all [scripted
     tests](https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html)
     of the sbt plugin (this takes a while and requires local publish of artifacts).
     Build against Scala 2.12 uses sbt 1.x, while Scala 3 uses sbt 2.x. Other versions are not supported.
 
--  `test-scritped <scala-binary-version> <optional-test-filters>` - run specific scripted tests of the sbt plugin. e.g. `test-scripted 3 run/backtrace`:   
+-  `test-scritped <scala-binary-version> <optional-test-filters>` - run specific scripted tests of the sbt plugin. e.g. `test-scripted 3 run/backtrace`:
         -   Scripted tests are used when you need to interact with the
             file system, networking, or the build system that cannot be
             done with a unit test.

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/DiscoverEnvJsonFormats.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/DiscoverEnvJsonFormats.scala
@@ -1,0 +1,43 @@
+package scala.scalanative
+package sbtplugin
+
+import scala.scalanative.build.*
+
+import sjsonnew.BasicJsonProtocol.{StringJsonKeyFormat, mapFormat}
+import sjsonnew.{Builder, JsonFormat, Unbuilder}
+
+object DiscoverEnvJsonFormats {
+  private[sbtplugin] implicit object DiscoverEnvCodec extends JsonFormat[build.Discover.Env] {
+    private val mapValueFormat: JsonFormat[Map[String, Option[String]]] = mapFormat[String, Option[String]]
+
+    override def write[J](obj: Discover.Env, builder: sjsonnew.Builder[J]): Unit = {
+      val mapValue = Map(
+        "SCALANATIVE_GC" -> obj.`SCALANATIVE_GC`,
+        "SCALANATIVE_INCLUDE_DIRS" -> obj.`SCALANATIVE_INCLUDE_DIRS`,
+        "SCALANATIVE_LIB_DIRS" -> obj.`SCALANATIVE_LIB_DIRS`,
+        "SCALANATIVE_LTO" -> obj.`SCALANATIVE_LTO`,
+        "SCALANATIVE_MODE" -> obj.`SCALANATIVE_MODE`,
+        "SCALANATIVE_OPTIMIZE" -> obj.`SCALANATIVE_OPTIMIZE`,
+        "LLVM_BIN" -> obj.`LLVM_BIN`,
+        "PATH" -> obj.`PATH`
+      )
+
+      mapValueFormat.write(mapValue, builder)
+    }
+
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): Discover.Env = {
+      val mapValue = mapValueFormat.read[J](jsOpt, unbuilder)
+
+      Discover.Env(
+        `SCALANATIVE_GC` = mapValue.get("SCALANATIVE_GC").flatten,
+        `SCALANATIVE_INCLUDE_DIRS` = mapValue.get("SCALANATIVE_INCLUDE_DIRS").flatten,
+        `SCALANATIVE_LIB_DIRS` = mapValue.get("SCALANATIVE_LIB_DIRS").flatten,
+        `SCALANATIVE_LTO` = mapValue.get("SCALANATIVE_LTO").flatten,
+        `SCALANATIVE_MODE` = mapValue.get("SCALANATIVE_MODE").flatten,
+        `SCALANATIVE_OPTIMIZE` = mapValue.get("SCALANATIVE_OPTIMIZE").flatten,
+        `LLVM_BIN` = mapValue.get("LLVM_BIN").flatten,
+        `PATH` = mapValue.get("PATH").flatten
+      )
+    }
+  }
+}

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -3,8 +3,8 @@ package sbtplugin
 
 import sbt._
 
-import sjsonnew.{JsonFormat, HashWriter}
-import sjsonnew.BasicJsonProtocol.{mapFormat, given}
+import sjsonnew.BasicJsonProtocol.{given, mapFormat}
+import sjsonnew.{JsonFormat, JsonWriter}
 
 object ScalaNativePlugin extends AutoPlugin {
   override def requires: Plugins = plugins.JvmPlugin
@@ -63,29 +63,8 @@ object ScalaNativePlugin extends AutoPlugin {
     implicit def nativeConfigJsonFormat: JsonFormat[build.NativeConfig] =
       NativeConfigJsonFormats.NativeConfigCodec
 
-    implicit def nativeDiscoverEnvJsonWriter1: HashWriter[build.Discover.Env *: EmptyTuple] = ???
-
-    implicit def nativeDiscoverEnvJsonWriter: HashWriter[build.Discover.Env] =
-      new HashWriter[build.Discover.Env] {
-        override def write[J](obj: build.Discover.Env, builder: sjsonnew.Builder[J]): Unit = {
-          val mapValue = Map(
-            "SCALANATIVE_GC" -> obj.`SCALANATIVE_GC`,
-            "SCALANATIVE_INCLUDE_DIRS" -> obj.`SCALANATIVE_INCLUDE_DIRS`,
-            "SCALANATIVE_LIB_DIRS" -> obj.`SCALANATIVE_LIB_DIRS`,
-            "SCALANATIVE_LTO" -> obj.`SCALANATIVE_LTO`,
-            "SCALANATIVE_MODE" -> obj.`SCALANATIVE_MODE`,
-            "SCALANATIVE_OPTIMIZE" -> obj.`SCALANATIVE_OPTIMIZE`,
-            "LLVM_BIN" -> obj.`LLVM_BIN`
-          )
-
-          mapFormat[String, Option[String]].write(mapValue, builder)
-        }
-
-        override def addField[J](name: String, obj: build.Discover.Env, builder: sjsonnew.Builder[J]): Unit = {
-          builder.addFieldName(name)
-          write(obj, builder)
-        }
-      }
+    implicit def discoverEnvJsonFormat: JsonFormat[build.Discover.Env] =
+      DiscoverEnvJsonFormats.DiscoverEnvCodec
   }
 
   override def globalSettings: Seq[Setting[_]] =

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -3,7 +3,8 @@ package sbtplugin
 
 import sbt._
 
-import sjsonnew.JsonFormat
+import sjsonnew.{JsonFormat, HashWriter}
+import sjsonnew.BasicJsonProtocol.{mapFormat, given}
 
 object ScalaNativePlugin extends AutoPlugin {
   override def requires: Plugins = plugins.JvmPlugin
@@ -36,6 +37,11 @@ object ScalaNativePlugin extends AutoPlugin {
       val Link = Tags.Tag("native-link")
     }
 
+    val nativeDiscoverEnv =
+      settingKey[build.Discover.Env](
+        "System environment used to discover NativeConfig"
+      )
+
     val nativeConfig =
       taskKey[build.NativeConfig](
         "User configuration for the native build, NativeConfig"
@@ -56,6 +62,30 @@ object ScalaNativePlugin extends AutoPlugin {
 
     implicit def nativeConfigJsonFormat: JsonFormat[build.NativeConfig] =
       NativeConfigJsonFormats.NativeConfigCodec
+
+    implicit def nativeDiscoverEnvJsonWriter1: HashWriter[build.Discover.Env *: EmptyTuple] = ???
+
+    implicit def nativeDiscoverEnvJsonWriter: HashWriter[build.Discover.Env] =
+      new HashWriter[build.Discover.Env] {
+        override def write[J](obj: build.Discover.Env, builder: sjsonnew.Builder[J]): Unit = {
+          val mapValue = Map(
+            "SCALANATIVE_GC" -> obj.`SCALANATIVE_GC`,
+            "SCALANATIVE_INCLUDE_DIRS" -> obj.`SCALANATIVE_INCLUDE_DIRS`,
+            "SCALANATIVE_LIB_DIRS" -> obj.`SCALANATIVE_LIB_DIRS`,
+            "SCALANATIVE_LTO" -> obj.`SCALANATIVE_LTO`,
+            "SCALANATIVE_MODE" -> obj.`SCALANATIVE_MODE`,
+            "SCALANATIVE_OPTIMIZE" -> obj.`SCALANATIVE_OPTIMIZE`,
+            "LLVM_BIN" -> obj.`LLVM_BIN`
+          )
+
+          mapFormat[String, Option[String]].write(mapValue, builder)
+        }
+
+        override def addField[J](name: String, obj: build.Discover.Env, builder: sjsonnew.Builder[J]): Unit = {
+          builder.addFieldName(name)
+          write(obj, builder)
+        }
+      }
   }
 
   override def globalSettings: Seq[Setting[_]] =

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -3,7 +3,7 @@ package sbtplugin
 
 import sbt._
 
-import sjsonnew.BasicJsonProtocol.{given, mapFormat}
+import sjsonnew.BasicJsonProtocol.{mapFormat, given}
 import sjsonnew.{JsonFormat, JsonWriter}
 
 object ScalaNativePlugin extends AutoPlugin {

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -121,16 +121,21 @@ object ScalaNativePluginInternal {
       checkJVMVersion(sLog.value)
       onLoad.value
     },
+    nativeDiscoverEnv := {
+      build.Discover.Env.fromSysEnv
+    },
     nativeConfig := {
+      val discover = new Discover(nativeDiscoverEnv.value)
+
       build.NativeConfig.empty
-        .withClang(interceptBuildException(Discover.clang()))
-        .withClangPP(interceptBuildException(Discover.clangpp()))
-        .withCompileOptions(Discover.compileOptions())
-        .withLinkingOptions(Discover.linkingOptions())
-        .withLTO(Discover.LTO())
-        .withGC(Discover.GC())
-        .withMode(Discover.mode())
-        .withOptimize(Discover.optimize())
+        .withClang(interceptBuildException(discover.clang()))
+        .withClangPP(interceptBuildException(discover.clangpp()))
+        .withCompileOptions(discover.compileOptions())
+        .withLinkingOptions(discover.linkingOptions())
+        .withLTO(discover.LTO())
+        .withGC(discover.GC())
+        .withMode(discover.mode())
+        .withOptimize(discover.optimize())
     },
     ThisBuild / nativeConfig := (Global / nativeConfig).value,
     nativeWarnOldJVM := {

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -136,19 +136,21 @@ object Discover {
         `SCALANATIVE_LTO` = getenv("SCALANATIVE_LTO"),
         `SCALANATIVE_MODE` = getenv("SCALANATIVE_MODE"),
         `SCALANATIVE_OPTIMIZE` = getenv("SCALANATIVE_OPTIMIZE"),
-        `LLVM_BIN` = getenv("LLVM_BIN")
+        `LLVM_BIN` = getenv("LLVM_BIN"),
+        `PATH` = getenv("PATH")
       )
     }
   }
 
   case class Env(
-    `SCALANATIVE_GC`: Option[String],
-    `SCALANATIVE_INCLUDE_DIRS`: Option[String],
-    `SCALANATIVE_LIB_DIRS`: Option[String],
-    `SCALANATIVE_LTO`: Option[String],
-    `SCALANATIVE_MODE`: Option[String],
-    `SCALANATIVE_OPTIMIZE`: Option[String],
-    `LLVM_BIN`: Option[String],
+      `SCALANATIVE_GC`: Option[String],
+      `SCALANATIVE_INCLUDE_DIRS`: Option[String],
+      `SCALANATIVE_LIB_DIRS`: Option[String],
+      `SCALANATIVE_LTO`: Option[String],
+      `SCALANATIVE_MODE`: Option[String],
+      `SCALANATIVE_OPTIMIZE`: Option[String],
+      `LLVM_BIN`: Option[String],
+      `PATH`: Option[String]
   )
 
   private case class ClangInfo(

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -14,7 +14,8 @@ import scala.scalanative.build.IO.RichPath
 /** Utilities for discovery of command-line tools and settings required to build
  *  Scala Native applications.
  */
-object Discover {
+class Discover(env: Discover.Env) {
+  import Discover._
 
   /** Compilation mode name from SCALANATIVE_MODE env var or default. */
   def mode(): Mode =
@@ -121,6 +122,34 @@ object Discover {
     val extraLibDirs = if (targetsMac) Nil else llvmLibDirs
     (libDirs ++ extraLibDirs).map(s => s"-L$s")
   }
+}
+
+object Discover {
+  object Env {
+    def fromSysEnv: Env = {
+      def getenv(name: String): Option[String] = Option(System.getenv.get(name))
+
+      Env(
+        `SCALANATIVE_GC` = getenv("SCALANATIVE_GC"),
+        `SCALANATIVE_INCLUDE_DIRS` = getenv("SCALANATIVE_INCLUDE_DIRS"),
+        `SCALANATIVE_LIB_DIRS` = getenv("SCALANATIVE_LIB_DIRS"),
+        `SCALANATIVE_LTO` = getenv("SCALANATIVE_LTO"),
+        `SCALANATIVE_MODE` = getenv("SCALANATIVE_MODE"),
+        `SCALANATIVE_OPTIMIZE` = getenv("SCALANATIVE_OPTIMIZE"),
+        `LLVM_BIN` = getenv("LLVM_BIN")
+      )
+    }
+  }
+
+  case class Env(
+    `SCALANATIVE_GC`: Option[String],
+    `SCALANATIVE_INCLUDE_DIRS`: Option[String],
+    `SCALANATIVE_LIB_DIRS`: Option[String],
+    `SCALANATIVE_LTO`: Option[String],
+    `SCALANATIVE_MODE`: Option[String],
+    `SCALANATIVE_OPTIMIZE`: Option[String],
+    `LLVM_BIN`: Option[String],
+  )
 
   private case class ClangInfo(
       majorVersion: Int,


### PR DESCRIPTION
WIP: Submitting draft here for initial feedback. Fails scripted tests due to the `Discover` interface change.

Issue: Changes to LLVM environment would not be reflected in builds. This was particularly notable in nix based builds where a different path would easily be generated on update of `nixpkgs`. 

H: This is from underbaked caching of `nativeConfig`: Old tool paths would still be used.

Per 

- https://www.scala-sbt.org/2.x/docs/en/reference/cached-task.html#the-effect-of-system-properties

This can be resolved by reflecting the environment variables in a `Setting`. Which is then evaluated every time the build is loaded.

design choices worth highlighting:

0. `Discover` is now a class that requires a `Discover.Env`
1. The environment is reflected as an instance of `Discover.Env`. One parameter per environment variable
2. The `PATH` environment is included. This is only implicitly referenced via `system` executes but accounts for the ever-changing PATH of nix.