### PR TITLE
Implement JDK 26 ju.Comparator#{max, min}; requires Scala 2.13.18 minimum

### DIFF
--- a/javalib/src/main/scala/java/util/Comparator.scala
+++ b/javalib/src/main/scala/java/util/Comparator.scala
@@ -1,4 +1,7 @@
 // Ported from Scala.js commit 00e462d dated: 2023-01-22
+/* Scala Native Additions
+ *  2026-07-29 - Added JDK 26 max() and min() methods.
+ */
 
 package java.util
 
@@ -22,7 +25,26 @@ trait Comparator[A] { self =>
   import Comparator._
 
   def compare(o1: A, o2: A): Int
+
   def equals(obj: Any): Boolean
+
+  /** @since JDK 26 */
+  def max[U <: A](o1: U, o2: U): U = {
+    /* Rely upon compare()'s use of Comparable#compareTo to handle
+     * documented NullPointerException and ClassCastException, Java does.
+     */
+    if (compare(o1, o2) >= 0) o1
+    else o2
+  }
+
+  /** @since JDK 26 */
+  def min[U <: A](o1: U, o2: U): U = {
+    /* Rely upon compare()'s use of Comparable#compareTo to handle
+     * documented NullPointerException and ClassCastException, Java does.
+     */
+    if (compare(o1, o2) <= 0) o1
+    else o2
+  }
 
   def reversed(): Comparator[A] =
     Collections.reverseOrder(this)

--- a/unit-tests/shared/src/test/require-jdk26/org/scalanative/testsuite/javalib/util/ComparatorTestOnJDK26.scala
+++ b/unit-tests/shared/src/test/require-jdk26/org/scalanative/testsuite/javalib/util/ComparatorTestOnJDK26.scala
@@ -1,0 +1,126 @@
+package org.scalanative.testsuite.javalib.util
+
+import java.util.{function => juf}
+import java.{util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ComparatorTestOnJDK26 {
+
+  @Test def max_Exceptions_NPE(): Unit = {
+    val cmp = ju.Comparator.naturalOrder[String]()
+    val s = "xyz"
+
+    assertThrows(
+      "cmp.max(null, s)",
+      classOf[NullPointerException],
+      cmp.max(null, s)
+    )
+
+    assertThrows(
+      "cmp.max(s, null)",
+      classOf[NullPointerException],
+      cmp.max(s, null)
+    )
+  }
+
+  @Test def max_Exceptions_ClassCast(): Unit = {
+    class TestComparator extends ju.Comparator[AnyVal] {
+      def compare(v1: AnyVal, v2: AnyVal): Int =
+        throw new ClassCastException("max")
+    }
+
+    val cmp = new TestComparator
+    val s = "xyz"
+    val blivet = java.lang.Long.valueOf(3)
+
+    assertThrows(
+      "cmp.max(s, blivet)",
+      classOf[ClassCastException],
+      cmp.max(s, blivet)
+    )
+
+    assertThrows(
+      "cmp.max(blivet, s)",
+      classOf[ClassCastException],
+      cmp.max(blivet, s)
+    )
+  }
+
+  @Test def max(): Unit = {
+    val cmp = ju.Comparator.naturalOrder[String]()
+    val s1 = "abc"
+    val s2 = "aec"
+
+    locally {
+      assertTrue(
+        s"""max("${s1}", "${s2}") should be "${s2}"""",
+        cmp.max(s1, s2).equals(s2)
+      )
+
+      assertTrue(
+        s"""max("${s2}", "${s1}") should be "${s2}"""",
+        cmp.max(s2, s1).equals(s2)
+      )
+    }
+  }
+
+  @Test def min_Exceptions_NPE(): Unit = {
+    val cmp = ju.Comparator.naturalOrder[String]()
+    val s = "xyz"
+
+    assertThrows(
+      "cmp.min(null, s)",
+      classOf[NullPointerException],
+      cmp.min(null, s)
+    )
+
+    assertThrows(
+      "cmp.min(s, null)",
+      classOf[NullPointerException],
+      cmp.min(s, null)
+    )
+  }
+
+  @Test def min_Exceptions_ClassCast(): Unit = {
+    class TestComparator extends ju.Comparator[AnyVal] {
+      def compare(v1: AnyVal, v2: AnyVal): Int =
+        throw new ClassCastException("min")
+    }
+
+    val cmp = new TestComparator
+    val s = "xyz"
+    val blivet = java.lang.Long.valueOf(3)
+
+    assertThrows(
+      "cmp.min(s, blivet)",
+      classOf[ClassCastException],
+      cmp.min(s, blivet)
+    )
+
+    assertThrows(
+      "cmp.min(blivet, s)",
+      classOf[ClassCastException],
+      cmp.min(blivet, s)
+    )
+  }
+
+  @Test def min(): Unit = {
+    val cmp = ju.Comparator.naturalOrder[String]()
+    val s1 = "abc"
+    val s2 = "aec"
+
+    assertTrue(
+      s"""min("${s1}", "${s2}") should be "${s1}"""",
+      cmp.min(s1, s2).equals(s1)
+    )
+
+    assertTrue(
+      s"""min("${s2}", "${s1}") should be "${s1}"""",
+      cmp.min(s2, s1).equals(s1)
+    )
+  }
+}


### PR DESCRIPTION
As described at the bottom of this PR, this PR requires that the minimum version of Scala 
used to publish artifacts becomes 2.13.18 or greater.

I am leaving it as 'Ready for review' rather than 'Draft' so that it stays in the universe
of consideration.

Until then, the  CI "version used to release artifacts" failure is real and valid.

Suggestions for alternate fixes are welcome.

<hr>
Implement the javalib `java.util.Comparator` `max()` and `min()` methods introduced in JDK and 
associated unit-test.