### PR TITLE
Fix #4980: Add JDK 18 and 25 jl.Math methods

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -1,5 +1,7 @@
 package java.lang
 
+import java.{lang => jl}
+
 import scalanative.annotation.alwaysinline
 import scalanative.libc.{math => cmath}
 import scalanative.runtime.LLVMIntrinsics._
@@ -71,6 +73,84 @@ object Math {
   @alwaysinline def ceil(a: scala.Double): scala.Double =
     `llvm.ceil.f64`(a)
 
+  /** @since JDK 18 */
+  def ceilDiv(dividend: scala.Int, divisor: scala.Int): scala.Int = {
+    if ((dividend == jl.Integer.MIN_VALUE) && (divisor == -1))
+      jl.Integer.MIN_VALUE
+    else
+      ceilDiv(dividend.toLong, divisor.toLong).toInt
+  }
+
+  /** @since JDK 18 */
+  def ceilDiv(dividend: scala.Long, divisor: scala.Int): scala.Long =
+    ceilDiv(dividend, divisor.toLong)
+
+  /** @since JDK 18 */
+  def ceilDiv(dividend: scala.Long, divisor: scala.Long): scala.Long = {
+    if (divisor == 0L)
+      throw new ArithmeticException("/ by zero")
+
+    if ((dividend == jl.Long.MIN_VALUE) && (divisor == -1L)) {
+      jl.Long.MIN_VALUE
+    } else {
+      val quotient = dividend / divisor
+      var result = quotient
+
+      if (quotient > 0) {
+        if (Math.abs(dividend) != Math.abs(divisor))
+          result += 1
+      } else if (quotient == 0) {
+        val shiftCount = jl.Long.SIZE - 1
+        val signsMatch =
+          (dividend >>> shiftCount) == (divisor >>> shiftCount)
+
+        if (signsMatch && (dividend != 0))
+          result += 1
+      }
+      // else < 0, result is the same as Integer truncating division: '/'.
+
+      result
+    }
+  }
+
+  /** @since JDK 25 */
+  def ceilDivExact(dividend: scala.Int, divisor: scala.Int): scala.Int = {
+    if ((dividend == jl.Integer.MIN_VALUE) && (divisor == -1))
+      throw new ArithmeticException("integer overflow")
+
+    ceilDiv(dividend, divisor)
+  }
+
+  /** @since JDK 25 */
+  def ceilDivExact(dividend: scala.Long, divisor: scala.Long): scala.Long = {
+    if (divisor == 0L)
+      throw new ArithmeticException("/ by zero")
+
+    if ((dividend == jl.Long.MIN_VALUE) && (divisor == -1))
+      throw new ArithmeticException("integer overflow")
+
+    ceilDiv(dividend, divisor)
+  }
+
+  /** @since JDK 18 */
+  def ceilMod(dividend: scala.Int, divisor: scala.Int): scala.Int =
+    ceilMod(dividend.toLong, divisor.toLong).toInt
+
+  /** @since JDK 18 */
+  def ceilMod(dividend: scala.Long, divisor: scala.Int): scala.Int = {
+    // Note Well: the return type differs from corresponding ceilDiv(long, int)
+    ceilMod(dividend, divisor.toLong).toInt
+  }
+
+  /** @since JDK 18 */
+  def ceilMod(dividend: scala.Long, divisor: scala.Long): scala.Long = {
+    if (divisor == 0L)
+      throw new ArithmeticException("/ by zero")
+
+    dividend - (ceilDiv(dividend, divisor) * divisor)
+  }
+
+  /** @since JDK 21 */
   def clamp(
       value: scala.Double,
       min: scala.Double,
@@ -90,6 +170,7 @@ object Math {
     Math.min(Math.max(value, min), max)
   }
 
+  /** @since JDK 21 */
   def clamp(
       value: scala.Float,
       min: scala.Float,
@@ -109,6 +190,7 @@ object Math {
     Math.min(Math.max(value, min), max)
   }
 
+  /** @since JDK 21 */
   def clamp(
       value: scala.Long,
       min: scala.Int,
@@ -118,11 +200,12 @@ object Math {
       throw new IllegalArgumentException(s"${min} > ${max}")
 
     /* The toInt call is safe. 'min' and 'max' arguments are Ints, so computed
-     * result is known to be in range [Integer.MIN_Value, Integer.MAX_VALUE].
+     * result is known to be in range [Integer.MIN_VALUE, Integer.MAX_VALUE].
      */
     Math.min(Math.max(value, min), max).toInt
   }
 
+  /** @since JDK 21 */
   def clamp(
       value: scala.Long,
       min: scala.Long,
@@ -154,6 +237,28 @@ object Math {
   @alwaysinline def decrementExact(a: scala.Long): scala.Long =
     subtractExact(a, 1L)
 
+  /** @since JDK 25 */
+  def divideExact(dividend: scala.Int, divisor: scala.Int): scala.Int = {
+    if (divisor == 0L)
+      throw new ArithmeticException("/ by zero")
+
+    if ((dividend == jl.Integer.MIN_VALUE) && (divisor == -1))
+      throw new ArithmeticException("integer overflow")
+
+    dividend / divisor
+  }
+
+  /** @since JDK 25 */
+  def divideExact(dividend: scala.Long, divisor: scala.Long): scala.Long = {
+    if (divisor == 0L)
+      throw new ArithmeticException("/ by zero")
+
+    if ((dividend == jl.Long.MIN_VALUE) && (divisor == -1))
+      throw new ArithmeticException("integer overflow")
+
+    dividend / divisor
+  }
+
   @alwaysinline def exp(a: scala.Double): scala.Double =
     `llvm.exp.f64`(a)
 
@@ -177,6 +282,25 @@ object Math {
 
   @alwaysinline def floorDiv(a: scala.Long, b: scala.Int): scala.Long =
     floorDiv(a, b.toLong)
+
+  /** @since JDK 25 */
+  def floorDivExact(dividend: scala.Int, divisor: scala.Int): scala.Int = {
+    if ((dividend == jl.Integer.MIN_VALUE) && (divisor == -1))
+      throw new ArithmeticException("integer overflow")
+
+    floorDiv(dividend, divisor)
+  }
+
+  /** @since JDK 25 */
+  def floorDivExact(dividend: scala.Long, divisor: scala.Long): scala.Long = {
+    if (divisor == 0L)
+      throw new ArithmeticException("/ by zero")
+
+    if ((dividend == jl.Long.MIN_VALUE) && (divisor == -1))
+      throw new ArithmeticException("integer overflow")
+
+    floorDiv(dividend, divisor)
+  }
 
   @inline def floorMod(a: scala.Int, b: scala.Int): scala.Int = {
     val rem = a % b

--- a/unit-tests/shared/src/test/require-jdk18/org/scalanative/testsuite/javalib/lang/MathTestOnJDK18.scala
+++ b/unit-tests/shared/src/test/require-jdk18/org/scalanative/testsuite/javalib/lang/MathTestOnJDK18.scala
@@ -1,4 +1,5 @@
 /* Ported from Scala.js commit: 7569c24 dated: 2025-05-20
+ * Post JDK 8 methods added for Scala Native.
  *
  * For reasons internal to Scala.js practice, the Scala.js file was
  * named MathTestOnJDK21.
@@ -12,9 +13,12 @@ package org.scalanative.testsuite.javalib.lang
 
 import java.math.BigInteger
 import java.util.SplittableRandom
+import java.{lang => jl}
 
 import org.junit.Assert._
 import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 
 class MathTestOnJDK18 {
 
@@ -53,4 +57,181 @@ class MathTestOnJDK18 {
     }
   }
 
+  // ceilDiv
+
+  case class CeilTestCase(
+      dividend: scala.Long,
+      divisor: scala.Long,
+      expected: scala.Long
+  )
+
+  val ceilDivTestCases = Array(
+    // from JVM 26 ceilDiv(i, i) example, ordered as in example
+    CeilTestCase(-4L, 3L, -1L),
+    CeilTestCase(4L, 3L, 2L),
+
+    // Scala Native
+    CeilTestCase(4L, 4L, 1L),
+    CeilTestCase(4L, -4L, -1L),
+    CeilTestCase(-4L, 4L, -1L),
+    CeilTestCase(-4L, -4L, 1L),
+    // Zero
+    CeilTestCase(0L, 4L, 0L),
+    CeilTestCase(0L, -4L, 0L),
+    // check floating point quotient in (-1.0, 1.0) is rounded correctly.
+    CeilTestCase(1L, 4L, 1L),
+    CeilTestCase(1L, -4L, 0L),
+    CeilTestCase(-1L, 4L, 0L),
+    CeilTestCase(-1L, -4L, 1L)
+  )
+
+  @Test def ceilDiv_Exceptions(): Unit = {
+    assertThrows(
+      "ceilDiv(Int, Int)",
+      classOf[ArithmeticException],
+      Math.ceilDiv(4, 0)
+    )
+
+    assertThrows(
+      "ceilDiv(Long, Int)",
+      classOf[ArithmeticException],
+      Math.ceilDiv(4L, 0)
+    )
+
+    assertThrows(
+      "ceilDiv(Long, Long)",
+      classOf[ArithmeticException],
+      Math.ceilDiv(4L, 0L)
+    )
+  }
+
+  @Test def ceilDiv_SpecialCases(): Unit = {
+    assertEquals(
+      "ceilDiv(Int, Int)",
+      jl.Integer.MIN_VALUE,
+      Math.ceilDiv(jl.Integer.MIN_VALUE, -1)
+    )
+
+    assertEquals(
+      "ceilDiv(Long, Int)",
+      jl.Long.MIN_VALUE,
+      Math.ceilDiv(jl.Long.MIN_VALUE, -1)
+    )
+
+    assertEquals(
+      "ceilDiv(Long, Long)",
+      jl.Long.MIN_VALUE,
+      Math.ceilDiv(jl.Long.MIN_VALUE, -1L)
+    )
+  }
+
+  @Test def ceilDiv_IntInt(): Unit = {
+    for (j <- 0 until ceilDivTestCases.length) {
+      val tc = ceilDivTestCases(j)
+      assertEquals(
+        s" ceilDivII(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.ceilDiv(tc.dividend.toInt, tc.divisor.toInt)
+      )
+    }
+  }
+
+  @Test def ceilDiv_LongInt(): Unit = {
+    for (j <- 0 until ceilDivTestCases.length) {
+      val tc = ceilDivTestCases(j)
+      assertEquals(
+        s" ceilDivLI(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.ceilDiv(tc.dividend, tc.divisor.toInt)
+      )
+    }
+  }
+
+  @Test def ceilDiv_LongLong(): Unit = {
+    for (j <- 0 until ceilDivTestCases.length) {
+      val tc = ceilDivTestCases(j)
+      assertEquals(
+        s" ceilDivLL(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.ceilDiv(tc.dividend, tc.divisor)
+      )
+    }
+  }
+
+  // ceilMod
+
+  val ceilModTestCases = Array(
+    // from JVM 26 ceilMod(i, i) example, ordered as in example
+    CeilTestCase(+4L, +3L, -2L),
+    CeilTestCase(-4L, -3L, +2L),
+    CeilTestCase(+4L, -3L, +1L),
+    CeilTestCase(-4L, +3L, -1L),
+
+    // Scala Native
+    CeilTestCase(4L, 4L, 0L),
+    CeilTestCase(4L, -4L, 0L),
+    CeilTestCase(-4L, 4L, 0L),
+    CeilTestCase(-4L, -4L, 0L),
+    // Zero
+    CeilTestCase(0L, 4L, 0L),
+    CeilTestCase(0L, -4L, 0L),
+    // check floating point quotient in (-1.0, 1.0) is rounded correctly.
+    CeilTestCase(1L, 4L, -3L),
+    CeilTestCase(1L, -4L, 1L),
+    CeilTestCase(-1L, 4L, -1L),
+    CeilTestCase(-1L, -4L, 3L)
+  )
+
+  @Test def ceilMod_Exceptions(): Unit = {
+    assertThrows(
+      "ceilMod(Int, Int)",
+      classOf[ArithmeticException],
+      Math.ceilMod(4, 0)
+    )
+
+    assertThrows(
+      "ceilMod(Long, Int)",
+      classOf[ArithmeticException],
+      Math.ceilMod(4L, 0)
+    )
+
+    assertThrows(
+      "ceilMod(Long, Long)",
+      classOf[ArithmeticException],
+      Math.ceilMod(4L, 0L)
+    )
+  }
+
+  @Test def ceilMod_IntInt(): Unit = {
+    for (j <- 0 until ceilModTestCases.length) {
+      val tc = ceilModTestCases(j)
+      assertEquals(
+        s" ceilModLI(${tc.dividend}, ${tc.divisor})",
+        tc.expected.toInt,
+        Math.ceilMod(tc.dividend.toInt, tc.divisor.toInt)
+      )
+    }
+  }
+
+  @Test def ceilMod_LongInt(): Unit = {
+    for (j <- 0 until ceilModTestCases.length) {
+      val tc = ceilModTestCases(j)
+      assertEquals(
+        s" ceilModLI(${tc.dividend}, ${tc.divisor})",
+        tc.expected.toInt,
+        Math.ceilMod(tc.dividend, tc.divisor.toInt)
+      )
+    }
+  }
+
+  @Test def ceilMod_LongLong(): Unit = {
+    for (j <- 0 until ceilModTestCases.length) {
+      val tc = ceilModTestCases(j)
+      assertEquals(
+        s" ceilModLL(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.ceilMod(tc.dividend, tc.divisor)
+      )
+    }
+  }
 }

--- a/unit-tests/shared/src/test/require-jdk25/org/scalanative/testsuite/javalib/lang/MathTestOnJDK25.scala
+++ b/unit-tests/shared/src/test/require-jdk25/org/scalanative/testsuite/javalib/lang/MathTestOnJDK25.scala
@@ -1,6 +1,7 @@
 package org.scalanative.testsuite.javalib.lang
 
 import java.lang._
+import java.{lang => jl}
 
 import org.junit.Assert._
 import org.junit.Test
@@ -287,6 +288,242 @@ class MathTestOnJDK25 {
         case e: ArithmeticException =>
           fail(s"ArithmeticException unsignedPowExact(${tc.x}, ${tc.y})")
       }
+    }
+  }
+
+  // ceilDivExact
+
+  case class ExactMathTestPoint(
+      dividend: scala.Long,
+      divisor: scala.Long,
+      expected: scala.Long
+  )
+
+  /* Much of the ceilDivExact testing is same or close to
+   * corresponding ceilDiv tests in MthTestOnJDK18.
+   * That is the point, the results should be the same except for
+   * the (MIN_VALUE, -1) case. The test code almost-duplication is unfortunate.
+   */
+
+  val ceilDivExactTestPoints = Array(
+    // from JVM 26 ceilDiv(i, i) example, ordered as in example
+    ExactMathTestPoint(-4L, 3L, -1L),
+    ExactMathTestPoint(4L, 3L, 2L),
+
+    // Scala Native
+    ExactMathTestPoint(4L, 4L, 1L),
+    ExactMathTestPoint(4L, -4L, -1L),
+    ExactMathTestPoint(-4L, 4L, -1L),
+    ExactMathTestPoint(-4L, -4L, 1L),
+    // Zero
+    ExactMathTestPoint(0L, 4L, 0L),
+    ExactMathTestPoint(0L, -4L, 0L),
+    // check floating point quotient in (-1.0, 1.0) is rounded correctly.
+    ExactMathTestPoint(1L, 4L, 1L),
+    ExactMathTestPoint(1L, -4L, 0L),
+    ExactMathTestPoint(-1L, 4L, 0L),
+    ExactMathTestPoint(-1L, -4L, 1L)
+  )
+
+  @Test def ceilDivExact_Exceptions(): Unit = {
+    locally {
+      assertThrows(
+        "ceilDivExact(Int, Int)",
+        classOf[ArithmeticException],
+        Math.ceilDivExact(4, 0)
+      )
+
+      assertThrows(
+        "ceilDivExact(Int, Int)",
+        classOf[ArithmeticException],
+        Math.ceilDivExact(jl.Integer.MIN_VALUE, -1)
+      )
+    }
+
+    locally {
+      assertThrows(
+        "ceilDivExact(Long, Long)",
+        classOf[ArithmeticException],
+        Math.ceilDivExact(4L, 0L)
+      )
+
+      assertThrows(
+        "ceilDivExact(Long, Long)",
+        classOf[ArithmeticException],
+        Math.ceilDivExact(jl.Long.MIN_VALUE, -1L)
+      )
+    }
+  }
+
+  @Test def ceilDivExact_IntInt(): Unit = {
+    for (j <- 0 until ceilDivExactTestPoints.length) {
+      val tc = ceilDivExactTestPoints(j)
+      assertEquals(
+        s"ceilDiExactII(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.ceilDivExact(tc.dividend.toInt, tc.divisor.toInt)
+      )
+    }
+  }
+
+  @Test def ceilDivExact_LongLong(): Unit = {
+    for (j <- 0 until ceilDivExactTestPoints.length) {
+      val tc = ceilDivExactTestPoints(j)
+      assertEquals(
+        s" ceilDivExactLL(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.ceilDivExact(tc.dividend, tc.divisor)
+      )
+    }
+  }
+
+  // divideExact
+
+  @Test def divideExact_Exceptions(): Unit = {
+    locally {
+      assertThrows(
+        "divideExact(Int, Int)",
+        classOf[ArithmeticException],
+        Math.divideExact(4, 0)
+      )
+
+      assertThrows(
+        "divideExact(Int, Int)",
+        classOf[ArithmeticException],
+        Math.divideExact(jl.Integer.MIN_VALUE, -1)
+      )
+    }
+
+    locally {
+      assertThrows(
+        "divideExact(Long, Long)",
+        classOf[ArithmeticException],
+        Math.divideExact(4L, 0L)
+      )
+
+      assertThrows(
+        "divideExact(Long, Long)",
+        classOf[ArithmeticException],
+        Math.divideExact(jl.Long.MIN_VALUE, -1L)
+      )
+    }
+  }
+
+  val divideExactTestPoints = Array(
+    // standard Java/Scala integer division.
+    // rounds towards zero, a.k.a truncation.
+    ExactMathTestPoint(-4L, 3L, -1L),
+    ExactMathTestPoint(4L, 3L, 1L),
+
+    // Scala Native
+    ExactMathTestPoint(4L, 4L, 1L),
+    ExactMathTestPoint(4L, -4L, -1L),
+    ExactMathTestPoint(-4L, 4L, -1L),
+    ExactMathTestPoint(-4L, -4L, 1L),
+    // Zero
+    ExactMathTestPoint(0L, 4L, 0L),
+    ExactMathTestPoint(0L, -4L, 0L),
+    // check floating point quotient in (-1.0, 1.0) is rounded correctly.
+    ExactMathTestPoint(1L, 4L, 0L),
+    ExactMathTestPoint(1L, -4L, 0L),
+    ExactMathTestPoint(-1L, 4L, 0L),
+    ExactMathTestPoint(-1L, -4L, 0L)
+  )
+
+  @Test def divideExact_IntInt(): Unit = {
+    for (j <- 0 until floorDivExactTestPoints.length) {
+      val tc = divideExactTestPoints(j)
+      assertEquals(
+        s" divideExactII(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.divideExact(tc.dividend.toInt, tc.divisor.toInt)
+      )
+    }
+  }
+
+  @Test def divideExact_LongLong(): Unit = {
+    for (j <- 0 until floorDivExactTestPoints.length) {
+      val tc = divideExactTestPoints(j)
+      assertEquals(
+        s" divideExactLL(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.divideExact(tc.dividend, tc.divisor)
+      )
+    }
+  }
+
+  // floorDivExact
+
+  val floorDivExactTestPoints = Array(
+    // from JVM 26 floorDiv(i, i) example, ordered as in example.
+    // rounds towards NEGATIVE_INFINITY.
+    ExactMathTestPoint(-4L, 3L, -2L),
+    ExactMathTestPoint(4L, 3L, 1L),
+
+    // Scala Native
+    ExactMathTestPoint(4L, 4L, 1L),
+    ExactMathTestPoint(4L, -4L, -1L),
+    ExactMathTestPoint(-4L, 4L, -1L),
+    ExactMathTestPoint(-4L, -4L, 1L),
+    // Zero
+    ExactMathTestPoint(0L, 4L, 0L),
+    ExactMathTestPoint(0L, -4L, 0L),
+    // check floating point quotient in (-1.0, 1.0) is rounded correctly.
+    ExactMathTestPoint(1L, 4L, 0L),
+    ExactMathTestPoint(1L, -4L, -1L),
+    ExactMathTestPoint(-1L, 4L, -1L),
+    ExactMathTestPoint(-1L, -4L, 0L)
+  )
+
+  @Test def floorDivExact_Exceptions(): Unit = {
+    locally {
+      assertThrows(
+        "floorDivExact(Int, Int)",
+        classOf[ArithmeticException],
+        Math.floorDivExact(4, 0)
+      )
+
+      assertThrows(
+        "floorDivExact(Int, Int)",
+        classOf[ArithmeticException],
+        Math.floorDivExact(jl.Integer.MIN_VALUE, -1)
+      )
+    }
+
+    locally {
+      assertThrows(
+        "floorDivExact(Long, Long)",
+        classOf[ArithmeticException],
+        Math.floorDivExact(4L, 0L)
+      )
+
+      assertThrows(
+        "floorDivExact(Long, Long)",
+        classOf[ArithmeticException],
+        Math.floorDivExact(jl.Long.MIN_VALUE, -1L)
+      )
+    }
+  }
+
+  @Test def floorDivExact_IntInt(): Unit = {
+    for (j <- 0 until floorDivExactTestPoints.length) {
+      val tc = floorDivExactTestPoints(j)
+      assertEquals(
+        s" floorDivExactII(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.floorDivExact(tc.dividend.toInt, tc.divisor.toInt)
+      )
+    }
+  }
+
+  @Test def floorDivExact_LongLong(): Unit = {
+    for (j <- 0 until floorDivExactTestPoints.length) {
+      val tc = floorDivExactTestPoints(j)
+      assertEquals(
+        s" floorDivExactLL(${tc.dividend}, ${tc.divisor})",
+        tc.expected,
+        Math.floorDivExact(tc.dividend, tc.divisor)
+      )
     }
   }
 }


### PR DESCRIPTION
Fix #4980

Implement javalib `java.lang.Math` methods introduced in JDK 18 and 25 and their associated tests.

In some cases an extra call or two or variable test is spent in order to use common code paths.
