### PR TITLE
linux-setup-env now uses current nick-fields/retry@v4

### DIFF
--- a/.github/actions/linux-setup-env/action.yml
+++ b/.github/actions/linux-setup-env/action.yml
@@ -32,7 +32,7 @@ runs:
         fi
 
     - name: Install dependencies
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 10
         max_attempts: 10


### PR DESCRIPTION
Eliminate the warning in linux CI runs:

```
Complete job
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: nick-fields/retry@v3. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
`.github/workflows/run-tests-linux-multiarch.yml` & 
`.github/workflows/run-tests-linux-multiarch.yml` have been using `nick-fields/retry@v4` 
since approximately March 23, 2026. I do not know why dependabot missed this file.
