### PR TITLE
Fix #4963: jur.RandomGenerator#equiDoubles now returns non-empty DoubleStream

### DIFF
--- a/javalib/src/main/scala/java/util/random/RandomGenerator.scala
+++ b/javalib/src/main/scala/java/util/random/RandomGenerator.scala
@@ -132,7 +132,6 @@ trait RandomGenerator {
 
   import java.util.ScalaOps._
 
-// Begin Ported from Scala.js commit: 9cb865f dated: 2025-03-16
   import scala.annotation.tailrec
 
   // Comments starting with `// >` are cited from the JavaDoc.
@@ -530,25 +529,99 @@ trait RandomGenerator {
     StreamSupport.doubleStream(downstreamSpliter, parallel = false)
   }
 
-  /* This implementation of equiDoubles() is scaffolding to allow
-   * implementation of Random.from() in a way that does not require
-   * re-visiting.  The intent is to provide a follow-on PR which
-   * implements the method correctly.
-   *
-   * Providing an empty stream is better than, say, calling doubles()
-   * because equiDoubles() is advertised as providing equidistant doubles
-   * to avoid known 'bunching' in doubles(). An empty stream makes
-   * the breakage evident.
-   */
-
   // Since: Java 22
   def equiDoubles(
       left: scala.Double,
       right: scala.Double,
       isLeftIncluded: Boolean,
       isRightIncluded: Boolean
-  ): DoubleStream =
-    DoubleStream.empty() // Incorrect implementation.
+  ): DoubleStream = {
+    /* The current evolution is focused on a believable and useful
+     * equidistribution across a number of scales.
+     *
+     * A future evolution to Industrial Strength could look at reducing the
+     * length of execution paths and number of allocations. In particular,
+     * there are two divisions where the denominator 'delta' is known to be
+     * an exact power of two. Modern compilers often have fast paths for
+     * such exact powers of two. Is there any runtime speedup from
+     * open coding a powers-of-two division bit twiddle here? Is it worth
+     * the development complexity?  To be determined as demand warrants.
+     * That will be a good problem to have. Even better, it is not
+     * today's problem.
+     */
+
+    val illegalArgumentMsg =
+      "the boundaries must be finite and the interval must not be empty"
+
+    /* Filter out Infinities & NaNs before getting down to work.
+     * JVM tests 'left' & 'right' as given and does consider is*Included yet.
+     */
+    if (!(jl.Double.isFinite(left) && jl.Double.isFinite(right)))
+      throw new IllegalArgumentException(illegalArgumentMsg)
+
+    // both 'low' and 'high' will be inclusive; makes math easier.
+    val low =
+      if (isLeftIncluded) left
+      else Math.nextUp(left)
+
+    val high =
+      if (isRightIncluded) right
+      else Math.nextDown(right)
+
+    var delta = 0.0
+    var kl = 0L
+    var n = 0L
+
+    def setup(): Unit = {
+      /* Returning a 3-tuple here would be more readable and would avoid
+       * using 'var's. Unfortunately reviewers strongly discourage that idiom.
+       */
+      val magnitudeOfLow = Math.abs(low)
+      val magnitudeOfHigh = Math.abs(high)
+
+      val maxMagnitude = Math.max(magnitudeOfLow, magnitudeOfHigh)
+      val ulpOfMaxMagnitude = Math.ulp(maxMagnitude)
+
+      delta = ulpOfMaxMagnitude
+
+      // If low == 0.0, kl is already 0L
+      if (low != 0.0) // exact integer test, so ==, no epsilon is OK.
+        kl = jl.Math.ceil(low / delta).longValue()
+
+      /* Overflowing a Long is not a concern here. The number of ulps
+       * Math.ulp(Double.MAX_VALUE) between and
+       * -Double.MAX_VALUE and Double.MAX_VALUE is known to be well less than
+       * Long.MAX_VALUE.
+       */
+
+      // Careful; counter intuitive but useful, kh can be negative
+      val kh = (high / delta).longValue() // kHigh
+
+      /* Snapping low up to exact delta kl may have emptied emptied range
+       * if it was not already empty.
+       */
+      if (kl >= kh)
+        throw new IllegalArgumentException(illegalArgumentMsg)
+
+      // +1 to be just above range high for nextDouble(n), n exclusive
+      n = (kh - kl) + 1
+    }
+
+    val spliter = new AbstractDoubleSpliterator(
+      jl.Long.MAX_VALUE,
+      Spliterator.IMMUTABLE //  0x400, decimal 1024, same as doubles()
+    ) {
+
+      def tryAdvance(action: DoubleConsumer): Boolean = {
+        val equiDouble = (kl + nextLong(n)) * delta
+        action.accept(equiDouble)
+        true
+      }
+    }
+
+    setup()
+    StreamSupport.doubleStream(spliter, parallel = false)
+  }
 
   def ints(): IntStream =
     ints(jl.Long.MAX_VALUE)

--- a/javalib/src/main/scala/java/util/random/RandomGenerator.scala
+++ b/javalib/src/main/scala/java/util/random/RandomGenerator.scala
@@ -132,6 +132,29 @@ trait RandomGenerator {
 
   import java.util.ScalaOps._
 
+// Begin Ported from Scala.js commit: 9cb865f dated: 2025-03-16
+
+  /* 2026-08-16
+   *   There have been three commits to Scala.js RandomGenerator since
+   *   the Scala.js commit 9cb865f. A total re-report was attempted
+   *   but committed here.
+   *
+   *   The first 2025-12-15 commit was a large refactoring.
+   *   One import imported another and so on. The changes here rippled to the
+   *   point of infeasiblity within the available constraints.
+   *
+   *   The other two changes seemed at first examination to be performance
+   *   changes. Given correctness, one seldom wants to leave performance on
+   *   the table. Those changes, particularly the 'Smarter use of long
+   *   divisions and remainders" or close relatives could be considered
+   *   for a later evolution. The other is removing one branch and
+   *   may not be cost effective for Scala Native (forcing lots of types
+   *   to change to 'unsigned').
+   *
+   *   Here correctness is the greater concern for the current and few
+   *   following evolutions.
+   */
+
   import scala.annotation.tailrec
 
   // Comments starting with `// >` are cited from the JavaDoc.

--- a/javalib/src/main/scala/java/util/random/RandomGenerator.scala
+++ b/javalib/src/main/scala/java/util/random/RandomGenerator.scala
@@ -134,6 +134,8 @@ trait RandomGenerator {
 
 // Begin Ported from Scala.js commit: 9cb865f dated: 2025-03-16
 
+  // scalafmt keeps deleting this block comment, fi!
+  // format: off
   /* 2026-08-16
    *   There have been three commits to Scala.js RandomGenerator since
    *   the Scala.js commit 9cb865f. A total re-report was attempted
@@ -154,6 +156,7 @@ trait RandomGenerator {
    *   Here correctness is the greater concern for the current and few
    *   following evolutions.
    */
+  // format: on
 
   import scala.annotation.tailrec
 

--- a/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/RandomTestOnJDK19.scala
+++ b/unit-tests/shared/src/test/require-jdk19/org/scalanative/testsuite/javalib/util/RandomTestOnJDK19.scala
@@ -1,8 +1,5 @@
 package org.scalanative.testsuite.javalib.util
 
-// import java.util._
-// import java.util.function.{DoubleConsumer, IntConsumer, LongConsumer}
-
 import java.{lang => jl, util => ju}
 
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/require-jdk22/org/scalanative/testsuite/javalib/util/RandomGeneratorTestOnJDK22.scala
+++ b/unit-tests/shared/src/test/require-jdk22/org/scalanative/testsuite/javalib/util/RandomGeneratorTestOnJDK22.scala
@@ -1,0 +1,285 @@
+package org.scalanative.testsuite.javalib.util.random
+
+import java.util.Spliterator
+import java.util.random.RandomGenerator
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
+/* This file uses RandomGenerator.getDefault(), which is, as of this writing
+ * L32X64MixRandom.
+ *
+ * This is not because that rng is well equidistibuted or has a long period
+ * but because it is the default.
+ *
+ * People using this method in the real world, or doing tests for
+ * equidistribution probably want to specify a 'better' rng, such as
+ * L64X128MixRandom.
+ */
+class RandomGeneratorTestOnJDK22 {
+
+  @Test def equiDoubles_Exceptions_JDK(): Unit = {
+    val rng = RandomGenerator.getDefault()
+
+    assertThrows(
+      "left is not finite",
+      classOf[IllegalArgumentException],
+      rng.equiDoubles(jl.Double.NEGATIVE_INFINITY, 0.0, true, false)
+    )
+
+    assertThrows(
+      "right is not finite",
+      classOf[IllegalArgumentException],
+      rng.equiDoubles(0.0, jl.Double.POSITIVE_INFINITY, false, true)
+    )
+
+    assertThrows(
+      "interval is empty",
+      classOf[IllegalArgumentException],
+      rng.equiDoubles(1.0, 1.0, false, true)
+    )
+  }
+
+  @Test def equiDoubles_Spliterator(): Unit = {
+    val rng = RandomGenerator.getDefault()
+
+    val equiDoublesSpliterator =
+      rng
+        .equiDoubles(-jl.Double.MAX_VALUE, jl.Double.MAX_VALUE, true, true)
+        .spliterator()
+
+    // Same as for doubles()
+    val expectedStreamCharacteristics =
+      Spliterator.IMMUTABLE //  0x400, decimal 1024
+
+    val equiDoublesStreamCharacteristics =
+      equiDoublesSpliterator.characteristics()
+
+    assertEquals(
+      "characteristics",
+      expectedStreamCharacteristics,
+      equiDoublesStreamCharacteristics
+    )
+
+    assertEquals(
+      "estimated size",
+      jl.Long.MAX_VALUE,
+      equiDoublesSpliterator.estimateSize()
+    )
+  }
+
+  @Test def equiDoubles_SmokeTest(): Unit = {
+    /* This is a simple test, to see if the entry point executes and
+     * produces output that is within bounds and distinct.
+     * It does not test the 'goodness-of-fit' to a uniform distribution
+     * or for the 'clumpliness' of doubles() described in the JDK 22
+     * release notes.
+     *
+     * Tests such as the Anderson-Darling goodness-of-fit test are not
+     * suitable for CI and need to be run manually.
+     */
+
+    val rng = RandomGenerator.getDefault()
+
+    // low is an exact multiple of delta, kl becomes that whole multiple
+    val lowBound = 0.0
+    val highBound = 128.0 // Exclusive
+    val limit = 100
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      equiDoubles
+        .limit(limit)
+        .forEach(d => {
+          assertTrue(
+            s"$d should be >= low bound ${lowBound}",
+            d >= lowBound
+          )
+          assertTrue(
+            s"$d should be < high bound ${highBound}",
+            d < highBound
+          )
+        })
+    }
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      assertEquals(
+        s"number distinct",
+        limit,
+        equiDoubles.limit(limit).distinct().count()
+      )
+    }
+  }
+
+  @Test def equiDoubles_SnapTo_UlpHighGrid(): Unit = {
+    val rng = RandomGenerator.getDefault()
+
+    // low is not an exact multiple of delta, kl becomes the whole multiple + 1
+    val lowBound = Math.nextDown(1.0)
+    val highBound = 10.0 // Exclusive
+    val limit = 100
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      equiDoubles
+        .limit(limit)
+        .forEach(d => {
+          assertTrue(
+            s"$d should be >= low bound ${lowBound}",
+            d >= lowBound
+          )
+          assertTrue(
+            s"$d should be < high bound ${highBound}",
+            d < highBound
+          )
+        })
+    }
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      assertEquals(
+        s"number distinct",
+        limit,
+        equiDoubles.limit(limit).distinct().count()
+      )
+    }
+  }
+
+  @Test def equiDoubles_0Inclusive_To_1Exclusive(): Unit = {
+    val rng = RandomGenerator.getDefault()
+
+    val lowBound = 0.0
+    val highBound = 1.0 // Exclusive
+    val limit = 100
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      equiDoubles
+        .limit(limit)
+        .forEach(d => {
+          assertTrue(
+            s"$d should be >= low bound ${lowBound}",
+            d >= lowBound
+          )
+          assertTrue(
+            s"$d should be < high bound ${highBound}",
+            d < highBound
+          )
+        })
+    }
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      assertEquals(
+        s"number distinct",
+        limit,
+        equiDoubles.limit(limit).distinct().count()
+      )
+    }
+  }
+
+  @Test def equiDoubles_Negative_Bounds(): Unit = {
+    val rng = RandomGenerator.getDefault()
+
+    val lowBound = -10.0
+    val highBound = -0.0 // Exclusive, negative 0.0 to complicate life.
+    val limit = 100
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      equiDoubles
+        .limit(limit)
+        .forEach(d => {
+          assertTrue(
+            s"$d should be >= low bound ${lowBound}",
+            d >= lowBound
+          )
+          assertTrue(
+            s"$d should be < high bound ${highBound}",
+            d < highBound
+          )
+        })
+    }
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      assertEquals(
+        s"number distinct",
+        limit,
+        equiDoubles.limit(limit).distinct().count()
+      )
+    }
+  }
+
+  @Test def equiDoubles_Huge_Range(): Unit = {
+    val rng = RandomGenerator.getDefault()
+
+    val lowBound = -jl.Double.MAX_VALUE
+    val highBound = jl.Double.MAX_VALUE // Inclusive
+    val limit = 100
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, true)
+
+      equiDoubles
+        .limit(limit)
+        .forEach(d => {
+          assertTrue(
+            s"$d should be >= low bound ${lowBound}",
+            d >= lowBound
+          )
+          assertTrue(
+            s"$d should be < high bound ${highBound}",
+            d < highBound
+          )
+        })
+    }
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      assertEquals(
+        s"number distinct",
+        limit,
+        equiDoubles.limit(limit).distinct().count()
+      )
+    }
+  }
+
+  @Test def equiDoubles_SmokeTest_IEEE754_Subnormals(): Unit = {
+    val rng = RandomGenerator.getDefault()
+
+    val lowBound = jl.Double.MIN_VALUE
+    val highBound = jl.Double.MIN_NORMAL - Math.ulp(jl.Double.MIN_VALUE)
+    val limit = 100
+
+    locally {
+      val equiDoubles = rng.equiDoubles(lowBound, highBound, true, false)
+
+      equiDoubles
+        .limit(limit)
+        .forEach(d => {
+          assertTrue(
+            s"$d should be >= low bound ${lowBound}",
+            d >= lowBound
+          )
+          assertTrue(
+            s"$d should be < high bound ${highBound}",
+            d < highBound
+          )
+        })
+    }
+  }
+}


### PR DESCRIPTION
Fix #4963 

Implement a competent javalib `java.util.RandomGenerator#equiDoubles` which returns a non-empty `DoubleStream` 
and several high-level unit-tests 'smoke' Tests.

##### Testing

TL;DR The SN results are believable when compared to  the JVM equivalent

A series of academic papers on statistical and software practice could probably be published describing
the Scala Native implementation of `equiDoubles`.   This section describes some manual testing 
intended to warrant belief in the distribution returned by the implemented method.

More detail requires rounds of beverages and probably room and board for a few semesters.

Java primitive `doubles`, a.k.a IEEE754 doubles, is specified as a discrete distribution. That is,
not every value between `-java.lang.Double.MAX_VALUE` and `+java.lang.Double.MAX_VALUE`
can be represented.  There are also widely described issues with comparing doubles with vastly
different scales (degrees of magnitude).

The well regarded `Anderson Darling` (A-D) statistical test can be used to determine the `goodness-of-fit`
of  samples from the discrete distribution to a continuous distribution, in this usage, the uniform 
distribution `[-MAX_VALUE , MAX_VALUE]`.  

The results of using `equiDoubles()` to generate samples of 1000 entries were run on each of JVM
and SN at five different points.  Each test was run once using the  L64X128MixRandom algorithm.

 Running each test 30 or so times would be better, but once is better than not at all.

p-values < 0.05 mean that it is unlikely the observed sample came from the uniform distribution.
Tiny p-values mean that it is astronomically unlikely.

###### ulp() at scale is greater than 1

The `jl.Math.ulp()` 'unit in the last place` is 2. A-D detects and reports that it is highly
unlikely to come from a uniform distribution. This is consistent with the IEEE specification
and expected.

```
JVM

       Anderson-Darling test of goodness-of-fit
        Null hypothesis: uniform distribution
        with parameters min = -1, max = 1.79769313486232e+308
        Parameters assumed to be fixed

        data:  dataIn$x
        An = Inf, p-value = 6e-07

SN - given JVM results, no need to run.    
```

###### ulp() at scale is 1
Passes, could come from uniform distribution.  

IEEE 754 Doubles with absolute magnitude of (2^53) - 1 or 9_007_199_254_740_991L 
will have a ulp of 1. Values slightly greater than that will have a ulp of 2. The ulp 
increases as scale increases. Such holes get reported, as they should be, as variations from 
uniform  distribution.

```
JVM -magicUlpOf1 spot inclusive to +magicUlpOf1 inclusive
      N = 1000

        Anderson-Darling test of goodness-of-fit
        Null hypothesis: uniform distribution
        with parameters min = -9007199254740991, max = 9007199254740991
        Parameters assumed to be fixed

        data:  dataIn$x
        An = 0.33542, p-value = 0.9094

SN -magicUlpOf1 spot inclusive to +magicUlpOf1 inclusive
      N = 1000

        Anderson-Darling test of goodness-of-fit
        Null hypothesis: uniform distribution
        with parameters min = -9007199254740991, max = 9007199254740991
        Parameters assumed to be fixed

        data:  dataIn$x
        An = 0.62284, p-value = 0.6266
```

###### ulp() at [0.0, 128.0)
Passes, could come from uniform distribution.  

```
JVM 0.0 inclusive to 128.0 exclusive N = 1000

        Anderson-Darling test of goodness-of-fit
        Null hypothesis: uniform distribution
        with parameters min = 0, max = 128
        Parameters assumed to be fixed

        data:  dataIn$x
        An = 1.1629, p-value = 0.2821


SN  0.0 inclusive to 128.0 exclusive N = 1000

        Anderson-Darling test of goodness-of-fit
        Null hypothesis: uniform distribution
        with parameters min = 0, max = 128
        Parameters assumed to be fixed

        data:  dataIn$x
        An = 1.2144, p-value = 0.2621
```
###### ulp() at [0.0, 1.0)
Passes, could come from uniform distribution.  
```
JVM 0.0 inclusive to 1.0 exclusive N = 1000

        Anderson-Darling test of goodness-of-fit
        Null hypothesis: uniform distribution
        with parameters min = 0, max = 1
        Parameters assumed to be fixed

        data:  dataIn$x
        An = 0.67982, p-value = 0.5759

SN  0.0 inclusive to 1.0 exclusive N = 1000
        Anderson-Darling test of goodness-of-fit
        Null hypothesis: uniform distribution
        with parameters min = 0, max = 1
        Parameters assumed to be fixed

        data:  dataIn$x
        An = 0.28124, p-value = 0.9515 ! a large p-value here is _good_
```
##### Undone

For future readers and maintainers. The following are beyond my current time budget
but are interesting thought experiments.

* I did not compare  the distribution of  `equiDoubles()` to the corresponding distrbution
  of `doubles()` on either JVM or Scala Native.

* I read that there is a version of the Anderson-Darling test which can be used to check if
  two or more samples are likely to have come from the same distribution.  One could
  use that to compare a sample of `equiDoubles()` from the JVM to one produced by
  Scala Native.  One could so something similar comparing a sample of `doubles()` with
  a sample of  `equiDoubles()` on each platform.