### PR TITLE
[runtime] Populate module-init context before the publishing CAS

### DIFF
--- a/nativelib/src/main/resources/scala-native/module_load.c
+++ b/nativelib/src/main/resources/scala-native/module_load.c
@@ -82,11 +82,17 @@ __scalanative_waitForModuleInitialization(ModuleSlot slot, void *classInfo) {
 NOINLINE static ModuleRef __scalanative_startAndWaitForModuleInitialization(
     ModuleSlot slot, void *classInfo, size_t size, ModuleCtor ctor) {
     InitializationContext ctx = {};
+    // Populate the context before publishing &ctx into the slot. The winning
+    // atomic_compare_exchange_strong is a release operation, so any thread that
+    // later acquire-loads the slot and observes &ctx also observes the fully
+    // written fields. Writing initThreadId and instance after the publish (the
+    // previous ordering) left a window in which another thread could read them
+    // before they were set, a data race on those fields.
+    ctx.initThreadId = getThreadId();
+    ModuleRef instance = scalanative_GC_alloc(classInfo, size);
+    ctx.instance = instance;
     void **expected = NULL;
     if (atomic_compare_exchange_strong(slot, &expected, (void **)&ctx)) {
-        ModuleRef instance = scalanative_GC_alloc(classInfo, size);
-        ctx.initThreadId = getThreadId();
-        ctx.instance = instance;
         return scalanative_initializeModule(ctor, instance, slot, classInfo);
     } else {
         return __scalanative_waitForModuleInitialization(slot, classInfo);

--- a/scripted-tests/run/module-init-race/build.sbt
+++ b/scripted-tests/run/module-init-race/build.sbt
@@ -1,0 +1,123 @@
+import java.util.concurrent.TimeUnit
+
+enablePlugins(ScalaNativePlugin)
+
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  else scalaVersion
+}
+
+// The race lives on the multithreaded module-init path, so build the code path
+// under test explicitly rather than relying on auto-detection.
+nativeConfig ~= { _.withMultithreading(true) }
+
+/** sbt 1 returns the link output as a [[java.io.File]]; sbt 2 returns a virtual
+ *  file ref that an [[xsbti.FileConverter]] resolves to a path.
+ */
+def nativeExecutable(
+    linkOutput: Any
+)(implicit conv: xsbti.FileConverter): java.io.File =
+  linkOutput match {
+    case f: java.io.File           => f
+    case ref: xsbti.VirtualFileRef => conv.toPath(ref).toFile()
+  }
+
+/** Run the linked binary once, capturing its combined output, and return the
+ *  exit code together with that output.
+ */
+def runBinary(
+    binary: java.io.File,
+    env: Map[String, String],
+    timeoutSeconds: Int
+): (Int, String) = {
+  val pb = new ProcessBuilder(binary.getAbsolutePath)
+  env.foreach { case (k, v) => pb.environment().put(k, v) }
+  pb.redirectErrorStream(true)
+  val log = java.io.File.createTempFile("module-init-race-", ".log")
+  pb.redirectOutput(log)
+  val proc = pb.start()
+  val finished = proc.waitFor(timeoutSeconds.toLong, TimeUnit.SECONDS)
+  if (!finished) {
+    proc.destroyForcibly()
+    throw new RuntimeException(
+      s"binary did not finish within $timeoutSeconds seconds"
+    )
+  }
+  val output =
+    new String(java.nio.file.Files.readAllBytes(log.toPath))
+  log.delete()
+  (proc.exitValue(), output)
+}
+
+/** Plain phase: pin the observable contract and act as a crash canary. Each run
+ *  is a fresh process, hence a fresh concurrent first-touch of every module.
+ */
+lazy val stress = taskKey[Unit]("Run the module-init race stress test")
+stress := {
+  implicit val conv: xsbti.FileConverter = Keys.fileConverter.value
+  val binary = nativeExecutable((Compile / nativeLink).value)
+  val runs = 3
+  (1 to runs).foreach { n =>
+    val (code, output) = runBinary(binary, Map.empty, timeoutSeconds = 120)
+    print(output)
+    if (code != 0)
+      throw new RuntimeException(
+        s"module-init-race stress run $n of $runs exited with code $code"
+      )
+  }
+  println(s"module-init-race: $runs plain runs passed")
+}
+
+/** ThreadSanitizer phase: the actual race detector. Runs only when the config
+ *  carries a sanitizer (set from the `test` script on non-Windows platforms;
+ *  ThreadSanitizer is unavailable on Windows).
+ *
+ *  TSAN_OPTIONS uses exitcode=0 so unrelated sanitizer reports (for example in
+ *  GC internals) do not fail the run, and halt_on_error=0 so the program runs
+ *  to completion and every report is captured. The assertion is then targeted:
+ *  it fails only when a report implicates the module-initialization code under
+ *  test, and when the process itself crashed. Maintainers who prefer the
+ *  stricter exitcode=66 default can pair it with a GC-scoped suppressions file.
+ */
+lazy val stressSanitized =
+  taskKey[Unit]("Run the stress test under ThreadSanitizer")
+stressSanitized := {
+  (Compile / nativeConfig).value.sanitizer match {
+    case None =>
+      println(
+        "module-init-race: ThreadSanitizer phase skipped " +
+          "(no sanitizer configured on this platform)"
+      )
+    case Some(_) =>
+      implicit val conv: xsbti.FileConverter = Keys.fileConverter.value
+      val binary = nativeExecutable((Compile / nativeLink).value)
+      val env = Map("TSAN_OPTIONS" -> "halt_on_error=0 exitcode=0")
+      val (code, output) = runBinary(binary, env, timeoutSeconds = 300)
+      print(output)
+      val moduleFrames = Seq(
+        "module_load",
+        "loadModule",
+        "startAndWaitForModuleInitialization",
+        "waitForModuleInitialization",
+        "awaitForInitialization"
+      )
+      val reportedModuleRace =
+        output.contains("ThreadSanitizer: data race") &&
+          moduleFrames.exists(output.contains)
+      if (reportedModuleRace)
+        throw new RuntimeException(
+          "ThreadSanitizer reported a data race in module initialization; " +
+            "the publish-ordering fix in module_load.c has regressed"
+        )
+      if (code != 0)
+        throw new RuntimeException(
+          s"sanitized run exited abnormally with code $code"
+        )
+      println("module-init-race: ThreadSanitizer phase clean")
+  }
+}

--- a/scripted-tests/run/module-init-race/project/scala-native.sbt
+++ b/scripted-tests/run/module-init-race/project/scala-native.sbt
@@ -1,0 +1,9 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  else addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
+}

--- a/scripted-tests/run/module-init-race/src/main/scala/Test.scala
+++ b/scripted-tests/run/module-init-race/src/main/scala/Test.scala
@@ -1,0 +1,206 @@
+import java.util.concurrent.atomic.AtomicIntegerArray
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+// Regression guard for the module-init publish-ordering data race in
+// nativelib/src/main/resources/scala-native/module_load.c.
+//
+// __scalanative_startAndWaitForModuleInitialization must write the
+// InitializationContext fields (initThreadId, instance) BEFORE publishing &ctx
+// into the shared module slot with the release compare-and-swap. If they are
+// written after the publish, a thread that concurrently first-touches the same
+// module can acquire-load the published &ctx and read those fields before they
+// are set: a C11 data race, visible to ThreadSanitizer.
+//
+// The plain runs pin the observable contract (every thread that first-touches a
+// module gets the one shared instance with correct field values, and each
+// constructor runs exactly once) and act as a crash canary under heavy
+// concurrent first-touch. The ThreadSanitizer phase (see build.sbt) is the
+// actual race detector: with the fields written before the publish it reports
+// no module-init race; with the previous ordering it does.
+
+object Config {
+  final val K = 32 // distinct modules, each first-touched under contention
+  final val T = 8 // threads racing on each module's first touch
+  final val MarkerBase = 0x5ca1ab1eL
+}
+
+// Records how many times each module constructor ran. Initialized from main
+// before any worker starts, so touching a module under test never triggers this
+// holder's own initialization inside the raced window.
+object Counters {
+  private val ctorRuns = new AtomicIntegerArray(Config.K)
+  def bump(index: Int): Unit = { ctorRuns.incrementAndGet(index); () }
+  def runs(index: Int): Int = ctorRuns.get(index)
+}
+
+// Base of the modules under test. Each object below is a distinct module, so it
+// exercises a distinct module-init slot; they share this constructor but not
+// their initialization. `marker` is read back by every racing thread and
+// `Counters.bump` records the single construction.
+abstract class Mod(index: Int) {
+  Counters.bump(index)
+  val marker: Long = Config.MarkerBase + index
+}
+
+object M00 extends Mod(0)
+object M01 extends Mod(1)
+object M02 extends Mod(2)
+object M03 extends Mod(3)
+object M04 extends Mod(4)
+object M05 extends Mod(5)
+object M06 extends Mod(6)
+object M07 extends Mod(7)
+object M08 extends Mod(8)
+object M09 extends Mod(9)
+object M10 extends Mod(10)
+object M11 extends Mod(11)
+object M12 extends Mod(12)
+object M13 extends Mod(13)
+object M14 extends Mod(14)
+object M15 extends Mod(15)
+object M16 extends Mod(16)
+object M17 extends Mod(17)
+object M18 extends Mod(18)
+object M19 extends Mod(19)
+object M20 extends Mod(20)
+object M21 extends Mod(21)
+object M22 extends Mod(22)
+object M23 extends Mod(23)
+object M24 extends Mod(24)
+object M25 extends Mod(25)
+object M26 extends Mod(26)
+object M27 extends Mod(27)
+object M28 extends Mod(28)
+object M29 extends Mod(29)
+object M30 extends Mod(30)
+object M31 extends Mod(31)
+
+object Test {
+  // Deferred first-touch thunks: referencing Mxx here rather than eagerly is
+  // what makes each module's initialization happen on a worker thread once the
+  // latch opens, instead of serially from main.
+  private val modules: Array[() => Mod] = Array(
+    () => M00,
+    () => M01,
+    () => M02,
+    () => M03,
+    () => M04,
+    () => M05,
+    () => M06,
+    () => M07,
+    () => M08,
+    () => M09,
+    () => M10,
+    () => M11,
+    () => M12,
+    () => M13,
+    () => M14,
+    () => M15,
+    () => M16,
+    () => M17,
+    () => M18,
+    () => M19,
+    () => M20,
+    () => M21,
+    () => M22,
+    () => M23,
+    () => M24,
+    () => M25,
+    () => M26,
+    () => M27,
+    () => M28,
+    () => M29,
+    () => M30,
+    () => M31
+  )
+
+  private def check(cond: Boolean, message: => String): Unit =
+    if (!cond) throw new AssertionError(message)
+
+  private final class Worker(
+      moduleIndex: Int,
+      slot: Int,
+      latch: CountDownLatch,
+      instances: Array[AnyRef],
+      markers: Array[Long]
+  ) extends Thread {
+    @volatile var failure: Throwable = null
+    override def run(): Unit =
+      try {
+        latch.await()
+        val module = modules(moduleIndex)()
+        instances(slot) = module
+        markers(slot) = module.marker
+      } catch {
+        case t: Throwable => failure = t
+      }
+  }
+
+  def main(args: Array[String]): Unit = {
+    val k = Config.K
+    val t = Config.T
+
+    // Force the support holders to initialize before any worker starts.
+    Counters.runs(0)
+
+    val latch = new CountDownLatch(1)
+    val instances = new Array[AnyRef](k * t)
+    val markers = new Array[Long](k * t)
+    val workers = new Array[Worker](k * t)
+
+    var i = 0
+    while (i < k) {
+      var j = 0
+      while (j < t) {
+        val slot = i * t + j
+        val worker = new Worker(i, slot, latch, instances, markers)
+        workers(slot) = worker
+        worker.start()
+        j += 1
+      }
+      i += 1
+    }
+
+    // Release every worker at once to maximize concurrent first-touch.
+    latch.countDown()
+
+    var w = 0
+    while (w < workers.length) {
+      workers(w).join(TimeUnit.SECONDS.toMillis(60))
+      check(!workers(w).isAlive(), s"worker $w did not finish in time")
+      if (workers(w).failure != null) throw workers(w).failure
+      w += 1
+    }
+
+    i = 0
+    while (i < k) {
+      val expectedMarker = Config.MarkerBase + i
+      val first = instances(i * t)
+      check(first != null, s"module $i produced a null instance")
+      var j = 0
+      while (j < t) {
+        val slot = i * t + j
+        check(
+          instances(slot) eq first,
+          s"module $i: worker $j observed a different instance"
+        )
+        check(
+          markers(slot) == expectedMarker,
+          s"module $i: worker $j observed marker ${markers(slot)}, " +
+            s"expected $expectedMarker"
+        )
+        j += 1
+      }
+      check(
+        Counters.runs(i) == 1,
+        s"module $i constructor ran ${Counters.runs(i)} times, expected 1"
+      )
+      i += 1
+    }
+
+    println(
+      s"module-init-race: OK ($k modules x $t threads, one shared instance " +
+        "with correct marker and a single construction each)"
+    )
+  }
+}

--- a/scripted-tests/run/module-init-race/test
+++ b/scripted-tests/run/module-init-race/test
@@ -1,0 +1,6 @@
+# Phase 1: pin the module-init contract and run as a crash canary.
+> stress
+
+# Phase 2: enable ThreadSanitizer (skipped on Windows) and detect the race.
+> set nativeConfig ~= { c => if (scala.util.Properties.isWin) c else c.withSanitizer(scala.scalanative.build.Sanitizer.ThreadSanitizer) }
+> stressSanitized


### PR DESCRIPTION
## Problem

`__scalanative_startAndWaitForModuleInitialization` (nativelib/src/main/resources/scala-native/module_load.c) publishes the address of a stack-local `InitializationContext` into the shared module slot with a compare-and-swap, then writes that context's `initThreadId` and `instance` fields afterward, with a GC allocation sitting in between. A thread that concurrently first-touches the same module acquire-loads the slot, observes the published `&ctx`, and can read those fields before the winner has written them.

The winning CAS is a release operation, but it is sequenced before the field writes, so it establishes no happens-before that covers them: the reader's plain load of the published context races the winner's writes. This is a C11 data race, undefined behavior, and is reported by ThreadSanitizer under concurrent module first-touch in a downstream multithreaded application. The ordering is present unchanged on main and in every released 0.5.x. PR #4279 restructured module init to propagate failed-initialization exceptions to Scala; it left this publish ordering untouched.

## Solution

Write `initThreadId` and `instance` (running the GC allocation that produces it) before the CAS publishes `&ctx`, so all of it is sequenced before the release operation. Any thread that acquire-loads the slot and observes `&ctx` now also observes a fully written context.

A contender that loses the CAS has already allocated an instance that becomes unreachable and is collected as ordinary garbage. The allocation only stamps rtti and never runs the module constructor, so the loser path adds no re-entrancy and no leak.

## Notes

Adds scripted-tests/run/module-init-race, which first-touches many modules from latch-gated threads and asserts each yields one shared instance with the expected field value and a single constructor run. Plain runs pin that contract and act as a crash canary; the ThreadSanitizer phase (skipped on Windows) is the actual regression detector, since the raced values a reader can observe otherwise route to the safe wait path and converge. It reports the race on the previous ordering and is clean on this one.

The fix is a plain reorder of three lines with no change in synchronization primitives or contract: same-thread reentrant init, the CAS itself, and the constructor-runs-once-per-module guarantee are all unchanged.