### PR TITLE
Fix #4981: Implement four javalib JDK 9 parse{Long, Integer}CharSequence methods

### DIFF
--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -1,6 +1,7 @@
 package java.lang
 
 import java.lang.constant.{Constable, ConstantDesc}
+import java.{util => ju}
 
 import scalanative.runtime.Intrinsics.{divUInt, intToULong, remUInt}
 import scalanative.runtime.LLVMIntrinsics
@@ -287,6 +288,21 @@ object Integer {
   @inline def parseInt(s: String): scala.Int =
     parseInt(s, 10)
 
+  /** @since JDK 9 */
+  def parseInt(
+      s: CharSequence,
+      beginIndex: Int,
+      endIndex: Int,
+      radix: Int
+  ): scala.Int = {
+    ju.Objects.requireNonNull(s)
+    ju.Objects.checkFromToIndex(beginIndex, endIndex, s.length())
+    // let callee check radix
+
+    val extracted = s.subSequence(beginIndex, endIndex).toString()
+    parseInt(extracted, radix)
+  }
+
   def parseInt(s: String, radix: scala.Int): scala.Int = {
     if (s == null)
       throw new NumberFormatException("null")
@@ -516,6 +532,20 @@ object Integer {
     valueOf(parseInt(s, radix))
 
   @inline def parseUnsignedInt(s: String): scala.Int = parseUnsignedInt(s, 10)
+
+  def parseUnsignedInt(
+      s: CharSequence,
+      beginIndex: Int,
+      endIndex: Int,
+      radix: Int
+  ): scala.Int = {
+    ju.Objects.requireNonNull(s)
+    ju.Objects.checkFromToIndex(beginIndex, endIndex, s.length())
+    // let callee check radix
+
+    val extracted = s.subSequence(beginIndex, endIndex).toString()
+    parseUnsignedInt(extracted, radix)
+  }
 
   def parseUnsignedInt(s: String, radix: scala.Int): scala.Int = {
     if (s == null)

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -1,6 +1,7 @@
 package java.lang
 
 import java.lang.constant.{Constable, ConstantDesc}
+import java.{util => ju}
 
 import scalanative.runtime.Intrinsics.{divULong, remULong}
 import scalanative.runtime.LLVMIntrinsics
@@ -282,6 +283,21 @@ object Long {
   @inline def numberOfTrailingZeros(l: scala.Long): Int =
     LLVMIntrinsics.`llvm.cttz.i64`(l, iszeroundef = false).toInt
 
+  /** @since JDK 9 */
+  def parseLong(
+      s: CharSequence,
+      beginIndex: Int,
+      endIndex: Int,
+      radix: Int
+  ): scala.Long = {
+    ju.Objects.requireNonNull(s)
+    ju.Objects.checkFromToIndex(beginIndex, endIndex, s.length())
+    // let callee check radix
+
+    val extracted = s.subSequence(beginIndex, endIndex).toString()
+    parseLong(extracted, radix)
+  }
+
   @inline def parseLong(s: String): scala.Long =
     parseLong(s, 10)
 
@@ -487,6 +503,21 @@ object Long {
 
   @inline def valueOf(s: String, radix: Int): Long =
     valueOf(parseLong(s, radix))
+
+  /** @since JDK 9 */
+  def parseUnsignedLong(
+      s: CharSequence,
+      beginIndex: Int,
+      endIndex: Int,
+      radix: Int
+  ): scala.Long = {
+    ju.Objects.requireNonNull(s)
+    ju.Objects.checkFromToIndex(beginIndex, endIndex, s.length())
+    // let callee check radix
+
+    val extracted = s.subSequence(beginIndex, endIndex).toString()
+    parseUnsignedLong(extracted, radix)
+  }
 
   @inline def parseUnsignedLong(s: String): scala.Long =
     parseUnsignedLong(s, 10)

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/IntegerTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/IntegerTestOnJDK9.scala
@@ -1,0 +1,255 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class IntegerTestOnJDK9 {
+
+  @Test def parseInteger_Exceptions(): Unit = {
+    val payload = "xx012349yy"
+    val cs = new StringBuilder(payload)
+
+    assertThrows(
+      "parseLong(null, n, n, n)",
+      classOf[NullPointerException],
+      jl.Integer.parseInt(null.asInstanceOf[CharSequence], 0, 10, 2)
+    )
+
+    assertThrows(
+      "parseLong(cs, -1, n, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Integer.parseInt(cs, -1, 1, 2)
+    )
+
+    assertThrows(
+      "parseLong(cs, 2, 0, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Integer.parseInt(cs, 2, 0, 3)
+    )
+
+    assertThrows(
+      "parseLong(cs, 0, cs.length + 1, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Integer.parseInt(cs, 0, cs.length + 1, 3)
+    )
+  }
+
+  @Test def parseInteger_Exceptions_Radix(): Unit = {
+    val payload = "xx012349yy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = 7
+
+    locally {
+      val radix = 3
+
+      assertThrows(
+        "digit 3 in radix 3 parse should throw",
+        classOf[NumberFormatException],
+        jl.Integer.parseInt(cs, startParse, endParse, radix)
+      )
+    }
+
+    locally {
+      val radix = Character.MIN_RADIX - 1
+
+      assertThrows(
+        "radix less than MIN_RADIX should throw",
+        classOf[NumberFormatException],
+        jl.Integer.parseInt(cs, startParse, endParse, radix)
+      )
+    }
+
+    locally {
+      val radix = Character.MAX_RADIX + 1
+
+      assertThrows(
+        "radix greater than MAX_RADIX should throw",
+        classOf[NumberFormatException],
+        jl.Integer.parseInt(cs, startParse, endParse, radix)
+      )
+    }
+  }
+
+  @Test def parseInteger_radix10(): Unit = {
+    val payload = "xx012349yy" // digits 0 and 9 should not be in result Int.
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = 7
+    val radix = 10
+
+    val expected = 1234L
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Integer.parseInt(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseInteger_radix2(): Unit = {
+    val binaryString = jl.Integer.toBinaryString(jl.Integer.MAX_VALUE)
+    val payload = s"xx1${binaryString}0yy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = payload.length - 3
+    val radix = 2
+
+    val expected = jl.Integer.MAX_VALUE
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Integer.parseInt(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseInteger_radix16(): Unit = {
+    val binaryString = jl.Integer.toHexString(jl.Integer.MIN_VALUE)
+
+    // Signed, notice leading minus sign required/used here.
+    val payload = s"0x-${binaryString}Ayy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 2
+    val endParse = payload.length - 3
+    val radix = 16
+
+    val expected = jl.Integer.MIN_VALUE
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Integer.parseInt(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseUnsignedLong_Exceptions(): Unit = {
+    val payload = "xx012349yy"
+    val cs = new StringBuilder(payload)
+
+    assertThrows(
+      "parseUnsignedLong(null, n, n, n)",
+      classOf[NullPointerException],
+      jl.Integer.parseUnsignedInt(null.asInstanceOf[CharSequence], 0, 10, 2)
+    )
+
+    assertThrows(
+      "parseUnsignedLong(cs, -1, n, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Integer.parseUnsignedInt(cs, -1, 1, 2)
+    )
+
+    assertThrows(
+      "parseUnsignedLong(cs, 2, 0, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Integer.parseUnsignedInt(cs, 2, 0, 3)
+    )
+
+    assertThrows(
+      "parseUnsignedLong(cs, 0, cs.length + 1, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Integer.parseUnsignedInt(cs, 0, cs.length + 1, 3)
+    )
+  }
+
+  @Test def parseUnsignedLong_Exceptions_Radix(): Unit = {
+    val payload = "xx012349yy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = 7
+
+    locally {
+      val radix = 3
+
+      assertThrows(
+        "digit 3 in radix 3 parse should throw",
+        classOf[NumberFormatException],
+        jl.Integer.parseUnsignedInt(cs, startParse, endParse, radix)
+      )
+    }
+
+    locally {
+      val radix = Character.MIN_RADIX - 1
+
+      assertThrows(
+        "radix less than MIN_RADIX should throw",
+        classOf[NumberFormatException],
+        jl.Integer.parseUnsignedInt(cs, startParse, endParse, radix)
+      )
+    }
+
+    locally {
+      val radix = Character.MAX_RADIX + 1
+
+      assertThrows(
+        "radix greater than MAX_RADIX should throw",
+        classOf[NumberFormatException],
+        jl.Integer.parseUnsignedInt(cs, startParse, endParse, radix)
+      )
+    }
+  }
+
+  @Test def parseUnsignedLong_radix10(): Unit = {
+    val payload = "xx012349yy" // digits 0 and 9 should not be in result Int.
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = 7
+    val radix = 10
+
+    val expected = 1234L
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Integer.parseUnsignedInt(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseUnsignedLong_radix2(): Unit = {
+    val binaryString = jl.Integer.toBinaryString(jl.Integer.MAX_VALUE)
+    val payload = s"xx1${binaryString}0yy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = payload.length - 3
+    val radix = 2
+
+    val expected = jl.Integer.MAX_VALUE
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Integer.parseUnsignedInt(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseUnsignedLong_radix16(): Unit = {
+    val binaryString = jl.Integer.toHexString(jl.Integer.MIN_VALUE)
+
+    // Unsigned, notice no leading minus sign (not allowed).
+    val payload = s"0x${binaryString}Ayy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 2
+    val endParse = payload.length - 3
+    val radix = 16
+
+    val expected = jl.Integer.MIN_VALUE
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Integer.parseUnsignedInt(cs, startParse, endParse, radix)
+    )
+  }
+}

--- a/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/LongTestOnJDK9.scala
+++ b/unit-tests/shared/src/test/require-jdk9/org/scalanative/testsuite/javalib/lang/LongTestOnJDK9.scala
@@ -1,0 +1,255 @@
+package org.scalanative.testsuite.javalib.lang
+
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+class LongTestOnJDK9 {
+
+  @Test def parseLong_Exceptions(): Unit = {
+    val payload = "xx012349yy"
+    val cs = new StringBuilder(payload)
+
+    assertThrows(
+      "parseLong(null, n, n, n)",
+      classOf[NullPointerException],
+      jl.Long.parseLong(null.asInstanceOf[CharSequence], 0, 10, 2)
+    )
+
+    assertThrows(
+      "parseLong(cs, -1, n, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Long.parseLong(cs, -1, 1, 2)
+    )
+
+    assertThrows(
+      "parseLong(cs, 2, 0, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Long.parseLong(cs, 2, 0, 3)
+    )
+
+    assertThrows(
+      "parseLong(cs, 0, cs.length + 1, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Long.parseLong(cs, 0, cs.length + 1, 3)
+    )
+  }
+
+  @Test def parseLong_Exceptions_Radix(): Unit = {
+    val payload = "xx012349yy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = 7
+
+    locally {
+      val radix = 3
+
+      assertThrows(
+        "digit 3 in radix 3 parse should throw",
+        classOf[NumberFormatException],
+        jl.Long.parseLong(cs, startParse, endParse, radix)
+      )
+    }
+
+    locally {
+      val radix = Character.MIN_RADIX - 1
+
+      assertThrows(
+        "radix less than MIN_RADIX should throw",
+        classOf[NumberFormatException],
+        jl.Long.parseLong(cs, startParse, endParse, radix)
+      )
+    }
+
+    locally {
+      val radix = Character.MAX_RADIX + 1
+
+      assertThrows(
+        "radix greater than MAX_RADIX should throw",
+        classOf[NumberFormatException],
+        jl.Long.parseLong(cs, startParse, endParse, radix)
+      )
+    }
+  }
+
+  @Test def parseLong_radix10(): Unit = {
+    val payload = "xx012349yy" // digits 0 and 9 should not be in result Long.
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = 7
+    val radix = 10
+
+    val expected = 1234L
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Long.parseLong(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseLong_radix2(): Unit = {
+    val binaryString = jl.Long.toBinaryString(jl.Long.MAX_VALUE)
+    val payload = s"xx1${binaryString}0yy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = payload.length - 3
+    val radix = 2
+
+    val expected = jl.Long.MAX_VALUE
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Long.parseLong(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseLong_radix16(): Unit = {
+    val binaryString = jl.Long.toHexString(jl.Long.MIN_VALUE)
+
+    // Signed, notice leading minus sign required/used here.
+    val payload = s"0x-${binaryString}Ayy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 2
+    val endParse = payload.length - 3
+    val radix = 16
+
+    val expected = jl.Long.MIN_VALUE
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Long.parseLong(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseUnsignedLong_Exceptions(): Unit = {
+    val payload = "xx012349yy"
+    val cs = new StringBuilder(payload)
+
+    assertThrows(
+      "parseUnsignedLong(null, n, n, n)",
+      classOf[NullPointerException],
+      jl.Long.parseUnsignedLong(null.asInstanceOf[CharSequence], 0, 10, 2)
+    )
+
+    assertThrows(
+      "parseUnsignedLong(cs, -1, n, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Long.parseUnsignedLong(cs, -1, 1, 2)
+    )
+
+    assertThrows(
+      "parseUnsignedLong(cs, 2, 0, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Long.parseUnsignedLong(cs, 2, 0, 3)
+    )
+
+    assertThrows(
+      "parseUnsignedLong(cs, 0, cs.length + 1, n)",
+      classOf[IndexOutOfBoundsException],
+      jl.Long.parseUnsignedLong(cs, 0, cs.length + 1, 3)
+    )
+  }
+
+  @Test def parseUnsignedLong_Exceptions_Radix(): Unit = {
+    val payload = "xx012349yy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = 7
+
+    locally {
+      val radix = 3
+
+      assertThrows(
+        "digit 3 in radix 3 parse should throw",
+        classOf[NumberFormatException],
+        jl.Long.parseUnsignedLong(cs, startParse, endParse, radix)
+      )
+    }
+
+    locally {
+      val radix = Character.MIN_RADIX - 1
+
+      assertThrows(
+        "radix less than MIN_RADIX should throw",
+        classOf[NumberFormatException],
+        jl.Long.parseUnsignedLong(cs, startParse, endParse, radix)
+      )
+    }
+
+    locally {
+      val radix = Character.MAX_RADIX + 1
+
+      assertThrows(
+        "radix greater than MAX_RADIX should throw",
+        classOf[NumberFormatException],
+        jl.Long.parseUnsignedLong(cs, startParse, endParse, radix)
+      )
+    }
+  }
+
+  @Test def parseUnsignedLong_radix10(): Unit = {
+    val payload = "xx012349yy" // digits 0 and 9 should not be in result Long.
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = 7
+    val radix = 10
+
+    val expected = 1234L
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Long.parseUnsignedLong(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseUnsignedLong_radix2(): Unit = {
+    val binaryString = jl.Long.toBinaryString(jl.Long.MAX_VALUE)
+    val payload = s"xx1${binaryString}0yy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 3
+    val endParse = payload.length - 3
+    val radix = 2
+
+    val expected = jl.Long.MAX_VALUE
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Long.parseUnsignedLong(cs, startParse, endParse, radix)
+    )
+  }
+
+  @Test def parseUnsignedLong_radix16(): Unit = {
+    val binaryString = jl.Long.toHexString(jl.Long.MIN_VALUE)
+
+    // Unsigned, notice no leading minus sign (not allowed).
+    val payload = s"0x${binaryString}Ayy"
+    val cs = new StringBuilder(payload)
+
+    val startParse = 2
+    val endParse = payload.length - 3
+    val radix = 16
+
+    val expected = jl.Long.MIN_VALUE
+
+    assertEquals(
+      s"parse radix ${radix}",
+      expected,
+      jl.Long.parseUnsignedLong(cs, startParse, endParse, radix)
+    )
+  }
+}


### PR DESCRIPTION
Fix #4981

Implement javalib JDK 9 `java.lang.Long`  `parseLong(CharSequence, n, n, m)`,  `parseUnsignedLong(CharSequence, n, n, m)`, similar methods for `java.lang.Integer`,  and corresponding unit-tests. 