### PR TITLE
Add 3 JDK 27 jl.Math hyperbolic arc* methods

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -46,6 +46,10 @@ object Math {
   @alwaysinline def acos(a: scala.Double): scala.Double =
     cmath.acos(a)
 
+  /** @since JDK 27 */
+  @alwaysinline def acosh(a: scala.Double): scala.Double =
+    cmath.acosh(a)
+
   @inline def addExact(a: scala.Int, b: scala.Int): scala.Int = {
     val overflow = `llvm.sadd.with.overflow.i32`(a, b)
     if (overflow.flag) throw new ArithmeticException("Integer overflow")
@@ -61,11 +65,19 @@ object Math {
   @alwaysinline def asin(a: scala.Double): scala.Double =
     cmath.asin(a)
 
+  /** @since JDK 27 */
+  @alwaysinline def asinh(a: scala.Double): scala.Double =
+    cmath.asinh(a)
+
   @alwaysinline def atan(a: scala.Double): scala.Double =
     cmath.atan(a)
 
   @alwaysinline def atan2(y: scala.Double, x: scala.Double): scala.Double =
     cmath.atan2(y, x)
+
+  /** @since JDK 27 */
+  @alwaysinline def atanh(a: scala.Double): scala.Double =
+    cmath.atanh(a)
 
   @alwaysinline def cbrt(a: scala.Double): scala.Double =
     cmath.cbrt(a)


### PR DESCRIPTION
Implement javalib `java.lang.Math` `acosh`, `asinh`, and `atanh` introduced in JDK 27.

This follows on from merged PR #4987 and completes the methods mentioned in 
Issue #4980.

Early work on this PR helped identify the ancient minimal LLVM version used by
Scala Native build. See Issue #5001. 

Pass-through  methods in `java.lang.Math` historically have not had SN unit-tests. The methods in this PR can
not easily be tested before JDK 27 is released in mid-September.