### PR TITLE
Make GC's NO_SANITIZE cover UndefinedBehaviorSanitizer

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/shared/GCTypes.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/GCTypes.h
@@ -16,8 +16,16 @@
 #if __has_feature(thread_sanitizer)
 #define NO_SANITIZE_THREAD __attribute__((no_sanitize("thread"))) NOINLINE
 #endif
-#if defined(NO_SANITIZE_ADDRESS) || defined(NO_SANITIZE_THREAD)
-#define NO_SANITIZE __attribute__((disable_sanitizer_instrumentation)) NOINLINE
+#if __has_feature(undefined_behavior_sanitizer)
+// UBSan checks are not covered by disable_sanitizer_instrumentation -
+// suppressing them needs an explicit no_sanitize attribute.
+#define NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined"))) NOINLINE
+#endif
+#if defined(NO_SANITIZE_ADDRESS) || defined(NO_SANITIZE_THREAD) ||             \
+    defined(NO_SANITIZE_UNDEFINED)
+#define NO_SANITIZE                                                            \
+    __attribute__((disable_sanitizer_instrumentation,                          \
+                   no_sanitize("undefined"))) NOINLINE
 #endif
 #endif // has_feature
 
@@ -25,6 +33,9 @@
 #define NO_SANITIZE
 #define NO_SANITIZE_ADDRESS
 #define NO_SANITIZE_THREAD
+#endif
+#ifndef NO_SANITIZE_UNDEFINED
+#define NO_SANITIZE_UNDEFINED
 #endif
 
 #define UNLIKELY(b) __builtin_expect((b), 0)


### PR DESCRIPTION
⚠️  Disclaimer: this is 100% Claude Fable's work, I've submitted it as a draft in hopes it may genuinely be useful to someone, but I admit I don't fully understand what's happening here 😅 


## Problem

`GCTypes.h` intends to exempt the GC's conservative marking code from sanitizer instrumentation via `NO_SANITIZE`, but the exemption doesn't apply to UndefinedBehaviorSanitizer, for two independent reasons:

1. The gate only checks `__has_feature(address_sanitizer)` / `__has_feature(thread_sanitizer)`. UBSan sets neither, so under `-fsanitize=undefined` alone, `NO_SANITIZE` expands to nothing.
2. Even when the gate is active, the attribute it expands to — `disable_sanitizer_instrumentation` — does not suppress UBSan checks (verified empirically with clang 21: a misaligned load in a function carrying that attribute still reports; `no_sanitize("undefined")` suppresses it).

## Consequence

On every target that captures registers via `setjmp` (`CAPTURE_SETJMP` in `RegistersCapture.h` — i.e. everything except x86/x86_64), `Marker_markProgramStack` scans the `jmp_buf` registers buffer with `stride = sizeof(uint32_t)`, deliberately per its own comment ("Pointers in jmp_buf might be non word-size aligned"). Under UBSan this deterministically reports at the first collection:

```
gc/immix/Marker.c:149:24: runtime error: load of misaligned address 0x… for type
  'word_t *' (aka 'unsigned long *'), which requires 8 byte alignment
```

In clang's default recover mode this is diagnostic spam on every GC; under `-fsanitize-trap=undefined` or `-fno-sanitize-recover` it's a hard abort at the first collection, which makes UBSan (including the first-party `NativeConfig.sanitizer = Sanitizer.UndefinedBehaviourSanitizer` option) effectively unusable on AArch64 and other non-x86 targets. x86 CI can't catch this: x86/x86_64 take the hand-rolled `CAPTURE_X86*` capture path (a struct of aligned `void *`s scanned at word stride), so the unaligned loads never happen there.

Commix shares the same header and the same registers-buffer scan, so it's equally affected.

## Reproduction

Any allocation-heavy program on an AArch64 host (e.g. an Apple Silicon Mac), built with `-fsanitize=undefined` in compile and link options — e.g. with scala-cli:

```bash
scala-cli --power package . -o repro -f --native \
  --native-compile -fsanitize=undefined --native-linking -fsanitize=undefined
./repro   # Marker.c:149 alignment reports on every collection
```

A minimal 50-line churn program is enough (recursive frames holding live arrays + garbage allocation in a loop).

## Fix

Detect `__has_feature(undefined_behavior_sanitizer)` alongside ASan/TSan, and add `no_sanitize("undefined")` to the combined `NO_SANITIZE` attribute (keeping `disable_sanitizer_instrumentation` for the instrumentation-based sanitizers).

Verified against Scala Native 0.5.12 by patching the unpacked nativelib sources and rebuilding the repro with `-fsanitize=undefined`: the alignment reports disappear and the program's output is unchanged. An alternative would be to make the scan itself UB-free (e.g. `memcpy`-based reads), but the project already chose exemption over rewriting for ASan/TSan, and conservative stack scanning is inherently outside the C object model — this just completes the existing intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)