### PR TITLE
Implement JDK 11 ji.ByteArrayOutputStream#writeBytes

### DIFF
--- a/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
@@ -1,6 +1,7 @@
 package java.io
 
 import java.nio.charset.Charset
+import java.util.Objects
 
 class ByteArrayOutputStream(initBufSize: Int) extends OutputStream {
 
@@ -26,6 +27,15 @@ class ByteArrayOutputStream(initBufSize: Int) extends OutputStream {
 
     System.arraycopy(b, off, buf, count, len)
     count += len
+  }
+
+  def writeBytes(b: Array[Byte]): Unit = {
+    Objects.requireNonNull(
+      b,
+      """Cannot read the array length because "b" is null"""
+    )
+
+    write(b, 0, b.length)
   }
 
   def writeTo(out: OutputStream): Unit =

--- a/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/ByteArrayOutputStreamTestOnJDK11.scala
+++ b/unit-tests/shared/src/test/require-jdk11/org/scalanative/testsuite/javalib/io/ByteArrayOutputStreamTestOnJDK11.scala
@@ -1,0 +1,48 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.{util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ByteArrayOutputStreamTestOnJDK11 {
+
+  private def byteArrayAsUTF_8(ba: Array[scala.Byte]): String =
+    new String(ba, StandardCharsets.UTF_8)
+
+  @Test def writeBytes_Exception(): Unit = {
+    assertThrows(
+      "Null argument",
+      classOf[NullPointerException],
+      (new ByteArrayOutputStream(1)).writeBytes(null)
+    )
+  }
+
+  val testCases = ju.List.of(
+    "",
+    "Nobody ever figures out what life is all about" // R. Feynman
+  )
+
+  @Test def writeBytes_fromString(): Unit = {
+    testCases.forEach(tc => {
+      val bytes = tc.getBytes
+      val outStream = new ByteArrayOutputStream()
+
+      outStream.writeBytes(bytes)
+
+      val outStreamBytes = outStream.toByteArray()
+
+      val expected = byteArrayAsUTF_8(bytes)
+      val got = byteArrayAsUTF_8(outStreamBytes)
+
+      assertTrue(
+        s"content differs:\n\texpected: |${expected}|\n\treceived: |${got}|\n",
+        ju.Arrays.equals(bytes, outStreamBytes)
+      )
+    })
+  }
+}


### PR DESCRIPTION
Implement JDK11 `java.io.ByteArrayOutputStream#writeBytes` and associated unit-test.