### PR TITLE
Implement Post-JDK8 BigInteger sqrt* and rootn* methods

### DIFF
--- a/javalib/src/main/scala/java/math/BigInteger.scala
+++ b/javalib/src/main/scala/java/math/BigInteger.scala
@@ -5,6 +5,10 @@
  * 2025-02-10
  *    - May be possible earlier changes, check Repository history.
  *    - Added Java 9 BigInteger.TWO.
+ *
+ * 2026-07-09
+ *    - Added Java 9 sqrt() and sqrtAndRemainder()
+ *    - Added Java 26 rootn() and rootNAndRemainder()
  */
 
 /*
@@ -1061,5 +1065,129 @@ class BigInteger extends Number with Comparable[BigInteger] {
     this.numberLength = digitIndex
     this.digits = _digits
     this.cutOffLeadingZeroes()
+  }
+
+  // Scala Native additions -----------------------------------------------
+
+  /** @since 9
+   */
+  def sqrt(): BigInteger =
+    this.rootnAndRemainder(2)(0)
+
+  /** @since 9
+   */
+  def sqrtAndRemainder(): Array[BigInteger] =
+    this.rootnAndRemainder(2)
+
+  /** @since 26
+   */
+  def rootn(n: scala.Int): BigInteger =
+    this.rootnAndRemainder(n)(0)
+
+  /** @since 26
+   */
+  def rootnAndRemainder(n: scala.Int): Array[BigInteger] = {
+    val radicand = this
+    val degree = n
+
+    def firstGuess(): BigInteger = {
+      /* A heuristic to possibly save iterations.
+       * One could spend professional lifetimes determining
+       * better heuristics.
+       *
+       * The classical choice of guess is the signum of the radicand.
+       * Because of code above, that will always be 1.0 here. Values
+       * less than 1.0 lead to poor behavior. This huristic will use 1.0
+       * for small radicands, say 5, even to high degree, say 99.
+       * It will then shift to larger values as the magnitude of the
+       * radicand increases, as one would expect the true root to increase.
+       *
+       * Assumes/requires a positive radicand.
+       */
+
+      val shiftCount = ((radicand.bitLength() + degree - 1) / degree)
+      BigInteger.ONE.max(BigInteger.ONE.shiftLeft(shiftCount))
+    }
+
+    // pass known & invariant degree values to avoid runtime expense in loop
+    @inline def nextGuess(
+        guess: BigInteger,
+        nextGuessDegreeInt: scala.Int,
+        nextGuessDegreeBI: BigInteger,
+        degreeBI: BigInteger
+    ): BigInteger = {
+      val term_1 = guess.multiply(nextGuessDegreeBI)
+      val term_2 = radicand.divide(guess.pow(nextGuessDegreeInt))
+
+      val inner = term_1.add(term_2)
+      inner.divide(degreeBI)
+    }
+
+    val penultimateDegree = degree - 1
+    val penultimateDegreeBI = new BigInteger(penultimateDegree.toString)
+
+    @inline def testDone(guess: BigInteger): Boolean = {
+      // if remainder is < 0, then guess is too large.
+
+      /* This implementation is, I believe, mathematically correct.
+       * Unfortunately its use of "pow(degree)" is somewhat expensive,
+       * especially at scale.
+       *
+       * When/if benchmarks show this to be rate-limiting, this termination
+       * condition can be re-visited.
+       *
+       * Obvious alternatives for ending the loop add complexity.
+       */
+      val nextGreater = guess.add(BigInteger.ONE)
+      nextGreater.pow(degree).compareTo(radicand) == 1
+    }
+
+    if (degree <= 0)
+      throw new ArithmeticException("Non-positive root degree")
+
+    val results = Array[BigInteger](BigInteger.ZERO, BigInteger.ZERO)
+
+    if (radicand.compareTo(BigInteger.ZERO) < 0) {
+      if ((degree & 0x1) == 0) // isEven
+        throw new ArithmeticException("Negative BigInteger")
+      else {
+        /* Simplify the initial guess and other calculations by ensuring
+         * a positive radicand. Results are symmetrical.
+         */
+        val reflected = radicand.negate().rootnAndRemainder(degree)
+
+        results(0) = reflected(0).negate()
+        results(1) = reflected(1).negate()
+      }
+    } else if (radicand.compareTo(BigInteger.ZERO) == 0) results
+    else if (degree == 1) results(0) = radicand // min degree known to be > 0
+    else { // strictly positive radicand with degree >= 2
+      val degreeBI = new BigInteger(degree.toString)
+
+      var guess = firstGuess()
+      var remainder = BigInteger.ZERO
+
+      var done = false
+
+      while (!done) {
+        val guessToPenultimateDegree = guess.pow(penultimateDegree)
+        val guessToDegree = guess.multiply(guessToPenultimateDegree)
+
+        remainder = radicand.subtract(guessToDegree)
+        val cmpZero = remainder.compareTo(BigInteger.ZERO)
+
+        if (cmpZero == 0) done = true
+        else if ((cmpZero == 1) && testDone(guess)) done = true
+        else { // continue iterating
+          guess =
+            nextGuess(guess, penultimateDegree, penultimateDegreeBI, degreeBI)
+        }
+      }
+
+      results(0) = guess
+      results(1) = remainder
+    }
+
+    results
   }
 }

--- a/unit-tests/shared/src/test/require-jdk26/org/scalanative/testsuite/javalib/math/BigIntegerTestOnJDK26.scala
+++ b/unit-tests/shared/src/test/require-jdk26/org/scalanative/testsuite/javalib/math/BigIntegerTestOnJDK26.scala
@@ -1,0 +1,282 @@
+package org.scalanative.testsuite.javalib.math
+
+import java.math._
+import java.{lang => jl, util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class BigIntegerTestOnJDK26 {
+
+  @Test def rootn_Exceptions(): Unit = {
+    locally {
+      val bi = BigInteger.TWO
+
+      ju.List.of(0, -1).forEach { n =>
+        assertThrows(
+          s"n: $n <= 0",
+          classOf[ArithmeticException],
+          bi.rootn(n)
+        )
+      }
+    }
+
+    locally {
+      val bi = new BigInteger("-2")
+      val n = 4
+
+      assertThrows(
+        s"n: $n is even, this ${bi.longValue()} is negative",
+        classOf[ArithmeticException],
+        bi.rootn(n)
+      )
+    }
+  }
+
+  @Test def rootnThisGeZero(): Unit = {
+    locally {
+      val expectedRoot = 5L
+      val power = 7
+      val testValue = jl.Math.powExact(expectedRoot, power)
+
+      val bi = new BigInteger(testValue.toString)
+
+      val foundRoot = bi.rootn(power).longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+
+    locally {
+      val expectedRoot = 0L
+      val power = 7
+      val testValue = expectedRoot // 0 to 7th known to be 0
+
+      val bi = new BigInteger(testValue.toString)
+
+      val foundRoot = bi.rootn(power).longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+  }
+
+  @Test def rootnThisLtZero(): Unit = {
+
+    // Exact power, expected remainder 0.
+    locally {
+      val origin = -3L
+      val power = 5
+      val expectedRoot = origin
+
+      val testValue = jl.Math.powExact(expectedRoot, power)
+
+      val bi = new BigInteger(testValue.toString)
+
+      val foundRoot = bi.rootn(power).longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+
+    // Less absolute magnitude than an exact power.
+    locally {
+      val origin = -3L
+      val offset = 1
+      val power = 3
+      val expectedRoot = -2
+
+      val testValue = jl.Math.powExact(origin, power) + offset
+
+      val bi = new BigInteger(testValue.toString)
+
+      val foundRoot = bi.rootn(power).longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+
+    // Greater absolute magnitude than an exact power.
+    locally {
+      val origin = -3L
+      val offset = -2
+      val power = 3
+      val expectedRoot = origin
+
+      val testValue = jl.Math.powExact(origin, power) + offset
+
+      val bi = new BigInteger(testValue.toString)
+
+      val foundRoot = bi.rootn(power).longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+  }
+
+  /* Someday convert this to use a data table then test many values, not
+   * just one. Then again, two test points are better than zero.
+   */
+  @Test def rootnBigIntegerMagnitudeGreaterThanLong(): Unit = {
+    locally {
+      val expectedRoot = 4294967295L
+      val power = 2
+
+      // Exceed capacity of a Long to exercise large BI math.
+      val testValue = jl.Long.MAX_VALUE.toString
+      val bi = (new BigInteger(testValue)).multiply(BigInteger.TWO)
+
+      val foundRoot = bi.rootn(power).longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+
+    locally {
+      val expectedRoot = -4518177L
+      val power = 3
+
+      // Exceed capacity of a Long to exercise large BI math.
+      val testValue = jl.Long.MIN_VALUE.toString
+      val bi = (new BigInteger(testValue)).multiply(BigInteger.TEN)
+
+      val foundRoot = bi.rootn(power).longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+  }
+
+  @Test def rootnAndRemainder_Exceptions()(): Unit = {
+    locally {
+      val bi = BigInteger.TEN
+
+      ju.List.of(0, -2).forEach { n =>
+        assertThrows(
+          s"n: $n <= 0",
+          classOf[ArithmeticException],
+          bi.rootnAndRemainder(n)
+        )
+      }
+    }
+
+    locally {
+      val bi = new BigInteger("-4")
+      val n = 2
+
+      assertThrows(
+        s"n: $n is even, this ${bi.longValue()} is negative",
+        classOf[ArithmeticException],
+        bi.rootnAndRemainder(n)
+      )
+    }
+  }
+
+  @Test def rootnAndRemainderThisGeZero(): Unit = {
+    locally {
+      val expectedRoot = 5L
+      val expectedRemainder = 0L
+      val power = 7
+      val testValue = jl.Math.powExact(expectedRoot, power)
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.rootnAndRemainder(power)
+
+      assertEquals(expectedRoot, result(0).longValue)
+      assertEquals(expectedRemainder, result(1).longValue)
+    }
+
+    locally {
+      val expectedRoot = 7L
+      val expectedRemainder = 3L
+      val power = 4
+      val testValue = jl.Math.powExact(expectedRoot, power) + expectedRemainder
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.rootnAndRemainder(power)
+
+      assertEquals(expectedRoot, result(0).longValue)
+      assertEquals(expectedRemainder, result(1).longValue)
+    }
+
+    locally {
+      val expectedRoot = 7L
+      val expectedRemainder = 0L
+      val power = 1
+      val testValue = jl.Math.powExact(expectedRoot, power)
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.rootnAndRemainder(power)
+
+      assertEquals(expectedRoot, result(0).longValue)
+      assertEquals(expectedRemainder, result(1).longValue)
+    }
+
+    locally {
+      val expectedRoot = 0L
+      val expectedRemainder = 0L
+      val power = 7
+      val testValue = expectedRoot // 0 to 7th known to be 0
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.rootnAndRemainder(power)
+
+      assertEquals(expectedRoot, result(0).longValue)
+      assertEquals(expectedRemainder, result(1).longValue)
+    }
+  }
+
+  @Test def rootnAndRemainderThisLtZero(): Unit = {
+    // Exact power, expected remainder 0.
+    locally {
+      val origin = -3L
+      val expectedRoot = origin
+      val expectedRemainder = 0L
+      val power = 5
+
+      val testValue = jl.Math.powExact(expectedRoot, power)
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.rootnAndRemainder(power)
+
+      assertEquals(expectedRoot, result(0).longValue)
+      assertEquals(expectedRemainder, result(1).longValue)
+    }
+
+    // Less absolute magnitude than an exact power.
+    locally {
+      val origin = -3L
+      val expectedRoot = -2
+      val expectedRemainder = -18L
+      val offset = 1L
+      val power = 3
+
+      val testValue = jl.Math.powExact(origin, power) + offset
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.rootnAndRemainder(power)
+
+      assertEquals(expectedRoot, result(0).longValue)
+      assertEquals(expectedRemainder, result(1).longValue)
+    }
+
+    // Greater absolute magnitude than an exact power.
+    locally {
+      val origin = -3L
+      val expectedRoot = origin
+      val expectedRemainder = -3L
+      val offset = expectedRemainder
+      val power = 3
+
+      val testValue = jl.Math.powExact(origin, power) + offset
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.rootnAndRemainder(power)
+
+      assertEquals(expectedRoot, result(0).longValue)
+      assertEquals(expectedRemainder, result(1).longValue)
+    }
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/math/BigIntegerTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/math/BigIntegerTestOnJDK9.scala
@@ -106,7 +106,9 @@ class BigIntegerTestOnJDK9 {
       val expectedRoot = 7L
       val expectedRemainder = 1L
       val power = 2
-      val testValue = jl.Math.powExact(expectedRoot, power) + expectedRemainder
+      val testValue =
+        jl.Math.pow(expectedRoot.toDouble, power.toDouble).toLong +
+          expectedRemainder
 
       val bi = new BigInteger(testValue.toString)
 

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/math/BigIntegerTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/math/BigIntegerTestOnJDK9.scala
@@ -2,6 +2,7 @@ package org.scalanative.testsuite.javalib.math
 
 import java.math._
 import java.util.Arrays
+import java.{lang => jl}
 
 import org.junit.Assert._
 import org.junit.Test
@@ -38,4 +39,94 @@ class BigIntegerTestOnJDK9 {
     assertTrue(Arrays.equals(Arrays.copyOfRange(eBytes, 3, 7), exp.toByteArray))
   }
 
+// sqrt
+
+  @Test def sqrt_Exceptions(): Unit = {
+    val bi = new BigInteger("-2")
+
+    assertThrows(
+      classOf[ArithmeticException],
+      bi.sqrt()
+    )
+  }
+
+  @Test def sqrtGeZero(): Unit = {
+    locally {
+      val expectedRoot = 5L
+      val power = 2
+      val testValue = jl.Math.powExact(expectedRoot, power)
+
+      val bi = new BigInteger(testValue.toString)
+
+      val foundRoot = bi.sqrt().longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+
+    locally {
+      val expectedRoot = 0
+      val testValue = expectedRoot // // 0^2 known to be 0
+
+      val bi = new BigInteger(testValue.toString)
+
+      val foundRoot = bi.sqrt().longValue
+
+      assertEquals(expectedRoot, foundRoot)
+    }
+  }
+
+// sqrtAndRemainder
+
+  @Test def sqrtAndRemainder_Exceptions()(): Unit = {
+
+    val bi = new BigInteger("-1")
+
+    assertThrows(
+      classOf[ArithmeticException],
+      bi.sqrtAndRemainder()
+    )
+  }
+
+  @Test def sqrtAndRemainderGeZero(): Unit = {
+    locally {
+      val expectedRoot = 5L
+      val expectedRemainder = 0L
+      val power = 2
+      val testValue = jl.Math.powExact(expectedRoot, power)
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.sqrtAndRemainder()
+
+      assertEquals("a1_1", expectedRoot, result(0).longValue)
+      assertEquals("a1_2", expectedRemainder, result(1).longValue)
+    }
+
+    locally {
+      val expectedRoot = 7L
+      val expectedRemainder = 1L
+      val power = 2
+      val testValue = jl.Math.powExact(expectedRoot, power) + expectedRemainder
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.sqrtAndRemainder()
+
+      assertEquals("a2_1", expectedRoot, result(0).longValue)
+      assertEquals("a2_2", expectedRemainder, result(1).longValue)
+    }
+
+    locally {
+      val expectedRoot = 0L
+      val expectedRemainder = 0L
+      val testValue = expectedRoot // 0^2 known to be 0
+
+      val bi = new BigInteger(testValue.toString)
+
+      val result = bi.sqrtAndRemainder()
+
+      assertEquals("a4_1", expectedRoot, result(0).longValue)
+      assertEquals("a4_2", expectedRemainder, result(1).longValue)
+    }
+  }
 }

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/math/BigIntegerTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/math/BigIntegerTestOnJDK9.scala
@@ -54,7 +54,7 @@ class BigIntegerTestOnJDK9 {
     locally {
       val expectedRoot = 5L
       val power = 2
-      val testValue = jl.Math.powExact(expectedRoot, power)
+      val testValue = jl.Math.pow(expectedRoot.toDouble, power.toDouble).toLong
 
       val bi = new BigInteger(testValue.toString)
 
@@ -92,7 +92,7 @@ class BigIntegerTestOnJDK9 {
       val expectedRoot = 5L
       val expectedRemainder = 0L
       val power = 2
-      val testValue = jl.Math.powExact(expectedRoot, power)
+      val testValue = jl.Math.pow(expectedRoot.toDouble, power.toDouble).toLong
 
       val bi = new BigInteger(testValue.toString)
 


### PR DESCRIPTION
Implement javalib `java.math.BigInteger` methods and associated tests

- introduced in JDK 9 `sqrt()` and `sqrtAndRemainder()`

- introduced in JDK 26 `rootn()` and `rootnAndRemainder()`

Note: 

* The three other root finding methods call into `rootnAndRemainder()`.
  That method uses a variant of the Newton-Raphson algorithm specialized
  for finding the roots of `y = x^n`.  

* The implemented loop termination method is believed to be mathematically
   correct but is somewhat expensive at runtime.  If experience and or benchmarks
   show that method is a problem, it can be revisited by a specialist in the optimization
   of  numerical methods.  

   Reasonable performance, for  non-industrial scale uses, correctness 
   and ease of development & maintenance are the goals of this generation
   of the code.