### PR TITLE
[runtime] Fix flaky module-init scripted test by preventing signaling of terminating thread

### DIFF
--- a/javalib/src/main/scala/java/lang/impl/PosixThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/PosixThread.scala
@@ -41,6 +41,7 @@ private[java] class PosixThread(
   @volatile private var counter: Int = 0
   // index of currently used condition
   @volatile private var conditionIdx = ConditionUnset
+  @volatile private var terminated = false
 
   if (isMultithreadingEnabled) {
     // Init locks/conditions before starting the thread
@@ -92,12 +93,15 @@ private[java] class PosixThread(
     }
 
   override def onTermination(): Unit = {
-    super.onTermination()
     if (isMultithreadingEnabled) {
-      pthread_cond_destroy(condition(0))
-      pthread_cond_destroy(condition(1))
-      pthread_mutex_destroy(lock)
+      this.synchronized {
+        terminated = true
+        pthread_cond_destroy(condition(0))
+        pthread_cond_destroy(condition(1))
+        pthread_mutex_destroy(lock)
+      }
     }
+    super.onTermination()
   }
 
   override def setPriority(
@@ -187,14 +191,16 @@ private[java] class PosixThread(
   }
 
   override def unpark(): Unit = if (isMultithreadingEnabled) {
-    pthread_mutex_lock(lock)
-    val s = counter
-    counter = 1
-    val index = conditionIdx
-    pthread_mutex_unlock(lock)
-
-    if (s < 1 && index != ConditionUnset) {
-      pthread_cond_signal(condition(index))
+    if (terminated) return
+    this.synchronized {
+      if (terminated) return
+      pthread_mutex_lock(lock)
+      val s = counter
+      counter = 1
+      val index = conditionIdx
+      if (s < 1 && index != ConditionUnset)
+        pthread_cond_signal(condition(index))
+      pthread_mutex_unlock(lock)
     }
   }
 

--- a/javalib/src/main/scala/java/lang/impl/WindowsThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/WindowsThread.scala
@@ -48,6 +48,8 @@ private[java] class WindowsThread(
       )
     }
 
+  @volatile private var terminated = false
+
   private val handle: Handle = {
     if (isMainThread) 0.toPtr // main thread
     else if (!isMultithreadingEnabled) {
@@ -68,18 +70,24 @@ private[java] class WindowsThread(
   }
 
   override protected def onTermination() = {
-    super.onTermination()
     if (isMultithreadingEnabled) {
-      CloseHandle(parkEvent)
-      CloseHandle(sleepEvent)
-      if (!isMainThread) CloseHandle(handle)
+      this.synchronized {
+        terminated = true
+        CloseHandle(parkEvent)
+        CloseHandle(sleepEvent)
+        if (!isMainThread) CloseHandle(handle)
+      }
     }
+    super.onTermination()
   }
 
   override def setPriority(
       priority: CInt
   ): Unit = if (isMultithreadingEnabled) {
-    SetThreadPriority(handle, priorityMapping(priority))
+    this.synchronized {
+      if (terminated) return
+      SetThreadPriority(handle, priorityMapping(priority))
+    }
   }
 
   // java.lang.Thread priority to OS priority mapping
@@ -97,10 +105,13 @@ private[java] class WindowsThread(
     }
 
   override def interrupt(): Unit = if (isMultithreadingEnabled) {
-    // For JSR-166 / LockSupport
-    SetEvent(parkEvent)
-    // For Sleep
-    SetEvent(sleepEvent)
+    this.synchronized {
+      if (terminated) return
+      // For JSR-166 / LockSupport
+      SetEvent(parkEvent)
+      // For Sleep
+      SetEvent(sleepEvent)
+    }
   }
 
   override protected def park(
@@ -133,7 +144,11 @@ private[java] class WindowsThread(
   }
 
   @inline override def unpark(): Unit = if (isMultithreadingEnabled) {
-    SetEvent(parkEvent)
+    if (terminated) return
+    this.synchronized {
+      if (terminated) return
+      SetEvent(parkEvent)
+    }
   }
 
   override def sleep(millis: scala.Long): Unit = {

--- a/nativelib/src/main/resources/scala-native/module_load.c
+++ b/nativelib/src/main/resources/scala-native/module_load.c
@@ -14,28 +14,6 @@
 
 #include <assert.h>
 
-// Thread identity helpers
-#ifdef _WIN32
-typedef DWORD thread_id;
-#else
-typedef pthread_t thread_id;
-#endif
-
-static thread_id getThreadId() {
-#ifdef _WIN32
-    return GetCurrentThreadId();
-#else
-    return pthread_self();
-#endif
-}
-static bool isThreadEqual(thread_id l, thread_id r) {
-#ifdef _WIN32
-    return l == r;
-#else
-    return pthread_equal(l, r);
-#endif
-}
-
 // cross-platform sleep function
 static void sleep_ms(int milliseconds) {
 #ifdef WIN32
@@ -94,8 +72,8 @@ bool scalanative_isModuleInitializationContext(ModuleRef module) {
 ModuleRef
 scalanative_moduleInitializationInstanceForCurrentThread(ModuleRef module) {
     InitializationContext *ctx = initializationContext(module);
-    return isThreadEqual(ctx->initThreadId, getThreadId()) ? ctx->instance
-                                                           : NULL;
+    return thread_equals(ctx->initThreadId, thread_getid()) ? ctx->instance
+                                                            : NULL;
 }
 
 NOINLINE static ModuleRef
@@ -104,6 +82,11 @@ __scalanative_waitForModuleInitialization(ModuleSlot slot, void *classInfo) {
     // A competing initializer can replace the slot and return before this
     // thread gets to inspect it. awaitForInitialization rechecks the slot
     // under the class monitor, where only the reentrant owner may use ctx.
+    ModuleRef module = atomic_load_explicit(slot, memory_order_acquire);
+    ModuleRef instance =
+        scalanative_moduleInitializationInstanceForCurrentThread(module);
+    if (instance != NULL)
+        return instance;
     return scalanative_awaitForInitialization(slot, classInfo);
 }
 
@@ -116,7 +99,7 @@ NOINLINE static ModuleRef __scalanative_startAndWaitForModuleInitialization(
     // written fields. Writing initThreadId and instance after the publish (the
     // previous ordering) left a window in which another thread could read them
     // before they were set, a data race on those fields.
-    ctx.initThreadId = getThreadId();
+    ctx.initThreadId = thread_getid();
     ModuleRef instance = scalanative_GC_alloc(classInfo, size);
     ctx.instance = instance;
     void **expected = NULL;

--- a/nativelib/src/main/resources/scala-native/module_load.c
+++ b/nativelib/src/main/resources/scala-native/module_load.c
@@ -1,5 +1,6 @@
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #include "stdatomic.h"
+#include <stdint.h>
 #include "gc/shared/ScalaNativeGC.h"
 #include "gc/shared/ThreadUtil.h"
 
@@ -59,23 +60,50 @@ typedef struct InitializationContext {
     thread_id initThreadId;
 } InitializationContext;
 
+// Module instances are aligned pointers. Tag the otherwise stack-local
+// context so readers never need to dereference it to distinguish it from an
+// initialized module.
+#define INITIALIZATION_CONTEXT_TAG ((uintptr_t)1)
+
+static void **initializationContextRef(InitializationContext *ctx) {
+    return (void **)((uintptr_t)ctx | INITIALIZATION_CONTEXT_TAG);
+}
+
+static bool isInitializationContext(ModuleRef module) {
+    return ((uintptr_t)module & INITIALIZATION_CONTEXT_TAG) != 0;
+}
+
+static InitializationContext *initializationContext(ModuleRef module) {
+    return (InitializationContext *)((uintptr_t)module &
+                                     ~INITIALIZATION_CONTEXT_TAG);
+}
+
 extern ModuleRef scalanative_initializeModule(ModuleCtor ctor,
                                               ModuleRef instance,
                                               ModuleSlot slot, void *classInfo);
 extern ModuleRef scalanative_awaitForInitialization(ModuleSlot slot,
                                                     void *classInfo);
 
+// This is called while holding classInfo's monitor. If another thread owns the
+// initialization, it cannot return from startAndWait... (and invalidate ctx)
+// until it has published the initialized module and released that monitor.
+bool scalanative_isModuleInitializationContext(ModuleRef module) {
+    return isInitializationContext(module);
+}
+
+ModuleRef
+scalanative_moduleInitializationInstanceForCurrentThread(ModuleRef module) {
+    InitializationContext *ctx = initializationContext(module);
+    return isThreadEqual(ctx->initThreadId, getThreadId()) ? ctx->instance
+                                                           : NULL;
+}
+
 NOINLINE static ModuleRef
 __scalanative_waitForModuleInitialization(ModuleSlot slot, void *classInfo) {
-    ModuleRef module = atomic_load_explicit(slot, memory_order_acquire);
-    assert(module != NULL);
-    if (*module != classInfo) {
-        InitializationContext *ctx = (InitializationContext *)module;
-        // Usage of module in its constructor, return unitializied instance
-        if (isThreadEqual(ctx->initThreadId, getThreadId())) {
-            return ctx->instance;
-        }
-    }
+    // Do not dereference a published stack-local InitializationContext here.
+    // A competing initializer can replace the slot and return before this
+    // thread gets to inspect it. awaitForInitialization rechecks the slot
+    // under the class monitor, where only the reentrant owner may use ctx.
     return scalanative_awaitForInitialization(slot, classInfo);
 }
 
@@ -92,7 +120,8 @@ NOINLINE static ModuleRef __scalanative_startAndWaitForModuleInitialization(
     ModuleRef instance = scalanative_GC_alloc(classInfo, size);
     ctx.instance = instance;
     void **expected = NULL;
-    if (atomic_compare_exchange_strong(slot, &expected, (void **)&ctx)) {
+    if (atomic_compare_exchange_strong(slot, &expected,
+                                       initializationContextRef(&ctx))) {
         return scalanative_initializeModule(ctor, instance, slot, classInfo);
     } else {
         return __scalanative_waitForModuleInitialization(slot, classInfo);
@@ -110,7 +139,7 @@ INLINE ModuleRef __scalanative_loadModule(ModuleSlot slot, void *classInfo,
         return __scalanative_startAndWaitForModuleInitialization(
             slot, classInfo, size, ctor);
 
-    if (*module == classInfo)
+    if (!isInitializationContext(module) && *module == classInfo)
         return module;
     else
         return __scalanative_waitForModuleInitialization(slot, classInfo);

--- a/nativelib/src/main/resources/scala-native/module_load.c
+++ b/nativelib/src/main/resources/scala-native/module_load.c
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #include "stdatomic.h"
 #include <stdint.h>
@@ -145,4 +147,14 @@ INLINE ModuleRef __scalanative_loadModule(ModuleSlot slot, void *classInfo,
         return __scalanative_waitForModuleInitialization(slot, classInfo);
 }
 
+#else
+bool scalanative_isModuleInitializationContext(void *module) {
+    (void)module;
+    return false;
+}
+
+void *scalanative_moduleInitializationInstanceForCurrentThread(void *module) {
+    (void)module;
+    return (void *)0;
+}
 #endif

--- a/nativelib/src/main/resources/scala-native/module_load.c
+++ b/nativelib/src/main/resources/scala-native/module_load.c
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 #ifdef SCALANATIVE_MULTITHREADING_ENABLED
 #include "stdatomic.h"
 #include <stdint.h>
@@ -147,14 +145,4 @@ INLINE ModuleRef __scalanative_loadModule(ModuleSlot slot, void *classInfo,
         return __scalanative_waitForModuleInitialization(slot, classInfo);
 }
 
-#else
-bool scalanative_isModuleInitializationContext(void *module) {
-    (void)module;
-    return false;
-}
-
-void *scalanative_moduleInitializationInstanceForCurrentThread(void *module) {
-    (void)module;
-    return (void *)0;
-}
 #endif

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -279,31 +279,34 @@ package object runtime {
         moduleSlot.rawptr,
         ffi.stdatomic.memory_order.memory_order_acquire
       )
-      if (ModuleInitialization.isContext(moduleRef)) {
-        // A stack-local InitializationContext is valid only while its owner is
-        // initializing under this monitor. Competing threads wait and recheck
-        // after the owner publishes the completed module.
-        val initializingInstance =
-          ModuleInitialization.instanceForCurrentThread(moduleRef)
-        if (initializingInstance != null) return initializingInstance
-        cls.wait()
-      } else {
-        // Assumes Class[?] is always 1st filed in the object header
-        val rtti = Intrinsics.loadObject(moduleRef)
-        if (rtti eq cls)
-          return Intrinsics.castRawPtrToObject(moduleRef) // happy-path
+      val isInitializationContext =
+        if (if (isMultithreadingEnabled)
+              ModuleInitialization.isContext(moduleRef)
+            else false) {
+          // A stack-local InitializationContext is valid only while its owner is
+          // initializing under this monitor. Competing threads wait and recheck
+          // after the owner publishes the completed module.
+          val initializingInstance =
+            ModuleInitialization.instanceForCurrentThread(moduleRef)
+          if (initializingInstance != null) return initializingInstance
+          cls.wait()
+        } else {
+          // Assumes Class[?] is always 1st filed in the object header
+          val rtti = Intrinsics.loadObject(moduleRef)
+          if (rtti eq cls)
+            return Intrinsics.castRawPtrToObject(moduleRef) // happy-path
 
-        if (rtti eq classOf[ExceptionInInitializerError]) {
-          val ex: ExceptionInInitializerError = Intrinsics
-            .castRawPtrToObject(moduleRef)
-            .asInstanceOf[ExceptionInInitializerError]
-          throw new NoClassDefFoundError(
-            s"Could not initialize class ${cls.getName()}"
-          ).initCause(ex)
+          if (rtti eq classOf[ExceptionInInitializerError]) {
+            val ex: ExceptionInInitializerError = Intrinsics
+              .castRawPtrToObject(moduleRef)
+              .asInstanceOf[ExceptionInInitializerError]
+            throw new NoClassDefFoundError(
+              s"Could not initialize class ${cls.getName()}"
+            ).initCause(ex)
+          }
+
+          cls.wait()
         }
-
-        cls.wait()
-      }
     }
     ??? // Unreachable
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -269,6 +269,15 @@ package object runtime {
   private[runtime] def waitForModuleInitialization(
       moduleSlot: unsafe.Ptr[AnyRef],
       cls: Class[_]
+  ): AnyRef =
+    if (isMultithreadingEnabled)
+      waitForModuleInitializationMultithreaded(moduleSlot, cls)
+    else
+      waitForModuleInitializationSingleThreaded(moduleSlot, cls)
+
+  private def waitForModuleInitializationMultithreaded(
+      moduleSlot: unsafe.Ptr[AnyRef],
+      cls: Class[_]
   ): AnyRef = cls.synchronized {
     while (true) {
       // The slot can contain one of the 3 values:
@@ -279,36 +288,58 @@ package object runtime {
         moduleSlot.rawptr,
         ffi.stdatomic.memory_order.memory_order_acquire
       )
-      val isInitializationContext =
-        if (if (isMultithreadingEnabled)
-              ModuleInitialization.isContext(moduleRef)
-            else false) {
-          // A stack-local InitializationContext is valid only while its owner is
-          // initializing under this monitor. Competing threads wait and recheck
-          // after the owner publishes the completed module.
-          val initializingInstance =
-            ModuleInitialization.instanceForCurrentThread(moduleRef)
-          if (initializingInstance != null) return initializingInstance
-          cls.wait()
-        } else {
-          // Assumes Class[?] is always 1st filed in the object header
-          val rtti = Intrinsics.loadObject(moduleRef)
-          if (rtti eq cls)
-            return Intrinsics.castRawPtrToObject(moduleRef) // happy-path
+      if (ModuleInitialization.isContext(moduleRef)) {
+        // A stack-local InitializationContext is valid only while its owner is
+        // initializing under this monitor. Competing threads wait and recheck
+        // after the owner publishes the completed module.
+        val initializingInstance =
+          ModuleInitialization.instanceForCurrentThread(moduleRef)
+        if (initializingInstance != null) return initializingInstance
+        cls.wait()
+      } else {
+        // Assumes Class[?] is always 1st filed in the object header
+        val rtti = Intrinsics.loadObject(moduleRef)
+        if (rtti eq cls)
+          return Intrinsics.castRawPtrToObject(moduleRef) // happy-path
 
-          if (rtti eq classOf[ExceptionInInitializerError]) {
-            val ex: ExceptionInInitializerError = Intrinsics
-              .castRawPtrToObject(moduleRef)
-              .asInstanceOf[ExceptionInInitializerError]
-            throw new NoClassDefFoundError(
-              s"Could not initialize class ${cls.getName()}"
-            ).initCause(ex)
-          }
-
-          cls.wait()
+        if (rtti eq classOf[ExceptionInInitializerError]) {
+          val ex: ExceptionInInitializerError = Intrinsics
+            .castRawPtrToObject(moduleRef)
+            .asInstanceOf[ExceptionInInitializerError]
+          throw new NoClassDefFoundError(
+            s"Could not initialize class ${cls.getName()}"
+          ).initCause(ex)
         }
+
+        cls.wait()
+      }
     }
     ??? // Unreachable
+  }
+
+  private def waitForModuleInitializationSingleThreaded(
+      moduleSlot: unsafe.Ptr[AnyRef],
+      cls: Class[_]
+  ): AnyRef = cls.synchronized {
+    while (true) {
+      val moduleRef = ffi.stdatomic.atomic_load_intptr(
+        moduleSlot.rawptr,
+        ffi.stdatomic.memory_order.memory_order_acquire
+      )
+      val rtti = Intrinsics.loadObject(moduleRef)
+      if (rtti eq cls) return Intrinsics.castRawPtrToObject(moduleRef)
+      if (rtti eq classOf[ExceptionInInitializerError]) {
+        val ex = Intrinsics
+          .castRawPtrToObject(moduleRef)
+          .asInstanceOf[ExceptionInInitializerError]
+        throw new NoClassDefFoundError(
+          s"Could not initialize class ${cls.getName()}"
+        )
+          .initCause(ex)
+      }
+      cls.wait()
+    }
+    ???
   }
 
   @extern private[runtime] object StackOverflowGuards {

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -279,21 +279,31 @@ package object runtime {
         moduleSlot.rawptr,
         ffi.stdatomic.memory_order.memory_order_acquire
       )
-      // Assumes Class[?] is always 1st filed in the object header
-      val rtti = Intrinsics.loadObject(moduleRef)
-      if (rtti eq cls)
-        return Intrinsics.castRawPtrToObject(moduleRef) // happy-path
+      if (ModuleInitialization.isContext(moduleRef)) {
+        // A stack-local InitializationContext is valid only while its owner is
+        // initializing under this monitor. Competing threads wait and recheck
+        // after the owner publishes the completed module.
+        val initializingInstance =
+          ModuleInitialization.instanceForCurrentThread(moduleRef)
+        if (initializingInstance != null) return initializingInstance
+        cls.wait()
+      } else {
+        // Assumes Class[?] is always 1st filed in the object header
+        val rtti = Intrinsics.loadObject(moduleRef)
+        if (rtti eq cls)
+          return Intrinsics.castRawPtrToObject(moduleRef) // happy-path
 
-      if (rtti eq classOf[ExceptionInInitializerError]) {
-        val ex: ExceptionInInitializerError = Intrinsics
-          .castRawPtrToObject(moduleRef)
-          .asInstanceOf[ExceptionInInitializerError]
-        throw new NoClassDefFoundError(
-          s"Could not initialize class ${cls.getName()}"
-        ).initCause(ex)
+        if (rtti eq classOf[ExceptionInInitializerError]) {
+          val ex: ExceptionInInitializerError = Intrinsics
+            .castRawPtrToObject(moduleRef)
+            .asInstanceOf[ExceptionInInitializerError]
+          throw new NoClassDefFoundError(
+            s"Could not initialize class ${cls.getName()}"
+          ).initCause(ex)
+        }
+
+        cls.wait()
       }
-
-      cls.wait()
     }
     ??? // Unreachable
   }
@@ -310,6 +320,14 @@ package object runtime {
 
     @name("scalanative_StackOverflowGuards_close")
     def close(): Unit = extern
+  }
+
+  @extern private[runtime] object ModuleInitialization {
+    @name("scalanative_isModuleInitializationContext")
+    def isContext(context: RawPtr): Boolean = extern
+
+    @name("scalanative_moduleInitializationInstanceForCurrentThread")
+    def instanceForCurrentThread(context: RawPtr): AnyRef = extern
   }
 
 }

--- a/scripted-tests/run/module-init-race/src/main/scala/Test.scala
+++ b/scripted-tests/run/module-init-race/src/main/scala/Test.scala
@@ -75,6 +75,12 @@ object M29 extends Mod(29)
 object M30 extends Mod(30)
 object M31 extends Mod(31)
 
+// The initializer must be able to see its own partially constructed module.
+// This takes the reentrant path through the tagged InitializationContext.
+object Reentrant {
+  val self: Reentrant.type = Reentrant
+}
+
 object Test {
   // Deferred first-touch thunks: referencing Mxx here rather than eagerly is
   // what makes each module's initialization happen on a worker thread once the
@@ -139,6 +145,8 @@ object Test {
   def main(args: Array[String]): Unit = {
     val k = Config.K
     val t = Config.T
+
+    check(Reentrant.self eq Reentrant, "recursive module initialization failed")
 
     // Force the support holders to initialize before any worker starts.
     Counters.runs(0)

--- a/unit-tests/shared/src/test/scala/utils/CollectionConverters.scala
+++ b/unit-tests/shared/src/test/scala/utils/CollectionConverters.scala
@@ -24,9 +24,9 @@ object CollectionConverters {
 
     def toJavaMap[K, V](implicit ev: T =:= (K, V)): java.util.Map[K, V] = {
       val m = new LinkedHashMap[K, V]()
-      self.iterator.foreach { elem =>
-        val (key, value): (K, V) = elem: @unchecked
-        m.put(key, value)
+      self.iterator.foreach {
+        case (key, value) =>
+          m.put(key, value)
       }
       m
     }

--- a/unit-tests/shared/src/test/scala/utils/CollectionConverters.scala
+++ b/unit-tests/shared/src/test/scala/utils/CollectionConverters.scala
@@ -26,7 +26,7 @@ object CollectionConverters {
       val m = new LinkedHashMap[K, V]()
       self.iterator.foreach {
         case (key, value) =>
-          m.put(key, value)
+          m.put(key.asInstanceOf[K], value.asInstanceOf[V])
       }
       m
     }


### PR DESCRIPTION
Fixes recently observed TSAN failures in the scritped test for module-init