### PR TITLE
Fix #4994: Port Scala.js jl.Double MIN_VALUE & MAX_VALUE declarations

### DIFF
--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -174,10 +174,10 @@ final class Double(val _value: scala.Double)
 object Double {
   final val BYTES = 8
   final val MAX_EXPONENT = 1023
-  final val MAX_VALUE = 1.79769313486231570e+308
+  final val MAX_VALUE = scala.Double.MaxValue
   final val MIN_EXPONENT = -1022
   final val MIN_NORMAL = 2.2250738585072014e-308
-  final val MIN_VALUE = 5e-324
+  final val MIN_VALUE = scala.Double.MinPositiveValue
   final val NaN = 0.0 / 0.0
   final val NEGATIVE_INFINITY = 1.0 / -0.0
   final val POSITIVE_INFINITY = 1.0 / 0.0


### PR DESCRIPTION
Ensure that javalib `java.lang.Double#MIN_VALUE` uses correct value (bit pattern) and
make it easier to visually confirm both `MIN_VALUE` and `MAX_VALUE`.

Java, and Scala.js, use a  `MIN_VALUE` of `4.9E-324`. 

Previously Scala Native used `5E-324`. This was one ulp (unit of least precision) off.
