### PR TITLE
Implement a better distributed jur.L32X64MixRandom#nextLong

### DIFF
--- a/javalib/src/main/scala/java/util/random/L32X64MixRandom.scala
+++ b/javalib/src/main/scala/java/util/random/L32X64MixRandom.scala
@@ -29,6 +29,12 @@ private final class L32X64MixRandom private[random] (
    * constructor forces a & s to be odd and x0 & x1 to be "both not zero"
    */
 
+  /* This and other magic constants from JDK 17 documentation:
+   *   https://docs.oracle.com/en/java/javase/17/docs/api/java.base
+   *     /java/util/random/package-summary.html
+   *
+   * JDK 26 appears to specify the same constants.
+   */
   final val M = 0xadb4a92d; // Fixed multiplier
 
   def this(buf: Array[Int]) =
@@ -74,7 +80,7 @@ private final class L32X64MixRandom private[random] (
 
   // JVM fills upper 32 bits, not a nextInt().toLong which clears them.
   def nextLong(): scala.Long =
-    (nextInt().toLong << 32) | nextInt().toLong
+    (nextInt().toLong << 32) | (nextInt().toLong & 0x00000000ffffffffL)
 
   /* Since most callers will want 32 bit results, implement nextLong()
    * in terms of nextInt(). The other way around is the usual practice

--- a/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_L32X64MixRandomTestOnJDK17.scala
+++ b/unit-tests/shared/src/test/require-jdk17/org/scalanative/testsuite/javalib/util/random/JEP356_L32X64MixRandomTestOnJDK17.scala
@@ -758,6 +758,100 @@ class JEP356_L32X64MixRandomTestOnJDK17 {
     }
   }
 
+  /* Since nextLong() is so fundamental, provide a few manual tests
+   * for maintainers & developers.
+   */
+
+  @Ignore // Manual developer test
+  @Test def nextLong_Binomial_AboveBelowZero(): Unit = {
+    val rng = RandomGenerator.of("L32X64MixRandom")
+
+    val lowBound = -jl.Double.MAX_VALUE
+    val highBound = jl.Double.MAX_VALUE // Inclusive
+
+    val limit = 1000 * 1000
+
+    var countLt0 = 0
+    var countZero = 0
+    var countGt0 = 0
+
+    val delta = Math.ulp(highBound)
+    val nMax = ((highBound / delta).longValue * 2) + 1
+
+    val boundary = 0.0
+
+    for (j <- 0 until limit) {
+      val next = rng.nextLong()
+      if (next < boundary) countLt0 += 1
+      else if (next == boundary) countZero += 1
+      else countGt0 += 1
+    }
+
+    /* // Hard failure for maintainer debugging.
+       // You know times are rough if you are here.
+        assertEquals(
+          s"nNeg: ${countLt0}, nPos: $countGt0",
+          countLt0,
+          countGt0
+        )
+     */
+
+    /* Anything outside this range is almost surely an egregious deviation from
+     * the expected binomial distribution.
+     *
+     * The tolerance is set pretty high for possible devo-time automated
+     * smoke tests. Passing this test is a necessary but not sufficient
+     * condition to believe the observed data was sampled from a
+     * binomial distribution.
+     */
+
+    /* JVM almost always passes as +/0 0.01 (1%) with a sufficiently large
+     * limit.
+     *
+     * A more relaxed 0.05 (5%) is sometimes useful for development.
+     */
+    val tolerance = Math.round(limit * 0.01)
+
+    assertTrue(
+      s"nNeg ${countLt0}, nPos: $countGt0 tolerance +/-: ${tolerance}",
+      Math.abs(countLt0 - countGt0) / 2 <= tolerance
+    )
+  }
+
+  @Ignore // Manual developer test
+  @Test def nextLong_Binomial_EvenOdd(): Unit = {
+    val rng = RandomGenerator.of("L32X64MixRandom")
+
+    val lowBound = -jl.Double.MAX_VALUE
+    val highBound = jl.Double.MAX_VALUE // Inclusive
+
+    val limit = 1000 * 1000
+
+    var countEven = 0
+    var countOdd = 0
+
+    val delta = Math.ulp(highBound)
+    val nMax = ((highBound / delta).longValue * 2) + 1
+
+    for (j <- 0 until limit) {
+      val next = rng.nextLong(nMax)
+      if ((next & 1L) == 1) countOdd += 1
+      else countEven += 1
+    }
+
+    /* JVM almost always passes as +/0 0.01 (1%) with a sufficiently large
+     * limit.
+     *
+     * A more relaxed 0.05 (5%) is sometimes useful for development.
+     */
+    val tolerance = Math.round(limit * 0.01)
+
+    assertTrue(
+      s"nOdd ${countOdd}, nEven: $countEven tolerance +/-: ${tolerance}",
+      Math.abs(countOdd - countEven) / 2 <= tolerance
+    )
+  }
+
   @Test def nextLong_Bound(): Unit = {
     val rng = factory.create(481582459L)
 


### PR DESCRIPTION
Implement a javalib  `java.util.random.L32X64MixRandom#nextLong` which fits the expected
binomial distribution of positive and negative values. 

`L32X64MixRandom` is the `RandomGeneratorFactory` returned by `RandomGenerator.getDefault()`
and `getLong()` is the key method used by most other methods, so improving the quality of
the returned `Longs` is likely to have noticeable benefit.

Previously the Scala Native implementation would return, at size, approximately 1 negative value for every
3 positive values, for a ratio of 1:3. The expected ratio is 1:1 or fitting the binomial distribution. 
`L64X128MixRandom` appears to not have this defect.

The JVM implementation fits the binomial distribution at even quite small N. 

Associated unit-tests are provided.  They are marked `@Ignored` for CI because they require manual
interpretation. Running stochastic tests in CI is always dicy: the sensitive ones give false failures too
often and the insensitive ones are a waste of electrons. 

One of the tests, which was run manually, is a dual diligence test of the expected binomial 
distribution of odd and even values returned by  `nextLong()`. The previous Scala implementation
passed that test, as does the current change.

More powerful goodness-of-fit tests were not done and are left as an exercise for the reader.