### PR TITLE
Fix typo in SubmissionPublisherTest  which warns in a CI case

### DIFF
--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/SubmissionPublisherTest.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/SubmissionPublisherTest.scala
@@ -285,7 +285,7 @@ class SubmissionPublisherTest extends JSR166Test {
     s.awaitComplete()
     assertEquals(0, s.nexts)
     assertEquals(0, s.errors)
-    assertEquals(1, s.completes, 1)
+    assertEquals(1, s.completes)
   }
 
   /** If closedExceptionally, upon subscription, the subscriber's onError method


### PR DESCRIPTION
2026-07-11

On further study, turns out this is a warning rather than a build breaker. This warning  & its JUnitTest
buddy were near the scene of the crime but apparently not guilty.

Still any warning fixed & silenced is a good warning.

As discovered in PR #4988 

```
Today, the [Compile sources with the Scala 3 version used for publishing artifacts case
seems to be failing because of two compilation errors. The one in SubmissionPublisherTest seems
fair enough. Correction in a future PR is probably assertEquals(1, s.completes) because
s.completes is a scala.Int and not floating point.

-- Deprecation Warning: /home/runner/work/scala-native/scala-native/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/SubmissionPublisherTest.scala:288:20 
[warn] 288 |    assertEquals(1, s.completes, 1)
[warn]     |                    ^
[warn]     |method int2float in object Int
 is deprecated since 2.13.1: Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.
[warn] -- Deprecation Warning: /home/runner/work/scala-native/scala-native/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/util/concurrent/SubmissionPublisherTest.scala:288:20 
[warn] 288 |    assertEquals(1, s.completes, 1)

``` 

