### PR TITLE
Implement JDK 26  jm.BigDecimal#sqrt

### DIFF
--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -34,6 +34,9 @@
  * 2026-07-01 10:13 -0400
  *    - Ported Scala.js commit 0d6509a, dated 2026-06-28.
  *      That fixes Scala.js Issue #5381, also identical SN Issue #4967
+ *
+ * 2026-07-26
+ *    - Added Java 9 BigDecimal.sqrt(mc)
  */
 
 /* 2025-01-27
@@ -72,7 +75,8 @@
 package java.math
 
 import java.lang.{Double => JDouble, Long => JLong}
-import java.util.Arrays
+import java.math._
+import java.util.{Arrays, Objects}
 import java.{lang => jl}
 
 import scala.annotation.tailrec
@@ -1862,5 +1866,341 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     _bitLength = unscaledVal.bitLength()
     if (_bitLength < 64)
       _smallValue = unscaledVal.longValue()
+  }
+
+  // Scala Native additions -----------------------------------------------
+
+  /* Math facts to aid understanding this sqrt() implementation:
+   *
+   *   * By definition, all irrational numbers have an infinitely
+   *     repeating fraction. JDK sqrt() will throw.
+   *
+   *   * all rational numbers which are not perfect squares have
+   *     an infinitely repeating fraction. JDK sqrt() will throw.
+   *
+   *   * all rational numbers which are perfect squares have a
+   *     fractional part which eventually terminates.
+   */
+
+  /* See additional developer notes below in the
+   * 'def sqrt(mc: MathContext): BigDecimal' implementation.
+   */
+
+  final val sqrt_NotExactMessage = "Computed square root not exact."
+
+  // Always use JDK 26+ practice. See 'JDK-8370057' note below.
+  @inline private def sqrt_preferredScale(bd: BigDecimal): Int =
+    Math.ceil(bd.scale() / 2.0).toInt
+
+  private def sqrt_PrecisionZero(
+      radicand: BigDecimal
+  ): BigDecimal = {
+    /* Preconditions:
+     *   -- mc.precision == 0
+     *
+     *   -- known ZERO and negative radicands have been filtered out,
+     *      leaving only strictly positive candidates, possibly with
+     *      trailing zeros.
+     */
+
+    val radicandNTZ = radicand.stripTrailingZeros()
+    val unsv = radicandNTZ.unscaledValue()
+
+    val rootnResults = unsv.rootnAndRemainder(2) // 2 yields Integer sqrt
+    val root = rootnResults(0)
+    val remainder = rootnResults(1)
+
+    if (remainder.compareTo(BigInteger.ZERO) != 0)
+      throw new ArithmeticException(sqrt_NotExactMessage)
+
+    // Careful, scale manipulation is sensitive to small changes.
+    (new BigDecimal(root, sqrt_preferredScale(radicandNTZ)))
+      .setScale(sqrt_preferredScale(radicand))
+  }
+
+  private def sqrt_PrecisionPositive_NO_Rounding(
+      radicand: BigDecimal,
+      mc: MathContext
+  ): BigDecimal = {
+    /* Preconditions:
+     *   * mc.getRoundingMode() is RoundingMode.UNNECESSARY.
+     *
+     *   * radicand is a prefect square.
+     */
+
+    // root returned will be perfect square with proper preferredScale.
+    val root = sqrt_PrecisionZero(radicand)
+
+    if (root.scale() <= 0) { // no decimal point, no worries
+      root
+    } else if (root.precision() <= mc.getPrecision()) {
+      root // can fit as-is into required precision.
+    } else {
+      /* There are probably more elegant and less runtime costly
+       * ways of checking if a version of the root where trailing
+       * zeros after the minimal scale 1 can fit into the mc precision.
+       *
+       * For now, let BigDecimal do the heavy lifting and avoid
+       * implementing messy, one time, near-but-not-exactly duplicating'
+       * code. Chicken or wise?
+       */
+
+      try {
+        /* Yes, the method name says NO_Rounding.
+         * The mc argument MathContext is known at this point to
+         * have RoundingMode.UNNECESSARY.
+         *
+         * Rounding using that MathContext will succeed and return the
+         * desired result if the root without trailing zeros will fit the
+         * indicated position. Otherwise, it will throw an Exception.
+         *
+         * A "Big Hammer", but gets the job done.
+         */
+
+        root.round(mc)
+      } catch {
+        /* Examining the text of the message for "Rounding necessary"
+         * is fragile, to say the least. That text is defined in
+         * this file. That makes it under the control of Scala Native
+         * developers and not subject to external change or localization.
+         *
+         * Unfortunately, prior art defines that text in several places
+         * in the file.
+         *
+         * Worst that can happen if the message text ever does change
+         * and this usage does not is that the original exception will
+         * get propagated. Someone up the call chain will eventually
+         * discover the change, usually just before shipping product.
+         *
+         * Examining the message text is a lesser risk than assuming that
+         * assuming _any_ Arithmetic exception is because the root is not
+         * exact.
+         */
+        case exc: ArithmeticException =>
+          val rethrowExc =
+            if (exc.getMessage().equals("Rounding necessary"))
+              new ArithmeticException(sqrt_NotExactMessage)
+            else exc
+
+          throw rethrowExc
+      }
+    }
+  }
+
+  private def sqrt_firstGuess(radicand: BigDecimal): BigDecimal = {
+    // Precondition - radicand is strictly positive, but perhaps < 1.0
+
+    /* Implement the Hyperbolic_estimate algorithm for gaining an
+     * initial estimation for iterative square root methods.
+     *
+     * Wikipedia:
+     *  https://en.wikipedia.org/wiki/Square_root_algorithms#Initial_estimate
+     *  https://en.wikipedia.org/wiki/Square_root_algorithms#Hyperbolic_estimate
+     */
+
+    /* Hyperbolic_estimate description uses modified scientific notation for
+     * the radicand: a * 10^2n.
+     */
+
+    val rawExponent = radicand.precision() - radicand.scale() - 1
+
+    val evenExponent =
+      if ((rawExponent & 1) == 0) rawExponent // is even now
+      else if (rawExponent > 0) rawExponent - 1
+      else rawExponent + 1
+
+    val rootSignificand = radicand.movePointLeft(evenExponent) // extract 'a'
+    val rootExponent = evenExponent / 2 // extract 'n'
+
+    // Avoid an allocation, use an existing static MathContext.
+    val mc = MathContext.DECIMAL32
+
+    val divisor = rootSignificand.add(new BigDecimal("20"))
+
+    val adjustment = new BigDecimal("190").divide(divisor, mc)
+
+    /* (10 - 190/(a + 20)) * 10^n
+     *  No need to round, low digits are below accuracy of estimate anyway.
+     */
+    BigDecimal.TEN
+      .subtract(adjustment)
+      .scaleByPowerOfTen(rootExponent)
+  }
+
+  private def sqrt_adjustFractionalScale(
+      bd: BigDecimal,
+      minimalScale: scala.Int,
+      mc: MathContext
+  ): BigDecimal = {
+    /* Preconditions:
+     *   * bd.scale() > 0. That is, bd has fractional part.
+     *   * mc.getRoundingMode() != RoundingMode.UNNECESSARY
+     *   * bd has been rounded to mc.scale().
+     *   * minimalScale is at least 1.
+     */
+
+    val bdNTZ = bd.stripTrailingZeros()
+    val bdNTZscale = bdNTZ.scale()
+
+    if (bdNTZscale >= minimalScale) bdNTZ
+    else bdNTZ.setScale(minimalScale, mc.getRoundingMode())
+  }
+
+  private def sqrt_PrecisionPositive_Yes_Rounding(
+      radicand: BigDecimal,
+      mc: MathContext
+  ): BigDecimal = {
+    /* Preconditions:
+     *   * mc.precision > 0; recall that precision can never be < 0.
+     *
+     *   * RoundingMode is _never_ RoundingMode.UNNECESSARY. Guard digit
+     *     handling depends upon this precondition.
+     */
+
+    /* Implement the Heron or Babylonian method. That is a simplification for
+     * square roots of the more general Newton-Raphson method and
+     * avoids explicit calculus.
+     *
+     * This is the Wikipedia example modified on two ways. See
+     * the just-in-time comments at the usage sites.
+     *
+     *   - fewer guard digits are used to save BigMath cycles.
+     *
+     *   - The loop stopping condition has been changed from using an
+     *     epsilon to direct equality.
+     */
+
+    /* Choosing the number of extra digits to use as guard digits
+     * is a playground for people who enjoy and are skilled in
+     * numerical analysis.
+     *
+     * Conventionally, one is absolute minimum, more are usually recommended.
+     * Here the an arbitrary number is chosen which appears to be large
+     * enough to suffice but which is small enough to avoid doing
+     * expensive BigMath on digits which will be discarded and
+     * add successively less useful discrimination.
+     *
+     * A subject expert may perhaps someday make the choice sliding depending
+     * on number of digits in mc.precison.
+     */
+
+    val nGuardDigits = 4
+
+    val guardMC =
+      new MathContext(mc.getPrecision() + nGuardDigits, mc.getRoundingMode())
+
+    var guess = sqrt_firstGuess(radicand)
+
+    var done = false
+
+    while (!done) {
+      val adjustment = radicand.divide(guess, guardMC)
+
+      val nextGuess = guess.add(adjustment).divide(BigDecimal.TWO, guardMC)
+
+      /* Given the precondition that radicand is known to be a perfect square,
+       * math says that the algorithm will eventually converge.
+       * Rounding to the guard digits should keep the number of iterations
+       * bounded to a number derived from the precision in the MathContext
+       * by the caller of sqrt(mc).
+       *
+       * The Wikipedia article used IEEE 754 floating point math and
+       * compared the difference to a very small value, calculated
+       * from the radicand.
+       *
+       * This code does the nextGuess math out to the guardMC precision
+       * and rounds the difference math to the mc argument precision.
+       * This allows a test for exact match; equality to exactly zero.
+       */
+
+      if ((guess.subtract(nextGuess, mc).compareTo(BigDecimal.ZERO) == 0)) {
+        // break loop but use nextGuess for its possible extra digits
+        done = true
+      }
+
+      guess = nextGuess
+    }
+
+    val candidate = guess.round(mc) // utilize & discard guard digits
+
+    if (candidate.scale() <= 0) candidate
+    else {
+      /* Preferred or minimal scale, but subject to increase as number of
+       * non-zero trailing digits demands.
+       */
+      sqrt_adjustFractionalScale(candidate, sqrt_preferredScale(radicand), mc)
+    }
+  }
+
+  /** @since 9 */
+  def sqrt(mc: MathContext): BigDecimal = {
+    /* Principal (positive) square root is returned or an Exception thrown.
+     *
+     * Note well:
+     *   This implementation follows Java JDK26 practices in all cases.
+     *
+     *     - Java 25 introduced a check for a null MathContext argument.
+     *
+     *     - Java 26 changed the description and implementation of
+     *       "preferred scale" to "ceil(radicand.scale()/2.0)". URL:
+     * https://www.oracle.com/java/technologies/javase/26-relnote-issues.html
+     *         Section: Correct Scale Handling of BigDecimal.sqrt (JDK-8370057)     *
+     *       Previously it had been "radicandScale / 2", using integer
+     *       truncating division, equivalent to "floor()". They differ
+     *       by one when the scale is positive and odd.
+     */
+
+    /* This is a first implementation, with plenty of room for improvement
+     * as demand and resources allow.
+     *
+     *   - An obvious improvement is to handle radicands in the range of
+     *     [Double.MIN_NORMAL, Double.MAX_VALUE] by calling the operating
+     *     system library sqrt() function. See the _smallValue code above.
+     *     Have to leave something for our betters who come after us.
+     *
+     *     For this first implementation, doing the math directly exercises
+     *     the paths that are also used for values where only BigDecimal will
+     *     suffice.  This increases confidence that such values will be handled
+     *     correctly.
+     *
+     *   - One could count and micro-optimize the number of BigDecimal math
+     *     operations utilized. Each one probably leads to an object creation.
+     *
+     *   - One can apply some properties of perfect squares, such as
+     *     only having certain digits, and some manipulations by
+     *     powers of 5 to determine if a value is a prefect square or
+     *     not.  That might save some BigInteger math, with its attendant
+     *     allocation costs.
+     *
+     *  - As always, proper benchmarking is always in order.
+     */
+
+    // JDK 26+ throws, but earlier version do not.
+    val nullMcMsg =
+      """Cannot read field "roundingMode" because "mc" is null"""
+    Objects.requireNonNull(mc, nullMcMsg)
+
+    val radicand = this
+
+    val cmp = radicand.compareTo(BigDecimal.ZERO)
+
+    if (cmp == 0) {
+      BigDecimal.ZERO
+    } else if (cmp < 0) {
+      throw new ArithmeticException(
+        "Attempted square root of negative BigDecimal"
+      )
+    } else {
+      /* Each decision in the tree either handles the case or has established
+       * that a precondition for subsequent steps holds.
+       */
+
+      if (mc.getPrecision() == 0)
+        sqrt_PrecisionZero(radicand)
+      else if (mc.getRoundingMode() == RoundingMode.UNNECESSARY)
+        sqrt_PrecisionPositive_NO_Rounding(radicand, mc)
+      else
+        sqrt_PrecisionPositive_Yes_Rounding(radicand, mc)
+    }
   }
 }

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/math/BigDecimalTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/math/BigDecimalTestOnJDK9.scala
@@ -1,0 +1,855 @@
+package org.scalanative.testsuite.javalib.math
+
+import java.math.{BigDecimal, MathContext, RoundingMode}
+import java.util.Arrays
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform
+
+class BigDecimalTestOnJDK9 {
+
+// sqrt
+
+  private def fixupExpectedByJdkVersion(
+      expectedOnJdkGe26: String
+  ): BigDecimal = {
+    val fixedUp =
+      if (Platform.executingInScalaNative ||
+          Platform.executingInJVMWithJDKIn(26 to Integer.MAX_VALUE)) {
+        expectedOnJdkGe26
+      } else {
+        // assume expectedOnJdkExpected26 is not null or empty.
+        val s1 = expectedOnJdkGe26.substring(0, expectedOnJdkGe26.length - 1)
+        if (s1.endsWith(".")) s1.substring(0, expectedOnJdkGe26.length - 1)
+        else s1
+      }
+
+    new BigDecimal(fixedUp)
+  }
+
+//  final case class SqrtTestCase(
+  case class SqrtTestCase(
+      radicand: BigDecimal,
+      expected: BigDecimal
+  )
+
+  final val sqrtTestCases_Mctx32 = Array(
+    SqrtTestCase(new BigDecimal("2.0"), new BigDecimal("1.414214")),
+    SqrtTestCase(new BigDecimal("0.04"), new BigDecimal("0.2")),
+    SqrtTestCase(new BigDecimal("0.05"), new BigDecimal("0.2236068"))
+  )
+
+  final val sqrtTestCases_Mctx64 = Array(
+    SqrtTestCase(new BigDecimal("2.0"), new BigDecimal("1.414213562373095")),
+    SqrtTestCase(new BigDecimal("0.04"), new BigDecimal("0.2")),
+    SqrtTestCase(new BigDecimal("0.05"), new BigDecimal("0.223606797749979"))
+  )
+
+  final val sqrtTestCases_Mctx128 = Array(
+    SqrtTestCase(
+      new BigDecimal("2.0"),
+      new BigDecimal("1.414213562373095048801688724209698")
+    ),
+    SqrtTestCase(new BigDecimal("0.04"), new BigDecimal("0.2")),
+    SqrtTestCase(
+      new BigDecimal("0.05"),
+      new BigDecimal("0.2236067977499789696409173668731276")
+    )
+  )
+
+  /* Test cases for MathContext.UNLIMITED, which uses precision=0.
+   * The mc.RoundingMode is documented as unused when precision=0.
+   *
+   * Here the RoundingMode is RoundingMode.HALF_EVEN. If there ever were a
+   * sneak path which did use RoundingMode, this scenario would still
+   * be distinguished from others which exercise special paths of
+   * RoundingMode.UNNECESSARY which might have similar behavior.
+   */
+  final val sqrtTestCases_MctxUNLIMITED = Array(
+    /* Note: This table is  similar to sqrtTestCases_MctxCustom but one
+     *       expected value differs. The 'why' of that difference is
+     *       best left to JVM internal devos. Scala Native matches the JVM
+     *       behavior, even if that seems strange.
+     */
+    SqrtTestCase(
+      new BigDecimal("4"),
+      new BigDecimal("2") // used preferred scale
+    ),
+    SqrtTestCase(
+      new BigDecimal("4.0"),
+      fixupExpectedByJdkVersion("2.0")
+    ),
+    SqrtTestCase(
+      new BigDecimal("4.00"),
+      new BigDecimal("2.0") // only 1 trailing zero
+    ),
+    SqrtTestCase(
+      new BigDecimal("4.000"),
+      /* Two trailing zeros, differs from mctxUNNECESSARY because
+       * MathContet precisions differ.
+       */
+      fixupExpectedByJdkVersion("2.00")
+    ),
+    SqrtTestCase(
+      new BigDecimal("9.0"),
+      fixupExpectedByJdkVersion("3.0")
+    )
+  )
+
+  /* Test cases for user-defined custom MathContext. Here
+   *   val mc = new MathContext(2, RoundingMode.UNNECESSARY)
+   *
+   *  Using precision greater than zero and RoundingMode.UNNECESSARY,
+   *  the radicands should all be perfect
+   *  squares whose sqrt() fits into the indicted precision.
+   */
+  final val sqrtTestCases_MctxCustom = Array(
+    SqrtTestCase(
+      new BigDecimal("4"),
+      new BigDecimal("2") // used preferred scale
+    ),
+    SqrtTestCase(
+      new BigDecimal("4.0"),
+      fixupExpectedByJdkVersion("2.0")
+    ),
+    SqrtTestCase(
+      /* Test: root exceeds mc.precision but root where all but
+       * the first fractional zero, if any, have been removed does.
+       */
+      new BigDecimal("4.00"),
+      new BigDecimal("2.0") // only 1 trailing zero, because mc precision=2
+    ),
+    SqrtTestCase(
+      // true root is 2.00 but expected is limited by mc precision=2 to 2.0
+      new BigDecimal("4.000"),
+      new BigDecimal("2.0")
+    ),
+    SqrtTestCase(
+      new BigDecimal("9.0"),
+      fixupExpectedByJdkVersion("3.0")
+    )
+  )
+
+  @Test def sqrt_Exceptions(): Unit = {
+    /* Exception of expected type is expected but exact message text can vary.
+     * Better if they match but things change over time and people
+     * sometimes use local customizations.
+     */
+
+    if (Platform.executingInJVMWithJDKIn(25 to Integer.MAX_VALUE)) {
+      val bd = new BigDecimal("1.0")
+      assertThrows(
+        "sqrt(null) on Scala Native or JDK >= 25",
+        classOf[NullPointerException],
+        bd.sqrt(null)
+      )
+    }
+
+    locally {
+      /* Provoke JVM
+       *  'ArithmeticException: Attempted square root of negative BigDecimal'
+       */
+      val bd = new BigDecimal("-2.0")
+      val mc = MathContext.DECIMAL64
+      assertThrows(
+        "sqrt(negative)",
+        classOf[ArithmeticException],
+        bd.sqrt(mc)
+      )
+    }
+
+    locally { // mc.precision=0
+      // Provoke JVM 'ArithmeticException: Computed square root not exact'
+      val bd = new BigDecimal("3.99")
+      val mc = new MathContext(0, RoundingMode.FLOOR)
+      assertThrows(
+        "sqrt() not exact, mc(0, RoundingMode.FLOOR)",
+        classOf[ArithmeticException],
+        bd.sqrt(mc)
+      )
+    }
+
+    locally { // mc.precision=5
+      // Provoke JVM 'ArithmeticException: Computed square root not exact'
+      val bd = new BigDecimal("3.99")
+      val mc = new MathContext(5, RoundingMode.UNNECESSARY)
+      assertThrows(
+        "sqrt() not exact, mc(5, RoundingMode.UNNECESSARY)",
+        classOf[ArithmeticException],
+        bd.sqrt(mc)
+      )
+    }
+
+    // Check RoundingModes with not-a-perfect square.
+    locally {
+      val bd = new BigDecimal("144.1")
+
+      val mc = MathContext.UNLIMITED
+      assertThrows(
+        s"trailing 1 mc: ${mc}",
+        classOf[ArithmeticException],
+        bd.sqrt(mc)
+      )
+
+      /* One would expect a more idiomtic Scala case class here.
+       * Use parallel arrays instead to get the test up and running.
+       *
+       * For some time wasting reason case classes were slaying the
+       * build optimizer. Problem for another time.
+       */
+      val mathContexts = Array(
+        MathContext.DECIMAL32,
+        MathContext.DECIMAL64,
+        MathContext.DECIMAL128
+      )
+
+      val expected = Array(
+        "12.00417",
+        "12.0041659435381",
+        "12.00416594353810155624530784259113"
+      )
+
+      for (j <- 0 until mathContexts.length) {
+        val mc = mathContexts(j)
+        assertEquals(
+          s"mc: ${mc}",
+          expected(j),
+          bd.sqrt(mc).toPlainString()
+        )
+      }
+    }
+  }
+
+  @Test def sqrt_Zero(): Unit = {
+    // Intentionally test for reference equality, per the JVM description.
+
+    val bdZero = new BigDecimal("0.0")
+
+    locally {
+      val mc = MathContext.DECIMAL32
+      assertTrue(
+        "DECIMAL32",
+        bdZero.sqrt(mc).eq(BigDecimal.ZERO)
+      )
+    }
+
+    locally {
+      val mc = MathContext.DECIMAL64
+      assertTrue(
+        "DECIMAL64",
+        bdZero.sqrt(mc).eq(BigDecimal.ZERO)
+      )
+    }
+
+    locally {
+      val mc = MathContext.DECIMAL128
+      assertTrue(
+        "DECIMAL128",
+        bdZero.sqrt(mc).eq(BigDecimal.ZERO)
+      )
+    }
+
+    locally {
+      val mc = MathContext.UNLIMITED
+      assertTrue(
+        "UNLIMITED",
+        bdZero.sqrt(mc).eq(BigDecimal.ZERO)
+      )
+    }
+
+    locally {
+      val mc = new MathContext(99, RoundingMode.UNNECESSARY)
+      assertTrue(
+        s"Custom mc ${mc}",
+        bdZero.sqrt(mc).eq(BigDecimal.ZERO)
+      )
+    }
+  }
+
+  /* Alert! The road takes a sharp, unexpected turn here.
+   *
+   * Explicitly use both the BD 'clone membership' test '.compareTo()'
+   * and the the BD content equality test ".equals()" in the sqrt_Mctx*
+   * tests below.
+   *
+   * The ".equals()" test ensures the expected "preferred scale"
+   * has been returned by Scala Native. A fine point of JVM compliance.
+   *
+   * If the contents and scale match, then the corresponding Strings should
+   * match. The check of '.toString()' appears redundant but is reassuring.
+   */
+
+  @Test def sqrt_MctxDECIMAL32(): Unit = {
+    val mc = MathContext.DECIMAL32
+
+    for (j <- 0 until sqrtTestCases_Mctx32.length) {
+      val tc = sqrtTestCases_Mctx32(j)
+
+      val root = tc.radicand.sqrt(mc)
+
+      // Contents match, BigDecimal cohort equality idiom
+      assertTrue(
+        s"sqrt(${tc.radicand}) mc: ${mc} compareTo()",
+        root.compareTo(tc.expected) == 0
+      )
+
+      // precision and scale match. LHS & RHS equals() but probably not eq().
+      assertTrue(
+        s"sqrt(${tc.radicand}) mc: ${mc} equals()",
+        root.equals(tc.expected)
+      )
+
+      assertEquals(
+        "SN String presentation does not match JVM reference",
+        tc.expected.toString(),
+        root.toString
+      )
+    }
+  }
+
+  // @Ignore
+  @Test def sqrt_MctxDECIMAL64(): Unit = {
+    val mc = MathContext.DECIMAL64
+
+    for (j <- 0 until sqrtTestCases_Mctx64.length) {
+      val tc = sqrtTestCases_Mctx64(j)
+
+      val root = tc.radicand.sqrt(mc)
+
+      // Contents match, BigDecimal cohort equality idiom
+      assertTrue(
+        s"sqrt(${tc.radicand}) mc: ${mc} compareTo()",
+        root.compareTo(tc.expected) == 0
+      )
+
+      // precision and scale match. LHS & RHS equals() but probably not eq().
+      assertTrue(
+        s"sqrt(${tc.radicand}) mc: ${mc} equals()",
+        root.equals(tc.expected)
+      )
+
+      assertEquals(
+        "SN String presentation does not match JVM reference",
+        tc.expected.toString(),
+        root.toString
+      )
+    }
+  }
+
+  // @Ignore
+  @Test def sqrt_MctxDECIMAL128(): Unit = {
+    val mc = MathContext.DECIMAL128
+
+    for (j <- 0 until sqrtTestCases_Mctx128.length) {
+      val tc = sqrtTestCases_Mctx128(j)
+
+      val root = tc.radicand.sqrt(mc)
+
+      // Contents match, BigDecimal cohort equality idiom
+      assertTrue(
+        s"sqrt(${tc.radicand}) mc: ${mc} compareTo()",
+        root.compareTo(tc.expected) == 0
+      )
+
+      // precision and scale match. LHS & RHS equals() but probably not eq().
+      assertTrue(
+        s"sqrt(${tc.radicand}) mc: ${mc} equals()",
+        root.equals(tc.expected)
+      )
+
+      assertEquals(
+        "SN String presentation does not match JVM reference",
+        tc.expected.toString(),
+        root.toString
+      )
+    }
+  }
+
+  // @Ignore
+  @Test def sqrt_MctxUNLIMITED(): Unit = {
+    val mc = MathContext.UNLIMITED
+
+    for (j <- 0 until sqrtTestCases_MctxUNLIMITED.length) {
+      val tc = sqrtTestCases_MctxUNLIMITED(j)
+
+      val root = tc.radicand.sqrt(mc)
+
+      // Message is bulky to supply info needed to understand failures.
+      val assertMsg_part1 = s"sqrt(${tc.radicand})"
+      val assertMsg_part2 = s"\texpected: ${tc.expected}\n"
+      val assertMsg_part3 = s"\troot    : ${root}\n"
+
+      def composeAssertMsg(action: String): String =
+        s"${assertMsg_part1} ${action} \n${assertMsg_part2}${assertMsg_part3}"
+
+      // Contents match, BigDecimal cohort equality idiom
+      assertTrue(
+        composeAssertMsg("compareTo()"),
+        root.compareTo(tc.expected) == 0
+      )
+
+      // precision and scale match. LHS & RHS equals() but probably not eq().
+      assertTrue(composeAssertMsg("equals()"), root.equals(tc.expected))
+
+      assertEquals(
+        "SN String presentation does not match JVM reference",
+        tc.expected.toString(),
+        root.toString
+      )
+    }
+
+    // Check tiny fraction is distinguished from near neighbor perfect square.
+    locally {
+      val bd = new BigDecimal("4.0000000000000000000000000000001")
+
+      assertThrows(
+        "tiny trailing 1",
+        classOf[ArithmeticException],
+        bd.sqrt(mc)
+      )
+    }
+  }
+
+  /* Entries are perfect squares whose principal root will fit into
+   *    new MathContext(10, RoundingMode.UNNECESSARY)
+   */
+  val sqrtTestCases_RmUNNECESSARY = Array(
+    SqrtTestCase(
+      new BigDecimal("4.4944"),
+      new BigDecimal("2.12")
+    ),
+    SqrtTestCase(
+      new BigDecimal("4"),
+      new BigDecimal("2") // used preferred scale
+    )
+  )
+
+  // @Ignore
+  @Test def sqrt_RoundingUNNECESSARY(): Unit = {
+    /* This Test focuses on the features of RoundingMode.UNNECESSARY
+     * and covers some edge cases.
+     *
+     * It is related to and may partially duplicate others, such as
+     * sqrt_Exceptions and sqrt_MctxCustom, which may use
+     * RoundingMode.UNNECESSARY tangentially.
+     */
+
+    // imperfect square
+    locally {
+      val bd = new BigDecimal("4.999")
+      val mc = new MathContext(99, RoundingMode.UNNECESSARY)
+
+      assertThrows(
+        "imperfect square should throw",
+        classOf[ArithmeticException],
+        bd.sqrt(mc)
+      )
+    }
+
+    // Perfect square; fenceposts of fit to indicated precision, no rounding.
+    locally {
+      val bdString = "4.4944"
+      val bd = new BigDecimal(bdString)
+      val expectedRoot = new BigDecimal("2.12")
+      val expectedRootLength = expectedRoot.precision()
+
+      val mcPrecisionLT = expectedRootLength - 1
+      val mcLT = new MathContext(mcPrecisionLT, RoundingMode.UNNECESSARY)
+
+      assertThrows(
+        s"root of $bdString should not fit context precision: $mcPrecisionLT",
+        classOf[ArithmeticException],
+        bd.sqrt(mcLT)
+      )
+    }
+
+    /* perfect squares, which fit indicated precision.
+     * Maintainers: when changing precision, check the associated data table.
+     */
+    val mc = new MathContext(10, RoundingMode.UNNECESSARY)
+
+    for (j <- 0 until sqrtTestCases_RmUNNECESSARY.length) {
+      val tc = sqrtTestCases_RmUNNECESSARY(j)
+
+      val root = tc.radicand.sqrt(mc)
+
+      // Message is bulky to supply info needed to understand failures.
+      val assertMsg_part1 = s"sqrt(${tc.radicand})"
+      val assertMsg_part2 = s"\texpected: ${tc.expected}\n"
+      val assertMsg_part3 = s"\troot    : ${root}\n"
+
+      def composeAssertMsg(action: String): String =
+        s"${assertMsg_part1} ${action} \n${assertMsg_part2}${assertMsg_part3}"
+
+      // Contents match, BigDecimal cohort equality idiom
+      assertTrue(
+        composeAssertMsg("compareTo()"),
+        root.compareTo(tc.expected) == 0
+      )
+
+      // precision and scale match. LHS & RHS equals() but probably not eq().
+      assertTrue(composeAssertMsg("equals()"), root.equals(tc.expected))
+
+      assertEquals(
+        "SN String presentation does not match JVM reference",
+        tc.expected.toString(),
+        root.toString
+      )
+    }
+  }
+
+  // @Ignore
+  @Test def sqrt_MctxCustom(): Unit = {
+    val mc = new MathContext(2, RoundingMode.UNNECESSARY)
+
+    for (j <- 0 until sqrtTestCases_MctxCustom.length) {
+      val tc = sqrtTestCases_MctxCustom(j)
+
+      val root = tc.radicand.sqrt(mc)
+
+      // Message is bulky to supply info needed to understand failures.
+      val assertMsg_part1 = s"sqrt(${tc.radicand})"
+      val assertMsg_part2 = s"\texpected: ${tc.expected}\n"
+      val assertMsg_part3 = s"\troot    : ${root}\n"
+
+      def composeAssertMsg(action: String): String =
+        s"${assertMsg_part1} ${action} \n${assertMsg_part2}${assertMsg_part3}"
+
+      // Contents match, BigDecimal cohort equality idiom
+      assertTrue(
+        composeAssertMsg("compareTo()"),
+        root.compareTo(tc.expected) == 0
+      )
+
+      // precision and scale match. LHS & RHS equals() but probably not eq().
+      assertTrue(composeAssertMsg("equals()"), root.equals(tc.expected))
+
+      assertEquals(
+        "SN String presentation does not match JVM reference",
+        tc.expected.toString(),
+        root.toString
+      )
+    }
+
+    // Check tiny fraction is distinguished from near neighbor perfect square.
+    locally {
+      val bd = new BigDecimal("4.0000000000000000000000000000001")
+
+      assertThrows(
+        "tiny trailing 1",
+        classOf[ArithmeticException],
+        bd.sqrt(mc)
+      )
+    }
+  }
+
+  // @Ignore
+  @Test def testCustomMC_precision_99(): Unit = {
+    val testAtPrecision = 99
+
+    val customMcRmHE = new MathContext(testAtPrecision, RoundingMode.HALF_EVEN)
+
+    val customMcRmDOWN = new MathContext(testAtPrecision, RoundingMode.DOWN)
+
+    val radicand = new BigDecimal("3.0")
+
+    val rootHE = radicand.sqrt(customMcRmHE)
+    val rootDown = radicand.sqrt(customMcRmDOWN)
+
+    if (rootHE.compareTo(rootDown) == 0) {
+      fail("failed - roots should not match")
+    }
+
+    assertTrue(
+      "roots should not match rootHE: ${rootHE}\n rootDown: ${rootDown}",
+      rootHE.compareTo(rootDown) != 0
+    )
+
+    val differenceBD = rootHE
+      .subtract(rootDown)
+      .scaleByPowerOfTen(rootHE.scale)
+
+    val difference = differenceBD.unscaledValue.longValueExact()
+
+    /* In this carefully crafted artificial but possible case,
+     * rootHE should be 1 greater than rootDown in last place and only there.
+     *
+     * If one examines using precision 103, there is a succession of
+     * place roundings which result in the off-by-one difference at
+     * precision 99. This shows that different rounding modes were acutally
+     * used and had a cumulative effect.
+     *
+     * With other radicands and combinations of RoundingModes, there might
+     * be no difference or only a few leftmost places diference. The
+     * JDK specification implies/states that the difference should only
+     * be in the last place and be within plus or minus 1.
+     *
+     */
+    assertEquals(
+      s"unexpected difference: HE: ${rootHE}\n DOWN: ${rootDown}",
+      1L,
+      difference
+    )
+  }
+
+  // @Ignore
+  @Test def sqrt_BigDecimal_LargerThan_LongMAX_VALUE(): Unit = {
+    val mcHE = new MathContext(110, RoundingMode.HALF_EVEN)
+
+    val longMaxBD = new BigDecimal(jl.Long.MAX_VALUE)
+    val longMaxPow2 = longMaxBD.pow(2)
+
+    // verify that we are outside the range of a Java Long.
+    assertThrows(
+      "expected BigDecimal test point > jl.Long.MAX_VALUE",
+      classOf[ArithmeticException],
+      longMaxPow2.longValueExact()
+    )
+
+    val root =
+      longMaxPow2.multiply(new BigDecimal(4.0)).sqrt(mcHE)
+
+    // root still outside the range of a Java Long.
+    assertThrows(
+      "expected root BigDecimal > jl.Long.MAX_VALUE",
+      classOf[ArithmeticException],
+      root.longValueExact()
+    )
+
+    val expected = new BigDecimal("18446744073709551614")
+
+    // Message is bulky to supply info needed to understand failures.
+    val assertMsg_part1 = "usefully large Long-based BigDecimal root"
+    val assertMsg_part2 = s"\texpected: ${expected}\n"
+    val assertMsg_part3 = s"\troot    : ${root}\n"
+
+    def composeAssertMsg(action: String): String =
+      s"${assertMsg_part1} ${action} \n${assertMsg_part2}${assertMsg_part3}"
+
+    // Contents match, BigDecimal cohort equality idiom
+    assertTrue(composeAssertMsg("compareTo()"), root.compareTo(expected) == 0)
+
+    // precision and scale match. LHS & RHS equals() but probably not eq().
+    assertTrue(composeAssertMsg("equals()"), root.equals(expected))
+
+    assertEquals(
+      "SN String presentation does not match JVM reference",
+      expected.toString(),
+      root.toString
+    )
+  }
+
+  // @Ignore
+  @Test def sqrt_BigDecimal_LargerThan_DoubleMAX_VALUE(): Unit = {
+    val mcHE = new MathContext(50, RoundingMode.HALF_EVEN)
+
+    val doubleMaxBD = new BigDecimal(jl.Double.MAX_VALUE)
+    val doubleMaxPow2 = doubleMaxBD.pow(2)
+
+    // verify that we are outside the range of a Java Double.
+    assertTrue(
+      "expected BigDecimal test point > jl.Double.MAX_VALUE",
+      doubleMaxPow2.doubleValue() == jl.Double.POSITIVE_INFINITY
+    )
+
+    val root =
+      doubleMaxPow2.multiply(new BigDecimal(4.0)).sqrt(mcHE)
+
+    // root still outside the range of a Java Double.
+    assertTrue(
+      "expected root BigDecimal > jl.Double.MAX_VALUE",
+      root.doubleValue() == jl.Double.POSITIVE_INFINITY
+    )
+
+    val expected = new BigDecimal(
+      "3.5953862697246314162905484746340871359614113505169E+308"
+    )
+
+    // Message is bulky to supply info needed to understand failures.
+    val assertMsg_part1 = "usefully large Double-based BigDecimal root"
+    val assertMsg_part2 = s"\texpected: ${expected}\n"
+    val assertMsg_part3 = s"\troot    : ${root}\n"
+
+    def composeAssertMsg(action: String): String =
+      s"${assertMsg_part1} ${action} \n${assertMsg_part2}${assertMsg_part3}"
+
+    // Contents match, BigDecimal cohort equality idiom
+    assertTrue(composeAssertMsg("compareTo()"), root.compareTo(expected) == 0)
+
+    // precision and scale match. LHS & RHS equals() but probably not eq().
+    assertTrue(composeAssertMsg("equals()"), root.equals(expected))
+
+    assertEquals(
+      "SN String presentation does not match JVM reference",
+      expected.toString(),
+      root.toString
+    )
+  }
+
+  @Test def sqrt_BigDecimal_CloserToZeroThan_DoubleMIN_NORMAL(): Unit = {
+    /* Exercise an expected value in the IEEE 754 subnormal range:
+     * [jl.Double.MIN_VALUE, jl.Double.MIN_NORMAL) which can not
+     * be exactly represented as a scala.Double. That is, one less than
+     * one full ulp from a representable subnormal.
+     *
+     * The radicand based on that expected value will be closer-to-zero
+     * than jl.Double.MIN_VALUE.
+     */
+
+    def assertIsInSubnormalUlp(msgPrefix: String, bd: BigDecimal): Unit = {
+      val ieeeValue = bd.doubleValue()
+
+      assertTrue(
+        s"${msgPrefix}: IEEE value is not finite:  ${ieeeValue}",
+        jl.Double.isFinite(ieeeValue)
+      )
+
+      assertTrue(
+        s"${msgPrefix}: IEEE value is a zero:  ${ieeeValue}",
+        ieeeValue != 0.0 // or -0.0
+      )
+
+      assertTrue(
+        s"${msgPrefix}: IEEE value is not less than Double.MIN_NORMAL:  ${ieeeValue}",
+        jl.Double.compare(ieeeValue, jl.Double.MIN_NORMAL) == -1
+      )
+
+      assertTrue(
+        s"${msgPrefix}: IEEE value is less than Double.MIN_VALUE:  ${ieeeValue}",
+        jl.Double.compare(ieeeValue, jl.Double.MIN_VALUE) != -1
+      )
+
+      assertTrue(
+        "bd is an exact IEEE subnormal",
+        bd.compareTo(BigDecimal.valueOf(ieeeValue)) != 0
+      )
+    }
+
+    val factor = BigDecimal
+      .valueOf(4.0)
+      .divide(
+        BigDecimal.valueOf(3.0),
+        MathContext.DECIMAL128 // arbitrary; large enough to yield gap.
+      )
+
+    val expected = BigDecimal.valueOf(jl.Double.MIN_VALUE).multiply(factor)
+
+    assertIsInSubnormalUlp("expected", expected)
+
+    // avoid possible power-of-two special cases in pow()
+    val radicand = expected.multiply(expected)
+
+    /* re: Magic number 256
+     * 251 was determined empirically to give enough places so values match.
+     * 256 is the next large power of two, and those have pizzazz, even if no
+     * greater utility.
+     */
+    val mc = new MathContext(256, RoundingMode.HALF_EVEN)
+
+    // radicand will be closer-to-zero than smallest representable IEEE value.
+    val root = radicand.sqrt(mc)
+
+    assertIsInSubnormalUlp("root", root)
+
+    // Message is bulky to supply info needed to understand failures.
+    val assertMsg_part1 = "unexpected sqrt(unrepresentable IEEE subnormal)"
+    val assertMsg_part2 = s"\texpected: ${expected}\n)"
+    val assertMsg_part3 = s"\troot    : ${root}\n)"
+
+    def composeAssertMsg(action: String): String =
+      s"${assertMsg_part1} ${action} \n${assertMsg_part2}${assertMsg_part3}"
+
+    // Contents match, BigDecimal cohort equality idiom
+    assertTrue(composeAssertMsg("compareTo()"), root.compareTo(expected) == 0)
+
+    // precision and scale match. LHS & RHS equals() but probably not eq().
+    assertTrue(composeAssertMsg("equals()"), root.equals(expected))
+
+    assertEquals(
+      "SN String presentation does not match JVM reference",
+      expected.toString(),
+      root.toString
+    )
+  }
+
+  @Test def sqrt_BigDecimal_CloserToZeroThan_DoubleMIN_VALUE(): Unit = {
+    /* Exercise an expected value less than jl.Double.MIN_NORMAL.
+     * BigDecimal allows such but IEEE scala.Double can not represent them,
+     * even as a subnormal.
+     *
+     * The radicand based on that expected value will be closer to zero
+     * than jl.Double.MIN_VALUE.
+     */
+
+    def assertIsNotIEEE(msgPrefix: String, bd: BigDecimal): Unit = {
+      assertTrue(
+        s"${msgPrefix}: bd is <= zero:  ${bd}",
+        bd.compareTo(BigDecimal.ZERO) == 1
+      )
+
+      assertTrue(
+        s"${msgPrefix}: bd is >= jl.Double.MIN_VALUE:  ${bd}",
+        bd.compareTo(BigDecimal.valueOf(jl.Double.MIN_VALUE)) == -1
+      )
+
+      val ieeeValue = bd.doubleValue()
+
+      // Another way of determining if bd is too small to be an IEEE double.
+      assertTrue(
+        s"${msgPrefix}: IEEE value must be zero:  ${ieeeValue}",
+        jl.Double.compare(ieeeValue, 0.0) == 0
+      )
+    }
+
+    val factor = BigDecimal
+      .valueOf(1.0)
+      .divide(
+        BigDecimal.valueOf(3.0),
+        MathContext.DECIMAL128 // arbitrary; large enough to cause < MIN_VALUE
+      )
+
+    val expected = BigDecimal.valueOf(jl.Double.MIN_VALUE).multiply(factor)
+
+    assertIsNotIEEE("expected", expected)
+
+    // avoid possible power-of-two special cases in pow()
+    val radicand = expected.multiply(expected)
+
+    /* re: Magic number 64
+     * 37 was determined empirically to give enough places so values match.
+     * 64 is the next large power of two, and those have pizzazz, even if no
+     * greater utility.
+     */
+
+    val mc = new MathContext(37, RoundingMode.HALF_EVEN)
+
+    // radicand will be closer-to-zero than smallest representable IEEE value.
+    val root = radicand.sqrt(mc)
+
+    assertIsNotIEEE("root", root)
+
+    // Message is bulky to supply info needed to understand failures.
+    val assertMsg_part1 = "unexpected sqrt(unrepresentable IEEE)"
+    val assertMsg_part2 = s"\texpected: ${expected}\n"
+    val assertMsg_part3 = s"\troot    : ${root}\n"
+
+    def composeAssertMsg(action: String): String =
+      s"${assertMsg_part1} ${action} \n${assertMsg_part2}${assertMsg_part3}"
+
+    // Contents match, BigDecimal cohort equality idiom
+    assertTrue(composeAssertMsg("compareTo()"), root.compareTo(expected) == 0)
+
+    // precision and scale match. LHS & RHS equals() but probably not eq().
+    assertTrue(composeAssertMsg("equals()"), root.equals(expected))
+
+    assertEquals(
+      "SN String presentation does not match JVM reference",
+      expected.toString(),
+      root.toString
+    )
+  }
+}


### PR DESCRIPTION
Implement the javalib `java.math.BigDecimal` `sqrt` method introduced in JDK 26
and associated Tests.

<hr> 

After I prepared this PR for submission, I learned that JDK 27 is slated to introduce a `rootn()` 
method, similar to the method in `BigInteger` that was recently implemented for Scala Native.

`BigInteger` implements its `sqrt()` in terms of its `rootn()`.  A similar approach could
be taken in `BigDecimal` after JDK 27 is released.

That means that the current code needs to be correct, diligent, and skillful but need not
be pico-optimized.  It contains a 'hyperbolic first estimate' that would carry over to 
`rootn` for degree 2.

The unit-tests should prove especially useful in showing that a re-factor to use `rootn`
still works.