### PR TITLE
Fix #4918: Implement JDK 24 ji.Reader#of

### DIFF
--- a/javalib/src/main/scala/java/io/CharSequenceReader.scala
+++ b/javalib/src/main/scala/java/io/CharSequenceReader.scala
@@ -1,0 +1,83 @@
+package java.io
+
+import java.{lang => jl}
+
+/* Adapted from StringReader.scala.
+ * See method   override def read(cbuf: Array[Char], off: Int, len: Int): Int
+ * for major change.
+ */
+
+private[io] class CharSequenceReader(cs: jl.CharSequence) extends Reader {
+  private var closed = false
+  private var pos = 0
+  private var mark = 0
+
+  override def close(): Unit =
+    closed = true
+
+  override def mark(readAheadLimit: Int): Unit = {
+    ensureOpen()
+
+    mark = pos
+  }
+
+  override def markSupported(): Boolean = true
+
+  override def read(): Int = {
+    ensureOpen()
+
+    if (pos < cs.length()) {
+      val res = cs.charAt(pos).toInt
+      pos += 1
+      res
+    } else -1
+  }
+
+  /* Once SN PRs #5006 and #5007 have merged, this key method
+   * should be re-implemented in terms of the potentially faster
+   * and more efficient getChars(). Each subclass may have provided
+   * an implementation aware of and using its internals rather than
+   * repeated calls to 'charAt()'. Until then 'charAt()' provides the
+   * method and is better than waiting for devo time which may never come.
+   */
+  override def read(cbuf: Array[Char], off: Int, len: Int): Int = {
+    ensureOpen()
+
+    if (off < 0 || len < 0 || len > cbuf.length - off)
+      throw new IndexOutOfBoundsException
+
+    if (len == 0) 0
+    else {
+      val count = Math.min(len, cs.length() - pos)
+      var i = 0
+      while (i < count) {
+        cbuf(off + i) = cs.charAt(pos + i)
+        i += 1
+      }
+      pos += count
+      if (count == 0) -1 else count
+    }
+  }
+
+  override def ready(): Boolean = {
+    ensureOpen()
+    true
+  }
+
+  override def reset(): Unit = {
+    ensureOpen()
+    pos = mark
+  }
+
+  override def skip(ns: Long): Long = {
+    // Follow StringReader.skip JVM practice of allowing negative skips
+    val count = Math.max(Math.min(ns, cs.length() - pos).toInt, -pos)
+    pos += count
+    count.toLong
+  }
+
+  private def ensureOpen(): Unit = {
+    if (closed)
+      throw new IOException("Operation on closed stream")
+  }
+}

--- a/javalib/src/main/scala/java/io/Reader.scala
+++ b/javalib/src/main/scala/java/io/Reader.scala
@@ -148,4 +148,10 @@ object Reader {
       }
     }
   }
+
+  /** @since JDK 24 */
+  def of(cs: CharSequence): Reader = {
+    Objects.requireNonNull(cs, "cs") // JVM uses immensely helpful null msg
+    new CharSequenceReader(cs)
+  }
 }

--- a/unit-tests/shared/src/test/require-jdk24/org/scalanative/testsuite/javalib/io/ReaderTestOnJDK24.scala
+++ b/unit-tests/shared/src/test/require-jdk24/org/scalanative/testsuite/javalib/io/ReaderTestOnJDK24.scala
@@ -1,0 +1,94 @@
+package org.scalanative.testsuite.javalib.io
+
+import java.io.{Reader, StringWriter}
+import java.nio.CharBuffer
+import java.util.{stream => jus}
+import java.{util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class ReaderTestOnJDK24 {
+
+  /* Selected verses from public domain "We Shall Overcome".
+   *
+   * URLs:
+   *
+   *  - Rich author history & January 26, 2018 dedication to the public domain
+   *      https://en.wikipedia.org/wiki/We_Shall_Overcome
+   *
+   *  - Lyrics from:
+   *     https://www.african-american-civil-rights.org/
+   *       we-shall-overcome/#google_vignette
+   */
+
+  val songByLine = ju.List.of(
+    "We shall overcome,",
+    "We shall overcome,",
+    "We shall overcome, some day.",
+    "",
+    "Oh, deep in my heart,",
+    "I do believe",
+    "We shall overcome, some day.",
+    "",
+    "We’ll walk hand in hand,",
+    "We’ll walk hand in hand,",
+    "We’ll walk hand in hand, some day.",
+    "",
+    "We are not afraid,",
+    "We are not afraid,",
+    "We are not afraid, TODAY",
+    "",
+    "Oh, deep in my heart,",
+    "I do believe",
+    "We shall overcome, some day.      "
+  )
+
+  val song = songByLine
+    .stream()
+    .collect(jus.Collectors.joining("\n"))
+
+  class CustomCharSequence(underlying: String) extends CharSequence {
+    def charAt(x0: Int): Char = underlying.charAt(x0)
+    def length(): Int = underlying.length()
+    def subSequence(x0: Int, x1: Int): CharSequence =
+      underlying.subSequence(x0, x1)
+  }
+
+  case class CharSequenceSource(name: String, cs: CharSequence)
+
+  val sources = ju.List.of(
+    CharSequenceSource("String", song),
+    CharSequenceSource("StringBuilder", new StringBuilder(song)),
+    CharSequenceSource("StringBuffer", new StringBuffer(song)),
+    CharSequenceSource("CharBuffer", CharBuffer.wrap(song)),
+    CharSequenceSource("CustomCharSequence", new CustomCharSequence(song))
+  )
+
+  @Test def readerOf_Exceptions(): Unit = {
+    assertThrows(
+      "null argument",
+      classOf[NullPointerException],
+      Reader.of(null)
+    )
+  }
+
+  @Test def readerOf(): Unit = {
+    sources.forEach { src =>
+      val reader = Reader.of(src.cs)
+      val writer = new StringWriter()
+
+      val nWritten = reader.transferTo(writer)
+
+      assertEquals(s"reader.of(${src.name}) size", song.size, nWritten)
+
+      assertEquals(
+        s"reader.of(${src.name}) contents",
+        song,
+        writer.toString()
+      )
+    }
+  }
+}


### PR DESCRIPTION
This PR stands independently. Once pending PRs #5002 and #5009 have merged, in the fullness of time,
it will fix Issue #4918.

Implement JDK 24 `java.io.Reader#of` method and associated unit-test.

<hr>

As noted in the new `CharSequenceReader`, once PR #5006 and #5007 merge,
the opportunity for a runtime improvement to reading multiple characters at a time using  `getChars()` 
opens.

The current PR makes the convenience method available, even though it is not going to win any
performance awards.  

It my private development, it has proven to be quite convenient.

