### PR TITLE
Implement JDK 25 ji.Reader ReadAll* methods 

### DIFF
--- a/javalib/src/main/scala/java/io/Reader.scala
+++ b/javalib/src/main/scala/java/io/Reader.scala
@@ -5,6 +5,7 @@ package java.io
 
 import java.nio.CharBuffer
 import java.util.Objects
+import java.{nio => jnio, util => ju}
 
 import scala.annotation.tailrec
 
@@ -50,6 +51,127 @@ abstract class Reader() extends Readable with Closeable {
     read(cbuf, 0, cbuf.length)
 
   def read(cbuf: Array[Char], off: Int, len: Int): Int
+
+  /** @since JDK 25 */
+  def readAllAsString(): String = {
+    /* Maintainer:
+     *   if cbuf.length get increased, change ReaderTestOnJDK25 so
+     *   the while loop below is exercised more than once. See comments there.
+     *   That Test exercises buffer re-fill logic.
+     */
+    val cbuf = new Array[Char](256)
+
+    // 256 is a generous guess to avoid initial ramp-up allocations.
+    val sBldr = new StringBuilder(256)
+
+    var done = false
+
+    while (!done) {
+      val nRead = read(cbuf, 0, cbuf.length)
+
+      /* else clause works around suspected bug in sBldr.append(cbuf, 0, nRead)
+       * where the cbuf gets appended as an Object, and not its constituent
+       * characters.
+       */
+
+      if (nRead < 0) done = true
+      else sBldr.append(String.valueOf(cbuf, 0, nRead))
+    }
+
+    sBldr.toString()
+  }
+
+  /** @since JDK 25 */
+  def readAllLines(): ju.List[String] = {
+    /* Someday it would be nice to reduce duplication between this code
+     * and earlier, similar code in BufferedReader.scala.
+     */
+
+    /* Maintainer:
+     *   if cbuf.length get increased, change ReaderTestOnJDK25 so
+     *   the while loop below is exercised more than once. See comments there.
+     *   That Test exercises buffer re-fill logic.
+     */
+    val cbuf = new Array[Char](256)
+
+    // 256 is a generous guess to avoid initial ramp-up allocations.
+    val sBldr = new StringBuilder(256)
+
+    val al = new ju.ArrayList[String](256) // arbitrary generous estimate
+
+    var crSeenAt = -1 // -1 indicates 'not encountered', else in [0, nRead)
+
+    var done = false
+
+    while (!done) {
+      val nRead = read(cbuf, 0, cbuf.length)
+
+      if (nRead <= 0) {
+        done = true
+
+        if (sBldr.length() != 0)
+          al.addLast(sBldr.toString())
+      } else {
+        var start = 0
+
+        for (j <- 0 until nRead) {
+          if ((cbuf(j) == '\n') || (cbuf(j) == '\r')) {
+
+            /* The JVM readAllLines() specification of line terminators
+             * taken with the need to read a finite number of characters
+             * is a recipe for bugs, especially off-by-one bugs.
+             * Sigh, wimper, moan.
+             *
+             * The following 'if()' clause is hard to read and comprehend
+             * on-the-fly.
+             *
+             * The idea and intent is skip '\n' _immediately_ after '\r'
+             * but only then.
+             *
+             * An English translation so somewhat like the following:
+             *   if a '\r' has been recently encountered
+             *     if looking at a '\n'
+             *   and either, in order
+             *     if
+             *       at the beginning of the characters just read,
+             *       meaning the '\r' was the final character of the
+             *       previous read.
+             *     or
+             *       now j is known to be >= 1, so can safely look back one
+             *       to see if the '\r' was immediately preceeding current '\n'
+             *
+             *  Extracting into a method would probably be just as messy.
+             *
+             *  Any section of code which has 13 times more comment lines
+             *  explaining it is probably going to be visited again.
+             */
+            if ((crSeenAt >= 0) && (cbuf(j) == '\n') &&
+                ((j == 0) || (crSeenAt == j - 1))) {
+              crSeenAt = -1 // unseen
+              start = j + 1 // skip current '\n'
+            } else {
+              if (cbuf(j) == '\r')
+                crSeenAt = j
+
+              // count (j - start) skips <LF> & solo <CR>terminators by intent
+              sBldr.append(String.valueOf(cbuf, start, j - start))
+
+              al.addLast(sBldr.toString())
+              sBldr.setLength(0)
+
+              // OK if + 1 is past nRead, next buffered read will reset to 0.
+              start = j + 1
+            }
+          } else if (j == (nRead - 1)) { // partial line, cache it.
+            sBldr.append(String.valueOf(cbuf, start, j - start + 1))
+          }
+        }
+      }
+    }
+
+    al.trimToSize()
+    al.asInstanceOf[ju.List[String]]
+  }
 
   def skip(n: Long): Long = {
     if (n < 0)

--- a/javalib/src/main/scala/java/io/Reader.scala
+++ b/javalib/src/main/scala/java/io/Reader.scala
@@ -5,7 +5,7 @@ package java.io
 
 import java.nio.CharBuffer
 import java.util.Objects
-import java.{nio => jnio, util => ju}
+import java.{lang => jl, nio => jnio, util => ju}
 
 import scala.annotation.tailrec
 
@@ -62,7 +62,7 @@ abstract class Reader() extends Readable with Closeable {
     val cbuf = new Array[Char](256)
 
     // 256 is a generous guess to avoid initial ramp-up allocations.
-    val sBldr = new StringBuilder(256)
+    val sBldr = new jl.StringBuilder(256)
 
     var done = false
 
@@ -95,7 +95,7 @@ abstract class Reader() extends Readable with Closeable {
     val cbuf = new Array[Char](256)
 
     // 256 is a generous guess to avoid initial ramp-up allocations.
-    val sBldr = new StringBuilder(256)
+    val sBldr = new jl.StringBuilder(256)
 
     val al = new ju.ArrayList[String](256) // arbitrary generous estimate
 

--- a/unit-tests/shared/src/test/require-jdk25/org/scalanative/testsuite/javalib/io/ReaderTestOnJDK25.scala
+++ b/unit-tests/shared/src/test/require-jdk25/org/scalanative/testsuite/javalib/io/ReaderTestOnJDK25.scala
@@ -1,0 +1,196 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io.{Reader, StringReader}
+import java.util.{stream => jus}
+import java.{util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+class ReaderTestOnJDK25 {
+
+  /* Java 26 documents ReadAllAsString() and ReadAllLines() as possibly
+   * throwing only IOException and OutOfMemoryError.
+   *
+   * Rely upon Tests in the underlying methods used by Reader to exercise
+   * those possibilities. StringBuilder in particular should throw
+   * OutOfMemoryError on any attempt to grow the string beyond VM limits.
+   */
+
+  /* Selected verses from public domain:
+   * Robert Louis Stephenson "Sing me a Song of a Lad that is Gone"
+   *
+   * URLs:
+   *
+   *   https://en.wikipedia.org/wiki/The_Skye_Boat_Song
+   *
+   *   https://www.poetryfoundation.org/poems/45949/
+   *     sing-me-a-song-of-a-lad-that-is-gone
+   */
+
+  /* This list is crafted using some knowledge of Reader internals,
+   * specifically the buffer sizes used by readAllAsString() and
+   * readAllLines(). As of this writing, they both use 256 characters
+   * for raw reads. The selected verses of the poem contain 369 so
+   * that at least two buffered reads are necessary. This tests
+   * the transition between buffers.
+   *
+   * No good way to ensure this balance, beyond a comment in Reader.scala
+   * to change here if either of those sizes are changed.
+   */
+
+  val poemByLine = ju.List.of(
+    "", // The first line is empty in an attempt to trip up read logic.
+    "Sing me a song of a lad that is gone,",
+    "Say, could that lad be I?",
+    "Merry of soul he sailed on a day",
+    "Over the sea to Skye.",
+    "",
+    "Mull was astern, Rum on the port,",
+    "Eigg on the starboard bow;",
+    "Glory of youth glowed in his soul;",
+    "Where is that glory now?",
+    "",
+    "Give me again all that was there,",
+    "Give me the sun that shone!",
+    "Give me the eyes, give me the soul,",
+    "Give me the lad that's gone!"
+  )
+
+  /* The final line does not get terminated to test non-terminated EOF.
+   * A similar condition holds for <CR> and <CR><LF> variants.
+   */
+  val poemNlTerminated = poemByLine
+    .stream()
+    .collect(jus.Collectors.joining("\n"))
+
+  @Test def ReadAllAsString(): Unit = {
+    val poem = poemNlTerminated
+
+    val reader = new StringReader(poem)
+
+    val asString = reader.readAllAsString()
+
+    assertEquals("size", poem.size, asString.size)
+    assertEquals("contents", poem, asString)
+  }
+
+  @Test def ReadAllLines_LfTerminated(): Unit = { // linefeed a.k.a '\n'
+
+    val reader = new StringReader(poemNlTerminated)
+
+    val asLines = reader.readAllLines()
+
+    assertEquals("size", poemByLine.size(), asLines.size())
+    assertEquals("contents", poemByLine, asLines)
+
+    // Be paranoid, check that each of the lines do not contain a terminator.
+    for (j <- 0 until asLines.size())
+      assertTrue(
+        s"output(${j}) should not contain terminator '\\n'",
+        asLines.get(j).indexOf('\n') == -1
+      )
+  }
+
+  @Test def ReadAllLines_CrTerminated(): Unit = { // Carriage return '\r'
+    val poemCrTerminated = poemByLine
+      .stream()
+      .collect(jus.Collectors.joining("\r"))
+
+    assertEquals(
+      s"poemCrTerminated() should not contain terminator '\\n'",
+      -1,
+      poemCrTerminated.indexOf('\n')
+    )
+
+    assertEquals(
+      s"poemCrTerminated() should contain terminator '\\r'",
+      0,
+      poemCrTerminated.indexOf('\r')
+    )
+
+    val reader = new StringReader(poemCrTerminated)
+
+    val asLines = reader.readAllLines()
+
+    assertEquals("size", poemByLine.size(), asLines.size())
+    assertEquals("contents", poemByLine, asLines)
+
+    // Check that each of the lines do not contain a terminator.
+    for (j <- 0 until asLines.size())
+      assertTrue(
+        s"output(${j}) should not contain terminator '\\n'",
+        asLines.get(j).indexOf('\n') == -1
+      )
+
+    for (j <- 0 until asLines.size())
+      assertTrue(
+        s"output(${j}) |${asLines.get(j)}|should not contain terminator '\\r'",
+        asLines.get(j).indexOf('\r') == -1
+      )
+  }
+
+  @Test def ReadAllLines_CrLfTerminated(): Unit = { // '\r' '\n'
+    val poemCrLfTerminated = poemByLine
+      .stream()
+      .collect(jus.Collectors.joining("\r\n"))
+
+    val reader = new StringReader(poemCrLfTerminated)
+
+    val asLines = reader.readAllLines()
+
+    assertEquals("size", poemByLine.size(), asLines.size())
+    assertEquals("contents", poemByLine, asLines)
+
+    // Check that each of the lines do not contain a terminator.
+    for (j <- 0 until asLines.size())
+      assertTrue(
+        s"output(${j}) should not contain terminator '\\n'",
+        asLines.get(j).indexOf('\n') == -1
+      )
+
+    for (j <- 0 until asLines.size())
+      assertTrue(
+        s"output(${j}) should not contain terminator '\\r'",
+        asLines.get(j).indexOf('\r') == -1
+      )
+  }
+
+  /* Someday create a test where the lines have a mixture of lf, cr, and crlf
+   * terminators. Should probably do the 9 combinations of one kind
+   * of terminator being followed by different. A project for a
+   * snowy eve.
+   */
+
+  @Test def ReadAllLines_CrAndLf_NotAdjacent(): Unit = {
+    /* Exercise a corner case  where the CR and LF are not immediately
+     * adjacent.
+     * The LF should cause a line break and NOT be skipped for having come
+     * after, but not immediately after, a CR.
+     */
+
+    val trickyText = "abc\rdef\nhij"
+
+    val expected = ju.List.of("abc", "def", "hij")
+
+    val reader = new StringReader(trickyText)
+
+    val asLines = reader.readAllLines()
+
+    assertEquals("size", expected.size(), asLines.size())
+    assertEquals("contents", expected, asLines)
+
+    // Check that each of the lines do not contain a terminator.
+    for (j <- 0 until asLines.size())
+      assertTrue(
+        s"output(${j}) should not contain terminator '\\n'",
+        asLines.get(j).indexOf('\n') == -1
+      )
+
+    for (j <- 0 until asLines.size())
+      assertTrue(
+        s"output(${j}) should not contain terminator '\\r'",
+        asLines.get(j).indexOf('\r') == -1
+      )
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk25/org/scalanative/testsuite/javalib/io/ReaderTestOnJDK25.scala
+++ b/unit-tests/shared/src/test/require-jdk25/org/scalanative/testsuite/javalib/io/ReaderTestOnJDK25.scala
@@ -58,7 +58,7 @@ class ReaderTestOnJDK25 {
   )
 
   /* The final line does not get terminated to test non-terminated EOF.
-   * A similar condition holds for <CR> and <CR><LF> variants.
+   * A similar condition holds for both <CR> and <CR><LF> variants.
    */
   val poemNlTerminated = poemByLine
     .stream()


### PR DESCRIPTION
Implement the `java.io.Reader` `readAllAsString()` and `readAllLines()` methods introduced
in JDK 25 and associated unit-tests.

A quiet but probably useful consequence of this PR is that classes which extend `Reader`,
such as `StringReader` and  `FileReader`, can now uses these two method.
Time will tell if they are useful or hazardous with `InputStreamReader`.